### PR TITLE
Fix Resto Shaman totem buff display bugs

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -243,8 +243,7 @@ local _cdmInVehicle = false      -- true when [vehicleui] or [petbattle] is acti
 local _ecmeRawDurCache = {}      -- [ch] = dur captured from SetCooldown hook
 local _tickTotemCache = {}       -- [slot] = haveTotem (cached per tick to avoid inconsistent reads)
 
--- Cached wrapper for GetTotemInfo: returns the same haveTotem value for a given
--- slot within a single tick, preventing show/hide oscillation during totem expiry.
+-- Per-tick cached GetTotemInfo to prevent inconsistent reads during totem expiry.
 local function GetCachedTotemInfo(slot)
     local cached = _tickTotemCache[slot]
     if cached ~= nil then return cached end
@@ -253,12 +252,9 @@ local function GetCachedTotemInfo(slot)
     return haveTotem
 end
 
--- Validate that a totem CDM child still represents a live effect.
--- GetTotemInfo only confirms "a totem exists in this slot" but not WHICH totem.
--- This secondary check verifies the child's own aura/cooldown data is still live,
--- preventing stale children (e.g. expired SLT) from ghosting back.
+-- Secondary validation: GetTotemInfo confirms a totem exists in the slot but not
+-- WHICH totem. This checks the child's own aura/cooldown data is still live.
 local function IsTotemChildStillValid(ch)
-    -- Check aura instance first
     if ch.auraInstanceID then
         local ok, data = pcall(C_UnitAuras.GetAuraDataByAuraInstanceID,
                                ch.auraDataUnit or "player", ch.auraInstanceID)
@@ -268,7 +264,6 @@ local function IsTotemChildStillValid(ch)
         end
         return true  -- pcall failed, trust GetTotemInfo
     end
-    -- No auraInstanceID: check cooldown state from our hooks
     if _ecmeChildHasDurObj[ch] then return true end
     local rd = _ecmeRawDurCache[ch]
     if rd then
