### PR TITLE
Fix CDM GetTexture crash, buff viewer duplicates, and Balance Druid resource bars

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3696,12 +3696,16 @@ local function UpdateCustomBarIcons(barKey)
                      or _tickBlizzAllChildCache[resolvedID] or _tickBlizzAllChildCache[spellID])
                 or nil
             local blizzBuffChildCTexSet = false
-            if blizzBuffChildC and not overrideTex and blizzBuffChildC.Icon and blizzBuffChildC.Icon.GetTexture then
-                local childTexC = blizzBuffChildC.Icon:GetTexture()
-                if childTexC then
-                    ourIcon._tex:SetTexture(childTexC)
-                    ourIcon._lastTex = 0
-                    blizzBuffChildCTexSet = true
+            if blizzBuffChildC and not overrideTex and blizzBuffChildC.Icon then
+                local iwC = blizzBuffChildC.Icon
+                if not iwC.GetTexture and iwC.Icon then iwC = iwC.Icon end
+                if iwC.GetTexture then
+                    local childTexC = iwC:GetTexture()
+                    if childTexC then
+                        ourIcon._tex:SetTexture(childTexC)
+                        ourIcon._lastTex = 0
+                        blizzBuffChildCTexSet = true
+                    end
                 end
             end
             local effectiveTex = overrideTex or texID
@@ -4016,17 +4020,30 @@ UpdateCDMBarIcons = function(barKey)
     -- We do NOT filter by IsShown() because Blizzard children can briefly
     -- hide/show during state transitions (GCD end, cooldown start, etc.),
     -- which causes our icons to flicker.  Instead we check for a texture.
+    -- BuffIcon children have Icon as a Texture (with GetTexture).
+    -- BuffBar children wrap it: Icon is a Frame, Icon.Icon is the Texture.
+    -- Guard both paths to avoid "GetTexture is nil" errors on BuffBar children.
     -- Reuse buffer to avoid table allocation per tick
     local blizzIcons = _blizzIconsBuf
     local blizzCount = 0
+    -- Dedup by resolved spellID across primary + secondary viewers so that
+    -- spells appearing in both (e.g. Remorseless Winter) only show once.
+    -- Primary viewer children are collected first and win on conflict.
+    local _blizzIconSeen = {}
 
     do
         local children = { blizzFrame:GetChildren() }
         for i = 1, #children do
             local child = children[i]
-            if child and child.Icon and child.Icon:GetTexture() then
-                blizzCount = blizzCount + 1
-                blizzIcons[blizzCount] = child
+            if child and child.Icon then
+                local iw = child.Icon
+                if not iw.GetTexture and iw.Icon then iw = iw.Icon end
+                if iw.GetTexture and iw:GetTexture() then
+                    local sid = child._ecmeResolvedSid
+                    if sid and sid > 0 then _blizzIconSeen[sid] = true end
+                    blizzCount = blizzCount + 1
+                    blizzIcons[blizzCount] = child
+                end
             end
         end
     end
@@ -4039,9 +4056,17 @@ UpdateCDMBarIcons = function(barKey)
             local children = { secondaryFrame:GetChildren() }
             for i = 1, #children do
                 local child = children[i]
-                if child and child.Icon and child.Icon:GetTexture() then
-                    blizzCount = blizzCount + 1
-                    blizzIcons[blizzCount] = child
+                if child and child.Icon then
+                    local iw = child.Icon
+                    if not iw.GetTexture and iw.Icon then iw = iw.Icon end
+                    if iw.GetTexture and iw:GetTexture() then
+                        local sid = child._ecmeResolvedSid
+                        if not sid or sid <= 0 or not _blizzIconSeen[sid] then
+                            if sid and sid > 0 then _blizzIconSeen[sid] = true end
+                            blizzCount = blizzCount + 1
+                            blizzIcons[blizzCount] = child
+                        end
+                    end
                 end
             end
         end
