### PR TITLE
Resource threshold colouring bugfix and UI update

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -3234,6 +3234,39 @@ initFrame:SetScript("OnEvent", function(self)
                         cogBtn2:SetScript("OnClick", function(self) entryCogShow(self) end)
                         ef._cogBtn = cogBtn2
 
+                        -- Cog for bar-type specs."Reverse Threshold Fill Color" puts the
+						-- threshold color below the value
+                        local _, entryRevCogShow = EllesmereUI.BuildCogPopup({
+                            title = "Threshold Coloring", bgAlpha = 1, frameStrata = "FULLSCREEN_DIALOG", frameLevel = 500,
+                            rows = {
+                                { type = "toggle", label = "Reverse Threshold Fill Color",
+                                  get = function()
+                                      if not ef._entryIdx then return false end
+                                      local p2 = DB(); if not p2 then return false end
+                                      local ent = p2.secondary.thresholdSpecs and p2.secondary.thresholdSpecs[ef._entryIdx]
+                                      return ent and ent.thresholdReverse
+                                  end,
+                                  set = function(v)
+                                      if not ef._entryIdx then return end
+                                      local p2 = DB(); if not p2 then return end
+                                      local ent = p2.secondary.thresholdSpecs and p2.secondary.thresholdSpecs[ef._entryIdx]
+                                      if ent then ent.thresholdReverse = v; RefreshClass() end
+                                  end },
+                            },
+                        })
+                        local cogBtnBar = CreateFrame("Button", nil, ef)
+                        cogBtnBar:SetSize(20, 20)
+                        cogBtnBar:SetPoint("LEFT", entryToggle, "RIGHT", 6, 0)
+                        cogBtnBar:SetFrameLevel(ef:GetFrameLevel() + 5)
+                        cogBtnBar:SetAlpha(0.4)
+                        local cogTexBar = cogBtnBar:CreateTexture(nil, "OVERLAY")
+                        cogTexBar:SetAllPoints()
+                        cogTexBar:SetTexture(EllesmereUI.COGS_ICON)
+                        cogBtnBar:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+                        cogBtnBar:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+                        cogBtnBar:SetScript("OnClick", function(self) entryRevCogShow(self) end)
+                        ef._cogBtnBar = cogBtnBar
+
                         -- Disabled overlay for threshold row (excludes toggle so it stays clickable)
                         local threshDis = CreateFrame("Frame", nil, ef)
                         threshDis:SetPoint("TOPLEFT", threshLbl2, "TOPLEFT", -2, 4)
@@ -3280,6 +3313,12 @@ initFrame:SetScript("OnEvent", function(self)
                         ef._hashInput:Show(); ef._hashCogBtn:Show()
                         ef._threshLbl:SetPoint("TOPLEFT", ef, "TOPLEFT", 8, -61)
                     end
+
+                    -- Swap the cog: pip specs get "Only Color At/Above Threshold",
+                    -- bar specs get "Reverse Threshold Fill Color".
+                    ef._threshLbl:SetText(EllesmereUI.L("Threshold") .. (isBar and " %" or ""))
+                    if ef._cogBtn then ef._cogBtn:SetShown(not isBar) end
+                    if ef._cogBtnBar then ef._cogBtnBar:SetShown(isBar) end
 
                     -- spec label
                     ef._specLbl:SetText(EntryLabel(entry))

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -1249,6 +1249,25 @@ initFrame:SetScript("OnEvent", function(self)
                 else
                     newEntry.thresholdPct = 30
                 end
+                -- Smart default for the power bar's "Threshold color below value":
+                -- spender resources (mana/energy/focus) start ON (warn when low),
+                -- builders (rage/runic/fury) start OFF (warn when high). Only when the
+                -- entry covers the current spec -- the one whose power type we can read.
+                if cfg.showPartialCog then
+                    local curIdx = GetSpecialization()
+                    local curSpecID = curIdx and C_SpecializationInfo and C_SpecializationInfo.GetSpecializationInfo(curIdx)
+                    if curSpecID then
+                        for _, sid in ipairs(ids) do
+                            if sid == curSpecID then
+                                local _, token = UnitPowerType("player")
+                                if token == "MANA" or token == "FOCUS" or token == "ENERGY" then
+                                    newEntry.thresholdPartialOnly = true
+                                end
+                                break
+                            end
+                        end
+                    end
+                end
                 bd.thresholdSpecs[#bd.thresholdSpecs + 1] = newEntry
                 wipe(_tempSpecSel)
                 WrappedRefresh()
@@ -1515,7 +1534,7 @@ initFrame:SetScript("OnEvent", function(self)
                             title = "Threshold Coloring", bgAlpha = 1,
                             frameStrata = "FULLSCREEN_DIALOG", frameLevel = 500,
                             rows = {
-                                { type = "toggle", label = "Reverse Threshold Fill Color",
+                                { type = "toggle", label = "Threshold color below value",
                                   get = function()
                                       if not ef._entryIdx then return false end
                                       local bd2 = cfg.getBarData(); if not bd2 then return false end
@@ -2923,6 +2942,26 @@ initFrame:SetScript("OnEvent", function(self)
                         thresholdB = p2.thresholdB or 0x9d/255,
                         thresholdA = p2.thresholdA or 1,
                     }
+                    -- Smart default for "Threshold color below value": the only
+                    -- bar-type spender class resource is Hunter Focus -> start ON
+                    -- (warn when low); builders (Maelstrom/Insanity/Astral) start OFF.
+                    -- Only when the entry covers the current spec (resource readable).
+                    if isBar then
+                        local curIdx = GetSpecialization()
+                        local curSpecID = curIdx and C_SpecializationInfo and C_SpecializationInfo.GetSpecializationInfo(curIdx)
+                        if curSpecID then
+                            for _, sid in ipairs(ids) do
+                                if sid == curSpecID then
+                                    local gsr = _G._ERB_GetSecondaryResource
+                                    local info = gsr and gsr()
+                                    if info and info.power == "FOCUS_BAR" then
+                                        newEntry.thresholdReverse = true
+                                    end
+                                    break
+                                end
+                            end
+                        end
+                    end
                     p.secondary.thresholdSpecs[#p.secondary.thresholdSpecs + 1] = newEntry
                     wipe(_tempSpecSel)
                     if WrappedRefresh then WrappedRefresh() end
@@ -3239,7 +3278,7 @@ initFrame:SetScript("OnEvent", function(self)
                         local _, entryRevCogShow = EllesmereUI.BuildCogPopup({
                             title = "Threshold Coloring", bgAlpha = 1, frameStrata = "FULLSCREEN_DIALOG", frameLevel = 500,
                             rows = {
-                                { type = "toggle", label = "Reverse Threshold Fill Color",
+                                { type = "toggle", label = "Threshold color below value",
                                   get = function()
                                       if not ef._entryIdx then return false end
                                       local p2 = DB(); if not p2 then return false end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -723,6 +723,7 @@ local DEFAULTS = {
             thresholdEnabled = false,
             thresholdCount   = 3,
             thresholdPartialOnly = false,
+            thresholdReverse = false,  -- bar-type only: threshold color below the value (spenders)
             thresholdR = 0x0c/255, thresholdG = 0xd2/255, thresholdB = 0x9d/255, thresholdA = 1,
             tickValues  = "",   -- comma-separated absolute resource values for tick marks (bar-type only)
             thresholdSpecs = {},  -- per-spec threshold/hash entries: { specIDs={0}, hashValues="", thresholdCount=3, thresholdPartialOnly=false }
@@ -3209,6 +3210,10 @@ local function UpdateSecondaryResource()
     local _tsThreshCount = _tsEntry and _tsEntry.thresholdCount or sp.thresholdCount
     local _tsPartialOnly = _tsEntry and _tsEntry.thresholdPartialOnly
     if _tsPartialOnly == nil then _tsPartialOnly = sp.thresholdPartialOnly end
+    -- Bar-type only: reverse the threshold direction so the threshold color shows
+    -- below the value
+    local _tsReverse = _tsEntry and _tsEntry.thresholdReverse
+    if _tsReverse == nil then _tsReverse = sp.thresholdReverse end
     -- Per-entry threshold color (falls back to global sp.thresholdR/G/B/A)
     local _tsR = _tsEntry and _tsEntry.thresholdR or sp.thresholdR
     local _tsG = _tsEntry and _tsEntry.thresholdG or sp.thresholdG
@@ -3519,10 +3524,23 @@ local function UpdateSecondaryResource()
                     if _tsEntry and pType and UnitPowerPercent then
                         -- Use ColorCurve + UnitPowerPercent: WoW evaluates the secret
                         -- value against the curve on the C side, returns a Color object.
-                        local curve = GetBarThresholdCurve(
-                            r, g, b,
-                            _tsR or 1, _tsG or 0.2, _tsB or 0.2,
-                            _tsThreshCount or 30)
+                        -- Default: threshold color above the value, fill below it
+                        -- (builders -- warn when high). "Reverse Threshold Fill Color"
+                        -- (thresholdReverse) flips it to threshold color below
+						-- for spender resources like Hunter Focus where you
+                        -- want to warn when low.
+                        local curve
+                        if _tsReverse then
+                            curve = GetBarThresholdCurve(
+                                r, g, b,                                -- fill color (above)
+                                _tsR or 1, _tsG or 0.2, _tsB or 0.2,   -- threshold color (below)
+                                _tsThreshCount or 30)
+                        else
+                            curve = GetBarThresholdCurve(
+                                _tsR or 1, _tsG or 0.2, _tsB or 0.2,   -- threshold color (above)
+                                r, g, b,                                -- fill color (below)
+                                _tsThreshCount or 30)
+                        end
                         if curve then
                             local ok, colorResult = pcall(UnitPowerPercent, "player", pType, false, curve)
                             if ok and colorResult and colorResult.GetRGBA then


### PR DESCRIPTION
Bugfix: Resource threshold was not working correctly

Testing:
images of many specs tested with resource/power/health 
https://imgur.com/a/7EXW3dW

UI update:
Added a clearer text for toggle above/below for class resource bars that are not pip based
<img width="403" height="300" alt="image" src="https://github.com/user-attachments/assets/e71fcb77-f20a-440b-be79-3759d7bafccc" />

When creating a new threshold will set default below for spenders (eg; mana), default above for builders (eg; rage)