### PR TITLE
Add Auto Combat Logging feature & options

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_AutoLogging_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_AutoLogging_Options.lua
@@ -1,0 +1,93 @@
+-------------------------------------------------------------------------------
+--  EUI_QoL_AutoLogging_Options.lua
+--  Options page for the Auto Combat Logging feature.
+-------------------------------------------------------------------------------
+
+-- Must match TRIGGER_DEFAULTS in the runtime.
+local TRIGGER_DEFAULTS = {
+    logMythic   = true,
+    logHeroic   = true,
+    logNormal   = true,
+    logLFR      = true,
+    log5pp      = true,
+    logArena    = true,
+    logScenario = false,
+}
+
+local TRIGGER_ITEMS = {
+    { key = "logMythic",   label = "Mythic Raid" },
+    { key = "logHeroic",   label = "Heroic Raid" },
+    { key = "logNormal",   label = "Normal Raid" },
+    { key = "logLFR",      label = "LFR" },
+    { key = "log5pp",      label = "Mythic+ Dungeons" },
+    { key = "logArena",    label = "Arena" },
+    { key = "logScenario", label = "Scenarios" },
+}
+
+local function Cfg()
+    if not EllesmereUIDB then return {} end
+    EllesmereUIDB.autoLogging = EllesmereUIDB.autoLogging or {}
+    return EllesmereUIDB.autoLogging
+end
+
+local function Recheck()
+    if _G._EUI_AutoLogging_Check then _G._EUI_AutoLogging_Check() end
+end
+
+local function BuildAutoLoggingPage(pageName, parent, yOffset)
+    local W  = EllesmereUI.Widgets
+    local PP = EllesmereUI.PanelPP
+    local y  = yOffset
+    local _, h
+
+    if EllesmereUI.ClearContentHeader then EllesmereUI:ClearContentHeader() end
+    parent._showRowDivider = true
+
+    _, h = W:SectionHeader(parent, "AUTO COMBAT LOGGING", y); y = y - h
+
+    local trigRow, trigH = W:DualRow(parent, y,
+        { type    = "toggle",
+          text    = "Enable Auto Logging",
+          tooltip = "Automatically starts and stops combat logging when entering or leaving a loggable instance.",
+          getValue = function() return Cfg().enabled == true end,
+          setValue = function(v)
+              Cfg().enabled = v or nil
+              Recheck()
+              EllesmereUI:RefreshPage()
+          end },
+        { type    = "dropdown", text = "Auto-Log Triggers",
+          values  = { __placeholder = "..." }, order = { "__placeholder" },
+          getValue = function() return "__placeholder" end,
+          setValue = function() end }
+    ); y = y - trigH
+
+    -- Replace dummy dropdown with a checkbox dropdown.
+    do
+        local rightRgn = trigRow._rightRegion
+        if rightRgn._control then rightRgn._control:Hide() end
+
+        local cbDD, cbDDRefresh = EllesmereUI.BuildVisOptsCBDropdown(
+            rightRgn,
+            210,
+            rightRgn:GetFrameLevel() + 2,
+            TRIGGER_ITEMS,
+            function(k)
+                local v = Cfg()[k]
+                if v == nil then return TRIGGER_DEFAULTS[k] end
+                return v
+            end,
+            function(k, v) Cfg()[k] = v; Recheck() end
+        )
+        PP.Point(cbDD, "RIGHT", rightRgn, "RIGHT", -20, 0)
+        rightRgn._control = cbDD
+        rightRgn._lastInline = nil
+
+        EllesmereUI.RegisterWidgetRefresh(cbDDRefresh)
+    end
+
+    _, h = W:Spacer(parent, y, 20); y = y - h
+
+    parent:SetHeight(math.abs(y - yOffset))
+end
+
+_G._EUI_BuildAutoLoggingPage = BuildAutoLoggingPage

--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -4,9 +4,10 @@
 --    * Quality of Life -- general QoL features (built by parent general options)
 --    * Cursor          -- cursor skin (built by EUI_QoL_Cursor_Options.lua)
 -------------------------------------------------------------------------------
