### PR TITLE
Fixes for "Grow Centered" and item count on misc CDM bars.

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3465,6 +3465,7 @@ local function UpdateCustomBarIcons(barKey)
             -- On-use bag items use large negative IDs (<= -100, negated itemID)
             elseif spellID <= -100 then
                 local bagItemID = -spellID
+                local itemCount = C_Item.GetItemCount(bagItemID, false, true) or 0
                 local tex = C_Item.GetItemIconByID(bagItemID)
                 if tex then
                     if tex ~= ourIcon._lastTex then
@@ -3490,7 +3491,12 @@ local function UpdateCustomBarIcons(barKey)
                             ourIcon._lastDesat = false
                         end
                     end
-                    ourIcon._chargeText:Hide()
+                    if barData.showCharges and itemCount > 0 then
+                        ourIcon._chargeText:SetText(tostring(itemCount))
+                        ourIcon._chargeText:Show()
+                    else
+                        ourIcon._chargeText:Hide()
+                    end
                     ourIcon:Show()
                     visibleCount = visibleCount + 1
                 else


### PR DESCRIPTION
1. CDMFrameAnchorPoint now uses the "anchorSide" and "centered" parameters. This allows "Grow Centered" in CDM bars to work. Note: when Grow Centered is on, grow direction is ignored for selecting the anchor point.

2. Added item count to icons on misc CDM bars for custom items.
Note: code for items should probably be consolidated to avoid any inconsistencies in the future (so that updates made to health items relevant to custom items don't have to be written twice)