### PR TITLE
Fix TBB stale _isPassive state on alt switch

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -1078,6 +1078,10 @@ function ns.BuildTrackedBuffBars()
             -- Mark bar as ready but keep hidden; the tick will show it
             -- when the tracked buff is actually active on the player.
             bar._tbbReady = true
+            bar._isPassive = nil
+            bar._resolvedAuraID = nil
+            bar._customStart = nil
+            bar._activeDuration = nil
             bar:Hide()
         end
     end


### PR DESCRIPTION
## Summary
- Clears per-bar timer state (`_isPassive`, `_resolvedAuraID`, `_customStart`, `_activeDuration`) when `BuildTrackedBuffBars` rebuilds bars on zone-in or alt switch
- Fixes Roll the Bones (and similar aura-only) buff bars showing as permanently full with no countdown after switching to an Outlaw Rogue alt

## Problem
When switching characters, TBB bar frames are reused but their timer state persists. During the 0.5s CDM population window on zone-in, aura-only buffs (like RtB procs) have no CDM child yet, so the tick sets `_isPassive = true`. Once in combat, secret values prevent this flag from clearing, leaving the bar frozen as full for the entire fight.

## Test plan
- [ ] Log into an Outlaw Rogue alt with Roll the Bones active
- [ ] Verify buff bars show correct countdown timers
- [ ] Enter combat and confirm bars continue to update
- [ ] Switch between alts and verify no stale bar state persists