### PR TITLE
feat(CDM): add rotation helper via C_AssistedCombat

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -6799,6 +6799,44 @@ initFrame:SetScript("OnEvent", function(self)
             end
         end
 
+        -- Rotation Helper (global CDM setting, reads from cdmBars root)
+        do
+            local function CDM() local pp = DB(); return pp and pp.cdmBars end
+
+            local ROT_GLOW_VALUES = {}
+            local ROT_GLOW_ORDER  = {}
+            if ns.GLOW_STYLES then
+                for i, entry in ipairs(ns.GLOW_STYLES) do
+                    if not entry.shapeGlow then
+                        ROT_GLOW_VALUES[i] = entry.name
+                        ROT_GLOW_ORDER[#ROT_GLOW_ORDER + 1] = i
+                    end
+                end
+            end
+
+            _, h = W:DualRow(parent, y,
+                { type="toggle", text="Rotation Helper",
+                  getValue=function() local c = CDM(); return c and c.rotationHelperEnabled ~= false end,
+                  setValue=function(v)
+                      local c = CDM(); if not c then return end
+                      c.rotationHelperEnabled = v
+                      if ns.UpdateRotationHighlights then ns.UpdateRotationHighlights() end
+                      Refresh()
+                  end,
+                  tooltip="Highlight the suggested next spell from Blizzard's rotation assistant on CDM icons" },
+                { type="dropdown", text="Rotation Glow Style",
+                  values=ROT_GLOW_VALUES, order=ROT_GLOW_ORDER,
+                  getValue=function() local c = CDM(); return c and c.rotationHelperGlowStyle or 5 end,
+                  setValue=function(v)
+                      local c = CDM(); if not c then return end
+                      c.rotationHelperGlowStyle = v
+                      if ns.UpdateRotationHighlights then ns.UpdateRotationHighlights() end
+                      Refresh()
+                  end,
+                  tooltip="Glow style used for the rotation helper highlight" }
+            );  y = y - h
+        end
+
         _, h = W:Spacer(parent, y, 8);  y = y - h
 
         -------------------------------------------------------------------

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -1070,6 +1070,8 @@ local DEFAULTS = {
             enabled = true,
             hideBlizzard = true,
             useBlizzardBuffBars = false,
+            rotationHelperEnabled = true,
+            rotationHelperGlowStyle = 5,
             -- The 3 default bars (match Blizzard CDM)
             bars = {
                 {
@@ -8554,6 +8556,82 @@ function ECME:CDMFinishSetup()
 end
 
 -------------------------------------------------------------------------------
+--  Rotation Helper Integration (Blizzard C_AssistedCombat)
+--  Highlights the currently suggested spell from the rotation assistant
+--  with a glow on its CDM icon.
+-------------------------------------------------------------------------------
+local _rotationGlowedIcons = {}  -- icon -> true for currently glowed icons
+local _lastSuggestedSpell = nil
+
+local function UpdateRotationHighlights()
+    local p = ECME.db and ECME.db.profile
+    if not p or not p.cdmBars or not p.cdmBars.rotationHelperEnabled then
+        -- Clear all glows if disabled
+        for icon in pairs(_rotationGlowedIcons) do
+            if icon._glowOverlay then
+                _G_Glows.StopAllGlows(icon._glowOverlay)
+                icon._glowOverlay:SetAlpha(0)
+            end
+            _rotationGlowedIcons[icon] = nil
+        end
+        _lastSuggestedSpell = nil
+        return
+    end
+
+    local suggestedSpell = C_AssistedCombat and C_AssistedCombat.GetNextCastSpell and C_AssistedCombat.GetNextCastSpell()
+
+    -- Early exit if nothing changed
+    if suggestedSpell == _lastSuggestedSpell then return end
+    _lastSuggestedSpell = suggestedSpell
+
+    -- Clear previous glows
+    for icon in pairs(_rotationGlowedIcons) do
+        if icon._glowOverlay then
+            _G_Glows.StopAllGlows(icon._glowOverlay)
+            icon._glowOverlay:SetAlpha(0)
+        end
+    end
+    wipe(_rotationGlowedIcons)
+
+    if not suggestedSpell then return end
+
+    -- Find matching icons across all bars and apply glow
+    local glowStyle = p.cdmBars.rotationHelperGlowStyle or 5
+    for barKey, icons in pairs(cdmBarIcons) do
+        for _, icon in ipairs(icons) do
+            if icon._spellID and icon._spellID == suggestedSpell and icon:IsShown() then
+                if icon._glowOverlay then
+                    icon._glowOverlay:SetAlpha(1)
+                    StartNativeGlow(icon._glowOverlay, glowStyle, 1, 0.82, 0.1)
+                    _rotationGlowedIcons[icon] = true
+                end
+            end
+        end
+    end
+end
+ns.UpdateRotationHighlights = UpdateRotationHighlights
+
+-- Hook into Blizzard's rotation change callback (deferred until after login)
+local _rotationHookInstalled = false
+local function InstallRotationHook()
+    if _rotationHookInstalled then return end
+    _rotationHookInstalled = true
+
+    if EventRegistry and EventRegistry.RegisterCallback then
+        EventRegistry:RegisterCallback("AssistedCombatManager.OnAssistedHighlightSpellChange", function()
+            UpdateRotationHighlights()
+        end, "ECME_CDM_RotationHelper")
+    end
+
+    -- Also hook the manager's update method as a fallback
+    if AssistedCombatManager and AssistedCombatManager.UpdateAllAssistedHighlightFramesForSpell then
+        hooksecurefunc(AssistedCombatManager, "UpdateAllAssistedHighlightFramesForSpell", function()
+            UpdateRotationHighlights()
+        end)
+    end
+end
+
+-------------------------------------------------------------------------------
 --  Event-Driven Runtime Maintenance
 --
 --  This frame owns the non-tick triggers: login/world transitions, spec swaps,
@@ -8802,6 +8880,10 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
         if ns.StartSpecValidation then
             ns.StartSpecValidation()
         end
+        -- Install rotation helper hook after CDM frames have been built
+        C_Timer.After(1, function()
+            InstallRotationHook()
+        end)
     end
     if event == "SPELLS_CHANGED" then
         -- SPELLS_CHANGED fires reliably after spec data is available.


### PR DESCRIPTION
## What this does

Adds rotation helper integration to CDM bars. If you have Blizzard's rotation assistant turned on, the next suggested spell gets a glow on its CDM icon.

- Hooks into `C_AssistedCombat.GetNextCastSpell()` and the `AssistedCombatManager` event
- Scans all CDM bars for a matching spell and glows it
- Uses the existing `StartNativeGlow` system so it fits right in with proc glows
- Toggle and glow style dropdown added to CDM options
- On by default with the GCD glow style

## How it works

Listens for spell suggestion changes from the assisted combat system. When the suggestion changes, it clears any previous glow, finds the matching CDM icon by spell ID, and applies a glow. Same glow system as proc glows so all 7 styles work.

Hooks get installed on `PLAYER_ENTERING_WORLD` with a short delay so CDM frames are ready. Also handles spec changes by clearing glows and re-evaluating after CDM rebuilds.

## Testing

- Enable rotation assistant in WoW gameplay settings
- Get into combat and check that CDM icons glow for the suggested spell
- Toggle it off in CDM options, glows should clear
- Change glow style, should update
- Switch specs, should handle the CDM rebuild cleanly