### PR TITLE
CDM: show buff duration on icon for charge spells tracked by buff-viewer

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3790,7 +3790,16 @@ local function UpdateCustomBarIcons(barKey)
                             auraHandled = false
                         else
                             local isChargeSid = _multiChargeSpells[resolvedID] == true
-                            if auraID and (not isChargeSid or isBuffBarForOverride) then
+                            -- Charge spells: prefer recharge timer unless the
+                            -- buff-viewer is actively tracking this spell.
+                            local chargeShowsAura = not isChargeSid or isBuffBarForOverride
+                            if isChargeSid and not isBuffBarForOverride then
+                                local bufCh = _tickBlizzBuffChildCache[resolvedID] or _tickBlizzBuffChildCache[spellID]
+                                if IsBufChildCooldownActive(bufCh) then
+                                    chargeShowsAura = true
+                                end
+                            end
+                            if auraID and chargeShowsAura then
                                 local ok, auraDurObj = pcall(C_UnitAuras.GetAuraDuration, auraUnit, auraID)
                                 if ok and auraDurObj then
                                     ourIcon._cooldown:Clear()
@@ -4147,11 +4156,19 @@ UpdateCDMBarIcons = function(barKey)
             local skipCDDisplay = false
 
             if isAura and activeAnim ~= "hideActive" then
-                local isChargeSid = resolvedSid and _multiChargeSpells[resolvedSid] == true
-                -- Buff bars always show buff duration; other bars skip aura duration for charge spells
                 local isBuffBar = (barKey == "buffs")
+                local isChargeSid = resolvedSid and _multiChargeSpells[resolvedSid] == true
+                -- Charge spells: prefer recharge timer unless the
+                -- buff-viewer is actively tracking this spell.
+                local chargeShowsAura = not isChargeSid or isBuffBar
+                if isChargeSid and not isBuffBar then
+                    local bufCh = _tickBlizzBuffChildCache[resolvedSid] or (spellID and _tickBlizzBuffChildCache[spellID])
+                    if IsBufChildCooldownActive(bufCh) then
+                        chargeShowsAura = true
+                    end
+                end
                 local auraID = blizzIcon.auraInstanceID
-                if auraID and (not isChargeSid or isBuffBar) then
+                if auraID and chargeShowsAura then
                     -- Show buff duration on the cooldown frame
                     local unit = blizzIcon.auraDataUnit or "player"
                     local ok, auraDurObj = pcall(C_UnitAuras.GetAuraDuration, unit, auraID)
@@ -4184,7 +4201,6 @@ UpdateCDMBarIcons = function(barKey)
                         end
                     end
                 else
-                    -- Charge spell on non-buff bar: mark active for glow, show charge CD
                     auraHandled = true
                 end
             end
@@ -4939,7 +4955,16 @@ local function UpdateTrackedBarIcons(barKey)
                             auraHandled = false
                         else
                             local isChargeSid = _multiChargeSpells[resolvedID] == true
-                            if auraID and (not isChargeSid or isBuffBarForOvr) then
+                            -- Charge spells: prefer recharge timer unless the
+                            -- buff-viewer is actively tracking this spell.
+                            local chargeShowsAura = not isChargeSid or isBuffBarForOvr
+                            if isChargeSid and not isBuffBarForOvr then
+                                local bufCh = _tickBlizzBuffChildCache[resolvedID] or _tickBlizzBuffChildCache[spellID]
+                                if IsBufChildCooldownActive(bufCh) then
+                                    chargeShowsAura = true
+                                end
+                            end
+                            if auraID and chargeShowsAura then
                                 local ok, auraDurObj = pcall(C_UnitAuras.GetAuraDuration, auraUnit, auraID)
                                 if ok and auraDurObj then
                                     ourIcon._cooldown:Clear()


### PR DESCRIPTION
Aimed shot
<img width="306" height="155" alt="image" src="https://github.com/user-attachments/assets/b7a4a3f7-8846-4efa-a2f7-bfbc5b3ead6a" />


## Summary

- Charge spells with an active aura (e.g. Zenith) were showing the charge recharge timer on CD/utility bar icons instead of the buff's remaining duration
- Now checks if Blizzard's buff-viewer is actively tracking the spell — if so, shows the buff duration on the icon, matching default Blizzard CDM behavior
- Charge spells not tracked by the buff-viewer (e.g. Riptide HoT) continue showing the recharge timer as before

## Test plan

- [ ] Zenith on a CD/utility bar: when active, icon should show buff remaining duration instead of charge recharge time
- [ ] Riptide on a CD/utility bar: should still show recharge timer when HoT is active (no regression)
- [ ] Buff-type bars: unchanged behavior for all charge spells
- [ ] Non-charge spells: unchanged behavior on all bar types