### PR TITLE
Add grow direction picker for CDM bars

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -5202,7 +5202,7 @@ initFrame:SetScript("OnEvent", function(self)
             end
             local spacing  = bd.spacing or 2
             local zoom     = bd.iconZoom or 0.08
-            local grow     = bd.growDirection or "RIGHT"
+            local grow     = "RIGHT"  -- preview always horizontal to save space
             local numRows  = bd.numRows or 1
             if numRows < 1 then numRows = 1 end
 


### PR DESCRIPTION
## Summary
- Replaces the **Vertical Orientation** toggle with a **Grow Direction** dropdown on CDM bars
- Users can now choose between **Horizontal** or **Vertical** growth with clearer labelling
- Preview remains horizontal layout

## Details
The old binary toggle ("Vertical Orientation") was unclear — this replaces it with a dropdown labelled "Grow Direction" with Horizontal/Vertical options. Same underlying behaviour, better UX.

Backwards compatible — existing profiles with `verticalOrientation` saved will read correctly, and the setter keeps both fields in sync.

## Test plan
- [ ] Open CDM options for any bar (cooldowns, utility, buffs)
- [ ] Verify "Grow Direction" dropdown appears where "Vertical Orientation" toggle was
- [ ] Select Horizontal — icons should flow left to right
- [ ] Select Vertical — icons should flow top to bottom
- [ ] Load an existing profile that had Vertical Orientation enabled — should show "Vertical" selected