### PR TITLE
feat(CDM): add pandemic glow to CDM icons and tracking bars

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -157,6 +157,296 @@ initFrame:SetScript("OnEvent", function(self)
         return labels, order
     end
 
+    ---------------------------------------------------------------------------
+    --  Pandemic Glow shared helpers (used by CDM Bars + TBB options pages)
+    ---------------------------------------------------------------------------
+
+    -- Pandemic glow style dropdown values (excludes ShapeGlow, adds "None")
+    local PAN_GLOW_VALUES = { [0] = "None" }
+    local PAN_GLOW_ORDER  = { 0 }
+    if ns.GLOW_STYLES then
+        for i, entry in ipairs(ns.GLOW_STYLES) do
+            if not entry.shapeGlow then
+                PAN_GLOW_VALUES[i] = entry.name
+                PAN_GLOW_ORDER[#PAN_GLOW_ORDER + 1] = i
+            end
+        end
+    end
+
+    -- Get nameplate profile from central DB
+    local function GetNPProfile()
+        if not EllesmereUIDB or not EllesmereUIDB.profiles then return nil end
+        local pName = EllesmereUIDB.activeProfile or "Default"
+        local prof = EllesmereUIDB.profiles[pName]
+        return prof and prof.addons and prof.addons.EllesmereUINameplates
+    end
+
+    -- Copy pandemic fields from one table to another
+    local function CopyPandemicFields(src, dst)
+        dst.pandemicGlow = src.pandemicGlow
+        dst.pandemicGlowStyle = src.pandemicGlowStyle
+        dst.pandemicGlowColor = src.pandemicGlowColor and CopyTable(src.pandemicGlowColor) or nil
+        dst.pandemicGlowLines = src.pandemicGlowLines
+        dst.pandemicGlowThickness = src.pandemicGlowThickness
+        dst.pandemicGlowSpeed = src.pandemicGlowSpeed
+    end
+
+    -- Compare pandemic fields between two tables
+    local function PandemicFieldsMatch(a, b)
+        if (a.pandemicGlow or false) ~= (b.pandemicGlow or false) then return false end
+        if (a.pandemicGlowStyle or 1) ~= (b.pandemicGlowStyle or 1) then return false end
+        local ac = a.pandemicGlowColor or {}
+        local bc = b.pandemicGlowColor or {}
+        if (ac.r or 1) ~= (bc.r or 1) or (ac.g or 1) ~= (bc.g or 1) or (ac.b or 0) ~= (bc.b or 0) then return false end
+        if (a.pandemicGlowLines or 8) ~= (b.pandemicGlowLines or 8) then return false end
+        if (a.pandemicGlowThickness or 2) ~= (b.pandemicGlowThickness or 2) then return false end
+        if (a.pandemicGlowSpeed or 4) ~= (b.pandemicGlowSpeed or 4) then return false end
+        return true
+    end
+
+    -- Apply pandemic settings to all targets (NP, CDM bars, TBB bars) except skipKey
+    local function ApplyPandemicToAll(src, skipCdmKey, skipTbbIdx)
+        local np = GetNPProfile()
+        if np then CopyPandemicFields(src, np) end
+        local pdb = DB()
+        if pdb and pdb.cdmBars and pdb.cdmBars.bars then
+            for _, b in ipairs(pdb.cdmBars.bars) do
+                if b.key ~= skipCdmKey then CopyPandemicFields(src, b) end
+            end
+        end
+        local tbb = ns.GetTrackedBuffBars and ns.GetTrackedBuffBars()
+        if tbb and tbb.bars then
+            for i, tb in ipairs(tbb.bars) do
+                if i ~= skipTbbIdx then CopyPandemicFields(src, tb) end
+            end
+        end
+        ns.BuildAllCDMBars()
+        if ns.BuildTrackedBuffBars then ns.BuildTrackedBuffBars() end
+        if _G._ENP_RefreshAllSettings then _G._ENP_RefreshAllSettings() end
+        Refresh()
+    end
+
+    -- Check if pandemic settings are synced across all targets
+    local function IsPandemicSyncedEverywhere(src, skipCdmKey, skipTbbIdx)
+        local np = GetNPProfile()
+        if np and not PandemicFieldsMatch(src, np) then return false end
+        local pdb = DB()
+        if pdb and pdb.cdmBars and pdb.cdmBars.bars then
+            for _, b in ipairs(pdb.cdmBars.bars) do
+                if b.key ~= skipCdmKey and not PandemicFieldsMatch(src, b) then return false end
+            end
+        end
+        local tbb = ns.GetTrackedBuffBars and ns.GetTrackedBuffBars()
+        if tbb and tbb.bars then
+            for i, tb in ipairs(tbb.bars) do
+                if i ~= skipTbbIdx and not PandemicFieldsMatch(src, tb) then return false end
+            end
+        end
+        return true
+    end
+
+    -- Create a pandemic glow preview icon in a DualRow right-half
+    local function BuildPandemicPreview(row, isOffFn, getDataFn)
+        local SIDE_PAD = 20
+        local iconSize = 36
+        local iconFrame = CreateFrame("Frame", nil, row)
+        PP.Size(iconFrame, iconSize, iconSize)
+        PP.Point(iconFrame, "RIGHT", row, "RIGHT", -SIDE_PAD, 0)
+
+        local iconTex = iconFrame:CreateTexture(nil, "ARTWORK")
+        iconTex:SetAllPoints()
+        iconTex:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+        iconTex:SetTexture(136197)
+
+        local onePx = PP.Scale(1)
+        for _, info in ipairs({
+            {"TOPLEFT", "TOPRIGHT", true}, {"BOTTOMLEFT", "BOTTOMRIGHT", true},
+            {"TOPLEFT", "BOTTOMLEFT", false}, {"TOPRIGHT", "BOTTOMRIGHT", false},
+        }) do
+            local t = iconFrame:CreateTexture(nil, "OVERLAY", nil, 7)
+            t:SetColorTexture(0, 0, 0, 1)
+            if t.SetSnapToPixelGrid then t:SetSnapToPixelGrid(false); t:SetTexelSnappingBias(0) end
+            PP.Point(t, info[1], iconFrame, info[1], 0, 0)
+            PP.Point(t, info[2], iconFrame, info[2], 0, 0)
+            if info[3] then t:SetHeight(onePx) else t:SetWidth(onePx) end
+        end
+
+        local glowOvr = CreateFrame("Frame", nil, iconFrame)
+        glowOvr:SetAllPoints(iconFrame)
+        glowOvr:SetFrameLevel(iconFrame:GetFrameLevel() + 2)
+        glowOvr:EnableMouse(false)
+
+        local function RefreshPreview()
+            EllesmereUI.Glows.StopAllGlows(glowOvr)
+            if isOffFn() then
+                iconFrame:SetAlpha(0.3)
+                return
+            end
+            iconFrame:SetAlpha(1)
+            local bd = getDataFn()
+            if not bd then return end
+            local style = bd.pandemicGlowStyle or 1
+            local c = bd.pandemicGlowColor or { r = 1, g = 1, b = 0 }
+            ns.StartNativeGlow(glowOvr, style, c.r or 1, c.g or 1, c.b or 0)
+        end
+        RefreshPreview()
+
+        local previewLabel = ({ row._rightRegion:GetRegions() })[1]
+        EllesmereUI.RegisterWidgetRefresh(function()
+            local off = isOffFn()
+            iconFrame:SetAlpha(off and 0.3 or 1)
+            if previewLabel and previewLabel.SetAlpha then
+                previewLabel:SetAlpha(off and 0.3 or 1)
+            end
+            RefreshPreview()
+        end)
+
+        row._refreshPreview = RefreshPreview
+    end
+
+    -- Create a pixel glow cog popup for pandemic settings
+    -- getDataFn: returns the settings table; refreshFn: called after changes
+    local _sharedPgPopup, _sharedPgPopupOwner
+    local function ShowPandemicPixelGlowPopup(anchorBtn, getDataFn, refreshFn)
+        if not _sharedPgPopup then
+            local SolidTex   = EllesmereUI.SolidTex
+            local MakeBorder = EllesmereUI.MakeBorder
+            local MakeFont   = EllesmereUI.MakeFont
+            local BuildSliderCore = EllesmereUI.BuildSliderCore
+            local BORDER_COLOR   = EllesmereUI.BORDER_COLOR
+
+            local SIDE_PAD = 14; local TOP_PAD = 14
+            local TITLE_H = 11; local TITLE_GAP = 10; local GAP = 10
+            local ROW_H = 24; local POPUP_INPUT_A = 0.55
+            local INPUT_W = 34; local SLIDER_INPUT_GAP = 8; local LABEL_SLIDER_GAP = 12
+            local MIN_POPUP_W = 180
+
+            local totalH = TOP_PAD + TITLE_H + TITLE_GAP + GAP + ROW_H + GAP + ROW_H + GAP + ROW_H + TOP_PAD
+
+            local pf = CreateFrame("Frame", nil, UIParent)
+            pf:SetSize(260, totalH); pf:SetFrameStrata("DIALOG"); pf:SetFrameLevel(200)
+            pf:EnableMouse(true); pf:Hide()
+
+            local bg = SolidTex(pf, "BACKGROUND", 0.06, 0.08, 0.10, 0.95); bg:SetAllPoints()
+            MakeBorder(pf, BORDER_COLOR.r, BORDER_COLOR.g, BORDER_COLOR.b, 0.15)
+
+            local titleFS = MakeFont(pf, 11, "", 1, 1, 1); titleFS:SetAlpha(0.7)
+            titleFS:SetPoint("TOP", pf, "TOP", 0, -TOP_PAD); titleFS:SetText("Pixel Glow Settings")
+
+            local tmpFS = pf:CreateFontString(nil, "OVERLAY")
+            tmpFS:SetFont(EllesmereUI.EXPRESSWAY or "Fonts\\FRIZQT__.TTF", 11, "")
+            local maxLblW = 0
+            for _, txt in ipairs({"Lines", "Thickness", "Speed"}) do
+                tmpFS:SetText(txt); local w = tmpFS:GetStringWidth(); if w > maxLblW then maxLblW = w end
+            end
+            tmpFS:Hide(); if maxLblW < 10 then maxLblW = 60 end
+
+            local SLIDER_LEFT = SIDE_PAD + maxLblW + LABEL_SLIDER_GAP
+            local SLIDER_W = math.max(80, 260 - SLIDER_LEFT - SLIDER_INPUT_GAP - INPUT_W - SIDE_PAD)
+            local POPUP_W = math.max(MIN_POPUP_W, SLIDER_LEFT + SLIDER_W + SLIDER_INPUT_GAP + INPUT_W + SIDE_PAD)
+            pf:SetWidth(POPUP_W)
+
+            local r1Y = -(TOP_PAD + TITLE_H + TITLE_GAP + GAP)
+            local lbl1 = MakeFont(pf, 11, nil, 1, 1, 1); lbl1:SetAlpha(0.6)
+            lbl1:SetText("Lines"); lbl1:SetPoint("TOPLEFT", pf, "TOPLEFT", SIDE_PAD, r1Y)
+            local t1, v1 = BuildSliderCore(pf, SLIDER_W, 4, 12, INPUT_W, ROW_H, 11, POPUP_INPUT_A,
+                2, 16, 1,
+                function() local d = pf._getData(); return d and d.pandemicGlowLines or 8 end,
+                function(v) local d = pf._getData(); if d then d.pandemicGlowLines = v end; if pf._refresh then pf._refresh() end end, true)
+            t1:SetPoint("TOPLEFT", pf, "TOPLEFT", SLIDER_LEFT, r1Y - 2)
+            v1:ClearAllPoints(); v1:SetPoint("TOPRIGHT", pf, "TOPRIGHT", -SIDE_PAD, r1Y)
+
+            local r2Y = r1Y - ROW_H - GAP
+            local lbl2 = MakeFont(pf, 11, nil, 1, 1, 1); lbl2:SetAlpha(0.6)
+            lbl2:SetText("Thickness"); lbl2:SetPoint("TOPLEFT", pf, "TOPLEFT", SIDE_PAD, r2Y)
+            local t2, v2 = BuildSliderCore(pf, SLIDER_W, 4, 12, INPUT_W, ROW_H, 11, POPUP_INPUT_A,
+                1, 4, 1,
+                function() local d = pf._getData(); return d and d.pandemicGlowThickness or 2 end,
+                function(v) local d = pf._getData(); if d then d.pandemicGlowThickness = v end; if pf._refresh then pf._refresh() end end, true)
+            t2:SetPoint("TOPLEFT", pf, "TOPLEFT", SLIDER_LEFT, r2Y - 2)
+            v2:ClearAllPoints(); v2:SetPoint("TOPRIGHT", pf, "TOPRIGHT", -SIDE_PAD, r2Y)
+
+            local r3Y = r2Y - ROW_H - GAP
+            local lbl3 = MakeFont(pf, 11, nil, 1, 1, 1); lbl3:SetAlpha(0.6)
+            lbl3:SetText("Speed"); lbl3:SetPoint("TOPLEFT", pf, "TOPLEFT", SIDE_PAD, r3Y)
+            local t3, v3 = BuildSliderCore(pf, SLIDER_W, 4, 12, INPUT_W, ROW_H, 11, POPUP_INPUT_A,
+                1, 8, 1,
+                function() local d = pf._getData(); local p = d and d.pandemicGlowSpeed or 4; return 9 - p end,
+                function(v) local d = pf._getData(); if d then d.pandemicGlowSpeed = 9 - v end; if pf._refresh then pf._refresh() end end, true)
+            t3:SetPoint("TOPLEFT", pf, "TOPLEFT", SLIDER_LEFT, r3Y - 2)
+            v3:ClearAllPoints(); v3:SetPoint("TOPRIGHT", pf, "TOPRIGHT", -SIDE_PAD, r3Y)
+
+            local wasDown = false
+            pf:SetScript("OnHide", function(self)
+                self:SetScript("OnUpdate", nil)
+                if _sharedPgPopupOwner then _sharedPgPopupOwner:SetAlpha(0.4) end
+                _sharedPgPopupOwner = nil
+            end)
+            pf._clickOutside = function(self, _)
+                local down = IsMouseButtonDown("LeftButton")
+                if down and not wasDown then
+                    if not self:IsMouseOver() and not (_sharedPgPopupOwner and _sharedPgPopupOwner:IsMouseOver()) then
+                        self:Hide()
+                    end
+                end
+                wasDown = down
+            end
+            if EllesmereUI._mainFrame then
+                EllesmereUI._mainFrame:HookScript("OnHide", function()
+                    if pf:IsShown() then pf:Hide() end
+                end)
+            end
+            _sharedPgPopup = pf
+        end
+
+        if _sharedPgPopupOwner == anchorBtn and _sharedPgPopup:IsShown() then
+            _sharedPgPopup:Hide(); return
+        end
+        -- Bind data source and refresh callback for this invocation
+        _sharedPgPopup._getData = getDataFn
+        _sharedPgPopup._refresh = refreshFn
+        _sharedPgPopupOwner = anchorBtn
+
+        _sharedPgPopup:ClearAllPoints()
+        _sharedPgPopup:SetPoint("BOTTOM", anchorBtn, "TOP", 0, 6)
+        _sharedPgPopup:SetAlpha(0); _sharedPgPopup:Show()
+        local elapsed = 0
+        _sharedPgPopup:SetScript("OnUpdate", function(self, dt)
+            elapsed = elapsed + dt; local t = math.min(elapsed / 0.15, 1)
+            self:SetAlpha(t); self:ClearAllPoints()
+            self:SetPoint("BOTTOM", anchorBtn, "TOP", 0, 6 + (-8 * (1 - t)))
+            if t >= 1 then self:SetScript("OnUpdate", self._clickOutside) end
+        end)
+    end
+
+    -- Build a pandemic glow cog button that opens the shared pixel glow popup
+    local function BuildPandemicCogButton(row, isAntsOffFn, getDataFn, refreshFn)
+        local leftRgn = row._leftRegion
+        local btn = CreateFrame("Button", nil, leftRgn)
+        btn:SetSize(26, 26)
+        btn:SetPoint("RIGHT", leftRgn._lastInline or leftRgn._control, "LEFT", -9, 0)
+        btn:SetFrameLevel(leftRgn:GetFrameLevel() + 5)
+        btn:SetAlpha(0.4)
+        local cogTex = btn:CreateTexture(nil, "OVERLAY")
+        cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.COGS_ICON)
+        btn:SetScript("OnEnter", function(self)
+            if isAntsOffFn() then
+                EllesmereUI.ShowWidgetTooltip(self, "This option requires Pixel Glow to be the selected glow type")
+            else self:SetAlpha(0.7) end
+        end)
+        btn:SetScript("OnLeave", function(self)
+            EllesmereUI.HideWidgetTooltip()
+            if _sharedPgPopupOwner ~= btn then self:SetAlpha(isAntsOffFn() and 0.15 or 0.4) end
+        end)
+        btn:SetScript("OnClick", function(self)
+            if isAntsOffFn() then return end
+            ShowPandemicPixelGlowPopup(self, getDataFn, refreshFn)
+        end)
+        EllesmereUI.RegisterWidgetRefresh(function()
+            if _sharedPgPopupOwner ~= btn then btn:SetAlpha(isAntsOffFn() and 0.15 or 0.4) end
+        end)
+    end
+
     -- Get the icon texture from a real Blizzard action button
     local function GetActionButtonIcon(barIdx, slot)
         local prefix = BAR_BUTTON_PREFIXES[barIdx]
@@ -2707,6 +2997,86 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
             EllesmereUI.RegisterWidgetRefresh(UpdateThreshCogState)
             UpdateThreshCogState()
+        end
+
+        -- Pandemic Glow (tracked buff bars)
+        do
+            local function tbbPandemicOff()
+                local bd = SelectedTBB(); return not bd or bd.pandemicGlow ~= true
+            end
+            local function tbbAntsOff()
+                if tbbPandemicOff() then return true end
+                local bd = SelectedTBB()
+                return not bd or type(bd.pandemicGlowStyle) ~= "number" or bd.pandemicGlowStyle ~= 1
+            end
+
+            local tbbPanRow
+            tbbPanRow, h = W:DualRow(parent, y,
+                { type = "dropdown", text = "Pandemic Glow",
+                  values = PAN_GLOW_VALUES, order = PAN_GLOW_ORDER,
+                  getValue = function()
+                      local bd = SelectedTBB(); if not bd then return 0 end
+                      if bd.pandemicGlow ~= true then return 0 end
+                      return bd.pandemicGlowStyle or 1
+                  end,
+                  setValue = function(v)
+                      local bd = SelectedTBB(); if not bd then return end
+                      if v == 0 then bd.pandemicGlow = false
+                      else bd.pandemicGlow = true; bd.pandemicGlowStyle = v end
+                      RefreshTBB()
+                      if tbbPanRow and tbbPanRow._refreshPreview then tbbPanRow._refreshPreview() end
+                      C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
+                  end,
+                  tooltip = "Show a glow on the bar when the remaining duration is in the pandemic window (last 30%)" },
+                { type = "label", text = "Pandemic Glow Preview" });  y = y - h
+
+            BuildPandemicPreview(tbbPanRow, tbbPandemicOff, SelectedTBB)
+
+            -- Inline color swatch
+            do
+                local tbbLR = tbbPanRow._leftRegion
+                local tbbCtrl = tbbLR and tbbLR._control
+                if tbbCtrl and EllesmereUI.BuildColorSwatch then
+                    local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
+                        tbbLR, tbbPanRow:GetFrameLevel() + 3,
+                        function()
+                            local bd = SelectedTBB(); local c = bd and bd.pandemicGlowColor
+                            if c then return c.r or 1, c.g or 1, c.b or 0 end; return 1, 1, 0
+                        end,
+                        function(r, g, b)
+                            local bd = SelectedTBB(); if not bd then return end
+                            bd.pandemicGlowColor = { r = r, g = g, b = b }; RefreshTBB()
+                            if tbbPanRow._refreshPreview then tbbPanRow._refreshPreview() end
+                        end, nil, 20)
+                    PP.Point(swatch, "RIGHT", tbbCtrl, "LEFT", -12, 0)
+                    tbbLR._lastInline = swatch
+                    EllesmereUI.RegisterWidgetRefresh(function()
+                        local off = tbbPandemicOff()
+                        swatch:SetAlpha(off and 0.15 or 1); swatch:EnableMouse(not off)
+                        if updateSwatch then updateSwatch() end
+                    end)
+                    swatch:SetAlpha(tbbPandemicOff() and 0.15 or 1)
+                    swatch:EnableMouse(not tbbPandemicOff())
+                end
+            end
+
+            BuildPandemicCogButton(tbbPanRow, tbbAntsOff, SelectedTBB, function() RefreshTBB() end)
+
+            -- Apply All
+            if EllesmereUI.BuildSyncIcon then
+                EllesmereUI.BuildSyncIcon({
+                    region = tbbPanRow._leftRegion,
+                    tooltip = "Apply Pandemic Glow settings to all (Nameplates, CDM Bars, Tracking Bars)",
+                    isSynced = function()
+                        local src = SelectedTBB(); if not src then return true end
+                        return IsPandemicSyncedEverywhere(src, nil, _tbbSelectedBar)
+                    end,
+                    onClick = function()
+                        local src = SelectedTBB(); if not src then return end
+                        ApplyPandemicToAll(src, nil, _tbbSelectedBar)
+                    end,
+                })
+            end
         end
 
         -- Border Style (slider + inline swatch) | Background Color
