### PR TITLE
Add action bar 1 page cycling

### DIFF
--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -3013,6 +3013,18 @@ initFrame:SetScript("OnEvent", function(self)
         if SelectedKey() == "MainBar" then
             _, h = W:SectionHeader(parent, "PAGING", y);  y = y - h
 
+            -- Row: Show Paging Arrows toggle
+            _, h = W:DualRow(parent, y,
+                { type="toggle", text="Show Paging Arrows",
+                  getValue=function() return SGet("showPagingArrows") or false end,
+                  setValue=function(v)
+                      SSet("showPagingArrows", v, function(k)
+                          if ns.LayoutPagingFrame then ns.LayoutPagingFrame() end
+                      end)
+                  end,
+                  tooltip="Show page up/down arrows next to Action Bar 1 for cycling through action bar pages 1-6." },
+                nil);  y = y - h
+
             local function BuildPagingKeybindRow(par, yOff, labelText, dbKey, bindBtnName)
                 local ROW_H = 50
                 local SIDE_PAD = 20

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -249,6 +249,7 @@ for _, info in ipairs(BAR_CONFIG) do
         overrideNumRows  = nil,
         growDirection    = "up",
         alwaysShowButtons = true,
+        showPagingArrows = false,
         bgEnabled = false,
         bgColor = { r = 0, g = 0, b = 0, a = 0.5 },
         outOfRangeColoring = false,
@@ -1494,7 +1495,7 @@ local function LayoutPagingFrame()
     local s = EAB and EAB.db and EAB.db.profile and EAB.db.profile.bars and EAB.db.profile.bars["MainBar"]
     if not s then f:Hide(); return end
 
-    if s.alwaysHidden or s.enabled == false then
+    if s.alwaysHidden or s.enabled == false or not s.showPagingArrows then
         f:Hide()
         return
     end
@@ -1541,6 +1542,7 @@ local function LayoutPagingFrame()
 
     f:Show()
 end
+ns.LayoutPagingFrame = LayoutPagingFrame
 
 -------------------------------------------------------------------------------
 --  Secure Bar Frame Creation


### PR DESCRIPTION
## Summary
- Adds page up/down arrow buttons with page number indicator to Action Bar 1
- Arrows cycle through action bar pages 1-6 with wrap-around
- Paging arrows toggled via "Show Paging Arrows" setting in Action Bar 1 options (off by default)
- Page Up / Page Down keybinds configurable in the PAGING section of Action Bar 1 options
- Paging frame respects bar 1 visibility settings (mouseover fade, combat show/hide)
- Hides automatically during vehicle/override bar states
- Supports both horizontal and vertical bar orientations

## How it works
- Uses `[bar:N]` macro conditionals in the existing state driver so `ChangeActionBarPage()` integrates with the existing paging system
- Class forms and dragonriding take precedence over manual page selection
- Keybinds use `SetOverrideBindingClick` pattern (same as Party Mode keybinds)

## Test plan
- [ ] Enable "Show Paging Arrows" in Action Bar 1 settings
- [ ] Click arrows to cycle pages 1-6, verify wrap-around
- [ ] Set keybinds for page up/down, verify they work
- [ ] Test mouseover fade syncs with bar 1
- [ ] Test combat show/hide syncs with bar 1  
- [ ] Enter vehicle — arrows should hide
- [ ] Switch to vertical orientation — arrows reposition
- [ ] Reload UI — keybinds persist