### PR TITLE
fix(UnitFrames): add cast bar anchor selection with X/Y offset for ta…

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -5007,6 +5007,33 @@ initFrame:SetScript("OnEvent", function(self)
             })
         end
 
+        -- Row 3: Cast Bar Anchor (target/focus only)
+        local cbAnchorValues = { ["auto"]="Auto", ["health"]="Health Bar", ["power"]="Power Bar", ["text"]="Text Bar" }
+        local cbAnchorOrder = { "auto", "health", "power", "text" }
+        local cbAnchorRow
+        cbAnchorRow, h = W:DualRow(parent, y,
+            { type="dropdown", text="Anchor To", values=cbAnchorValues, order=cbAnchorOrder,
+              getValue=function() return UNIT_DB_MAP[selectedUnit]().castbarAnchor or "auto" end,
+              setValue=function(v) UNIT_DB_MAP[selectedUnit]().castbarAnchor = v; ReloadAndUpdate(); UpdatePreview() end },
+            {});  y = y - h
+
+        -- Cog on Anchor To for X/Y offsets
+        do
+            local anchorRgn = cbAnchorRow._leftRegion
+            local _, cbAnchorCogShow = EllesmereUI.BuildCogPopup({
+                title = "Cast Bar Anchor Offsets",
+                rows = {
+                    { type="slider", label="X", min=-200, max=200, step=1,
+                      get=function() return UNIT_DB_MAP[selectedUnit]().castbarAnchorX or 0 end,
+                      set=function(v) UNIT_DB_MAP[selectedUnit]().castbarAnchorX = v; ReloadAndUpdate(); UpdatePreview() end },
+                    { type="slider", label="Y", min=-200, max=200, step=1,
+                      get=function() return UNIT_DB_MAP[selectedUnit]().castbarAnchorY or 0 end,
+                      set=function(v) UNIT_DB_MAP[selectedUnit]().castbarAnchorY = v; ReloadAndUpdate(); UpdatePreview() end },
+                },
+            })
+            MakeCogBtn(anchorRgn, cbAnchorCogShow, nil, EllesmereUI.DIRECTIONS_ICON)
+        end
+
         _, h = W:Spacer(parent, y, 20); y = y - h
 
         -------------------------------------------------------------------

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -172,6 +172,9 @@ local defaults = {
             healthClassColored = true,
             customBgColor = { r = 0.067, g = 0.067, b = 0.067 },
             castbarHeight = 14,
+            castbarAnchor = "auto",
+            castbarAnchorX = 0,
+            castbarAnchorY = 0,
             showCastbar = true,
             showCastIcon = true,
             castbarHideWhenInactive = false,
@@ -288,6 +291,9 @@ local defaults = {
             powerPercentTextPowerColor = false,
             healthClassColored = true,
             castbarHeight = 14,
+            castbarAnchor = "auto",
+            castbarAnchorX = 0,
+            castbarAnchorY = 0,
             maxBuffs = 4,
             maxDebuffs = 20,
             healthDisplay = "both",
@@ -4775,9 +4781,14 @@ local function ReloadFrames()
                                 castbarBg:ClearAllPoints()
                                 local tBtbPos = settings.btbPosition or "bottom"
                                 local btbVisible = (settings.bottomTextBar and tBtbPos == "bottom" and frame.BottomTextBar and frame.BottomTextBar:IsShown())
-                                local cbAnchor = btbVisible and frame.BottomTextBar or tPpBtbAnchor
-                                local cbXOff = btbVisible and 0 or castBarOffset
-                                castbarBg:SetPoint("TOP", cbAnchor, "BOTTOM", cbXOff, 0)
+                                local cbAnchorMode = settings.castbarAnchor or "auto"
+                                local cbAnchor
+                                if cbAnchorMode == "health" then cbAnchor = frame.Health
+                                elseif cbAnchorMode == "power" and frame.Power and frame.Power:IsShown() then cbAnchor = frame.Power
+                                elseif cbAnchorMode == "text" and frame.BottomTextBar and frame.BottomTextBar:IsShown() then cbAnchor = frame.BottomTextBar
+                                else cbAnchor = btbVisible and frame.BottomTextBar or tPpBtbAnchor end
+                                local cbXOff = (cbAnchor == frame.BottomTextBar) and 0 or castBarOffset
+                                castbarBg:SetPoint("TOP", cbAnchor, "BOTTOM", cbXOff + (settings.castbarAnchorX or 0), settings.castbarAnchorY or 0)
                                 -- Respect hide-while-not-casting: only show bg if inactive hiding is off or cast is active
                                 if settings.castbarHideWhenInactive and not frame.Castbar:IsShown() then
                                     castbarBg:Hide()
@@ -5103,9 +5114,14 @@ local function ReloadFrames()
                             castbarBg:ClearAllPoints()
                             local fBtbPos2 = settings.btbPosition or "bottom"
                             local btbVisible = (settings.bottomTextBar and fBtbPos2 == "bottom" and frame.BottomTextBar and frame.BottomTextBar:IsShown())
-                            local cbAnchor = btbVisible and frame.BottomTextBar or fPpBtbAnchor
-                            local cbXOff = btbVisible and 0 or castBarOffset
-                            castbarBg:SetPoint("TOP", cbAnchor, "BOTTOM", cbXOff, 0)
+                            local cbAnchorMode = settings.castbarAnchor or "auto"
+                            local cbAnchor
+                            if cbAnchorMode == "health" then cbAnchor = frame.Health
+                            elseif cbAnchorMode == "power" and frame.Power and frame.Power:IsShown() then cbAnchor = frame.Power
+                            elseif cbAnchorMode == "text" and frame.BottomTextBar and frame.BottomTextBar:IsShown() then cbAnchor = frame.BottomTextBar
+                            else cbAnchor = btbVisible and frame.BottomTextBar or fPpBtbAnchor end
+                            local cbXOff = (cbAnchor == frame.BottomTextBar) and 0 or castBarOffset
+                            castbarBg:SetPoint("TOP", cbAnchor, "BOTTOM", cbXOff + (settings.castbarAnchorX or 0), settings.castbarAnchorY or 0)
                             -- Respect hide-while-not-casting: only show bg if inactive hiding is off or cast is active
                             if settings.castbarHideWhenInactive and not frame.Castbar:IsShown() then
                                 castbarBg:Hide()


### PR DESCRIPTION
## Summary

- Adds an "Anchor To" dropdown to Cast Bar settings for target/focus frames
- Options: Auto (original behavior), Health Bar, Power Bar, Text Bar
- Includes a cog popup with X/Y offset sliders for fine-tuning position

## Changes

- `EllesmereUIUnitFrames.lua`: Added `castbarAnchor`, `castbarAnchorX`, `castbarAnchorY` defaults and anchor logic for target + focus
- `EUI_UnitFrames_Options.lua`: Added DualRow dropdown + cog popup using existing BuildCogPopup/MakeCogBtn helpers

https://github.com/user-attachments/assets/73a2722d-4794-47e1-8f6e-da227dce3a0e

