### PR TITLE
Fix minimap middle-click menu without triggering ping

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -3272,6 +3272,10 @@ local function ApplyMinimap()
 
     -- Mark module as active so persistent hooks know they can fire
     GetFFD(minimap).active = true
+
+    if _G._EMM_InstallMinimapMiddleClick then
+        _G._EMM_InstallMinimapMiddleClick(minimap)
+    end
 end
 
 
@@ -3475,23 +3479,55 @@ do
         SetMenuVisible(not menuOpen)
     end
 
-    local _microMenuHooked = false
-    local function HookMinimapMiddleClick()
-        if _microMenuHooked then return end
-        local minimap = Minimap
-        if not minimap then return end
-        _microMenuHooked = true
-        minimap:HookScript("OnMouseUp", function(_, btn)
-            if btn == "MiddleButton" then ToggleMicroMenu() end
-        end)
+    local function PassThroughLR(frame)
+        if not frame or not frame.SetPassThroughButtons then return end
+        if securecallfunction then
+            securecallfunction(frame.SetPassThroughButtons, frame, "LeftButton", "RightButton")
+        else
+            frame:SetPassThroughButtons("LeftButton", "RightButton")
+        end
     end
 
-    local hookFrame = CreateFrame("Frame")
-    hookFrame:RegisterEvent("PLAYER_LOGIN")
-    hookFrame:SetScript("OnEvent", function(self)
-        self:UnregisterEvent("PLAYER_LOGIN")
-        CreateMenuFrame()
-        HookMinimapMiddleClick()
+    local function InstallMinimapMiddleClick(minimap)
+        if not minimap then return end
+        local ffd = GetFFD(minimap)
+
+        local clickHandler = ffd.middleClickHandler
+        if not clickHandler then
+            clickHandler = CreateFrame("Frame", "EllesmereUIMinimapClickHandler", minimap)
+            ffd.middleClickHandler = clickHandler
+            clickHandler:SetScript("OnMouseDown", function(_, btn)
+                if btn == "MiddleButton" then ToggleMicroMenu() end
+            end)
+        end
+
+        clickHandler:SetAllPoints()
+        clickHandler:EnableMouse(true)
+        clickHandler:SetPropagateMouseMotion(true)
+        if clickHandler.SetFrameLevel then
+            clickHandler:SetFrameLevel(minimap:GetFrameLevel() + 101)
+        end
+        PassThroughLR(clickHandler)
+
+        if not _G.HybridMinimap and C_AddOns and C_AddOns.LoadAddOn then
+            pcall(C_AddOns.LoadAddOn, "Blizzard_HybridMinimap")
+        end
+        local mapCanvas = _G.HybridMinimap and _G.HybridMinimap.MapCanvas
+        if mapCanvas then
+            PassThroughLR(mapCanvas)
+            PassThroughLR(mapCanvas.ScrollContainer)
+        end
+    end
+
+    _G._EMM_InstallMinimapMiddleClick = InstallMinimapMiddleClick
+
+    local hybridWatcher = CreateFrame("Frame")
+    hybridWatcher:RegisterEvent("ADDON_LOADED")
+    hybridWatcher:SetScript("OnEvent", function(_, _, addon)
+        if addon == "Blizzard_HybridMinimap" then
+            hybridWatcher:UnregisterAllEvents()
+            InstallMinimapMiddleClick(Minimap)
+        end
     end)
 end
 


### PR DESCRIPTION
## Problem

Middle-click on the minimap is meant to toggle the EllesmereUI micro menu, but it was also triggering a minimap ping.

Several earlier fixes made things worse:

- `HookScript("OnMouseUp")` opened the menu, but Blizzard's ping handler runs first on mouse-up, so the ping still appeared.
- Replacing `OnMouseUp` and calling `Minimap:OnClick()` from addon code caused `ADDON_ACTION_FORBIDDEN` because `PingLocation` is protected and cannot be invoked from addon handlers.
- Wrapping `PingLocation` directly hit the same protected-function restriction.

## Approach

Follow the ElvUI minimap pattern:

- Add a full-size click overlay (`EllesmereUIMinimapClickHandler`) on `Minimap` at frame level `+101` (above retail `HybridMinimap` at 100).
- Use `SetPassThroughButtons("LeftButton", "RightButton")` so left/right reach Blizzard's native handlers for ping and tracking.
- Handle middle-click on `OnMouseDown` only, opening the micro menu without ever calling `OnClick` or `PingLocation`.
- On retail, pass left/right through `HybridMinimap.MapCanvas` and its scroll container so clicks reach `Minimap` underneath.
- Re-apply the overlay from `ApplyMinimap` after minimap rebuilds; watch for `Blizzard_HybridMinimap` loading after `OnEnable`.

## Limitations

- Middle-click over minimap indicator buttons (calendar, mail, flyout, etc.) opens the micro menu instead of activating that button. Left/right still pass through to the button underneath.
- Scroll-to-zoom over the minimap surface is untested. ElvUI forwards `OnMouseWheel` on its overlay; this PR does not yet.
- Only applies to Blizzard's `Minimap` frame, not third-party minimap replacements.

## Test plan

- [x] Middle-click minimap opens micro menu without ping
- [x] Left-click minimap still pings
- [x] Right-click minimap still opens tracking menu
- [x] Works with square/circle minimap shapes and after changing minimap options (`ApplyMinimap` rebuild)
- [x] Scroll-to-zoom still works over the minimap surface