### PR TITLE
Fix v7.7.2 character sheet gem regression (2 global + 2 OnShow events)

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -3968,6 +3968,27 @@ local function SkinCharacterSheet()
         end
     end
 
+    local function CharSheetGemsActive()
+        if EllesmereUIDB and EllesmereUIDB.themedCharacterSheet == false then return false end
+        if EllesmereUIDB and EllesmereUIDB.showGems == false then return false end
+        return true
+    end
+
+    local _equippedItemIDs = {}
+    local function RefreshEquippedItemIDs()
+        wipe(_equippedItemIDs)
+        for _, slotName in ipairs(itemSlots) do
+            local sl = _G[slotName]
+            if sl and sl.GetID then
+                local iid = GetInventoryItemID("player", sl:GetID())
+                if iid and iid > 0 then
+                    _equippedItemIDs[iid] = true
+                end
+            end
+        end
+    end
+    RefreshEquippedItemIDs()
+
     -- Equipment / item-load hooks: trailing debounce so bursts of
     -- GET_ITEM_INFO_RECEIVED schedule one refresh after data settles (a
     -- leading debounce can fire once on stale links right after /reload).
@@ -3986,15 +4007,23 @@ local function SkinCharacterSheet()
     end
 
     local socketWatcher = CreateFrame("Frame")
-    -- Low-frequency events: always registered (equip changes, login).
     socketWatcher:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
     socketWatcher:RegisterEvent("PLAYER_ENTERING_WORLD")
