### PR TITLE
Add healthstones to EUI_Health recovery macro

### DIFF
--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -4,6 +4,15 @@
 --  Called by BuildQoLPage via EllesmereUI.BuildMacroFactory(parent, y, PP)
 -------------------------------------------------------------------------------
 
+-- Retail healthstones: 5512 (Healthstone), 224464 (Demonic Healthstone) — see AutoPotion Core/Potions.lua
+local EUI_HEALTH_MACRO_BODY = table.concat({
+    "/cast [nocombat] Recuperate",
+    "/use [combat] item:5512",
+    "/use [combat] item:224464",
+    "/use [combat] item:241304",
+    "/use [combat] item:241305",
+}, "\n")
+
 -- One-time migration: update EUI_Health macro body to use spell name instead of ID.
 -- Runs once per account (v2 flag).
 do
@@ -16,9 +25,26 @@ do
         local idx = GetMacroIndexByName("EUI_Health")
         if idx == 0 then EllesmereUIDB._healthMacroMigratedV2 = true; return end
         if InCombatLockdown() then return end
-        local body = "#showtooltip item:241304\n/cast [nocombat] Recuperate\n/use [combat] item:241304\n/use [combat] item:241305"
+        local body = "#showtooltip item:241304\n" .. EUI_HEALTH_MACRO_BODY
         EditMacro(idx, nil, nil, body)
         EllesmereUIDB._healthMacroMigratedV2 = true
+    end)
+end
+
+-- One-time migration: add Midnight retail healthstones before healing potions (v3 flag).
+do
+    local f = CreateFrame("Frame")
+    f:RegisterEvent("PLAYER_LOGIN")
+    f:SetScript("OnEvent", function(self)
+        self:UnregisterAllEvents()
+        if not EllesmereUIDB then EllesmereUIDB = {} end
+        if EllesmereUIDB._healthMacroMigratedV3 then return end
+        local idx = GetMacroIndexByName("EUI_Health")
+        if idx == 0 then EllesmereUIDB._healthMacroMigratedV3 = true; return end
+        if InCombatLockdown() then return end
+        local body = "#showtooltip item:5512\n" .. EUI_HEALTH_MACRO_BODY
+        EditMacro(idx, nil, nil, body)
+        EllesmereUIDB._healthMacroMigratedV3 = true
     end)
 end
 
@@ -53,8 +79,8 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
             name = "EUI_Health",
             icon = "Interface\\Icons\\inv_potion_131",
             label = "Health / Recuperate (Combat Based)",
