### PR TITLE
Add enemy level display on nameplates

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -16,6 +16,7 @@ local UnitCastingInfo, UnitChannelInfo = UnitCastingInfo, UnitChannelInfo
 local GetTime = GetTime
 local C_NamePlate = C_NamePlate
 local GetRaidTargetIndex, SetRaidTargetIconTexture = GetRaidTargetIndex, SetRaidTargetIconTexture
+local GetCreatureDifficultyColor = GetCreatureDifficultyColor
 local C_CVar, NamePlateConstants, Enum = C_CVar, NamePlateConstants, Enum
 local function GetFont()
     if EllesmereUI and EllesmereUI.GetFontPath then
@@ -420,13 +421,19 @@ local function GetLevelPrefix(unit)
     local db = EllesmereUINameplatesDB or defaults
     if not db.showLevel then return nil end
     local level = UnitLevel(unit)
-    local levelStr = level == -1 and "??" or tostring(level)
-    local lr, lg, lb
-    if db.levelDifficultyColor and GetCreatureDifficultyColor then
-        local color = GetCreatureDifficultyColor(level)
-        lr, lg, lb = color.r, color.g, color.b
+    if not level or level <= 0 and level ~= -1 then return nil end
+    local levelStr, lr, lg, lb
+    if level == -1 then
+        levelStr = "??"
+        lr, lg, lb = 1, 0, 0
     else
-        lr, lg, lb = 1, 0.82, 0
+        levelStr = tostring(level)
+        if db.levelDifficultyColor and GetCreatureDifficultyColor then
+            local color = GetCreatureDifficultyColor(level)
+            lr, lg, lb = color.r, color.g, color.b
+        else
+            lr, lg, lb = 1, 0.82, 0
+        end
     end
     return string.format("|cff%02x%02x%02x%s|r", lr * 255, lg * 255, lb * 255, levelStr)
 end
@@ -3272,9 +3279,10 @@ end
 function NameplateFrame:UpdateNameWidth()
     local barW = GetHealthBarWidth()
     local nameSlot = FindSlotForElement("enemyName")
+    local levelExtra = ((EllesmereUINameplatesDB or defaults).showLevel) and 25 or 0
     if nameSlot == "textSlotTop" then
         -- Above the bar: full bar width minus raid marker if shown
-        local nameW = barW
+        local nameW = barW + levelExtra
         local rmPos = GetRaidMarkerPos()
         if rmPos ~= "none" and self.raidFrame:IsShown() then
             nameW = nameW - 2 * (GetRaidMarkerSize() - 2) - 7

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -94,6 +94,8 @@ local defaults = {
     textSlotRight = "healthPercent",
     textSlotLeft = "none",
     textSlotCenter = "none",
+    showLevel = true,
+    levelDifficultyColor = true,
     showTargetArrows = false,
     targetArrowScale = 1.0,
     showClassPower = false,
@@ -411,6 +413,22 @@ local function FormatCombinedHealth(element, pctText, numText)
     elseif element == "healthNumPct" then return numText .. " | " .. pctText
     end
     return ""
+end
+
+-- Build a colored level prefix string for a unit, or nil if disabled.
+local function GetLevelPrefix(unit)
+    local db = EllesmereUINameplatesDB or defaults
+    if not db.showLevel then return nil end
+    local level = UnitLevel(unit)
+    local levelStr = level == -1 and "??" or tostring(level)
+    local lr, lg, lb
+    if db.levelDifficultyColor and GetCreatureDifficultyColor then
+        local color = GetCreatureDifficultyColor(level)
+        lr, lg, lb = color.r, color.g, color.b
+    else
+        lr, lg, lb = 1, 0.82, 0
+    end
+    return string.format("|cff%02x%02x%02x%s|r", lr * 255, lg * 255, lb * 255, levelStr)
 end
 
 -- Estimate pixel width of health text for a given element type.
@@ -3199,6 +3217,10 @@ function NameplateFrame:UpdateName()
     end
     local name = UnitName(unit)
     if type(name) == "string" then
+        local levelPrefix = GetLevelPrefix(unit)
+        if levelPrefix then
+            name = levelPrefix .. "  " .. name
+        end
         self.name:SetText(name)
     end
 end
@@ -4494,6 +4516,7 @@ do
 
     -- Store preset keys so the login handler can use them (set once, never changes)
     ns._displayPresetKeys = {
+        "showLevel", "levelDifficultyColor",
         "borderStyle", "borderColor", "targetGlowStyle", "showTargetArrows",
         "showClassPower", "classPowerPos", "classPowerYOffset", "classPowerXOffset", "classPowerScale",
         "classPowerClassColors", "classPowerCustomColor", "classPowerGap",


### PR DESCRIPTION
## Summary
- Show unit level as a colored prefix before the enemy name on nameplates
- Uses `GetCreatureDifficultyColor` for difficulty-based coloring (gray/green/yellow/orange/red)
- Bosses (level -1) display as "??" in red
- Two new settings: `showLevel` (default: true), `levelDifficultyColor` (default: true)

## Implementation
- New `GetLevelPrefix(unit)` helper that builds a WoW color-coded string (`|cffRRGGBB`)
- Integrated into `UpdateName()` — level is prepended to the name text
- Both settings added to `_displayPresetKeys` for per-spec preset support
- Zero new UI elements — uses existing FontString with inline color codes

## Test plan
- [x] Verify level shows before enemy names on hostile nameplates
- [x] Verify difficulty colors match expected values (gray → green → yellow → orange → red)
- [x] Verify bosses show "??" in red
- [x] Verify `showLevel = false` hides the level prefix
- [x] Verify `levelDifficultyColor = false` falls back to gold color
- [x] Verify name truncation is acceptable with level prefix on narrow bars