### PR TITLE
fix(cdm): prevent totem icon duplication on /reload

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -271,6 +271,8 @@ local function IsTotemChildStillValid(ch)
         if issecretvalue and issecretvalue(rd) then return true end
         return rd > 0
     end
+    -- Fallback: hook caches are empty after /reload until SetCooldown fires.
+    if ch.Cooldown and ch.Cooldown:IsVisible() then return true end
     return false
 end
 


### PR DESCRIPTION
## Summary

- Fixes totem buff icons accumulating on every `/reload` (N reloads = N+1 icons)

## Root cause

After `/reload`, Lua state resets but Blizzard CDM frames persist. The `SetCooldown` hooks haven't fired yet on tick 1, so `IsTotemChildStillValid()` returns `false` — but the companion-icon expansion uses `mc:IsShown()` which is `true`. This disagreement grows a phantom icon into the pool each reload.

## Fix

Added `Cooldown:IsVisible()` fallback in `IsTotemChildStillValid` when hook caches are cold. Once hooks fire (same or next tick), they take precedence.

+2 lines in `EllesmereUICooldownManager.lua`.

## Test plan

- [ ] Drop HST, `/reload` multiple times — should stay at exactly 1 icon
- [ ] Let totem expire after reload — icon disappears cleanly
- [ ] SLT → expire → HST — no SLT ghost
- [ ] Non-shaman spells unaffected