### PR TITLE
AuraBuff Reminders: consumable low-time thresholds

### DIFF
--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -1126,7 +1126,14 @@ initFrame:SetScript("OnEvent", function(self)
         local consumHdr
         consumHdr, h = W:SectionHeader(parent, SECTION_CONSUMABLES, y);  y = y - h
 
-        -- Flask toggle | Preferred Click to Buff dropdown
+        local consumBuffRemindSliderTip =
+            "0 = only when the buff is missing. Above 0 = also remind while it has fewer than this many minutes left (same instance / M+ detection rules as before)."
+        local weRemindTip =
+            "0 = only when a weapon temp enchant is missing on a slot. Above 0 = also remind when that enchant has fewer than this many minutes left."
+        local augmentRuneTip =
+            "0 = only when no augment rune buff. Above 0 = also remind while the rune has fewer than this many minutes left (not during an active Mythic+ key)."
+
+        -- Flask toggle | Preferred Click to Buff dropdown (+ cog: time threshold)
         local consumFirstRow
         local flaskRow
         do
@@ -1147,9 +1154,29 @@ initFrame:SetScript("OnEvent", function(self)
                   setValue=function(v) local c = CDB(); if c then c.preferredFlask = v; RefreshAll() end end }
             );  y = y - h
             consumFirstRow = flaskRow
+            do
+                local rgn = flaskRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Flask — renew early",
+                    rows = {
+                        { type = "slider", label = "Remind under (minutes)", min = 0, max = 120, step = 1,
+                          get = function() local c = CDB(); return c and c.flaskReminderMinutes or 0 end,
+                          set = function(v) local c = CDB(); if c then c.flaskReminderMinutes = v; RefreshAll(); RebuildPreviewHeader() end end },
+                    },
+                })
+                local cogBtn = MakeCogBtn(rgn, cogShow)
+                cogBtn:SetScript("OnEnter", function(self)
+                    self:SetAlpha(0.7)
+                    EllesmereUI.ShowWidgetTooltip(self, consumBuffRemindSliderTip)
+                end)
+                cogBtn:SetScript("OnLeave", function(self)
+                    self:SetAlpha(0.4)
+                    EllesmereUI.HideWidgetTooltip()
+                end)
+            end
         end
 
-        -- Food toggle | Preferred Click to Buff dropdown
+        -- Food toggle | Preferred Click to Buff dropdown (+ cog)
         local foodRow
         do
             local FOOD_ITEMS = _G._EABR_FOOD_ITEMS or {}
@@ -1168,9 +1195,29 @@ initFrame:SetScript("OnEvent", function(self)
                   getValue=function() local c = CDB(); return c and c.preferredFood or "last_used" end,
                   setValue=function(v) local c = CDB(); if c then c.preferredFood = v; RefreshAll() end end }
             );  y = y - h
+            do
+                local rgn = foodRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Food — renew early",
+                    rows = {
+                        { type = "slider", label = "Remind under (minutes)", min = 0, max = 120, step = 1,
+                          get = function() local c = CDB(); return c and c.foodReminderMinutes or 0 end,
+                          set = function(v) local c = CDB(); if c then c.foodReminderMinutes = v; RefreshAll(); RebuildPreviewHeader() end end },
+                    },
+                })
+                local cogBtn = MakeCogBtn(rgn, cogShow)
+                cogBtn:SetScript("OnEnter", function(self)
+                    self:SetAlpha(0.7)
+                    EllesmereUI.ShowWidgetTooltip(self, consumBuffRemindSliderTip)
+                end)
+                cogBtn:SetScript("OnLeave", function(self)
+                    self:SetAlpha(0.4)
+                    EllesmereUI.HideWidgetTooltip()
+                end)
+            end
         end
 
