### PR TITLE
raid frames: use custom colour for square buff in preview

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -9316,7 +9316,7 @@ local function GetConfiguredBuffSpells()
                     spells[#spells + 1] = {
                         id = sid, icon = iconTex,
                         indType = ind.type,
-                        color = ind.color,
+                        color = (ind.spellColors and ind.spellColors[sid]) or ind.color,
                         size = spellSz,
                         position = ind.position or "TOPLEFT",
                         offsetX = ind.offsetX or 0,


### PR DESCRIPTION
Full preview did not use custom colour for square indicators in buffs.

Previously:
<img width="148" height="70" alt="image" src="https://github.com/user-attachments/assets/d111e652-f971-4536-aa91-d60e04968872" />

With this change:
<img width="181" height="86" alt="image" src="https://github.com/user-attachments/assets/97287b06-d8ee-4937-ad42-24da16b99862" />
