### PR TITLE
fix(actionbars): Buttons on action bar vanish when dismounting

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --  EllesmereUIActionBars.lua  Custom Action Bars (full rewrite)
 --
 --  Creates its own secure action bar frames and buttons instead of hooking
@@ -2205,8 +2205,8 @@ local function LayoutBar(key)
                 btn:SetAlpha(0)
                 btn:Hide()
             else
-                -- Don't override alpha here; mouseover system handles it
                 btn:Show()
+                btn:SetAlpha(1)
             end
         end
     end


### PR DESCRIPTION
Tested with MouseOver and Always Bar Visibility. Works good.
In combat it doesnt work though (mount, go infight, dismount).

Quick info: Always show all buttons didn't have this problem.