### PR TITLE
Fix color picker closing immediately on open

### DIFF
--- a/EllesmereUI_Widgets.lua
+++ b/EllesmereUI_Widgets.lua
@@ -1954,8 +1954,14 @@ local function BuildColorPickerPopup()
         end
     end)
     popup:HookScript("OnShow", function()
-        clickOffFrame:RegisterEvent("GLOBAL_MOUSE_DOWN")
-        clickOffFrame:Show()
+        -- Defer registration by one frame so the mouse-down that opened the
+        -- popup doesn't immediately trigger click-outside-to-close.
+        C_Timer.After(0, function()
+            if popup:IsShown() then
+                clickOffFrame:RegisterEvent("GLOBAL_MOUSE_DOWN")
+                clickOffFrame:Show()
+            end
+        end)
     end)
     popup:HookScript("OnHide", function()
         clickOffFrame:UnregisterEvent("GLOBAL_MOUSE_DOWN")


### PR DESCRIPTION
## Summary
- The GLOBAL_MOUSE_DOWN click-outside handler was being registered during the same mouse-down event that opened the popup
- Since the popup appears offset from the cursor, `IsMouseOver()` returned false and the handler immediately closed it
- Defers GLOBAL_MOUSE_DOWN registration by one frame so the opening click doesn't trigger click-outside-to-close

## Test plan
- [x] Open EUI settings, go to General > Extras
- [x] Set Character Crosshair to any thickness, click the color swatch — color picker should open and stay open
- [x] Change color, confirm it applies to the crosshair
- [x] Enable FPS Counter, click its color swatch — same behavior
- [x] Test color swatches on other pages (Resource Bars, Nameplates, etc.)
- [x] Verify click-outside-to-close still works (click away from the picker to dismiss)