### PR TITLE
Fix keybinds not transferring to Pet Battle UI

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -4756,7 +4756,7 @@ _vehicleStateFrame:SetAttribute("_onstate-vehicleui", [[
 ]])
 _vehicleStateFrame.OnVehicleEnter = ClearKeybindsForVehicle
 _vehicleStateFrame.OnVehicleExit  = RestoreKeybindsAfterVehicle
-RegisterStateDriver(_vehicleStateFrame, "vehicleui", "[vehicleui] invehicle; novehicle")
+RegisterStateDriver(_vehicleStateFrame, "vehicleui", "[petbattle] invehicle; [vehicleui] invehicle; novehicle")
 
 -------------------------------------------------------------------------------
 --  Vehicle Exit Button


### PR DESCRIPTION
## Summary

- The vehicle keybind state driver only checked `[vehicleui]`, so `SetOverrideBindingClick` bindings were never cleared when entering a pet battle
- Blizzard's Pet Battle UI expects `ACTIONBUTTON1-6` but our override bindings intercepted them first
- Added `[petbattle]` to the existing state driver condition so the same `ClearKeybindsForVehicle` / `RestoreKeybindsAfterVehicle` infrastructure handles pet battles automatically

Reported by **ansaol** on Discord.

## Test plan

- [ ] Enter a pet battle and verify keybinds (1-6) activate pet battle abilities
- [ ] Exit pet battle and verify keybinds restore to action bar buttons
- [ ] Enter a vehicle and verify keybinds still work correctly
- [ ] Test entering pet battle during combat (keybinds should clear after combat ends)