### PR TITLE
fix(cdm): treat SetCooldown(0,0) as Clear to prevent stuck tracker cooldowns

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -4745,9 +4745,7 @@ local function UpdateAllCDMBars(dt)
                                         _ecmeRawStartCache[ch] = start
                                         _ecmeRawDurCache[ch] = dur
                                     else
-                                        -- SetCooldown(0,0) is equivalent to Clear(); wipe cached state
-                                        -- so IsBufChildCooldownActive does not permanently return true
-                                        -- (Lua treats 0 as truthy, so storing dur=0 would stick)
+                                        -- dur=0 means inactive; wipe like Clear() (0 is truthy in Lua)
                                         _ecmeDurObjCache[ch] = nil
                                         _ecmeChildHasDurObj[ch] = nil
                                         _ecmeRawStartCache[ch] = nil


### PR DESCRIPTION
## Summary
- **Bug:** Tracker/utility spell cooldowns permanently display during combat
- **Root cause:** Lua truthiness bug — when Blizzard calls `SetCooldown(0, 0)` to deactivate a CDM child (instead of `Clear()`), the hook stored `dur = 0` in `_ecmeRawDurCache`. In Lua, `0` is truthy, so `IsBufChildCooldownActive` permanently returned `true`
- **Fix:** Treat `SetCooldown` with `dur <= 0` the same as `Clear()` — wipe all cached cooldown state so the display correctly clears

## Test plan
- [ ] Enter combat with a tracker ability active (e.g., Track Beasts)
- [ ] Verify tracker cooldown does not permanently show on CDM bars
- [ ] Verify normal spell cooldowns still display and expire correctly
- [ ] Verify totem cooldowns are unaffected (separate code path)