### PR TITLE
Fix CDM cooldown swipe not covering full icon at high zoom

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3032,11 +3032,8 @@ local function CreateCDMIcon(barKey, index)
     icon._isActive = false
     icon._barKey = barKey
 
-    -- Apply saved icon shape on creation
-    local shape = barData.iconShape or "none"
-    if shape ~= "none" then
-        ApplyShapeToCDMIcon(icon, shape, barData)
-    end
+    -- Apply icon shape on creation (includes "none" for proper cooldown inset)
+    ApplyShapeToCDMIcon(icon, barData.iconShape or "none", barData)
 
     icon:Hide()
     return icon
@@ -3129,11 +3126,10 @@ ApplyShapeToCDMIcon = function(icon, shape, barData)
             end
         end
 
-        -- Restore cooldown
+        -- Restore cooldown (full frame so swipe covers the entire icon)
         if icon._cooldown then
             icon._cooldown:ClearAllPoints()
-            PP.Point(icon._cooldown, "TOPLEFT", icon, "TOPLEFT", borderSz, -borderSz)
-            PP.Point(icon._cooldown, "BOTTOMRIGHT", icon, "BOTTOMRIGHT", -borderSz, borderSz)
+            icon._cooldown:SetAllPoints(icon)
             pcall(icon._cooldown.SetSwipeTexture, icon._cooldown, "Interface\\Buttons\\WHITE8x8")
             if icon._cooldown.SetUseCircularEdge then pcall(icon._cooldown.SetUseCircularEdge, icon._cooldown, false) end
         end
@@ -4076,11 +4072,10 @@ local function RefreshCDMIconAppearance(barKey)
             PP.Point(icon._tex, "BOTTOMRIGHT", icon, "BOTTOMRIGHT", -borderSize, borderSize)
             icon._tex:SetTexCoord(zoom, 1 - zoom, zoom, 1 - zoom)
         end
-        -- Update cooldown inset
+        -- Update cooldown (full frame so swipe covers the entire icon)
         if icon._cooldown then
             icon._cooldown:ClearAllPoints()
-            PP.Point(icon._cooldown, "TOPLEFT", icon, "TOPLEFT", borderSize, -borderSize)
-            PP.Point(icon._cooldown, "BOTTOMRIGHT", icon, "BOTTOMRIGHT", -borderSize, borderSize)
+            icon._cooldown:SetAllPoints(icon)
             icon._cooldown:SetSwipeColor(0, 0, 0, barData.swipeAlpha or 0.7)
             icon._cooldown:SetHideCountdownNumbers(not barData.showCooldownText)
             -- Mark pending font update (applied in batch after frame renders)


### PR DESCRIPTION
## Summary
- Cooldown swipe doesn't cover the full icon at zoom 0.10 with cropped shape (icon size 36) — visible gap on the left side
- The cooldown frame was inset by `borderSize` using `PP.Point`, but on non-square "cropped" frames the engine's swipe rendering doesn't fully cover the edges at that size
- Custom masked shapes (circle, diamond, etc.) already use `SetAllPoints` and are unaffected

## Changes
- Use `SetAllPoints(icon)` for the cooldown frame on square-type shapes (none, cropped) instead of insetting by `borderSize` — ensures the swipe fills the entire icon
- Always call `ApplyShapeToCDMIcon` at icon creation including for "none" shape so the cooldown gets `SetUseCircularEdge(false)` from the start

## Test plan
- [ ] Set CDM bar to cropped shape, icon zoom 0.10, icon size 36 — verify cooldown swipe fully covers the icon
- [ ] Verify default zoom (0.08) with cropped shape still renders correctly
- [ ] Verify "none" shape renders correctly
- [ ] Test custom shapes (circle, diamond) to verify no regression
- [ ] `/reload` and verify bars render correctly