### PR TITLE
Add WCRecorder compatability for Autologger with option.

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_AutoLogging_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_AutoLogging_Options.lua
@@ -12,6 +12,7 @@ local TRIGGER_DEFAULTS = {
     log5pp      = true,
     logArena    = true,
     logScenario = false,
+    delaystop   = true,
 }
 
 local TRIGGER_ITEMS = {
@@ -86,6 +87,21 @@ local function BuildAutoLoggingPage(pageName, parent, yOffset)
     end
 
     _, h = W:Spacer(parent, y, 20); y = y - h
+
+    _, h = W:DualRow(parent, y,
+        { type    = "toggle",
+          text    = \"Warcraft Recorder Compatibility\",
+          tooltip = "Delays stopping combat logging by 30 seconds after leaving an instance. Recommended for Warcraft Recorder compatibility.",
+          getValue = function()
+              local v = Cfg().delaystop
+              if v == nil then return TRIGGER_DEFAULTS.delaystop end
+              return v
+          end,
+          setValue = function(v)
+              Cfg().delaystop = v
+          end },
+        nil
+    ); y = y - h
 
     parent:SetHeight(math.abs(y - yOffset))
 end

--- a/EllesmereUIQoL/EllesmereUIQoL_AutoLogging.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_AutoLogging.lua
@@ -39,6 +39,7 @@ local TRIGGER_DEFAULTS = {
     log5pp      = true,
     logArena    = true,
     logScenario = false,
+    delaystop   = true,
 }
 
 local function GetTrigger(c, key)
@@ -99,14 +100,29 @@ local function ZoneShouldBeLogged()
 end
 
 local wasLogging = false
+local _stopTimer  = nil
+
+local function CancelStopTimer()
+    if _stopTimer then _stopTimer:Cancel(); _stopTimer = nil end
+end
 
 local function ApplyLoggingState()
     local shouldLog = ZoneShouldBeLogged()
     if shouldLog then
+        CancelStopTimer()
         EnsureAdvancedLogging()
         LoggingCombat(true)
     elseif wasLogging and LoggingCombat() then
-        LoggingCombat(false)
+        local c = Cfg()
+        local delay = GetTrigger(c, "delaystop")
+        if delay and not _stopTimer then
+            _stopTimer = C_Timer.NewTimer(30, function()
+                _stopTimer = nil
+                LoggingCombat(false)
+            end)
+        elseif not delay then
+            LoggingCombat(false)
+        end
     end
     wasLogging = shouldLog
 end


### PR DESCRIPTION
Introduce a new 'delaystop' auto-logging option (default true) and expose it as a toggle in the options UI labelled for Warcraft Recorder compatibility. When enabled, stopping combat logging is deferred by 30 seconds using a C_Timer; a _stopTimer and CancelStopTimer were added so the pending stop is cancelled if logging resumes. Updated TRIGGER_DEFAULTS and config get/set logic accordingly.