### PR TITLE
Fix empty action button visibility on page and bonus swaps

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -4819,7 +4819,7 @@ end
 --  Grid Show/Hide (show empty slots during spell drag)
 -------------------------------------------------------------------------------
 local gridShown = false
-local _slotChangedPending = false -- debounce for ACTIONBAR_SLOT_CHANGED
+local _buttonVisibilityPending = false -- debounce for empty-button visibility refresh
 local _spellsChangedPending = false -- debounce for SPELLS_CHANGED
 
 local function OnGridChange()
@@ -5622,11 +5622,26 @@ function EAB:FinishSetup()
         end
     end)
 
-    -- UPDATE_BONUS_ACTIONBAR is intentionally NOT registered. The secure
-    -- state driver (RegisterStateDriver on MainBar) handles bar paging in
-    -- C code, and ACTIONBAR_SLOT_CHANGED (debounced) handles button
-    -- visibility updates. Re-applying scale and layout here was redundant
-    -- and caused FPS drops during mount/dismount and druid form shifts.
+    local function QueueAlwaysShowButtonsRefresh()
+        -- During drag, skip. OnGridChange already shows everything, and
+        -- HIDEGRID / CURSOR_CHANGED will restore afterwards.
+        if gridShown then return end
+        if _buttonVisibilityPending then return end
+        _buttonVisibilityPending = true
+        C_Timer_After(0, function()
+            _buttonVisibilityPending = false
+            if gridShown then return end
+            for _, info in ipairs(BAR_CONFIG) do
+                self:ApplyAlwaysShowButtons(info.key)
+            end
+        end)
+    end
+
+    -- Slot changes alone are not sufficient for all paging transitions
+    -- (dragonriding, druid forms, mount state). Include page/bonus events
+    -- so empty-slot visibility refreshes immediately on those swaps.
+    self:RegisterEvent("ACTIONBAR_PAGE_CHANGED", QueueAlwaysShowButtonsRefresh)
+    self:RegisterEvent("UPDATE_BONUS_ACTIONBAR", QueueAlwaysShowButtonsRefresh)
 
     self:RegisterEvent("ZONE_CHANGED_NEW_AREA", function()
         self:UpdateHousingVisibility()
@@ -5656,23 +5671,10 @@ function EAB:FinishSetup()
         end)
     end)
 
-    -- Slot changed: update visibility when a spell is placed/removed from a slot
-    -- This fires per-slot (12+ times during a bar page swap), so debounce into
-    -- a single deferred pass.
-    self:RegisterEvent("ACTIONBAR_SLOT_CHANGED", function()
-        -- During drag, skip -- OnGridChange already shows everything,
-        -- and HIDEGRID / CURSOR_CHANGED will restore afterwards
-        if gridShown then return end
-        if _slotChangedPending then return end
-        _slotChangedPending = true
-        C_Timer_After(0, function()
-            _slotChangedPending = false
-            if gridShown then return end
-            for _, info in ipairs(BAR_CONFIG) do
-                self:ApplyAlwaysShowButtons(info.key)
-            end
-        end)
-    end)
+    -- Slot changed: update visibility when a spell is placed/removed from a slot.
+    -- This can fire per-slot (12+ times during a bar page swap), so use the
+    -- shared debounced visibility queue.
+    self:RegisterEvent("ACTIONBAR_SLOT_CHANGED", QueueAlwaysShowButtonsRefresh)
 
     -- Pet bar: re-layout and refresh visibility when the pet's action bar
     -- changes. PET_BAR_UPDATE covers ability changes; PET_UI_UPDATE covers


### PR DESCRIPTION
## Summary
This fixes a visibility bug where empty action buttons could remain visible after mount/dismount or dragonriding/bonus-bar page transitions when `Always Show Buttons` is disabled.

The root issue was that empty-slot refresh logic depended on `ACTIONBAR_SLOT_CHANGED` only, which can miss some page/state swaps.

## Changes
- Added a shared debounced refresh helper for empty-button visibility:
  - `QueueAlwaysShowButtonsRefresh()`
- Reused that helper for:
  - `ACTIONBAR_SLOT_CHANGED`
  - `ACTIONBAR_PAGE_CHANGED`
  - `UPDATE_BONUS_ACTIONBAR`
- Kept the refresh path visibility-only:
  - No `ApplyAll`
  - No relayout/scale/shape re-application
- Preserved existing safety behavior:
  - Skip during drag/grid (`gridShown`)
  - Debounced with `C_Timer_After(0, ...)`

## Why this is safe
- No SavedVariables or public API changes.
- No protected frame show/hide behavior changes added.
- Uses existing `ApplyAlwaysShowButtons` logic; this only improves event coverage/timing.

## Manual Test Plan
1. Repro case:
- Main bar page with 12 assigned spells.
- DR/bonus page with fewer assigned spells (e.g. 6).
- Mount/enter DR state.
- Disable `Always Show Buttons`.
- Confirm empty slots hide immediately (no `/reload`).
- Dismount and confirm no stale empty placeholders.

2. Regression:
- With full current page, disable `Always Show Buttons`.
- Switch to a page with fewer assigned slots.
- Confirm unassigned slots are hidden.

3. Drag/grid:
- Start dragging a spell (grid visible), verify temporary visibility.
- Drop/cancel drag, verify hidden empties restore correctly.

4. Combat sanity:
- Trigger page/bonus transitions in combat where possible.
- Confirm no taint/errors and no protected frame issues.