### PR TITLE
Add Demo Lock guardian presets to Buff Bars

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -122,6 +122,39 @@ local TBB_POPULAR_BUFFS = {
         },
         customDuration = 10,
     },
+    ---------------------------------------------------------------------------
+    --  Demonology Warlock Guardians
+    --  These summons have no player aura; detection relies on the Blizzard CDM
+    --  active-state / buff-viewer fallback (see EllesmereUICooldownManager.lua).
+    ---------------------------------------------------------------------------
+    {
+        key            = "call_dreadstalkers",
+        name           = "Call Dreadstalkers",
+        icon           = 1378282,
+        spellIDs       = { 104316 },
+        customDuration = 12,
+    },
+    {
+        key            = "demonic_tyrant",
+        name           = "Summon Demonic Tyrant",
+        icon           = 2065628,
+        spellIDs       = { 265187 },
+        customDuration = 15,
+    },
+    {
+        key            = "summon_vilefiend",
+        name           = "Summon Vilefiend",
+        icon           = 1616211,
+        spellIDs       = { 264119 },
+        customDuration = 15,
+    },
+    {
+        key            = "grimoire_felguard",
+        name           = "Grimoire: Felguard",
+        icon           = 136216,
+        spellIDs       = { 111898 },
+        customDuration = 17,
+    },
 }
 ns.TBB_POPULAR_BUFFS = TBB_POPULAR_BUFFS
 


### PR DESCRIPTION
## Summary
- Adds Demonology Warlock guardian summons to `TBB_POPULAR_BUFFS` so they appear in the Buff Bar spell picker
- Covers: Call Dreadstalkers, Summon Demonic Tyrant, Summon Vilefiend, Grimoire: Felguard
- These summons have no player aura — detection uses the existing CDM active-state / buff-viewer fallback path (which already handles no-aura summons)

## Notes
- `customDuration` values are base durations and won't adjust for haste/talents
- Wild Imps excluded — would need count tracking which the current system doesn't support
- Icon fileIDs are best-effort; runtime resolves via `C_Spell.GetSpellInfo()` as fallback
- Needs in-game testing on a Demo Lock to confirm Blizzard's CDM surfaces these spells

## Test plan
- [ ] Log in on a Demonology Warlock
- [ ] Open Buff Bar config and verify the 4 new guardians appear in the popular buffs picker
- [ ] Add each guardian to a buff bar
- [ ] Cast each summon and verify the bar activates and counts down
- [ ] Verify bars deactivate when guardians expire