### PR TITLE
Aurabuff Reminders: Add the ability to remind for buffs under a certain threshold remaining.

### DIFF
--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -945,6 +945,31 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
+        -- Row 5: Opacity | Frame Strata
+        _, h = W:DualRow(parent, y,
+            { type="slider", text="Dungeon: Show Buffs With Duration Less Than", min=0, max=60, step=1,
+              tooltip="In a Mythic 0 dungeon, Show buffs when the duration is less than this many minutes. Set to 0 to disable.",
+              getValue=function() local d = DDB(); return  d and d.showUnderDurationDungeon or 0 end,
+              setValue=function(v)
+                  local d = DDB(); if not d then return end; d.showUnderDurationDungeon = v
+                  RefreshAll()
+                  EllesmereUI:RefreshPage()
+              end }
+        );  y = y - h
+
+        
+        -- Row 6: Opacity | Frame Strata
+        _, h = W:DualRow(parent, y,
+            { type="slider", text="Raid: Show Buffs With Duration Less Than", min=0, max=60, step=1,
+              tooltip="In a Mythic 0 dungeon, Show buffs when the duration is less than this many minutes. Set to 0 to disable.",
+              getValue=function() local d = DDB(); return  d and d.showUnderDurationRaid or 0 end,
+              setValue=function(v)
+                  local d = DDB(); if not d then return end; d.showUnderDurationRaid = v
+                  RefreshAll()
+                  EllesmereUI:RefreshPage()
+              end }
+        );  y = y - h
+
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
         -----------------------------------------------------------------------

