### PR TITLE
Fix absorb bar overflow to the left

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1830,7 +1830,7 @@ local function CreateAbsorbBar(frame, unit, settings)
     local barWidth = settings.frameWidth
     local barHeight = settings.healthHeight
 
-    hpBar:SetClipsChildren(false)
+    hpBar:SetClipsChildren(true)
 
     local shieldBar = CreateFrame("StatusBar", nil, hpBar)
     shieldBar:SetStatusBarTexture("Interface\\AddOns\\EllesmereUIUnitFrames\\Media\\shield.tga")


### PR DESCRIPTION
Minor adjustment to prevent the absorb bar from clipping into the unit frame icon.
The shield behavior itself remains unchanged and still follows the default oUF behavior.