### PR TITLE
Fix Hide when Mounted for druid travel forms

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -6508,6 +6508,60 @@ EllesmereUI.VIS_OPT_ITEMS = {
 
 -- Runtime check: returns true if the element should be HIDDEN by visibility options.
 -- `opts` is the settings table containing the vis option booleans.
+local DRUID_MOUNT_FORM_IDS = {
+    [3] = true,   -- travel form
+    [4] = true,   -- aquatic form
+    [27] = true,  -- flight form
+    [29] = true,  -- flight form variant
+}
+
+local DRUID_MOUNT_FORM_SPELLS = {
+    [783] = true,    -- Travel Form
+    [1066] = true,   -- Aquatic Form
+    [33943] = true,  -- Flight Form
+    [40120] = true,  -- Swift Flight Form
+    [165962] = true, -- Mount Form
+    [210053] = true, -- Mount Form (variant)
+}
+
+function EllesmereUI.IsPlayerMountedLike()
+    -- Fast path for regular mounts.
+    if IsMounted and IsMounted() then return true end
+
+    -- Druid travel/flight/aquatic forms are mount-like for visibility checks.
+    local _, classFile = UnitClass("player")
+    if classFile ~= "DRUID" then return false end
+
+    if GetShapeshiftFormID then
+        local formID = GetShapeshiftFormID()
+        if formID and DRUID_MOUNT_FORM_IDS[formID] then
+            return true
+        end
+    end
+
+    -- Spell fallback to catch mount-form variants when form IDs differ.
+    if GetShapeshiftForm and GetShapeshiftFormInfo then
+        local form = GetShapeshiftForm()
+        if form and form > 0 then
+            local _, a2, a3, a4, a5 = GetShapeshiftFormInfo(form)
+            local active
+            local spellID
+            if type(a2) == "boolean" then
+                active = a2
+                spellID = (type(a4) == "number" and a4) or (type(a5) == "number" and a5) or nil
+            elseif type(a3) == "boolean" then
+                active = a3
+                spellID = (type(a5) == "number" and a5) or (type(a4) == "number" and a4) or nil
+            end
+            if active and spellID and DRUID_MOUNT_FORM_SPELLS[spellID] then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
 function EllesmereUI.CheckVisibilityOptions(opts)
     if not opts then return false end
 
@@ -6536,7 +6590,7 @@ function EllesmereUI.CheckVisibilityOptions(opts)
 
     -- Hide when Mounted
     if opts.visHideMounted then
-        if IsMounted and IsMounted() then return true end
+        if EllesmereUI.IsPlayerMountedLike and EllesmereUI.IsPlayerMountedLike() then return true end
     end
 
     -- Hide without Target

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -3894,9 +3894,9 @@ function EAB:UpdateHousingVisibility()
     -- (e.g. CameraOrSelectOrMoveStop triggering PLAYER_MOUNT_DISPLAY_CHANGED)
     C_Timer.After(0, function()
         if InCombatLockdown() then return end
-        -- Check only housing and instance-only options here. Mounted, target,
-        -- and enemy options are handled by the secure state driver via
-        -- BuildVisibilityString and re-evaluate automatically.
+        -- Check non-macro visibility options here. Secure frames still use the
+        -- state driver for target/enemy conditions, but mounted-like druid
+        -- forms are also handled here to cover cases [mounted] does not match.
         local function ShouldHideNonMacro(s)
             if not s then return false end
             if s.visOnlyInstances then
@@ -3918,6 +3918,14 @@ function EAB:UpdateHousingVisibility()
                     if mapID and mapID > 2600 then return true end
                 end
             end
+            -- Mounted is normally handled by secure [mounted] state conditions.
+            -- Also check the shared runtime mounted-like helper here so druid
+            -- travel/flight/aquatic forms hide correctly on non-macro refreshes.
+            if s.visHideMounted then
+                if EllesmereUI and EllesmereUI.IsPlayerMountedLike and EllesmereUI.IsPlayerMountedLike() then
+                    return true
+                end
+            end
             return false
         end
 
@@ -3927,8 +3935,9 @@ function EAB:UpdateHousingVisibility()
             if s then
                 local frame = barFrames[key] or (info.isDataBar and dataBarFrames[key]) or (info.isBlizzardMovable and blizzMovableHolders[key]) or (extraBarHolders[key]) or (info.visibilityOnly and _G[info.frameName])
                 if frame then
-                    -- Secure action bar frames use the state driver for mounted/
-                    -- target/enemy options, so only check housing/instances here.
+                    -- Secure action bar frames use the state driver for
+                    -- target/enemy options; mounted-like druid forms are
+                    -- additionally handled in ShouldHideNonMacro().
                     -- Non-secure frames (data bars, extra bars, visibility-only)
                     -- need the full check since they have no state driver.
                     local isSecure = not info.visibilityOnly and not info.isDataBar and not info.isBlizzardMovable and barFrames[key]
@@ -5847,6 +5856,9 @@ function EAB:FinishSetup()
 
     -- Visibility option events: mounted, target, group changes
     self:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED", function()
+        self:UpdateHousingVisibility()
+    end)
+    self:RegisterEvent("UPDATE_SHAPESHIFT_FORM", function()
         self:UpdateHousingVisibility()
     end)
     self:RegisterEvent("PLAYER_TARGET_CHANGED", function()

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7459,6 +7459,7 @@ eventFrame:RegisterEvent("STOP_MOVIE")
 -- Visibility option events: mounted, target, instance zone changes
 eventFrame:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED")
 eventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
+eventFrame:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
 
 -- Debounce token for talent-change rebuilds: rapid talent clicks collapse
 -- into a single deferred rebuild rather than firing once per click.
@@ -7602,7 +7603,7 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
         end
         return
     end
-    if event == "PLAYER_MOUNT_DISPLAY_CHANGED" or event == "PLAYER_TARGET_CHANGED" then
+    if event == "PLAYER_MOUNT_DISPLAY_CHANGED" or event == "PLAYER_TARGET_CHANGED" or event == "UPDATE_SHAPESHIFT_FORM" then
         _CDMApplyVisibility()
         return
     end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -6254,6 +6254,7 @@ function InitializeFrames()
         frames._visFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
         frames._visFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
         frames._visFrame:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED")
+        frames._visFrame:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
         frames._visFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
         frames._visFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
     end


### PR DESCRIPTION
## Summary
- add shared mounted-like visibility detection in core (`EllesmereUI.IsPlayerMountedLike`)
- treat druid travel/flight/aquatic forms as mounted for runtime visibility checks
- wire `UPDATE_SHAPESHIFT_FORM` visibility refresh in CDM, UnitFrames, and ActionBars
- update ActionBars non-macro secure visibility refresh path to hide on druid mounted-like forms

## Why
`Hide when Mounted` worked for regular mounts but not druid travel/flight form in ResourceBars/CDM, and ActionBars needed additional non-macro runtime handling for druid forms.

## Testing
Manual in-game validation planned:
1. Enable `Hide when Mounted` on ResourceBars/CDM/ActionBars
2. Verify hide on regular mount
3. Verify hide on druid travel form
4. Verify hide on druid flight/skyriding form
5. Verify hide on druid aquatic form
6. Verify show returns on unmount/unshift according to selected visibility mode