### PR TITLE
Sort minimap addon flyout buttons alphabetically

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -277,6 +277,11 @@ local function IsUngrouped(btn)
     return name and mp.ungroupedButtons[name]
 end
 
+local function GetMinimapButtonLabel(btn)
+    local name = btn:GetName() or ""
+    return name:gsub("^LibDBIcon10_", ""):gsub("^Lib_GPI_Minimap_", ""):gsub("MinimapButton$", ""):gsub("_MinimapButton$", "")
+end
+
 local function CollectFlyoutButtons()
     -- Return only buttons the addon wants visible and not ungrouped
     local collected = {}
@@ -285,6 +290,9 @@ local function CollectFlyoutButtons()
             collected[#collected + 1] = btn
         end
     end
+    table.sort(collected, function(a, b)
+        return GetMinimapButtonLabel(a):lower() < GetMinimapButtonLabel(b):lower()
+    end)
     return collected
 end
 


### PR DESCRIPTION
## Summary

Minimap grouped addon buttons (the flyout grid next to the map) were shown in arbitrary order — whatever order WoW returned children from `Minimap:GetChildren()`, which changes between sessions and addons.

This sorts that list **A–Z by display name** before placing icons in the flyout grid.

## What changed

In `EllesmereUIMinimap.lua`:

- Added `GetMinimapButtonLabel()` to derive a readable name from each minimap button frame (strips common LibDBIcon prefixes/suffixes such as `LibDBIcon10_` and `MinimapButton`).
- In `CollectFlyoutButtons()`, `table.sort()` the collected buttons by that label (case-insensitive) before `LayoutFlyoutButtons()` assigns grid positions.

No new options, saved variables, or layout behavior changes beyond sort order.

## Test plan

- [ ] Enable EllesmereUI Minimap with grouped addon buttons (default flyout toggle visible).
- [ ] Open the addon-button flyout; confirm icons are ordered A–Z left-to-right, top-to-bottom (e.g. addons starting with A–C in the first row, not a random addon like WeakAuras first unless its label sorts first).
- [ ] `/reload`, open flyout again — order should stay consistent.
- [ ] Load a new addon that adds a minimap button; after it appears in the flyout, re-open the panel and confirm the full list is still alphabetical.
- [ ] Ungrouped buttons (pinned beside the map) are unchanged — still use their existing order from settings.


Made with [Cursor](https://cursor.com)