### PR TITLE
feat(nameplates): redesign threat color system

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -5730,11 +5730,16 @@ initFrame:SetScript("OnEvent", function(self)
                   end },
               } });  y = y - h
 
-        -- Row 2: Show Special "Has Aggro" Color (left) ---- blank (right)
+        -- Row 2: Show Special "Has Aggro" Color (left) ---- Classic Tank Aggro (right)
         local function isTankHasAggroDisabled()
             local db = DB()
             if db and db.tankHasAggroEnabled ~= nil then return not db.tankHasAggroEnabled end
             return not defaults.tankHasAggroEnabled
+        end
+        local function isClassicTankAggroDisabled()
+            local db = DB()
+            if db and db.classicTankAggro ~= nil then return not db.classicTankAggro end
+            return not defaults.classicTankAggro
         end
 
         local tankDualFrame
@@ -5751,9 +5756,20 @@ initFrame:SetScript("OnEvent", function(self)
                 RefreshAllPlates()
                 EllesmereUI:RefreshPage()
               end },
-            { type="label", text="" });  y = y - h
+            { type="toggle", text="Classic Tank Aggro",
+              tooltip="Enables a three-tier tank aggro system: has aggro, losing aggro, and no aggro colors override all mob-type colors.",
+              getValue=function()
+                local db = DB()
+                if db and db.classicTankAggro ~= nil then return db.classicTankAggro end
+                return defaults.classicTankAggro
+              end,
+              setValue=function(v)
+                DB().classicTankAggro = v
+                RefreshAllPlates()
+                EllesmereUI:RefreshPage()
+              end });  y = y - h
 
-        -- Inline Tank Has Aggro color swatch next to toggle
+        -- Inline "Has Aggro" color swatch next to left toggle
         do
             local leftRgn = tankDualFrame._leftRegion
             local tankAggroColorGet = function() return DBColor("tankHasAggro") end
@@ -5770,6 +5786,27 @@ initFrame:SetScript("OnEvent", function(self)
                 updateSwatch()
             end)
             local off = isTankHasAggroDisabled()
+            swatch:SetAlpha(off and 0.15 or 1)
+            swatch:EnableMouse(not off)
+        end
+
+        -- Inline "Has Aggro" color swatch next to Classic Tank Aggro toggle
+        do
+            local rightRgn = tankDualFrame._rightRegion
+            local aggroColorGet = function() return DBColor("tankHasAggro") end
+            local aggroColorSet = function(r, g, b)
+                DB().tankHasAggro = { r = r, g = g, b = b }
+                RefreshAllPlates()
+            end
+            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(rightRgn, rightRgn:GetFrameLevel() + 5, aggroColorGet, aggroColorSet, nil, 20)
+            PP.Point(swatch, "RIGHT", rightRgn._control, "LEFT", -12, 0)
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = isClassicTankAggroDisabled()
+                swatch:SetAlpha(off and 0.15 or 1)
+                swatch:EnableMouse(not off)
+                updateSwatch()
+            end)
+            local off = isClassicTankAggroDisabled()
             swatch:SetAlpha(off and 0.15 or 1)
             swatch:EnableMouse(not off)
         end

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -71,6 +71,7 @@ local defaults = {
     enemyInCombat = { r = 0.800, g = 0.137, b = 0.137 },
     tankHasAggro = { r = 0.05, g = 0.82, b = 0.62 },
     tankHasAggroEnabled = false,
+    classicTankAggro = false,
     tankLosingAggro = { r = 0.81, g = 0.72, b = 0.19 },
     tankNoAggro = { r = 1.00, g = 0.22, b = 0.17 },
     dpsNearAggro = { r = 0.81, g = 0.72, b = 0.19 },
@@ -2387,8 +2388,9 @@ local function RefreshThreatCache()
     or (C_Garrison and C_Garrison.IsOnGarrisonMap and C_Garrison.IsOnGarrisonMap()) then
         _inThreatContent = false
     else
+        local isDelve = C_PartyInfo and C_PartyInfo.IsDelveInProgress and C_PartyInfo.IsDelveInProgress()
         _inThreatContent = (instanceType == "party" or instanceType == "raid"
-                            or difficultyID == 204)  -- delve difficulty
+                            or isDelve)
     end
     -- Role: cache so we don't recalculate on every nameplate update
     local role = UnitGroupRolesAssigned("player")
@@ -2533,7 +2535,16 @@ local function GetReactionColor(unit)
                     end
                     -- Another tank has aggro -- fall through, no warning color
                 end
-                -- Tank has aggro falls through to be handled below focus/caster/miniboss
+                -- Classic tank aggro: has-aggro overrides all mob-type colors
+                if status >= 3 then
+                    local classic = db.classicTankAggro
+                    if classic == nil then classic = defaults.classicTankAggro end
+                    if classic then
+                        local c = C("tankHasAggro")
+                        return c.r, c.g, c.b
+                    end
+                end
+                -- Default: tank has aggro falls through to caster/miniboss colors
             end
         end
     end


### PR DESCRIPTION
## Summary

- Add "Classic Tank Aggro" toggle (off by default) with inline color swatch — enables a three-tier tank aggro system where has-aggro color overrides all mob-type colors
- Existing "Show Special Has Aggro Color" toggle and default behavior unchanged
- Fix delve detection: use `C_PartyInfo.IsDelveInProgress()` instead of hardcoded `difficultyID == 204`

## Test plan

- [ ] Default tank behavior unchanged: losing aggro (yellow) and no aggro (red) active; has-aggro mobs show normal red/blue/purple
- [ ] "Classic Tank Aggro" on: all mobs with aggro show green; losing/no aggro unchanged
- [ ] Classic Tank Aggro swatch grays out when toggle is off
- [ ] Existing "Show Special Has Aggro Color" toggle works as before
- [ ] Threat colors work correctly in delves
- [ ] Non-tank threat behavior unchanged