### PR TITLE
perf: reduce GC pressure and per-frame overhead

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3044,30 +3044,30 @@ local function CreateCDMIcon(barKey, index)
     keybindText:Hide()
     icon._keybindText = keybindText
 
-    -- Tooltip on hover ΓÇö uses OnUpdate cursor check so the icon stays click-through
-    -- Tooltip on hover: only register the OnUpdate poll when tooltips are enabled for this bar.
+    -- Tooltip on hover via OnEnter/OnLeave on a motion-only overlay (click-through).
     -- Icons are rebuilt via BuildAllCDMBars when showTooltip changes, so creation-time gating is sufficient.
     local tooltipOverlay = CreateFrame("Frame", nil, icon)
     tooltipOverlay:SetAllPoints(icon)
     tooltipOverlay:SetFrameLevel(icon:GetFrameLevel() + 4)
-    tooltipOverlay:EnableMouse(false)
     icon._tooltipShown = false
     if barData.showTooltip then
-        icon:SetScript("OnUpdate", function(self)
-            local over = self:IsMouseOver()
-            if over and not self._tooltipShown then
-                local sid = self._spellID
-                if sid then
-                    GameTooltip:SetOwner(self, "ANCHOR_CURSOR")
-                    GameTooltip:SetSpellByID(sid)
-                    GameTooltip:Show()
-                    self._tooltipShown = true
-                end
-            elseif not over and self._tooltipShown then
-                GameTooltip:Hide()
-                self._tooltipShown = false
+        tooltipOverlay:SetMouseMotionEnabled(true)
+        tooltipOverlay:SetMouseClickEnabled(false)
+        tooltipOverlay:SetScript("OnEnter", function()
+            local sid = icon._spellID
+            if sid then
+                GameTooltip:SetOwner(icon, "ANCHOR_CURSOR")
+                GameTooltip:SetSpellByID(sid)
+                GameTooltip:Show()
+                icon._tooltipShown = true
             end
         end)
+        tooltipOverlay:SetScript("OnLeave", function()
+            GameTooltip:Hide()
+            icon._tooltipShown = false
+        end)
+    else
+        tooltipOverlay:EnableMouse(false)
     end
     icon._tooltipOverlay = tooltipOverlay
 
@@ -4644,11 +4644,10 @@ local function UpdateAllCDMBars(dt)
             local vf = _G[vName]
             local isBuffViewer = (vi == 3 or vi == 4)
             if vf then
-                -- Load children into reusable buffer with a single GetChildren call
+                -- Load children into reusable buffer without intermediate table allocation
                 local nChildren = vf:GetNumChildren()
                 if nChildren > 0 then
-                    local children = { vf:GetChildren() }
-                    for ci = 1, nChildren do _viewerChildBuf[ci] = children[ci] end
+                    for ci = 1, nChildren do _viewerChildBuf[ci] = select(ci, vf:GetChildren()) end
                     for ci = nChildren + 1, #_viewerChildBuf do _viewerChildBuf[ci] = nil end
                 else
                     wipe(_viewerChildBuf)

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -2746,9 +2746,11 @@ end
 ns.HideBlizzardFrame = HideBlizzardFrame
 local castFallbackFrame = CreateFrame("Frame")
 local fallbackCastCount = 0
+local _fallbackPlates = {}
+local _importantSetBuf = {}
 castFallbackFrame:SetScript("OnUpdate", function()
-    for _, plate in pairs(ns.plates) do
-        if plate._castFallback and plate.isCasting and plate.unit and plate.nameplate then
+    for plate in pairs(_fallbackPlates) do
+        if plate.isCasting and plate.unit and plate.nameplate then
             local bc = plate.nameplate.UnitFrame and plate.nameplate.UnitFrame.castBar
             if bc and bc:IsShown() then
                 plate.cast:SetMinMaxValues(bc:GetMinMaxValues())
@@ -2759,6 +2761,7 @@ castFallbackFrame:SetScript("OnUpdate", function()
                 end
                 plate.isCasting = false
                 plate._castFallback = nil
+                _fallbackPlates[plate] = nil
                 fallbackCastCount = fallbackCastCount - 1
                 if fallbackCastCount <= 0 then
                     fallbackCastCount = 0
@@ -3043,6 +3046,7 @@ function NameplateFrame:ClearUnit()
         self.isCasting = false
         if self._castFallback then
             self._castFallback = nil
+            _fallbackPlates[self] = nil
             fallbackCastCount = fallbackCastCount - 1
             if fallbackCastCount <= 0 then fallbackCastCount = 0; castFallbackFrame:Hide() end
         end
@@ -3104,6 +3108,7 @@ function NameplateFrame:ClearUnit()
     self.castBarOverlay:SetAlpha(0)
     self.isCasting = false
     self._castFallback = nil
+    _fallbackPlates[self] = nil
     self._kickProtected = nil
     self:HideKickTick()
     if self._interruptTimer then
@@ -3644,7 +3649,8 @@ function NameplateFrame:UpdateAuras(updateInfo)
     -- UnitFrame has already processed the event and debuffList is current.
     local importantSet
     if not showAll and self.nameplate then
-        importantSet = {}
+        wipe(_importantSetBuf)
+        importantSet = _importantSetBuf
         local uf = self.nameplate.UnitFrame
         if uf and uf.AurasFrame and uf.AurasFrame.debuffList and uf.AurasFrame.debuffList.Iterate then
             uf.AurasFrame.debuffList:Iterate(function(auraInstanceID)
@@ -3815,6 +3821,7 @@ function NameplateFrame:UpdateCast()
         if self.isCasting then
             if self._castFallback then
                 self._castFallback = nil
+                _fallbackPlates[self] = nil
                 fallbackCastCount = fallbackCastCount - 1
                 if fallbackCastCount <= 0 then fallbackCastCount = 0; castFallbackFrame:Hide() end
             end
@@ -3918,6 +3925,7 @@ function NameplateFrame:UpdateCast()
         if not self.isCasting then
             self.isCasting = true
             self._castFallback = true
+            _fallbackPlates[self] = true
             fallbackCastCount = fallbackCastCount + 1
             castFallbackFrame:Show()
             NotifyCastStarted()
@@ -4065,6 +4073,7 @@ function NameplateFrame:ShowInterrupted(interrupterGUID)
     if self.isCasting then
         if self._castFallback then
             self._castFallback = nil
+            _fallbackPlates[self] = nil
             fallbackCastCount = fallbackCastCount - 1
             if fallbackCastCount <= 0 then fallbackCastCount = 0; castFallbackFrame:Hide() end
         end


### PR DESCRIPTION
## Summary

- **CDM viewer tick**: populate `_viewerChildBuf` via `select()` instead of allocating a throwaway `{ vf:GetChildren() }` table (~40 allocs/sec eliminated)
- **CDM tooltips**: replace per-icon `OnUpdate` + `IsMouseOver()` polling with `OnEnter`/`OnLeave` on a motion-only overlay (`SetMouseMotionEnabled` + `SetMouseClickEnabled`), eliminating 600–1200 calls/sec
- **Nameplate cast fallback**: track fallback plates in a dedicated `_fallbackPlates` set so the `OnUpdate` iterates only active plates instead of all `ns.plates` (1–2 vs up to 40)
- **Nameplate UpdateAuras**: reuse a module-level `_importantSetBuf` with `wipe()` instead of allocating `importantSet = {}` on every call

## Test plan

- [ ] Verify CDM bars display and update correctly in combat
- [ ] Hover CDM icons with tooltips enabled — tooltip should appear/disappear cleanly
- [ ] Confirm click-through still works on CDM icons overlaying action bars
- [ ] Test nameplate cast bars with fallback casts (mobs without CLEU cast events)
- [ ] Verify nameplate debuff filtering still shows correct auras
- [ ] Check for any Lua errors in `/console scriptErrors 1` during dungeon/raid