@@ -6320,44 +6690,80 @@ initFrame:SetScript("OnEvent", function(self)
             end
         end
 
-        -- Pandemic Glow (buff bars only)
-        if barData.barType == "buffs" or barData.key == "buffs" then
-            local panRow
-            panRow, h = W:DualRow(parent, y,
-                { type="toggle", text="Pandemic Glow",
-                  getValue=function() return BD().pandemicGlow ~= false end,
-                  setValue=function(v) BD().pandemicGlow = v; Refresh(); EllesmereUI:RefreshPage() end,
-                  tooltip="Show a glow on buff icons when the remaining duration is in the pandemic window (refreshable)" },
-                { type="label", text="" });  y = y - h
+        -- Pandemic Glow (all bar types)
+        do
+            local function pandemicOff() return BD().pandemicGlow ~= true end
+            local function antsOff()
+                if pandemicOff() then return true end
+                local raw = BD().pandemicGlowStyle
+                return type(raw) ~= "number" or raw ~= 1
+            end
+
+            local panGlowRow
+            panGlowRow, h = W:DualRow(parent, y,
+                { type="dropdown", text="Pandemic Glow",
+                  values=PAN_GLOW_VALUES, order=PAN_GLOW_ORDER,
+                  getValue=function()
+                      if pandemicOff() then return 0 end
+                      local raw = BD().pandemicGlowStyle
+                      if type(raw) ~= "number" then return 1 end
+                      return raw
+                  end,
+                  setValue=function(v)
+                      if v == 0 then BD().pandemicGlow = false
+                      else BD().pandemicGlow = true; BD().pandemicGlowStyle = v end
+                      ns.BuildAllCDMBars(); Refresh()
+                      if panGlowRow and panGlowRow._refreshPreview then panGlowRow._refreshPreview() end
+                      C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
+                  end,
+                  tooltip="Show a glow on icons when the remaining duration is in the pandemic window (last 30%)" },
+                { type="label", text="Pandemic Glow Preview" });  y = y - h
+
+            BuildPandemicPreview(panGlowRow, pandemicOff, BD)
+
+            -- Inline color swatch
             do
-                local rgn = panRow._leftRegion
-                local ctrl = rgn and rgn._control
+                local leftRgn = panGlowRow._leftRegion
+                local ctrl = leftRgn and leftRgn._control
                 if ctrl and EllesmereUI.BuildColorSwatch then
-                    local panSwatch, updatePanSwatch = EllesmereUI.BuildColorSwatch(
-                        rgn, panRow:GetFrameLevel() + 3,
-                        function() return BD().pandemicR or 1, BD().pandemicG or 1, BD().pandemicB or 0 end,
-                        function(r, g, b)
-                            BD().pandemicR = r; BD().pandemicG = g; BD().pandemicB = b
-                            Refresh(); EllesmereUI:RefreshPage()
+                    local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
+                        leftRgn, panGlowRow:GetFrameLevel() + 3,
+                        function()
+                            local c = BD().pandemicGlowColor
+                            if c then return c.r or 1, c.g or 1, c.b or 0 end
+                            return BD().pandemicR or 1, BD().pandemicG or 1, BD().pandemicB or 0
                         end,
-                        false, 20)
-                    PP.Point(panSwatch, "RIGHT", ctrl, "LEFT", -8, 0)
-                    -- Blocking overlay when Pandemic Glow is off
-                    local panBlock = CreateFrame("Frame", nil, panSwatch)
-                    panBlock:SetAllPoints()
-                    panBlock:SetFrameLevel(panSwatch:GetFrameLevel() + 10)
-                    panBlock:EnableMouse(true)
-                    panBlock:SetScript("OnEnter", function()
-                        EllesmereUI.ShowWidgetTooltip(panSwatch, EllesmereUI.DisabledTooltip("Pandemic Glow"))
-                    end)
-                    panBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                        function(r, g, b)
+                            BD().pandemicGlowColor = { r = r, g = g, b = b }
+                            ns.BuildAllCDMBars(); Refresh()
+                            if panGlowRow._refreshPreview then panGlowRow._refreshPreview() end
+                        end, nil, 20)
+                    PP.Point(swatch, "RIGHT", ctrl, "LEFT", -12, 0)
+                    leftRgn._lastInline = swatch
                     EllesmereUI.RegisterWidgetRefresh(function()
-                        if updatePanSwatch then updatePanSwatch() end
-                        local on = BD().pandemicGlow ~= false
-                        panSwatch:SetAlpha(on and 1 or 0.3)
-                        if on then panBlock:Hide() else panBlock:Show() end
+                        local off = pandemicOff()
+                        swatch:SetAlpha(off and 0.15 or 1); swatch:EnableMouse(not off)
+                        if updateSwatch then updateSwatch() end
                     end)