-    -- High-frequency events (TOOLTIP_DATA_UPDATE, GET_ITEM_INFO_RECEIVED,
-    -- UNIT_INVENTORY_CHANGED, SOCKET_INFO_UPDATE) are registered in OnShow
-    -- and unregistered in OnHide so they cost zero when the sheet is closed.
+    -- Hydration (2 global): must hear item load while Character is closed after
+    -- /reload. UNIT_INVENTORY_CHANGED + SOCKET_INFO_UPDATE (2 OnShow-only) below.
+    if CharSheetGemsActive() then
+        socketWatcher:RegisterEvent("TOOLTIP_DATA_UPDATE")
+        socketWatcher:RegisterEvent("GET_ITEM_INFO_RECEIVED")
+    end
     socketWatcher:SetScript("OnEvent", function(_, event, arg1)
-        if EllesmereUIDB and EllesmereUIDB.themedCharacterSheet == false then return end
+        if not CharSheetGemsActive() then return end
         if event == "UNIT_INVENTORY_CHANGED" and arg1 ~= "player" then return end
+        if event == "PLAYER_EQUIPMENT_CHANGED" or event == "PLAYER_ENTERING_WORLD" then
+            RefreshEquippedItemIDs()
+        end
+        if event == "GET_ITEM_INFO_RECEIVED" and (not arg1 or not _equippedItemIDs[arg1]) then
+            return
+        end
         -- Clear stale gem art for the slot that just changed BEFORE the
         -- debounced refresh runs. Without this, the old item's gem icons
         -- can remain visible until /reload if the refresh path somehow
@@ -4003,21 +4032,23 @@ local function SkinCharacterSheet()
             local slotName = _invSlotToName[arg1]
             if slotName then ClearSlotGems(_G[slotName]) end
         end
-        if frame:IsShown() and (frame.selectedTab or 1) == 1 then
-            QueueSocketRefresh()
+        -- No refresh work while the sheet is closed (handler still runs for
+        -- equipped-item cache / clear-slot above).
+        if not frame:IsShown() or (frame.selectedTab or 1) ~= 1 then
+            return
         end
+        QueueSocketRefresh()
     end)
 
     -- Hook frame show/hide
     frame:HookScript("OnShow", function()
-        -- Register high-frequency events only while the sheet is visible.
-        socketWatcher:RegisterEvent("TOOLTIP_DATA_UPDATE")
-        socketWatcher:RegisterEvent("GET_ITEM_INFO_RECEIVED")
+        -- Non-hydration high-frequency events: only while the sheet is visible.
         socketWatcher:RegisterEvent("UNIT_INVENTORY_CHANGED")
         socketWatcher:RegisterEvent("SOCKET_INFO_UPDATE")
         -- Only refresh sockets and show container if on character tab
         local isCharacterTab = (frame.selectedTab or 1) == 1
         if isCharacterTab then
+            RefreshEquippedItemIDs()
             RefreshAllSocketIcons()
             QueueSocketRefresh()
             globalSocketContainer:Show()
@@ -4041,9 +4072,6 @@ local function SkinCharacterSheet()
     end)
 
     frame:HookScript("OnHide", function()
-        -- Unregister high-frequency events so they cost zero while closed.
-        socketWatcher:UnregisterEvent("TOOLTIP_DATA_UPDATE")
-        socketWatcher:UnregisterEvent("GET_ITEM_INFO_RECEIVED")
         socketWatcher:UnregisterEvent("UNIT_INVENTORY_CHANGED")
         socketWatcher:UnregisterEvent("SOCKET_INFO_UPDATE")
         if _socketRefreshTimer then


### PR DESCRIPTION
## Summary

Fixes a **regression in v7.7.2** where themed character sheet **gem sockets** broke again after **#324** had shipped (wrong / empty-looking sockets after `/reload`, stale gems on swap, etc.).

## What happened (regression)

**#324** added reliable gem display by listening for item hydration (`TOOLTIP_DATA_UPDATE`, `GET_ITEM_INFO_RECEIVED`, etc.) and refreshing socket icons when link data caught up with `GetItemStats`.

In **v7.7.2**, all four `socketWatcher` events were moved to **register only on `CharacterFrame` OnShow** and **unregister on OnHide** to reduce cost of globally registered high-frequency events.

That is reasonable for perf, but it breaks a common path:

1. Player **`/reload`** with Character **closed**
2. Blizzard hydrates item links in the background (`GetItemStats` may show sockets before `C_Item.GetItemGem` has gem IDs)
3. `TOOLTIP_DATA_UPDATE` / `GET_ITEM_INFO_RECEIVED` fire **while the handler is unregistered**
4. Player opens Character → one refresh runs, but the client often **does not fire those events again** for already-cached items
5. UI shows **false empty-socket** chrome or stale gem art

We also tried a lighter follow-up (OnShow-only events + **0.75s delayed refresh** + `RequestLoadItemDataByID` on every equipped slot on open). **In-game testing showed that was not sufficient**; hydration listeners must stay active while the panel is closed.

**Note:** #324 also included **spec portrait suppression** (top-left circle). That code was **not** changed in the v7.7.2 diff we compared; this PR only adjusts the **socket event** wiring.

## Original concerns (from maintainer review)

> Performance concerns with **4 globally registered events**, so gating them behind the character sheet being open. Top priorities: **perf** and **taint risk**.

This PR respects that intent:

| Event | Registration | Rationale |
|--------|----------------|-----------|
| `TOOLTIP_DATA_UPDATE` | **Always on** (when gems enabled) | Required for hydration after `/reload` with panel closed |
| `GET_ITEM_INFO_RECEIVED` | **Always on** (when gems enabled) | Same |
| `UNIT_INVENTORY_CHANGED` | **OnShow only** | Only needed while viewing / changing gear on the sheet |
| `SOCKET_INFO_UPDATE` | **OnShow only** | Jeweler / socket UI; sheet is open |

So we go from **“4 globals”** to **“2 globals + 2 gated”**, not back to four always-on refresh paths.

**Perf guards in the handler:**

- Hydration events are **not registered** if themed sheet is off or **Show gems** is off
- While Character is **closed** or not on the **character tab**, the handler **returns before** `QueueSocketRefresh` / repainting (no debounce timer, no full slot pass)
- `GET_ITEM_INFO_RECEIVED` is ignored unless `arg1` is an **equipped** item ID (small cached set, refreshed on equip / login / open)
- Existing **~0.12s trailing debounce** on `QueueSocketRefresh` is unchanged (bursts coalesce to one refresh)

**Taint:** Unchanged from #324 — still `C_Item.GetItemGem` + `GetItemStats` on the item link; **no** `GameTooltipTemplate` scrape on the character sheet.

## Files

- `EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua`

## Test plan

- [ ] `/reload` with Character **closed** → wait a few seconds → open Character tab → gemmed gear shows correct gems (no bogus empty-socket / white chrome)
- [ ] Close and reopen Character several times → gems stay correct
- [ ] Swap gemmed ↔ un-gemmed ring → icons match the equipped item
- [ ] Socket / replace a gem at jeweler → sheet updates
- [ ] With **Show gems** or themed sheet disabled → no errors; gems hidden as expected

_(Demo video can be attached in a follow-up comment.)_
