### PR TITLE
fix(cdm): prevent buff bar tracked spells from being dropped during talent reconcile

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6491,9 +6491,13 @@ local function TalentAwareReconcile()
                         local removed = barData.removedSpells or {}
                         local kept, keptSet = {}, {}
                         for _, sid in ipairs(barData.trackedSpells) do
-                            if sid and sid ~= 0 and pool[sid] and not removed[sid] then
-                                kept[#kept + 1] = sid
-                                keptSet[sid] = true
+                            if sid and sid ~= 0 and not removed[sid] then
+                                -- Also accept knownSet so a partially-populated
+                                -- viewer can't permanently drop buff bar spells.
+                                if pool[sid] or knownSet[sid] then
+                                    kept[#kept + 1] = sid
+                                    keptSet[sid] = true
+                                end
                             end
                         end
                         -- Append new spells in stable viewer child order


### PR DESCRIPTION
## Summary

- Fixes `TalentAwareReconcile` permanently dropping buff bar tracked spells when the viewer isn't fully populated after talent swaps

## Problem

`TalentAwareReconcile` only kept buff spells found in the viewer child pool. After a talent swap, the buff viewer may not be fully repopulated when reconcile fires (0.5s debounce). Spells absent from the partial pool were permanently dropped — buff bars have no dormant slot support, so there's no recovery path.

This caused the CDM buff bar options panel to lose tracked spells (e.g. 7 icons → 2) after changing talent loadouts or hero talent swaps.

## Fix

Falls back to `knownSet` (from `GetCooldownViewerCategorySet`) so spells still known to the game are preserved even when the viewer hasn't repopulated. Matches the safety already in `ReconcileMainBarSpells` for non-talent-aware bars.

## Test plan

- [ ] Change talent loadout, verify buff bar tracked spells are preserved in the CDM options panel
- [ ] Switch hero talent trees, verify buff bar spell list stays intact
- [ ] Verify new spells from talent swaps still append to the buff bar
- [ ] Verify no regression on cooldown/utility bar talent-aware dormant behavior