+                    swatch:SetAlpha(pandemicOff() and 0.15 or 1)
+                    swatch:EnableMouse(not pandemicOff())
                 end
+            end
+
+            BuildPandemicCogButton(panGlowRow, antsOff, BD, function() ns.BuildAllCDMBars() end)
+
+            -- Apply All
+            if EllesmereUI.BuildSyncIcon then
+                EllesmereUI.BuildSyncIcon({
+                    region = panGlowRow._leftRegion,
+                    tooltip = "Apply Pandemic Glow settings to all (Nameplates, CDM Bars, Tracking Bars)",
+                    isSynced = function()
+                        return IsPandemicSyncedEverywhere(BD(), barKey, nil)
+                    end,
+                    onClick = function()
+                        ApplyPandemicToAll(BD(), barKey, nil)
+                    end,
+                })
             end
         end
 

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -309,6 +309,12 @@ local TBB_DEFAULT_BAR = {
     stackThresholdMaxEnabled = false,
     stackThresholdMax = 10,
     stackThresholdTicks = "",
+    pandemicGlow = false,
+    pandemicGlowStyle = 1,
+    pandemicGlowColor = { r = 1, g = 1, b = 0 },
+    pandemicGlowLines = 8,
+    pandemicGlowThickness = 2,
+    pandemicGlowSpeed = 4,
 }
 ns.TBB_DEFAULT_BAR = TBB_DEFAULT_BAR
 
