### PR TITLE
Fix character crosshair layering under UI panels

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -1666,7 +1666,8 @@ do
     local function CreateCrosshair()
         if crosshairFrame then return end
         crosshairFrame = CreateFrame("Frame", "EUI_CharacterCrosshair", UIParent)
-        crosshairFrame:SetFrameStrata("HIGH")
+        -- MEDIUM sits above gameplay HUD but below DIALOG/HIGH panels (talents, character, etc.).
+        crosshairFrame:SetFrameStrata("MEDIUM")
         crosshairFrame:SetFrameLevel(100)
         crosshairFrame:EnableMouse(false)
         crosshairFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)


### PR DESCRIPTION
## Summary
- Lower the Character Crosshair from `HIGH` to `MEDIUM` (level 100) so it stays under UI windows like talents and the character sheet.
- Keeps the reticle visible over gameplay HUD and nameplate health bars without panel-specific hide logic.

## Test plan
- [ ] Enable Character Crosshair in QoL options
- [ ] Confirm the crosshair remains visible in the open world and over enemy nameplates
- [ ] Open talents / character sheet and confirm the crosshair no longer draws on top
- [ ] `/reload` after toggling the option to verify apply/refresh still works