### PR TITLE
Refactor dungeon completion logic in timer module

### DIFF
--- a/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
+++ b/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
@@ -698,6 +698,7 @@ local function StartRun()
     currentRun.affixes       = affixes or {}
     currentRun.preciseStart = GetTimePreciseSec and GetTimePreciseSec() or nil
     currentRun.preciseCompletedElapsed = nil
+    currentRun._lastDungeonComplete = false
     wipe(currentRun.objectives)
 
     if updateTicker then updateTicker:Cancel() end
@@ -737,6 +738,7 @@ local function ResetRun()
     currentRun.deathTimeLost = 0
     currentRun.preciseStart = nil
     currentRun.preciseCompletedElapsed = nil
+    currentRun._lastDungeonComplete = false
     wipe(currentRun.affixes)
     wipe(currentRun.objectives)
     if db and db.profile then db.profile._activeRunSplits = nil end
@@ -1614,22 +1616,23 @@ local function ApplyStandalonePosition()
     end
 end
 
-local function ArePrimaryObjectivesComplete()
+-- True only when every scenario objective is complete: Avoids false times being saved/missed runs due to completion on same tick
+local function IsDungeonComplete()
     local numCriteria = select(3, C_Scenario.GetStepInfo()) or 0
     if numCriteria == 0 then return false end
 
-    local seenPrimary = false
+    local seenAny = false
     for i = 1, numCriteria do
         local info = C_ScenarioInfo.GetCriteriaInfo(i)
-        if info and not info.isWeightedProgress then
-            seenPrimary = true
+        if info then
+            seenAny = true
             if not info.completed then
                 return false
             end
         end
     end
 
-    return seenPrimary
+    return seenAny
 end
 
 local runtimeFrame = CreateFrame("Frame")
@@ -1664,11 +1667,23 @@ local function RuntimeOnUpdate(_, elapsed)
     if activeMapID then
         if not currentRun.active and not currentRun.completed then
             StartRun()
-        elseif currentRun.active and ArePrimaryObjectivesComplete() then
+        elseif currentRun.active and IsDungeonComplete() then
+            -- Every objective done (bosses + Enemy Forces). Blizzard is about
+            -- to clear the M+, so save now with the accurate time.
             CompleteRun()
         end
+        -- Cache completion state while scenario APIs still answer. Used below
+        -- to salvage a run if the M+ clears between polls.
+        if currentRun.active then
+            currentRun._lastDungeonComplete = IsDungeonComplete()
+        end
     elseif currentRun.active or currentRun.completed then
-        ResetRun()
+        -- M+ cleared. Salvage as completion if last poll saw it complete.
+        if currentRun.active and currentRun._lastDungeonComplete then
+            CompleteRun()
+        else
+            ResetRun()
+        end
     end
 end
 


### PR DESCRIPTION
- Completion now requires all objectives including Enemy Forces, fixing artificially short times when the last boss died before trash hit 100%
- Added salvage path for the poll-race edge case where the M+ clears in the same 0.25s window that the final objective completes, which previously caused runs to be silently discarded