### PR TITLE
fix: handle haste changes mid channel cast bar

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -438,7 +438,7 @@ local RefreshAnchoredBarsForUnlockTarget
 -- Forward declarations
 local UpdateCastBar
 local BuildCastBar
-local OnCastStart, OnChannelStart, OnCastStop, OnEmpowerStart, OnEmpowerUpdate
+local OnCastStart, OnChannelStart, OnChannelUpdate, OnCastStop, OnEmpowerStart, OnEmpowerUpdate
 
 -------------------------------------------------------------------------------
 --  Helpers
@@ -3012,6 +3012,17 @@ OnChannelStart = function()
     castBarFrame:Show()
 end
 
+OnChannelUpdate = function()
+    if not castBarFrame then return end
+    if not castBarFrame._channeling then return end
+
+    local name, _, _, startTimeMS, endTimeMS = UnitChannelInfo("player")
+    if not name then return end
+
+    castBarFrame._startTime = startTimeMS / 1000
+    castBarFrame._endTime = endTimeMS / 1000
+end
+
 -- Called for UNIT_SPELLCAST_STOP only (normal cast completion).
 -- Ignores the event if the castID doesn't match the active cast -- this
 -- prevents hiding the bar when a new cast has already started.
@@ -3351,6 +3362,9 @@ local function OnEvent(self, event, ...)
     elseif event == "UNIT_SPELLCAST_CHANNEL_START" then
         local unit = ...
         if unit == "player" then OnChannelStart() end
+    elseif event == "UNIT_SPELLCAST_CHANNEL_UPDATE" then
+        local unit = ...
+        if unit == "player" then OnChannelUpdate() end
     elseif event == "UNIT_SPELLCAST_CHANNEL_STOP" then
         -- args: unit, castGUID, spellID, interruptedBy, castID
         local unit, _, _, _, castID = ...
@@ -3417,6 +3431,7 @@ function ERB:OnEnable()
     eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_FAILED", "player")
     eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_INTERRUPTED", "player")
     eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_START", "player")
+    eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_UPDATE", "player")
     eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_STOP", "player")
     eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_START", "player")
     eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_STOP", "player")


### PR DESCRIPTION
## Bug
If haste changes mid-channel (Bloodlust, Power Infusion, trinket proc), the cast bar drain rate and timer text go stale — the bar keeps draining at the pre-haste speed until the channel ends.

## Root Cause
UNIT_SPELLCAST_CHANNEL_UPDATE was never registered or handled. _endTime and _startTime were only set once at channel start and never updated when WoW fired the update event with new timing.

## Fix
Added OnChannelUpdate handler (following the existing OnEmpowerUpdate pattern) that re-queries UnitChannelInfo("player") and writes fresh _startTime/_endTime. Registered UNIT_SPELLCAST_CHANNEL_UPDATE on the cast bar event frame and wired it into OnEvent.

## Test
- channel Mind Flay or Disintegrate
- receive Bloodlust mid-channel 
- observe bar drain rate and timer should update immediately
Cursor cast circle (already handled this) should be unaffected.