### PR TITLE
feat(actionbars): add default blizzard keybind

### DIFF
--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -804,6 +804,27 @@ initFrame:SetScript("OnEvent", function(self)
                 SetCVarSafe("SpellQueueWindow", v)
               end });  y = y - h
 
+        do
+            local EAB_addon = EllesmereUI.Lite and EllesmereUI.Lite.GetAddon("EllesmereUIActionBars", true)
+            if EAB_addon and EAB_addon.db then
+                _, h = W:DualRow(parent, y,
+                    { type="toggle", text="Blizzard Keybinds",
+                      tooltip="Use Blizzard's default action bars but control the look and layout",
+                      getValue=function() return EAB_addon.db.profile.nativeKeybinds end,
+                      setValue=function(v)
+                          EAB_addon.db.profile.nativeKeybinds = v
+                          EllesmereUI:ShowConfirmPopup({
+                              title       = "Reload Required",
+                              message     = "Native Keybinds changed. A UI reload is needed to apply.",
+                              confirmText = "Reload Now",
+                              cancelText  = "Later",
+                              onConfirm   = function() ReloadUI() end,
+                          })
+                      end },
+                    { type="label", text="" });  y = y - h
+            end
+        end
+
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
         -------------------------------------------------------------------

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -219,6 +219,7 @@ local defaults = {
         procGlowScale = 1.0,
         procGlowEnabled = false,
         hideCastingAnimations = true,
+        nativeKeybinds = false,
         barPositions = {},
         bars = {},
     },
@@ -814,25 +815,29 @@ local function HideBlizzardBars()
         RegisterAttributeDriver(OverrideActionBar, "state-visibility",
             "[vehicleui][overridebar] show; hide")
     end
-    -- Wipe Blizzard's actionButtons tables so they don't interfere
-    for _, name in ipairs({"MainActionBar", "MainMenuBar", "MultiBarBottomLeft", "MultiBarBottomRight", "MultiBarRight", "MultiBarLeft", "MultiBar5", "MultiBar6", "MultiBar7"}) do
-        local bar = _G[name]
-        if bar and bar.actionButtons then
-            wipe(bar.actionButtons)
+    -- In native keybinds mode, keep Blizzard's binding handlers and
+    -- actionButtons tables intact so standard bindings work for all bars.
+    if not (EAB.db and EAB.db.profile.nativeKeybinds) then
+        -- Wipe Blizzard's actionButtons tables so they don't interfere
+        for _, name in ipairs({"MainActionBar", "MainMenuBar", "MultiBarBottomLeft", "MultiBarBottomRight", "MultiBarRight", "MultiBarLeft", "MultiBar5", "MultiBar6", "MultiBar7"}) do
+            local bar = _G[name]
+            if bar and bar.actionButtons then
+                wipe(bar.actionButtons)
+            end
         end
-    end
-    -- Replace Blizzard's multi-bar button handlers with no-ops.
-    -- After wiping actionButtons, the original functions would error
-    -- if a Blizzard binding fires before our override bindings are set.
-    if MultiActionButtonDown then _G.MultiActionButtonDown = function() end end
-    if MultiActionButtonUp then _G.MultiActionButtonUp = function() end end
-    -- Also wipe button container references on MainActionBar
-    local mainAB = _G["MainActionBar"]
-    if mainAB then
-        for i = 1, 3 do
-            local container = _G["MainActionBarButtonContainer" .. i]
-            if container and container.actionButtons then
-                wipe(container.actionButtons)
+        -- Replace Blizzard's multi-bar button handlers with no-ops.
+        -- After wiping actionButtons, the original functions would error
+        -- if a Blizzard binding fires before our override bindings are set.
+        if MultiActionButtonDown then _G.MultiActionButtonDown = function() end end
+        if MultiActionButtonUp then _G.MultiActionButtonUp = function() end end
+        -- Also wipe button container references on MainActionBar
+        local mainAB = _G["MainActionBar"]
+        if mainAB then
+            for i = 1, 3 do
+                local container = _G["MainActionBarButtonContainer" .. i]
+                if container and container.actionButtons then
+                    wipe(container.actionButtons)
+                end
             end
         end
     end
