### PR TITLE
Fix resource bar anchor behavior

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -222,7 +222,9 @@ end
 
 local function IsAnchored(barKey)
     local info = GetAnchorInfo(barKey)
-    return info ~= nil
+    if info ~= nil then return true end
+    local elem = registeredElements[barKey]
+    return elem and elem.isAnchored and elem.isAnchored() or false
 end
 
 -- Smoothly fade the background overlay between normal and select-element alpha
@@ -1520,12 +1522,16 @@ local function SortMoverFrameLevels()
 end
 
 local function CreateMover(barKey)
-    if movers[barKey] then return movers[barKey] end
-
-    -- Skip elements that are intentionally hidden (e.g. alwaysHidden action bars)
     local elem = registeredElements[barKey]
-    if elem and elem.isHidden and elem.isHidden() then return nil end
-    if elem and elem.isAnchored and elem.isAnchored() then return nil end
+    local existing = movers[barKey]
+
+    -- Skip elements that are intentionally hidden or currently anchored.
+    if elem and ((elem.isHidden and elem.isHidden()) or (elem.isAnchored and elem.isAnchored())) then
+        if existing then existing:Hide() end
+        return nil
+    end
+
+    if existing then return existing end
 
     local bar = GetBarFrame(barKey)
     if not bar then return nil end
@@ -2030,6 +2036,11 @@ local function CreateMover(barKey)
                 end
             end
 
+            local elem = registeredElements[s._barKey]
+            if elem and elem.onLiveMove then
+                pcall(elem.onLiveMove, s._barKey)
+            end
+
             ShowAlignmentGuides(s._barKey)
         end)
     end)
@@ -2100,6 +2111,11 @@ local function CreateMover(barKey)
                     if movers[childKey] then movers[childKey]:Sync() end
                 end
             end
