### PR TITLE
Fix: Prevent text and number clipping on bars (Nameplates, ResourceBar, and Unitframes)

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -976,7 +976,7 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
     plate.health:SetPoint("CENTER", plate, "CENTER", 0, GetNameplateYOffset())
     plate.health:SetSize(GetHealthBarWidth(), GetHealthBarHeight())
     plate.health:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
-    plate.health:SetClipsChildren(true)
+    plate.health:SetClipsChildren(false)
     plate.healthBG = plate.health:CreateTexture(nil, "BACKGROUND")
     plate.healthBG:SetAllPoints()
     plate.healthBG:SetColorTexture(0.12, 0.12, 0.12, 1.0)

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1298,7 +1298,7 @@ local function BuildBars()
     if sp.enabled ~= false and cachedSecondary then
         if not secondaryFrame then
             secondaryFrame = CreateFrame("Frame", "ERB_SecondaryFrame", mainFrame)
-            secondaryFrame:SetClipsChildren(true)
+            secondaryFrame:SetClipsChildren(false)
         end
 
         local maxPts = cachedSecondary.max or 5

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1830,7 +1830,7 @@ local function CreateAbsorbBar(frame, unit, settings)
     local barWidth = settings.frameWidth
     local barHeight = settings.healthHeight
 
-    hpBar:SetClipsChildren(true)
+    hpBar:SetClipsChildren(false)
 
     local shieldBar = CreateFrame("StatusBar", nil, hpBar)
     shieldBar:SetStatusBarTexture("Interface\\AddOns\\EllesmereUIUnitFrames\\Media\\shield.tga")
@@ -2097,7 +2097,7 @@ local function CreatePortrait(frame, side, frameHeight, unit)
     backdrop:SetFrameStrata(frame:GetFrameStrata())
     backdrop:SetFrameLevel(frame:GetFrameLevel() + 1)
     PP.Size(backdrop, adjustedHeight, adjustedHeight)
-    backdrop:SetClipsChildren(true)
+    backdrop:SetClipsChildren(false)
 
     local bgTex = backdrop:CreateTexture(nil, "BACKGROUND")
     PP.Point(bgTex, "TOPLEFT", backdrop, "TOPLEFT", 0, 0)


### PR DESCRIPTION
**Purpose:**
This fix prevents text and number clipping on various bars, allowing players to increase font sizes beyond the bar's height.

**Details:**
* Enables a more modern UI style (similar to ElvUI) where text can overlap the bar borders.
* Applies to Nameplates, ResourceBar, and Unitframes.
* Fixes the issue where larger numbers or names were being cut off by the container limits.

This gives users much more flexibility in customizing their layout without losing visibility of important information.