### PR TITLE
Fix TBB bars showing static icon/name instead of live aura data

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -1083,6 +1083,8 @@ function ns.BuildTrackedBuffBars()
             bar._blizzChild = nil
             bar._customStart = nil
             bar._activeDuration = nil
+            bar._lastLiveIcon = nil
+            bar._lastLiveName = nil
             bar:Hide()
         end
     end
@@ -1519,6 +1521,31 @@ function ns.UpdateTrackedBuffBarTimers()
                 if not bar:IsShown() then bar:Show() end
                 UpdateTBBStacks(bar, cfg)
 
+                -- Dynamically update icon from Blizzard CDM child's live texture
+                -- so aura-driven icon changes (e.g. Roll the Bones sub-buffs) are
+                -- reflected each tick instead of staying on the static config icon.
+                if blzChild and bar._icon and bar._icon._tex and blzChild.Icon and blzChild.Icon.GetTexture then
+                    local liveIconTex = blzChild.Icon:GetTexture()
+                    if liveIconTex and liveIconTex ~= bar._lastLiveIcon then
+                        bar._icon._tex:SetTexture(liveIconTex)
+                        bar._lastLiveIcon = liveIconTex
+                    end
+                end
+
+                -- Dynamically update name text from the actual active aura so
+                -- spells like Roll the Bones show the specific roll name instead
+                -- of the generic parent spell name.
+                if bar._nameText and bar._nameText:IsShown() and blzChild and blzChild.auraInstanceID then
+                    local nOk, ad = pcall(C_UnitAuras.GetAuraDataByAuraInstanceID, blzChild.auraDataUnit or "player", blzChild.auraInstanceID)
+                    if nOk and ad and ad.name then
+                        local isSecret = issecretvalue and issecretvalue(ad.name)
+                        if not isSecret and ad.name ~= bar._lastLiveName then
+                            bar._nameText:SetText(ad.name)
+                            bar._lastLiveName = ad.name
+                        end
+                    end
+                end
+
                 local activeDur = bar._activeDuration or cfg.customDuration
                 if activeDur and activeDur > 0 and bar._customStart then
                     local elapsed = now - bar._customStart
@@ -1706,6 +1733,8 @@ function ns.UpdateTrackedBuffBarTimers()
                 bar._customStart = nil
                 bar._activeDuration = nil
                 bar._isPassive = nil
+                bar._lastLiveIcon = nil
+                bar._lastLiveName = nil
                 if bar._cooldown then bar._cooldown:Clear() end
             end
         end


### PR DESCRIPTION

<img width="203" height="101" alt="image" src="https://github.com/user-attachments/assets/1ed76402-49d1-4311-801b-35971445f459" />
<img width="203" height="104" alt="image" src="https://github.com/user-attachments/assets/2494dda7-1add-4c6b-8ff6-d6d6bb7d9e23" />


## Summary

- Buff bars set their icon and name once at build time from the configured spellID, so spells like Roll the Bones that resolve to different sub-buffs at runtime would show the wrong icon and generic parent name instead of the actual active roll
- Mirror the CDM icon approach: read the Blizzard CDM child's live Icon texture and aura name each tick when the bar is active
- Clear cached values on hide and rebuild so re-activation always refreshes

## Test plan

- [ ] Track a Roll the Bones sub-buff → verify buff bar icon/name updates to match the actual active roll
- [ ] Track Roll the Bones (parent spell) → verify buff bar shows specific roll name, not generic "Roll the Bones"
- [ ] Verify no taint errors in combat (pcall + issecretvalue guards)
- [ ] Alt-switch with active Roll the Bones → verify bar clears and refreshes correctly