### PR TITLE
fix: restore search-hidden elements when switching tabs

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -5063,6 +5063,9 @@ function EllesmereUI:SelectPage(pageName)
         cached.wrapper:Show()
         contentFrame:SetHeight(cached.totalH + 30)
 
+        -- Restore any elements hidden by a previous inline search
+        EllesmereUI:ApplyInlineSearch("")
+
         -- Restore this page's refresh list
         ClearWidgetRefreshList()
         if cached.refreshList then


### PR DESCRIPTION
## Summary
- When searching within a tab and then switching tabs, the filtered (hidden) elements persisted on the original tab even though the search box was cleared
- Adds an `ApplyInlineSearch("")` call in the cached page restore path to ensure all elements are shown when returning to a tab

## Test plan
- [ ] Search for something (e.g. "max camera") on Global Settings
- [ ] Switch to another tab (e.g. Action Bars)
- [ ] Switch back to Global Settings — all settings should be visible
- [ ] Search, manually clear, switch tabs — should still work correctly