+        end
+
+        local elem = registeredElements[self._barKey]
+        if elem and elem.onLiveMove then
+            pcall(elem.onLiveMove, self._barKey)
         end
     end)
 

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -1466,7 +1466,9 @@ initFrame:SetScript("OnEvent", function(self)
               getValue = function() local p = DB(); return p and p.secondary.anchorTo or "none" end,
               setValue = function(v)
                   local p = DB(); if not p then return end
-                  p.secondary.anchorTo = v; SmoothRefresh()
+                  p.secondary.anchorTo = v
+                  if v ~= "none" then p.secondary.unlockPos = nil end
+                  SmoothRefresh()
               end },
             { type = "dropdown", text = "Anchor Position",
               disabled = function() local p = DB(); return p and (not p.secondary.enabled or (p.secondary.anchorTo or "none") == "none") end,
@@ -1942,7 +1944,9 @@ initFrame:SetScript("OnEvent", function(self)
               getValue = function() local p = DB(); return p and p.primary.anchorTo or "none" end,
               setValue = function(v)
                   local p = DB(); if not p then return end
-                  p.primary.anchorTo = v; SmoothRefresh()
+                  p.primary.anchorTo = v
+                  if v ~= "none" then p.primary.unlockPos = nil end
+                  SmoothRefresh()
               end },
             { type = "dropdown", text = "Anchor Position",
               disabled = function() local p = DB(); return p and (not p.primary.enabled or (p.primary.anchorTo or "none") == "none") end,
@@ -2394,7 +2398,9 @@ initFrame:SetScript("OnEvent", function(self)
               getValue = function() local p = DB(); return p and p.health.anchorTo or "none" end,
               setValue = function(v)
                   local p = DB(); if not p then return end
-                  p.health.anchorTo = v; SmoothRefresh()
+                  p.health.anchorTo = v
+                  if v ~= "none" then p.health.unlockPos = nil end
+                  SmoothRefresh()
               end },
             { type = "dropdown", text = "Anchor Position",
               disabled = function() local p = DB(); return p and (not p.health.enabled or (p.health.anchorTo or "none") == "none") end,

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -408,6 +408,7 @@ local targetAlpha = 1
 local cachedClass
 local cachedPrimary
 local cachedSecondary
+local RefreshAnchoredBarsForUnlockTarget
 
 -- Forward declarations
 local UpdateCastBar
@@ -755,6 +756,7 @@ local function RegisterUnlockElements()
         end,
         applyPosition = function()
             local hp = ERB.db.profile.health
+            if hp.anchorTo and hp.anchorTo ~= "none" then return end
             local pos = hp.unlockPos
             if not pos then return end
             if healthBar then
@@ -763,6 +765,9 @@ local function RegisterUnlockElements()
                 healthBar:ClearAllPoints()
                 healthBar:SetPoint(pos.point, UIParent, pos.relPoint or pos.point, pos.x, pos.y)
             end
+        end,
+        onLiveMove = function(key)
+            if RefreshAnchoredBarsForUnlockTarget then RefreshAnchoredBarsForUnlockTarget(key) end
         end,
     }
 
@@ -807,6 +812,7 @@ local function RegisterUnlockElements()
         end,
         applyPosition = function()
             local pp = ERB.db.profile.primary
+            if pp.anchorTo and pp.anchorTo ~= "none" then return end
             local pos = pp.unlockPos
             if not pos then return end
             if primaryBar then
@@ -815,6 +821,9 @@ local function RegisterUnlockElements()
                 primaryBar:ClearAllPoints()
                 primaryBar:SetPoint(pos.point, UIParent, pos.relPoint or pos.point, pos.x, pos.y)
             end
+        end,
+        onLiveMove = function(key)
+            if RefreshAnchoredBarsForUnlockTarget then RefreshAnchoredBarsForUnlockTarget(key) end
         end,
     }
 
@@ -863,6 +872,7 @@ local function RegisterUnlockElements()
         end,
         applyPosition = function()
             local sp = ERB.db.profile.secondary
+            if sp.anchorTo and sp.anchorTo ~= "none" then return end
             local pos = sp.unlockPos
             if not pos then return end
             if secondaryFrame then
@@ -871,6 +881,9 @@ local function RegisterUnlockElements()
                 secondaryFrame:ClearAllPoints()
                 secondaryFrame:SetPoint(pos.point, UIParent, pos.relPoint or pos.point, pos.x or 0, pos.y or 0)
             end
+        end,
+        onLiveMove = function(key)
+            if RefreshAnchoredBarsForUnlockTarget then RefreshAnchoredBarsForUnlockTarget(key) end
         end,
     }
 
