### PR TITLE
Add Mythic LFG Location QoL toggle, disable support, and module documentation

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -1144,7 +1144,26 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        _, h = W:Spacer(parent, y, 20);  y = y - h
+        -- Module toggle for the forked LFGMythicLocation feature.
+        -- When disabled, the addon stops listening for LFG invite updates.
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Mythic LFG Location",
+              tooltip="Enable or disable the automatic Mythic LFG invite summary when an LFG invite is accepted.",
+              getValue=function()
+                  if not EllesmereUIDB then return true end
+                  return EllesmereUIDB.lfgMythicLocation ~= false
+              end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.lfgMythicLocation = v
+                  if _G.EUI_LFGMythicLocation_UpdateState then
+                      _G.EUI_LFGMythicLocation_UpdateState()
+                  end
+              end },
+            { type="label", text=" " }
+        );  y = y - h
+
+        _, h = W:Spacer(parent, y, 44);  y = y - h
 
         ---------------------------------------------------------------------------
         --  UI
@@ -1242,6 +1261,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.instanceResetAnnounceMsg = ""
                 EllesmereUIDB.quickSignup = false
                 EllesmereUIDB.persistSignupNote = false
+                EllesmereUIDB.lfgMythicLocation = true
                 EllesmereUIDB.ahCurrentExpansion = false
                 EllesmereUIDB.healthMacroEnabled = false
                 EllesmereUIDB.healthMacroPrio1 = 1

--- a/EllesmereUIQoL/EllesmereUIQoL.toc
+++ b/EllesmereUIQoL/EllesmereUIQoL.toc
@@ -17,6 +17,7 @@ EllesmereUIQoL_AutoLogging.lua
 EllesmereUIQoL_Keys.lua
 EllesmereUIQoL_Shifter.lua
 EUI_UpgradeCalc.lua
+LFGMythicLocation.lua
 
 # Options
 EUI_QoL_Options.lua

--- a/EllesmereUIQoL/EllesmereUIQoL.toc
+++ b/EllesmereUIQoL/EllesmereUIQoL.toc
@@ -17,7 +17,7 @@ EllesmereUIQoL_AutoLogging.lua
 EllesmereUIQoL_Keys.lua
 EllesmereUIQoL_Shifter.lua
 EUI_UpgradeCalc.lua
-LFGMythicLocation.lua
+EllesmereUIQoL_LFGMythicLocation.lua
 
 # Options
 EUI_QoL_Options.lua

--- a/EllesmereUIQoL/EllesmereUIQoL_LFGMythicLocation.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_LFGMythicLocation.lua
@@ -2,6 +2,7 @@
 -- Changelog:
 -- 2026-05-16: Added QoL options toggle for the Mythic LFG Location module.
 --              The toggle now enables/disables event handling and prevents /lfgtest output when disabled.
