### PR TITLE
fix(cdm): preserve stack display during hero talent procs in combat

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7059,11 +7059,17 @@ local function ScheduleTalentRebuild()
         -- stale charge data from spells that changed with the talent swap.
         -- Also wipe the persisted DB entries so CacheMultiChargeSpell
         -- re-detects from live API rather than reading a stale false entry.
-        wipe(_multiChargeSpells)
-        wipe(_maxChargeCount)
-        local db = ECME.db
-        if db and db.global and db.global.multiChargeSpells then
-            wipe(db.global.multiChargeSpells)
+        -- Skip during combat: actual talent changes are combat-locked, so these
+        -- events only fire mid-combat from hero talent procs (e.g. Celestial
+        -- Infusion). Wiping here would clear charge data for all spells with no
+        -- way to re-detect it until the next out-of-combat cache rebuild.
+        if not InCombatLockdown() then
+            wipe(_multiChargeSpells)
+            wipe(_maxChargeCount)
+            local db = ECME.db
+            if db and db.global and db.global.multiChargeSpells then
+                wipe(db.global.multiChargeSpells)
+            end
         end
         -- Reconcile bar spellIDs against the new talent set.
         -- Unavailable spells are moved to dormant slots (preserving position);


### PR DESCRIPTION
## Bug
Stacks disappear from all spells with stacks on the CDM when a hero talent proc transforms an ability mid-combat (e.g. Celestial Infusion: Keg Smash → Empty Barrel on Brewmaster Monk).
## Root Cause
PLAYER_TALENT_UPDATE fires when hero talent procs swap abilities, triggering ScheduleTalentRebuild() which wipes _multiChargeSpells and _maxChargeCount. These caches cannot be rebuilt during combat due to secret values, so all spells lose their stack display for the rest of the fight.
## Fix
Guard the cache wipe with InCombatLockdown(). Actual talent changes are blocked in combat, so these events mid-combat are always hero talent procs — charge data is preserved and the rest of the rebuild still runs normally.
## Test
1. Find someone with a brm
2. keg smash! celestial infusion! 
3. Observe empty barrel in CDM and abilities like Roll and Purifying Brew have stacks! 