### PR TITLE
fix(CDM): bind data source before pixel glow popup slider creation

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -308,6 +308,11 @@ initFrame:SetScript("OnEvent", function(self)
     -- getDataFn: returns the settings table; refreshFn: called after changes
     local _sharedPgPopup, _sharedPgPopupOwner
     local function ShowPandemicPixelGlowPopup(anchorBtn, getDataFn, refreshFn)
+        -- Bind data source before popup creation so slider getValue callbacks work
+        if _sharedPgPopup then
+            _sharedPgPopup._getData = getDataFn
+            _sharedPgPopup._refresh = refreshFn
+        end
         if not _sharedPgPopup then
             local SolidTex   = EllesmereUI.SolidTex
             local MakeBorder = EllesmereUI.MakeBorder
@@ -326,6 +331,9 @@ initFrame:SetScript("OnEvent", function(self)
             local pf = CreateFrame("Frame", nil, UIParent)
             pf:SetSize(260, totalH); pf:SetFrameStrata("DIALOG"); pf:SetFrameLevel(200)
             pf:EnableMouse(true); pf:Hide()
+            -- Bind data source before sliders are built so getValue callbacks work
+            pf._getData = getDataFn
+            pf._refresh = refreshFn
 
             local bg = SolidTex(pf, "BACKGROUND", 0.06, 0.08, 0.10, 0.95); bg:SetAllPoints()
             MakeBorder(pf, BORDER_COLOR.r, BORDER_COLOR.g, BORDER_COLOR.b, 0.15)


### PR DESCRIPTION
## Summary

Fixes a Lua error when opening the pandemic pixel glow cog popup for the first time.

## Problem

The shared popup frame's slider `getValue` callbacks call `pf._getData()`, but `_getData` was only bound when the popup was re-shown — not during initial creation. `BuildSliderCore` calls `getValue` during construction, causing `attempt to call field '_getData' (a nil value)`.

## Fix

Bind `pf._getData` and `pf._refresh` immediately after frame creation (before sliders are built), and re-bind on subsequent opens to update the data source when switching between CDM Bars and Tracking Bars pages.

## Test plan

- [ ] Open CDM Bars page, click pandemic pixel glow cog — no error, sliders work
- [ ] Open Tracking Bars page, click pandemic pixel glow cog — no error, sliders work
- [ ] Switch between pages and reopen cog — correct data source each time