### PR TITLE
Fix spell flyout direction for all action bar buttons

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2582,8 +2582,17 @@ local function LayoutBar(key)
     end
     for i = 1, #buttons do
         local btn = buttons[i]
-        if btn and not InCombatLockdown() then
-            btn:SetAttribute("flyoutDirection", flyDir)
+        if btn then
+            -- Ensure the button has GetPopupDirection for Blizzard's SpellFlyout system
+            -- (must be available on all buttons, regardless of squareIcons setting)
+            if not btn.GetPopupDirection then
+                btn.GetPopupDirection = function(self)
+                    return self:GetAttribute("flyoutDirection") or "UP"
+                end
+            end
+            if not InCombatLockdown() then
+                btn:SetAttribute("flyoutDirection", flyDir)
+            end
         end
     end
 


### PR DESCRIPTION
Blizzard's SpellFlyout system calls GetPopupDirection() on buttons to determine the direction to open menus (Mage Portals, Warbands, etc.). This method was only being set on buttons when squareIcons was enabled (in MakeButtonSquare).

For buttons without squareIcons, GetPopupDirection() didn't exist, causing Blizzard's SpellFlyout to default to "UP" regardless of the action bar position.

Solution: Ensure GetPopupDirection() is set for ALL buttons during bar layout, not just squared ones. This ensures flyout menus respect the action bar's screen position:

Vertical bar on RIGHT → flyout opens LEFT
Horizontal bar on TOP → flyout opens DOWN

Known limitation:
Bar layout changes require a /reload to take full effect. Fixing this properly would require a larger refactor to stay within Lua's 200 local variable limit per function scope, which was out of scope for this fix.