### PR TITLE
Nameplates: add Border hover style + class-color option

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -3567,7 +3567,7 @@ initFrame:SetScript("OnEvent", function(self)
             swatch:EnableMouse(not off)
         end
 
-        -- Row 2: Background (+ inline color swatch) | Hover Effect (+ inline color swatch)
+        -- Row 2: Background (+ inline color swatch) | Hover Style (dropdown + cog)
         local bgHoverRow
         bgHoverRow, h = W:DualRow(parent, y,
             { type="slider", text="Background", min=0, max=100, step=1,
@@ -3582,15 +3582,16 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 UpdatePreview()
               end },
-            { type="slider", text="Hover Effect", min=0, max=100, step=1,
-              tooltip="Controls the highlight shown over a nameplate when you mouse over it. Set to 0 to disable.",
-              getValue=function()
-                return math.floor(((DBVal("hoverAlpha") or defaults.hoverAlpha) * 100) + 0.5)
-              end,
+            { type="dropdown", text="Hover Style",
+              tooltip="How a nameplate is highlighted on mouseover: a fill over the health bar, or a border around the plate. Use the cog for its options.",
+              values={ highlight = "Health Bar Highlight", border = "Border" },
+              order={ "highlight", "border" },
+              getValue=function() return DBVal("hoverStyle") or defaults.hoverStyle end,
               setValue=function(v)
-                DB().hoverAlpha = v / 100
+                DB().hoverStyle = v
                 ns.RefreshHoverEffect()
                 UpdatePreview()
+                C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
               end })
         y = y - h
         -- Inline color swatch on Background (left region)
@@ -3613,22 +3614,59 @@ initFrame:SetScript("OnEvent", function(self)
             leftRgn._lastInline = cbSwatch
             EllesmereUI.RegisterWidgetRefresh(function() cbUpdateSwatch() end)
         end
-        -- Inline color swatch on Hover Effect (right region)
+        -- Context-sensitive cog on the Hover Style region (right). Highlight ->
+        -- opacity + color; Border -> thickness + color + class color. The cog is
+        -- always enabled and shows the popup that matches the selected style.
         do
-            local rightRgn = bgHoverRow._rightRegion
-            local hvColorGet = function()
-                local c = (DB() and DB().hoverColor) or defaults.hoverColor
-                return c.r, c.g, c.b
-            end
-            local hvColorSet = function(r, g, b)
-                DB().hoverColor = { r = r, g = g, b = b }
-                ns.RefreshHoverEffect()
-                UpdatePreview()
-            end
-            local hvSwatch, hvUpdateSwatch = EllesmereUI.BuildColorSwatch(rightRgn, rightRgn:GetFrameLevel() + 5, hvColorGet, hvColorSet, nil, 20)
-            PP.Point(hvSwatch, "RIGHT", rightRgn._control, "LEFT", -12, 0)
-            rightRgn._lastInline = hvSwatch
-            EllesmereUI.RegisterWidgetRefresh(function() hvUpdateSwatch() end)
+            local function isBorder() return (DBVal("hoverStyle") or defaults.hoverStyle) == "border" end
+            -- Highlight popup: opacity + color (the old "Hover Effect" controls).
+            local _, hlCogShow = EllesmereUI.BuildCogPopup({
+                title = "Hover Highlight",
+                rows = {
+                    { type="slider", label="Opacity", min=0, max=100, step=1,
+                      get=function() return math.floor(((DBVal("hoverAlpha") or defaults.hoverAlpha) * 100) + 0.5) end,
+                      set=function(v) DB().hoverAlpha = v / 100; ns.RefreshHoverEffect(); UpdatePreview() end },
+                    { type="colorpicker", label="Color",
+                      get=function()
+                        local c = (DB() and DB().hoverColor) or defaults.hoverColor
+                        return c.r, c.g, c.b
+                      end,
+                      set=function(r, g, b) DB().hoverColor = { r = r, g = g, b = b }; ns.RefreshHoverEffect(); UpdatePreview() end },
+                },
+            })
+            -- Border popup: thickness + color + class color (color dims when class).
+            local _, brCogShow = EllesmereUI.BuildCogPopup({
+                title = "Hover Border",
+                rows = {
+                    { type="slider", label="Thickness", min=1, max=4, step=1,
+                      get=function() return DBVal("hoverBorderSize") or defaults.hoverBorderSize end,
+                      set=function(v) DB().hoverBorderSize = v; ns.RefreshHoverEffect(); UpdatePreview() end },
+                    { type="colorpicker", label="Color",
+                      disabled=function() return DBVal("hoverBorderClassColored") and true or false end,
+                      get=function()
+                        local c = (DB() and DB().hoverBorderColor) or defaults.hoverBorderColor
+                        return c.r, c.g, c.b
+                      end,
+                      set=function(r, g, b) DB().hoverBorderColor = { r = r, g = g, b = b }; ns.RefreshHoverEffect(); UpdatePreview() end },
+                    { type="toggle", label="Class Color",
+                      tooltip="Color the hover border with your own class color.",
+                      get=function() return DBVal("hoverBorderClassColored") and true or false end,
+                      set=function(v) DB().hoverBorderClassColored = v and true or false; ns.RefreshHoverEffect(); UpdatePreview() end },
+                },
+            })
+            local rgn = bgHoverRow._rightRegion
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._control, "LEFT", -8, 0)
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.COGS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self)
+                if isBorder() then brCogShow(self) else hlCogShow(self) end
+            end)
+            cogBtn:SetAlpha(0.4)
         end
 
         -- Row 3: Bar Texture | Absorb Style

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -2104,8 +2104,8 @@ function ns.ShowPlateHover(plate, shown)
     if style == "border" then
         if plate.highlight then plate.highlight:Hide() end
         if plate.hoverBorder then
