### PR TITLE
Add 4-way grow direction for CDM bars

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -6063,8 +6063,8 @@ initFrame:SetScript("OnEvent", function(self)
                   ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
               end },
             { type="dropdown", text="Grow Direction",
-              values={ RIGHT="Horizontal", DOWN="Vertical" },
-              order={ "RIGHT", "DOWN" },
+              values={ RIGHT="Right", LEFT="Left", DOWN="Down", UP="Up" },
+              order={ "RIGHT", "LEFT", "DOWN", "UP" },
               getValue=function()
                   local bd = BD()
                   if bd.growDirection then return bd.growDirection end
@@ -6072,7 +6072,7 @@ initFrame:SetScript("OnEvent", function(self)
               end,
               setValue=function(v)
                   BD().growDirection = v
-                  BD().verticalOrientation = (v == "DOWN")
+                  BD().verticalOrientation = (v == "DOWN" or v == "UP")
                   ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
               end });  y = y - h
 


### PR DESCRIPTION
## Summary
- Expands the **Grow Direction** dropdown from 2 options (Horizontal/Vertical) to all 4 directions: **Right, Left, Down, Up**
- Users can now control exactly which way CDM bar icons grow
- Backwards compatible — existing profiles with `verticalOrientation` or `growDirection` saved will read correctly

## Test plan
- [ ] Open CDM options for any bar (cooldowns, utility, buffs)
- [ ] Verify "Grow Direction" dropdown shows Right, Left, Down, Up
- [ ] Select each direction — icons should grow in the chosen direction
- [ ] Load an existing profile that had Vertical Orientation enabled — should show "Down" selected