### PR TITLE
New tooltip options: mouse anchor and hide during combat

### DIFF
--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -100,6 +100,19 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Anchor Tooltips to Mouse",
+              tooltip="Anchors tooltips to your mouse cursor instead of their normal HUD position.",
+              getValue=function()
+                  return EllesmereUIDB and EllesmereUIDB.tooltipAnchorMouse or false
+              end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.tooltipAnchorMouse = v
+              end },
+            { type="label", text="" } -- Empty placeholder to keep the grid aligned
+        );  y = y - h
+
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
         _, h = W:SectionHeader(parent, "GROUP FINDER QUEUE", y);  y = y - h

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -100,7 +100,11 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        _, h = W:DualRow(parent, y,
+        local modValues = { NONE = "None", SHIFT = "Shift", CTRL = "Control", ALT = "Alt" }
+        local modOrder  = { "NONE", "SHIFT", "CTRL", "ALT" }
+
+        local tooltipModifierRow
+        tooltipModifierRow, h = W:DualRow(parent, y,
             { type="toggle", text="Anchor Tooltips to Mouse",
               tooltip="Anchors tooltips to your mouse cursor instead of their normal HUD position.",
               getValue=function()
@@ -110,6 +114,63 @@ initFrame:SetScript("OnEvent", function(self)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.tooltipAnchorMouse = v
               end },
+              { type="dropdown", text="Show Tooltip Modifier",
+              tooltip="Require a modifier key to be held down to display tooltips.",
+              values=modValues, order=modOrder,
+              getValue=function()
+                  return EllesmereUIDB and EllesmereUIDB.tooltipModifier or "NONE"
+              end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.tooltipModifier = v
+              end }
+        );
+
+        -- Popup cog menu to choose what tooltip types to hide
+        local hideTypesCogOpts = {
+            title = "Hide Tooltip Types",
+            rows = {
+                { type="toggle", label="Units", get=function() return not EllesmereUIDB or EllesmereUIDB.ttHideType_Unit ~= false end, set=function(v) if not EllesmereUIDB then EllesmereUIDB = {} end EllesmereUIDB.ttHideType_Unit = v end },
+                { type="toggle", label="Spells", get=function() return not EllesmereUIDB or EllesmereUIDB.ttHideType_Spell ~= false end, set=function(v) if not EllesmereUIDB then EllesmereUIDB = {} end EllesmereUIDB.ttHideType_Spell = v end },
+                { type="toggle", label="Items", get=function() return not EllesmereUIDB or EllesmereUIDB.ttHideType_Item ~= false end, set=function(v) if not EllesmereUIDB then EllesmereUIDB = {} end EllesmereUIDB.ttHideType_Item = v end },
+            },
+        }
+        local _, cogShow = EllesmereUI.BuildCogPopup(hideTypesCogOpts)
+        local cogBtn = CreateFrame("Button", nil, tooltipModifierRow._rightRegion)
+        cogBtn:SetSize(26, 26)
+        cogBtn:SetPoint("RIGHT", tooltipModifierRow._rightRegion._lastInline or tooltipModifierRow._rightRegion._control, "LEFT", -8, 0)
+        tooltipModifierRow._rightRegion._lastInline = cogBtn
+        cogBtn:SetFrameLevel(tooltipModifierRow._rightRegion:GetFrameLevel() + 5)
+        local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+        cogTex:SetAllPoints()
+        cogTex:SetTexture(EllesmereUI.COGS_ICON)
+        local function IsModifierActive()
+            return EllesmereUIDB and EllesmereUIDB.tooltipModifier and EllesmereUIDB.tooltipModifier ~= "NONE"
+        end
+        local function refreshCog()
+            cogBtn:EnableMouse(true)
+            if IsModifierActive() then cogBtn:SetAlpha(0.4) else cogBtn:SetAlpha(0.15) end
+        end
+        cogBtn:SetScript("OnEnter", function(self) 
+            if IsModifierActive() then
+                self:SetAlpha(0.7)
+            else
+                EllesmereUI.ShowWidgetTooltip(self, "This option requires a modifier to be assigned.")
+            end 
+        end)
+        cogBtn:SetScript("OnLeave", function(self) 
+            self:SetAlpha(IsModifierActive() and 0.4 or 0.15) 
+            EllesmereUI.HideWidgetTooltip()
+        end)
+        cogBtn:SetScript("OnClick", function(self) 
+            if IsModifierActive() then cogShow(self) end 
+        end)
+        EllesmereUI.RegisterWidgetRefresh(refreshCog)
+        refreshCog()
+        
+        y = y - h
+        
+        _, h = W:DualRow(parent, y,
             { type="toggle", text="Hide Tooltips in Combat",
               tooltip="Prevents tooltips from showing while you are in combat.",
               getValue=function()
@@ -118,8 +179,9 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.tooltipHideInCombat = v
-              end }
-        );  y = y - h
+              end },
+              { type="label", text="" }
+        ); y = y - h
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
 

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -110,7 +110,15 @@ initFrame:SetScript("OnEvent", function(self)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.tooltipAnchorMouse = v
               end },
