### PR TITLE
fix: pandemic glow behind the cooldown 'sweeping' on nameplates

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -766,7 +766,7 @@ local function StartPandemicGlow(slot, slotSize)
     if not pg then
         local wrapper = CreateFrame("Frame", nil, slot)
         wrapper:SetAllPoints()
-        wrapper:SetFrameLevel(slot:GetFrameLevel() + 1)
+        wrapper:SetFrameLevel(slot:GetFrameLevel() + 2) -- +1 is not enough and will put the glow underneath the icon
         local flipTex = wrapper:CreateTexture(nil, "OVERLAY", nil, 7)
         flipTex:SetPoint("CENTER")
         local animGroup = flipTex:CreateAnimationGroup()


### PR DESCRIPTION
# Motivation

When a pandemic glow is setup with a thicker line width; the biggest part of it ends up behind the nameplate frame cooldown sweeping.

I validated manually that bumping to +2 was enough to fix the problem by updating the addon source files.

I don't know if we can do better than this trivial fix by switching to a different layer above that icon.

## Reproducing

<img width="963" height="205" alt="image" src="https://github.com/user-attachments/assets/808c3481-11a0-41fd-a4b3-f5a2ce46163e" />
<img width="306" height="183" alt="image" src="https://github.com/user-attachments/assets/ec4997d0-47f6-4d57-80ab-cdba055e1cf9" />

## Before

<img width="223" height="160" alt="image" src="https://github.com/user-attachments/assets/a3eb4206-3986-4bea-87ce-a5944c77d654" />


## After

<img width="254" height="185" alt="image" src="https://github.com/user-attachments/assets/2c29c83a-a5dc-4d6d-ab05-58d5d3fa6238" />

