### PR TITLE
Quick fix for unknown spells showing in custom CDM non-misc bars

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3652,7 +3652,13 @@ local function UpdateCustomBarIcons(barKey)
     local icons = cdmBarIcons[barKey]
 
     -- Build spell list with render-time racial substitution
-    local spells = rawSpells
+    local spells = {}
+    for _, spellID in pairs(rawSpells) do
+        if (barData.barType == "misc") or C_SpellBook.IsSpellInSpellBook(spellID) then
+            spells[#spells+1] = spellID
+        end
+    end
+
     if _myRacials[1] then
         local needsSub = false
         for _, sid in ipairs(rawSpells) do


### PR DESCRIPTION
Quick/partial fix for [WWWhen swapping talent tree (Es M+ to Raid) CDM is store talent that aren't available](https://discord.com/channels/585577383847788554/1484489920839028810)

As far as I was able to replicate this bug, this only occurred for the custom bars, both in preview and live.
For the moment, I was only able to fix for the live version and my fix may be too "quick and dirty" as I am still learning about WoW API and EllesmereUI's API.