### PR TITLE
fix(mini-frames): persist scale/position on login and slider change

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -6534,17 +6534,7 @@ initFrame:SetScript("OnEvent", function(self)
               getValue=function() return settingsTable.frameScale or 100 end,
               setValue=function(v)
                 settingsTable.frameScale = v
-                if ns.ApplyFrameScale then
-                    for unit, frame in pairs(ns.frames or {}) do
-                        if type(unit) == "string" and unit:sub(1,1) ~= "_" then
-                            local uKey = unit:match("^boss%d$") and "boss" or (unit == "targettarget" or unit == "focustarget") and "totPet" or unit
-                            if db.profile[uKey] == settingsTable then
-                                ns.ApplyFrameScale(frame, unit)
-                            end
-                        end
-                    end
-                end
-                UpdatePreview()
+                ReloadAndUpdate()
               end }, { type="label", text="" });  y = y - h
 
         -- TEXT section

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -5959,6 +5959,7 @@ function InitializeFrames()
     oUF:SetActiveStyle("EllesmerePet")
     frames.pet = oUF:Spawn("pet", "EllesmereUIUnitFrames_Pet")
     ApplyFramePosition(frames.pet, "pet")
+    ApplyFrameScale(frames.pet, "pet")
     SetupUnitMenu(frames.pet, "pet")
     if enabled.pet == false then
         frames.pet:Hide()
@@ -5968,6 +5969,7 @@ function InitializeFrames()
     oUF:SetActiveStyle("EllesmereTargetTarget")
     frames.targettarget = oUF:Spawn("targettarget", "EllesmereUIUnitFrames_TargetTarget")
     ApplyFramePosition(frames.targettarget, "targettarget")
+    ApplyFrameScale(frames.targettarget, "targettarget")
     SetupUnitMenu(frames.targettarget, "targettarget")
     if enabled.targettarget == false then
         frames.targettarget:Hide()
@@ -5977,6 +5979,7 @@ function InitializeFrames()
     oUF:SetActiveStyle("EllesmereFocusTarget")
     frames.focustarget = oUF:Spawn("focustarget", "EllesmereUIUnitFrames_FocusTarget")
     ApplyFramePosition(frames.focustarget, "focustarget")
+    ApplyFrameScale(frames.focustarget, "focustarget")
     SetupUnitMenu(frames.focustarget, "focustarget")
     if enabled.focustarget == false then
         frames.focustarget:Hide()
@@ -6339,6 +6342,7 @@ function SetupOptionsPanel()
                     if scale then
                         local unitKey = (k == "boss") and "boss"
                                      or (k == "classPower") and nil
+                                     or (k == "targettarget" or k == "focustarget") and "totPet"
                                      or k
                         if unitKey and db.profile[unitKey] then
                             db.profile[unitKey].frameScale = math.floor(scale * 100 + 0.5)


### PR DESCRIPTION
## Bug
Target of Target, Focus Target, and Pet Frame resets size and position after logging in/out and /reload. It sometimes goes extra wild on slider change in unlock mode and appears with a random location on screen. 

## Root Cause
Missing ApplyFrameScale call in InitializeFrames for pet/targettarget/focustarget. Everything else cascades from that — the wrong position on reload, the options panel needing ReloadAndUpdate, the savePosition key mapping bug being exposed. The core omission is that three frames were simply never having their saved scale applied on login.

## Fix
ApplyFrameScale never called in InitializeFrames for pet/targettarget/focustarget — scale always loaded as 1.0 on login savePosition wrote frameScale to db.profile["targettarget"] which doesn't exist — targettarget and focustarget both share db.profile.totPet, so the scale was silently dropped on every unlock mode save
Options panel scale slider used ns.ApplyFrameScale (no position compensation) instead of ReloadAndUpdate

## Test
Open unlock mode, set pet scale to something non-default (e.g. 150%)
/reload — pet should stay at 150%, same position
Repeat for ToT and focustarget
Change ToT scale — confirm focustarget also changes (they share totPet)

/eui → Unit Frames → Mini Frames Edit → set pet scale to non-default
Frames should update visually immediately (live preview)
/reload — pet should stay at that scale, correct position (not bottom-right corner)
/reload again — still correct
Repeat for ToT/focustarget slider

Regression check
Set scale back to 100% via both paths — confirm frames return to default position cleanly
Confirm player/target/focus frames are unaffected throughout
Set position via unlock mode drag, then change scale — confirm position compensates correctly and survives /reload