### PR TITLE
Prevent a call to a protected function to GameMenuFrame:SetHeight()

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -6590,6 +6590,12 @@ initFrame:SetScript("OnEvent", function(self, event)
 
         local _gameMenuBaseHeight = nil
         hooksecurefunc(GameMenuFrame, "Layout", function()
+            if InCombatLockdown() then
+                btn:Hide()
+                return
+            end
+            btn:Show()
+
             local eg = ELLESMERE_GREEN
             local hex = string.format("|cff%02x%02x%02x", (eg.r or 0.05) * 255, (eg.g or 0.82) * 255, (eg.b or 0.62) * 255)
             btn:SetText(hex .. "Ellesmere|r|cffffffff" .. "UI|r")


### PR DESCRIPTION
Now hiding EllesmereUI button in Game Menu if in combat lockdown (to prevent a call to a protected function to GameMenuFrame:SetHeight()).

The BugSack report:
> [ADDON_ACTION_BLOCKED] AddOn 'EllesmereUI' tried to call the protected function 'GameMenuFrame:SetHeight()'.
> [!BugGrabber/BugGrabber.lua]:532: in function '?'
> [!BugGrabber/BugGrabber.lua]:516: in function <!BugGrabber/BugGrabber.lua:516>
> [C]: in function 'SetHeight'
> [EllesmereUI/EllesmereUI.lua]:6634: in function <EllesmereUI/EllesmereUI.lua:6592>
> [C]: in function 'Layout'
> [Blizzard_SharedXML/LayoutFrame.lua]:80: in function <Blizzard_SharedXML/LayoutFrame.lua:78>

This BugSack report was reported in the bug report "Buffbars dont find fixed anchor or smthg" (https://discord.com/channels/585577383847788554/1484220166718886119) but appears to be unrelated to the bug the user experienced.

To replicate the bug (before the fix):
1. Open Game Menu (out of combat)
2. Enter combat
3. Open Game Menu (while in combat)

EllesmereUI will be there but the Game Menu frame will have the default height. 
Given EllesmereUI Options cannot be opened while in combat anyway, I went with hiding the button (and leaving the Game Menu frame in its original state, without the extra space for the addon's button)