### PR TITLE
Fix beacon reminder not showing in dungeons

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -2302,11 +2302,19 @@ local _beaconCachedInInstance = false
 local function BeaconUpdateInstanceCache()
     local _, instanceType, difficultyID = GetInstanceInfo()
     difficultyID = tonumber(difficultyID) or 0
-    if difficultyID == 0 then _beaconCachedInInstance = false; return end
     if C_Garrison and C_Garrison.IsOnGarrisonMap and C_Garrison.IsOnGarrisonMap() then
         _beaconCachedInInstance = false; return
     end
-    _beaconCachedInInstance = (instanceType == "party" or instanceType == "raid")
+    local isGroupInstance = (instanceType == "party" or instanceType == "raid")
+    if isGroupInstance and difficultyID == 0 then
+        C_Timer.After(1, function()
+            BeaconUpdateInstanceCache()
+            BeaconUpdateOverlayEvents()
+            BeaconRefresh()
+        end)
+        return
+    end
+    _beaconCachedInInstance = isGroupInstance and difficultyID > 0
 end
 
 local function BeaconUpdateOverlayEvents()


### PR DESCRIPTION
## Summary
- Beacon reminder was not appearing in dungeons due to a race condition in `BeaconUpdateInstanceCache()`
- `GetInstanceInfo()` can momentarily return `difficultyID=0` during zone-in before the server provides the real value
- The `difficultyID==0` guard is needed to exclude housing (which reports `instanceType="party"` with `difficultyID=0`), so it can't simply be removed
- Fix: when we see a group `instanceType` with `difficultyID=0`, retry after 1 second instead of immediately caching `false` — in a real dungeon the retry picks up the correct difficultyID, in housing it stays 0

## Test plan
- [ ] Enter a dungeon in a group — beacon reminder should appear when beacon is missing
- [ ] Enter player housing — beacon reminder should NOT appear
- [ ] `/reload` inside a dungeon — beacon reminder still works
- [ ] `/beacondebug` shows `cachedInInstance: true` and `overlayEventsRegistered: true` in dungeons