### PR TITLE
fix: remove numButtonsShowable/UpdateShownButtons overrides that taint

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -750,28 +750,6 @@ local function HideBlizzardBars()
         local bar = _G[name]
         if bar then
             bar:UnregisterAllEvents()
-            -- Only override numButtonsShowable / UpdateShownButtons on the
-            -- numbered action bars.  StanceBar and PetActionBar have their
-            -- own secure visibility systems (ActionBarController_UpdateAll
-            -- calls SetShown -> SetShownBase) and tainting them causes
-            -- ADDON_ACTION_BLOCKED.
-            if name ~= "StanceBar" and name ~= "PetActionBar" then
-                -- Force Blizzard's numButtonsShowable to the maximum so any
-                -- residual Blizzard code (e.g. UpdateShownState) that checks
-                -- the bar's visible button count never hides buttons we want
-                -- shown.  Edit Mode may have set this to fewer than 12, but
-                -- we control button visibility ourselves.
-                if bar.numButtonsShowable ~= nil then
-                    bar.numButtonsShowable = 12
-                end
-                -- Replace UpdateShownButtons with a no-op so Blizzard's
-                -- OnEnter -> UpdateAction chain cannot call SetShown() on
-                -- buttons we manage.  This prevents the stale
-                -- numButtonsShowable from hiding buttons on hover.
-                if bar.UpdateShownButtons then
-                    bar.UpdateShownButtons = function() end
-                end
-            end
             bar:SetParent(hiddenParent)
             bar:Hide()
         end
@@ -5914,14 +5892,6 @@ function EAB:FinishSetup()
             local bar = _G[name]
             if bar then
                 bar:UnregisterAllEvents()
-                if name ~= "StanceBar" and name ~= "PetActionBar" then
-                    if bar.numButtonsShowable ~= nil then
-                        bar.numButtonsShowable = 12
-                    end
-                    if bar.UpdateShownButtons then
-                        bar.UpdateShownButtons = function() end
-                    end
-                end
                 bar:SetParent(hiddenParent)
                 bar:Hide()
             end


### PR DESCRIPTION
## Bug 
OverrideActionBarButtons throw "attempt to compare a secret number value (tainted by EllesmereUIActionBars)" and ADDON_ACTION_BLOCKED on SetAttribute during combat.
                                                                                                                                                                                                
## Root Cause
HideBlizzardBars writes bar.numButtonsShowable = 12 from insecure code, tainting the value. When Blizzard's UpdateShownButtons reads it during the shared ActionBarActionEventsFrame dispatch loop, the taint propagates to all action buttons in the loop -- including OverrideActionBarButtons that the addon never directly touches. The UpdateShownButtons = function() end replacement was a bandaid that introduced its own taint by replacing a secure function with an insecure one.                                                                                              
                                                                                                                                                                                                
## Fix
Remove both numButtonsShowable writes and UpdateShownButtons replacements from the initial hide loop and the PLAYER_TALENT_UPDATE handler. Neither is needed -- the bars are already reparented to a hidden frame and have their events unregistered, so Blizzard's UpdateShownButtons never fires on them.                                                                        
                                                                                                                                                                                                
## Test                                                                                                                                                                                       
  - Log in, target a dummy, go out of range, come back in range, enter combat -- no secret value or ADDON_ACTION_BLOCKED errors                                                                 
  - Use abilities through a rotation -- no errors                                                                                                                                               
  - Swap specs -- bars restore correctly, all buttons visible                                                                                                                                   
  - Change talents -- bars remain correct                                                                                                                                                       
  - /reload -- bars restore correctly   