-            { type="label", text="" } -- Empty placeholder to keep the grid aligned
+            { type="toggle", text="Hide Tooltips in Combat",
+              tooltip="Prevents tooltips from showing while you are in combat.",
+              getValue=function()
+                  return EllesmereUIDB and EllesmereUIDB.tooltipHideInCombat or false
+              end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.tooltipHideInCombat = v
+              end }
         );  y = y - h
 
         _, h = W:Spacer(parent, y, 20);  y = y - h

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -165,6 +165,16 @@ local ADDON_NAME = ...
             _GameTooltip:HookScript("OnTooltipSetUnit", _ttUnitColor)
             _GameTooltip:HookScript("OnTooltipSetSpell", _ttAccentTitle)
         end
+        -- Sets tooltip anchor
+        if GameTooltip_SetDefaultAnchor then
+            hooksecurefunc("GameTooltip_SetDefaultAnchor", function(tt, parent)
+                if EllesmereUIDB and EllesmereUIDB.tooltipAnchorMouse then
+                    if parent then
+                        tt:SetOwner(parent, "ANCHOR_CURSOR_RIGHT")
+                    end
+                end
+            end)
+        end
     end
 
     -- Context menu skinning

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -67,10 +67,33 @@ local ADDON_NAME = ...
     end
 
     local function _ttOnShow(self) 
-        -- Block tooltips from showing if the hide in combat toggle is on and combat is active
-        if EllesmereUIDB and EllesmereUIDB.tooltipHideInCombat and InCombatLockdown() then
-            self:Hide()
-            return
+        if EllesmereUIDB then
+            -- Combat check
+            if EllesmereUIDB.tooltipHideInCombat and InCombatLockdown() then
+                self:Hide()
+                return
+            end
+            -- Modifier check
+            local modifier = EllesmereUIDB.tooltipModifier or "NONE"
+            if modifier ~= "NONE" then
+                local isHeld = false
+                if modifier == "SHIFT" then isHeld = IsShiftKeyDown()
+                elseif modifier == "CTRL" then isHeld = IsControlKeyDown()
+                elseif modifier == "ALT" then isHeld = IsAltKeyDown()
+                end
+
+                if not isHeld then
+                    local ttData = self.GetTooltipData and self:GetTooltipData()
+                    if ttData then
+                        if ttData.type == Enum.TooltipDataType.Unit and (EllesmereUIDB.ttHideType_Unit ~= false) then self:Hide() end
+                        if ttData.type == Enum.TooltipDataType.Item and (EllesmereUIDB.ttHideType_Item ~= false) then self:Hide() end
+                        if (ttData.type == Enum.TooltipDataType.Spell or ttData.type == Enum.TooltipDataType.Macro) 
+                           and (EllesmereUIDB.ttHideType_Spell ~= false) then self:Hide() end
+                    else
+                        -- Fallback for custom/older frames without TooltipData (treat them as generic UI elements)
+                    end
+                end
+            end
         end
         _ttSkin(self); _ttFonts(self) 
     end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -66,7 +66,14 @@ local ADDON_NAME = ...
         end
     end
 
-    local function _ttOnShow(self) _ttSkin(self); _ttFonts(self) end
+    local function _ttOnShow(self) 
+        -- Block tooltips from showing if the hide in combat toggle is on and combat is active
+        if EllesmereUIDB and EllesmereUIDB.tooltipHideInCombat and InCombatLockdown() then
+            self:Hide()
+            return
+        end
+        _ttSkin(self); _ttFonts(self) 
+    end
 
     local function _ttHook(tt)
         if not tt or tt:IsForbidden() or _ttSkinned[tt] then return end
@@ -175,6 +182,17 @@ local ADDON_NAME = ...
                 end
             end)
         end
+        -- Hide currently open tooltips when combat starts if the hide in combat toggle is on
+        local combatTooltipHider = CreateFrame("Frame")
+        combatTooltipHider:RegisterEvent("PLAYER_REGEN_DISABLED") -- Fires when entering combat
+        combatTooltipHider:SetScript("OnEvent", function()
+            if EllesmereUIDB and EllesmereUIDB.tooltipHideInCombat then
+                -- Hide the main game tooltip if it's currently on screen
+                if _GameTooltip:IsShown() then
+                    _GameTooltip:Hide()
+                end
+            end
+        end)
     end
 
     -- Context menu skinning


### PR DESCRIPTION
I have found that addons such as TipTac Reborn and Leatrix Plus conflict with the BlizzardSkin module and are not able to change the anchor or hide the skinned tooltips, so this PR adds a couple of options to control tooltips: anchoring them to the mouse and hiding them during combat.

Please let me know if it needs any improvements :)