### PR TITLE
fix(actionbars): prevent UIParentBottomManagedFrameContainer:SetSize() taint

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -6514,12 +6514,22 @@ _blizzMovableCombatFrame:SetScript("OnEvent", function()
             end
         end
         if holder and blizzFrame and not InCombatLockdown() then
+            -- Remove from Blizzard's managed layout before reparenting to
+            -- prevent UIParentBottomManagedFrameContainer:SetSize() taint.
+            blizzFrame.ignoreInLayout = true
+            if blizzFrame.SetIsLayoutFrame then
+                pcall(blizzFrame.SetIsLayoutFrame, blizzFrame, false)
+            end
             blizzFrame:SetParent(holder)
             blizzFrame:ClearAllPoints()
             blizzFrame:SetPoint("CENTER", holder, "CENTER", 0, 0)
         end
         -- Also reparent widget power bar for encounter bar
         if barKey == "EncounterBar" and holder and UIWidgetPowerBarContainerFrame and not InCombatLockdown() then
+            UIWidgetPowerBarContainerFrame.ignoreInLayout = true
+            if UIWidgetPowerBarContainerFrame.SetIsLayoutFrame then
+                pcall(UIWidgetPowerBarContainerFrame.SetIsLayoutFrame, UIWidgetPowerBarContainerFrame, false)
+            end
             UIWidgetPowerBarContainerFrame:SetParent(holder)
             UIWidgetPowerBarContainerFrame:ClearAllPoints()
             UIWidgetPowerBarContainerFrame:SetPoint("CENTER", holder, "CENTER", 0, 0)


### PR DESCRIPTION
## Summary

- Fixes `[ADDON_ACTION_BLOCKED] AddOn 'EllesmereUIActionBars' tried to call the protected function 'UIParentBottomManagedFrameContainer:SetSize()'`
- The `PLAYER_REGEN_ENABLED` deferred handler reparented Blizzard frames without first removing them from the managed layout system, causing the container's protected `SetSize()` to fire from tainted addon code
- Adds `ignoreInLayout = true` and `SetIsLayoutFrame(false)` guards before each `SetParent()` call in the deferred handler, matching the existing pattern in `ReparentIntoHolder()`

## Bug report

https://discord.com/channels/585577383847788554/1481185319637352650

## Test plan

- [ ] Enter combat with ExtraActionButton/EncounterBar visible, exit combat — verify no `ADDON_ACTION_BLOCKED` error
- [ ] Test with MicroBar and BagBar reparenting after combat
- [ ] Verify action bars still reposition correctly after combat ends