### PR TITLE
fix: hideActive always shows recharge cooldown instead of aura duration

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3500,7 +3500,7 @@ local function UpdateCustomBarIcons(barKey)
                         end
                     end
 
-                    if isAura then
+                    if isAura and activeAnim ~= "hideActive" then
                         -- When the spell has a runtime override on a non-buff bar,
                         -- skip aura duration display so the override spell's actual
                         -- cooldown is shown (e.g. 2min ability becomes 24s kick).
@@ -3535,7 +3535,7 @@ local function UpdateCustomBarIcons(barKey)
                     -- On buff bars, copy the child's cooldown to show effect duration.
                     -- Also check if the buff-viewer child is visible (covers summon
                     -- spells like Dreadstalkers that have no aura and no wasSetFromAura).
-                    if not hasRuntimeOverride and not auraHandled then
+                    if not hasRuntimeOverride and not auraHandled and activeAnim ~= "hideActive" then
                         local blzFbActive2 = _tickBlizzActiveCache[resolvedID] or _tickBlizzActiveCache[spellID]
                         if not blzFbActive2 then
                             local blzBufCh = _tickBlizzBuffChildCache[resolvedID] or _tickBlizzBuffChildCache[spellID]
@@ -4445,7 +4445,7 @@ local function UpdateTrackedBarIcons(barKey)
                         end
                     end
 
-                    if isAura then
+                    if isAura and activeAnim ~= "hideActive" then
                         -- When the spell has a runtime override on a non-buff bar,
                         -- skip aura duration display so the override spell's actual
                         -- cooldown is shown (e.g. 2min ability becomes 24s kick).
@@ -4475,7 +4475,7 @@ local function UpdateTrackedBarIcons(barKey)
                     -- Also check if the buff-viewer child is visible (covers summon
                     -- spells like Dreadstalkers that have no aura and no wasSetFromAura).
                     -- Copy the child's cooldown state to show the effect duration.
-                    if not hasRuntimeOverride and not auraHandled then
+                    if not hasRuntimeOverride and not auraHandled and activeAnim ~= "hideActive" then
                         if isBuffBarForOvr then
                             local blzFbActive = _tickBlizzActiveCache[resolvedID] or _tickBlizzActiveCache[spellID]
                             if not blzFbActive then


### PR DESCRIPTION
Fix: hideActive showing aura duration instead of recharge cooldown

Two update functions were missing the activeAnim ~= "hideActive" condition that the main update function already had, causing all three to behave identically and display the buff's remaining duration instead of the recharge cooldown. The fix adds the missing condition to the aura duration block and the summon fallback block in both affected functions, so hideActive now consistently skips aura duration display and shows the recharge cooldown across all bar types.

Related discord bugs:
https://discord.com/channels/585577383847788554/1481332713381429350
https://discord.com/channels/585577383847788554/1480771667989893160
https://discord.com/channels/585577383847788554/1481332713381429350

