### PR TITLE
fix(cdm): hide tooltips during edit mode

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3179,6 +3179,14 @@ end
 --  When disabled, the OnUpdate is nil -- zero performance cost.
 -------------------------------------------------------------------------------
 local _cdmTooltipOnUpdate = function(self)
+    -- Suppress tooltips while in edit / unlock mode
+    if EllesmereUI and EllesmereUI._unlockActive then
+        if self._tooltipShown then
+            GameTooltip:Hide()
+            self._tooltipShown = false
+        end
+        return
+    end
     local over = self:IsMouseOver()
     if over and not self._tooltipShown then
         local sid = self._spellID


### PR DESCRIPTION
## Summary

- CDM icons show tooltips when hovered during edit/unlock mode — this is distracting when repositioning bars at the top of the screen
- Added an `_unlockActive` guard to `_cdmTooltipOnUpdate` to suppress tooltips while in edit mode
- Also cleans up any tooltip already showing if you enter edit mode mid-hover

## Test plan

- [ ] Enter edit mode, hover over CDM icons at top of screen — no tooltips should appear
- [ ] Exit edit mode, hover over CDM icons — tooltips should work as normal
- [ ] Enter edit mode while hovering a CDM icon — tooltip should disappear immediately