### PR TITLE
feat: add cast bar marks (channel ticks, last tick, gcd boundary)

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -3352,6 +3352,140 @@ initFrame:SetScript("OnEvent", function(self)
             UpdateCogDisTimer()
         end
 
+        -- ── MARKS section ───────────────────────────────────────────
+        _, h = W:SectionHeader(parent, "MARKS", y);  y = y - h
+
+        local marksOff = function()
+            local p = DB()
+            return castOff() or not (p and p.castBar.showChannelTicks)
+        end
+
+        -- Helper: attach an inline color swatch to a region with disabled overlay
+        local function AttachInlineSwatch(rgn, getFunc, setFunc, disabledFunc, disabledTooltip)
+            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5, getFunc, setFunc, true, 20)
+            PP.Point(swatch, "RIGHT", rgn._control, "LEFT", -12, 0)
+
+            local block = CreateFrame("Frame", nil, swatch)
+            block:SetAllPoints()
+            block:SetFrameLevel(swatch:GetFrameLevel() + 10)
+            block:EnableMouse(true)
+            block:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(swatch, EllesmereUI.DisabledTooltip(disabledTooltip))
+            end)
+            block:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = disabledFunc()
+                swatch:SetAlpha(off and 0.3 or 1)
+                if off then block:Show() else block:Hide() end
+                updateSwatch()
+            end)
+            local initOff = disabledFunc()
+            swatch:SetAlpha(initOff and 0.3 or 1)
+            if initOff then block:Show() else block:Hide() end
+        end
+
+        -- Marks Row 1: Enable Cast Bar Marks (master) | Channel Ticks (+ color)
+        local marksRow1
+        marksRow1, h = W:DualRow(parent, y,
+            { type = "toggle", text = "Enable Cast Bar Marks",
+              disabled = castOff,
+              disabledTooltip = "Enable Player Cast Bar",
+              getValue = function() local p = DB(); return p and p.castBar.showChannelTicks end,
+              setValue = function(v)
+                  local p = DB(); if not p then return end
+                  p.castBar.showChannelTicks = v
+                  if v and not (p.castBar.showTickMarks or p.castBar.showLastTick or p.castBar.showGCDBoundary) then
+                      p.castBar.showTickMarks = true
+                  end
+                  RefreshCast()
+                  EllesmereUI:RefreshPage()
+              end },
+            { type = "toggle", text = "Channel Ticks",
+              tooltip = "Damage tick marks on channeled spells. Only supported spells are shown — request missing spells on Discord.",
+              disabled = marksOff,
+              disabledTooltip = "Enable Cast Bar Marks",
+              getValue = function() local p = DB(); return p and p.castBar.showTickMarks end,
+              setValue = function(v)
+                  local p = DB(); if not p then return end
+                  p.castBar.showTickMarks = v; RefreshCast()
+                  EllesmereUI:RefreshPage()
+              end }
+        );  y = y - h
+
+        AttachInlineSwatch(marksRow1._rightRegion,
+            function()
+                local p = DB(); if not p then return 1, 1, 1, 0.7 end
+                return p.castBar.tickMarksR or 1, p.castBar.tickMarksG or 1,
+                       p.castBar.tickMarksB or 1, p.castBar.tickMarksA or 0.7
+            end,
+            function(r, g, b, a)
+                local p = DB(); if not p then return end
+                p.castBar.tickMarksR = r; p.castBar.tickMarksG = g
+                p.castBar.tickMarksB = b; p.castBar.tickMarksA = a
+                RefreshCast()
+            end,
+            function() return marksOff() or not (DB() and DB().castBar.showTickMarks) end,
+            "Enable Channel Ticks"
+        )
+
+        -- Marks Row 2: GCD Boundary (+ color) | Last Tick (+ color)
+        local marksRow2
+        marksRow2, h = W:DualRow(parent, y,
+            { type = "toggle", text = "GCD Boundary",
+              tooltip = "Shows where your GCD ends during a channel.",
+              disabled = marksOff,
+              disabledTooltip = "Enable Cast Bar Marks",
+              getValue = function() local p = DB(); return p and p.castBar.showGCDBoundary end,
+              setValue = function(v)
+                  local p = DB(); if not p then return end
+                  p.castBar.showGCDBoundary = v; RefreshCast()
+                  EllesmereUI:RefreshPage()
+              end },
+            { type = "toggle", text = "Last Tick",
+              tooltip = "Highlights the final damage tick. Requires a supported channeled spell.",
+              disabled = marksOff,
+              disabledTooltip = "Enable Cast Bar Marks",
+              getValue = function() local p = DB(); return p and p.castBar.showLastTick end,
+              setValue = function(v)
+                  local p = DB(); if not p then return end
+                  p.castBar.showLastTick = v; RefreshCast()
+                  EllesmereUI:RefreshPage()
+              end }
+        );  y = y - h
+
+        AttachInlineSwatch(marksRow2._leftRegion,
+            function()
+                local p = DB(); if not p then return 1, 0.82, 0, 0.95 end
+                return p.castBar.gcdBoundaryR or 1, p.castBar.gcdBoundaryG or 0.82,
+                       p.castBar.gcdBoundaryB or 0, p.castBar.gcdBoundaryA or 0.95
+            end,
+            function(r, g, b, a)
+                local p = DB(); if not p then return end
+                p.castBar.gcdBoundaryR = r; p.castBar.gcdBoundaryG = g
+                p.castBar.gcdBoundaryB = b; p.castBar.gcdBoundaryA = a
+                RefreshCast()
+            end,
+            function() return marksOff() or not (DB() and DB().castBar.showGCDBoundary) end,
+            "Enable GCD Boundary"
+        )
+
+        AttachInlineSwatch(marksRow2._rightRegion,
+            function()
+                local p = DB(); if not p then return 1, 0.82, 0, 0.95 end
+                return p.castBar.lastTickR or 1, p.castBar.lastTickG or 0.82,
+                       p.castBar.lastTickB or 0, p.castBar.lastTickA or 0.95
+            end,
+            function(r, g, b, a)
+                local p = DB(); if not p then return end
+                p.castBar.lastTickR = r; p.castBar.lastTickG = g
+                p.castBar.lastTickB = b; p.castBar.lastTickA = a
+                RefreshCast()
+            end,
+            function() return marksOff() or not (DB() and DB().castBar.showLastTick) end,
+            "Enable Last Tick"
+        )
+
         -- Wire up click mappings for cast bar preview hit overlays
         _clickMappings.castBar       = { section = castSection, target = classSizeRow }
         _clickMappings.castIcon      = { section = castSection, target = castEnableRow, slotSide = "right" }

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -65,6 +65,22 @@ local PT = {
     ESSENCE     = 19, -- Evoker
 }
 
