### PR TITLE
Fix: Extra Action Button blocks right-click camera movement

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -6360,9 +6360,7 @@ local function SetupBlizzardMovableFrame(barKey)
             blizzFrame:SetParent(holder)
             blizzFrame:ClearAllPoints()
             blizzFrame:SetPoint("CENTER", holder, "CENTER", 0, 0)
-            -- Allow right-click to pass through for camera movement (bug fix:
-            -- Blizzard's ExtraAbilityContainer and its children have mouse
-            -- enabled by default, blocking right-click+drag camera rotation).
+            -- Let right-click pass through for camera rotation
             if barKey == "ExtraActionButton" then
                 blizzFrame:SetPassThroughButtons("RightButton")
                 if ExtraActionBarFrame then


### PR DESCRIPTION
## Summary

- Blizzard's `ExtraAbilityContainer` and its children (`ExtraActionBarFrame`, `ExtraActionButton1`, `ZoneAbilityFrame`) have mouse enabled by default, intercepting right-click+drag and preventing camera rotation when the cursor is over the Extra Action Button area
- Applied `SetPassThroughButtons("RightButton")` to all frames in the hierarchy inside `ReparentIntoHolder()` so right-clicks pass through to the game world
- Left-click to activate the extra action ability is unaffected

## Test plan

- [ ] Enable Extra Action Button bar in EllesmereUI
- [ ] Trigger an extra action button in-game (e.g. via a quest or encounter mechanic)
- [ ] Right-click + drag over the Extra Action Button area — camera should rotate freely
- [ ] Left-click the Extra Action Button — ability should activate normally
- [ ] Test with Zone Ability buttons as well (e.g. dragonriding abilities)

Reported by aka_tpayne in Discord: https://discord.com/channels/585577383847788554/1481910321504325684