-        -- Weapon Enhancement toggle | Preferred Click to Buff dropdown
+        -- Weapon Enhancement toggle | Preferred Click to Buff dropdown (+ cog)
         local weaponEnchantRow
         do
             local WE_CHOICES = _G._EABR_WEAPON_ENCHANT_CHOICES or {}
@@ -1189,19 +1236,60 @@ initFrame:SetScript("OnEvent", function(self)
                   getValue=function() local c = CDB(); return c and c.preferredWeaponEnchant or "last_used" end,
                   setValue=function(v) local c = CDB(); if c then c.preferredWeaponEnchant = v; RefreshAll() end end }
             );  y = y - h
+            do
+                local rgn = weaponEnchantRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Weapon enhancement — renew early",
+                    rows = {
+                        { type = "slider", label = "Remind under (minutes)", min = 0, max = 120, step = 1,
+                          get = function() local c = CDB(); return c and c.weaponEnchantReminderMinutes or 0 end,
+                          set = function(v) local c = CDB(); if c then c.weaponEnchantReminderMinutes = v; RefreshAll(); RebuildPreviewHeader() end end },
+                    },
+                })
+                local cogBtn = MakeCogBtn(rgn, cogShow)
+                cogBtn:SetScript("OnEnter", function(self)
+                    self:SetAlpha(0.7)
+                    EllesmereUI.ShowWidgetTooltip(self, weRemindTip)
+                end)
+                cogBtn:SetScript("OnLeave", function(self)
+                    self:SetAlpha(0.4)
+                    EllesmereUI.HideWidgetTooltip()
+                end)
+            end
         end
 
