### PR TITLE
fix(cdm): stale child cache causing Brewmaster stack/recharge bugs

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -4665,6 +4665,17 @@ local function UpdateAllCDMBars(dt)
                             local resolvedSid = ch._ecmeResolvedSid
                             local baseSpellID = ch._ecmeBaseSpellID
                             local cachedOverride = ch._ecmeOverrideSid
+                            -- Invalidate cache when cooldownID changes (child recycled
+                            -- by Blizzard CDM for a different spell, e.g. Empty Barrel
+                            -- proc replacing another spell's child frame).
+                            if resolvedSid and ch._ecmeCachedCdID ~= cdID then
+                                resolvedSid = nil
+                                baseSpellID = nil
+                                cachedOverride = nil
+                                ch._ecmeResolvedSid = nil
+                                ch._ecmeBaseSpellID = nil
+                                ch._ecmeOverrideSid = nil
+                            end
                             if not resolvedSid then
                                 local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID)
                                 if info then
@@ -4674,6 +4685,7 @@ local function UpdateAllCDMBars(dt)
                                     ch._ecmeBaseSpellID = baseSpellID
                                     ch._ecmeOverrideSid = cachedOverride
                                     ch._ecmeResolvedSid = resolvedSid
+                                    ch._ecmeCachedCdID = cdID
                                 end
                             else
                                 -- Refresh override from lightweight API (returns
@@ -6996,6 +7008,7 @@ local function ScheduleTalentRebuild()
                         ch._ecmeResolvedSid = nil
                         ch._ecmeBaseSpellID = nil
                         ch._ecmeOverrideSid = nil
+                        ch._ecmeCachedCdID = nil
                     end
                 end
             end


### PR DESCRIPTION
## Summary

- Fixes CDM child frame cache (`_ecmeResolvedSid`) becoming stale when Blizzard's CDM recycles a child for a different spell
- Tracks `cooldownID` alongside cached data and invalidates when it changes, forcing a fresh API resolve
- Fixes `TalentAwareReconcile` permanently dropping buff bar tracked spells when viewer isn't fully populated after talent swaps

## Problem

### Stale child cache (commit 1)

When Blizzard's CDM recycles a child frame (e.g. gaining Empty Barrel proc on Brewmaster), the cached `_ecmeResolvedSid` stayed stale. This caused wrong child-to-spell mappings in `_tickBlizzAllChildCache` and `_tickBlizzActiveCache`, leading to:

1. **Stack counts disappearing** when gaining Empty Barrel (from Celestial Brew / Fortifying Brew / Celestial Infusion) — stacks return when the proc fades
2. **Missing recharge info** on Purifying Brew and Exploding Keg when using non-Blizzard active animations — incorrect active state detection from wrong child mapping

Both only occur in combat because that's when the CDM actively recycles child frames for buff procs.

### Buff bar spell list mutation (commit 2)

`TalentAwareReconcile` was too aggressive with buff bars — it only kept spells found in the viewer child pool. After a talent swap, the buff viewer may not be fully repopulated when reconcile fires, causing spells absent from the partial pool to be permanently dropped (buff bars have no dormant slot support).

Now falls back to `knownSet` (from `GetCooldownViewerCategorySet`) so known spells are preserved even when the viewer hasn't repopulated. This matches the safety already present in `ReconcileMainBarSpells`.

## Test plan

- [ ] Brewmaster: Cast Celestial Brew in combat, verify stack counts on other spells persist through Empty Barrel proc
- [ ] Brewmaster: Verify Purifying Brew charge count and recharge swipe show correctly with Pixel Glow / Action Button Glow active animations
- [ ] Change talent loadout, verify buff bar tracked spells are preserved in the options panel
- [ ] Verify no regression on other specs' CDM charge/stack displays