### PR TITLE
RaidFrames: fix out-of-range alpha + OOR fill/bg blend

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -1868,7 +1868,13 @@ initFrame:SetScript("OnEvent", function(self)
         row, h = W:DualRow(parent, y,
             { type="slider", text="Out of Range Alpha", min=10, max=100, step=1,
               getValue=function() return floor((SVal("oorAlpha", 0.4)) * 100) end,
-              setValue=function(v) SSet("oorAlpha", v / 100) end },
+              setValue=function(v)
+                  SSet("oorAlpha", v / 100)
+                  -- Re-apply range alpha live: SetAlphaFromBoolean bakes the value
+                  -- in at call time, so already-OOR units keep the old alpha until
+                  -- a range re-eval. Seed all buttons so the slider takes effect now.
+                  if ns._RangeSeedAll then ns._RangeSeedAll() end
+              end },
             { type="toggle", text="Show Tooltip",
               getValue=function() return SVal("showTooltip", true) end,
               setValue=function(v) SSet("showTooltip", v) end });  y = y - h

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -1019,7 +1019,8 @@ local function GetHealthColor(unit, s)
         return c.r, c.g, c.b
     else -- "class"
         local _, classToken = UnitClass(unit)
-        if classToken then
+        -- Secret-safe: a secret classToken would throw on GetClassColor's table index.
+        if classToken and not issecretvalue(classToken) then
             local cc = EllesmereUI.GetClassColor(classToken)
             if cc then return cc.r, cc.g, cc.b end
         end
@@ -2440,9 +2441,15 @@ local function UpdateButton(button)
             d.bg:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
             d.bg:SetColorTexture(DARK_BG_R, DARK_BG_G, DARK_BG_B, 1)
         else
-            -- Full bar background
+            -- BG only covers the missing-health portion (anchored to the fill's
+            -- right edge), never behind the fill. A full-width bg behind the fill
+            -- bleeds through when the range fade's secret alpha under-renders the
+            -- fill -> the OOR "blend". This matches oUF/ElvUI and EUI's Dark mode,
+            -- so OOR fades cleanly to the world like ElvUI (in and out of combat).
+            -- For an opaque fill this is visually identical in range.
             d.bg:ClearAllPoints()
-            d.bg:SetAllPoints()
+            d.bg:SetPoint("TOPLEFT", health:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
+            d.bg:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
             local bgc = s.customBgColor
             d.bg:SetColorTexture(bgc.r, bgc.g, bgc.b, (s.bgDarkness or 50) / 100)
         end
@@ -4806,7 +4813,11 @@ end
 -- UNIT_IN_RANGE_UPDATE event, the refiner poll, the seed pass, and roster
 -- assignment. Standard living units take the secret-safe UnitInRange path.
 local function UpdateButtonRange(unit, btn)
-    local oorAlpha = db.profile.oorAlpha or 0.4
+    -- Read oorAlpha through the party-aware proxy so a custom party_oorAlpha
+    -- actually applies to party frames (was reading the raid value directly).
+    local rd = GetFFD(btn)
+    local rs = rd._isParty and ns._scaledPartyProxy or ns._scaledProfile
+    local oorAlpha = rs.oorAlpha or 0.4
     if UnitIsUnit(unit, "player") or not UnitExists(unit) then
         ApplyRangeAlpha(btn, 1)
     elseif UnitPhaseReason and UnitPhaseReason(unit) then


### PR DESCRIPTION
Three related fixes to the range fader on raid/party frames:

1. Party Out-of-Range Alpha was ignored. UpdateButtonRange read db.profile.oorAlpha directly, bypassing the party override, so a custom party_oorAlpha never reached party frames. Now read through the party-aware proxy (matches how the rest of the rendering resolves keys).

2. The slider didn't apply live. SetAlphaFromBoolean bakes the alpha in at call time, so already-out-of-range units kept the old value until a range re-eval. The setter now seeds all buttons so the new alpha takes effect immediately.

3. OOR fill/bg "blend". The health-bar background was drawn full-width *behind* the fill (SetAllPoints). When the range fade applies its secret alpha, the fill under-renders and the full-width bg bleeds through, so the bar reads as a muddy blend at range. Anchor the bg to the missing-health portion only (like oUF/ElvUI and EUI's own Dark mode) so nothing sits behind the fill -- OOR then fades cleanly to the world, in and out of combat. For an opaque fill this is visually identical in range.

Also makes the class health-color lookup secret-safe (a secret classToken from an out-of-range/uninspectable unit would otherwise throw on the GetClassColor table index).