### PR TITLE
Fix for protected call to frame:EnableMouse if gaining an ExtraAbilityButton in combat

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -6570,7 +6570,7 @@ local function SetupBlizzardMovableFrame(barKey)
         -- Hook AddFrame so newly added ability buttons stay clickable.
         if ExtraAbilityContainer.AddFrame then
             hooksecurefunc(ExtraAbilityContainer, "AddFrame", function(_, frame)
-                if frame and frame.EnableMouse then
+                if frame and frame.EnableMouse and not InCombatLockdown() then
                     frame:EnableMouse(true)
                 end
             end)


### PR DESCRIPTION
Fix for the lua error below, happening when the ExtraAbilityButton appears while in combat (can replicate by going in the Silvermoon's delve an grabbing an extra ability item while in combat)

[ADDON_ACTION_BLOCKED] AddOn 'EllesmereUIActionBars' tried to call the protected function 'ExtraActionBarFrame:EnableMouse()'.
[!BugGrabber/BugGrabber.lua]:532: in function '?'
[!BugGrabber/BugGrabber.lua]:516: in function <!BugGrabber/BugGrabber.lua:516>
[C]: in function 'EnableMouse'
[EllesmereUIActionBars/EllesmereUIActionBars.lua]:6574: in function <...dOns/EllesmereUIActionBars/EllesmereUIActionBars.lua:6572>
[C]: in function 'AddFrame'
[Blizzard_ActionBar/Shared/ExtraActionBar.lua]:17: in function 'ExtraActionBar_Update'
[Blizzard_ActionBarController/ActionBarController.lua]:92: in function <...Blizzard_ActionBarController/ActionBarController.lua:55>