### PR TITLE
Fix Blizzard party frame appearing when solo

### DIFF
--- a/EUI_QoL.lua
+++ b/EUI_QoL.lua
@@ -913,8 +913,6 @@ qolFrame:SetScript("OnEvent", function(self)
                         end
                     end)
                 end
-            else
-                mgr:Show()
             end
         end
 
@@ -922,8 +920,11 @@ qolFrame:SetScript("OnEvent", function(self)
 
         local initFrame = CreateFrame("Frame")
         initFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
-        initFrame:SetScript("OnEvent", function(self)
-            self:UnregisterEvent("PLAYER_ENTERING_WORLD")
+        initFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
+        initFrame:SetScript("OnEvent", function(self, event)
+            if event == "PLAYER_ENTERING_WORLD" then
+                self:UnregisterEvent("PLAYER_ENTERING_WORLD")
+            end
             ApplyHideBlizzardPartyFrame()
         end)
     end


### PR DESCRIPTION
Remove mgr:Show() call that was forcing the Blizzard CompactRaidFrameManager to display even when the player was solo. Now the frame visibility is controlled entirely by WoW's default logic when hideBlizzardPartyFrame is disabled:
  - Hidden when solo
  - Visible when in a group

When hideBlizzardPartyFrame is enabled, the frame is hidden and hooked to stay hidden if WoW tries to show it.