### PR TITLE
fix(pet bar): show pet ability cds on pet bar

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -5669,6 +5669,12 @@ function EAB:FinishSetup()
     -- unregistered from all events, so Blizzard's own update never fires).
     local function UpdatePetBar()
         C_Timer_After(0, function()
+            -- PetActionBar:Update() only sets textures and cooldown frames —
+            -- not combat-restricted, so run it before the lockdown guard so
+            -- PET_BAR_UPDATE_COOLDOWN (which fires during combat) still works.
+            if PetActionBar and PetActionBar.Update then
+                PetActionBar:Update()
+            end
             if InCombatLockdown() then return end
             LayoutBar("PetBar")
             self:ApplyAlwaysShowButtons("PetBar")
@@ -5680,17 +5686,11 @@ function EAB:FinishSetup()
             if petInfo and petFrame and petS and not petS.alwaysHidden then
                 RegisterAttributeDriver(petFrame, "state-visibility", BuildVisibilityString(petInfo, petS))
             end
-            -- Repopulate button content (icons, cooldowns, autocast rings,
-            -- behavior checked states). PetActionBar.actionButtons still
-            -- holds references to the reparented buttons, so Update() works
-            -- even though the bar frame itself is on hiddenParent.
-            if PetActionBar and PetActionBar.Update then
-                PetActionBar:Update()
-            end
         end)
     end
     local _petEventFrame = CreateFrame("Frame")
     _petEventFrame:RegisterEvent("PET_BAR_UPDATE")
+    _petEventFrame:RegisterEvent("PET_BAR_UPDATE_COOLDOWN")
     _petEventFrame:RegisterEvent("PET_UI_UPDATE")
     _petEventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
     _petEventFrame:RegisterUnitEvent("UNIT_PET", "player")


### PR DESCRIPTION
## Bug
Pet ability cooldowns do not show up in the pet bar

## Root Cause
PetActionBar:UnregisterAllEvents() (in HideBlizzardBars()) silenced Blizzard's entire update cycle for the pet bar — including its PET_BAR_UPDATE_COOLDOWN handler. EAB's _petEventFrame replacement never registered that event as a substitute, so cooldown changes were silently dropped with no handler at all.

The combat guard compounded it: even for the events that were registered, PetActionBar:Update() sat after if InCombatLockdown() then return end, so any update that did fire during combat (when cooldowns actually expire) was immediately bailed out before the content refresh ran.

## Fix
register PET_BAR_UPDATE_COOLDOWN and move PetActionBar:Update() before the combat guard

## Test
1. Send pet to attack something
2. Use a pet ability with a CD
3. Behold! There is now a cd timer on the icon