### PR TITLE
QoL: Shows durability % on QoL Extras

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -590,6 +590,25 @@ initFrame:SetScript("OnEvent", function(self)
             end)
         end
 
+        -- Row 2: Show Durability on FPS Counter (left) | helper label (right)
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Durability on FPS Counter",
+              tooltip="Shows lowest equipped-item durability % on the FPS counter.",
+              disabled=function()
+                return not (EllesmereUIDB and EllesmereUIDB.showFPS)
+              end,
+              disabledTooltip="Show FPS Counter",
+              getValue=function()
+                return EllesmereUIDB and EllesmereUIDB.fpsShowDurability or false
+              end,
+              setValue=function(v)
+                if not EllesmereUIDB then EllesmereUIDB = {} end
+                EllesmereUIDB.fpsShowDurability = v
+                if EllesmereUI._applyFPSCounter then EllesmereUI._applyFPSCounter() end
+              end },
+            { type="label", text="Requires FPS Counter" }
+        );  y = y - h
+
         -- Row 3: Low Durability Warning (left, with cog+eye+swatch) | Disable Right Click Targeting (right)
         local durWarnRow
         durWarnRow, h = W:DualRow(parent, y,

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -1126,6 +1126,23 @@ do
 end
 
 -------------------------------------------------------------------------------
+--  Shared: lowest equipped-item durability %
+-------------------------------------------------------------------------------
+-- Used by both the FPS Counter durability segment and the Low Durability
+-- Warning so both readouts always agree on the value.
+local function GetLowestEquippedDurability()
+    local lowest = 100
+    for slot = 1, 18 do
+        local cur, mx = GetInventoryItemDurability(slot)
+        if cur and mx and mx > 0 then
+            local pct = (cur / mx) * 100
+            if pct < lowest then lowest = pct end
+        end
+    end
+    return lowest
+end
+
+-------------------------------------------------------------------------------
 --  FPS Counter
 -------------------------------------------------------------------------------
 do
@@ -1172,12 +1189,21 @@ do
         local fsWorldLbl = MakeFS(LABEL_SIZE)
         fpsFrame._divWorld = divWorld
         fpsFrame._textWorld = fsWorldVal
+        fpsFrame._lblWorld = fsWorldLbl
 
         local divLocal = MakeDivider()
         local fsLocalVal = MakeFS(FONT_SIZE)
         local fsLocalLbl = MakeFS(LABEL_SIZE)
         fpsFrame._divLocal = divLocal
         fpsFrame._textLocal = fsLocalVal
+        fpsFrame._lblLocal = fsLocalLbl
+
+        local divDur = MakeDivider()
+        local fsDurVal = MakeFS(FONT_SIZE)
+        local fsDurLbl = MakeFS(LABEL_SIZE)
+        fpsFrame._divDur = divDur
+        fpsFrame._textDur = fsDurVal
+        fpsFrame._lblDur = fsDurLbl
 
         local function UpdateFPS(self)
             local db = EllesmereUIDB or {}
@@ -1189,14 +1215,18 @@ do
             fsWorldLbl:SetTextColor(cr, cg, cb, ca * 0.6)
             fsLocalVal:SetTextColor(cr, cg, cb, ca)
             fsLocalLbl:SetTextColor(cr, cg, cb, ca * 0.6)
+            fsDurVal:SetTextColor(cr, cg, cb, ca)
+            fsDurLbl:SetTextColor(cr, cg, cb, ca * 0.6)
             divWorld:SetColorTexture(cr, cg, cb, ca * 0.35)
             divLocal:SetColorTexture(cr, cg, cb, ca * 0.35)
+            divDur:SetColorTexture(cr, cg, cb, ca * 0.35)
 
             local fps = floor(GetFramerate() + 0.5)
             fsFps:SetText(fps .. " fps")
 
             local showWorld = db.fpsShowWorldMS
             local showLocal = (db.fpsShowLocalMS == nil) and true or db.fpsShowLocalMS
+            local showDur   = db.fpsShowDurability
             local _, _, latHome, latWorld = GetNetStats()
 
             fsFps:ClearAllPoints()
@@ -1237,9 +1267,27 @@ do
                 divLocal:Hide(); fsLocalVal:Hide(); fsLocalLbl:Hide()
             end
 
+            if showDur then
+                fsDurVal:SetText(floor(GetLowestEquippedDurability() + 0.5) .. "%")
+                fsDurLbl:SetText("(dur)")
+                divDur:ClearAllPoints()
+                divDur:SetPoint("LEFT", anchor, "RIGHT", DIV_PAD, 0)
+                divDur:Show()
+                fsDurVal:ClearAllPoints()
+                fsDurVal:SetPoint("LEFT", divDur, "RIGHT", DIV_PAD, 0)
+                fsDurVal:Show()
+                fsDurLbl:ClearAllPoints()
+                fsDurLbl:SetPoint("LEFT", fsDurVal, "RIGHT", 3, 0)
+                fsDurLbl:Show()
+                anchor = fsDurLbl
+            else
+                divDur:Hide(); fsDurVal:Hide(); fsDurLbl:Hide()
+            end
+
             local totalW = fsFps:GetStringWidth()
             if showWorld then totalW = totalW + DIV_PAD + DIV_W + DIV_PAD + fsWorldVal:GetStringWidth() + 3 + fsWorldLbl:GetStringWidth() end
             if showLocal then totalW = totalW + DIV_PAD + DIV_W + DIV_PAD + fsLocalVal:GetStringWidth() + 3 + fsLocalLbl:GetStringWidth() end
+            if showDur   then totalW = totalW + DIV_PAD + DIV_W + DIV_PAD + fsDurVal:GetStringWidth()   + 3 + fsDurLbl:GetStringWidth()   end
             self:SetSize(totalW + 4, 20)
         end
 
@@ -1265,8 +1313,10 @@ do
             if fpsFrame._text then fpsFrame._text:SetFont(fp, sz, outF) end
             if fpsFrame._textWorld then fpsFrame._textWorld:SetFont(fp, sz, outF) end
             if fpsFrame._textLocal then fpsFrame._textLocal:SetFont(fp, sz, outF) end
+            if fpsFrame._textDur   then fpsFrame._textDur:SetFont(fp, sz, outF) end
             if fpsFrame._lblWorld then fpsFrame._lblWorld:SetFont(fp, lblSz, outF) end
             if fpsFrame._lblLocal then fpsFrame._lblLocal:SetFont(fp, lblSz, outF) end
+            if fpsFrame._lblDur   then fpsFrame._lblDur:SetFont(fp, lblSz, outF) end
             local pos = EllesmereUIDB and EllesmereUIDB.fpsPos
             if pos and pos.point then
                 if pos.scale then pcall(function() fpsFrame:SetScale(pos.scale) end) end
@@ -1507,14 +1557,7 @@ do
         end
         if InCombatLockdown() then return end
 
-        local lowestDur = 100
-        for slot = 1, 18 do
-            local cur, mx = GetInventoryItemDurability(slot)
-            if cur and mx and mx > 0 then
-                local pct = (cur / mx) * 100
-                if pct < lowestDur then lowestDur = pct end
-            end
-        end
+        local lowestDur = GetLowestEquippedDurability()
 
         if lowestDur < (EllesmereUIDB.durWarnThreshold or 40) then
             CreateDurabilityWarning()


### PR DESCRIPTION
## Summary

Adds an optional durability readout to the FPS counter so you can see your lowest equipped-item durability % alongside FPS, world MS, and local MS.

- Extends the FPS counter with a new `87% (dur)` segment that follows the same divider + value + label styling as the existing MS readouts
- Adds a **Show Durability on FPS Counter** toggle in the QoL **EXTRAS** section (disabled when the FPS counter is off)
- Extracts shared `GetLowestEquippedDurability()` logic used by both the FPS display and the existing Low Durability Warning, so both always report the same value
- Fixes missing `_lblWorld` / `_lblLocal` references so FPS label font sizing applies correctly

**Saved variable:** `EllesmereUIDB.fpsShowDurability` (defaults to off)

## Test plan

- [ ] Enable **Show FPS Counter** and confirm FPS (and optional world/local MS) still display correctly
- [ ] Enable **Show Durability on FPS Counter** and confirm `NN% (dur)` appears after the MS segments
- [ ] Damage gear or repair and confirm the % updates within ~1s
- [ ] Confirm the displayed % matches the value used by **Low Durability Warning**
- [ ] Toggle durability off — segment disappears, FPS counter remains
- [ ] Disable the FPS counter — durability segment is hidden and the durability toggle is dimmed with the "requires Show FPS Counter" tooltip
- [ ] Toggle world/local MS independently — durability always anchors after the last visible segment
- [ ] Confirm the FPS counter unlock/position entry still works with the wider frame