@@ -510,6 +516,14 @@ local function CreateTrackedBuffBarFrame(parent, idx)
     bdrContainer:SetFrameLevel(wrapFrame:GetFrameLevel() + 5)
     bdrContainer:Hide()
     wrapFrame._barBorder = bdrContainer
+
+    -- Pandemic glow overlay: covers the whole bar, above border
+    local panGlowOverlay = CreateFrame("Frame", nil, wrapFrame)
+    panGlowOverlay:SetAllPoints(wrapFrame)
+    panGlowOverlay:SetFrameLevel(wrapFrame:GetFrameLevel() + 6)
+    panGlowOverlay:SetAlpha(0)
+    panGlowOverlay:EnableMouse(false)
+    wrapFrame._pandemicGlowOverlay = panGlowOverlay
 
     -- Hidden Cooldown widget for DurationObject mirroring
     local cd = CreateFrame("Cooldown", nil, bar, "CooldownFrameTemplate")
@@ -1790,6 +1804,59 @@ function ns.UpdateTrackedBuffBarTimers()
                         if bar._timerText then bar._timerText:Hide() end
                         if bar._spark then bar._spark:Hide() end
                     end
+
+                    -- Pandemic glow on tracked buff bars
+                    if cfg.pandemicGlow and durObj and ns.cdmPandemicCurve then
+                        -- Determine glow target: icon if shown, otherwise the bar overlay
+                        local glowTarget
+                        if bar._icon and bar._icon:IsShown() then
+                            if not bar._pandemicGlowOnIcon then
+                                if not bar._icon._pandemicOverlay then
+                                    local ov = CreateFrame("Frame", nil, bar._icon)
+                                    ov:SetAllPoints(bar._icon)
+                                    ov:SetFrameLevel(bar._icon:GetFrameLevel() + 2)
+                                    ov:SetAlpha(0)
+                                    ov:EnableMouse(false)
+                                    bar._icon._pandemicOverlay = ov
+                                end
+                            end
+                            glowTarget = bar._icon._pandemicOverlay
+                            bar._pandemicGlowOnIcon = true
+                        else
+                            glowTarget = bar._pandemicGlowOverlay
+                            bar._pandemicGlowOnIcon = false
+                        end
+                        local style = cfg.pandemicGlowStyle or 1
+                        -- When glowing the bar overlay (no icon), only Pixel Glow (1)
+                        -- and Auto-Cast Shine (4) render properly on a wide rectangle.
+                        -- Fall back to Pixel Glow for icon-shaped styles.
+                        if not bar._pandemicGlowOnIcon and style ~= 1 and style ~= 4 then
+                            style = 1
+                        end
+                        if not bar._pandemicGlowActive or bar._pandemicGlowStyleIdx ~= style or bar._pandemicGlowTarget ~= glowTarget then
+                            if bar._pandemicGlowActive and bar._pandemicGlowTarget and bar._pandemicGlowTarget ~= glowTarget then
+                                ns.StopNativeGlow(bar._pandemicGlowTarget)
+                            end
+                            local c = cfg.pandemicGlowColor or { r = 1, g = 1, b = 0 }
+                            ns.StartNativeGlow(glowTarget, style, c.r or 1, c.g or 1, c.b or 0)
+                            bar._pandemicGlowActive = true
+                            bar._pandemicGlowStyleIdx = style
+                            bar._pandemicGlowTarget = glowTarget
+                        end
+                        glowTarget:SetAlpha(
+                            C_CurveUtil.EvaluateColorValueFromBoolean(
+                                durObj:IsZero(), 0,
+                                durObj:EvaluateRemainingPercent(ns.cdmPandemicCurve)))
+                        ns.activeCdmPandemicBars[bar] = durObj
+                    elseif bar._pandemicGlowActive then
+                        if bar._pandemicGlowTarget then
+                            ns.StopNativeGlow(bar._pandemicGlowTarget)
+                        end
+                        bar._pandemicGlowActive = false
+                        bar._pandemicGlowStyleIdx = nil
+                        bar._pandemicGlowTarget = nil
+                        ns.activeCdmPandemicBars[bar] = nil
+                    end
                 end
                 -- Feed threshold overlay each tick (secret-safe, no comparison)
                 FeedTBBThresholdOverlay(bar)
