### PR TITLE
Re-enable Remember Last Chat Lines (taint-safe open-world capture)

### DIFF
--- a/EllesmereUIChat/EUI_Chat_Options.lua
+++ b/EllesmereUIChat/EUI_Chat_Options.lua
@@ -413,8 +413,7 @@ initFrame:SetScript("OnEvent", function(self)
         _, h = W:SectionHeader(parent, "EXTRAS", y); y = y - h
 
         -- Row 1: Remember Last Chat Lines (+ cog: Max Lines) | Hide Tooltip on Hover
-        -- Disabled: session history not yet shipped. Uncomment to re-enable.
-        --[[ local histRow
+        local histRow
         histRow, h = W:DualRow(parent, y,
             { type="toggle", text="Remember Last Chat Lines",
               tooltip="Saves the most recent lines per chat tab (per character), except Blizzard's combat log window, so they reappear after /reload or relog. Stored separately from layout profiles.",
@@ -454,14 +453,6 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnLeave", function(s) s:SetAlpha(0.4) end)
             cogBtn:SetScript("OnClick", function(s) cogShow(s) end)
         end
-        y = y - h --]]
-
-        -- Row 1 (active): Hide Tooltip on Hover | (empty)
-        _, h = W:DualRow(parent, y,
-            { type="toggle", text="Hide Tooltip on Hover",
-              getValue=function() return Cfg("hideTooltipOnHover") or false end,
-              setValue=function(v) Set("hideTooltipOnHover", v) end },
-            { type="label", text="" })
         y = y - h
 
         -- Row 2: Hide Borders | Input on Top

--- a/EllesmereUIChat/EllesmereUIChat.toc
+++ b/EllesmereUIChat/EllesmereUIChat.toc
@@ -16,5 +16,5 @@ EllesmereUIChat.lua
 # Options
 EUI_Chat_Options.lua
 
-# Session scrollback via historyBuffer snapshot (combat log excluded)
+# Session scrollback via CHAT_MSG (open world, PushBack restore)
 EllesmereUIChat_SessionHistory.lua

--- a/EllesmereUIChat/EllesmereUIChat_SessionHistory.lua
+++ b/EllesmereUIChat/EllesmereUIChat_SessionHistory.lua
@@ -1,40 +1,51 @@
 -------------------------------------------------------------------------------
 --  EllesmereUIChat_SessionHistory.lua
 --
---  Persists recent chat per docked tab (SavedVariablesPerCharacter) across
---  /reload and relog. Snapshots historyBuffer on logout/reload only (no
---  AddMessage hooks). Restores via BackFillMessage. Skips capture and restore
---  in protected instances and when addon chat restrictions are forced. Each tab
---  only stores what Blizzard delivered to that frame. Combat log and temp
---  windows excluded.
+--  Persists recent player chat across /reload and relog. Saves on CHAT_MSG
+--  in open world only (instances cannot provide storable text). Stores message
+--  body plus serverTime/timestamp; restore prepends timestamp from that format.
 -------------------------------------------------------------------------------
 local _, ns = ...
 local ECHAT = ns.ECHAT
 if not ECHAT then return end
 
--- Disabled for now; keeping code for future use.
-do return end
-
 local strsub = string.sub
+local gsub = string.gsub
 local wipe = wipe
 local GetTime = GetTime
 local GetServerTime = GetServerTime
-local pairs = pairs
-local ipairs = ipairs
-local type = type
 local pcall = pcall
+local date = date
 
 local SV_NAME = "EllesmereUIChatScrollDB"
 local MAX_TEXT_LEN = 4096
 local RESTORE_DELAY_SEC = 2.0
+local RESTORE_RETRY_SEC = 2.0
+local RESTORE_MAX_ATTEMPTS = 3
+-- Capture starts RESTORE_DELAY + this many seconds after login/reload (avoids login spam).
+local SESSION_EPOCH_DELAY_SEC = 3.0
 
-local lifecycleHooksInstalled = false
+local chatEventsInstalled = false
 local restoreToken = 0
-local restoredFrames = {} -- [frameName] = true this reload
+local restoredFrames = {}
+local sessionEpochTime = nil
+local captureSeq = 0
 
 local eventFrame = CreateFrame("Frame")
 local deferFrame = CreateFrame("Frame")
 local UnarmDeferredRestore
+
+-- Capture in open world only (CaptureAllowed); instance chat still not storable.
+local CAPTURE_EVENTS = {
+    "CHAT_MSG_SAY", "CHAT_MSG_YELL",
+    "CHAT_MSG_EMOTE", "CHAT_MSG_TEXT_EMOTE",
+    "CHAT_MSG_PARTY", "CHAT_MSG_PARTY_LEADER",
+    "CHAT_MSG_GUILD", "CHAT_MSG_OFFICER",
+    "CHAT_MSG_CHANNEL",
+    "CHAT_MSG_RAID", "CHAT_MSG_RAID_LEADER", "CHAT_MSG_RAID_WARNING",
+    "CHAT_MSG_WHISPER", "CHAT_MSG_WHISPER_INFORM",
+    "CHAT_MSG_BN_WHISPER", "CHAT_MSG_BN_WHISPER_INFORM",
+}
 
 -------------------------------------------------------------------------------
 --  Helpers
@@ -53,6 +64,19 @@ local function SessionHistorySafe()
     return true
 end
 
+local function InOpenWorld()
+    local inInstance, instanceType = IsInInstance()
+    if not inInstance then return true end
+    return instanceType == "none" or instanceType == ""
+end
+
+local function CaptureAllowed()
+    if not PersistEnabled() then return false end
+    if GetCVarBool and GetCVarBool("addonChatRestrictionsForced") then return false end
+    if not InOpenWorld() then return false end
+    return true
+end
+
 local function MaxLines()
     local maxN = 100
     if ECHAT.DB then
@@ -66,18 +90,18 @@ local function MaxLines()
     return maxN
 end
 
+local function MarkSessionEpoch()
+    sessionEpochTime = GetTime()
+end
+
 local function IsCombatLogChatFrame(cf)
     if not cf then return false end
     local combat = _G.COMBATLOG
-    if combat and cf == combat then
-        return true
-    end
+    if combat and cf == combat then return true end
     local fn = _G.IsCombatLog
     if type(fn) == "function" then
         local ok, r = pcall(fn, cf)
-        if ok and r then
-            return true
-        end
+        if ok and r then return true end
     end
     return false
 end
@@ -93,34 +117,150 @@ end
 local function GetSV()
     local sv = _G[SV_NAME]
     if type(sv) ~= "table" then
-        sv = { byFrame = {} }
+        sv = { sessionLog = {} }
         _G[SV_NAME] = sv
     end
-    if type(sv.byFrame) ~= "table" then
-        sv.byFrame = {}
+    if type(sv.sessionLog) ~= "table" then
+        sv.sessionLog = {}
+    end
+    if sv.byFrame then
+        sv.byFrame = nil
     end
     return sv
 end
 
 local function IsValidMessage(msg)
-    if type(msg) ~= "string" or msg == "" then return false end
+    if msg == nil then return false end
     if issecretvalue and issecretvalue(msg) then return false end
-    return true
+    local ok, valid = pcall(function()
+        return type(msg) == "string" and msg ~= ""
+    end)
+    return ok and valid
+end
+
+local function MessageForStorage(msg)
+    if not IsValidMessage(msg) then return nil end
+    local ok, stored = pcall(function()
+        if #msg > MAX_TEXT_LEN then
+            return strsub(msg, 1, MAX_TEXT_LEN)
+        end
+        return msg
+    end)
+    if ok then return stored end
+    return nil
+end
+
+-- Strip timestamp text baked into legacy saves (older builds prefixed on store).
+local function StripLegacyTimestampPrefix(msg)
+    if type(msg) ~= "string" then return msg end
+    local rest = msg:match("^%d%d?:%d%d(?::%d%d)?%s*([AP]M)?%s+(.*)$")
+    if rest and rest ~= "" then return rest end
+    return msg
+end
+
+local function MessageBodyOnly(msg)
+    return StripLegacyTimestampPrefix(msg)
+end
+
+local function TimestampFormatFromDB()
+    if not ECHAT.DB then return nil end
+    local db = ECHAT.DB()
+    local fmt = db and db.timestampFormat
+    if fmt == "none" or fmt == "__blizzard" then return nil end
+    if type(fmt) == "string" and fmt ~= "" then return fmt end
+    return nil
+end
+
+local function EffectiveTimestampFormat()
+    local fmt = TimestampFormatFromDB()
+    if fmt then return fmt end
+    if ChatFrameUtil and ChatFrameUtil.GetTimestampFormat then
+        local ok, f = pcall(ChatFrameUtil.GetTimestampFormat)
+        if ok and f then return f end
+    end
+    if GetCVar then
+        local cvar = GetCVar("showTimestamps")
+        if cvar and cvar ~= "" and cvar ~= "none" then return cvar end
+    end
+    return nil
+end
+
+local function FormatTimestampPrefix(serverTime)
+    local fmt = EffectiveTimestampFormat()
+    if not fmt or not serverTime or not date then return "" end
+    local ok, ts = pcall(date, fmt, serverTime)
+    if ok and type(ts) == "string" and ts ~= "" then return ts end
+    return ""
+end
+
+-- PushBack does not apply showTimestamps to message text; prefix on restore only.
+local function RestoreDisplayMessage(entry)
+    local body = MessageForStorage(entry and entry.message)
+    if not body then return nil end
+    body = MessageBodyOnly(body)
+    local prefix = FormatTimestampPrefix(entry.serverTime)
+    if prefix ~= "" then return prefix .. body end
+    return body
+end
+
+local function IsEmoteChatType(chatType)
+    return chatType == "EMOTE" or chatType == "TEXT_EMOTE"
+end
+
+local function IsEmoteChatEvent(event)
+    if type(event) ~= "string" then return false end
+    return IsEmoteChatType(strsub(event, 10))
+end
+
+local function IsPlayerChatLine(msg, chatType)
+    if type(msg) ~= "string" then return false end
+    if chatType and IsEmoteChatType(chatType) then return true end
+    if msg:find("|Hplayer:", 1, true) or msg:find("|HBNplayer:", 1, true) then
+        return true
+    end
+    if msg:find("|Hchannel:", 1, true) then return true end
+    if msg:find(" says:", 1, true) or msg:find(" yells:", 1, true) then
+        return true
+    end
+    if msg:find(" whispers:", 1, true) or msg:find("To [", 1, true) then
+        return true
+    end
+    if msg:match("^%[%d+%.") or msg:match("^%[[^%]]+%]:") then
+        return true
+    end
+    if msg:match("^%[[^%]]+%] %[[^%]]+%]:") then
+        return true
+    end
+    return false
+end
+
+local function NormalizeForDedup(msg)
+    local text = MessageBodyOnly(msg)
+    if not text then return nil end
+    text = text:gsub("|H.-|h(.-)|h", "%1")
+    text = text:gsub("|c%x%x%x%x%x%x%x%x", "")
+    text = text:gsub("|r", "")
+    return text
+end
+
+local function OldestFrameTimestamp(cf)
+    local oldest
+    local buf = cf and cf.historyBuffer
+    if buf and type(buf.elements) == "table" then
+        for i = 1, #buf.elements do
+            local e = buf.elements[i]
+            if e and type(e.timestamp) == "number" then
+                if not oldest or e.timestamp < oldest then
+                    oldest = e.timestamp
+                end
+            end
+        end
+    end
+    if oldest then return oldest - 0.05 end
+    return GetTime() - 1
 end
 
 local TrimLinesToMax
-
-local function PurgeCombatLogFromSV()
-    local sv = GetSV()
-    local bf = sv.byFrame
-    if not bf then return end
-    for frameName in pairs(bf) do
-        local fr = _G[frameName]
-        if fr and IsCombatLogChatFrame(fr) then
-            bf[frameName] = nil
-        end
-    end
-end
 
 TrimLinesToMax = function(lines, maxN)
     local n = #lines
@@ -133,23 +273,36 @@ TrimLinesToMax = function(lines, maxN)
     return out
 end
 
+local function SortLinesChronological(lines)
+    table.sort(lines, function(a, b)
+        local ta = a.serverTime or a.timestamp or 0
+        local tb = b.serverTime or b.timestamp or 0
+        if ta ~= tb then return ta < tb end
+        return (a.captureSeq or 0) < (b.captureSeq or 0)
+    end)
+    return lines
+end
+
 local function SanitizeLineList(lines)
     if type(lines) ~= "table" then return nil end
     local out = {}
     for _, L in ipairs(lines) do
         if type(L) == "table" then
-            local msg = L.message
-            if IsValidMessage(msg) then
-                local entry = {
-                    message = (#msg > MAX_TEXT_LEN) and strsub(msg, 1, MAX_TEXT_LEN) or msg,
+            local msg = MessageForStorage(L.message)
+            if msg then msg = MessageBodyOnly(msg) end
+            local chatType = type(L.event) == "string" and strsub(L.event, 10) or nil
+            if msg and (IsPlayerChatLine(msg, chatType) or IsEmoteChatEvent(L.event)) then
+                out[#out + 1] = {
+                    message = msg,
+                    event = L.event,
                     r = (type(L.r) == "number" and L.r) or 1,
                     g = (type(L.g) == "number" and L.g) or 1,
                     b = (type(L.b) == "number" and L.b) or 1,
                     id = (type(L.id) == "number" and L.id) or 1,
                     timestamp = (type(L.timestamp) == "number" and L.timestamp) or GetTime(),
                     serverTime = (type(L.serverTime) == "number" and L.serverTime) or GetServerTime(),
+                    captureSeq = (type(L.captureSeq) == "number" and L.captureSeq) or nil,
                 }
-                out[#out + 1] = entry
             end
         end
     end
@@ -158,165 +311,156 @@ end
 
 local function SanitizeSV()
     local sv = GetSV()
-    if not sv.byFrame then return end
-    for frameName, lines in pairs(sv.byFrame) do
-        local cleaned = SanitizeLineList(lines)
-        if cleaned and #cleaned > 0 then
-            sv.byFrame[frameName] = cleaned
-        else
-            sv.byFrame[frameName] = nil
+    local cleaned = SanitizeLineList(sv.sessionLog)
+    if cleaned and #cleaned > 0 then
+        sv.sessionLog = cleaned
+    else
+        sv.sessionLog = {}
+    end
+end
+
+local function ChatColorsForType(chatType)
+    if chatType and ChatTypeInfo[chatType] then
+        local info = ChatTypeInfo[chatType]
+        return info.r or 1, info.g or 1, info.b or 1, info.id or 1
+    end
+    return 1, 1, 1, 1
+end
+
+local function TextFromChatLineID(lineID)
+    if not lineID or type(lineID) ~= "number" then return nil end
+    if not C_ChatInfo or not C_ChatInfo.GetChatLineText then return nil end
+    local ok, text = pcall(C_ChatInfo.GetChatLineText, lineID)
+    if not ok or not text then return nil end
+    if issecretvalue and issecretvalue(text) then return nil end
+    return MessageForStorage(text)
+end
+
+local function SenderFromChatLineID(lineID)
+    if not lineID or type(lineID) ~= "number" then return nil end
+    if not C_ChatInfo or not C_ChatInfo.GetChatLineSenderName then return nil end
+    local ok, name = pcall(C_ChatInfo.GetChatLineSenderName, lineID)
+    if not ok or not name then return nil end
+    if issecretvalue and issecretvalue(name) then return nil end
+    return MessageForStorage(name)
+end
+
+local function BuildLineFromChatEvent(event, ...)
+    if type(event) ~= "string" or strsub(event, 1, 8) ~= "CHAT_MSG" then
+        return nil
+    end
+    local arg1, arg2 = ...
+    local lineID = select(11, ...)
+    local chatType = strsub(event, 10)
+    local body = TextFromChatLineID(lineID) or MessageForStorage(arg1)
+    if not body then return nil end
+
+    local sender = SenderFromChatLineID(lineID)
+    if not sender and type(arg2) == "string" and arg2 ~= "" then
+        if not (issecretvalue and issecretvalue(arg2)) then
+            sender = MessageForStorage(arg2)
         end
     end
-end
 
-local function NormalizeStoredLine(L)
-    if type(L) ~= "table" then return nil end
-    local msg = L.message
-    if not IsValidMessage(msg) then return nil end
-    if #msg > MAX_TEXT_LEN then
-        msg = strsub(msg, 1, MAX_TEXT_LEN)
+    if chatType == "WHISPER_INFORM" or chatType == "BN_WHISPER_INFORM" then
+        if sender then return "To [" .. sender .. "]: " .. body end
+        return body
     end
-    return {
-        message = msg,
-        r = (type(L.r) == "number" and L.r) or 1,
-        g = (type(L.g) == "number" and L.g) or 1,
-        b = (type(L.b) == "number" and L.b) or 1,
-        id = (type(L.id) == "number" and L.id) or 1,
-        timestamp = (type(L.timestamp) == "number" and L.timestamp) or GetTime(),
-        serverTime = (type(L.serverTime) == "number" and L.serverTime) or GetServerTime(),
-    }
-end
-
-local function CopyBufferEntryForStorage(entry)
-    if type(entry) ~= "table" then return nil end
-    local msg = entry.message
-    if not IsValidMessage(msg) then return nil end
-    if #msg > MAX_TEXT_LEN then
-        msg = strsub(msg, 1, MAX_TEXT_LEN)
+    if chatType == "WHISPER" or chatType == "BN_WHISPER" then
+        if sender then return "[" .. sender .. "] whispers: " .. body end
+        return body
     end
-    return {
-        message = msg,
-        r = (type(entry.r) == "number" and entry.r) or 1,
-        g = (type(entry.g) == "number" and entry.g) or 1,
-        b = (type(entry.b) == "number" and entry.b) or 1,
-        id = (type(entry.id) == "number" and entry.id) or 1,
-        timestamp = (type(entry.timestamp) == "number" and entry.timestamp) or GetTime(),
-        serverTime = (type(entry.serverTime) == "number" and entry.serverTime) or GetServerTime(),
-    }
-end
-
-local function GetBufferEntryAt(buf, index)
-    if not buf or not index or index < 1 then return nil end
-    if buf.GetEntryAtIndex then
-        local ok, entry = pcall(buf.GetEntryAtIndex, buf, index)
-        if ok then return entry end
+    if chatType == "SAY" then
+        if sender then return sender .. " says: " .. body end
+        return body
     end
-    if type(buf.elements) ~= "table" or #buf.elements == 0 then return nil end
-    local headIndex = type(buf.headIndex) == "table" and buf.headIndex.value or buf.headIndex
-    local maxElements = type(buf.maxElements) == "table" and buf.maxElements.value or buf.maxElements
-    if not headIndex or not maxElements then return nil end
-    if index > #buf.elements then return nil end
-    local globalIndex = headIndex - index + 1
-    local elementIndex = (globalIndex - 1) % maxElements + 1
-    return buf.elements[elementIndex]
+    if chatType == "YELL" then
+        if sender then return sender .. " yells: " .. body end
+        return body
+    end
+    if IsEmoteChatType(chatType) then
+        if sender and body and not body:find(sender, 1, true) then
+            return sender .. " " .. body
+        end
+        return body
+    end
+    if chatType == "CHANNEL" then
+        local channelName = MessageForStorage(select(4, ...))
+        if channelName and sender then
+            return "[" .. channelName .. "] [" .. sender .. "]: " .. body
+        end
+    end
+    if sender then return "[" .. sender .. "]: " .. body end
+    return body
 end
 
-local function GetBufferEntryCount(buf)
-    if not buf or type(buf.elements) ~= "table" then return 0 end
-    return #buf.elements
+local function FrameShowsEvent(cf, event)
+    if not cf or not event then return false end
+    local chatType = gsub(strsub(event, 10), "_INFORM", "")
+    local list = cf.messageTypeList
+    if type(list) ~= "table" then return true end
+    for i = 1, #list do
+        if list[i] == chatType then
+            return true
+        end
+    end
+    return false
 end
 
-local function WriteFrameLinesToSV(frameName, lines)
-    if not frameName or not lines or #lines == 0 then return end
-    local cleaned = SanitizeLineList(lines)
-    if not cleaned or #cleaned == 0 then return end
-    GetSV().byFrame[frameName] = cleaned
+local function AppendLogEntry(entry)
+    local sv = GetSV()
+    local log = sv.sessionLog
+    local last = log[#log]
+    if last and NormalizeForDedup(last.message) == NormalizeForDedup(entry.message) then
+        return
+    end
+    log[#log + 1] = entry
+    sv.sessionLog = TrimLinesToMax(log, MaxLines())
 end
 
 -------------------------------------------------------------------------------
---  Snapshot (buffer -> SV)
+--  Capture (CHAT_MSG -> sessionLog, open world only)
 -------------------------------------------------------------------------------
-local function SnapshotFrame(cf)
-    if not ShouldTrackFrame(cf) then return nil end
-    local lines = {}
-    local buf = cf.historyBuffer
+local function SaveChatEvent(event, ...)
+    if not CaptureAllowed() or not sessionEpochTime then return end
+    if GetTime() < sessionEpochTime - 0.5 then return end
 
-    if buf and GetBufferEntryCount(buf) > 0 then
-        local count = GetBufferEntryCount(buf)
-        local newestFirst = {}
-        for i = 1, count do
-            local stored = CopyBufferEntryForStorage(GetBufferEntryAt(buf, i))
-            if stored then
-                newestFirst[#newestFirst + 1] = stored
-            end
-        end
-        for i = #newestFirst, 1, -1 do
-            lines[#lines + 1] = newestFirst[i]
-        end
-    elseif cf.GetNumMessages and cf.GetMessageInfo then
-        local ok, n = pcall(cf.GetNumMessages, cf)
-        if ok and type(n) == "number" and n > 0 then
-            local srv = GetServerTime()
-            local t0 = GetTime() - n * 0.05
-            for i = 1, n do
-                local mok, text = pcall(cf.GetMessageInfo, cf, i)
-                if mok and IsValidMessage(text) then
-                    if #text > MAX_TEXT_LEN then
-                        text = strsub(text, 1, MAX_TEXT_LEN)
-                    end
-                    lines[#lines + 1] = {
-                        message = text,
-                        r = 1,
-                        g = 1,
-                        b = 1,
-                        id = 1,
-                        timestamp = t0 + i * 0.05,
-                        serverTime = srv,
-                    }
-                end
-            end
-        end
-    end
+    local chatType = strsub(event, 10)
+    local line = BuildLineFromChatEvent(event, ...)
+    if not line or not IsPlayerChatLine(line, chatType) then return end
 
-    return SanitizeLineList(lines)
+    local serverTime = GetServerTime()
+    local message = MessageForStorage(line)
+    if not message then return end
+    local r, g, b, id = ChatColorsForType(chatType)
+    captureSeq = captureSeq + 1
+
+    AppendLogEntry({
+        event = event,
+        message = message,
+        r = r, g = g, b = b, id = id,
+        timestamp = GetTime(),
+        serverTime = serverTime,
+        captureSeq = captureSeq,
+    })
 end
 
 local function ClearSavedSessionHistory()
     restoreToken = restoreToken + 1
     wipe(restoredFrames)
+    captureSeq = 0
+    sessionEpochTime = nil
     UnarmDeferredRestore()
-    local sv = GetSV()
-    wipe(sv.byFrame)
+    GetSV().sessionLog = {}
 end
 
 function ECHAT.SnapshotChatSessionHistory()
-    if not SessionHistorySafe() then return end
-    local sv = GetSV()
-    PurgeCombatLogFromSV()
-
-    for i = 1, 50 do
-        local cf = _G["ChatFrame" .. i]
-        if cf and ShouldTrackFrame(cf) then
-            local name = cf:GetName()
-            if name then
-                local lines = SnapshotFrame(cf)
-                if lines and #lines > 0 then
-                    WriteFrameLinesToSV(name, lines)
-                end
-            end
-        end
-    end
-
-    for frameName in pairs(sv.byFrame) do
-        local cf = _G[frameName]
-        if not cf or not ShouldTrackFrame(cf) then
-            sv.byFrame[frameName] = nil
-        end
-    end
+    if not PersistEnabled() then return end
+    SanitizeSV()
 end
 
 -------------------------------------------------------------------------------
---  Restore (SV -> historyBuffer)
+--  Restore (sessionLog -> historyBuffer)
 -------------------------------------------------------------------------------
 UnarmDeferredRestore = function()
     deferFrame:UnregisterAllEvents()
@@ -324,98 +468,135 @@ UnarmDeferredRestore = function()
 end
 
 local function RefreshFrameDisplay(cf)
-    if cf.ResetAllFadeTimes then
-        pcall(cf.ResetAllFadeTimes, cf)
-    end
-    if cf.UpdateDisplay then
-        pcall(cf.UpdateDisplay, cf)
-    end
-    if cf.ScrollToBottom then
-        pcall(cf.ScrollToBottom, cf)
-    end
+    if cf.ResetAllFadeTimes then pcall(cf.ResetAllFadeTimes, cf) end
+    if cf.UpdateDisplay then pcall(cf.UpdateDisplay, cf) end
+    if cf.ScrollToBottom then pcall(cf.ScrollToBottom, cf) end
 end
 
-local function SortLinesChronological(lines)
-    table.sort(lines, function(a, b)
-        local ta = a.serverTime or a.timestamp or 0
-        local tb = b.serverTime or b.timestamp or 0
-        if ta ~= tb then
-            return ta < tb
+local function FrameAlreadyHasMessage(cf, msg)
+    if not cf or not msg then return false end
+    local core = NormalizeForDedup(msg)
+    if not core or core == "" then return false end
+    if cf.GetNumMessages and cf.GetMessageInfo then
+        local ok, n = pcall(cf.GetNumMessages, cf)
+        if ok and type(n) == "number" then
+            for i = 1, n do
+                local mok, raw = pcall(cf.GetMessageInfo, cf, i)
+                local stored = mok and MessageForStorage(raw) or nil
+                if stored and NormalizeForDedup(stored) == core then
+                    return true
+                end
+            end
         end
-        return (a.timestamp or 0) < (b.timestamp or 0)
-    end)
-    return lines
+    end
+    return false
 end
 
-local function RestoreFrame(cf, frameName, rawLines)
-    if not cf or not rawLines or #rawLines == 0 then return false end
+local function ShouldRestoreEntry(cf, entry)
+    return entry
+        and entry.event
+        and entry.message
+        and FrameShowsEvent(cf, entry.event)
+        and not FrameAlreadyHasMessage(cf, entry.message)
+end
+
+local function PushRestoreEntry(cf, buf, entry, baseTs, pushIndex, tsStep)
+    local text = RestoreDisplayMessage(entry)
+    if not text then return false end
+    if buf and type(buf.PushBack) == "function" then
+        return pcall(buf.PushBack, buf, {
+            message = text,
+            r = entry.r, g = entry.g, b = entry.b, id = entry.id,
+            serverTime = entry.serverTime,
+            timestamp = baseTs - (pushIndex * tsStep),
+        })
+    end
+    if cf.BackFillMessage then
+        return pcall(cf.BackFillMessage, cf, text, entry.r, entry.g, entry.b)
+    end
+    return false
+end
+
+local function RestoreFrame(cf, frameName, log)
+    if not cf or not log or #log == 0 then return false end
     if not ShouldTrackFrame(cf) then return false end
     if restoredFrames[frameName] then return false end
 
-    local lines = SanitizeLineList(rawLines)
+    local lines = SanitizeLineList(log)
     if not lines or #lines == 0 then return false end
     lines = SortLinesChronological(lines)
 
-    restoredFrames[frameName] = true
+    local buf = cf.historyBuffer
+    if not ((buf and type(buf.PushBack) == "function") or cf.BackFillMessage) then
+        return false
+    end
 
-    -- BackFillMessage prepends each line; fill newest-first so oldest ends up at the top
-    -- of the window and newest sits just above the current session (normal chat order).
-    if cf.BackFillMessage then
-        for i = #lines, 1, -1 do
-            local entry = NormalizeStoredLine(lines[i])
-            if entry and entry.message then
-                pcall(cf.BackFillMessage, cf, entry.message, entry.r, entry.g, entry.b)
-            end
-        end
-    else
-        local buf = cf.historyBuffer
-        if not buf or type(buf.PushBack) ~= "function" then
-            restoredFrames[frameName] = nil
-            return false
-        end
-        for i = #lines, 1, -1 do
-            local entry = NormalizeStoredLine(lines[i])
-            if entry then
-                pcall(buf.PushBack, buf, entry)
+    local pushed = 0
+    local baseTs = OldestFrameTimestamp(cf)
+    local tsStep = 0.001
+    local pushIndex = 0
+
+    for i = #lines, 1, -1 do
+        local entry = lines[i]
+        if ShouldRestoreEntry(cf, entry) then
+            pushIndex = pushIndex + 1
+            if PushRestoreEntry(cf, buf, entry, baseTs, pushIndex, tsStep) then
+                pushed = pushed + 1
             end
         end
     end
 
+    if pushed == 0 then
+        return false
+    end
+
+    restoredFrames[frameName] = true
     RefreshFrameDisplay(cf)
     return true
 end
 
 local function RunRestore(token)
     if token ~= restoreToken then return end
-    if not SessionHistorySafe() then return end
+    if not SessionHistorySafe() then return false end
 
-    local sv = GetSV()
-    if not sv.byFrame then return end
+    local log = GetSV().sessionLog
+    if not log or #log == 0 then return false end
 
-    for frameName, rawLines in pairs(sv.byFrame) do
-        if type(rawLines) == "table" and #rawLines > 0 then
-            local cf = _G[frameName]
-            if cf then
-                RestoreFrame(cf, frameName, rawLines)
+    local any = false
+    local chatFrames = _G.CHAT_FRAMES
+    if type(chatFrames) == "table" then
+        for i = 1, #chatFrames do
+            local cf = _G[chatFrames[i]]
+            if cf and RestoreFrame(cf, chatFrames[i], log) then
+                any = true
+            end
+        end
+    else
+        for i = 1, 50 do
+            local name = "ChatFrame" .. i
+            local cf = _G[name]
+            if cf and RestoreFrame(cf, name, log) then
+                any = true
             end
         end
     end
+    return any
 end
 
 local function ArmDeferredRestore(token)
     UnarmDeferredRestore()
-    local function onDefer(_, event, ...)
+    local function onDefer(_, deferEvent, ...)
         if token ~= restoreToken then
             UnarmDeferredRestore()
             return
         end
-        if event == "PLAYER_ENTERING_WORLD" then
+        if deferEvent == "PLAYER_ENTERING_WORLD" then
             local _, isReloadingUi = ...
             if isReloadingUi then return end
         end
         if not SessionHistorySafe() then return end
         UnarmDeferredRestore()
-        RunRestore(token)
+        TryRestore(token, 1)
     end
     deferFrame:SetScript("OnEvent", onDefer)
     deferFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
@@ -425,14 +606,25 @@ local function ArmDeferredRestore(token)
     end
 end
 
-local function TryRestore(token)
+local function TryRestore(token, attempt)
     if token ~= restoreToken then return end
     if not PersistEnabled() then return end
     if not SessionHistorySafe() then
         ArmDeferredRestore(token)
         return
     end
-    RunRestore(token)
+
+    attempt = attempt or 1
+    local log = GetSV().sessionLog
+    local hasLog = log and #log > 0
+    local restored = RunRestore(token)
+
+    if hasLog and not restored and attempt < RESTORE_MAX_ATTEMPTS then
+        wipe(restoredFrames)
+        C_Timer.After(RESTORE_RETRY_SEC, function()
+            TryRestore(token, attempt + 1)
+        end)
+    end
 end
 
 function ECHAT.RestoreChatSessionHistory()
@@ -442,7 +634,7 @@ function ECHAT.RestoreChatSessionHistory()
     local token = restoreToken
     if not PersistEnabled() then return end
     C_Timer.After(RESTORE_DELAY_SEC, function()
-        TryRestore(token)
+        TryRestore(token, 1)
     end)
 end
 
@@ -455,36 +647,34 @@ function ECHAT.OnSessionHistoryToggled(enabled)
     end
 end
 
--------------------------------------------------------------------------------
---  Frame lifecycle
--------------------------------------------------------------------------------
-local function InstallLifecycleHooks()
-    if lifecycleHooksInstalled then return end
-    lifecycleHooksInstalled = true
+local function ScheduleSessionEpochAfterLogin()
+    C_Timer.After(RESTORE_DELAY_SEC + SESSION_EPOCH_DELAY_SEC, MarkSessionEpoch)
+end
 
-    if FCF_Close then
-        hooksecurefunc("FCF_Close", function(frame)
-            if not frame or not frame.GetName then return end
-            local name = frame:GetName()
-            if frame.isTemporary then
-                local sv = GetSV()
-                if sv.byFrame then
-                    sv.byFrame[name] = nil
-                end
-            end
-        end)
+local function InstallChatCaptureEvents()
+    if chatEventsInstalled then return end
+    chatEventsInstalled = true
+    for _, ev in ipairs(CAPTURE_EVENTS) do
+        eventFrame:RegisterEvent(ev)
+    end
+end
+
+local function UninstallChatCaptureEvents()
+    if not chatEventsInstalled then return end
+    chatEventsInstalled = false
+    for _, ev in ipairs(CAPTURE_EVENTS) do
+        eventFrame:UnregisterEvent(ev)
     end
 end
 
 function ECHAT.InitChatSessionHistory()
     if not PersistEnabled() then
+        UninstallChatCaptureEvents()
         ClearSavedSessionHistory()
-        InstallLifecycleHooks()
         return
     end
-    PurgeCombatLogFromSV()
     SanitizeSV()
-    InstallLifecycleHooks()
+    InstallChatCaptureEvents()
 end
 
 -------------------------------------------------------------------------------
@@ -513,6 +703,11 @@ eventFrame:SetScript("OnEvent", function(_, event, ...)
         return
     end
 
+    if strsub(event, 1, 8) == "CHAT_MSG" then
+        SaveChatEvent(event, ...)
+        return
+    end
+
     if event == "PLAYER_ENTERING_WORLD" then
         local isInitialLogin, isReloadingUi = ...
         if not isInitialLogin and not isReloadingUi then
@@ -521,9 +716,12 @@ eventFrame:SetScript("OnEvent", function(_, event, ...)
             end
             return
         end
+        sessionEpochTime = nil
+        captureSeq = 0
         ECHAT.InitChatSessionHistory()
         if PersistEnabled() then
             ECHAT.RestoreChatSessionHistory()
+            ScheduleSessionEpochAfterLogin()
         end
     end
 end)


### PR DESCRIPTION
## Summary

Re-enables **Remember Last Chat Lines** in EllesmereUI Chat with a redesigned, taint-safe implementation. Player chat is captured in the **open world** on `CHAT_MSG` events, stored in per-character `EllesmereUIChatScrollDB.sessionLog`, and restored after `/reload` or relog via Blizzard’s `historyBuffer:PushBack` (with `BackFillMessage` fallback).

- Re-enables the options toggle and max-lines cog (previously commented out).
- Removes the early `do return end` that disabled the module on `main`.
- Migrates storage from legacy `byFrame` snapshots to a single chronological `sessionLog`.
- Supports say/yell/party/guild/officer/channel/raid/whisper/BN/emote channels (open world only).

## How we avoided taint

Earlier approaches were reverted because they ran inside Blizzard’s protected chat display path:

| Avoided | Why it tainted or broke |
|---------|-------------------------|
| `hooksecurefunc(chatFrame, "AddMessage", …)` per line | Hooks the live display pipeline; whisper/temp window churn and HistoryKeeper sensitivity |
| `cf:AddMessage(...)` restore loops | Re-enters the same pipeline; duplicates and ordering issues |
| `ChatFrame_AddMessageEventFilter` + `SendChatMessage` capture in instances | Filter ran in secure context; still inconsistent with secret strings in instanced content |
| Scraping `historyBuffer` on every line / live snapshot hooks | Read timing + frame mutation risk; empty snapshots on `/reload` wiped SV |

**Current approach (Prat/ElvUI-aligned, adapted for EUI chat):**

1. **Capture** — Private `Frame` registers `CHAT_MSG_*` only; builds storable plaintext from event args / `C_ChatInfo.GetChatLineText` when available. No hooks on `AddMessage`, FCF, or tab code.
2. **Restore** — `historyBuffer:PushBack` / `BackFillMessage` only; never replays through `AddMessage` or message event handlers.
3. **When** — Restore is deferred via `EllesmereUI.InProtectedInstance()` (M+ key, raid/PvP combat) until `PLAYER_REGEN_ENABLED`, `PLAYER_ENTERING_WORLD`, or `CHALLENGE_MODE_COMPLETED`.
4. **Dedup** — Normalized body comparison before push so relog + new chat does not duplicate lines already on the tab.

## Behaviour

- **Save:** Message body + `serverTime` / `timestamp` / colors / source `event` (no timestamp baked into SV).
- **Restore:** Prepends timestamp text using the same format as chat settings (`date()` + `showTimestamps` / EUI dropdown); `PushBack` does not apply `showTimestamps` to bare `serverTime` alone.
- **Ordering:** Restored lines get buffer `timestamp` values just below the oldest line already in the tab so scrollback sits above login/MOTD spam.
- **Retries:** Up to 3 restore attempts (2s apart) if login spam lands after the first pass.
- **Post-login capture:** New lines are not recorded until ~5s after login/reload (`RESTORE_DELAY` + `SESSION_EPOCH`) to skip login noise.

## Limitations

- **Open world only** — `CaptureAllowed()` requires not being in an instance (same practical limit as ElvUI/Prat: instanced chat often uses secret/non-storable strings). Delves, dungeons, M+, raids, BGs, etc. do not persist new lines.
- **Not a full chat log export** — Player-directed lines only (filters structural/system text); consecutive duplicate bodies are collapsed on save.
- **Tab routing** — Restore respects each tab’s `messageTypeList` (e.g. whispers go to the whisper tab, not General).
- **Timestamps on restore** — Uses saved wall-clock `serverTime`, not “time ago now”; format follows your timestamp setting at restore time.
- **`addonChatRestrictionsForced`** — Capture and restore are skipped when Blizzard forces addon chat restrictions.

## Test plan

- [ ] Open world: say, party, guild, channel, whisper — `/reload` — lines reappear above login spam with correct timestamps
- [ ] Type the same line again after reload — no duplicate
- [ ] `/reload` without typing — previous session lines still restore
- [ ] Delve/dungeon/M+: new lines not saved; no Lua errors; open-world lines from earlier still restore after leaving
- [ ] Toggle off **Remember Last Chat Lines** — SV cleared; toggle on — capture resumes
- [ ] Change timestamp format (e.g. `15:27`, `03:27 PM`) — restored lines match selected format