--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -947,7 +947,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Row 5: Opacity | Frame Strata
         _, h = W:DualRow(parent, y,
-            { type="slider", text="Dungeon: Show Buffs With Duration Less Than", min=0, max=60, step=1,
+            { type="slider", text="Dungeon: Show Buffs With Duration Less Than:", min=0, max=60, step=1,
               tooltip="In a Mythic 0 dungeon, Show buffs when the duration is less than this many minutes. Set to 0 to disable.",
               getValue=function() local d = DDB(); return  d and d.showUnderDurationDungeon or 0 end,
               setValue=function(v)
@@ -960,7 +960,7 @@ initFrame:SetScript("OnEvent", function(self)
         
         -- Row 6: Opacity | Frame Strata
         _, h = W:DualRow(parent, y,
-            { type="slider", text="Raid: Show Buffs With Duration Less Than", min=0, max=15, step=1,
+            { type="slider", text="Raid: Show Buffs With Duration Less Than:", min=0, max=15, step=1,
               tooltip="In a Raid, Show buffs when the duration is less than this many minutes. Set to 0 to disable.",
               getValue=function() local d = DDB(); return  d and d.showUnderDurationRaid or 0 end,
               setValue=function(v)

--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -960,8 +960,8 @@ initFrame:SetScript("OnEvent", function(self)
         
         -- Row 6: Opacity | Frame Strata
         _, h = W:DualRow(parent, y,
-            { type="slider", text="Raid: Show Buffs With Duration Less Than", min=0, max=60, step=1,
-              tooltip="In a Mythic 0 dungeon, Show buffs when the duration is less than this many minutes. Set to 0 to disable.",
+            { type="slider", text="Raid: Show Buffs With Duration Less Than", min=0, max=15, step=1,
+              tooltip="In a Raid, Show buffs when the duration is less than this many minutes. Set to 0 to disable.",
               getValue=function() local d = DDB(); return  d and d.showUnderDurationRaid or 0 end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.showUnderDurationRaid = v

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -30,6 +30,7 @@ local DEFAULT_TEXT_COLOR = {r=1, g=1, b=1}
 -- cast or combat end. OOC falls back to target debuff check.
 local _huntersMarkNeeded = false
 
+local db  -- set in EABR:OnInitialize()
 -- Flask state snapshotted before PvP restriction activates (aura API locked in PvP).
 
 
@@ -137,10 +138,16 @@ local function InMythicPlusKey()
     return C_ChallengeMode and C_ChallengeMode.IsChallengeModeActive and C_ChallengeMode.IsChallengeModeActive()
 end
 
+local function InMythicZeroDungeon()
+    if _cachedIType == "party" and (_cachedDiffID == 23 or _cachedDiffID == 8) then return true end
+    return false
+end
+
+
 -- Mythic 0 dungeon (party, normal difficulty 1) or Mythic raid (difficulty 16)
 local function InMythicZeroDungeonOrMythicRaid()
-    if _cachedIType == "party" and (_cachedDiffID == 23 or _cachedDiffID == 8) then return true end
-    if _cachedIType == "raid" and _cachedDiffID == 16 then return true end
+    if InMythicZeroDungeon() then return true end
+    if IsInRaid() and _cachedDiffID == 16 then return true end
     return false
 end
 
@@ -290,6 +297,17 @@ function _AC.ensureNames()
     end
 end
 
+local function IsUnderDuration(aura)
+    if InMythicZeroDungeon() and db and db.profile.display.showUnderDurationDungeon > 0 and aura['duration'] >= db.profile.display.showUnderDurationDungeon*60 and aura['expirationTime'] - GetTime() < db.profile.display.showUnderDurationDungeon*60 then
+        return true
+    end
+    if IsInRaid() and db and db.profile.display.showUnderDurationRaid > 0 and aura['duration'] >= db.profile.display.showUnderDurationRaid*60 and aura['expirationTime'] - GetTime() < db.profile.display.showUnderDurationRaid*60 then
+        return true
+    end
+    
+    return false 
+end
+
 local function PlayerHasAuraByID(spellIDs)
     if not spellIDs or not spellIDs[1] then return true end
     local inCombat = InCombat()
@@ -300,7 +318,12 @@ local function PlayerHasAuraByID(spellIDs)
         if NON_SECRET_SPELL_IDS[id] then
             local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
             if ok then
-                if result ~= nil then return true end
+                if result ~= nil then 
+                    if IsUnderDuration(result) then
+                        return false
+                    end
+                    return true 
+                end
                 if inCombat and _preCombatAuraCache[id] then return true end
             else
                 if inCombat and _preCombatAuraCache[id] then return true end
@@ -309,7 +332,12 @@ local function PlayerHasAuraByID(spellIDs)
             -- Non-whitelisted OOC: use GetPlayerAuraBySpellID anyway (may return
             -- secret values, but non-nil means the aura exists)
             local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
-            if ok and result ~= nil then return true end
+            if ok and result ~= nil then
+                if IsUnderDuration(result) then
+                    return false
+                end
+                return true
+            end
         else
             if _preCombatAuraCache[id] then return true end
         end
@@ -1121,6 +1149,8 @@ local defaults = {
             opacity = 1.0,
             frameStrata = "MEDIUM",
             cursorAttach = false,
+            showUnderDurationDungeon = 0,
+            showUnderDurationRaid = 0,
         },
         raidBuffs = {
             showNonInstanced = false,
@@ -1171,7 +1201,6 @@ local defaults = {
     },
 }
 
-local db  -- set in EABR:OnInitialize()
 local euiPanelOpen = false
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -297,11 +297,11 @@ function _AC.ensureNames()
     end
 end
 
-local function IsUnderDuration(aura)
-    if InMythicZeroDungeon() and db and db.profile.display.showUnderDurationDungeon > 0 and aura['duration'] >= db.profile.display.showUnderDurationDungeon*60 and aura['expirationTime'] - GetTime() < db.profile.display.showUnderDurationDungeon*60 then
+local function IsUnderDuration(duration, expirationTime)
+    if InMythicZeroDungeon() and db and db.profile.display.showUnderDurationDungeon > 0 and duration >= db.profile.display.showUnderDurationDungeon*60 and expirationTime - GetTime() < db.profile.display.showUnderDurationDungeon*60 then
         return true
     end
-    if IsInRaid() and db and db.profile.display.showUnderDurationRaid > 0 and aura['duration'] >= db.profile.display.showUnderDurationRaid*60 and aura['expirationTime'] - GetTime() < db.profile.display.showUnderDurationRaid*60 then
+    if IsInRaid() and db and db.profile.display.showUnderDurationRaid > 0 and duration >= db.profile.display.showUnderDurationRaid*60 and expirationTime - GetTime() < db.profile.display.showUnderDurationRaid*60 then
         return true
     end
     
@@ -319,7 +319,7 @@ local function PlayerHasAuraByID(spellIDs)
             local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
             if ok then
                 if result ~= nil then 
-                    if IsUnderDuration(result) then
+                    if IsUnderDuration(result.duration, result.expirationTime) then
                         return false
                     end
                     return true 
@@ -333,7 +333,7 @@ local function PlayerHasAuraByID(spellIDs)
             -- secret values, but non-nil means the aura exists)
             local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
             if ok and result ~= nil then
-                if IsUnderDuration(result) then
+                if IsUnderDuration(result.duration, result.expirationTime) then
                     return false
                 end
                 return true
@@ -965,7 +965,12 @@ local function PlayerHasWellFed()
         local aura = C_UnitAuras.GetAuraDataByIndex("player", i, "HELPFUL")
         if not aura then break end
         local ic = aura.icon
-        if ic and not isSecret(ic) and ic == 136000 then return true end
+        if ic and not isSecret(ic) and ic == 136000 then 
+            if IsUnderDuration(aura.duration, aura.expirationTime) then
+                return false
+            end
+            return true
+        end
     end
     return false
 end
@@ -977,7 +982,12 @@ local function PlayerHasFlaskBuff()
     -- Direct ID lookup for known flask buff IDs (zero allocation)
     for id in pairs(FLASK_BUFF_ID_SET) do
         local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
-        if ok and result ~= nil then return true end
+        if ok and result ~= nil then 
+            if IsUnderDuration(result.duration, result.expirationTime) then
+                return false
+            end
+            return true
+        end
     end
     -- Name-based fallback for flasks not in our ID set (lazy scan)
     if _AC.valid then

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1870,14 +1870,24 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
             -- both weapon slots. GetWeaponEnchantInfo returns the specific
             -- enchant ID on each hand (4th and 8th return values).
             if playerClass == "SHAMAN" then
-                local hasMH, _, _, mhEnchID, hasOH, _, _, ohEnchID = GetWeaponEnchantInfo()
+                local hasMH, mhExpire, _, mhEnchID, hasOH, ohExpire, _, ohEnchID = GetWeaponEnchantInfo()
                 for _, imbue in ipairs(SHAMAN_IMBUES) do
                     if co.enabled[imbue.key] and Known(imbue.castSpell) then
                         local found = false
                         if imbue.wepEnchID then
                             for _, eid in ipairs(imbue.wepEnchID) do
                                 if eid > 0 and ((hasMH and mhEnchID == eid) or (hasOH and ohEnchID == eid)) then
-                                    found = true; break
+                                    if not mhExpire then
+                                        mhExpire = math.huge -- if expiration is missing, assume it's active (pre-9.2 client versions)
+                                    end
+                                    if not ohExpire then
+                                        ohExpire = math.huge
+                                    end
+                                    if IsUnderDuration(3600, math.min(mhExpire, ohExpire)/1000 + GetTime()) then -- the expire duration is different than this function assumes given in ms remaining. Convert to the expected value by dividing by 1000 adding time 
+                                        found = false
+                                    else
+                                        found = true
+                                    end
                                 end
                             end
                         end

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.toc
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.toc
@@ -4,7 +4,7 @@
 ## Group: EllesmereUI
 ## Notes: Reminders for upkeeping Auras, Buffs and Consumables
 ## Author: Ellesmere
-## Version: 7.5.9
+## Version: 7.6.1
 ## Dependencies: EllesmereUI
 ## SavedVariables: EllesmereUIAuraBuffRemindersDB
 ## IconTexture: Interface\AddOns\EllesmereUI\media\eg-logo.tga

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.toc
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.toc
@@ -4,7 +4,7 @@
 ## Group: EllesmereUI
 ## Notes: Reminders for upkeeping Auras, Buffs and Consumables
 ## Author: Ellesmere
-## Version: 7.6.1
+## Version: 7.5.9
 ## Dependencies: EllesmereUI
 ## SavedVariables: EllesmereUIAuraBuffRemindersDB
 ## IconTexture: Interface\AddOns\EllesmereUI\media\eg-logo.tga


### PR DESCRIPTION
Applies to all non-raid buffs with a duration above the specified duration.

Two seperate sliders, one for raid, one for dungeon.

Example in dungeon with value set to 59

<img width="643" height="193" alt="image" src="https://github.com/user-attachments/assets/ec11045c-2650-4c3a-904a-13551a52655f" />




The UI settings change:

<img width="952" height="360" alt="image" src="https://github.com/user-attachments/assets/778f3806-d62f-499e-abdb-00798661f352" />


