### PR TITLE
fix(resourcebars): defer vehicle proxy creation during combat lockdown

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -3042,15 +3042,19 @@ function ERB:ApplyAll()
 
     -- Vehicle proxy: hide resource bars during full vehicle UI ([vehicleui] condition)
     if not ERB._vehicleProxy then
-        ERB._vehicleProxy = CreateFrame("Frame", nil, UIParent, "SecureHandlerStateTemplate")
-        ERB._vehicleProxy:SetAttribute("_onstate-erbvehicle", [[
-            self:CallMethod("OnVehicleStateChanged", newstate)
-        ]])
-        ERB._vehicleProxy.OnVehicleStateChanged = function(_, state)
-            ERB._inVehicle = (state == "hide")
-            UpdateVisibility()
+        if InCombatLockdown() then
+            ERB._vehicleProxyPending = true
+        else
+            ERB._vehicleProxy = CreateFrame("Frame", nil, UIParent, "SecureHandlerStateTemplate")
+            ERB._vehicleProxy:SetAttribute("_onstate-erbvehicle", [[
+                self:CallMethod("OnVehicleStateChanged", newstate)
+            ]])
+            ERB._vehicleProxy.OnVehicleStateChanged = function(_, state)
+                ERB._inVehicle = (state == "hide")
+                UpdateVisibility()
+            end
+            RegisterStateDriver(ERB._vehicleProxy, "erbvehicle", "[vehicleui][petbattle] hide; show")
         end
-        RegisterStateDriver(ERB._vehicleProxy, "erbvehicle", "[vehicleui][petbattle] hide; show")
     end
 end
 
@@ -3105,6 +3109,10 @@ local function OnEvent(self, event, ...)
     elseif event == "PLAYER_REGEN_ENABLED" then
         isInCombat = false
         UpdateVisibility()
+        if ERB._vehicleProxyPending and not ERB._vehicleProxy then
+            ERB._vehicleProxyPending = nil
+            ERB:ApplyAll()
+        end
         -- Clean up Whirlwind GUID cache on combat end
         if EllesmereUI and EllesmereUI.HandleWhirlwindStacks then
             EllesmereUI.HandleWhirlwindStacks(event)


### PR DESCRIPTION
## Summary
- `SetAttribute()` and `RegisterStateDriver()` on `SecureHandlerStateTemplate` are protected operations blocked during combat
- `PLAYER_ENTERING_WORLD` can fire mid-combat (BG/arena entry), causing `ADDON_ACTION_BLOCKED` when `ApplyAll()` tries to create the vehicle proxy
- Defers proxy creation with `InCombatLockdown()` guard and retries on `PLAYER_REGEN_ENABLED`

## Context
Discord report: https://discord.com/channels/585577383847788554/1481233218375122994

## Test plan
- [ ] `/reload` while in combat — no `ADDON_ACTION_BLOCKED` error
- [ ] Enter a battleground — resource bars still hide correctly in vehicle UI after combat ends
- [ ] Normal login out of combat — vehicle proxy created immediately as before