-            fixedBody = "/cast [nocombat] Recuperate\n/use [combat] item:241304\n/use [combat] item:241305",
-            fixedTooltip = "item:241304",
+            fixedBody = EUI_HEALTH_MACRO_BODY,
+            fixedTooltip = "item:5512",
         },
         {
             name = "EUI_Food",

--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -54,18 +54,28 @@ local healthMacroPendingUpdate = false
 local function ApplyHealthRecoveryMacro(items)
     items = items or CollectHealthRecoveryItems()
     local key = HealthRecoverySequenceKey(items)
-    if key == lastHealthRecoveryKey then return end
-    lastHealthRecoveryKey = key
 
     local idx = GetMacroIndexByName(EUI_HEALTH_MACRO_NAME)
-    if idx == 0 then return end
+    if idx == 0 then
+        lastHealthRecoveryKey = key
+        healthMacroPendingUpdate = false
+        return
+    end
 
     if InCombatLockdown() then
-        healthMacroPendingUpdate = true
+        if key ~= lastHealthRecoveryKey then
+            healthMacroPendingUpdate = true
+        end
+        return
+    end
+
+    if key == lastHealthRecoveryKey then
+        healthMacroPendingUpdate = false
         return
     end
 
     EditMacro(idx, nil, nil, EllesmereUI.BuildHealthRecoveryMacroBody(GetHealthMacroDB(), items))
+    lastHealthRecoveryKey = key
     healthMacroPendingUpdate = false
 end
 
@@ -105,6 +115,7 @@ do
     f:SetScript("OnEvent", function(_, event)
         if event == "PLAYER_REGEN_ENABLED" then
             if healthMacroPendingUpdate then
+                healthMacroPendingUpdate = false
                 ApplyHealthRecoveryMacro()
             end
             return

--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -12,11 +12,6 @@ local HEALTH_RECOVERY_POTS = {
     241304, 241305, -- Midnight: Silvermoon Health Potion
 }
 
-local function HealthMacroInstancedPvP()
-    local inInstance, instanceType = IsInInstance()
-    return inInstance and (instanceType == "pvp" or instanceType == "arena")
-end
-
 local function HealthMacroItemCount(itemID)
     return GetItemCount(itemID, false) or 0
 end
@@ -31,12 +26,10 @@ local function CollectHealthRecoveryItems()
             end
         end
     end
-    if not HealthMacroInstancedPvP() then
-        for _, itemID in ipairs(HEALTH_RECOVERY_POTS) do
-            if HealthMacroItemCount(itemID) > 0 then
-                items[#items + 1] = itemID
-                break
-            end
+    for _, itemID in ipairs(HEALTH_RECOVERY_POTS) do
+        if HealthMacroItemCount(itemID) > 0 then
+            items[#items + 1] = itemID
+            break
         end
     end
     return items
@@ -80,28 +73,20 @@ function EllesmereUI.BuildHealthRecoveryMacroBody(db, items)
     db = db or {}
     items = items or CollectHealthRecoveryItems()
     local lines = {}
-    local useRecuperate = not HealthMacroInstancedPvP()
 
     if db.showTooltip ~= false then
-        local tip = (items[1] and ("item:" .. items[1])) or (useRecuperate and "Recuperate" or nil)
-        if tip then
-            lines[#lines + 1] = "#showtooltip " .. tip
-        else
-            lines[#lines + 1] = "#showtooltip"
-        end
+        local tip = (items[1] and ("item:" .. items[1])) or "Recuperate"
+        lines[#lines + 1] = "#showtooltip " .. tip
     end
 
-    if useRecuperate then
-        lines[#lines + 1] = "/cast [nocombat] Recuperate"
-    end
+    lines[#lines + 1] = "/cast [nocombat] Recuperate"
 
     if #items > 0 then
         local seqParts = {}
         for _, itemID in ipairs(items) do
             seqParts[#seqParts + 1] = "item:" .. itemID
         end
-        local combatCond = useRecuperate and ",combat" or ""
-        lines[#lines + 1] = "/castsequence [@player" .. combatCond .. "] reset=combat "
+        lines[#lines + 1] = "/castsequence [@player,combat] reset=combat "
             .. table.concat(seqParts, ", ")
     end
 

--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -4,47 +4,136 @@
 --  Called by BuildQoLPage via EllesmereUI.BuildMacroFactory(parent, y, PP)
 -------------------------------------------------------------------------------
 
--- Retail healthstones: 5512 (Healthstone), 224464 (Demonic Healthstone) — see AutoPotion Core/Potions.lua
-local EUI_HEALTH_MACRO_BODY = table.concat({
-    "/cast [nocombat] Recuperate",
-    "/use [combat] item:5512",
-    "/use [combat] item:224464",
-    "/use [combat] item:241304",
-    "/use [combat] item:241305",
-}, "\n")
+local EUI_HEALTH_MACRO_NAME = "EUI_Health"
 
--- One-time migration: update EUI_Health macro body to use spell name instead of ID.
--- Runs once per account (v2 flag).
-do
-    local f = CreateFrame("Frame")
-    f:RegisterEvent("PLAYER_LOGIN")
-    f:SetScript("OnEvent", function(self)
-        self:UnregisterAllEvents()
-        if not EllesmereUIDB then EllesmereUIDB = {} end
-        if EllesmereUIDB._healthMacroMigratedV2 then return end
-        local idx = GetMacroIndexByName("EUI_Health")
-        if idx == 0 then EllesmereUIDB._healthMacroMigratedV2 = true; return end
-        if InCombatLockdown() then return end
-        local body = "#showtooltip item:241304\n" .. EUI_HEALTH_MACRO_BODY
-        EditMacro(idx, nil, nil, body)
-        EllesmereUIDB._healthMacroMigratedV2 = true
-    end)
+-- Retail recovery consumables (priority order). Stones before pots; one pot rank if multiple in bags.
+local HEALTH_RECOVERY_STONES = { 5512, 224464 }
+local HEALTH_RECOVERY_POTS = {
+    241304, 241305, -- Midnight: Silvermoon Health Potion
+}
+
+local function HealthMacroInstancedPvP()
+    local inInstance, instanceType = IsInInstance()
+    return inInstance and (instanceType == "pvp" or instanceType == "arena")
 end
 
--- One-time migration: add Midnight retail healthstones before healing potions (v3 flag).
+local function HealthMacroItemCount(itemID)
+    return GetItemCount(itemID, false) or 0
+end
+
+local function CollectHealthRecoveryItems()
+    local items = {}
+    for _, itemID in ipairs(HEALTH_RECOVERY_STONES) do
+        if HealthMacroItemCount(itemID) > 0 then
+            items[#items + 1] = itemID
+            if #items >= #HEALTH_RECOVERY_STONES then
+                break
+            end
+        end
+    end
+    if not HealthMacroInstancedPvP() then
+        for _, itemID in ipairs(HEALTH_RECOVERY_POTS) do
+            if HealthMacroItemCount(itemID) > 0 then
+                items[#items + 1] = itemID
+                break
+            end
+        end
+    end
+    return items
+end
+
+local function HealthRecoverySequenceKey(items)
+    return table.concat(items, ",")
+end
+
+local function GetHealthMacroDB()
+    if not EllesmereUIDB then EllesmereUIDB = {} end
+    if not EllesmereUIDB.macroFactory then EllesmereUIDB.macroFactory = {} end
+    if not EllesmereUIDB.macroFactory[EUI_HEALTH_MACRO_NAME] then
+        EllesmereUIDB.macroFactory[EUI_HEALTH_MACRO_NAME] = {}
+    end
+    return EllesmereUIDB.macroFactory[EUI_HEALTH_MACRO_NAME]
+end
+
+local lastHealthRecoveryKey = nil
+local healthMacroPendingUpdate = false
+
+local function ApplyHealthRecoveryMacro(items)
+    items = items or CollectHealthRecoveryItems()
+    local key = HealthRecoverySequenceKey(items)
+    if key == lastHealthRecoveryKey then return end
+    lastHealthRecoveryKey = key
+
+    local idx = GetMacroIndexByName(EUI_HEALTH_MACRO_NAME)
+    if idx == 0 then return end
+
+    if InCombatLockdown() then
+        healthMacroPendingUpdate = true
+        return
+    end
+
+    EditMacro(idx, nil, nil, EllesmereUI.BuildHealthRecoveryMacroBody(GetHealthMacroDB(), items))
+    healthMacroPendingUpdate = false
+end
+
+function EllesmereUI.BuildHealthRecoveryMacroBody(db, items)
+    db = db or {}
+    items = items or CollectHealthRecoveryItems()
+    local lines = {}
+    local useRecuperate = not HealthMacroInstancedPvP()
+
+    if db.showTooltip ~= false then
+        local tip = (items[1] and ("item:" .. items[1])) or (useRecuperate and "Recuperate" or nil)
+        if tip then
+            lines[#lines + 1] = "#showtooltip " .. tip
+        else
+            lines[#lines + 1] = "#showtooltip"
+        end
+    end
+
+    if useRecuperate then
+        lines[#lines + 1] = "/cast [nocombat] Recuperate"
+    end
+
+    if #items > 0 then
+        local seqParts = {}
+        for _, itemID in ipairs(items) do
+            seqParts[#seqParts + 1] = "item:" .. itemID
+        end
+        local combatCond = useRecuperate and ",combat" or ""
+        lines[#lines + 1] = "/castsequence [@player" .. combatCond .. "] reset=combat "
+            .. table.concat(seqParts, ", ")
+    end
+
+    if #lines == 0 then return "" end
+    return table.concat(lines, "\n")
+end
+
+-- Keep EUI_Health in sync with bags / login without opening the Macro Factory UI.
 do
     local f = CreateFrame("Frame")
+    local bagPending = false
     f:RegisterEvent("PLAYER_LOGIN")
-    f:SetScript("OnEvent", function(self)
-        self:UnregisterAllEvents()
-        if not EllesmereUIDB then EllesmereUIDB = {} end
-        if EllesmereUIDB._healthMacroMigratedV3 then return end
-        local idx = GetMacroIndexByName("EUI_Health")
-        if idx == 0 then EllesmereUIDB._healthMacroMigratedV3 = true; return end
-        if InCombatLockdown() then return end
-        local body = "#showtooltip item:5512\n" .. EUI_HEALTH_MACRO_BODY
-        EditMacro(idx, nil, nil, body)
-        EllesmereUIDB._healthMacroMigratedV3 = true
+    f:RegisterEvent("PLAYER_ENTERING_WORLD")
+    f:RegisterEvent("PLAYER_REGEN_ENABLED")
+    f:RegisterEvent("BAG_UPDATE")
+    f:SetScript("OnEvent", function(_, event)
+        if event == "PLAYER_REGEN_ENABLED" then
+            if healthMacroPendingUpdate then
+                ApplyHealthRecoveryMacro()
+            end
+            return
+        end
+        if event == "PLAYER_LOGIN" or event == "PLAYER_ENTERING_WORLD" then
+            C_Timer.After(1, ApplyHealthRecoveryMacro)
+            return
+        end
+        if bagPending then return end
+        bagPending = true
+        C_Timer.After(0.5, function()
+            bagPending = false
+            ApplyHealthRecoveryMacro()
+        end)
     end)
 end
 
@@ -76,11 +165,10 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
             },
         },
         {
-            name = "EUI_Health",
+            name = EUI_HEALTH_MACRO_NAME,
             icon = "Interface\\Icons\\inv_potion_131",
             label = "Health / Recuperate (Combat Based)",
-            fixedBody = EUI_HEALTH_MACRO_BODY,
-            fixedTooltip = "item:5512",
+            healthRecovery = true,
         },
         {
             name = "EUI_Food",
@@ -482,6 +570,13 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
         return nil
     end
 
+    local function GetMacroInventoryKey(def, db)
+        if def.healthRecovery then
+            return lastHealthRecoveryKey or HealthRecoverySequenceKey(CollectHealthRecoveryItems())
+        end
+        return GetFirstAvailableItemID(def, db)
+    end
+
     local function BuildMacroBody(def, db)
         if def.checkboxes then
             local cbs = def.checkboxes
@@ -517,6 +612,8 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
             end
             if #lines == 0 then return "" end
             return body .. table.concat(lines, "\n")
+        elseif def.healthRecovery then
+            return EllesmereUI.BuildHealthRecoveryMacroBody(db, nil)
         elseif def.fixedBody then
             local body = ""
             if db.showTooltip ~= false and def.fixedTooltip then
@@ -532,6 +629,10 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
     local pendingMacroUpdates = {}
 
     local function UpdateMacro(def, db)
+        if def.healthRecovery then
+            ApplyHealthRecoveryMacro()
+            return
+        end
         local idx = GetMacroIndexByName(def.name)
         if idx ~= 0 then
             if InCombatLockdown() then
@@ -831,6 +932,11 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
                             if icon then break end
                         end
                     end
+                elseif def.healthRecovery then
+                    local tipID = tonumber((lastHealthRecoveryKey or ""):match("^(%d+)"))
+                    if tipID and C_Item.GetItemIconByID then
+                        icon = C_Item.GetItemIconByID(tipID)
+                    end
                 elseif def.fixedTooltip then
                     local slot = tonumber(def.fixedTooltip)
                     if slot then
@@ -886,10 +992,15 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
                     if InCombatLockdown() then return end
                     if MacroExists() then
                         DeleteMacro(def.name)
+                        if def.healthRecovery then lastHealthRecoveryKey = nil end
                     else
                         local db = GetDB()
                         CreateMacro(def.name, def.macroIcon or "INV_MISC_QUESTIONMARK", BuildMacroBody(def, db), nil)
-                        lastAvailableItems[def.name] = GetFirstAvailableItemID(def, db)
+                        if def.healthRecovery then
+                            lastHealthRecoveryKey = nil
+                            ApplyHealthRecoveryMacro()
+                        end
+                        lastAvailableItems[def.name] = GetMacroInventoryKey(def, db)
                         PlayFlash()
                         C_Timer.After(0.15, function()
                             if not InCombatLockdown() then ShowMacroFrame() end
@@ -1120,7 +1231,11 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
                 if InCombatLockdown() then return end
                 local db = GetDB()
                 CreateMacro(def.name, def.macroIcon or "INV_MISC_QUESTIONMARK", BuildMacroBody(def, db), nil)
-                lastAvailableItems[def.name] = GetFirstAvailableItemID(def, db)
+                if def.healthRecovery then
+                    lastHealthRecoveryKey = nil
+                    ApplyHealthRecoveryMacro()
+                end
+                lastAvailableItems[def.name] = GetMacroInventoryKey(def, db)
                 self._playFlash()
                 C_Timer.After(0.1, RefreshState)
                 C_Timer.After(0.15, function()
@@ -1157,16 +1272,21 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
     local function UpdateInventoryDependentMacros()
         for _, btn in ipairs(allMacroButtons) do
             local mdef = btn._def
-            if mdef and mdef.checkboxes and btn._tex then
+            if mdef and btn._tex and mdef.checkboxes then
                 local idx = GetMacroIndexByName(mdef.name)
                 if idx ~= 0 then
                     local db = GetMacroDB(mdef.name)
-                    local newAvailableItemID = GetFirstAvailableItemID(mdef, db)
-                    local oldAvailableItemID = lastAvailableItems[mdef.name]
-                    if newAvailableItemID ~= oldAvailableItemID then
-                        lastAvailableItems[mdef.name] = newAvailableItemID
+                    local newKey = GetMacroInventoryKey(mdef, db)
+                    if newKey ~= lastAvailableItems[mdef.name] then
+                        lastAvailableItems[mdef.name] = newKey
                         UpdateMacro(mdef, db)
                     end
+                end
+            elseif mdef and btn._tex and mdef.healthRecovery then
+                local newKey = lastHealthRecoveryKey or GetMacroInventoryKey(mdef, GetMacroDB(mdef.name))
+                if newKey ~= lastAvailableItems[mdef.name] then
+                    lastAvailableItems[mdef.name] = newKey
+                    if btn._refreshIcon then btn._refreshIcon() end
                 end
             end
         end
@@ -1183,9 +1303,16 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
             local mdef = btn._def
             if mdef and btn._tex then
                 local ex = GetMacroIndexByName(mdef.name) ~= 0
-                if btn._isGray and not ex then btn._tex:SetDesaturated(false); btn._isGray = false
-                elseif not btn._isGray and ex then btn._tex:SetDesaturated(true); btn._isGray = true end
-                if btn._refreshIcon then btn._refreshIcon() end
+                local wasCreated = btn._isGray
+                if wasCreated and not ex then
+                    btn._tex:SetDesaturated(false)
+                    btn._isGray = false
+                    if btn._refreshIcon then btn._refreshIcon() end
+                elseif not wasCreated and ex then
+                    btn._tex:SetDesaturated(true)
+                    btn._isGray = true
+                    if btn._refreshIcon then btn._refreshIcon() end
+                end
                 if btn._cogPopup and btn._cogPopup:IsShown() and btn._cogPopup._refreshAction then
                     btn._cogPopup._refreshAction()
                 end


### PR DESCRIPTION
## Summary
- Rebuild `EUI_Health` as a dynamic recovery macro: `/cast [nocombat] Recuperate` plus a bag-driven `/castsequence` (`reset=combat`) for consumables you actually have
- Combat priority: Healthstone (`5512`) → Demonic Healthstone (`224464`) → best Silvermoon Health Potion rank in bags (`241304` / `241305`)
- Inspired by [AutoPotion](https://github.com/ollidiemaus/AutoPotion) retail ordering, but implemented in EUI style (`ApplyHealthRecoveryMacro`, deduped updates, Macro Factory integration)
- Always-on `BAG_UPDATE` / login / regen sync so `EUI_Health` updates without opening Macro Factory; Macro Factory poll only refreshes create/delete state (not icons every 2s)
- Recuperate and pots stay in the macro everywhere (no instanced BG/arena gating), matching the original fixed macro behavior

## Test plan
- [ ] Create or refresh `EUI_Health` from QoL → Macro Factory
- [ ] Out of combat: macro casts Recuperate (including in BG/arena)
- [ ] In combat with a healthstone: castsequence uses stone before pot
- [ ] With both stones in bags: both can appear in the sequence; one heal per keypress
- [ ] With only a Silvermoon pot: sequence uses the highest-priority rank you have
- [ ] Pick up / drop a stone or pot (or `/reload`): macro body updates without reopening QoL
- [ ] Existing `EUI_Health` macro updates after login or bag change