### PR TITLE
fix(nameplates): shrink hitbox to exclude name-text spacing

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -1759,17 +1759,17 @@ local function SetupAuraCVars()
     end
     local function ApplyNamePlateClickArea()
         if InCombatLockdown() then return end
+        local nameGap = 4 + GetEnemyNameTextSize()
         if C_NamePlate and C_NamePlate.SetNamePlateSize then
             -- Size must cover the full visual footprint (name + health + cast)
             -- to prevent stacking jitter. Health bar alone is too small.
             local barH = GetHealthBarHeight()
             local castH = GetCastBarHeight()
-            local nameGap = 4 + GetEnemyNameTextSize()
             local totalH = nameGap + barH + castH
             C_NamePlate.SetNamePlateSize(GetHealthBarWidth(), totalH)
         end
         if C_NamePlateManager and C_NamePlateManager.SetNamePlateHitTestInsets and Enum and Enum.NamePlateType then
-            C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Enemy, -10000, -10000, -10000, -10000)
+            C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Enemy, 0, 0, nameGap, 0)
         end
     end
     ApplyNamePlateClickArea()


### PR DESCRIPTION
## Summary
- Nameplate hit-test insets now exclude the name-text gap above the health bar from the clickable area
- `SetNamePlateSize` still uses the full height (name + bar + cast) so stacking/overlap is unaffected
- Replaces the old `-10000` insets (which made hitboxes enormous) with a top inset equal to the name gap

## Test plan
- [ ] Verify nameplates no longer have oversized hitboxes extending into the name text area
- [ ] Verify nameplate stacking still works correctly with no jitter
- [ ] Test with different `textSlotTopSize` / `nameYOffset` values