### PR TITLE
fix(cdm): ghost buff icons persisting after combat end

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -259,7 +259,8 @@ local function IsBufChildCooldownActive(ch)
     end
     -- Non-totem: check our hook-captured cooldown state tables
     if _ecmeChildHasDurObj[ch] then return true end
-    if _ecmeRawDurCache[ch] then return true end
+    local rawDur = _ecmeRawDurCache[ch]
+    if rawDur and rawDur > 0 then return true end
     return false
 end
 


### PR DESCRIPTION
## Summary
- Fixes CDM buff icons that persist as "ghost" icons after the actual buff falls off when leaving combat
- Root cause: Lua treats `0` as truthy — when Blizzard calls `SetCooldown(0, 0)` to clear a cooldown (instead of `Clear()`), the cached `dur = 0` made `IsBufChildCooldownActive` return `true`, preventing hide-when-inactive from removing the icon
- Fix applied in two places: the `SetCooldown` hook now treats `dur <= 0` as a clear, and `IsBufChildCooldownActive` now checks `rawDur > 0` explicitly

## Test plan
- [ ] Equip a proc buff (e.g. Infusion of Light) in a CDM buff window anchored to mouse
- [ ] Enter combat, trigger the proc, then kill the mob while stacks are still active
- [ ] Verify the buff icon disappears when the buff naturally expires after combat ends
- [ ] Verify buffs still display correctly during combat (duration, stacks, swipe animation)
- [ ] Test with "hide when inactive" both enabled and disabled