### PR TITLE
Unit frames: independent left/right/center health and BTB text

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -284,6 +284,18 @@ initFrame:SetScript("OnEvent", function(self)
     }
     local healthTextOrder = { "none", "---", "name", "perhp", "perhpnosign", "curhpshort", "perhpnum", "both" }
 
+    local PREVIEW_TEXT_WIDTHS = {
+        both = 75, perhpnum = 75, curhpshort = 38, perhp = 38, perhpnosign = 30,
+        perpp = 38, curpp = 38, curhp_curpp = 75, perhp_perpp = 75,
+    }
+    local function EstimatePreviewTextWidth(content)
+        return (PREVIEW_TEXT_WIDTHS[content] or 0) + 10
+    end
+
+    local function IsCompactUFUnitKey(unitKey)
+        return unitKey == "pet" or unitKey == "targettarget" or unitKey == "boss"
+    end
+
     -- Text bar (BTB) text dropdown values (includes power options)
     local btbTextValues = {
         ["name"]         = "Name",
@@ -718,7 +730,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Mini frames (ToT/FoT/Pet) don't render power bars, debuffs, or
         -- castbars at runtime, so the preview must match.
-        local isMiniPreview = (unitKey == "targettarget" or unitKey == "pet")
+        local isMiniPreview = IsCompactUFUnitKey(unitKey)
         local noPowerPreview = isMiniPreview
         local noDebuffPreview = isMiniPreview
         local noCastbarPreview = isMiniPreview
@@ -1065,10 +1077,12 @@ initFrame:SetScript("OnEvent", function(self)
                 fs:SetTextColor(0, 0, 1)
             end
         end
-        local function ApplyPreviewTextPositions(s, donorS)
+        local function ApplyPreviewTextPositions(s, donorS, layoutOpts)
+            layoutOpts = layoutOpts or {}
             local lc = s.leftTextContent or "name"
             local rc = s.rightTextContent or (unitKey == "focus" and "perhp" or "both")
             local cc = s.centerTextContent or "none"
+            local showSides = not layoutOpts.centerExclusive or cc == "none"
             local fontS = donorS or s
             local lsz = fontS.leftTextSize or fontS.textSize or 12
             local rsz = fontS.rightTextSize or fontS.textSize or 12
@@ -1079,57 +1093,64 @@ initFrame:SetScript("OnEvent", function(self)
             local ryo = s.rightTextY or 0
             local cxo = s.centerTextX or 0
             local cyo = s.centerTextY or 0
+            local barW = s.frameWidth or 181
+            local wide = layoutOpts.wide
 
-
-            -- Center text: if active, hide left/right
             if cc ~= "none" then
-                leftFS:Hide()
-                rightFS:Hide()
                 centerFS:SetFont(PREVIEW_FONT, csz, GetUFOptOutline())
                 centerFS:ClearAllPoints()
                 centerFS:SetJustifyH("CENTER")
                 PP.Point(centerFS, "CENTER", textOverlay, "CENTER", cxo, cyo)
+                if wide then PP.Width(centerFS, barW * 0.9) else centerFS:SetWidth(0) end
                 centerFS:SetText(PreviewTextForContent(cc, s))
                 centerFS:Show()
                 PreviewClassColor(centerFS, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
             else
                 centerFS:Hide()
-                leftFS:SetFont(PREVIEW_FONT, lsz, GetUFOptOutline())
-                leftFS:ClearAllPoints()
-                if lc ~= "none" then
-                    leftFS:SetJustifyH("LEFT")
-                    PP.Point(leftFS, "LEFT", textOverlay, "LEFT", 5 + lxo, lyo)
-                    -- Constrain width when opposing right text exists (matches live frame truncation)
-                    local barW = s.frameWidth or 181
-                    if rc ~= "none" then
-                        local UF_TEXT_PADDING = 10
-                        local ufTW = { both = 75, curhpshort = 38, perhp = 38, perpp = 38, curpp = 38, curhp_curpp = 75, perhp_perpp = 75 }
-                        local rightUsed = (ufTW[rc] or 0) + UF_TEXT_PADDING
-                        PP.Width(leftFS, math.max(barW - rightUsed - 10, 20))
-                    else
-                        leftFS:SetWidth(0)
-                    end
-                    leftFS:SetText(PreviewTextForContent(lc, s))
-                    leftFS:Show()
-                    PreviewClassColor(leftFS, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
-                else
-                    leftFS:Hide()
-                end
+            end
 
-                rightFS:SetFont(PREVIEW_FONT, rsz, GetUFOptOutline())
-                rightFS:ClearAllPoints()
+            leftFS:SetFont(PREVIEW_FONT, lsz, GetUFOptOutline())
+            leftFS:ClearAllPoints()
+            if showSides and lc ~= "none" then
+                leftFS:SetJustifyH("LEFT")
+                PP.Point(leftFS, "LEFT", textOverlay, "LEFT", 5 + lxo, lyo)
                 if rc ~= "none" then
-                    rightFS:SetJustifyH("RIGHT")
-                    PP.Point(rightFS, "RIGHT", textOverlay, "RIGHT", -5 + rxo, ryo)
-                    rightFS:SetText(PreviewTextForContent(rc, s))
-                    rightFS:Show()
-                    PreviewClassColor(rightFS, s.rightTextClassColor, s.rightTextColorR, s.rightTextColorG, s.rightTextColorB)
+                    PP.Width(leftFS, math.max(barW - EstimatePreviewTextWidth(rc) - 10, 20))
+                elseif wide then
+                    PP.Width(leftFS, barW * 0.9)
                 else
-                    rightFS:Hide()
+                    leftFS:SetWidth(0)
                 end
+                leftFS:SetText(PreviewTextForContent(lc, s))
+                leftFS:Show()
+                PreviewClassColor(leftFS, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
+            else
+                leftFS:Hide()
+            end
+
+            rightFS:SetFont(PREVIEW_FONT, rsz, GetUFOptOutline())
+            rightFS:ClearAllPoints()
+            if showSides and rc ~= "none" then
+                rightFS:SetJustifyH("RIGHT")
+                PP.Point(rightFS, "RIGHT", textOverlay, "RIGHT", -5 + rxo, ryo)
+                if lc ~= "none" then
+                    PP.Width(rightFS, math.max(barW - EstimatePreviewTextWidth(lc) - 10, 20))
+                elseif wide then
+                    PP.Width(rightFS, barW * 0.9)
+                else
+                    rightFS:SetWidth(0)
+                end
+                rightFS:SetText(PreviewTextForContent(rc, s))
+                rightFS:Show()
+                PreviewClassColor(rightFS, s.rightTextClassColor, s.rightTextColorR, s.rightTextColorG, s.rightTextColorB)
+            else
+                rightFS:Hide()
             end
         end
-        ApplyPreviewTextPositions(settings)
+        ApplyPreviewTextPositions(settings, nil, {
+            centerExclusive = isMiniPreview,
+            wide = isMiniPreview,
+        })
 
         -- Power bar
         local power
@@ -1964,7 +1985,10 @@ initFrame:SetScript("OnEvent", function(self)
             end
 
             -- Update text via unified function
-            ApplyPreviewTextPositions(s, isMini and ds or nil)
+            ApplyPreviewTextPositions(s, isMini and ds or nil, {
+                centerExclusive = isMiniPreview,
+                wide = isMiniPreview,
+            })
 
             -- Resize barArea to health+power area (+ above pips if active)
             PP.Size(barArea, tw, bh2 + btbTopOff)
@@ -4287,8 +4311,6 @@ initFrame:SetScript("OnEvent", function(self)
                   end
                   UpdatePreview(); EllesmereUI:RefreshPage()
               end,
-              disabled=function() return SVal("centerTextContent", "none") ~= "none" end,
-              disabledTooltip="This option is disabled while a Center Text is selected.",
             },
             { type="dropdown", text="Right Text", values=healthTextValues, order=healthTextOrder,
               getValue=function() return SVal("rightTextContent", "both") end,
@@ -4300,8 +4322,6 @@ initFrame:SetScript("OnEvent", function(self)
                   end
                   UpdatePreview(); EllesmereUI:RefreshPage()
               end,
-              disabled=function() return SVal("centerTextContent", "none") ~= "none" end,
-              disabledTooltip="This option is disabled while a Center Text is selected.",
             });  y = y - h
         -- Sync icons: Left Text (left) and Right Text (right)
         do
@@ -4507,8 +4527,8 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v)
                   SSet("centerTextContent", v)
                   if v ~= "none" then
-                      SSet("leftTextContent", "none")
-                      SSet("rightTextContent", "none")
+                      if SGet("leftTextContent") == v then SSet("leftTextContent", "none") end
+                      if SGet("rightTextContent") == v then SSet("rightTextContent", "none") end
                   end
                   ReloadAndUpdate(); UpdatePreview()
               end },
@@ -6257,8 +6277,8 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v)
                   SSet("btbCenterContent", v)
                   if v ~= "none" then
-                      SSet("btbLeftContent", "none")
-                      SSet("btbRightContent", "none")
+                      if SGet("btbLeftContent") == v then SSet("btbLeftContent", "none") end
+                      if SGet("btbRightContent") == v then SSet("btbRightContent", "none") end
                   end
                   ReloadAndUpdate(); UpdatePreview()
               end },
@@ -8034,7 +8054,6 @@ initFrame:SetScript("OnEvent", function(self)
             UpdCog(); RegisterWidgetRefresh(UpdCog)
         end
 
-        -- Row 4: Center Text + Reverse Fill (with inline swatch + cog on Center)
         local centerRow
         centerRow, h = W:DualRow(parent, y,
             { type="dropdown", text="Center Text", values=healthTextValues, order=healthTextOrder,
@@ -8047,67 +8066,66 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 ReloadAndUpdate(); EllesmereUI:RefreshPage()
               end },
-            { type="toggle", text="Reverse Fill",
-              getValue=function() return settingsTable.healthReverseFill end,
-              setValue=function(v) settingsTable.healthReverseFill = v; ReloadAndUpdate() end });  y = y - h
-        -- Inline swatch + cog on Center Text
-        do
-            local rgn = centerRow._leftRegion
-            local swGet = function()
-                return MVal("centerTextColorR", 1), MVal("centerTextColorG", 1), MVal("centerTextColorB", 1)
-            end
-            local swSet = function(r, g, b)
-                settingsTable.centerTextColorR = r; settingsTable.centerTextColorG = g; settingsTable.centerTextColorB = b
-                ReloadAndUpdate()
-            end
-            local sw, swUp = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5, swGet, swSet, nil, 20)
-            PP.Point(sw, "RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-            rgn._lastInline = sw
-            local blk = CreateFrame("Frame", nil, sw)
-            blk:SetAllPoints(); blk:SetFrameLevel(sw:GetFrameLevel() + 10); blk:EnableMouse(true)
-            blk:SetScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(sw, EllesmereUI.DisabledTooltip("Center Text")) end)
-            blk:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-            RegisterWidgetRefresh(function()
-                local isNone = MVal("centerTextContent", "none") == "none"
-                local isClass = MVal("centerTextClassColor", false)
-                if isNone or isClass then sw:SetAlpha(0.3); blk:Show() else sw:SetAlpha(1); blk:Hide() end
-                swUp()
-            end)
-            local initOff = MVal("centerTextContent", "none") == "none" or MVal("centerTextClassColor", false)
-            sw:SetAlpha(initOff and 0.3 or 1)
-            if initOff then blk:Show() else blk:Hide() end
+                { type="toggle", text="Reverse Fill",
+                  getValue=function() return settingsTable.healthReverseFill end,
+                  setValue=function(v) settingsTable.healthReverseFill = v; ReloadAndUpdate() end });  y = y - h
+            do
+                local rgn = centerRow._leftRegion
+                local swGet = function()
+                    return MVal("centerTextColorR", 1), MVal("centerTextColorG", 1), MVal("centerTextColorB", 1)
+                end
+                local swSet = function(r, g, b)
+                    settingsTable.centerTextColorR = r; settingsTable.centerTextColorG = g; settingsTable.centerTextColorB = b
+                    ReloadAndUpdate()
+                end
+                local sw, swUp = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5, swGet, swSet, nil, 20)
+                PP.Point(sw, "RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = sw
+                local blk = CreateFrame("Frame", nil, sw)
+                blk:SetAllPoints(); blk:SetFrameLevel(sw:GetFrameLevel() + 10); blk:EnableMouse(true)
+                blk:SetScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(sw, EllesmereUI.DisabledTooltip("Center Text")) end)
+                blk:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                RegisterWidgetRefresh(function()
+                    local isNone = MVal("centerTextContent", "none") == "none"
+                    local isClass = MVal("centerTextClassColor", false)
+                    if isNone or isClass then sw:SetAlpha(0.3); blk:Show() else sw:SetAlpha(1); blk:Hide() end
+                    swUp()
+                end)
+                local initOff = MVal("centerTextContent", "none") == "none" or MVal("centerTextClassColor", false)
+                sw:SetAlpha(initOff and 0.3 or 1)
+                if initOff then blk:Show() else blk:Hide() end
 
-            local _, cogShowFn = EllesmereUI.BuildCogPopup({
-                title = "Center Text Settings",
-                rows = {
-                    { type="toggle", label="Class Color",
-                      get=function() return MVal("centerTextClassColor", false) end,
-                      set=function(v) MSet("centerTextClassColor", v); EllesmereUI:RefreshPage() end },
-                    { type="slider", label="Size", min=8, max=24, step=1,
-                      get=function() return MVal("centerTextSize", settingsTable.textSize or 12) end,
-                      set=function(v) MSet("centerTextSize", v) end },
-                    { type="slider", label="X", min=-50, max=50, step=1,
-                      get=function() return MVal("centerTextX", 0) end,
-                      set=function(v) MSet("centerTextX", v) end },
-                    { type="slider", label="Y", min=-30, max=30, step=1,
-                      get=function() return MVal("centerTextY", 0) end,
-                      set=function(v) MSet("centerTextY", v) end },
-                },
-            })
-            local cogBtn = MCogBtn(rgn, cogShowFn)
-            local function UpdCog()
-                local isNone = MVal("centerTextContent", "none") == "none"
-                cogBtn:SetAlpha(isNone and 0.15 or 0.4)
+                local _, cogShowFn = EllesmereUI.BuildCogPopup({
+                    title = "Center Text Settings",
+                    rows = {
+                        { type="toggle", label="Class Color",
+                          get=function() return MVal("centerTextClassColor", false) end,
+                          set=function(v) MSet("centerTextClassColor", v); EllesmereUI:RefreshPage() end },
+                        { type="slider", label="Size", min=8, max=24, step=1,
+                          get=function() return MVal("centerTextSize", settingsTable.textSize or 12) end,
+                          set=function(v) MSet("centerTextSize", v) end },
+                        { type="slider", label="X", min=-50, max=50, step=1,
+                          get=function() return MVal("centerTextX", 0) end,
+                          set=function(v) MSet("centerTextX", v) end },
+                        { type="slider", label="Y", min=-30, max=30, step=1,
+                          get=function() return MVal("centerTextY", 0) end,
+                          set=function(v) MSet("centerTextY", v) end },
+                    },
+                })
+                local cogBtn = MCogBtn(rgn, cogShowFn)
+                local function UpdCog()
+                    local isNone = MVal("centerTextContent", "none") == "none"
+                    cogBtn:SetAlpha(isNone and 0.15 or 0.4)
+                end
+                cogBtn:SetScript("OnEnter", function(self)
+                    if MVal("centerTextContent", "none") == "none" then
+                        EllesmereUI.ShowWidgetTooltip(self, EllesmereUI.DisabledTooltip("This option requires a text selection other than none."))
+                    else self:SetAlpha(0.7) end
+                end)
+                cogBtn:SetScript("OnLeave", function(self) UpdCog(); EllesmereUI.HideWidgetTooltip() end)
+                cogBtn:SetScript("OnClick", function(self) if MVal("centerTextContent", "none") ~= "none" then cogShowFn(self) end end)
+                UpdCog(); RegisterWidgetRefresh(UpdCog)
             end
-            cogBtn:SetScript("OnEnter", function(self)
-                if MVal("centerTextContent", "none") == "none" then
-                    EllesmereUI.ShowWidgetTooltip(self, EllesmereUI.DisabledTooltip("This option requires a text selection other than none."))
-                else self:SetAlpha(0.7) end
-            end)
-            cogBtn:SetScript("OnLeave", function(self) UpdCog(); EllesmereUI.HideWidgetTooltip() end)
-            cogBtn:SetScript("OnClick", function(self) if MVal("centerTextContent", "none") ~= "none" then cogShowFn(self) end end)
-            UpdCog(); RegisterWidgetRefresh(UpdCog)
-        end
 
         return y, displayHeader, sizeRow, textHeader, textRow, enableRowFrame
     end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1305,6 +1305,14 @@ local function EstimateUFTextWidth(content)
     return (ufTextWidths[content] or 0) + UF_TEXT_PADDING
 end
 
+local function UFBarTextKey(side, field, btb)
+    if btb then
+        local cap = side:sub(1, 1):upper() .. side:sub(2)
+        return "btb" .. cap .. field
+    end
+    return side .. "Text" .. field
+end
+
 -- Apply class color to a FontString based on the unit
 local function ApplyClassColor(fs, unit, useClassColor, customR, customG, customB)
     if not fs then return end
@@ -1316,6 +1324,97 @@ local function ApplyClassColor(fs, unit, useClassColor, customR, customG, custom
         end
     end
     fs:SetTextColor(customR or 1, customG or 1, customB or 1)
+end
+
+-- Position left / right / center overlay text (health bar or BTB).
+local function ApplyBarOverlayTextPositions(textOverlay, unit, s, leftFS, rightFS, centerFS, opts)
+    opts = opts or {}
+    local btb = opts.btb
+    local function val(side, field, default)
+        local v = s[UFBarTextKey(side, field, btb)]
+        if v == nil then return default end
+        return v
+    end
+
+    local baseTextSize = s.textSize or 12
+    local lc = val("left", "Content", opts.defaultLeft or "name")
+    local rc = val("right", "Content", opts.defaultRight or "none")
+    local cc = val("center", "Content", "none")
+    local showSides = not opts.centerExclusive or cc == "none"
+
+    local lsz = val("left", "Size", btb and 11 or baseTextSize)
+    local rsz = val("right", "Size", btb and 11 or baseTextSize)
+    local csz = val("center", "Size", btb and 11 or baseTextSize)
+    local lxo = val("left", "X", 0)
+    local lyo = val("left", "Y", 0)
+    local rxo = val("right", "X", 0)
+    local ryo = val("right", "Y", 0)
+    local cxo = val("center", "X", 0)
+    local cyo = val("center", "Y", 0)
+    local barW = s.frameWidth or opts.defaultBarW or 181
+    local wide = opts.wide
+    local useWidth = not opts.noWidthConstraints
+
+    if cc ~= "none" then
+        SetFSFont(centerFS, csz)
+        centerFS:ClearAllPoints()
+        centerFS:SetJustifyH("CENTER")
+        PP.Point(centerFS, "CENTER", textOverlay, "CENTER", cxo, cyo)
+        if useWidth then
+            if wide then PP.Width(centerFS, barW * 0.9) else centerFS:SetWidth(0) end
+        end
+        centerFS:Show()
+        ApplyClassColor(centerFS, unit, val("center", "ClassColor", false),
+            val("center", "ColorR", 1), val("center", "ColorG", 1), val("center", "ColorB", 1))
+    else
+        centerFS:Hide()
+    end
+
+    SetFSFont(leftFS, lsz)
+    leftFS:ClearAllPoints()
+    if showSides and lc ~= "none" then
+        leftFS:SetJustifyH("LEFT")
+        PP.Point(leftFS, "LEFT", textOverlay, "LEFT", 5 + lxo, lyo)
+        if useWidth then
+            if rc ~= "none" then
+                PP.Width(leftFS, math.max(barW - EstimateUFTextWidth(rc) - 10, 20))
+            elseif wide then
+                PP.Width(leftFS, barW * 0.9)
+            else
+                leftFS:SetWidth(0)
+            end
+        end
+        leftFS:Show()
+        ApplyClassColor(leftFS, unit, val("left", "ClassColor", false),
+            val("left", "ColorR", 1), val("left", "ColorG", 1), val("left", "ColorB", 1))
+    else
+        leftFS:Hide()
+    end
+
+    SetFSFont(rightFS, rsz)
+    rightFS:ClearAllPoints()
+    if showSides and rc ~= "none" then
+        rightFS:SetJustifyH("RIGHT")
+        PP.Point(rightFS, "RIGHT", textOverlay, "RIGHT", -5 + rxo, ryo)
+        if useWidth then
+            if lc ~= "none" then
+                PP.Width(rightFS, math.max(barW - EstimateUFTextWidth(lc) - 10, 20))
+            elseif wide then
+                PP.Width(rightFS, barW * 0.9)
+            else
+                rightFS:SetWidth(0)
+            end
+        end
+        rightFS:Show()
+        ApplyClassColor(rightFS, unit, val("right", "ClassColor", false),
+            val("right", "ColorR", 1), val("right", "ColorG", 1), val("right", "ColorB", 1))
+    else
+        rightFS:Hide()
+    end
+
+    if opts.afterApply then
+        opts.afterApply(lc, rc, cc)
+    end
 end
 
 local UF_ICONS_PATH = "Interface\\AddOns\\EllesmereUI\\media\\icons\\"
@@ -1626,54 +1725,25 @@ local function CreateBottomTextBar(frame, unit, settings, anchorFrame, xOffset, 
     end
 
     local function ApplyBTBTextPositions(s)
-        local lc = s.btbLeftContent or "none"
-        local rc = s.btbRightContent or "none"
-        local cc = s.btbCenterContent or "none"
-        local lsz = s.btbLeftSize or 11
-        local rsz = s.btbRightSize or 11
-        local csz = s.btbCenterSize or 11
-
-        SetFSFont(leftFS, lsz)
-        leftFS:ClearAllPoints()
-        if lc ~= "none" then
-            leftFS:SetJustifyH("LEFT")
-            PP.Point(leftFS, "LEFT", textOvr, "LEFT", 5 + (s.btbLeftX or 0), s.btbLeftY or 0)
-            leftFS:Show()
-        else leftFS:Hide() end
-
-        SetFSFont(rightFS, rsz)
-        rightFS:ClearAllPoints()
-        if rc ~= "none" then
-            rightFS:SetJustifyH("RIGHT")
-            PP.Point(rightFS, "RIGHT", textOvr, "RIGHT", -5 + (s.btbRightX or 0), s.btbRightY or 0)
-            rightFS:Show()
-        else rightFS:Hide() end
-
-        SetFSFont(centerFS, csz)
-        centerFS:ClearAllPoints()
-        if cc ~= "none" then
-            centerFS:SetJustifyH("CENTER")
-            PP.Point(centerFS, "CENTER", textOvr, "CENTER", s.btbCenterX or 0, s.btbCenterY or 0)
-            centerFS:Show()
-        else centerFS:Hide() end
-
-        ApplyClassColor(leftFS, unit, s.btbLeftClassColor, s.btbLeftColorR, s.btbLeftColorG, s.btbLeftColorB)
-        ApplyClassColor(rightFS, unit, s.btbRightClassColor, s.btbRightColorR, s.btbRightColorG, s.btbRightColorB)
-        ApplyClassColor(centerFS, unit, s.btbCenterClassColor, s.btbCenterColorR, s.btbCenterColorG, s.btbCenterColorB)
-        -- Power color overrides (applied after class color, takes priority for power-related text)
-        local function ApplyBTBPowerColor(fs, contentKey, usePowerColor)
-            if not fs or not usePowerColor then return end
-            if contentKey == "perpp" or contentKey == "curpp" or contentKey == "curhp_curpp" or contentKey == "perhp_perpp" then
-                local pType = UnitPowerType(unit)
-                local info = PowerBarColor[pType]
-                if info then
-                    fs:SetTextColor(info.r, info.g, info.b)
+        ApplyBarOverlayTextPositions(textOvr, unit, s, leftFS, rightFS, centerFS, {
+            btb = true,
+            noWidthConstraints = true,
+            afterApply = function(lc, rc, cc)
+                local function ApplyBTBPowerColor(fs, contentKey, usePowerColor)
+                    if not fs or not usePowerColor then return end
+                    if contentKey == "perpp" or contentKey == "curpp" or contentKey == "curhp_curpp" or contentKey == "perhp_perpp" then
+                        local pType = UnitPowerType(unit)
+                        local info = PowerBarColor[pType]
+                        if info then
+                            fs:SetTextColor(info.r, info.g, info.b)
+                        end
+                    end
                 end
-            end
-        end
-        ApplyBTBPowerColor(leftFS, lc, s.btbLeftPowerColor)
-        ApplyBTBPowerColor(rightFS, rc, s.btbRightPowerColor)
-        ApplyBTBPowerColor(centerFS, cc, s.btbCenterPowerColor)
+                ApplyBTBPowerColor(leftFS, lc, s.btbLeftPowerColor)
+                ApplyBTBPowerColor(rightFS, rc, s.btbRightPowerColor)
+                ApplyBTBPowerColor(centerFS, cc, s.btbCenterPowerColor)
+            end,
+        })
     end
 
     ApplyBTBTextTags(
@@ -3656,67 +3726,11 @@ local function StyleFullFrame(frame, unit)
     ApplyTextTags(leftContent, rightContent, centerContent)
     frame._applyTextTags = ApplyTextTags
 
-    -- Position and show/hide based on content + offsets
     local function ApplyTextPositions(s)
-        local lc = s.leftTextContent or "name"
-        local rc = s.rightTextContent or "both"
-        local cc = s.centerTextContent or "none"
-        local lsz = s.leftTextSize or s.textSize or 12
-        local rsz = s.rightTextSize or s.textSize or 12
-        local csz = s.centerTextSize or s.textSize or 12
-        local lxo = s.leftTextX or 0
-        local lyo = s.leftTextY or 0
-        local rxo = s.rightTextX or 0
-        local ryo = s.rightTextY or 0
-        local cxo = s.centerTextX or 0
-        local cyo = s.centerTextY or 0
-        local barW = s.frameWidth or 181
-
-        -- Center text: if active, hide left/right
-        if cc ~= "none" then
-            leftText:Hide()
-            rightText:Hide()
-            SetFSFont(centerText, csz)
-            centerText:ClearAllPoints()
-            centerText:SetJustifyH("CENTER")
-            PP.Point(centerText, "CENTER", textOverlay, "CENTER", cxo, cyo)
-            centerText:SetWidth(0)
-            centerText:Show()
-            ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
-        else
-            centerText:Hide()
-            SetFSFont(leftText, lsz)
-            leftText:ClearAllPoints()
-            if lc ~= "none" then
-                leftText:SetJustifyH("LEFT")
-                PP.Point(leftText, "LEFT", textOverlay, "LEFT", 5 + lxo, lyo)
-                -- Constrain width when opposing right text exists
-                if rc ~= "none" then
-                    local rightUsed = EstimateUFTextWidth(rc)
-                    PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
-                else
-                    leftText:SetWidth(0)
-                end
-                leftText:Show()
-                ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
-            else leftText:Hide() end
-
-            SetFSFont(rightText, rsz)
-            rightText:ClearAllPoints()
-            if rc ~= "none" then
-                rightText:SetJustifyH("RIGHT")
-                PP.Point(rightText, "RIGHT", textOverlay, "RIGHT", -5 + rxo, ryo)
-                -- Constrain width when opposing left text exists
-                if lc ~= "none" then
-                    local leftUsed = EstimateUFTextWidth(lc)
-                    PP.Width(rightText, math.max(barW - leftUsed - 10, 20))
-                else
-                    rightText:SetWidth(0)
-                end
-                rightText:Show()
-                ApplyClassColor(rightText, unit, s.rightTextClassColor, s.rightTextColorR, s.rightTextColorG, s.rightTextColorB)
-            else rightText:Hide() end
-        end
+        ApplyBarOverlayTextPositions(textOverlay, unit, s, leftText, rightText, centerText, {
+            defaultRight = "both",
+            defaultBarW = 181,
+        })
     end
     ApplyTextPositions(settings)
     frame._applyTextPositions = ApplyTextPositions
@@ -3895,65 +3909,11 @@ local function StyleFocusFrame(frame, unit)
     ApplyTextTags(leftContent, rightContent, centerContent)
     frame._applyTextTags = ApplyTextTags
 
-    -- Position and show/hide based on content + offsets
     local function ApplyTextPositions(s)
-        local lc = s.leftTextContent or "name"
-        local rc = s.rightTextContent or "perhp"
-        local cc = s.centerTextContent or "none"
-        local lsz = s.leftTextSize or s.textSize or 12
-        local rsz = s.rightTextSize or s.textSize or 12
-        local csz = s.centerTextSize or s.textSize or 12
-        local lxo = s.leftTextX or 0
-        local lyo = s.leftTextY or 0
-        local rxo = s.rightTextX or 0
-        local ryo = s.rightTextY or 0
-        local cxo = s.centerTextX or 0
-        local cyo = s.centerTextY or 0
-        local barW = s.frameWidth or 181
-
-        -- Center text: if active, hide left/right
-        if cc ~= "none" then
-            leftText:Hide()
-            rightText:Hide()
-            SetFSFont(centerText, csz)
-            centerText:ClearAllPoints()
-            centerText:SetJustifyH("CENTER")
-            PP.Point(centerText, "CENTER", textOverlay, "CENTER", cxo, cyo)
-            centerText:SetWidth(0)
-            centerText:Show()
-            ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
-        else
-            centerText:Hide()
-            SetFSFont(leftText, lsz)
-            leftText:ClearAllPoints()
-            if lc ~= "none" then
-                leftText:SetJustifyH("LEFT")
-                PP.Point(leftText, "LEFT", textOverlay, "LEFT", 5 + lxo, lyo)
-                if rc ~= "none" then
-                    local rightUsed = EstimateUFTextWidth(rc)
-                    PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
-                else
-                    leftText:SetWidth(0)
-                end
-                leftText:Show()
-                ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
-            else leftText:Hide() end
-
-            SetFSFont(rightText, rsz)
-            rightText:ClearAllPoints()
-            if rc ~= "none" then
-                rightText:SetJustifyH("RIGHT")
-                PP.Point(rightText, "RIGHT", textOverlay, "RIGHT", -5 + rxo, ryo)
-                if lc ~= "none" then
-                    local leftUsed = EstimateUFTextWidth(lc)
-                    PP.Width(rightText, math.max(barW - leftUsed - 10, 20))
-                else
-                    rightText:SetWidth(0)
-                end
-                rightText:Show()
-                ApplyClassColor(rightText, unit, s.rightTextClassColor, s.rightTextColorR, s.rightTextColorG, s.rightTextColorB)
-            else rightText:Hide() end
-        end
+        ApplyBarOverlayTextPositions(textOverlay, unit, s, leftText, rightText, centerText, {
+            defaultRight = "perhp",
+            defaultBarW = 181,
+        })
     end
     ApplyTextPositions(settings)
     frame._applyTextPositions = ApplyTextPositions
@@ -4102,59 +4062,12 @@ local function StyleSimpleFrame(frame, unit)
     frame._applyTextTags = ApplyTextTags
 
     local function ApplyTextPositions(s)
-        local lc = s.leftTextContent or "name"
-        local rc = s.rightTextContent or "none"
-        local cc = s.centerTextContent or "none"
-        local lsz = s.leftTextSize or s.textSize or 12
-        local rsz = s.rightTextSize or s.textSize or 12
-        local csz = s.centerTextSize or s.textSize or 12
-        local lxo = s.leftTextX or 0
-        local lyo = s.leftTextY or 0
-        local rxo = s.rightTextX or 0
-        local ryo = s.rightTextY or 0
-        local cxo = s.centerTextX or 0
-        local cyo = s.centerTextY or 0
-        local barW = s.frameWidth or 100
-        if cc ~= "none" then
-            SetFSFont(centerText, csz)
-            centerText:ClearAllPoints()
-            centerText:SetJustifyH("CENTER")
-            PP.Point(centerText, "CENTER", textOverlay, "CENTER", cxo, cyo)
-            PP.Width(centerText, barW * 0.9)
-            centerText:Show()
-            ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
-            leftText:Hide(); rightText:Hide()
-        else
-            centerText:Hide()
-            SetFSFont(leftText, lsz)
-            if lc ~= "none" then
-                leftText:ClearAllPoints()
-                leftText:SetJustifyH("LEFT")
-                PP.Point(leftText, "LEFT", textOverlay, "LEFT", 5 + lxo, lyo)
-                if rc ~= "none" then
-                    local rightUsed = EstimateUFTextWidth(rc)
-                    PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
-                else
-                    PP.Width(leftText, barW * 0.9)
-                end
-                leftText:Show()
-                ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
-            else leftText:Hide() end
-            SetFSFont(rightText, rsz)
-            if rc ~= "none" then
-                rightText:ClearAllPoints()
-                rightText:SetJustifyH("RIGHT")
-                PP.Point(rightText, "RIGHT", textOverlay, "RIGHT", -5 + rxo, ryo)
-                if lc ~= "none" then
-                    local leftUsed = EstimateUFTextWidth(lc)
-                    PP.Width(rightText, math.max(barW - leftUsed - 10, 20))
-                else
-                    PP.Width(rightText, barW * 0.9)
-                end
-                rightText:Show()
-                ApplyClassColor(rightText, unit, s.rightTextClassColor, s.rightTextColorR, s.rightTextColorG, s.rightTextColorB)
-            else rightText:Hide() end
-        end
+        ApplyBarOverlayTextPositions(textOverlay, unit, s, leftText, rightText, centerText, {
+            defaultRight = "none",
+            defaultBarW = 100,
+            wide = true,
+            centerExclusive = true,
+        })
     end
     ApplyTextPositions(settings)
     frame._applyTextPositions = ApplyTextPositions
@@ -4290,59 +4203,12 @@ local function StylePetFrame(frame, unit)
     frame._applyTextTags = ApplyTextTags
 
     local function ApplyTextPositions(s)
-        local lc = s.leftTextContent or "name"
-        local rc = s.rightTextContent or "none"
-        local cc = s.centerTextContent or "none"
-        local lsz = s.leftTextSize or s.textSize or 12
-        local rsz = s.rightTextSize or s.textSize or 12
-        local csz = s.centerTextSize or s.textSize or 12
-        local lxo = s.leftTextX or 0
-        local lyo = s.leftTextY or 0
-        local rxo = s.rightTextX or 0
-        local ryo = s.rightTextY or 0
-        local cxo = s.centerTextX or 0
-        local cyo = s.centerTextY or 0
-        local barW = s.frameWidth or 100
-        if cc ~= "none" then
-            SetFSFont(centerText, csz)
-            centerText:ClearAllPoints()
-            centerText:SetJustifyH("CENTER")
-            PP.Point(centerText, "CENTER", textOverlay, "CENTER", cxo, cyo)
-            PP.Width(centerText, barW * 0.9)
-            centerText:Show()
-            ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
-            leftText:Hide(); rightText:Hide()
-        else
-            centerText:Hide()
-            SetFSFont(leftText, lsz)
-            if lc ~= "none" then
-                leftText:ClearAllPoints()
-                leftText:SetJustifyH("LEFT")
-                PP.Point(leftText, "LEFT", textOverlay, "LEFT", 5 + lxo, lyo)
-                if rc ~= "none" then
-                    local rightUsed = EstimateUFTextWidth(rc)
-                    PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
-                else
-                    PP.Width(leftText, barW * 0.9)
-                end
-                leftText:Show()
-                ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
-            else leftText:Hide() end
-            SetFSFont(rightText, rsz)
-            if rc ~= "none" then
-                rightText:ClearAllPoints()
-                rightText:SetJustifyH("RIGHT")
-                PP.Point(rightText, "RIGHT", textOverlay, "RIGHT", -5 + rxo, ryo)
-                if lc ~= "none" then
-                    local leftUsed = EstimateUFTextWidth(lc)
-                    PP.Width(rightText, math.max(barW - leftUsed - 10, 20))
-                else
-                    PP.Width(rightText, barW * 0.9)
-                end
-                rightText:Show()
-                ApplyClassColor(rightText, unit, s.rightTextClassColor, s.rightTextColorR, s.rightTextColorG, s.rightTextColorB)
-            else rightText:Hide() end
-        end
+        ApplyBarOverlayTextPositions(textOverlay, unit, s, leftText, rightText, centerText, {
+            defaultRight = "none",
+            defaultBarW = 100,
+            wide = true,
+            centerExclusive = true,
+        })
     end
     ApplyTextPositions(settings)
     frame._applyTextPositions = ApplyTextPositions
@@ -4482,59 +4348,12 @@ local function StyleBossFrame(frame, unit)
     frame._applyTextTags = ApplyTextTags
 
     local function ApplyTextPositions(s)
-        local lc = s.leftTextContent or "name"
-        local rc = s.rightTextContent or "perhp"
-        local cc = s.centerTextContent or "none"
-        local lsz = s.leftTextSize or s.textSize or 12
-        local rsz = s.rightTextSize or s.textSize or 12
-        local csz = s.centerTextSize or s.textSize or 12
-        local lxo = s.leftTextX or 0
-        local lyo = s.leftTextY or 0
-        local rxo = s.rightTextX or 0
-        local ryo = s.rightTextY or 0
-        local cxo = s.centerTextX or 0
-        local cyo = s.centerTextY or 0
-        local barW = s.frameWidth or 100
-        if cc ~= "none" then
-            SetFSFont(centerText, csz)
-            centerText:ClearAllPoints()
-            centerText:SetJustifyH("CENTER")
-            PP.Point(centerText, "CENTER", textOverlay, "CENTER", cxo, cyo)
-            PP.Width(centerText, barW * 0.9)
-            centerText:Show()
-            ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
-            leftText:Hide(); rightText:Hide()
-        else
-            centerText:Hide()
-            SetFSFont(leftText, lsz)
-            if lc ~= "none" then
-                leftText:ClearAllPoints()
-                leftText:SetJustifyH("LEFT")
-                PP.Point(leftText, "LEFT", textOverlay, "LEFT", 5 + lxo, lyo)
-                if rc ~= "none" then
-                    local rightUsed = EstimateUFTextWidth(rc)
-                    PP.Width(leftText, math.max(barW - rightUsed - 10, 20))
-                else
-                    PP.Width(leftText, barW * 0.9)
-                end
-                leftText:Show()
-                ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
-            else leftText:Hide() end
-            SetFSFont(rightText, rsz)
-            if rc ~= "none" then
-                rightText:ClearAllPoints()
-                rightText:SetJustifyH("RIGHT")
-                PP.Point(rightText, "RIGHT", textOverlay, "RIGHT", -5 + rxo, ryo)
-                if lc ~= "none" then
-                    local leftUsed = EstimateUFTextWidth(lc)
-                    PP.Width(rightText, math.max(barW - leftUsed - 10, 20))
-                else
-                    PP.Width(rightText, barW * 0.9)
-                end
-                rightText:Show()
-                ApplyClassColor(rightText, unit, s.rightTextClassColor, s.rightTextColorR, s.rightTextColorG, s.rightTextColorB)
-            else rightText:Hide() end
-        end
+        ApplyBarOverlayTextPositions(textOverlay, unit, s, leftText, rightText, centerText, {
+            defaultRight = "perhp",
+            defaultBarW = 100,
+            wide = true,
+            centerExclusive = true,
+        })
     end
     ApplyTextPositions(settings)
     frame._applyTextPositions = ApplyTextPositions


### PR DESCRIPTION
## Summary

Health bar and bottom text bar (BTB) text on **player, target, and focus** can use **left, right, and center** at the same time. Each slot has its own content, size, color, and X/Y offset.

**Mini frames** (pet, target-of-target, boss) use **center or left/right**: center can be used alone, or left and/or right together, but not all three at once.

Refactored duplicated positioning logic into a shared helper and aligned the options preview with live frame truncation.

## What changed

### Full frames (Frame Display — player / target / focus)
- Left, right, and center health bar text can all be active together.
- Duplicate content across slots is prevented (the same value cannot occupy two slots).
- BTB supports the same combined layout; selecting center no longer clears left/right.

### Mini frames (Mini Frame Edit — pet / ToT / boss)
- Left, right, and center are all configurable in the UI.
- When center text is set, left and right are cleared, disabled in the UI, and hidden on the frame. When center is `none`, left and/or right work as usual.

### Code quality
- Added `ApplyBarOverlayTextPositions` for health bar and BTB layout.
- Fixed `ApplyClassColor` load order (nil on frame init).
- Preview applies width constraints to right text as well as left.

## Decisions

| Decision | Rationale |
|----------|-----------|
| All three slots on full frames | Normal-sized bars with per-slot X/Y offsets. |
| Mini frames: center or sides | Narrow bars; center and side text are mutually exclusive. |
| No center-aware width truncation | Left/right width still only accounts for each other; overlap is handled via offsets for now. |
| BTB only on full frames | Mini frames have no text bar settings or runtime bar. |
| Boss follows mini text rules | Same center-or-sides behavior as pet and ToT on Mini Frame Edit. |

## Test plan

- [ ] Player/target: left + right + center with X/Y offsets; `/reload`
- [ ] Focus: same with default right text `perhp`
- [ ] BTB: left, right, and center together
- [ ] Pet / ToT: center only vs left+right (not all three)
- [ ] Boss: same mini text rules as pet/ToT
- [ ] Options preview matches in-game layout