### PR TITLE
Fix Train All button not appearing after /rl or relog

### DIFF
--- a/EUI_QoL.lua
+++ b/EUI_QoL.lua
@@ -503,9 +503,14 @@ qolFrame:SetScript("OnEvent", function(self)
 
         local f = CreateFrame("Frame")
         f:RegisterEvent("PLAYER_LOGIN")
-        f:SetScript("OnEvent", function(self)
-            self:UnregisterEvent("PLAYER_LOGIN")
-            ApplyTrainAllButton()
+        f:RegisterEvent("ADDON_LOADED")
+        f:SetScript("OnEvent", function(self, event)
+            if event == "PLAYER_LOGIN" then
+                self:UnregisterEvent("PLAYER_LOGIN")
+                ApplyTrainAllButton()
+            elseif event == "ADDON_LOADED" then
+                ApplyTrainAllButton()
+            end
         end)
     end
 


### PR DESCRIPTION
The Train All button only initialized on PLAYER_LOGIN, which doesn't fire
  after a UI reload (/rl). Add ADDON_LOADED event handling to reapply the
  button after reload, fixing the issue where users had to manually toggle
  the setting to get the button back.