-        -- Augment Rune toggle | Display In dropdown
-        _, h = W:DualRow(parent, y,
+        -- Augment Rune toggle | Display In dropdown (+ cog)
+        local augmentRow
+        augmentRow, h = W:DualRow(parent, y,
             { type="toggle", text="Augment Rune",
               getValue=function() local c = CDB(); return c and c.enabled and c.enabled.augment_rune end,
               setValue=function(v) local c = CDB(); if c and c.enabled then c.enabled.augment_rune = v; RefreshAll(); RebuildPreviewHeader() end end },
-            { type="dropdown", text="Augment Reminder Only In:",
+            { type="dropdown", text="Augment Reminder Only In:", dropdownWidth=220,
               values={ mythic="Mythic Only", heroic_mythic="Heroic and Mythic", all="All Instanced Content" },
               order={ "mythic", "heroic_mythic", "all" },
               getValue=function() local c = CDB(); return c and c.runeDisplayMode or "mythic" end,
               setValue=function(v) local c = CDB(); if c then c.runeDisplayMode = v; RefreshAll() end end }
         );  y = y - h
+        do
+            local rgn = augmentRow._leftRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Augment rune — renew early",
+                rows = {
+                    { type = "slider", label = "Remind under (minutes)", min = 0, max = 120, step = 1,
+                      get = function() local c = CDB(); return c and c.augmentRuneReminderMinutes or 0 end,
+                      set = function(v) local c = CDB(); if c then c.augmentRuneReminderMinutes = v; RefreshAll(); RebuildPreviewHeader() end end },
+                },
+            })
+            local cogBtn = MakeCogBtn(rgn, cogShow)
+            cogBtn:SetScript("OnEnter", function(self)
+                self:SetAlpha(0.7)
+                EllesmereUI.ShowWidgetTooltip(self, augmentRuneTip)
+            end)
+            cogBtn:SetScript("OnLeave", function(self)
+                self:SetAlpha(0.4)
+                EllesmereUI.HideWidgetTooltip()
+            end)
+        end
 
         -- Healthstone toggle | Inky Black Potion toggle
         row, h = W:DualRow(parent, y,

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -961,6 +961,74 @@ local function PlayerHasFlaskBuff()
     return false
 end
 
+-- Remaining duration (seconds) on the active flask buff, or nil if unknown/none.
+-- Mirrors PlayerHasFlaskBuff restrictions (no scan in PvP / active M+ key).
+local function GetFlaskBuffRemainingSec()
+    if InPvPInstance() or InMythicPlusKey() then return nil end
+    local best = 0
+    for id in pairs(FLASK_BUFF_ID_SET) do
+        local ok, aura = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
+        if ok and aura and aura.expirationTime and aura.expirationTime > 0 then
+            local rem = aura.expirationTime - GetTime()
+            if rem > best then best = rem end
+        end
+    end
+    if best > 0 then return best end
+    if _AC.valid then
+        _AC.ensureNames()
+        for i = 1, AURA_SCAN_LIMIT do
+            local aura = C_UnitAuras.GetAuraDataByIndex("player", i, "HELPFUL")
+            if not aura then break end
+            local aName = aura.name
+            if aName and not isSecret(aName) and FLASK_NAME_SET[aName]
+                and aura.expirationTime and aura.expirationTime > 0 then
+                local rem = aura.expirationTime - GetTime()
+                if rem > best then best = rem end
+            end
+        end
+    end
+    return (best > 0) and best or nil
+end
+
+-- Well-fed (food) buff remaining seconds; nil if absent or in suppressed contexts.
+local function GetWellFedRemainingSec()
+    if InCombat() or InMythicPlusKey() or InPvPInstance() then return nil end
+    for i = 1, AURA_SCAN_LIMIT do
+        local aura = C_UnitAuras.GetAuraDataByIndex("player", i, "HELPFUL")
+        if not aura then break end
+        local ic = aura.icon
+        if ic and not isSecret(ic) and ic == 136000 then
+            if aura.expirationTime and aura.expirationTime > 0 then
+                return aura.expirationTime - GetTime()
+            end
+            return 86400 * 365 -- no expiry on aura; treat as well above any threshold
+        end
+    end
+    return nil
+end
+
+-- Temp weapon enchant remaining seconds from GetWeaponEnchantInfo (expiration is ms on Retail).
+local function TempWeaponEnchantRemainingSec(hasEnchant, rawExpiration)
+    if not hasEnchant or not rawExpiration or rawExpiration <= 0 then return nil end
+    local sec = rawExpiration / 1000
+    return sec > 0 and sec or nil
+end
+
+-- Longest remaining augment rune buff among known IDs (OOC; not used during active M+).
+local function GetAugmentRuneRemainingSec()
+    if InMythicPlusKey() then return nil end
+    local best = 0
+    for j = 1, #RUNE_BUFF_IDS do
+        local id = RUNE_BUFF_IDS[j]
+        local ok, aura = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
+        if ok and aura and aura.expirationTime and aura.expirationTime > 0 then
+            local rem = aura.expirationTime - GetTime()
+            if rem > best then best = rem end
+        end
+    end
+    return (best > 0) and best or nil
+end
+
 -------------------------------------------------------------------------------
 --  Item count cache: GetItemCount is a bag scan. Cache results and only
 --  invalidate on BAG_UPDATE_DELAYED (bags don't change during combat or
@@ -1159,6 +1227,11 @@ local defaults = {
             preferredWeaponEnchant = "last_used",
             runeDisplayMode = "mythic",
             inkyBlackZones = "",
+            -- 0 = only remind when buff/temp enchant is missing; >0 = also remind when remaining time is under this many minutes.
+            flaskReminderMinutes = 0,
+            foodReminderMinutes = 0,
+            weaponEnchantReminderMinutes = 0,
+            augmentRuneReminderMinutes = 0,
         },
         unlockPos = nil,
         talentReminders = {},  -- array of {zoneIDs={}, zoneNames={}, spellID=number, spellName=string, showNotNeeded=bool}
@@ -1893,8 +1966,13 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                 showRune = InRealInstancedContent()
             end
             if showRune then
-                local hasRuneBuff = InMythicPlusKey() or PlayerHasAuraByID(RUNE_BUFF_IDS)
-                if not hasRuneBuff then
+                -- During an active M+ key, rune detection is suppressed (unchanged).
+                if not InMythicPlusKey() then
+                    local hasRune = PlayerHasAuraByID(RUNE_BUFF_IDS)
+                    local thMin = co.augmentRuneReminderMinutes or 0
+                    local rem = GetAugmentRuneRemainingSec()
+                    local low = thMin > 0 and hasRune and rem and (rem < thMin * 60)
+                    if (not hasRune) or low then
                     local voidCount = CachedGetItemCount(259085)
                     local etherCount = CachedGetItemCount(243191)
                     local runeItem = nil
@@ -1908,6 +1986,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                         e.cat = "consumable"; e.scale = co.scale or 1.0
                         e.dismissKey = "consumable:rune"
                         missing[#missing+1] = e
+                    end
                     end
                 end
             end
@@ -1928,15 +2007,21 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
             if IsSpellKnown(sid) then _hasImbueSpell = true; break end
         end
         if co.enabled.weapon_enchant and not _hasImbueSpell then
-            local hasMH, _, _, _, hasOH = GetWeaponEnchantInfo()
+            local hasMH, mhExp, _, _, hasOH, ohExp = GetWeaponEnchantInfo()
             local mhCat = GetWeaponCategory(16)
             local ohCat = GetWeaponCategory(17)
+            local weThMin = co.weaponEnchantReminderMinutes or 0
 
             -- Check each weapon slot independently (both can show at once)
             local preferredKey = co.preferredWeaponEnchant or "last_used"
             local lastUsedID = db.char and db.char.lastUsedWeaponEnchant or nil
-            for _, si in ipairs({{slot=16, cat=mhCat, has=hasMH}, {slot=17, cat=ohCat, has=hasOH}}) do
-                if si.cat and not si.has then
+            for _, si in ipairs({
+                { slot = 16, cat = mhCat, has = hasMH, exp = mhExp },
+                { slot = 17, cat = ohCat, has = hasOH, exp = ohExp },
+            }) do
+                local remSec = TempWeaponEnchantRemainingSec(si.has, si.exp)
+                local lowWe = weThMin > 0 and si.has and remSec and (remSec < weThMin * 60)
+                if si.cat and ((not si.has) or lowWe) then
                     local bestItemID = FindWeaponEnchantItem(preferredKey, lastUsedID, si.cat)
                     local hasBags = (bestItemID ~= nil)
                     if not bestItemID then
@@ -1978,7 +2063,11 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
 
         -- Flask (OOC only; detection uses snapshot during keystones and PvP)
         if co.enabled.flask then
-            if not PlayerHasFlaskBuff() then
+            local thMin = co.flaskReminderMinutes or 0
+            local missingFlask = not PlayerHasFlaskBuff()
+            local remFlask = GetFlaskBuffRemainingSec()
+            local lowFlask = thMin > 0 and (not missingFlask) and remFlask and (remFlask < thMin * 60)
+            if missingFlask or lowFlask then
                 local preferredKey = co.preferredFlask or "last_used"
                 local lastUsedID = db.char and db.char.lastUsedFlask or nil
                 local flaskItemID = FindFlaskItem(preferredKey, lastUsedID)
@@ -2012,7 +2101,11 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
 
         -- Food / Well Fed (OOC only; detection uses snapshot during keystones)
         if co.enabled.food then
-            if not PlayerHasWellFed() then
+            local thFood = co.foodReminderMinutes or 0
+            local missingFood = not PlayerHasWellFed()
+            local remFood = GetWellFedRemainingSec()
+            local lowFood = thFood > 0 and (not missingFood) and remFood and (remFood < thFood * 60)
+            if missingFood or lowFood then
                 local preferredKey = co.preferredFood or "last_used"
                 local lastUsedID = db.char and db.char.lastUsedFood or nil
                 local foodItemID = FindFoodItem(preferredKey, lastUsedID)

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -2527,6 +2527,10 @@ local REFRESH_THROTTLE_COMBAT = 0.5
 local REFRESH_THROTTLE_OOC    = 0.5
 local _lastRefreshTime = 0
 local _refreshTimerActive = false
+-- When consumable "remind under N minutes" is used, duration can cross N without
+-- UNIT_AURA (Blizzard often does not fire it on passive countdown). Ticker handle
+-- is set in OnEnable.
+local _consumableThresholdTicker = nil
 local function _doRefresh()
     _refreshTimerActive = false
     refreshQueued = false
@@ -3127,6 +3131,25 @@ function EABR:OnEnable()
     RequestRefresh()
     BeaconInit()
     C_Timer.After(0.5, RegisterUnlockElements)
+
+    -- OOC tick while any consumable low-time threshold is enabled. Aura APIs update
+    -- expiration every frame, but UNIT_AURA often does not fire as time passes alone,
+    -- so without this the reminder could stay hidden until another event (bag, combat, etc.).
+    if not _consumableThresholdTicker then
+        _consumableThresholdTicker = C_Timer.NewTicker(10, function()
+            if not db or not db.profile then return end
+            if db.profile.display and db.profile.display.remindersEnabled == false then return end
+            local co = db.profile.consumables
+            if not co or InCombat() then return end
+            if (co.flaskReminderMinutes or 0) <= 0
+                and (co.foodReminderMinutes or 0) <= 0
+                and (co.weaponEnchantReminderMinutes or 0) <= 0
+                and (co.augmentRuneReminderMinutes or 0) <= 0 then
+                return
+            end
+            RequestRefresh()
+        end)
+    end
 
     -- Register broad UNIT_AURA only when the player's class actually needs
     -- group aura tracking AND only while out of combat.  Broad UNIT_AURA

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3132,11 +3132,11 @@ function EABR:OnEnable()
     BeaconInit()
     C_Timer.After(0.5, RegisterUnlockElements)
 
-    -- OOC tick while any consumable low-time threshold is enabled. Aura APIs update
-    -- expiration every frame, but UNIT_AURA often does not fire as time passes alone,
+    -- OOC tick every 30s while any consumable low-time threshold is enabled. Aura APIs
+    -- update expiration every frame, but UNIT_AURA often does not fire as time passes alone,
     -- so without this the reminder could stay hidden until another event (bag, combat, etc.).
     if not _consumableThresholdTicker then
-        _consumableThresholdTicker = C_Timer.NewTicker(10, function()
+        _consumableThresholdTicker = C_Timer.NewTicker(30, function()
             if not db or not db.profile then return end
             if db.profile.display and db.profile.display.remindersEnabled == false then return end
             local co = db.profile.consumables


### PR DESCRIPTION
## Summary

Adds optional per-consumable **remind when under N minutes** for flask, food, weapon temp enchants, and augment rune. When N is 0, behavior stays **missing buff / enchant only** (unchanged).

## UI

Threshold is set from a **cog** on each consumable row (two-column layout preserved). Popup: **Remind under (minutes)** (0–120).

## Logic

- **Flask / food:** Uses aura `expirationTime` vs `GetTime()` with the same instance / M+ / PvP rules as existing helpers.
- **Weapon temp enchants:** Uses `GetWeaponEnchantInfo` expiration (thousandths of a second → seconds) per slot.
- **Augment rune:** Outside an active Mythic+ key, missing or under threshold (still no reminder during an active key).

## Periodic refresh

`UNIT_AURA` often does not fire as duration counts down alone. While any threshold is greater than zero and the player is **out of combat**, a **30s** ticker calls `RequestRefresh()` so reminders can update after idle time (e.g. dungeon entrance).

## Testing

- [ ] `/reload`; set a threshold; confirm reminder when remaining time drops below N minutes OOC.
- [ ] Threshold 0: only missing-state reminders.