@@ -1001,18 +1014,17 @@ local function ApplyBarAnchor(frame, anchorKey, anchorPos, offsetX, offsetY, gro
     growthDir = growthDir or "UP"
     local centered = (growCentered ~= false)
 
-    -- Determine the frame's own anchor point -- always the near edge center.
-    -- LayoutCDMBar-equivalent offset logic handles non-centered icon positioning.
-    --   grow RIGHT -> near edge = LEFT   -> "LEFT"
-    --   grow LEFT  -> near edge = RIGHT  -> "RIGHT"
-    --   grow DOWN  -> near edge = TOP    -> "TOP"
-    --   grow UP    -> near edge = BOTTOM -> "BOTTOM"
-    local function GetFramePoint()
-        if growthDir == "RIGHT" then return "LEFT"   end
-        if growthDir == "LEFT"  then return "RIGHT"  end
-        if growthDir == "DOWN"  then return "TOP"    end
-        if growthDir == "UP"    then return "BOTTOM" end
-        return "LEFT"
+    local function GetAnchorPoints()
+        if anchorPos == "left" then
+            return "RIGHT", "LEFT"
+        elseif anchorPos == "right" then
+            return "LEFT", "RIGHT"
+        elseif anchorPos == "top" then
+            return "BOTTOM", "TOP"
+        elseif anchorPos == "bottom" then
+            return "TOP", "BOTTOM"
+        end
+        return "LEFT", "RIGHT"
     end
 
     if anchorKey == "mouse" then
@@ -1052,30 +1064,16 @@ local function ApplyBarAnchor(frame, anchorKey, anchorPos, offsetX, offsetY, gro
     elseif anchorKey == "partyframe" then
         local partyFrame = _G._ECME_FindPlayerPartyFrame and _G._ECME_FindPlayerPartyFrame()
         if not partyFrame then return false end
+        local framePoint, targetPoint = GetAnchorPoints()
         frame:ClearAllPoints()
-        if anchorPos == "left" then
-            frame:SetPoint(GetFramePoint(), partyFrame, "LEFT", offsetX, offsetY)
-        elseif anchorPos == "right" then
-            frame:SetPoint(GetFramePoint(), partyFrame, "RIGHT", offsetX, offsetY)
-        elseif anchorPos == "top" then
-            frame:SetPoint(GetFramePoint(), partyFrame, "TOP", offsetX, offsetY)
-        elseif anchorPos == "bottom" then
-            frame:SetPoint(GetFramePoint(), partyFrame, "BOTTOM", offsetX, offsetY)
-        end
+        frame:SetPoint(framePoint, partyFrame, targetPoint, offsetX, offsetY)
         return true
     elseif anchorKey == "playerframe" then
         local playerFrame = _G._ECME_FindPlayerUnitFrame and _G._ECME_FindPlayerUnitFrame()
         if not playerFrame then return false end
+        local framePoint, targetPoint = GetAnchorPoints()
         frame:ClearAllPoints()
-        if anchorPos == "left" then
-            frame:SetPoint(GetFramePoint(), playerFrame, "LEFT", offsetX, offsetY)
-        elseif anchorPos == "right" then
-            frame:SetPoint(GetFramePoint(), playerFrame, "RIGHT", offsetX, offsetY)
-        elseif anchorPos == "top" then
-            frame:SetPoint(GetFramePoint(), playerFrame, "TOP", offsetX, offsetY)
-        elseif anchorPos == "bottom" then
-            frame:SetPoint(GetFramePoint(), playerFrame, "BOTTOM", offsetX, offsetY)
-        end
+        frame:SetPoint(framePoint, playerFrame, targetPoint, offsetX, offsetY)
         return true
     end
 
@@ -1083,17 +1081,77 @@ local function ApplyBarAnchor(frame, anchorKey, anchorPos, offsetX, offsetY, gro
     if not targetFrame or not targetFrame:IsShown() then return false end
 
     frame:ClearAllPoints()
+    local framePoint, targetPoint = GetAnchorPoints()
     local ok
-    if anchorPos == "left" then
-        ok = pcall(frame.SetPoint, frame, GetFramePoint(), targetFrame, "LEFT", offsetX, offsetY)
-    elseif anchorPos == "right" then
-        ok = pcall(frame.SetPoint, frame, GetFramePoint(), targetFrame, "RIGHT", offsetX, offsetY)
-    elseif anchorPos == "top" then
-        ok = pcall(frame.SetPoint, frame, GetFramePoint(), targetFrame, "TOP", offsetX, offsetY)
-    elseif anchorPos == "bottom" then
-        ok = pcall(frame.SetPoint, frame, GetFramePoint(), targetFrame, "BOTTOM", offsetX, offsetY)
-    end
+    ok = pcall(frame.SetPoint, frame, framePoint, targetFrame, targetPoint, offsetX, offsetY)
     return ok or false
+end
+
+local UNLOCK_TARGET_TO_ERB_ANCHOR = {
+    ERB_Health = "erb_health",
+    ERB_Power = "erb_powerbar",
+    ERB_ClassResource = "erb_classresource",
+    ERB_CastBar = "erb_castbar",
+}
+
+local function GetAnchorOffsets(settings)
+    if not settings then return 0, 0 end
+    local offsetX = settings.anchorOffsetX
+    if offsetX == nil then offsetX = settings.anchorX end
+    local offsetY = settings.anchorOffsetY
+    if offsetY == nil then offsetY = settings.anchorY end
+    return offsetX or 0, offsetY or 0
+end
+
+local function ReapplyInternalBarAnchors()
+    if not (ERB and ERB.db and ERB.db.profile) then return end
+
+    local p = ERB.db.profile
+    local anchoredBars = {
+        { frame = healthBar, settings = p.health },
+        { frame = primaryBar, settings = p.primary },
+        { frame = secondaryFrame, settings = p.secondary },
+    }
+
+    for _ = 1, 2 do
+        for _, info in ipairs(anchoredBars) do
+            local frame = info.frame
+            local settings = info.settings
+            local anchorKey = settings and settings.anchorTo
+            if frame and settings and frame:IsShown()
+                and anchorKey and anchorKey ~= "none"
+                and ERB_ANCHOR_FRAMES[anchorKey]
+            then
+                local offsetX, offsetY = GetAnchorOffsets(settings)
+                ApplyBarAnchor(frame, anchorKey, settings.anchorPosition, offsetX, offsetY, settings.growthDirection, settings.growCentered)
+            end
+        end
+    end
+end
+
+RefreshAnchoredBarsForUnlockTarget = function(unlockKey)
+    local targetAnchor = UNLOCK_TARGET_TO_ERB_ANCHOR[unlockKey]
+    if not (targetAnchor and ERB and ERB.db and ERB.db.profile) then return end
+
+    local p = ERB.db.profile
+    local bars = {
+        { frame = healthBar, settings = p.health },
+        { frame = primaryBar, settings = p.primary },
+        { frame = secondaryFrame, settings = p.secondary },
+    }
+
+    for _ = 1, 2 do
+        for _, info in ipairs(bars) do
+            local frame = info.frame
+            local settings = info.settings
+            if frame and settings and frame:IsShown()
+                and settings.anchorTo == targetAnchor
+            then
+                local offsetX, offsetY = GetAnchorOffsets(settings)
+                ApplyBarAnchor(frame, settings.anchorTo, settings.anchorPosition, offsetX, offsetY, settings.growthDirection, settings.growCentered)
+            end
+        end
+    end
 end
 
 -------------------------------------------------------------------------------
@@ -1135,7 +1193,13 @@ local function BuildBars()
             healthBar = CreateStatusBar(mainFrame, "ERB_HealthBar", hp.width, hp.height,
                 hp.borderSize, hp.borderR, hp.borderG, hp.borderB, hp.borderA)
         end
-        if hp.unlockPos and hp.unlockPos.point then
+        if hp.anchorTo and hp.anchorTo ~= "none" then
+            local ow, oh = OrientedSize(hp.width, hp.height, hpOri)
+            local offsetX, offsetY = GetAnchorOffsets(hp)
+            healthBar:SetScale(hp.scale)
+            healthBar:SetSize(ow, oh)
+            ApplyBarAnchor(healthBar, hp.anchorTo, hp.anchorPosition, offsetX, offsetY, hp.growthDirection, hp.growCentered)
+        elseif hp.unlockPos and hp.unlockPos.point then
             -- Position fully managed by unlock mode -- no animations, just apply directly
             local rp = hp.unlockPos.relPoint or hp.unlockPos.point
             local ow, oh = OrientedSize(hp.width, hp.height, hpOri)
@@ -1143,11 +1207,6 @@ local function BuildBars()
             healthBar:SetSize(ow, oh)
             healthBar:ClearAllPoints()
             healthBar:SetPoint(hp.unlockPos.point, UIParent, rp, hp.unlockPos.x or 0, hp.unlockPos.y or 0)
-        elseif hp.anchorTo and hp.anchorTo ~= "none" then
-            local ow, oh = OrientedSize(hp.width, hp.height, hpOri)
-            healthBar:SetScale(hp.scale)
-            healthBar:SetSize(ow, oh)
-            ApplyBarAnchor(healthBar, hp.anchorTo, hp.anchorPosition, hp.anchorOffsetX, hp.anchorOffsetY, hp.growthDirection, hp.growCentered)
         else
             -- Clear any mouse-tracking OnUpdate from a previous anchor
             ApplyBarAnchor(healthBar, "none")
@@ -1211,7 +1270,13 @@ local function BuildBars()
             primaryBar = CreateStatusBar(mainFrame, "ERB_PrimaryBar", pp.width, pp.height,
                 pp.borderSize, pp.borderR, pp.borderG, pp.borderB, pp.borderA)
         end
-        if pp.unlockPos and pp.unlockPos.point then
+        if pp.anchorTo and pp.anchorTo ~= "none" then
+            local ow, oh = OrientedSize(pp.width, pp.height, ppOri)
+            local offsetX, offsetY = GetAnchorOffsets(pp)
+            primaryBar:SetScale(pp.scale)
+            primaryBar:SetSize(ow, oh)
+            ApplyBarAnchor(primaryBar, pp.anchorTo, pp.anchorPosition, offsetX, offsetY, pp.growthDirection, pp.growCentered)
+        elseif pp.unlockPos and pp.unlockPos.point then
             -- Position fully managed by unlock mode -- no animations, just apply directly
             local rp = pp.unlockPos.relPoint or pp.unlockPos.point
             local ow, oh = OrientedSize(pp.width, pp.height, ppOri)
@@ -1219,11 +1284,6 @@ local function BuildBars()
             primaryBar:SetSize(ow, oh)
             primaryBar:ClearAllPoints()
             primaryBar:SetPoint(pp.unlockPos.point, UIParent, rp, pp.unlockPos.x or 0, pp.unlockPos.y or 0)
-        elseif pp.anchorTo and pp.anchorTo ~= "none" then
-            local ow, oh = OrientedSize(pp.width, pp.height, ppOri)
-            primaryBar:SetScale(pp.scale)
-            primaryBar:SetSize(ow, oh)
-            ApplyBarAnchor(primaryBar, pp.anchorTo, pp.anchorPosition, pp.anchorOffsetX, pp.anchorOffsetY, pp.growthDirection, pp.growCentered)
         else
             -- Clear any mouse-tracking OnUpdate from a previous anchor
             ApplyBarAnchor(primaryBar, "none")
@@ -1323,15 +1383,16 @@ local function BuildBars()
         local frameW = isVertical and pipH or totalW
         local frameH = isVertical and totalW or pipH
 
-        if sp.unlockPos and sp.unlockPos.point then
+        if sp.anchorTo and sp.anchorTo ~= "none" then
+            local offsetX, offsetY = GetAnchorOffsets(sp)
+            secondaryFrame:SetScale(sp.scale or 1)
+            secondaryFrame:SetSize(frameW, frameH)
+            ApplyBarAnchor(secondaryFrame, sp.anchorTo, sp.anchorPosition, offsetX, offsetY, sp.growthDirection, sp.growCentered)
+        elseif sp.unlockPos and sp.unlockPos.point then
             secondaryFrame:SetScale(sp.scale or 1)
             secondaryFrame:SetSize(frameW, frameH)
             secondaryFrame:ClearAllPoints()
             secondaryFrame:SetPoint(sp.unlockPos.point, UIParent, sp.unlockPos.relPoint or sp.unlockPos.point, sp.unlockPos.x or 0, sp.unlockPos.y or 0)
-        elseif sp.anchorTo and sp.anchorTo ~= "none" then
-            secondaryFrame:SetScale(sp.scale or 1)
-            secondaryFrame:SetSize(frameW, frameH)
-            ApplyBarAnchor(secondaryFrame, sp.anchorTo, sp.anchorPosition, sp.anchorOffsetX, sp.anchorOffsetY, sp.growthDirection, sp.growCentered)
         else
             ApplyBarAnchor(secondaryFrame, "none")
             local function ApplySecondaryBarTransform()
@@ -1545,6 +1606,8 @@ local function BuildBars()
     elseif secondaryFrame then
         secondaryFrame:Hide()
     end
+
+    ReapplyInternalBarAnchors()
 end
 
 


### PR DESCRIPTION
## Summary
- fix resource bar anchoring so anchored ERB bars no longer keep independent unlock movers or stale unlock positions
- correct ERB anchor edge selection for top, bottom, left, and right placement so anchored bars snap without overlapping
- reapply internal ERB anchors after bar construction so `Power Bar -> Class Resource` survives `/reload`

## Testing
- manually verified in game that `Power Bar -> Class Resource` follows the parent in unlock mode and hides the child mover
- manually verified top, bottom, left, and right anchor positions, including the bottom overlap regression
- manually verified `Power Bar -> Class Resource` remains visible and anchored after `/reload`
