### PR TITLE
fix(profiles): respect per-character profile default in NewDB

### DIFF
--- a/EllesmereUI_Lite.lua
+++ b/EllesmereUI_Lite.lua
@@ -155,7 +155,8 @@ local dbRegistry = {}  -- all db objects, for logout cleanup
 -- Returns a db object with .profile pointing to the active profile table.
 -- @param svName  Global SavedVariables name (string)
 -- @param defaults  Table with a .profile sub-table of default values
-function EUILite.NewDB(svName, defaults)
+-- @param defaultToCharKey  When true, new characters default to their own profile
+function EUILite.NewDB(svName, defaults, defaultToCharKey)
     -- Get or create the global SV table
     local sv = _G[svName]
     if type(sv) ~= "table" then
@@ -166,7 +167,8 @@ function EUILite.NewDB(svName, defaults)
     -- Determine profile key
     local charKey = UnitName("player") .. " - " .. GetRealmName()
     if type(sv.profileKeys) ~= "table" then sv.profileKeys = {} end
-    local profileName = sv.profileKeys[charKey] or "Default"
+    local profileName = sv.profileKeys[charKey]
+        or (defaultToCharKey and charKey or "Default")
     sv.profileKeys[charKey] = profileName
 
     -- Get or create the profile table


### PR DESCRIPTION
## Summary

- `EUILite.NewDB()` ignored the third `defaultToCharKey` parameter, so all characters defaulted to the shared `"Default"` profile
- CDM bar changes on one character would overwrite settings on another character
- Now when `defaultToCharKey` is `true`, new characters get their own profile (`"CharName - RealmName"`) instead of sharing `"Default"`

Reported in [Discord](https://discord.com/channels/585577383847788554/1481217098985377882)

## Notes

- **Safe for existing users**: characters that already have a `profileKeys` entry continue using their current profile — the new fallback only applies to characters logging in for the first time
- Affects all addons passing `true` to `NewDB`: CDM, UnitFrames, ActionBars, ResourceBars, AuraBuffReminders

## Test plan

- [ ] Log in on Character A, configure CDM bars
- [ ] Log in on Character B, verify it gets its own profile and CDM bars are independent
- [ ] Log back into Character A, verify settings are unchanged