### PR TITLE
fix(cdm): clear stale cooldown state on alt switch

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7167,6 +7167,12 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
     end
     if event == "PLAYER_ENTERING_WORLD" then
         _inCombat = InCombatLockdown and InCombatLockdown() or false
+        -- Wipe hook-captured cooldown caches so stale state from a previous
+        -- character doesn't persist after alt switch or reload.
+        wipe(_ecmeChildHasDurObj)
+        wipe(_ecmeDurObjCache)
+        wipe(_ecmeRawStartCache)
+        wipe(_ecmeRawDurCache)
         -- Validate spec on every zone-in (catches auto spec swaps, login, etc.)
         C_Timer.After(0.5, function()
             ValidateSpec()


### PR DESCRIPTION
## Summary

- Wipes the 4 hook-captured cooldown cache tables (`_ecmeChildHasDurObj`, `_ecmeDurObjCache`, `_ecmeRawStartCache`, `_ecmeRawDurCache`) on `PLAYER_ENTERING_WORLD`
- Fixes ghost cooldown overlays appearing on an alt when Blizzard CDM viewer child frames are reused from a previous character session

## Root cause

The `SetCooldown` / `SetCooldownFromDurationObject` hook caches are keyed by child frame reference and never cleared on login. When child frames are recycled across sessions, `IsBufChildCooldownActive()` reads stale durations from the old character and shows incorrect cooldown state (e.g. 12h CD icons stuck on a gathering alt).

## Fix

Clear all 4 caches immediately in the `PLAYER_ENTERING_WORLD` handler, before the tick loop can read them. The hooks remain installed and repopulate naturally during `ForcePopulateBlizzardViewers`.

## Test plan

- [ ] Log into character A with active long cooldowns on a CDM bar
- [ ] Log out and into character B (alt)
- [ ] Verify CDM bar icons do not show ghost cooldowns from character A
- [ ] Zone into an instance on character B and verify cooldown state refreshes correctly