@@ -4664,6 +4669,7 @@ end
 local function UpdateKeybinds()
     if _vehicleBindsCleared or _housingBindsCleared then return end
     if InCombatLockdown() then return end
+    if EAB.db and EAB.db.profile.nativeKeybinds then return end
 
     local keyDownEnabled = IsKeyDownEnabled()
     local clickType = keyDownEnabled and "HOTKEY" or "LeftButton"
@@ -5314,13 +5320,16 @@ function EAB:FinishSetup()
             if OverrideActionBar then
                 RegisterAttributeDriver(OverrideActionBar, "state-visibility", "[vehicleui][overridebar] show; hide")
             end
-            -- Wipe Blizzard's actionButtons tables during combat reload
-            for _, name in ipairs({"MainActionBar", "MainMenuBar", "MultiBarBottomLeft", "MultiBarBottomRight", "MultiBarRight", "MultiBarLeft", "MultiBar5", "MultiBar6", "MultiBar7"}) do
-                local bar = _G[name]
-                if bar and bar.actionButtons then wipe(bar.actionButtons) end
+            -- In native keybinds mode, keep Blizzard's binding handlers intact
+            if not (EAB.db and EAB.db.profile.nativeKeybinds) then
+                -- Wipe Blizzard's actionButtons tables during combat reload
+                for _, name in ipairs({"MainActionBar", "MainMenuBar", "MultiBarBottomLeft", "MultiBarBottomRight", "MultiBarRight", "MultiBarLeft", "MultiBar5", "MultiBar6", "MultiBar7"}) do
+                    local bar = _G[name]
+                    if bar and bar.actionButtons then wipe(bar.actionButtons) end
+                end
+                if MultiActionButtonDown then _G.MultiActionButtonDown = function() end end
+                if MultiActionButtonUp then _G.MultiActionButtonUp = function() end end
             end
-            if MultiActionButtonDown then _G.MultiActionButtonDown = function() end end
-            if MultiActionButtonUp then _G.MultiActionButtonUp = function() end end
             C_CVar.SetCVar("SHOW_MULTI_ACTIONBAR_1", "1")
             C_CVar.SetCVar("SHOW_MULTI_ACTIONBAR_2", "1")
             C_CVar.SetCVar("SHOW_MULTI_ACTIONBAR_3", "1")


### PR DESCRIPTION
## Bugfixish Feature
This adds an option to use default Blizzard Keybinds/Action Bars. Actionbar addons use an abstracted version of key presses, but Blizzard's is coded on the C-level layer(ish). Blizzard has implemented "Press and Hold Casting", but it's only available using default Blizzard keybind/actionbars and not through the abstract level. Blizzard keybinds allows the addon to control the look and layout of the addons but defers to Blizzard system of keybinds. 

Note: the main reason to NOT use default blizzard keybind/action bars was to use "cast on key down", but that is natively support by default blizzard keybinds/action bars now. This commit leaves the option to continue using the old way, or you can join us in 2026 using blizzard defaults which gives you the benefit of using press and hold casting!

## Changes
Default (nativeKeybinds = false) — Added nativeKeybinds profile setting
UpdateKeybinds() guard — prevents override bindings from being installed; covers all call sites (startup, vehicle exit, housing close, CVar change, talent change)
HideBlizzardBars() guard — keeps actionButtons tables and MultiActionButtonDown/Up so bars 2-8 work via standard bindings
Combat reload guard — same protection for the /reload during combat path
Toggle with confirmation popup — saves setting, prompts reload, follows existing ShowConfirmPopup pattern

## Test
- Enable "Blizzard Keybinds", reload → all 8 bars cast, press-and-hold works, bars look correct
- Disable "Blizzard Keybinds", reload → override bindings restore, press-and-hold stops
- Vehicle UI appears correctly in both modes
- Flyout buttons work in both modes