### PR TITLE
Add Crafting Current Expansion Only filter for Place Crafter Order window

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -228,6 +228,18 @@ initFrame:SetScript("OnEvent", function(self)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.ahCurrentExpansion = v
               end },
+            { type="toggle", text="Crafting Current Expansion Only",
+              tooltip="Automatically enables the 'Current Expansion Only' filter whenever you open the Place Crafter Order window.",
+              getValue=function()
+                  return EllesmereUIDB and EllesmereUIDB.craftingCurrentExpansion or false
+              end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.craftingCurrentExpansion = v
+              end }
+        );  y = y - h
+
+        _, h = W:DualRow(parent, y,
             { type="toggle", text="Hide Talking Head",
               tooltip="Hides the large NPC dialogue popup that appears during quests and dungeons.",
               getValue=function()
@@ -236,7 +248,8 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.hideTalkingHead = v
-              end }
+              end },
+            { type="label", text="" }
         );  y = y - h
 
         -- Row 5: Show Coordinates on Map (left, with cog) | empty
@@ -1243,6 +1256,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.quickSignup = false
                 EllesmereUIDB.persistSignupNote = false
                 EllesmereUIDB.ahCurrentExpansion = false
+                EllesmereUIDB.craftingCurrentExpansion = false
                 EllesmereUIDB.healthMacroEnabled = false
                 EllesmereUIDB.healthMacroPrio1 = 1
                 EllesmereUIDB.healthMacroPrio2 = 2

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -436,6 +436,42 @@ qolFrame:SetScript("OnEvent", function(self)
     end
 
     ---------------------------------------------------------------------------
+    --  Crafting Current Expansion Only (Place Crafter Order window)
+    ---------------------------------------------------------------------------
+    do
+        local hooked = false
+        local function HookBrowseFilters()
+            if hooked then return end
+            local browse = ProfessionsCustomerOrdersFrame and ProfessionsCustomerOrdersFrame.BrowseOrders
+            if not browse or not browse.SetDefaultFilters then return end
+            hooked = true
+            -- SetDefaultFilters runs every time the window opens (via Init), resetting
+            -- the filter table; re-apply Current Expansion Only afterward when enabled.
+            hooksecurefunc(browse, "SetDefaultFilters", function(self)
+                if not (EllesmereUIDB and EllesmereUIDB.craftingCurrentExpansion) then return end
+                if not (Enum and Enum.AuctionHouseFilter and Enum.AuctionHouseFilter.CurrentExpansionOnly) then return end
+                local fd = self.SearchBar and self.SearchBar.FilterDropdown
+                if fd and fd.filters then
+                    fd.filters[Enum.AuctionHouseFilter.CurrentExpansionOnly] = true
+                end
+            end)
+        end
+
+        local coFrame = CreateFrame("Frame")
+        coFrame:RegisterEvent("ADDON_LOADED")
+        coFrame:SetScript("OnEvent", function(self, event, addonName)
+            if addonName == "Blizzard_ProfessionsCustomerOrders" then
+                self:UnregisterEvent("ADDON_LOADED")
+                HookBrowseFilters()
+            end
+        end)
+
+        if C_AddOns and C_AddOns.IsAddOnLoaded and C_AddOns.IsAddOnLoaded("Blizzard_ProfessionsCustomerOrders") then
+            HookBrowseFilters()
+        end
+    end
+
+    ---------------------------------------------------------------------------
     --  Auto Sell Junk + Auto Repair
     ---------------------------------------------------------------------------
     local merchantFrame = CreateFrame("Frame", "EUI_MerchantHandler", UIParent)


### PR DESCRIPTION
## Summary

Adds a **Crafting Current Expansion Only** QoL toggle that mirrors the existing **AH Current Expansion Only** option, but applies to the **Place Crafter Order** window (`Blizzard_ProfessionsCustomerOrders`).

When enabled, the "Current Expansion Only" filter is automatically applied each time the crafter order browse window opens, so searches are scoped to the current expansion without manually toggling the filter.

## How it works

The crafter-order browse window reuses the Auction House filter system — its search reads `filterDropdown.filters[Enum.AuctionHouseFilter.CurrentExpansionOnly]`, the same enum the AH feature uses. Each time the window opens, `ProfessionsCustomerOrdersBrowsePageMixin:SetDefaultFilters()` resets the filter table to defaults.

Since the orders addon is load-on-demand, the new code waits for `ADDON_LOADED` (or hooks immediately if already loaded), then `hooksecurefunc`s the live browse page's `SetDefaultFilters`. After Blizzard resets filters, it re-applies `CurrentExpansionOnly = true` when the option is enabled. Setting the filter table directly also makes the dropdown checkbox reflect the checked state, matching the AH behavior.

## Changes

- **`EllesmereUIQoL/EllesmereUIQoL.lua`** — new runtime block (after the AH block) that hooks the customer orders browse page filters.
- **`EllesmereUIQoL/EUI_QoL_Options.lua`** — added the toggle (split the AH/Talking Head `DualRow` since it only holds two cells) and a reset-to-defaults entry.

## Testing

- Both files pass `luac` syntax checks.
- Verified in-game: enabling the toggle applies the Current Expansion Only filter on the next search after opening the Place Crafter Order window.