### PR TITLE
refactor: remove dead code from combat reload path

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -5299,13 +5299,6 @@ function EAB:FinishSetup()
             if OverrideActionBar then
                 RegisterAttributeDriver(OverrideActionBar, "state-visibility", "[vehicleui][overridebar] show; hide")
             end
-            -- Wipe Blizzard's actionButtons tables during combat reload
-            for _, name in ipairs({"MainActionBar", "MainMenuBar", "MultiBarBottomLeft", "MultiBarBottomRight", "MultiBarRight", "MultiBarLeft", "MultiBar5", "MultiBar6", "MultiBar7"}) do
-                local bar = _G[name]
-                if bar and bar.actionButtons then wipe(bar.actionButtons) end
-            end
-            if MultiActionButtonDown then _G.MultiActionButtonDown = function() end end
-            if MultiActionButtonUp then _G.MultiActionButtonUp = function() end end
             C_CVar.SetCVar("SHOW_MULTI_ACTIONBAR_1", "1")
             C_CVar.SetCVar("SHOW_MULTI_ACTIONBAR_2", "1")
             C_CVar.SetCVar("SHOW_MULTI_ACTIONBAR_3", "1")


### PR DESCRIPTION
## Summary
 Removes leftover actionButtons wipe and MultiActionButtonDown/MultiActionButtonUp no-op replacement from the combat reload path. This code was needed for the old override keybinding system but is now dead — native Blizzard keybinds require these tables and handlers to stay intact. The combat reload path does execute on /reload during combat, but the wipe itself has no observable effect: Blizzard repopulates the tables after combat ends, so keybinds work with or without it.

When native keybinds became the only mode, HideBlizzardBars() was updated to keep these intact, but the parallel code in the FinishSetup() combat reload branch was missed. 

## Changes
Removed the 7-line wipe block from the combat reload else branch, matching HideBlizzardBars().

## Test
  - /reload during combat (don't die), verify bars 2-8 keybinds work after combat ends
  - Normal load, verify all keybinds work
  - No behavioral change expected — normal load path already keeps these intact