### PR TITLE
fix: taint fixes for action bar secret value errors   

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -750,13 +750,8 @@ local function HideBlizzardBars()
         local bar = _G[name]
         if bar then
             bar:UnregisterAllEvents()
-            if name ~= "StanceBar" and name ~= "PetActionBar" then
-                if bar.numButtonsShowable ~= nil then
-                    bar.numButtonsShowable = 12
-                end
-                bar:SetParent(hiddenParent)
-                bar:Hide()
-            end
+            bar:SetParent(hiddenParent)
+            bar:Hide()
         end
     end
     -- Also hide the MainActionBar container and related frames
@@ -5911,13 +5906,8 @@ function EAB:FinishSetup()
             local bar = _G[name]
             if bar then
                 bar:UnregisterAllEvents()
-                if name ~= "StanceBar" and name ~= "PetActionBar" then
-                    if bar.numButtonsShowable ~= nil then
-                        bar.numButtonsShowable = 12
-                    end
-                    bar:SetParent(hiddenParent)
-                    bar:Hide()
-                end
+                bar:SetParent(hiddenParent)
+                bar:Hide()
             end
         end
         if MainActionBarController then
@@ -5928,13 +5918,11 @@ function EAB:FinishSetup()
     -- Hook Show on the Blizzard bars so they can never re-appear regardless
     -- of what fires them (talent changes, spec swaps, zone transitions, etc.)
     for _, name in ipairs(BLIZZARD_BARS_TO_HIDE) do
-        if name ~= "StanceBar" and name ~= "PetActionBar" then
-            local bar = _G[name]
-            if bar then
-                bar:HookScript("OnShow", function(self)
-                    self:Hide()
-                end)
-            end
+        local bar = _G[name]
+        if bar then
+            bar:HookScript("OnShow", function(self)
+                self:Hide()
+            end)
         end
     end
 


### PR DESCRIPTION
## Bug                                                                                            
  `ActionButton.lua:609: attempt to compare a secret number value (tainted by 'EllesmereUIActionBars')` during combat. Lower frequency than the other one                                          
                                                                                                    
  ## Root Cause
  `GetButtonActionSlot()` reads `btn.action` directly — a protected attribute that became a secret value in Midnight. The `hooksecurefunc` on `UpdateUsable` calls this during combat, tainting the value before Blizzard's own `assertsafe()` comparison.


  ## Fix
  - Replace `btn.action` reads with a `buttonToBar` lookup table populated during setup
  - `GetButtonActionSlot()` resolves slots from `BAR_SLOT_OFFSETS` + cached `_mainBarOffset` instead
   of the protected attribute
  - `CaptureBlizzardDefaults()` uses `BAR_SLOT_OFFSETS` instead of
  `btn.action`/`HasAction(btn.action)`

  ## Test
  - Enter combat with range coloring enabled — no taint errors on action buttons
  - Verify out-of-range tinting still works
  - Stance bar and pet bar should remain functional (no ADDON_ACTION_BLOCKED)
  - Override action bar buttons (vehicles, etc.) should not throw errors