### PR TITLE
Add nameplate target arrow color option

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -534,6 +534,11 @@ initFrame:SetScript("OnEvent", function(self)
         arrows.right:SetSize(11, 16)
         arrows.right:SetPoint("LEFT", health, "RIGHT", 8, 0)
         arrows.right:Hide()
+        do
+            local c = (DB() and DB().targetArrowColor) or defaults.targetArrowColor
+            arrows.left:SetVertexColor(c.r, c.g, c.b, 1)
+            arrows.right:SetVertexColor(c.r, c.g, c.b, 1)
+        end
         pf._arrows = arrows  -- expose for Update resizing
 
         -- Classification icon (elite dragon) shown when transient toggle is on
@@ -792,6 +797,9 @@ initFrame:SetScript("OnEvent", function(self)
             if pf._arrows then
                 pf._arrows.left:SetSize(arrowW, arrowH)
                 pf._arrows.right:SetSize(arrowW, arrowH)
+                local arrowColor = (DB() and DB().targetArrowColor) or defaults.targetArrowColor
+                pf._arrows.left:SetVertexColor(arrowColor.r, arrowColor.g, arrowColor.b, 1)
+                pf._arrows.right:SetVertexColor(arrowColor.r, arrowColor.g, arrowColor.b, 1)
             end
             local cbColor    = (DB() and DB().castBar) or defaults.castBar
             local debuffY    = DBVal("debuffYOffset") or defaults.debuffYOffset
@@ -4669,10 +4677,36 @@ initFrame:SetScript("OnEvent", function(self)
                 UpdatePreview()
               end });  y = y - h
 
-        -- Inline cog on Show Arrows (right region) for arrow scale
+        -- Inline color swatch + cog on Show Arrows (right region)
         do
             local rightRgn = targetGlowRow._rightRegion
             local arrowOff = function() return DBVal("showTargetArrows") ~= true end
+
+            local arrowColorGet = function()
+                local c = (DB() and DB().targetArrowColor) or defaults.targetArrowColor
+                return c.r, c.g, c.b
+            end
+            local arrowColorSet = function(r, g, b)
+                DB().targetArrowColor = { r = r, g = g, b = b }
+                if ns.ApplyTargetArrowColor then
+                    for _, plate in pairs(plates) do ns.ApplyTargetArrowColor(plate) end
+                    for _, plate in pairs(ns.friendlyPlates or {}) do ns.ApplyTargetArrowColor(plate) end
+                end
+                UpdatePreview()
+            end
+            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(rightRgn, rightRgn:GetFrameLevel() + 5, arrowColorGet, arrowColorSet, nil, 20)
+            PP.Point(swatch, "RIGHT", rightRgn._control, "LEFT", -12, 0)
+            rightRgn._lastInline = swatch
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = arrowOff()
+                swatch:SetAlpha(off and 0.15 or 1)
+                swatch:EnableMouse(not off)
+                updateSwatch()
+            end)
+            local off = arrowOff()
+            swatch:SetAlpha(off and 0.15 or 1)
+            swatch:EnableMouse(not off)
+
             local _, arrowCogShow = EllesmereUI.BuildCogPopup({
                 title = "Arrow Scale",
                 rows = {
@@ -4693,7 +4727,7 @@ initFrame:SetScript("OnEvent", function(self)
             })
             local arrowCogBtn = CreateFrame("Button", nil, rightRgn)
             arrowCogBtn:SetSize(26, 26)
-            arrowCogBtn:SetPoint("RIGHT", rightRgn._control, "LEFT", -8, 0)
+            arrowCogBtn:SetPoint("RIGHT", rightRgn._lastInline or rightRgn._control, "LEFT", -8, 0)
             rightRgn._lastInline = arrowCogBtn
             arrowCogBtn:SetFrameLevel(rightRgn:GetFrameLevel() + 5)
             local arrowCogTex = arrowCogBtn:CreateTexture(nil, "OVERLAY")

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -152,6 +152,7 @@ local defaults = {
     textSlotCenter = "none",
     showTargetArrows = false,
     targetArrowScale = 1.0,
+    targetArrowColor = { r = 1.0, g = 1.0, b = 1.0 },
     showClassPower = false,
     classPowerPos = "bottom",
     classPowerYOffset = 1,
@@ -1343,6 +1344,7 @@ local function EnsureArrows(plate)
     PP.Size(plate.rightArrow, aw, ah)
     PP.Point(plate.rightArrow, "LEFT", plate.health, "RIGHT", 8, 0)
     plate.rightArrow:Hide()
+    ns.ApplyTargetArrowColor(plate)
 end
 
 local function EnsureFocusOverlay(plate)
@@ -4200,6 +4202,7 @@ function NameplateFrame:ApplyTarget()
             local aw, ah = math.floor(11 * sc + 0.5), math.floor(16 * sc + 0.5)
             PP.Size(self.leftArrow,  aw, ah)
             PP.Size(self.rightArrow, aw, ah)
+            ns.ApplyTargetArrowColor(self)
             self.leftArrow:Show()
             self.rightArrow:Show()
             PositionArrowsOutsideAuras(self)

--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -31,6 +31,16 @@ local Enum = Enum
 local friendlyEnabled = false
 local friendlyPlates = {}
 ns.friendlyPlates = friendlyPlates
+
+function ns.ApplyTargetArrowColor(plate)
+    if not plate.leftArrow then return end
+    local prof = ns.db and ns.db.profile
+    local def = ns.defaults and ns.defaults.targetArrowColor
+    local c = (prof and prof.targetArrowColor) or def or { r = 1, g = 1, b = 1 }
+    plate.leftArrow:SetVertexColor(c.r, c.g, c.b, 1)
+    plate.rightArrow:SetVertexColor(c.r, c.g, c.b, 1)
+end
+
 local _cachedFriendlyTargetPlate = nil
 
 local FRIENDLY_BAR_W = 150
@@ -665,6 +675,7 @@ local friendlyFrameCache = CreateFramePool("Frame", UIParent, nil, nil, false, f
     plate.rightArrow:SetSize(11, 16)
     plate.rightArrow:SetPoint("LEFT", plate.name, "RIGHT", 2, 0)
     plate.rightArrow:Hide()
+    if ns.ApplyTargetArrowColor then ns.ApplyTargetArrowColor(plate) end
 
     plate.raidFrame = CreateFrame("Frame", nil, plate)
     plate.raidFrame:SetSize(24, 24)
@@ -824,6 +835,7 @@ function FriendlyFrame:ApplyTarget()
     local isTarget = UnitIsUnit(self.unit, "target")
     self.glow:SetShown(isTarget)
     local showArrows = isTarget and FP() and FP().showTargetArrows
+    if showArrows and ns.ApplyTargetArrowColor then ns.ApplyTargetArrowColor(self) end
     self.leftArrow:SetShown(showArrows or false)
     self.rightArrow:SetShown(showArrows or false)
 end


### PR DESCRIPTION
## Summary
- Adds a `targetArrowColor` setting (default white) for nameplate target arrows on enemy and friendly plates.
- Adds an inline color swatch on the Display page next to **Show Arrows on Target**, matching other color controls.
- Defines `ns.ApplyTargetArrowColor` in the friendly nameplates file to avoid Lua 5.1 local-limit errors in the main nameplates module.

## Test plan
- [ ] Enable **Show Arrows on Target** on enemy nameplates; confirm arrows appear on your target.
- [ ] Change arrow color via the swatch; confirm live update on nameplates and in the options preview.
- [ ] Toggle arrows off; confirm the color swatch is dimmed and non-interactive.
- [ ] Adjust arrow scale via the cog; confirm size still works with the new color.
- [ ] `/reload` and confirm the chosen color persists.
- [ ] With friendly nameplates enabled, confirm target arrows tint correctly on friendly targets.