@@ -548,8 +543,7 @@ local function ApplySpellCooldown(icon, spellID, desatOnCD, showCharges, swAlpha
 
     -- Charge text: show spell charges for charge-based spells, or aura stacks as fallback
     if showCharges then
-        -- Totems: charge count shows totem charges (e.g. HST "2"), not aura stacks.
-        -- Hide charge text for totem spells to avoid misleading stack display.
+        -- Totems: hide charge count (e.g. HST "2") — not meaningful as stacks.
         local ts = blizzChild and blizzChild.preferredTotemUpdateSlot
         if ts and type(ts) == "number" and ts > 0 then
             icon._chargeText:Hide()
@@ -3565,9 +3559,7 @@ local function UpdateCustomBarIcons(barKey)
                                     auraHandled = true
                                     skipCDDisplay = true
                                 else
-                                    -- For totems with stale aura (e.g. Stormstream consumed),
-                                    -- skip auraHandled to fall through to the summon-type
-                                    -- fallback which reads remaining totem duration.
+                                    -- Totems: skip auraHandled so summon-type fallback shows totem duration
                                     local bts = blizzChild and blizzChild.preferredTotemUpdateSlot
                                     if not (bts and type(bts) == "number" and bts > 0) then
                                         auraHandled = true
@@ -3875,9 +3867,7 @@ UpdateCDMBarIcons = function(barKey)
                         auraHandled = true
                         skipCDDisplay = true
                     else
-                        -- For totems with stale aura (e.g. Stormstream consumed),
-                        -- skip auraHandled to fall through to the summon-type
-                        -- fallback which reads remaining totem duration.
+                        -- Totems: skip auraHandled so summon-type fallback shows totem duration
                         local bts = blizzIcon and blizzIcon.preferredTotemUpdateSlot
                         if not (bts and type(bts) == "number" and bts > 0) then
                             auraHandled = true
@@ -4523,9 +4513,7 @@ local function UpdateTrackedBarIcons(barKey)
                                     auraHandled = true
                                     skipCDDisplay = true
                                 else
-                                    -- For totems with stale aura (e.g. Stormstream consumed),
-                                    -- skip auraHandled to fall through to the summon-type
-                                    -- fallback which reads remaining totem duration.
+                                    -- Totems: skip auraHandled so summon-type fallback shows totem duration
                                     local bts = blizzChild and blizzChild.preferredTotemUpdateSlot
                                     if not (bts and type(bts) == "number" and bts > 0) then
                                         auraHandled = true
@@ -4786,7 +4774,6 @@ local function UpdateAllCDMBars(dt)
                                     _tickBlizzAllChildCache[correctSid] = ch
                                     _tickBlizzBuffChildCache[correctSid] = ch
                                     if ch.wasSetFromAura == true or ch.auraInstanceID ~= nil then
-                                        -- Totems: validate liveness via GetCachedTotemInfo + secondary check
                                         local totemSlot = ch.preferredTotemUpdateSlot
                                         local totemOk = true
                                         if totemSlot and type(totemSlot) == "number" and totemSlot > 0 then
@@ -4806,8 +4793,7 @@ local function UpdateAllCDMBars(dt)
                                     end
                                 end
                             end
-                            -- Active cache: validate totems via GetCachedTotemInfo + secondary check
-                            -- (flags can persist after totem expires into cooldown phase)
+                            -- Active cache: validate totems (flags can persist after expiry)
                             if ch.wasSetFromAura == true or ch.auraInstanceID ~= nil then
                                 local totemSlot = ch.preferredTotemUpdateSlot
                                 local totemValid = true


### PR DESCRIPTION
## Summary

Fixes 4 remaining Resto Shaman totem buff display bugs from the CDM cooldown manager:

- **HST charge text as stacks**: HST showed "2" (totem charges) on the buff icon, looking like aura stacks. Added a totem slot guard to `ApplySpellCooldown` that hides `_chargeText` for totem spells.
- **HST blinking on expiry**: Rapid show/hide flicker as totem expired due to `GetTotemInfo()` returning inconsistent values across multiple calls within a single tick. Added `_tickTotemCache` + `GetCachedTotemInfo()` to cache per slot per tick.
- **Static HST after Stormstream consumed**: When Stormstream proc fired and was consumed, HST reverted to a static icon with no duration. The stale `auraInstanceID` caused `GetAuraDuration` to fail, but `auraHandled` was still set to `true`, blocking the summon-type fallback. Now skips `auraHandled` for totem children so the fallback reads remaining totem duration.
- **SLT ghost reappearing with HST**: After SLT expired, its stale CDM child persisted and passed `GetTotemInfo` checks when HST was cast (same slot = "a totem exists"). Added `IsTotemChildStillValid()` secondary validation that checks whether the child's own aura/cooldown data is still live.

## Changes

Single file: `EllesmereUICooldownManager/EllesmereUICooldownManager.lua` (+92/-17)

### New helpers
- `GetCachedTotemInfo(slot)` — per-tick cached wrapper for `GetTotemInfo`
- `IsTotemChildStillValid(ch)` — validates a totem child's aura/cooldown is still live

### Modified functions
- `IsBufChildCooldownActive` — uses cached totem info + secondary validation
- `ApplySpellCooldown` — new `blizzChild` parameter, totem charge text guard
- Active cache population blocks — use cached totem info + secondary validation
- 3 aura duration `else` branches — conditional `auraHandled` skip for totems

## Test plan

- [ ] Cast HST: buff icon shows duration, NO charge count number
- [ ] Cast HST with Stormstream talent: single icon with proc glow, no extra stackless icon
- [ ] Stormstream proc consumed: HST icon continues showing remaining totem duration
- [ ] Cast SLT: buff shows for 6s, disappears on expiry
- [ ] Cast HST after SLT expired: only HST buff appears, NO SLT ghost
- [ ] HST expiring: clean disappearance, no rapid blinking
- [ ] Non-shaman spells: all existing behavior unchanged (charges, stacks, procs still work)