### PR TITLE
Add PvP Map support for Aura Buffs

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -120,7 +120,7 @@ local function InMythicPlusKey()
     return C_ChallengeMode and C_ChallengeMode.IsChallengeModeActive and C_ChallengeMode.IsChallengeModeActive()
 end
 
--- Mythic 0 dungeon or Mythic raid
+--Mythic 0 dungeon (party, normal difficulty 1) or Mythic raid (difficulty 16)
 local function InMythicZeroDungeonOrMythicRaid()
     if _cachedIType == "party" and (_cachedDiffID == 23 or _cachedDiffID == 8) then return true end
     if _cachedIType == "raid" and _cachedDiffID == 16 then return true end


### PR DESCRIPTION
Updated the logic and map table to include PvP Maps for AuraBuff tracking. (All maps are marked as Nil due to how blizzard has these as secret values) 

Also included flask of Horror for anyone wanting to use it for Honor farming.

Added in all raids as placeholders