-local PAGE_QOL    = "Quality of Life"
-local PAGE_CURSOR = "Cursor"
-local PAGE_BREZ   = "BattleRes"
+local PAGE_QOL      = "Quality of Life"
+local PAGE_CURSOR   = "Cursor"
+local PAGE_BREZ     = "BattleRes"
+local PAGE_AUTOLOG  = "Auto Logging"
 
 local initFrame = CreateFrame("Frame")
 initFrame:RegisterEvent("PLAYER_LOGIN")
@@ -1137,8 +1138,8 @@ initFrame:SetScript("OnEvent", function(self)
     EllesmereUI:RegisterModule("EllesmereUIQoL", {
         title       = "Quality of Life",
         description = "Quality of life features and custom cursor.",
-        pages       = { PAGE_QOL, PAGE_CURSOR, PAGE_BREZ },
-        searchTerms = { "brez", "bres", "battle res", "combat res", "cursor", "macro", "fps" },
+        pages       = { PAGE_QOL, PAGE_CURSOR, PAGE_BREZ, PAGE_AUTOLOG },
+        searchTerms = { "brez", "bres", "battle res", "combat res", "cursor", "macro", "fps", "logging", "combat log", "warcraft logs" },
         buildPage   = function(pageName, parent, yOffset)
             if pageName == PAGE_QOL then
                 return BuildQoLPage(pageName, parent, yOffset)
@@ -1148,6 +1149,9 @@ initFrame:SetScript("OnEvent", function(self)
             end
             if pageName == PAGE_BREZ and _G._EUI_BuildBattleResPage then
                 return _G._EUI_BuildBattleResPage(pageName, parent, yOffset)
+            end
+            if pageName == PAGE_AUTOLOG and _G._EUI_BuildAutoLoggingPage then
+                return _G._EUI_BuildAutoLoggingPage(pageName, parent, yOffset)
             end
         end,
         onReset = function()
@@ -1175,6 +1179,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.autoOpenContainers = false
                 EllesmereUIDB.autoRepairGuild = false
             end
+            EllesmereUIDB.autoLogging = nil
             if _G._EBS_ResetCursor then _G._EBS_ResetCursor() end
             if EllesmereUI._applyHideBlizzardPartyFrame then EllesmereUI._applyHideBlizzardPartyFrame() end
             EllesmereUI:InvalidatePageCache()

--- a/EllesmereUIQoL/EllesmereUIQoL.toc
+++ b/EllesmereUIQoL/EllesmereUIQoL.toc
@@ -13,8 +13,10 @@
 EllesmereUIQoL.lua
 EllesmereUIQoL_Cursor.lua
 EllesmereUIQoL_BattleRes.lua
+EllesmereUIQoL_AutoLogging.lua
 
 # Options
 EUI_QoL_Options.lua
 EUI_QoL_Cursor_Options.lua
 EUI_QoL_BattleRes_Options.lua
+EUI_QoL_AutoLogging_Options.lua

--- a/EllesmereUIQoL/EllesmereUIQoL_AutoLogging.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_AutoLogging.lua
@@ -1,0 +1,131 @@
+-------------------------------------------------------------------------------
+--  EllesmereUIQoL_AutoLogging.lua
+--  Toggles combat logging on zone transitions based on instance type/difficulty.
+--  Also forces Advanced Combat Logging on whenever logging starts.
+-------------------------------------------------------------------------------
+
+-- Retail content thresholds -- maps below these are excluded unless in LEGACY_DUNGEON_IDS.
+local RETAIL_RAID_THRESHOLD    = 2657
+local RETAIL_DUNGEON_THRESHOLD = 959
+
+-- Older dungeons still used as M+ maps.
+local LEGACY_DUNGEON_IDS = {
+    [1594] = true,  -- MOTHERLODE!!
+    [1208] = true,  -- Grimrail Depot
+    [1195] = true,  -- Iron Docks
+    [1651] = true,  -- Return to Karazhan
+    [657]  = true,  -- The Vortex Pinnacle
+    [643]  = true,  -- Throne of the Tides
+    [670]  = true,  -- Grim Batol
+    [658]  = true,  -- Pit of Saron
+}
+
+-- LFR difficulty IDs (regular + timewalking).
+local LFR_DIFFICULTIES = { [7] = true, [17] = true }
+
+-- Raid difficulty -> trigger key.
+local RAID_DIFF_KEYS = {
+    [16] = "logMythic",
+    [15] = "logHeroic",
+    [14] = "logNormal",
+}
+
+-- Defaults: everything on except Scenarios.
+local TRIGGER_DEFAULTS = {
+    logMythic   = true,
+    logHeroic   = true,
+    logNormal   = true,
+    logLFR      = true,
+    log5pp      = true,
+    logArena    = true,
+    logScenario = false,
+}
+
+local function GetTrigger(c, key)
+    local v = c[key]
+    if v == nil then return TRIGGER_DEFAULTS[key] end
+    return v
+end
+
+local function Cfg()
+    if not EllesmereUIDB then return {} end
+    EllesmereUIDB.autoLogging = EllesmereUIDB.autoLogging or {}
+    return EllesmereUIDB.autoLogging
+end
+
+-- Silently sets advancedCombatLogging if it isn't already on.
+local function EnsureAdvancedLogging()
+    if GetCVar and GetCVar("advancedCombatLogging") ~= "1" then
+        SetCVar("advancedCombatLogging", 1)
+    end
+end
+
+local function ZoneShouldBeLogged()
+    local c = Cfg()
+    if not c.enabled then return false end
+
+    local _, zoneType, rawDiff, _, playerCap, _, _, rawMapID = GetInstanceInfo()
+    local diff  = tonumber(rawDiff)
+    local mapID = tonumber(rawMapID)
+    if not diff or not mapID then return false end
+
+    if LFR_DIFFICULTIES[diff] then
+        return GetTrigger(c, "logLFR")
+    end
+
+    if zoneType == "raid" and mapID >= RETAIL_RAID_THRESHOLD then
+        local key = RAID_DIFF_KEYS[diff]
+        if key then return GetTrigger(c, key) end
+        return true  -- timewalking and other unrecognised raid difficulties
+    end
+
+    if GetTrigger(c, "log5pp") then
+        local isMythicDungeon = (diff == 23 or diff == 8)  -- 23=Keystone, 8=Mythic
+        local isRetailDungeon = mapID >= RETAIL_DUNGEON_THRESHOLD or LEGACY_DUNGEON_IDS[mapID]
+        if isMythicDungeon and isRetailDungeon then return true end
+    end
+
+    if GetTrigger(c, "logScenario") and zoneType == "scenario"
+       and (tonumber(playerCap) or 0) > 1
+       and mapID >= RETAIL_DUNGEON_THRESHOLD then
+        return true
+    end
+
+    if GetTrigger(c, "logArena") and (zoneType == "arena" or zoneType == "ratedarena") then
+        return true
+    end
+
+    return false
+end
+
+local wasLogging = false
+
+local function ApplyLoggingState()
+    local shouldLog = ZoneShouldBeLogged()
+    if shouldLog then
+        EnsureAdvancedLogging()
+        LoggingCombat(true)
+    elseif wasLogging and LoggingCombat() then
+        LoggingCombat(false)
+    end
+    wasLogging = shouldLog
+end
+
+_G._EUI_AutoLogging_Check = ApplyLoggingState
+
+local events = {
+    ZONE_CHANGED_NEW_AREA = function() C_Timer.After(2, ApplyLoggingState) end,
+    CHALLENGE_MODE_START   = function() C_Timer.After(1, ApplyLoggingState) end,
+}
+
+local logFrame = CreateFrame("Frame")
+logFrame:RegisterEvent("PLAYER_LOGIN")
+logFrame:SetScript("OnEvent", function(self, event)
+    if event == "PLAYER_LOGIN" then
+        self:UnregisterEvent("PLAYER_LOGIN")
+        for ev in pairs(events) do self:RegisterEvent(ev) end
+        C_Timer.After(2, ApplyLoggingState)
+    elseif events[event] then
+        events[event]()
+    end
+end)


### PR DESCRIPTION
Introduce an auto combat logging system and UI. Adds EllesmereUIQoL_AutoLogging.lua to toggle combat logging on zone transitions (raid/dungeon/LFR/arena/scenario) and forces advancedCombatLogging when logging starts; it listens for zone and challenge events and exposes _EUI_AutoLogging_Check. Adds EUI_QoL_AutoLogging_Options.lua to provide an options page with per-trigger checkboxes and defaults, and registers the page in EUI_QoL_Options.lua. Updates the addon .toc and reset logic to include autoLogging persistence and cleanup.