### PR TITLE
Nameplates: refresh tank threat colors on instance entry

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -4326,16 +4326,39 @@ local function UpdateFactionFrameForZone()
     end
 end
 
+local function RefreshThreatContextAndPlateColors()
+    RefreshThreatCache()
+    -- Unit tokens are recycled across zone/instance transitions; clear any
+    -- stale quest-mob decisions that were made under a different context.
+    wipe(questMobCache)
+    for _, plate in pairs(ns.plates) do
+        plate:UpdateHealthColor()
+    end
+end
+
 factionFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+factionFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
+factionFrame:RegisterEvent("PLAYER_DIFFICULTY_CHANGED")
 factionFrame:RegisterEvent("ROLE_CHANGED_INFORM")
+factionFrame:RegisterEvent("PLAYER_ROLES_ASSIGNED")
 factionFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
 factionFrame:SetScript("OnEvent", function(_, event, unit)
     if event == "PLAYER_ENTERING_WORLD"
+    or event == "ZONE_CHANGED_NEW_AREA"
+    or event == "PLAYER_DIFFICULTY_CHANGED"
     or event == "ROLE_CHANGED_INFORM"
+    or event == "PLAYER_ROLES_ASSIGNED"
     or event == "GROUP_ROSTER_UPDATE" then
-        RefreshThreatCache()
-        if event == "PLAYER_ENTERING_WORLD" then
+        RefreshThreatContextAndPlateColors()
+        if event == "PLAYER_ENTERING_WORLD" or event == "ZONE_CHANGED_NEW_AREA" then
             UpdateFactionFrameForZone()
+        end
+        if event == "PLAYER_ENTERING_WORLD" then
+            -- Initial PEW can fire before difficulty/instance data settles.
+            C_Timer.After(0.6, function()
+                RefreshThreatContextAndPlateColors()
+                UpdateFactionFrameForZone()
+            end)
         end
         return
     end


### PR DESCRIPTION
## Summary
Fixes a Nameplates issue in v4.8.4 where tank threat color modes did not apply until `/reload` after entering instanced content.

This MR ensures threat context is refreshed and visible nameplates are recolored immediately when zone/instance/role context changes, so both:
- `Show special has aggro color`
- `Classic tank aggro`

work correctly without a UI reload.

## Root Cause
Threat coloring relies on cached instance/role state. That cache was refreshed on a limited event set, and on instance entry `PLAYER_ENTERING_WORLD` can fire before instance difficulty data is finalized (`difficultyID == 0` briefly), leaving the cache stale until a reload.

## Changes
- Added centralized refresh path to:
  - recompute cached threat context,
  - clear stale quest-mob cache tied to recycled unit tokens,
  - force `UpdateHealthColor()` on active plates.
- Expanded event coverage for threat-context refresh:
  - `PLAYER_ENTERING_WORLD`
  - `ZONE_CHANGED_NEW_AREA`
  - `PLAYER_DIFFICULTY_CHANGED`
  - `ROLE_CHANGED_INFORM`
  - `PLAYER_ROLES_ASSIGNED`
  - `GROUP_ROSTER_UPDATE`
- Added delayed second pass (`C_Timer.After(0.6)`) after `PLAYER_ENTERING_WORLD` to catch post-load instance data stabilization.

## Expected Behavior After Merge
- Entering dungeon/raid/delve updates tank threat color behavior immediately.
- Toggling/using `Show special has aggro color` and `Classic tank aggro` no longer requires `/reload` after zone transition.
- No intended behavior change outside threat-context refresh timing.

## Testing Notes
Manual in-game validation recommended:
1. Enable `Classic tank aggro`; enter an instance as tank (Only reproducible if you enter instance from open world like m0/keys, not reproducible with follower dungeon); verify has/losing/no-aggro colors apply immediately.
2. Disable `Classic tank aggro`, enable `Show special has aggro color`; verify special has-aggro color works immediately on instance entry.
3. Swap role/spec and regroup while in instance; verify colors refresh without reload.
4. Exit to open world and re-enter instance; verify consistent behavior across transitions.