### PR TITLE
fix(cdm): auto-populate new miscellaneous bars with player extras

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -5752,6 +5752,13 @@ function ns.AddCDMBar(barType, name, numRows)
         customSpells = {},
         outOfRangeOverlay = false,
     }
+    -- Auto-populate new trinkets bars with player's current extras
+    if barType == "trinkets" then
+        local newBar = bars[#bars]
+        for _, ex in ipairs(GetExtraSpells()) do
+            newBar.customSpells[#newBar.customSpells + 1] = ex.spellID
+        end
+    end
     BuildAllCDMBars()
     RegisterCDMUnlockElements()
     return key


### PR DESCRIPTION
## Summary
- New trinkets/miscellaneous CDM bars were created with an empty `customSpells` list, causing the frame to render at 1x1 pixel (invisible)
- Now auto-populates with the player's equipped trinkets, racial abilities, and health potions via `GetExtraSpells()` at creation time
- Existing bars are unaffected — only runs when a new trinkets bar is added

## Related
- [Discord bug report](https://discord.com/channels/585577383847788554/1481235974800277515)

## Test plan
- [ ] Create a new Miscellaneous bar via CDM options (`+ Add Trinket/Racials/Potion Bar`)
- [ ] Verify the bar appears immediately with trinket/racial/potion icons
- [ ] Verify existing Miscellaneous bars retain their current spell configuration
- [ ] Verify spells can still be removed/reordered after auto-populate