### PR TITLE
Enhance buff bar timers for placed-unit effects

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -156,22 +156,34 @@ function ns.HasBuffBars()
 end
 
 -- Listen for spell casts to start duration timers for popular buffs that
--- don't leave a detectable aura (e.g. potions). Sets bar._customStart so
--- the fill animation runs for customDuration seconds.
+-- don't leave a detectable aura (e.g. potions), and to reset placed-unit
+-- timers for effects like Consecration on successful recast.
 local tbbCastListener = CreateFrame("Frame")
 tbbCastListener:SetScript("OnEvent", function(_, _, _, _, spellID)
     if not spellID then return end
+    if not ECME or not ECME.db then return end
+
+    local now = GetTime()
+
+    -- Reset placed-unit timers on recast (e.g. Consecration)
+    if ns.PLACED_UNIT_DURATIONS and ns.PLACED_UNIT_DURATIONS[spellID] then
+        ns._placedUnitStartCache = ns._placedUnitStartCache or {}
+        ns._placedUnitStartCache[spellID] = now
+    end
+
+    -- Start custom-duration timers for popular tracked buffs that do not
+    -- leave a detectable aura duration object. (e.g Consecration, Efflo etc)
     local entry = _popularSpellIDMap[spellID]
     if not entry or not entry.customDuration then return end
-    if not ECME or not ECME.db then return end
+
     local tbb = ns.GetTrackedBuffBars()
     if not tbb or not tbb.bars then return end
-    local now = GetTime()
+
     for i, cfg in ipairs(tbb.bars) do
         if cfg.popularKey == entry.key then
             local bar = tbbFrames[i]
             if bar and bar._tbbReady then
-                bar._customStart    = now
+                bar._customStart = now
                 bar._activeDuration = entry.customDuration
             end
         end


### PR DESCRIPTION
Added logic to reset timers for placed-unit effects on recast and improved handling of custom-duration timers for popular buffs like Consecration/Efflo