### PR TITLE
Fix missing Tooltip Update Logic (#302)

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -6797,6 +6797,18 @@ local function ApplyBlizzCastbarState()
     end
 end
 
+-- Helper function based on the Blizzard UnitFrame_UpdateTooltip method
+-- without the Right-Click instruction line
+local function UnitFrame_CustomUpdateTooltip(self)
+    GameTooltip_SetDefaultAnchor(GameTooltip, self)
+    if GameTooltip:SetUnit(self.unit) then
+        GameTooltip:Show()
+        self.UpdateTooltip = UnitFrame_CustomUpdateTooltip
+    else
+        self.UpdateTooltip = nil
+    end
+end
+
 local function UnitFrame_OnEnter(self)
     local unit = self.unit
     if not unit then return end
@@ -6808,9 +6820,7 @@ local function UnitFrame_OnEnter(self)
     if unit and GameTooltip and GameTooltip_SetDefaultAnchor then
         local showTooltip = not s or s.showUnitTooltip ~= false
         if showTooltip then
-            GameTooltip_SetDefaultAnchor(GameTooltip, self)
-            GameTooltip:SetUnit(unit)
-            GameTooltip:Show()
+            UnitFrame_CustomUpdateTooltip(self)
         end
     end
 end


### PR DESCRIPTION
Simple fix for the missing Update Logic.

The Result:
<img width="339" height="203" alt="image" src="https://github.com/user-attachments/assets/c2185411-fd8c-4475-a298-8e41a61571e8" />