+-------------------------------------------------------------------------------
+--  Channel tick data — spellID → { ticks, [modSpell, modTicks] } or { tickInterval }
+--  ticks: fixed tick count (haste changes tick speed, count stays the same).
+--  tickInterval: fixed interval in seconds (haste extends duration, adding ticks).
+--  modSpell/modTicks: if the player knows modSpell (talent), use modTicks instead.
+--  Spell IDs verified against Wowhead/Warcraft Wiki as of 12.0.1 — if a spell
+--  is reworked or a new channeled spell is added, add a row here.
+-------------------------------------------------------------------------------
+local CHANNEL_TICK_DATA = {
+    [356995]  = { ticks = 4, modSpell = 1219723, modTicks = 5 },                   -- Disintegrate (Evoker) / Azure Celerity
+    [15407]   = { ticks = 6 },                                     -- Mind Flay (Shadow Priest)
+    [5143]    = { ticks = 5 },                                     -- Arcane Missiles (Arcane Mage)
+    [198013]  = { tickInterval = 0.2 },                             -- Eye Beam (Havoc DH) — haste extends duration
+    [473728]  = { tickInterval = 0.2 },                             -- Void Ray (Devourer DH) — haste extends duration
+    [212084]  = { ticks = 10 },                                    -- Fel Devastation (Vengeance DH)
+}
 
 -------------------------------------------------------------------------------
 --  Class/Spec resource mapping