+-- Note: renamed file to match upstream EllesmereUIQoL module naming convention.
 local LFGML = {
     Name = "LFGMythicLocation",
     Prefix = "|cff00ff00[LFG-Memo]|r"

--- a/EllesmereUIQoL/LFGMythicLocation.lua
+++ b/EllesmereUIQoL/LFGMythicLocation.lua
@@ -1,0 +1,103 @@
+-- Main table for the addon
+-- Changelog:
+-- 2026-05-16: Added QoL options toggle for the Mythic LFG Location module.
+--              The toggle now enables/disables event handling and prevents /lfgtest output when disabled.
+local LFGML = {
+    Name = "LFGMythicLocation",
+    Prefix = "|cff00ff00[LFG-Memo]|r"
+}
+
+-- Create the event frame
+local Frame = CreateFrame("Frame")
+Frame:RegisterEvent("ADDON_LOADED")
+Frame:RegisterEvent("LFG_LIST_APPLICATION_STATUS_UPDATED")
+
+-- Function to display the data with the correct layout
+local function ShowDungeonInfo(dungeon, leader, title, details)
+    -- Separate prints ensure clean newlines and use the short [LFG-Memo] prefix
+    print(" ")
+    print(LFGML.Prefix .. " ---------------------------------------------")
+    print(LFGML.Prefix .. " ** INVITE ACCEPTED **")
+    print(LFGML.Prefix .. " Destination: |cffffffff" .. dungeon .. "|r")
+    print(LFGML.Prefix .. " Group Leader: |cff00ccff" .. leader .. "|r")
+
+    -- Print Title if available (this contains things like "+7 main 3.2k rio")
+    if title and title ~= "" then
+        print(LFGML.Prefix .. " Title: |cffffd100" .. title .. "|r")
+    end
+
+    -- Print Details/Comment if available
+    if details and details ~= "" then
+        print(LFGML.Prefix .. " Details: |cffb3b3b3" .. details .. "|r")
+    end
+    print(LFGML.Prefix .. " ---------------------------------------------")
+    print(" ")
+
+    PlaySound(8960, "Master")
+end
+
+-- Returns true when the feature is enabled in the QoL options.
+local function IsEnabled()
+    return not (EllesmereUIDB and EllesmereUIDB.lfgMythicLocation == false)
+end
+
+-- Keep the event frame enabled only when the option is active.
+local function UpdateEventRegistration()
+    if IsEnabled() then
+        Frame:RegisterEvent("LFG_LIST_APPLICATION_STATUS_UPDATED")
+    else
+        Frame:UnregisterEvent("LFG_LIST_APPLICATION_STATUS_UPDATED")
+    end
+end
+
+-- Exposed for the QoL options toggle to refresh this module's event registration.
+_G.EUI_LFGMythicLocation_UpdateState = UpdateEventRegistration
+
+-- Event handler logic
+Frame:SetScript("OnEvent", function(self, event, ...)
+    if event == "ADDON_LOADED" then
+        local name = ...
+        if name == LFGML.Name then
+            print(LFGML.Prefix .. " System ready. Use /lfgtest for a preview.")
+            UpdateEventRegistration()
+            self:UnregisterEvent("ADDON_LOADED")
+        end
+
+    elseif event == "LFG_LIST_APPLICATION_STATUS_UPDATED" then
+        local searchResultID, newStatus = ...
+        
+        if newStatus == "inviteaccepted" then
+            local data = C_LFGList.GetSearchResultInfo(searchResultID)
+            
+            if data then
+                local activityInfo = C_LFGList.GetActivityInfoTable(data.activityIDs[1])
+                
+                if activityInfo and activityInfo.categoryID == 2 then
+                    local dungeonName = activityInfo.fullName or "Unknown Dungeon"
+                    local leaderName = data.leaderName or "Unknown Leader"
+                    
+                    -- Extract the protected strings (Title and Comment/Details)
+                    local groupTitle = data.name or ""
+                    local groupDetails = data.comment or ""
+                    
+                    ShowDungeonInfo(dungeonName, leaderName, groupTitle, groupDetails)
+                end
+            end
+        end
+    end
+end)
+
+-- Slash Command for manual testing
+SLASH_LFGTEST1 = "/lfgtest"
+SlashCmdList["LFGTEST"] = function()
+    if not IsEnabled() then
+        print(LFGML.Prefix .. " Mythic LFG Location is disabled.")
+        return
+    end
+
+    -- Dynamically gets the name of the testing character
+    local currentCharacterName = UnitName("player") or "Katzenhirn"
+    
+    -- Simulates the exact layout output with your current character as leader
+    ShowDungeonInfo("Mythic Dungeon", currentCharacterName, "+7 main 3.2k rio", "Checking raider.io, bring big DPS!")
+end


### PR DESCRIPTION
Adds a new QoL toggle for the Mythic LFG Location module in EllesmereUIQoL.

The toggle now disables event handling and prevents /lfgtest output when turned off.

The new module file was renamed to follow upstream naming conventions and the TOC was updated, so the change is easier to review and integrate.