@@ -1803,6 +1870,13 @@ function ns.UpdateTrackedBuffBarTimers()
                 end
             else
                 -- Buff not active, hide the bar and clear state
+                if bar._pandemicGlowActive then
+                    if bar._pandemicGlowTarget then ns.StopNativeGlow(bar._pandemicGlowTarget) end
+                    bar._pandemicGlowActive = false
+                    bar._pandemicGlowStyleIdx = nil
+                    bar._pandemicGlowTarget = nil
+                    ns.activeCdmPandemicBars[bar] = nil
+                end
                 if bar:IsShown() then bar:Hide() end
                 if bar._stacksText then bar._stacksText:Hide() end
                 bar._resolvedAuraID = nil

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -116,6 +116,22 @@ ECME_DESAT_CURVE:SetType(Enum.LuaCurveType.Step)
 ECME_DESAT_CURVE:AddPoint(0, 0)
 ECME_DESAT_CURVE:AddPoint(0.001, 1)
 
+-------------------------------------------------------------------------------
+--  Pandemic Glow Curve
+--  Step curve: returns 1 (visible) when remaining percent <= 30% (pandemic
+--  window), 0 when above. Mirrors the nameplate pandemic curve.
+-------------------------------------------------------------------------------
+if C_CurveUtil and C_CurveUtil.CreateCurve then
+    ns.cdmPandemicCurve = C_CurveUtil.CreateCurve()
+    ns.cdmPandemicCurve:SetType(Enum.LuaCurveType.Step)
+    ns.cdmPandemicCurve:AddPoint(0, 1)
+    ns.cdmPandemicCurve:AddPoint(0.3, 0)
+end
+
+-- Active pandemic icon/bar tracking: only these get alpha-ticked
+ns.activeCdmPandemicIcons = {}
+ns.activeCdmPandemicBars = {}
+
 -- Forward declarations for glow helpers (defined later, used by consolidated helpers)
 local StartNativeGlow, StopNativeGlow
 
