### PR TITLE
Fix: Truncated long-names in unit frames

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1079,6 +1079,34 @@ local function EstimateUFTextWidth(content)
     return (ufTextWidths[content] or 0) + UF_TEXT_PADDING
 end
 
+-- Shorten a unit name that would overflow the health bar.
+-- Non-final words are reduced to their first initial; if still too long the
+-- result is hard-truncated with an ellipsis.
+local function ShortenName(name)
+    if not name or #name <= 20 then return name end
+    local words = {}
+    for word in name:gmatch("%S+") do words[#words + 1] = word end
+    if #words <= 1 then
+        return name:sub(1, 19) .. "\226\128\166"  -- …
+    end
+    local parts = {}
+    for i = 1, #words - 1 do
+        parts[#parts + 1] = words[i]:sub(1, 1) .. "."
+    end
+    parts[#parts + 1] = words[#words]
+    local result = table.concat(parts, " ")
+    if #result > 22 then
+        result = result:sub(1, 21) .. "\226\128\166"
+    end
+    return result
+end
+
+-- Override [name] tag to abbreviate long names (e.g. "Dungeoneer's Training Dummy" -> "D. T. Dummy")
+oUF.Tags.Methods["name"] = function(u, r)
+    return ShortenName(UnitName(r or u))
+end
+oUF.Tags.Events["name"] = "UNIT_NAME_UPDATE"
+
 -- Apply class color to a FontString based on the unit
 local function ApplyClassColor(fs, unit, useClassColor)
     if not fs then return end
@@ -2863,7 +2891,7 @@ local function StyleFullFrame(frame, unit)
                     local rightUsed = EstimateUFTextWidth(rc)
                     PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
                 else
-                    leftText:SetWidth(0)
+                    PP.Width(leftText, barW - 10)
                 end
                 leftText:Show()
                 ApplyClassColor(leftText, unit, s.leftTextClassColor)
@@ -3107,7 +3135,7 @@ local function StyleFocusFrame(frame, unit)
                     local rightUsed = EstimateUFTextWidth(rc)
                     PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
                 else
-                    leftText:SetWidth(0)
+                    PP.Width(leftText, barW - 10)
                 end
                 leftText:Show()
                 ApplyClassColor(leftText, unit, s.leftTextClassColor)
@@ -3265,7 +3293,7 @@ local function StyleSimpleFrame(frame, unit)
                     local rightUsed = EstimateUFTextWidth(rc)
                     PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
                 else
-                    leftText:SetWidth(0)
+                    PP.Width(leftText, barW - 10)
                 end
                 leftText:Show()
             else leftText:Hide() end
@@ -3422,7 +3450,7 @@ local function StylePetFrame(frame, unit)
                     local rightUsed = EstimateUFTextWidth(rc)
                     PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
                 else
-                    leftText:SetWidth(0)
+                    PP.Width(leftText, barW - 10)
                 end
                 leftText:Show()
             else leftText:Hide() end
@@ -3562,7 +3590,7 @@ local function StyleBossFrame(frame, unit)
                     local rightUsed = EstimateUFTextWidth(rc)
                     PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
                 else
-                    leftText:SetWidth(0)
+                    PP.Width(leftText, barW - 10)
                 end
                 leftText:Show()
             else leftText:Hide() end


### PR DESCRIPTION
Before:
<img width="557" height="102" alt="image" src="https://github.com/user-attachments/assets/ad593597-9e4a-4829-aa32-c203a26ed52c" />

After:
<img width="473" height="132" alt="image" src="https://github.com/user-attachments/assets/719e9d2b-3479-4282-bc74-442f1e44566c" />
