### PR TITLE
Add scale/resolution warning to preset imports

### DIFF
--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -3869,6 +3869,7 @@ initFrame:SetScript("OnEvent", function(self)
                         onApply = function()
                             if not spot.exportString then return end
                             local spotPayload = EllesmereUI.DecodeImportString(spot.exportString)
+                            local spotScaleWarn = BuildScaleWarning(spotPayload)
                             local ok, err, status = EllesmereUI.ImportProfile(spot.exportString, UniquePresetName("Weekly: " .. spot.name))
                             if ok and status == "spec_locked" then
                                 EllesmereUI:ShowInfoPopup({
@@ -3881,11 +3882,20 @@ initFrame:SetScript("OnEvent", function(self)
                                 ddLabel:SetText(EllesmereUI.GetActiveProfileName())
                                 if fontWillChange then
                                     EllesmereUI:ShowConfirmPopup({
-                                        title       = "Reload Required",
-                                        message     = "Font changed. A UI reload is needed to apply the new font.",
-                                        confirmText = "Reload Now",
-                                        cancelText  = "Later",
-                                        onConfirm   = function() ReloadUI() end,
+                                        title        = "Reload Required",
+                                        message      = "Font changed. A UI reload is needed to apply the new font.",
+                                        confirmText  = "Reload Now",
+                                        cancelText   = "Later",
+                                        scaleWarning = spotScaleWarn,
+                                        onConfirm    = function() ReloadUI() end,
+                                    })
+                                elseif spotScaleWarn then
+                                    EllesmereUI:ShowConfirmPopup({
+                                        title        = "Preset Applied",
+                                        message      = "\"Weekly: " .. spot.name .. "\" has been applied.",
+                                        confirmText  = "OK",
+                                        cancelText   = "Close",
+                                        scaleWarning = spotScaleWarn,
                                     })
                                 else
                                     EllesmereUI:RefreshPage()
@@ -3900,6 +3910,8 @@ initFrame:SetScript("OnEvent", function(self)
                         presetEntries[#presetEntries + 1] = {
                             label = p.name,
                             onApply = function()
+                                local pPayload = EllesmereUI.DecodeImportString(p.exportString)
+                                local pScaleWarn = BuildScaleWarning(pPayload)
                                 local ok, err, status = EllesmereUI.ImportProfile(p.exportString, UniquePresetName(p.name))
                                 if ok and status == "spec_locked" then
                                     EllesmereUI:ShowInfoPopup({
@@ -3907,17 +3919,25 @@ initFrame:SetScript("OnEvent", function(self)
                                         content = "Profile was saved but cannot be loaded because this spec has an assigned profile.",
                                     })
                                 elseif ok then
-                                    local pPayload = EllesmereUI.DecodeImportString(p.exportString)
                                     local fontWillChange = EllesmereUI.ProfileChangesFont(pPayload and pPayload.data)
                                     EllesmereUI.RefreshAllAddons()
                                     ddLabel:SetText(EllesmereUI.GetActiveProfileName())
                                     if fontWillChange then
                                         EllesmereUI:ShowConfirmPopup({
-                                            title       = "Reload Required",
-                                            message     = "Font changed. A UI reload is needed to apply the new font.",
-                                            confirmText = "Reload Now",
-                                            cancelText  = "Later",
-                                            onConfirm   = function() ReloadUI() end,
+                                            title        = "Reload Required",
+                                            message      = "Font changed. A UI reload is needed to apply the new font.",
+                                            confirmText  = "Reload Now",
+                                            cancelText   = "Later",
+                                            scaleWarning = pScaleWarn,
+                                            onConfirm    = function() ReloadUI() end,
+                                        })
+                                    elseif pScaleWarn then
+                                        EllesmereUI:ShowConfirmPopup({
+                                            title        = "Preset Applied",
+                                            message      = "\"" .. p.name .. "\" has been applied.",
+                                            confirmText  = "OK",
+                                            cancelText   = "Close",
+                                            scaleWarning = pScaleWarn,
                                         })
                                     else
                                         EllesmereUI:RefreshPage()


### PR DESCRIPTION
## Summary
- Wires up the existing `BuildScaleWarning` logic for Weekly Spotlight and Popular Presets
- Profile imports already showed this warning but presets skipped it entirely
- Moves Popular Presets `DecodeImportString` before `ImportProfile` (was redundantly decoding after)

## Changes
- Decode preset payload before import to check scale/resolution mismatch
- Pass `scaleWarning` to the existing "Reload Required" popup when font changes
- Show a "Preset Applied" popup with the warning when there's a mismatch but no font change