@@ -421,6 +437,13 @@ local DEFAULTS = {
             spellTextY    = 0,
             scale         = 1.0,
             unlockPos     = nil,
+            showChannelTicks  = true,
+            showTickMarks     = true,
+            tickMarksR = 1.0, tickMarksG = 1.0, tickMarksB = 1.0, tickMarksA = 0.7,
+            showLastTick      = false,
+            lastTickR = 1.0, lastTickG = 0.82, lastTickB = 0.0, lastTickA = 0.95,
+            showGCDBoundary   = false,
+            gcdBoundaryR = 1.0, gcdBoundaryG = 0.82, gcdBoundaryB = 0.0, gcdBoundaryA = 0.95,
         },
         general = {
             anchorX     = 0,
@@ -454,6 +477,7 @@ local RefreshAnchoredBarsForUnlockTarget
 local UpdateCastBar
 local BuildCastBar
 local OnCastStart, OnChannelStart, OnChannelUpdate, OnCastStop, OnEmpowerStart, OnEmpowerUpdate
+local ShowChannelTicks, HideChannelTicks
 
 -------------------------------------------------------------------------------
 --  Helpers
@@ -2707,6 +2731,8 @@ BuildCastBar = function()
         castBarFrame._spellName = ""
         castBarFrame._pips = {}
         castBarFrame._numStages = 0
+        castBarFrame._ticks = {}
+        castBarFrame._numTicks = 0
     end
 
     -- Apply settings
@@ -2896,11 +2922,157 @@ end
         end
     end
 
+    -- Hide channel ticks when not channeling
+    HideChannelTicks()
+
     -- Hide when not casting
     if not castBarFrame._casting and not castBarFrame._channeling and not castBarFrame._empowering then
         castBarFrame:Hide()
     else
         castBarFrame:Show()
+    end
+end
+
+
+-------------------------------------------------------------------------------
+--  Channel tick marks
+--  Shows vertical tick marks on the cast bar during channeled spells whose
+--  spell ID appears in CHANNEL_TICK_DATA.  The penultimate tick (the last
+--  safe point to chain/clip) is drawn slightly wider in gold.
+--  Layout mirrors the empower pip code above for visual consistency.
+-------------------------------------------------------------------------------
+ShowChannelTicks = function(spellID)
+    if not castBarFrame then return end
+    local cb = ERB.db.profile.castBar
+    if not cb.showChannelTicks then return end
+
+    local tickData = CHANNEL_TICK_DATA[spellID]
+
+    local bar = castBarFrame._bar
+    local barWidth = bar:GetWidth()
+    local barHeight = bar:GetHeight()
+    if barWidth <= 0 or barHeight <= 0 then return end
+
+    -- Pixel-snap helpers (same approach as empower pips)
+    local effectiveScale = bar:GetEffectiveScale()
+    local pixelSize = 1 / effectiveScale
+    local tickWidth = max(pixelSize, floor(2 * effectiveScale + 0.5) / effectiveScale)
+    local highlightWidth = max(pixelSize, floor(3 * effectiveScale + 0.5) / effectiveScale)
+
+    -- Tick marks — only for spells with known tick data
+    if tickData and (cb.showTickMarks or cb.showLastTick) then
+        local numTicks
+        if tickData.tickInterval then
+            -- Haste-extends-duration spells: compute ticks from actual channel duration
+            local channelDuration = castBarFrame._endTime - castBarFrame._startTime
+            if channelDuration > 0 then
+                numTicks = floor(channelDuration / tickData.tickInterval)
+            else
+                numTicks = 0
+            end
+        else
+            numTicks = tickData.ticks
+            if tickData.modSpell and IsPlayerSpell(tickData.modSpell) then
+                numTicks = tickData.modTicks
+            end
+        end
+
+        -- Place a mark at each tick boundary.
+        -- The channel bar drains from 1→0 (fill shrinks from right to left).
+        -- Tick i fires at (i/numTicks) of the duration elapsed, at which point
+        -- the bar progress = (numTicks - i) / numTicks.  That fraction of the
+        -- bar width from the LEFT is where the mark sits.
+        -- We skip the last tick (i == numTicks) since it's the bar's zero edge.
+        for i = 1, numTicks - 1 do
+            local isLastTick = (i == numTicks - 1)
+
+            -- If only Last Tick is on (no Tick Marks), skip non-last ticks
+            if not cb.showTickMarks and not isLastTick then
+                if castBarFrame._ticks[i] then castBarFrame._ticks[i]:Hide() end
+            else
+                local tick = castBarFrame._ticks[i]
+                if not tick then
+                    tick = bar:CreateTexture(nil, "OVERLAY", nil, 3)
+                    castBarFrame._ticks[i] = tick
+                end
+
+                local rawOffset = barWidth * (numTicks - i) / numTicks
+                local snappedOffset = floor(rawOffset * effectiveScale + 0.5) / effectiveScale
+                local snappedHeight = floor(barHeight * effectiveScale + 0.5) / effectiveScale
+
+                if isLastTick and cb.showLastTick then
+                    tick:SetColorTexture(cb.lastTickR or 1.0, cb.lastTickG or 0.82, cb.lastTickB or 0.0, cb.lastTickA or 0.95)
+                    tick:SetSize(highlightWidth, snappedHeight)
+                else
+                    tick:SetColorTexture(cb.tickMarksR or 1.0, cb.tickMarksG or 1.0, cb.tickMarksB or 1.0, cb.tickMarksA or 0.7)
+                    tick:SetSize(tickWidth, snappedHeight)
+                end
+
+                tick:ClearAllPoints()
+                tick:SetPoint("CENTER", bar, "LEFT", snappedOffset, 0)
+                tick:Show()
+            end
+        end
+
+        -- Hide extras from a previous channel that had more ticks
+        for i = max(1, numTicks), #castBarFrame._ticks do
+            castBarFrame._ticks[i]:Hide()
+        end
+
+        castBarFrame._numTicks = numTicks
+    else
+        -- No tick data or ticks disabled — hide any stale tick textures
+        for i = 1, #castBarFrame._ticks do
+            castBarFrame._ticks[i]:Hide()
+        end
+        castBarFrame._numTicks = 0
+    end
+
+    -- GCD boundary mark — a separate mark at the exact GCD time position,
+    -- computed from real haste so it's accurate even above the GCD floor.
+    -- Shown for ALL channeled spells (not gated on CHANNEL_TICK_DATA).
+    if cb.showGCDBoundary then
+        local gcdMark = castBarFrame._gcdMark
+        if not gcdMark then
+            gcdMark = bar:CreateTexture(nil, "OVERLAY", nil, 4)
+            castBarFrame._gcdMark = gcdMark
+        end
+
+        local channelDuration = castBarFrame._endTime - castBarFrame._startTime
+        if channelDuration > 0 then
+            local haste = UnitSpellHaste("player") / 100
+            local currentGCD = max(0.75, 1.5 / (1 + haste))
+            local gcdFraction = currentGCD / channelDuration
+
+            if gcdFraction > 0 and gcdFraction < 1 then
+                local gcdOffset = barWidth * (1 - gcdFraction)
+                local snappedGcdOffset = floor(gcdOffset * effectiveScale + 0.5) / effectiveScale
+                local snappedHeight = floor(barHeight * effectiveScale + 0.5) / effectiveScale
+
+                gcdMark:SetColorTexture(cb.gcdBoundaryR or 1.0, cb.gcdBoundaryG or 0.82, cb.gcdBoundaryB or 0.0, cb.gcdBoundaryA or 0.95)
+                gcdMark:SetSize(highlightWidth, snappedHeight)
+                gcdMark:ClearAllPoints()
+                gcdMark:SetPoint("CENTER", bar, "LEFT", snappedGcdOffset, 0)
+                gcdMark:Show()
+            else
+                gcdMark:Hide()
+            end
+        else
+            gcdMark:Hide()
+        end
+    elseif castBarFrame._gcdMark then
+        castBarFrame._gcdMark:Hide()
+    end
+end
+
+HideChannelTicks = function()
+    if not castBarFrame or not castBarFrame._ticks then return end
+    for i = 1, #castBarFrame._ticks do
+        castBarFrame._ticks[i]:Hide()
+    end
+    castBarFrame._numTicks = 0
+    if castBarFrame._gcdMark then
+        castBarFrame._gcdMark:Hide()
     end
 end
 
@@ -2980,6 +3152,7 @@ OnCastStart = function()
         for i = 1, #castBarFrame._pips do castBarFrame._pips[i]:Hide() end
     end
     castBarFrame._numStages = 0
+    HideChannelTicks()
 
     -- Icon
     do
@@ -3032,6 +3205,9 @@ OnChannelStart = function()
         end
     end
 
+    -- Channel tick marks
+    ShowChannelTicks(spellID)
+
     castBarFrame:Show()
 end
 
@@ -3039,11 +3215,14 @@ OnChannelUpdate = function()
     if not castBarFrame then return end
     if not castBarFrame._channeling then return end
 
-    local name, _, _, startTimeMS, endTimeMS = UnitChannelInfo("player")
+    local name, _, _, startTimeMS, endTimeMS, _, _, spellID = UnitChannelInfo("player")
     if not name then return end
 
     castBarFrame._startTime = startTimeMS / 1000
     castBarFrame._endTime = endTimeMS / 1000
+
+    -- Recompute tick mark and GCD boundary positions for new duration
+    if spellID then ShowChannelTicks(spellID) end
 end
 
 -- Called for UNIT_SPELLCAST_STOP only (normal cast completion).
@@ -3078,6 +3257,7 @@ local function OnChannelStop(eventCastID)
     if not eventCastID or not castBarFrame._castID or eventCastID ~= castBarFrame._castID then return end
     castBarFrame._channeling = false
     castBarFrame._castID = nil
+    HideChannelTicks()
     castBarFrame:Hide()
 end
 
@@ -3110,6 +3290,7 @@ OnCastStop = function()
         end
     end
     castBarFrame._numStages = 0
+    HideChannelTicks()
     castBarFrame:Hide()
 end
 
@@ -3135,6 +3316,7 @@ OnEmpowerStart = function()
     castBarFrame._spellName = name
     castBarFrame._nameText:SetText(name)
     castBarFrame._bar:SetValue(0)
+    HideChannelTicks()
 
     -- Icon
     do


### PR DESCRIPTION
## Summary
  - New "Marks" section in Cast Bar options with independent toggles for Channel Ticks, Last Tick, and GCD Boundary — each with its own color picker
  - GCD Boundary works on all channeled spells, not just those with tick data
  - Two tick count models: fixed count (ticks) for spells where haste changes tick speed, and computed from duration (tickInterval) for spells where haste extends duration
  - Marks reposition mid-channel when haste changes (Bloodlust, Power Infusion, etc.)

### Supported Spells                                                                                                                                                                    
              
  | Spell | Class/Spec | Ticks | Model |                                                                                                                                                  
  |-------|-----------|-------|-------|
  | Disintegrate | Evoker | 4 (5 with Azure Celerity) | Fixed count |                                                                                                                     
  | Mind Flay | Shadow Priest | 6 | Fixed count |
  | Arcane Missiles | Arcane Mage | 5 | Fixed count |
  | Eye Beam | Havoc DH | 10 (15 with Blind Fury) | Fixed interval (0.2s) |
  | Void Ray | Devourer DH | 15+ (varies with haste) | Fixed interval (0.2s) |
  | Fel Devastation | Vengeance DH | 10 | Fixed count |

  ### Adding new spells

  Add a row to `CHANNEL_TICK_DATA` in `EllesmereUIResourceBars.lua`:
  - Fixed tick count: `[spellID] = { ticks = N }`
  - Haste extends duration: `[spellID] = { tickInterval = seconds }`
  - Talent modifies ticks: `[spellID] = { ticks = N, modSpell = talentID, modTicks = M }`




## Test Plan
  Options panel:
  1. Open /eui → Resource Bars → Cast Bar — verify MARKS section appears with correct layout
  2. Toggle "Enable Cast Bar Marks" on → verify "Channel Ticks" auto-enables, other two stay off
  3. Verify sub-toggles grey out when master is off
  4. Verify color swatches grey out when their toggle is off, work when on
  5. Hover tooltips on Channel Ticks, Last Tick, GCD Boundary — verify text shows
  6. Turn off all three sub-toggles — verify master stays on (no auto-disable)

  Tick marks rendering:
  - Evoker: Disintegrate — 4 ticks (5 with Azure Celerity)
  - Mage: Arcane Missiles — 5 ticks
  - Shadow Priest: Mind Flay — 6 ticks
  - DH: Eye Beam — 10 ticks (15 with Blind Fury), Fel Devastation — 10 ticks, Void Ray — 15+ (varies with haste)

  For each channel test:
  1. Channel ticks on → verify marks appear, evenly spaced
  2. Last tick on → verify last mark highlighted in gold
  3. GCD boundary on → verify GCD mark appears on all channels (not just table spells)
  4. Custom colors → verify color changes apply

  Regression checks:
  - Non-channeled casts → no marks should appear
  - /reload → settings persist, marks render correctly
  - Cast bar resize → marks scale with bar