### PR TITLE
Fix custom spell ID icons stuck as red untracked overlay

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -7105,6 +7105,7 @@ initFrame:SetScript("OnEvent", function(self)
                     local isNonCDM = (sid and sid < 0)
                         or (sid and ns._myRacialsSet and ns._myRacialsSet[sid])
                         or isCustomBuffBar
+                        or (sid and sid > 0 and ns.IsSpellInAnyCDMCategory and not ns.IsSpellInAnyCDMCategory(sid))
                     if sid and sid > 0 and not isNonCDM and ns.ApplyUntrackedOverlay then
                         local barType = (bd.barType or bd.key)
                         local isUntracked = not ns.IsSpellTrackedForBarType(sid, barType)

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -1474,7 +1474,8 @@ local function CollectAndReanchor(bypassSpecGuard)
                             end
                             if not hasClaim then
                                 local isRacial = ns._myRacialsSet and ns._myRacialsSet[sid]
-                                if not isRacial and ns.IsSpellKnownInCDM and not ns.IsSpellKnownInCDM(sid) then
+                                local isCustomSpell = sd and sd.customSpellIDs and sd.customSpellIDs[sid]
+                                if not isRacial and not isCustomSpell and ns.IsSpellKnownInCDM and not ns.IsSpellKnownInCDM(sid) then
                                     -- Unknown spell, skip
                                 else
                                     local fkey = barKey .. ":" .. (isRacial and "racial" or "custom") .. ":" .. sid

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -2764,6 +2764,20 @@ local function ApplyUntrackedOverlay(ourIcon, isUntracked)
                     spellName .. "not tracked in Blizzard CDM.\nClick to open the |cff0cd29d" .. tabName .. "|r tab.")
             end)
             ov:SetScript("OnLeave", function() HideUntrackedTooltip() end)
+            -- Forward mouse-down/up to parent so drag reordering works
+            -- through the overlay (preview slots use OnMouseDown for drag).
+            ov:SetScript("OnMouseDown", function(self, button)
+                local parent = self:GetParent()
+                if parent and parent.GetScript and parent:GetScript("OnMouseDown") then
+                    parent:GetScript("OnMouseDown")(parent, button)
+                end
+            end)
+            ov:SetScript("OnMouseUp", function(self, button)
+                local parent = self:GetParent()
+                if parent and parent.GetScript and parent:GetScript("OnMouseUp") then
+                    parent:GetScript("OnMouseUp")(parent, button)
+                end
+            end)
             if fd then fd.untrackedOverlay = ov else ourIcon._untrackedOverlay = ov end
             utOv = ov
         end


### PR DESCRIPTION
## Summary
- Spells added by spell ID that aren't in Blizzard's CDM categories were showing a permanent red "Click to Track" overlay in the preview that couldn't be resolved and blocked drag reordering. On the live bar, these spells were silently skipped entirely.
- Forward `OnMouseDown`/`OnMouseUp` through the untracked overlay to the parent slot so drag reordering works even when the overlay is visible
- Skip the untracked overlay in the preview for spells outside all CDM categories since they cannot be tracked in Blizzard's CDM settings
- Allow `customSpellIDs`-tagged spells to bypass the `IsSpellKnownInCDM` gate so they get a custom frame on the live bar

## Test plan
- [ ] Add a spell by ID that is NOT in Blizzard's default CDM to a cooldown bar
- [ ] Verify the icon appears without the red "Click to Track" overlay in the preview
- [ ] Verify the icon can be dragged to reorder in the preview
- [ ] Verify the icon appears on the live bar in-game
- [ ] Verify spells that ARE in CDM but untracked still show the overlay correctly
- [ ] Verify removing a custom spell still works properly