-            -- Resolve color at show time so a class-colored border picks up the
-            -- plate's current unit (which changes as plates recycle).
+            -- Resolve color at show time so a setting change (custom color or the
+            -- class-color toggle) applies on the next hover without a reload.
             if shown and PP and PP.SetBorderColor then
                 local hr, hg, hb = HoverBorderRGB()
                 PP.SetBorderColor(plate.hoverBorder, hr, hg, hb, 1)

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -248,6 +248,10 @@ local defaults = {
     bgColor = { r = 0.12, g = 0.12, b = 0.12 },
     hoverColor = { r = 1, g = 1, b = 1 },
     hoverAlpha = 0.3,
+    hoverStyle = "highlight",  -- "highlight" (bar fill) | "border"
+    hoverBorderSize = 2,
+    hoverBorderColor = { r = 1, g = 1, b = 1 },
+    hoverBorderClassColored = false,
     castBgAlpha = 0.9,
     castBgColor = { r = 0.1, g = 0.1, b = 0.1 },
     hashLineEnabled = false,
@@ -1614,6 +1618,19 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
     local _ha = (p and p.hoverAlpha) or defaults.hoverAlpha
     plate.highlight:SetColorTexture(_hc.r, _hc.g, _hc.b, _ha)
     plate.highlight:Hide()
+    -- Hover border (alternative hover style): its own child frame overlaying the
+    -- health bar, since PP.CreateBorder caches one border per frame and the static
+    -- border already owns plate.health.
+    if PP and PP.CreateBorder then
+        local hbFrame = CreateFrame("Frame", nil, plate.health)
+        hbFrame:SetAllPoints(plate.health)
+        hbFrame:SetFrameLevel(plate.health:GetFrameLevel() + 2)
+        local _hbc = (p and p.hoverBorderColor) or defaults.hoverBorderColor
+        local _hbs = (p and p.hoverBorderSize) or defaults.hoverBorderSize
+        PP.CreateBorder(hbFrame, _hbc.r, _hbc.g, _hbc.b, 1, _hbs, "OVERLAY", 7)
+        hbFrame:Hide()
+        plate.hoverBorder = hbFrame
+    end
     -- Top text overlay: renders above health bar + borders so top-slot text is never hidden
     plate.topTextFrame = CreateFrame("Frame", nil, plate)
     plate.topTextFrame:SetAllPoints(plate.health)
@@ -2068,20 +2085,63 @@ function ns.RefreshAllSettings()
     if ns.ApplyClassPowerSetting then ns.ApplyClassPowerSetting() end
 end
 
--- Recolor the mouseover highlight on every live plate (enemy + friendly).
+-- Show/hide the active hover element on a plate, honoring the hoverStyle setting.
+-- Routes every mouseover show/hide so the call sites stay style-agnostic.
+-- Hover border color: the player's OWN class color when class-coloring is on,
+-- else the configured custom border color. (PLAYER_CLASS is cached at file load.)
+local function HoverBorderRGB()
+    local bc = (p and p.hoverBorderColor) or defaults.hoverBorderColor
+    if p and p.hoverBorderClassColored then
+        local cc = PLAYER_CLASS and EllesmereUI.GetClassColor and EllesmereUI.GetClassColor(PLAYER_CLASS)
+        if cc then return cc.r, cc.g, cc.b end
+    end
+    return bc.r, bc.g, bc.b
+end
+
+function ns.ShowPlateHover(plate, shown)
+    if not plate then return end
+    local style = (p and p.hoverStyle) or defaults.hoverStyle
+    if style == "border" then
+        if plate.highlight then plate.highlight:Hide() end
+        if plate.hoverBorder then
+            -- Resolve color at show time so a class-colored border picks up the
+            -- plate's current unit (which changes as plates recycle).
+            if shown and PP and PP.SetBorderColor then
+                local hr, hg, hb = HoverBorderRGB()
+                PP.SetBorderColor(plate.hoverBorder, hr, hg, hb, 1)
+            end
+            plate.hoverBorder:SetShown(shown and true or false)
+        end
+    else
+        if plate.hoverBorder then plate.hoverBorder:Hide() end
+        if plate.highlight then plate.highlight:SetShown(shown and true or false) end
+    end
+end
+
+-- Recolor/resize the hover effect on every live plate (enemy + friendly), and
+-- hide whichever element the current style doesn't use so a style switch applies
+-- immediately without a reload.
 function ns.RefreshHoverEffect()
     local c = (p and p.hoverColor) or defaults.hoverColor
     local a = (p and p.hoverAlpha) or defaults.hoverAlpha
-    for _, plate in pairs(ns.plates) do
+    local bs = (p and p.hoverBorderSize) or defaults.hoverBorderSize
+    local style = (p and p.hoverStyle) or defaults.hoverStyle
+    local function apply(plate)
         if plate.highlight then
             plate.highlight:SetColorTexture(c.r, c.g, c.b, a)
+            if style == "border" then plate.highlight:Hide() end
+        end
+        if plate.hoverBorder and PP then
+            if PP.SetBorderColor then
+                local hr, hg, hb = HoverBorderRGB()
+                PP.SetBorderColor(plate.hoverBorder, hr, hg, hb, 1)
+            end
+            if PP.SetBorderSize then PP.SetBorderSize(plate.hoverBorder, bs) end
+            if style ~= "border" then plate.hoverBorder:Hide() end
         end
     end
-    for _, plate in pairs(ns.friendlyPlates or {}) do
-        if plate.highlight then
-            plate.highlight:SetColorTexture(c.r, c.g, c.b, a)
-        end
-    end
+    for _, plate in pairs(ns.plates) do apply(plate) end
+    for _, plate in pairs(ns.friendlyPlates or {}) do apply(plate) end
 end
 
 local kickWatcher = CreateFrame("Frame")
@@ -3852,7 +3912,7 @@ function NameplateFrame:ClearUnit()
     end
     self._interrupted = nil
     if self.glow then self.glow:Hide() end
-    self.highlight:Hide()
+    ns.ShowPlateHover(self, false)
     self.raidFrame:Hide()
     self.classFrame:Hide()
     if self.leftArrow then self.leftArrow:Hide() end
@@ -4338,10 +4398,10 @@ end
 function NameplateFrame:ApplyMouseover()
     if not self.unit then return end
     if UnitExists("mouseover") and UnitIsUnit(self.unit, "mouseover") then
-        self.highlight:Show()
+        ns.ShowPlateHover(self, true)
         currentMouseoverPlate = self
     else
-        self.highlight:Hide()
+        ns.ShowPlateHover(self, false)
     end
 end
 function NameplateFrame:UpdateAuras(updateInfo)
@@ -5475,13 +5535,13 @@ factionFrame:SetScript("OnEvent", function(_, event, unit)
 end)
 local function UpdateMouseover()
     if currentMouseoverPlate then
-        currentMouseoverPlate.highlight:Hide()
+        ns.ShowPlateHover(currentMouseoverPlate, false)
         currentMouseoverPlate = nil
     end
     if UnitExists("mouseover") then
         for _, plate in pairs(ns.plates) do
             if plate.unit and UnitIsUnit(plate.unit, "mouseover") then
-                plate.highlight:Show()
+                ns.ShowPlateHover(plate, true)
                 currentMouseoverPlate = plate
                 break
             end
@@ -5801,6 +5861,7 @@ do
     -- per-function constant limit.
     ns._displayPresetKeys = {
         "showBorder", "borderSize", "borderColor", "targetGlowStyle", "showTargetArrows",
+        "hoverStyle", "hoverBorderSize", "hoverBorderColor", "hoverBorderClassColored",
         "showClassPower", "classPowerPos", "classPowerYOffset", "classPowerXOffset", "classPowerScale",
         "classPowerClassColors", "classPowerCustomColor", "classPowerGap",
         "textSlotTop", "textSlotRight", "textSlotLeft", "textSlotCenter",

--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -650,6 +650,18 @@ local friendlyFrameCache = CreateFramePool("Frame", UIParent, nil, nil, false, f
     local _ha = (FP() and FP().hoverAlpha) or ns.defaults.hoverAlpha
     plate.highlight:SetColorTexture(_hc.r, _hc.g, _hc.b, _ha)
     plate.highlight:Hide()
+    -- Hover border (alternative hover style), mirrors the enemy plate setup.
+    local _PP = EllesmereUI and EllesmereUI.PP
+    if _PP and _PP.CreateBorder then
+        local hbFrame = CreateFrame("Frame", nil, plate.health)
+        hbFrame:SetAllPoints(plate.health)
+        hbFrame:SetFrameLevel(plate.health:GetFrameLevel() + 2)
+        local _hbc = (FP() and FP().hoverBorderColor) or ns.defaults.hoverBorderColor
+        local _hbs = (FP() and FP().hoverBorderSize) or ns.defaults.hoverBorderSize
+        _PP.CreateBorder(hbFrame, _hbc.r, _hbc.g, _hbc.b, 1, _hbs, "OVERLAY", 7)
+        hbFrame:Hide()
+        plate.hoverBorder = hbFrame
+    end
 
     plate.name = plate:CreateFontString(nil, "OVERLAY")
     SetFSFont(plate.name, 12, "OUTLINE")
@@ -754,7 +766,7 @@ function FriendlyFrame:ClearUnit()
     self.unit = nil
     self.nameplate = nil
     self.glow:Hide()
-    self.highlight:Hide()
+    ns.ShowPlateHover(self, false)
     self.raidFrame:Hide()
     self.leftArrow:Hide()
     self.rightArrow:Hide()
@@ -927,7 +939,7 @@ function ns.RemoveFriendlyPlateNoRestore(unit)
     plate.unit = nil
     plate.nameplate = nil
     plate.glow:Hide()
-    plate.highlight:Hide()
+    ns.ShowPlateHover(plate, false)
     plate.raidFrame:Hide()
     plate.leftArrow:Hide()
     plate.rightArrow:Hide()
@@ -972,13 +984,13 @@ friendlyManager:SetScript("OnEvent", function(self, event)
         end
     elseif event == "UPDATE_MOUSEOVER_UNIT" then
         if friendlyMouseoverPlate then
-            friendlyMouseoverPlate.highlight:Hide()
+            ns.ShowPlateHover(friendlyMouseoverPlate, false)
             friendlyMouseoverPlate = nil
         end
         if UnitExists("mouseover") then
             for _, plate in pairs(friendlyPlates) do
                 if plate.unit and UnitIsUnit(plate.unit, "mouseover") then
-                    plate.highlight:Show()
+                    ns.ShowPlateHover(plate, true)
                     friendlyMouseoverPlate = plate
                     break
                 end


### PR DESCRIPTION
Extends the mouseover hover effect with a style choice and a class-color border, for enemy and friendly plates.

- New "Hover Style" dropdown: Health Bar Highlight (the existing bar-fill overlay) or Border (a pixel-perfect border around the plate). All show/hide sites route through a shared ns.ShowPlateHover(plate, shown) so the two elements never both show, and a style switch applies without a reload.
- The Hover Style cog is context-sensitive: Highlight exposes Opacity + Color (the former standalone "Hover Effect" controls, now consolidated); Border exposes Thickness + Color + Class Color.
- Class Color border uses the player's own class color (dims the custom Color picker while active); resolved at show time so it survives plate recycling. RefreshHoverEffect applies changes live.
- New DB keys (hoverStyle, hoverBorderSize, hoverBorderColor, hoverBorderClassColored) with defaults and per-profile sync.