@@ -728,19 +744,77 @@ local function ApplyTrinketCooldown(icon, slot, desatOnCD)
 end
 
 -------------------------------------------------------------------------------
---  Pandemic glow helper (buff bars only)
---  Shows pixel glow (or shape glow for shaped icons) when the Blizzard CDM
---  child frame's PandemicIcon is visible, indicating the buff is refreshable.
+--  Pandemic glow helpers (buff bars only)
+--  Uses C_CurveUtil step curve with DurationObject for secret-safe pandemic
+--  detection.  Glow becomes visible when remaining duration <= 30%.
+--  Priority: proc glow > pandemic glow > active state glow > buff glow.
 -------------------------------------------------------------------------------
-local function ApplyPandemicGlow(icon, blizzChild, barData)
-    -- Temporarily disabled -- pandemic glow feature is off for now.
-    -- To re-enable, restore the original function body.
+function ns.GetCdmPandemicColor(barData)
+    local c = barData.pandemicGlowColor
+    if c then return c.r or 1, c.g or 1, c.b or 0 end
+    return barData.pandemicR or 1, barData.pandemicG or 1, barData.pandemicB or 0
+end
+
+function ns.GetDurObjForIcon(icon)
+    local ch = icon._blizzChild
+    if not ch then return nil end
+    local auraID = ch.auraInstanceID
+    local auraUnit = ch.auraDataUnit or "player"
+    if auraID then
+        local ok, d = pcall(C_UnitAuras.GetAuraDuration, auraUnit, auraID)
+        if ok and d then return d end
+    end
+    return ns._ecmeDurObjCache and ns._ecmeDurObjCache[ch]
+end
+
+function ns.StopCdmPandemicGlow(icon)
+    ns.activeCdmPandemicIcons[icon] = nil
     if icon._pandemicGlowActive then
-        if not icon._procGlowActive and not icon._isActive then
+        if not icon._procGlowActive and not icon._isActive and not icon._buffGlowActive then
             StopNativeGlow(icon._glowOverlay)
         end
         icon._pandemicGlowActive = false
+        icon._pandemicGlowStyleIdx = nil
     end
+end
+
+local function ApplyPandemicGlow(icon, blizzChild, barData)
+    if not barData.pandemicGlow or not ns.cdmPandemicCurve then
+        ns.StopCdmPandemicGlow(icon)
+        return
+    end
+    -- Proc glow has highest priority
+    if icon._procGlowActive then
+        return
+    end
+    local durObj = ns.GetDurObjForIcon(icon)
+    if not durObj then
+        ns.StopCdmPandemicGlow(icon)
+        return
+    end
+    -- Start/restart glow only when style changes
+    local style = barData.pandemicGlowStyle or 1
+    if not icon._pandemicGlowActive or icon._pandemicGlowStyleIdx ~= style then
+        -- Stop any lower-priority glow on the overlay before starting pandemic
+        if icon._buffGlowActive then
+            StopNativeGlow(icon._glowOverlay)
+            icon._buffGlowActive = false
+            icon._buffGlowStyle = nil
+        end
+        if icon._isActive and icon._glowOverlay and icon._glowOverlay._glowActive then
+            StopNativeGlow(icon._glowOverlay)
+        end
+        local cr, cg, cb = ns.GetCdmPandemicColor(barData)
+        StartNativeGlow(icon._glowOverlay, style, cr, cg, cb)
+        icon._pandemicGlowActive = true
+        icon._pandemicGlowStyleIdx = style
+    end
+    -- Secret-safe alpha update: glow visible only in pandemic window
+    icon._glowOverlay:SetAlpha(
+        C_CurveUtil.EvaluateColorValueFromBoolean(
+            durObj:IsZero(), 0,
+            durObj:EvaluateRemainingPercent(ns.cdmPandemicCurve)))
+    ns.activeCdmPandemicIcons[icon] = true
 end
 
 -------------------------------------------------------------------------------
