### PR TITLE
fix(actionbars): g_glows missing declaration

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -4062,6 +4062,8 @@ ns.StopAutoCastShine   = StopAutoCastShine
 ns.StartShapeGlow      = StartShapeGlow
 ns.StopShapeGlow       = StopShapeGlow
 
+local _G_Glows = EllesmereUI.Glows
+
 local function StopAllProceduralGlows(wrapper)
     _G_Glows.StopAllGlows(wrapper)
 end


### PR DESCRIPTION
## Bug   
  EllesmereUIActionBars.lua:4066 errors with "attempt to index global '_G_Glows' (a nil value)" when          
  StopAllProceduralGlows is called.                                                                             
                                  
  ## Root Cause                                                                                                 
  _G_Glows is referenced at line 4066 but never defined in the ActionBars file. Every other module that uses it
  (CooldownManager, AuraBuffReminders, Nameplates) declares local _G_Glows = EllesmereUI.Glows before use --
  ActionBars was missing this declaration.

  ## Fix
  Added local _G_Glows = EllesmereUI.Glows immediately before StopAllProceduralGlows at line 4065, matching the
  pattern used in all other modules.

  ## Test Plan
  - /reload in-game and confirm no nil index error on _G_Glows
  - Trigger a proc glow on an action bar button, then let it expire to verify StopAllProceduralGlows runs
  without error
  - Swap specs to re-trigger glow cleanup path