### PR TITLE
fixed: Disable Bar Opacity slider when Dark Mode is enabled in UnitFrames settings

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -3664,12 +3664,14 @@ initFrame:SetScript("OnEvent", function(self)
                       return SVal("healthClassColored", true) and 1 or 0.3
                   end },
               } },
-            { type="slider", text="Bar Opacity", min=10, max=100, step=1,
-              getValue=function() return SVal("healthBarOpacity", 90) end,
-              setValue=function(v)
-                  SSet("healthBarOpacity", v)
-                  UpdatePreview()
-              end });  y = y - h
+                        { type="slider", text="Bar Opacity", min=10, max=100, step=1,
+                            disabled=function() return db.profile.darkTheme end,
+                              disabledTooltip="Bar Opacity is disabled in Dark Mode.",
+                            getValue=function() return SVal("healthBarOpacity", 90) end,
+                            setValue=function(v)
+                                    SSet("healthBarOpacity", v)
+                                    UpdatePreview()
+                            end });  y = y - h
         -- Sync icons: Bar Color (left) and Bar Opacity (right)
         do
             local rgn = sharedHealthColorRow._leftRegion


### PR DESCRIPTION
In dark mode, the opacity option is now disabled and grayed out.

Tests have shown that the display is barely visible in dark mode with opacity enabled, and therefore pointless.