### PR TITLE
fix(actionbars): make Queue Status visibility independent from the Micro Menu

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7512,16 +7512,43 @@ AttachExtraBarHoverHooks = function(info)
     local blizzFrame = _G[info.frameName]
     if not blizzFrame then return end
     local holder = extraBarHolders[info.key]
+    local hoverFrame = info.hoverFrame and _G[info.hoverFrame]
 
     -- Fade the Blizzard frame directly rather than the holder.
     -- The holder is for positioning only; fading it can be overridden by
     -- Blizzard's own layout code calling SetAlpha on the child frame.
     local fadeTarget = blizzFrame
+    local hoverRoot = hoverFrame or blizzFrame
 
     local state = { isHovered = false, fadeDir = nil, frame = fadeTarget }
     hoverStates[info.key] = state
 
+    local function IsChildOfHoverRoot(frame)
+        while frame do
+            if frame == hoverRoot then
+                return true
+            end
+            frame = frame.GetParent and frame:GetParent() or nil
+        end
+        return false
+    end
+
+    local function IsHoverRootActive()
+        local foci = GetMouseFoci and GetMouseFoci() or { GetMouseFocus and GetMouseFocus() }
+        if foci then
+            for _, focus in ipairs(foci) do
+                if focus and IsChildOfHoverRoot(focus) then
+                    return true
+                end
+            end
+        end
+
+        if not MouseIsOver then return true end
+        return MouseIsOver(hoverRoot)
+    end
+
     local function OnEnter()
+        if not IsHoverRootActive() then return end
         state.isHovered = true
         local bs = EAB.db.profile.bars[info.key]
         if bs and bs.mouseoverEnabled and state.fadeDir ~= "in" then
@@ -7533,6 +7560,10 @@ AttachExtraBarHoverHooks = function(info)
     local function OnLeave()
         state.isHovered = false
         C_Timer_After(0.1, function()
+            if IsHoverRootActive() then
+                state.isHovered = true
+                return
+            end
             if state.isHovered then return end
             if _quickKeybindState.open then return end
             local bs = EAB.db.profile.bars[info.key]
@@ -7543,13 +7574,8 @@ AttachExtraBarHoverHooks = function(info)
         end)
     end
 
-    blizzFrame:HookScript("OnEnter", OnEnter)
-    blizzFrame:HookScript("OnLeave", OnLeave)
-    local hoverFrame = info.hoverFrame and _G[info.hoverFrame]
-    if hoverFrame and hoverFrame ~= blizzFrame then
-        hoverFrame:HookScript("OnEnter", OnEnter)
-        hoverFrame:HookScript("OnLeave", OnLeave)
-    end
+    hoverRoot:HookScript("OnEnter", OnEnter)
+    hoverRoot:HookScript("OnLeave", OnLeave)
 
     -- Recurse into child frames to hook all interactive buttons, including
     -- those nested inside sub-containers (e.g. MicroMenu inside MicroMenuContainer).
@@ -7566,10 +7592,7 @@ AttachExtraBarHoverHooks = function(info)
             end
         end
     end
-    HookChildren(blizzFrame)
-    if hoverFrame and hoverFrame ~= blizzFrame then
-        HookChildren(hoverFrame)
-    end
+    HookChildren(hoverRoot)
 end
 
 function EAB_VTABLE.ExtraBars.AttachFrameToHolder(barKey, blizzFrame, holder, opts)


### PR DESCRIPTION
## Summary

  This PR fixes the Queue Status eye visibility behavior in `EllesmereUIActionBars`.

  Previously, `QueueStatusButton` inherited visibility and alpha from
  `MicroMenuContainer`, which caused two user-facing bugs:

  - setting the Micro Menu to `Mouseover` also made the Queue Status eye behave as mouseover
  - changing the Queue Status visibility setting did not work independently; it effectively followed the Micro Menu setting instead

  This change detaches the queue eye's visibility behavior from the Micro Menu while preserving Blizzard-owned positioning and interaction behavior.

  ## What changed

  - reparented `QueueStatusButton` into its own holder so it no longer inherits Micro Menu alpha/visibility
  - patched `MicroMenuContainer:Layout()` for the detached queue-eye case so the Micro Menu holder no longer reserves queue-eye space once detached
  - kept Blizzard-driven show/position updates recentering the queue eye into its holder
  - added holder size syncing for the touched extra-bar setup path

  ## Refactor included

  To keep the touched area maintainable without expanding the scope further:

  - introduced a structured cold-path helper table: `EAB_VTABLE.ExtraBars`
  - moved the detached queue-status layout patch under that namespace
  - extracted the shared frame-to-holder attachment flow used by the touched extra-bar setup paths

  This is intentionally limited to the code already being changed for the fix.