### PR TITLE
Add configurable chat history size option

### DIFF
--- a/EllesmereUIChat/EUI_Chat_Options.lua
+++ b/EllesmereUIChat/EUI_Chat_Options.lua
@@ -219,7 +219,13 @@ initFrame:SetScript("OnEvent", function(self)
                       Set("timestampFormat", v)
                       if ECHAT.ApplyTimestampCVar then ECHAT.ApplyTimestampCVar() end
                   end },
-                { type="label", text="" })
+                { type="slider", text="Chat History Size",
+              min = 128, max = 4096, step = 128,
+              getValue=function() return Cfg("chatHistorySize") or 512 end,
+              setValue=function(v)
+                  Set("chatHistorySize", v)
+                  if ECHAT.ApplyHistorySize then ECHAT.ApplyHistorySize() end
+              end })
         end
         y = y - h
 

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -65,6 +65,7 @@ local CHAT_DEFAULTS = {
             hideSidebarBg = false,
             sidebarIconScale = 1.0,
             sidebarIconSpacing = 10,
+            chatHistorySize = 512,
             freeMoveIcons = false,
             iconPositions = {},
             sidebarIconOrder = {
@@ -1633,6 +1634,17 @@ local CHAT_MSG_EVENTS = {
     CHAT_MSG_MONSTER_SAY = true, CHAT_MSG_MONSTER_YELL = true,
 }
 
+function ECHAT.ApplyHistorySize()
+    local cfg = ECHAT.DB()
+    local size = cfg.chatHistorySize or 512
+    for i = 1, 20 do
+        local cf = _G["ChatFrame" .. i]
+        if cf and _skinned[cf] then
+            cf:SetMaxLines(size)
+        end
+    end
+end
+
 -------------------------------------------------------------------------------
 --  Tab reskin: in-place reskin of Blizzard tabs.
 --  We work WITH Blizzard's tab system instead of replacing it.
@@ -2218,6 +2230,10 @@ local function SkinChatFrame(cf)
     if cf.SetShadowOffset then cf:SetShadowOffset(1, -1) end
     if cf.SetShadowColor then cf:SetShadowColor(0, 0, 0, 0.8) end
     cf:SetFading(false)
+
+    local db = EnsureDB()
+    local histSize = db and db.profile and db.profile.chat and db.profile.chat.chatHistorySize or 512
+    cf:SetMaxLines(histSize)
 
     -- 3. Hyperlink handlers (per-frame, on our bg frame -- not on Blizzard's cf)
     --    OnHyperlinkEnter/Leave for tooltip, OnHyperlinkClick for item toggle


### PR DESCRIPTION
# Add configurable chat history size

Adds a slider in Chat options (DISPLAY section) to control the scroll-back buffer size per chat frame.

- New `chatHistorySize` setting (128–4096, default 512 — Blizzard default is 128)
- Applied at skin time via `SetMaxLines` and live-updatable from the options panel
- Slider placed in Row 4 next to Timestamps