@@ -753,15 +827,15 @@ local function ApplyActiveAnimation(icon, auraHandled, barData, barKey, activeAn
         if activeAnim ~= "none" and activeAnim ~= "hideActive" then
             icon._cooldown:SetSwipeColor(animR, animG, animB, swAlpha)
             local glowIdx = tonumber(activeAnim)
-            -- Don't overwrite proc glow with active state glow
-            if glowIdx and icon._glowOverlay and not icon._procGlowActive then
+            -- Don't overwrite proc glow or pandemic glow with active state glow
+            if glowIdx and icon._glowOverlay and not icon._procGlowActive and not icon._pandemicGlowActive then
                 StartNativeGlow(icon._glowOverlay, glowIdx, animR, animG, animB)
             end
         end
     elseif (skipActiveAnim or not auraHandled) and icon._isActive then
         icon._cooldown:SetSwipeColor(0, 0, 0, swAlpha)
-        -- Don't stop glow if proc glow is active (it owns the overlay)
-        if icon._glowOverlay and not icon._procGlowActive then
+        -- Don't stop glow if proc or pandemic glow is active (they own the overlay)
+        if icon._glowOverlay and not icon._procGlowActive and not icon._pandemicGlowActive then
             StopNativeGlow(icon._glowOverlay)
         end
     end
@@ -1020,6 +1094,12 @@ local DEFAULTS = {
                     keybindSize = 10, keybindOffsetX = 2, keybindOffsetY = -2,
                     keybindR = 1, keybindG = 1, keybindB = 1, keybindA = 0.9,
                     outOfRangeOverlay = false,
+                    pandemicGlow = false,
+                    pandemicGlowStyle = 1,
+                    pandemicGlowColor = { r = 1, g = 1, b = 0 },
+                    pandemicGlowLines = 8,
+                    pandemicGlowThickness = 2,
+                    pandemicGlowSpeed = 4,
                 },
                 {
                     key = "utility", name = "Utility", enabled = true,
@@ -1048,6 +1128,12 @@ local DEFAULTS = {
                     keybindSize = 10, keybindOffsetX = 2, keybindOffsetY = -2,
                     keybindR = 1, keybindG = 1, keybindB = 1, keybindA = 0.9,
                     outOfRangeOverlay = false,
+                    pandemicGlow = false,
+                    pandemicGlowStyle = 1,
+                    pandemicGlowColor = { r = 1, g = 1, b = 0 },
+                    pandemicGlowLines = 8,
+                    pandemicGlowThickness = 2,
+                    pandemicGlowSpeed = 4,
                 },
                 {
                     key = "buffs", name = "Buffs", enabled = true,
@@ -1077,7 +1163,11 @@ local DEFAULTS = {
                     keybindR = 1, keybindG = 1, keybindB = 1, keybindA = 0.9,
                     outOfRangeOverlay = false,
                     pandemicGlow = false,
-                    pandemicR = 1, pandemicG = 1, pandemicB = 0,
+                    pandemicGlowStyle = 1,
+                    pandemicGlowColor = { r = 1, g = 1, b = 0 },
+                    pandemicGlowLines = 8,
+                    pandemicGlowThickness = 2,
+                    pandemicGlowSpeed = 4,
                 },
             },
         },
@@ -1990,6 +2080,47 @@ end
 ns.StartNativeGlow = StartNativeGlow
 ns.StopNativeGlow = StopNativeGlow
 
+-------------------------------------------------------------------------------
+--  Pandemic glow alpha-only tick: updates glow alpha for CDM icons and tracked
+--  buff bars that have active pandemic glows. Fires every 0.2s.
+-------------------------------------------------------------------------------
+do
+    local accum = 0
+    CreateFrame("Frame"):SetScript("OnUpdate", function(_, elapsed)
+        accum = accum + elapsed
+        if accum < 0.2 then return end
+        accum = 0
+        if not ns.cdmPandemicCurve then return end
+        for icon in pairs(ns.activeCdmPandemicIcons) do
+            local durObj = ns.GetDurObjForIcon(icon)
+            if durObj and icon._pandemicGlowActive and icon._glowOverlay then
+                icon._glowOverlay:SetAlpha(
+                    C_CurveUtil.EvaluateColorValueFromBoolean(
+                        durObj:IsZero(), 0,
+                        durObj:EvaluateRemainingPercent(ns.cdmPandemicCurve)))
+            else
+                ns.StopCdmPandemicGlow(icon)
+            end
+        end
+        for bar, durObj in pairs(ns.activeCdmPandemicBars) do
+            local target = bar._pandemicGlowTarget
+            if durObj and target then
+                target:SetAlpha(
+                    C_CurveUtil.EvaluateColorValueFromBoolean(
+                        durObj:IsZero(), 0,
+                        durObj:EvaluateRemainingPercent(ns.cdmPandemicCurve)))
+            else
+                if bar._pandemicGlowActive and target then
+                    StopNativeGlow(target)
+                end
+                bar._pandemicGlowActive = false
+                bar._pandemicGlowTarget = nil
+                ns.activeCdmPandemicBars[bar] = nil
+            end
+        end
+    end)
+end
+
 -- Our bar frames (keyed by bar key)
 local cdmBarFrames = {}
 -- Icon frames per bar (keyed by bar key, array of icon frames)
@@ -2106,6 +2237,10 @@ local function ShowProcGlow(icon, cr, cg, cb)
     if not icon or not icon._glowOverlay then return end
     -- Don't double-start if already showing proc glow
     if icon._procGlowActive then return end
+    -- Stop pandemic glow if active (proc glow takes priority)
+    if icon._pandemicGlowActive then
+        ns.StopCdmPandemicGlow(icon)
+    end
     -- If active state glow is running, stop it first (proc glow takes priority)
     if icon._isActive and icon._glowOverlay._glowActive then
         StopNativeGlow(icon._glowOverlay)
@@ -4327,15 +4462,8 @@ local function UpdateCustomBarIcons(barKey)
 
                 ApplyActiveAnimation(ourIcon, auraHandled, barData, barKey, activeAnim, animR, animG, animB, swAlpha)
 
-                -- Pandemic glow (buff bars only)
-                if isBuffBarForOverride then
-                    ApplyPandemicGlow(ourIcon, ourIcon._blizzChild, barData)
-                elseif ourIcon._pandemicGlowActive then
-                    if not ourIcon._procGlowActive and not ourIcon._isActive then
-                        StopNativeGlow(ourIcon._glowOverlay)
-                    end
-                    ourIcon._pandemicGlowActive = false
-                end
+                -- Pandemic glow
+                ApplyPandemicGlow(ourIcon, ourIcon._blizzChild, barData)
 
                 -- Out-of-range overlay (skip buff bars -- buffs don't target enemies)
                 if not isBuffBarForOverride then
@@ -4445,7 +4573,9 @@ local function UpdateCustomBarIcons(barKey)
             StopNativeGlow(ic._glowOverlay)
             ic._procGlowActive = false
         end
+        ns.activeCdmPandemicIcons[ic] = nil
         ic._pandemicGlowActive = false
+        ic._pandemicGlowStyleIdx = nil
         ic:Hide()
     end
 
@@ -4745,15 +4875,8 @@ UpdateCDMBarIcons = function(barKey)
             -- Active state animation (consolidated)
             ApplyActiveAnimation(ourIcon, auraHandled, barData, barKey, activeAnim, animR, animG, animB, swAlpha)
 
-            -- Pandemic glow (buff bars only)
-            if isBuffBar then
-                ApplyPandemicGlow(ourIcon, blizzIcon, barData)
-            elseif ourIcon._pandemicGlowActive then
-                if not ourIcon._procGlowActive and not ourIcon._isActive then
-                    StopNativeGlow(ourIcon._glowOverlay)
-                end
-                ourIcon._pandemicGlowActive = false
-            end
+            -- Pandemic glow
+            ApplyPandemicGlow(ourIcon, blizzIcon, barData)
 
             -- Out-of-range overlay (skip buff bars)
             if not isBuffBar then
@@ -4832,7 +4955,9 @@ UpdateCDMBarIcons = function(barKey)
             StopNativeGlow(ic._glowOverlay)
             ic._procGlowActive = false
         end
+        ns.activeCdmPandemicIcons[ic] = nil
         ic._pandemicGlowActive = false
+        ic._pandemicGlowStyleIdx = nil
         if ic:IsShown() then
             if not ic._hideGraceStart then
                 ic._hideGraceStart = GetTime()
@@ -5631,15 +5756,8 @@ local function UpdateTrackedBarIcons(barKey)
                 -- Store Blizzard child mapping so proc glow hooks can find our icon
                 ourIcon._blizzChild = blizzChild
 
-                -- Pandemic glow (buff bars only)
-                if isBuffBarForOvr then
-                    ApplyPandemicGlow(ourIcon, blizzChild, barData)
-                elseif ourIcon._pandemicGlowActive then
-                    if not ourIcon._procGlowActive and not ourIcon._isActive then
-                        StopNativeGlow(ourIcon._glowOverlay)
-                    end
-                    ourIcon._pandemicGlowActive = false
-                end
+                -- Pandemic glow
+                ApplyPandemicGlow(ourIcon, blizzChild, barData)
 
                 -- Untracked overlay: red tint for spells not in Blizzard CDM
                 -- Only applies to spells that exist in the CDM category system (have a cdID).
@@ -5727,7 +5845,9 @@ local function UpdateTrackedBarIcons(barKey)
             StopNativeGlow(ic._glowOverlay)
             ic._procGlowActive = false
         end
+        ns.activeCdmPandemicIcons[ic] = nil
         ic._pandemicGlowActive = false
+        ic._pandemicGlowStyleIdx = nil
         if ic._untrackedOverlay then ic._untrackedOverlay:Hide() end
         ic._isUntracked = false
         ic:Hide()
@@ -7277,7 +7397,11 @@ function ns.AddCDMBar(barType, name, numRows)
         -- Custom bars use a spell list instead of mirroring Blizzard
         outOfRangeOverlay = false,
         pandemicGlow = false,
-        pandemicR = 1, pandemicG = 1, pandemicB = 0,
+        pandemicGlowStyle = 1,
+        pandemicGlowColor = { r = 1, g = 1, b = 0 },
+        pandemicGlowLines = 8,
+        pandemicGlowThickness = 2,
+        pandemicGlowSpeed = 4,
     }
     -- Initialize spell data in the global store for this custom bar
     local sd = ns.GetBarSpellData(key)
@@ -7526,6 +7650,23 @@ end
 -------------------------------------------------------------------------------
 function ECME:OnInitialize()
     self.db = EllesmereUI.Lite.NewDB("EllesmereUICooldownManagerDB", DEFAULTS, true)
+
+    -- Migrate old pandemicR/G/B flat keys to pandemicGlowColor table
+    do
+        local p = self.db and self.db.profile
+        if p and p.cdmBars and p.cdmBars.bars then
+            for _, barData in ipairs(p.cdmBars.bars) do
+                if barData.pandemicR and not barData.pandemicGlowColor then
+                    barData.pandemicGlowColor = {
+                        r = barData.pandemicR or 1,
+                        g = barData.pandemicG or 1,
+                        b = barData.pandemicB or 0,
+                    }
+                    barData.pandemicGlowStyle = barData.pandemicGlowStyle or 1
+                end
+            end
+        end
+    end
 
     -- Save spec profile before StripDefaults runs on logout
     EllesmereUI.Lite.RegisterPreLogout(function()


### PR DESCRIPTION
## Summary

- Adds pandemic window detection (last 30% of aura duration) with configurable glow effects to CDM buff/cooldown/utility icons and tracked buff bars
- Mirrors the existing nameplate pandemic glow approach using secret-safe `C_CurveUtil` step curves with `DurationObject`
- Replaces the disabled `ApplyPandemicGlow` stub with a working implementation

## Changes

**Core (`EllesmereUICooldownManager.lua`)**
- Pandemic step curve (`C_CurveUtil`) and active-slot tracking on `ns`
- Rewritten `ApplyPandemicGlow` with secret-safe alpha via `EvaluateColorValueFromBoolean`
- Lightweight 0.2s `OnUpdate` ticker iterating only active pandemic slots
- Glow priority enforcement: proc > pandemic > active state > buff glow
- Settings migration from old `pandemicR/G/B` flat keys to `pandemicGlowColor` table
- Pandemic defaults added to all bar types (cooldowns, utility, buffs, custom)

**Tracked Buff Bars (`EllesmereUICdmBuffBars.lua`)**
- Pandemic glow overlay frame on each bar
- Tick-loop integration inside the `durObj` scope for correct secret-safe evaluation
- Glow targets icon overlay when icon is shown, bar overlay otherwise
- Non-square-safe fallback: forces Pixel Glow for icon-shaped styles on wide bar overlays

**Options UI (`EUI_CooldownManager_Options.lua`)**
- Style dropdown (None + 6 glow styles), inline color swatch, pixel glow cog popup (lines, thickness, speed)
- Live glow preview icon with gray-out when disabled
- Cross-module Apply All syncs pandemic settings to Nameplates, all CDM Bars, and all Tracking Bars
- Shared helper functions eliminate duplication between CDM Bars and TBB pages

## Test plan

- [ ] Enable pandemic glow on a CDM buff bar (e.g. Frost Fever) — verify icon glows in last 30% of duration
- [ ] Enable on cooldown/utility bars — verify glow appears on those bar types too
- [ ] Enable on a tracking bar — verify bar/icon glows in pandemic window
- [ ] Test glow priority: trigger proc glow while pandemic is active — proc should win
- [ ] Test Apply All from any page — verify settings sync to nameplates, all CDM bars, and all TBBs
- [ ] Test style switching and color changes — verify preview updates and old glow cleans up
- [ ] Test with old saved data containing `pandemicR/G/B` keys — verify migration works