@@ -4479,11 +4504,13 @@ local function SnapshotBlizzardCDM(barKey, barData)
     local filterPassives = (barKey ~= "buffs")
 
     local tracked = {}
+    local trackedSeen = {}  -- dedup by spellID across primary + secondary viewers
     for _, child in ipairs(blizzIcons) do
         local sid = ResolveChildSpellID(child)
-        if sid and sid > 0 then
+        if sid and sid > 0 and not trackedSeen[sid] then
             local skip = filterPassives and IsTrulyPassive(sid)
             if not skip then
+                trackedSeen[sid] = true
                 tracked[#tracked + 1] = sid
                 -- Store spellID -> cdID mapping for buff bars so the tick cache
                 -- can find the correct viewer child even when the cooldownInfo
@@ -7975,7 +8002,9 @@ SlashCmdList.CDMSTACKS = function()
 
         for i = 1, blizzFrame:GetNumChildren() do
             local child = select(i, blizzFrame:GetChildren())
-            if child and child.Icon and child.Icon:GetTexture() then
+            local dbgIw = child and child.Icon
+            if dbgIw and not dbgIw.GetTexture and dbgIw.Icon then dbgIw = dbgIw.Icon end
+            if dbgIw and dbgIw.GetTexture and dbgIw:GetTexture() then
                 local cdID = child.cooldownID
                 if not cdID and child.cooldownInfo then cdID = child.cooldownInfo.cooldownID end
 

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -88,6 +88,7 @@ initFrame:SetScript("OnEvent", function(self)
     IsBarTypeSecondary = function()
         local _, cf = UnitClass("player")
         local spec = GetSpecialization()
+        if cf == "DRUID" and spec == 1 then return true end -- Balance (Astral Power bar)
         if cf == "SHAMAN" and spec == 1 then return true end -- Elemental
         if cf == "PRIEST" and spec == 3 then return true end -- Shadow
         if cf == "MONK" and spec == 1 then return true end -- Brewmaster

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -129,6 +129,7 @@ local POWER_COLORS = {
     ["MAELSTROM_BAR"]    = { 0.00, 0.50, 1.00 },
     ["INSANITY_BAR"]     = { 0.40, 0.00, 0.80 },
     ["FOCUS_BAR"]        = { 0.77, 0.53, 0.24 },
+    ["LUNAR_POWER_BAR"]  = { 0.30, 0.52, 0.90 },
     ["TIP_OF_THE_SPEAR"] = { 0.67, 0.83, 0.45 },
     ["WHIRLWIND_STACKS"] = { 0.78, 0.61, 0.43 },
     ["BREWMASTER_STAGGER"] = { 0.52, 1.00, 0.52 },  -- green (light stagger default)
@@ -163,7 +164,9 @@ local function GetPrimaryPowerType()
     if classFile == "DRUID" then
         if form == 1 then return PT.ENERGY end
         if form == 5 then return PT.RAGE end
-        if spec == 1 then return PT.LUNAR_POWER end
+        -- Balance: Mana on the power bar; Astral Power is a class resource bar
+        -- (mirrors Shadow Priest / Elemental Shaman pattern)
+        if spec == 1 then return PT.MANA end
         return PT.MANA
     end
 
@@ -206,6 +209,12 @@ local function GetSecondaryResource()
     elseif classFile == "DRUID" and form == 1 then
         local mx = UnitPowerMax("player", PT.COMBO)
         return { power = PT.COMBO, max = (not issecretvalue or not issecretvalue(mx)) and mx or 5, type = "points" }
+    elseif classFile == "DRUID" and spec == 1 then
+        -- Balance: Astral Power as a class resource bar (like Elemental maelstrom)
+        local mx = UnitPowerMax("player", PT.LUNAR_POWER)
+        if issecretvalue and issecretvalue(mx) then mx = 100 end
+        if not mx or mx <= 0 then mx = 100 end
+        return { power = "LUNAR_POWER_BAR", max = mx, type = "bar" }
     elseif classFile == "MONK" and (spec == 3) then
         local mx = UnitPowerMax("player", PT.CHI)
         return { power = PT.CHI, max = (not issecretvalue or not issecretvalue(mx)) and mx or 5, type = "points" }
@@ -2049,6 +2058,11 @@ local function UpdateSecondaryResource()
                 maxC = UnitPowerMax("player", PT.FOCUS) or maxPts
                 if issecretvalue and issecretvalue(maxC) then maxC = maxPts end
                 if maxC <= 0 then maxC = maxPts end
+            elseif powerType == "LUNAR_POWER_BAR" then
+                cur = UnitPower("player", PT.LUNAR_POWER) or 0
+                maxC = UnitPowerMax("player", PT.LUNAR_POWER) or maxPts
+                if issecretvalue and issecretvalue(maxC) then maxC = maxPts end
+                if maxC <= 0 then maxC = maxPts end
             elseif powerType == "BREWMASTER_STAGGER" then
                 cur = UnitStagger("player") or 0
                 maxC = UnitHealthMax("player") or 1
@@ -2082,6 +2096,7 @@ local function UpdateSecondaryResource()
                     local pType = (powerType == "MAELSTROM_BAR") and PT.MAELSTROM
                                or (powerType == "INSANITY_BAR") and PT.INSANITY
                                or (powerType == "FOCUS_BAR") and PT.FOCUS
+                               or (powerType == "LUNAR_POWER_BAR") and PT.LUNAR_POWER
                                or nil
                     if sp.thresholdEnabled and pType and UnitPowerPercent then
                         -- Use ColorCurve + UnitPowerPercent: WoW evaluates the secret
@@ -2142,6 +2157,13 @@ local function UpdateSecondaryResource()
                         end
                     elseif powerType == "FOCUS_BAR" then
                         local pct = UnitPowerPercent and UnitPowerPercent("player", PT.FOCUS) or 0
+                        if not issecretvalue(pct) then
+                            secondaryFrame._countText:SetText(format("%d", pct) .. "%")
+                        else
+                            secondaryFrame._countText:SetText(tostring(cur))
+                        end
+                    elseif powerType == "LUNAR_POWER_BAR" then
+                        local pct = UnitPowerPercent and UnitPowerPercent("player", PT.LUNAR_POWER) or 0
                         if not issecretvalue(pct) then
                             secondaryFrame._countText:SetText(format("%d", pct) .. "%")
                         else


### PR DESCRIPTION
## Summary

- **CDM GetTexture crash** — BuffBar viewer children use `Icon` as a Frame wrapper, not a Texture widget. Calling `Icon:GetTexture()` directly caused a nil method error (reported 3301 occurrences). Now guards for both widget types, matching the pattern already used in the custom bar path.

- **Buff viewer duplicate icons** — Spells appearing in both `BuffIconCooldownViewer` and `BuffBarCooldownViewer` (e.g. Remorseless Winter) were merged into the icon list without dedup, causing them to display twice. Now deduplicates by resolved spellID across both viewers, with the primary viewer winning on conflict.

- **Balance Druid resource bars** — Astral Power was incorrectly mapped as the primary power bar, leaving no mana bar and an empty class resource slot. Now follows the same pattern as Shadow Priest and Elemental Shaman: Mana on the power bar, Astral Power as a class resource bar. The "Show Class Resource" toggle now correctly controls the Astral Power bar.

## Test plan

- [x] Play as Balance Druid — verify power bar shows mana, class resource bar shows Astral Power
- [x] Toggle "Show Class Resource" on/off — verify Astral Power bar appears/disappears
- [x] Shapeshift to cat/bear form — verify Energy/Rage + Combo Points still work correctly
- [x] Check CDM buff bar as Death Knight with Remorseless Winter active — should show once, not twice
- [x] Verify no GetTexture lua errors in CDM after /reload
- [x] Run `/cdmstacks` as any class — should not error