### PR TITLE
Fix secondary stat display using global font settings

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -5721,7 +5721,8 @@ do
             statsFrame:SetSize(160, 60)
             statsFrame:SetFrameStrata("LOW")
             statsText = statsFrame:CreateFontString(nil, "OVERLAY")
-            statsText:SetFont(STANDARD_TEXT_FONT, 12, "OUTLINE")
+            local font = EllesmereUI.ResolveFontName(EllesmereUI.GetFontsDB().global)
+            statsText:SetFont(font, 12, EllesmereUI.GetFontOutlineFlag())
             statsText:SetPoint("TOPLEFT")
             statsText:SetJustifyH("LEFT")
         end


### PR DESCRIPTION
Replaced hardcoded STANDARD_TEXT_FONT with the configured global font.

Secondary stat display now respects the addon's global font and outline settings.