### PR TITLE
[Feature] Add multi-select action bar visibility modes

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -266,36 +266,36 @@ local EXPRESSWAY = MEDIA_PATH .. "fonts\\Expressway.ttf"
 -- too. nil on Western Latin locales -> callers keep the bundled Expressway.
 local LOCALE_FONT_FALLBACK = _G.EllesmereUI and _G.EllesmereUI._localeFont or nil
 -------------------------------------------------------------------------------
---  Addon Roster  --  per-addon icon on/off from EllesmereUI/media
+--  Addon Roster  --  per-addon display name + search alias from EllesmereUI/media
 -------------------------------------------------------------------------------
 local ICONS_PATH    = MEDIA_PATH .. "icons\\"
 
 local ADDON_ROSTER = {
-    { folder = "EllesmereUIActionBars",        display = "Action Bars",        search_name = "EllesmereUI Action Bars",        icon_on = ICONS_PATH .. "sidebar\\actionbars-ig-on.png",      icon_off = ICONS_PATH .. "sidebar\\actionbars-ig.png"      },
-    { folder = "EllesmereUINameplates",        display = "Nameplates",         search_name = "EllesmereUI Nameplates",         icon_on = ICONS_PATH .. "sidebar\\nameplates-ig-on.png",      icon_off = ICONS_PATH .. "sidebar\\nameplates-ig.png"      },
-    { folder = "EllesmereUIUnitFrames",        display = "Unit Frames",        search_name = "EllesmereUI Unit Frames",        icon_on = ICONS_PATH .. "sidebar\\unitframes-ig-on.png",      icon_off = ICONS_PATH .. "sidebar\\unitframes-ig.png"      },
-    { folder = "EllesmereUIRaidFrames",        display = "Raid Frames",        search_name = "EllesmereUI Raid Frames",        icon_on = ICONS_PATH .. "sidebar\\raidframes-ig-on.png",      icon_off = ICONS_PATH .. "sidebar\\raidframes-ig.png"      },
-    { folder = "EllesmereUICooldownManager",   display = "Cooldown Manager",   search_name = "EllesmereUI Cooldown Manager",   icon_on = ICONS_PATH .. "sidebar\\cdmeffects-ig-on.png",      icon_off = ICONS_PATH .. "sidebar\\cdmeffects-ig.png"      },
-    { folder = "EllesmereUIResourceBars",      display = "Resource & Cast Bars", search_name = "EllesmereUI Resource Bars Cast Bars",      icon_on = ICONS_PATH .. "sidebar\\resourcebars-ig-on-2.png",  icon_off = ICONS_PATH .. "sidebar\\resourcebars-ig-2.png"  },
-    { folder = "EllesmereUIAuraBuffReminders", display = "AuraBuff Reminders", search_name = "EllesmereUI AuraBuff Reminders", icon_on = ICONS_PATH .. "sidebar\\beacons-ig-on.png",         icon_off = ICONS_PATH .. "sidebar\\beacons-ig.png" },
+    { folder = "EllesmereUIActionBars",        display = "Action Bars",          search_name = "EllesmereUI Action Bars"             },
+    { folder = "EllesmereUINameplates",        display = "Nameplates",           search_name = "EllesmereUI Nameplates"              },
+    { folder = "EllesmereUIUnitFrames",        display = "Unit Frames",          search_name = "EllesmereUI Unit Frames"             },
+    { folder = "EllesmereUIRaidFrames",        display = "Raid Frames",          search_name = "EllesmereUI Raid Frames"             },
+    { folder = "EllesmereUICooldownManager",   display = "Cooldown Manager",     search_name = "EllesmereUI Cooldown Manager"        },
+    { folder = "EllesmereUIResourceBars",      display = "Resource & Cast Bars", search_name = "EllesmereUI Resource Bars Cast Bars" },
+    { folder = "EllesmereUIAuraBuffReminders", display = "AuraBuff Reminders",   search_name = "EllesmereUI AuraBuff Reminders"      },
     -- Basics is intentionally NOT in the roster: its code has been split into
     -- the per-module addons below. The Basics folder still exists as a shim
     -- addon purely so the v6.6 split-migration can read its enable state.
-    { folder = "EllesmereUIQoL",               display = "Quality of Life",    search_name = "EllesmereUI Quality of Life",    icon_on = ICONS_PATH .. "sidebar\\basics-ig-on-2.png",        icon_off = ICONS_PATH .. "sidebar\\basics-ig-2.png"      },
-    { folder = "EllesmereUIBlizzardSkin",      display = "Blizz UI Enhanced",  search_name = "EllesmereUI Blizz UI Enhanced",  icon_on = ICONS_PATH .. "sidebar\\blizzard-ig-on.png",        icon_off = ICONS_PATH .. "sidebar\\blizzard-ig.png"      },
-    { folder = "EllesmereUIFriends",           display = "Friends List",       search_name = "EllesmereUI Friends List",       icon_on = ICONS_PATH .. "sidebar\\friends-ig-on-2.png",         icon_off = ICONS_PATH .. "sidebar\\friends-ig-2.png"       },
-    { folder = "EllesmereUIMythicTimer",       display = "Mythic+ Timer",      search_name = "EllesmereUI Mythic+ Timer",      icon_on = ICONS_PATH .. "sidebar\\mplus-ig-on.png",           icon_off = ICONS_PATH .. "sidebar\\mplus-ig.png"         },
-    { folder = "EllesmereUIQuestTracker",      display = "Quest Tracker",      search_name = "EllesmereUI Quest Tracker",      icon_on = ICONS_PATH .. "sidebar\\quests-ig-on-2.png",          icon_off = ICONS_PATH .. "sidebar\\quests-ig-2.png"        },
-    { folder = "EllesmereUIMinimap",           display = "Minimap",            search_name = "EllesmereUI Minimap",            icon_on = ICONS_PATH .. "sidebar\\map-ig-on.png",             icon_off = ICONS_PATH .. "sidebar\\map-ig.png"           },
-    { folder = "EllesmereUIChat",              display = "Chat",               search_name = "EllesmereUI Chat",               icon_on = ICONS_PATH .. "sidebar\\basics-ig-on-2.png",        icon_off = ICONS_PATH .. "sidebar\\basics-ig-2.png" },
-    { folder = "EllesmereUIDamageMeters",      display = "Damage Meters",      search_name = "EllesmereUI Damage Meters",      icon_on = ICONS_PATH .. "sidebar\\basics-ig-on-2.png",        icon_off = ICONS_PATH .. "sidebar\\basics-ig-2.png" },
-    { folder = "EllesmereUIBags",              display = "Bags",               search_name = "EllesmereUI Bags",               icon_on = ICONS_PATH .. "sidebar\\basics-ig-on-2.png",        icon_off = ICONS_PATH .. "sidebar\\basics-ig-2.png" },
-    { folder = "EllesmereUIPartyMode",         display = "Party Mode",         search_name = "EllesmereUI Party Mode",         icon_on = ICONS_PATH .. "sidebar\\partymode-ig-on.png",       icon_off = ICONS_PATH .. "sidebar\\partymode-ig.png",       alwaysLoaded = true },
+    { folder = "EllesmereUIQoL",               display = "Quality of Life",      search_name = "EllesmereUI Quality of Life"         },
+    { folder = "EllesmereUIBlizzardSkin",      display = "Blizz UI Enhanced",    search_name = "EllesmereUI Blizz UI Enhanced"       },
+    { folder = "EllesmereUIFriends",           display = "Friends List",         search_name = "EllesmereUI Friends List"            },
+    { folder = "EllesmereUIMythicTimer",       display = "Mythic+ Timer",        search_name = "EllesmereUI Mythic+ Timer"           },
+    { folder = "EllesmereUIQuestTracker",      display = "Quest Tracker",        search_name = "EllesmereUI Quest Tracker"           },
+    { folder = "EllesmereUIMinimap",           display = "Minimap",              search_name = "EllesmereUI Minimap"                 },
+    { folder = "EllesmereUIChat",              display = "Chat",                 search_name = "EllesmereUI Chat"                    },
+    { folder = "EllesmereUIDamageMeters",      display = "Damage Meters",        search_name = "EllesmereUI Damage Meters"           },
+    { folder = "EllesmereUIBags",              display = "Bags",                 search_name = "EllesmereUI Bags"                    },
+    { folder = "EllesmereUIPartyMode",         display = "Party Mode",           search_name = "EllesmereUI Party Mode",             alwaysLoaded = true },
 }
 
 -------------------------------------------------------------------------------
 --  Addon Groups  --  ordered categories that drive the sidebar layout.
---  Each group has its own parent header (icon + label, no power toggle); the
+--  Each group has its own text-only parent header (label, no power toggle); the
 --  listed members render as child rows beneath it (label + power only, no
 --  left icon). Member order is authoritative -- coming-soon entries are
 --  placed at the end of their group.
@@ -307,8 +307,6 @@ EllesmereUI.ADDON_GROUPS = {
     {
         key     = "core",
         label   = "Core Addons",
-        icon_on  = ICONS_PATH .. "sidebar\\actionbars-ig-on.png",
-        icon_off = ICONS_PATH .. "sidebar\\actionbars-ig.png",
         members = {
             "EllesmereUIActionBars",
             "EllesmereUINameplates",
@@ -321,8 +319,6 @@ EllesmereUI.ADDON_GROUPS = {
     {
         key     = "qol",
         label   = "QoL Addons",
-        icon_on  = ICONS_PATH .. "sidebar\\basics-ig-on-2.png",
-        icon_off = ICONS_PATH .. "sidebar\\basics-ig-2.png",
         members = {
             "EllesmereUIQoL",
             "EllesmereUIAuraBuffReminders",
@@ -332,8 +328,6 @@ EllesmereUI.ADDON_GROUPS = {
     {
         key     = "reskin",
         label   = "UI Reskin Addons",
-        icon_on  = ICONS_PATH .. "sidebar\\friends-ig-on-2.png",
-        icon_off = ICONS_PATH .. "sidebar\\friends-ig-2.png",
         members = {
             "EllesmereUIBlizzardSkin",
             "EllesmereUIDamageMeters",
@@ -378,8 +372,6 @@ if IS_STANDALONE then
         table.insert(EllesmereUI.ADDON_GROUPS, 1, {
             key     = "standalone",
             label   = "Standalone",
-            icon_on  = ICONS_PATH .. "sidebar\\basics-ig-on-2.png",
-            icon_off = ICONS_PATH .. "sidebar\\basics-ig-2.png",
             members = { selfFolder },
         })
     end
@@ -1333,30 +1325,6 @@ EllesmereUI.GLOBAL_KEY = "_EUIGlobal"
 EllesmereUI.ADDON_ROSTER = ADDON_ROSTER
 EllesmereUI.LOCALE_FONT_FALLBACK = LOCALE_FONT_FALLBACK
 EllesmereUI.EXPRESSWAY = LOCALE_FONT_FALLBACK or EXPRESSWAY
-
--- Weak-keyed per-frame state (defined early -- used by PLAYER_LOGIN init below).
-EllesmereUI._FFD = EllesmereUI._FFD or setmetatable({}, { __mode = "k" })
-function EllesmereUI._GetFFD(frame)
-    local d = EllesmereUI._FFD[frame]
-    if not d then d = {}; EllesmereUI._FFD[frame] = d end
-    return d
-end
-
--- Alpha-zero visibility for anchor-participating frames (defined early for child addons).
-function EllesmereUI.SetElementVisibility(frame, visible)
-    if not frame then return end
-    if visible then
-        frame:SetAlpha(EllesmereUI._GetFFD(frame).restoreAlpha or 1)
-        frame:EnableMouse(EllesmereUI._GetFFD(frame).restoreMouse or false)
-    else
-        if frame:GetAlpha() > 0 then
-            EllesmereUI._GetFFD(frame).restoreAlpha = frame:GetAlpha()
-        end
-        EllesmereUI._GetFFD(frame).restoreMouse = frame:IsMouseEnabled()
-        frame:SetAlpha(0)
-        frame:EnableMouse(false)
-    end
-end
 
 -- Taint-safe print. Uses AddMessage instead of the global print(), which
 -- routes through Blizzard's C-side handler and taints the chat frame
@@ -2516,9 +2484,15 @@ do
     function EllesmereUI.GetBorderDefaultSize(addonKey, textureKey)
         if textureKey == "shadow" then textureKey = "glow" end  -- Shadow shares Glow's defaults
         local addon = _borderDefaults[addonKey]
-        if not addon then return nil end
-        local tex = addon[textureKey]
-        return tex and tex.defaultSize or nil
+        local tex = addon and addon[textureKey]
+        if tex and tex.defaultSize then return tex.defaultSize end
+        -- Any SharedMedia border ("sm:<name>") defaults to size 1 unless a
+        -- specific defaultSize was registered above. This is the shared engine
+        -- function, so it applies to every consumer. It is only called from a
+        -- dropdown setValue (style change), never on load/apply, so stored
+        -- sizes are never touched until the user actively picks a SharedMedia style.
+        if type(textureKey) == "string" and textureKey:sub(1, 3) == "sm:" then return 1 end
+        return nil
     end
 
     -- Built-in border textures (always available, no SharedMedia required)
@@ -3105,9 +3079,34 @@ function EllesmereUI.GetFontOutlineFlag(addonKey)
     else
         mode = db.outlineMode or "none"
     end
-    if mode == "outline" then return "OUTLINE, SLUG"
-    elseif mode == "thick" then return "THICKOUTLINE, SLUG"
-    else return "" end
+    local flag
+    if mode == "outline" then flag = "OUTLINE, SLUG"
+    elseif mode == "thick" then flag = "THICKOUTLINE, SLUG"
+    else flag = "" end
+    return EllesmereUI.SlugFlag(flag)
+end
+
+-- Global "Never Show Slug" toggle. When ON, the SLUG token is stripped from
+-- every outline flag the UI produces -- body text and icon/aura text across all
+-- modules, plus the global Outline Mode itself. Stored centrally in
+-- EllesmereUIDB.neverShowSlug; OFF by default (slug outlines render as normal).
+function EllesmereUI.IsSlugDisabled()
+    return (EllesmereUIDB and EllesmereUIDB.neverShowSlug == true) or false
+end
+
+-- Strip the SLUG token from a font outline flag:
+-- "OUTLINE, SLUG" -> "OUTLINE", "THICKOUTLINE, SLUG" -> "THICKOUTLINE", "" -> "".
+function EllesmereUI.StripSlugFlag(flag)
+    if not flag or flag == "" then return flag or "" end
+    return (flag:gsub("%s*,%s*SLUG", ""))
+end
+
+-- Central gate: returns `flag` with SLUG removed when "Never Show Slug" is on,
+-- otherwise unchanged. Use this at every point a slug outline flag is produced
+-- (the outline helpers above and any hardcoded icon-text literal).
+function EllesmereUI.SlugFlag(flag)
+    if EllesmereUI.IsSlugDisabled() then return EllesmereUI.StripSlugFlag(flag) end
+    return flag
 end
 
 -- Returns true when the outline mode uses drop shadow instead of outline.
@@ -3189,9 +3188,11 @@ end
 function EllesmereUI.GetIconTextOutlineFlag(moduleKey)
     local t = EllesmereUIDB and EllesmereUIDB.outlineIconText
     if t and t[moduleKey] == false then
+        -- Follows the outline mode, which is already slug-gated at the source.
         return (EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag(moduleKey)) or ""
     end
-    return "OUTLINE, SLUG"
+    -- Forced crisp outline; "Never Show Slug" still drops the slug token.
+    return EllesmereUI.SlugFlag("OUTLINE, SLUG")
 end
 
 -- Applies the icon-text outline flag AND the matching shadow in one call.
@@ -3373,6 +3374,10 @@ function EllesmereUI.ApplyColorsToOUF()
     if ok and EAB and EAB.ApplyBorders and not InCombatLockdown() then
         EAB:ApplyBorders()
         if EAB.ApplyShapes then EAB:ApplyShapes() end
+    end
+    -- 6. Refresh damage meters (bars/text class colors)
+    if EllesmereUI._DM_RefreshColors then
+        EllesmereUI._DM_RefreshColors()
     end
 end
 
@@ -5504,12 +5509,12 @@ local function CreateMainFrame()
     EllesmereUI._sidebar = sidebar
 
     -- Nav buttons -- start below the logo area with proper spacing
-    local NAV_TOP     = -128   -- distance from sidebar top to first nav item
-    local NAV_ROW_H   = 50    -- height per nav row (Unlock / Global Settings)
-    local NAV_ICON_W  = 52    -- exact pixel width
-    local NAV_ICON_H  = 37    -- exact pixel height
+    local NAV_TOP     = -114   -- distance from sidebar top to first nav item
+    local NAV_ROW_H   = 40    -- height per nav row (Unlock / Global / Patch Notes / Profiles)
+    local NAV_ICON_W  = 46    -- exact pixel width
+    local NAV_ICON_H  = 31    -- exact pixel height
     local NAV_LEFT    = 20    -- left padding for icon
-    local NAV_TXT_GAP = 14    -- gap between icon and label
+    local NAV_TXT_GAP = 10    -- gap between icon and label
 
     -- Helper: create a 1px horizontal glow line on a sidebar button (TOP or BOTTOM edge)
     local function MakeNavEdgeLine(btn, edge)
@@ -5593,9 +5598,9 @@ local function CreateMainFrame()
         btn._iconOn  = ICONS_PATH .. "sidebar\\unlockmode-ig-on.png"
         btn._iconOff = ICONS_PATH .. "sidebar\\unlockmode-ig.png"
 
-        local label = MakeFont(btn, 15, nil, TEXT_DIM.r, TEXT_DIM.g, TEXT_DIM.b, TEXT_DIM.a)
+        local label = MakeFont(btn, 14, nil, TEXT_DIM.r, TEXT_DIM.g, TEXT_DIM.b, TEXT_DIM.a)
         label:SetPoint("LEFT", icon, "RIGHT", NAV_TXT_GAP, 0)
-        label:SetText("Unlock Mode")
+        label:SetText(EllesmereUI.L("Unlock Mode"))
         btn._label = label
 
         -- Always "loaded" appearance
@@ -5660,9 +5665,9 @@ local function CreateMainFrame()
         btn._iconOn  = ICONS_PATH .. "sidebar\\settings-ig-on-2.png"
         btn._iconOff = ICONS_PATH .. "sidebar\\settings-ig-2.png"
 
-        local label = MakeFont(btn, 15, nil, TEXT_DIM.r, TEXT_DIM.g, TEXT_DIM.b, TEXT_DIM.a)
+        local label = MakeFont(btn, 14, nil, TEXT_DIM.r, TEXT_DIM.g, TEXT_DIM.b, TEXT_DIM.a)
         label:SetPoint("LEFT", icon, "RIGHT", NAV_TXT_GAP, 0)
-        label:SetText("Global Settings")
+        label:SetText(EllesmereUI.L("Global Settings"))
         btn._label = label
 
         -- No download icon for global settings
@@ -5706,13 +5711,156 @@ local function CreateMainFrame()
         sidebarButtons[GLOBAL_KEY] = btn
     end
 
-    -- Addon offset: first addon starts two rows below (Unlock Mode + Global Settings)
-    local ORIG_ADDON_NAV_TOP = NAV_TOP - NAV_ROW_H * 2
+    -------------------------------------------------------------------
+    --  Patch Notes button  (own page -- selects the _EUIPatchNotes module)
+    -------------------------------------------------------------------
+    do
+        local btn = CreateFrame("Button", nil, sidebar)
+        btn:SetSize(SIDEBAR_W, NAV_ROW_H)
+        btn:SetPoint("TOPLEFT", sidebar, "TOPLEFT", 0, NAV_TOP - NAV_ROW_H * 2)
+        btn:SetFrameLevel(sidebar:GetFrameLevel() + 1)
+
+        DecorateSidebarButton(btn)
+
+        -- Glow layer (behind icon): tinted version of the -on texture
+        local iconGlow = btn:CreateTexture(nil, "ARTWORK", nil, 0)
+        iconGlow:SetTexture(ICONS_PATH .. "sidebar\\notes-on.png")
+        iconGlow:SetSize(NAV_ICON_W, NAV_ICON_H)
+        iconGlow:SetPoint("LEFT", btn, "LEFT", NAV_LEFT, 0)
+        iconGlow:SetDesaturated(true)
+        iconGlow:SetVertexColor(ELLESMERE_GREEN.r, ELLESMERE_GREEN.g, ELLESMERE_GREEN.b, 1)
+        iconGlow:Hide()
+        btn._iconGlow = iconGlow
+        RegAccent({ type="vertex", obj=iconGlow })
+
+        -- Icon layer (on top of glow): always the white off texture
+        local icon = btn:CreateTexture(nil, "ARTWORK", nil, 1)
+        icon:SetTexture(ICONS_PATH .. "sidebar\\notes-off.png")
+        icon:SetSize(NAV_ICON_W, NAV_ICON_H)
+        icon:SetPoint("LEFT", btn, "LEFT", NAV_LEFT, 0)
+        btn._icon    = icon
+        btn._iconOn  = ICONS_PATH .. "sidebar\\notes-on.png"
+        btn._iconOff = ICONS_PATH .. "sidebar\\notes-off.png"
+
+        local label = MakeFont(btn, 14, nil, TEXT_DIM.r, TEXT_DIM.g, TEXT_DIM.b, TEXT_DIM.a)
+        label:SetPoint("LEFT", icon, "RIGHT", NAV_TXT_GAP, 0)
+        label:SetText(EllesmereUI.L("Patch Notes"))
+        btn._label = label
+
+        label:SetTextColor(NAV_ENABLED_TEXT.r, NAV_ENABLED_TEXT.g, NAV_ENABLED_TEXT.b, NAV_ENABLED_TEXT.a)
+        icon:SetDesaturated(false)
+        icon:SetAlpha(NAV_ENABLED_ICON_A)
+
+        btn._folder = "_EUIPatchNotes"
+        btn._loaded = true
+
+        local hlTex = SolidTex(btn, "HIGHLIGHT", 1, 1, 1, 0)
+        hlTex:SetAllPoints()
+        btn:SetScript("OnEnter", function(self)
+            hlTex:SetAlpha(0.06)
+            if activeModule ~= self._folder then
+                self._hoverGlow:Show()
+                self._hoverIndicator:Show()
+                self._label:SetTextColor(NAV_HOVER_ENABLED_TEXT.r, NAV_HOVER_ENABLED_TEXT.g, NAV_HOVER_ENABLED_TEXT.b, NAV_HOVER_ENABLED_TEXT.a)
+            end
+        end)
+        btn:SetScript("OnLeave", function(self)
+            hlTex:SetAlpha(0)
+            self._hoverGlow:Hide()
+            self._hoverIndicator:Hide()
+            if activeModule ~= self._folder then
+                self._label:SetTextColor(NAV_ENABLED_TEXT.r, NAV_ENABLED_TEXT.g, NAV_ENABLED_TEXT.b, NAV_ENABLED_TEXT.a)
+            end
+        end)
+        btn:SetScript("OnClick", function(self)
+            if modules[self._folder] then
+                EllesmereUI:SelectModule(self._folder)
+            end
+        end)
+
+        sidebarButtons["_EUIPatchNotes"] = btn
+        EllesmereUI._patchNotesSidebarBtn = btn
+    end
+
+    -------------------------------------------------------------------
+    --  Profiles & Presets button  (own page -- selects the _EUIProfiles module)
+    -------------------------------------------------------------------
+    do
+        local btn = CreateFrame("Button", nil, sidebar)
+        btn:SetSize(SIDEBAR_W, NAV_ROW_H)
+        btn:SetPoint("TOPLEFT", sidebar, "TOPLEFT", 0, NAV_TOP - NAV_ROW_H * 3)
+        btn:SetFrameLevel(sidebar:GetFrameLevel() + 1)
+
+        DecorateSidebarButton(btn)
+
+        -- Glow layer (behind icon): tinted version of the -on texture
+        local iconGlow = btn:CreateTexture(nil, "ARTWORK", nil, 0)
+        iconGlow:SetTexture(ICONS_PATH .. "sidebar\\profiles-on.png")
+        iconGlow:SetSize(NAV_ICON_W, NAV_ICON_H)
+        iconGlow:SetPoint("LEFT", btn, "LEFT", NAV_LEFT, 0)
+        iconGlow:SetDesaturated(true)
+        iconGlow:SetVertexColor(ELLESMERE_GREEN.r, ELLESMERE_GREEN.g, ELLESMERE_GREEN.b, 1)
+        iconGlow:Hide()
+        btn._iconGlow = iconGlow
+        RegAccent({ type="vertex", obj=iconGlow })
+
+        -- Icon layer (on top of glow): always the white off texture
+        local icon = btn:CreateTexture(nil, "ARTWORK", nil, 1)
+        icon:SetTexture(ICONS_PATH .. "sidebar\\profiles-off.png")
+        icon:SetSize(NAV_ICON_W, NAV_ICON_H)
+        icon:SetPoint("LEFT", btn, "LEFT", NAV_LEFT, 0)
+        btn._icon    = icon
+        btn._iconOn  = ICONS_PATH .. "sidebar\\profiles-on.png"
+        btn._iconOff = ICONS_PATH .. "sidebar\\profiles-off.png"
+
+        local label = MakeFont(btn, 14, nil, TEXT_DIM.r, TEXT_DIM.g, TEXT_DIM.b, TEXT_DIM.a)
+        label:SetPoint("LEFT", icon, "RIGHT", NAV_TXT_GAP, 0)
+        label:SetText(EllesmereUI.L("Profiles & Presets"))
+        btn._label = label
+
+        label:SetTextColor(NAV_ENABLED_TEXT.r, NAV_ENABLED_TEXT.g, NAV_ENABLED_TEXT.b, NAV_ENABLED_TEXT.a)
+        icon:SetDesaturated(false)
+        icon:SetAlpha(NAV_ENABLED_ICON_A)
+
+        btn._folder = "_EUIProfiles"
+        btn._loaded = true
+
+        local hlTex = SolidTex(btn, "HIGHLIGHT", 1, 1, 1, 0)
+        hlTex:SetAllPoints()
+        btn:SetScript("OnEnter", function(self)
+            hlTex:SetAlpha(0.06)
+            if activeModule ~= self._folder then
+                self._hoverGlow:Show()
+                self._hoverIndicator:Show()
+                self._label:SetTextColor(NAV_HOVER_ENABLED_TEXT.r, NAV_HOVER_ENABLED_TEXT.g, NAV_HOVER_ENABLED_TEXT.b, NAV_HOVER_ENABLED_TEXT.a)
+            end
+        end)
+        btn:SetScript("OnLeave", function(self)
+            hlTex:SetAlpha(0)
+            self._hoverGlow:Hide()
+            self._hoverIndicator:Hide()
+            if activeModule ~= self._folder then
+                self._label:SetTextColor(NAV_ENABLED_TEXT.r, NAV_ENABLED_TEXT.g, NAV_ENABLED_TEXT.b, NAV_ENABLED_TEXT.a)
+            end
+        end)
+        btn:SetScript("OnClick", function(self)
+            if modules[self._folder] then
+                EllesmereUI:SelectModule(self._folder)
+            end
+        end)
+
+        sidebarButtons["_EUIProfiles"] = btn
+        EllesmereUI._profilesSidebarBtn = btn
+    end
+
+    -- Addon offset: first addon starts four rows below
+    -- (Unlock Mode + Global Settings + Patch Notes + Profiles & Presets)
+    local ORIG_ADDON_NAV_TOP = NAV_TOP - NAV_ROW_H * 4
 
     -----------------------------------------------------------------------
     --  Sidebar search bar (filters addon list by display name or page name)
     -----------------------------------------------------------------------
-    local SB_TOP_PAD     = 18   -- gap between Global Settings and the search bar
+    local SB_TOP_PAD     = 13   -- gap between Profiles & Presets and the search bar
     local SB_H           = 28
     local SB_BOT_PAD     = 6
     local SB_SIDE_INSET  = 20
@@ -5791,10 +5939,12 @@ local function CreateMainFrame()
     --  class art, so addon buttons live inside a ScrollFrame with smooth
     --  mouse-wheel scrolling and a thin thumb on the right edge.
     -----------------------------------------------------------------------
-    local ADDON_VISIBLE_ROWS    = 10.5
+    local ADDON_VISIBLE_ROWS    = 12   -- nav rows shrank to 40px; bump count so the addon viewport still fills to the bottom
     -- +30 = 20px viewport bonus plus 10px offsetting the SB_TOP_PAD bump above,
     -- so growing the search-bar padding doesn't silently shrink the viewport.
-    local ADDON_SCROLL_H        = ADDON_VISIBLE_ROWS * NAV_ROW_H - SB_TOTAL + 30
+    -- Reserve a strip below the viewport for the scroll-to-bottom arrow button.
+    local ADDON_ARROW_RESERVE   = 24
+    local ADDON_SCROLL_H        = ADDON_VISIBLE_ROWS * NAV_ROW_H - SB_TOTAL + 30 - ADDON_ARROW_RESERVE
     local ADDON_SCROLL_STEP     = 60   -- match the main content scroll
     local ADDON_SMOOTH_SPEED    = 12   -- match the main content scroll
 
@@ -5831,8 +5981,47 @@ local function CreateMainFrame()
     addonThumb:SetWidth(3)
     addonThumb:SetHeight(40)
 
+    -- Scroll-to-bottom arrow, centered just below the viewport. Dims when the
+    -- list is at the bottom (or doesn't scroll at all); click animates the list
+    -- to the bottom. OnClick is wired further below, once the smooth-scroll
+    -- state locals exist. Alpha tiers are stored on the frame (it's ours).
+    local arrowBtn = CreateFrame("Button", nil, sidebar)
+    arrowBtn:SetSize(22, 19)
+    arrowBtn:SetPoint("TOP", addonScrollFrame, "BOTTOM", 0, -5)
+    arrowBtn:SetFrameLevel(sidebar:GetFrameLevel() + 5)
+    arrowBtn:SetHitRectInsets(-12, -12, -6, -8)
+    arrowBtn._aEnabled, arrowBtn._aDisabled, arrowBtn._aHover = 0.7, 0.2, 1.0
+    arrowBtn._atBottom = false
+    do
+        local t = arrowBtn:CreateTexture(nil, "ARTWORK")
+        t:SetTexture(ICONS_PATH .. "eui-arrow-down3.png")
+        t:SetAllPoints()
+    end
+    arrowBtn:SetAlpha(arrowBtn._aEnabled)
+    arrowBtn:SetScript("OnEnter", function(self)
+        if not self._atBottom then self:SetAlpha(self._aHover) end
+    end)
+    arrowBtn:SetScript("OnLeave", function(self)
+        self:SetAlpha(self._atBottom and self._aDisabled or self._aEnabled)
+    end)
+    EllesmereUI._addonScrollArrow = arrowBtn
+
     local function UpdateAddonThumb()
         local maxScroll = EllesmereUI.SafeScrollRange and EllesmereUI.SafeScrollRange(addonScrollFrame) or 0
+        -- Scroll-to-bottom arrow state: disabled (dimmed) when there's nothing
+        -- below, enabled otherwise. Runs before the no-scroll early return.
+        do
+            local cur = tonumber(addonScrollFrame:GetVerticalScroll()) or 0
+            local atBottom = (maxScroll <= 0.5) or (cur >= maxScroll - 0.5)
+            arrowBtn._atBottom = atBottom
+            if atBottom then
+                arrowBtn:SetAlpha(arrowBtn._aDisabled)
+            elseif arrowBtn:IsMouseOver() then
+                arrowBtn:SetAlpha(arrowBtn._aHover)
+            else
+                arrowBtn:SetAlpha(arrowBtn._aEnabled)
+            end
+        end
         if maxScroll <= 0 then
             addonTrack:Hide()
             return
@@ -5905,6 +6094,20 @@ local function CreateMainFrame()
     addonScrollFrame:SetScript("OnScrollRangeChanged", UpdateAddonThumb)
     addonScrollFrame:HookScript("OnSizeChanged", UpdateAddonThumb)
 
+    -- Scroll-to-bottom arrow click: smooth-animate to the bottom (no-op when
+    -- already there). Reuses the same smooth-scroll state as the mouse wheel.
+    arrowBtn:SetScript("OnClick", function()
+        local maxScroll = EllesmereUI.SafeScrollRange and EllesmereUI.SafeScrollRange(addonScrollFrame) or 0
+        if maxScroll <= 0 then return end
+        local scale = addonScrollFrame:GetEffectiveScale()
+        maxScroll = math.floor(maxScroll * scale) / scale
+        addonScrollTarget = maxScroll
+        if not addonIsSmoothing then
+            addonIsSmoothing = true
+            addonSmoothFrame:Show()
+        end
+    end)
+
     -- Click / drag on the scrollbar track. Clicking anywhere on the track
     -- jumps the scroll to that position; holding the button drags.
     -- The visible track is 3px wide so we add a wider invisible hit frame.
@@ -5976,7 +6179,7 @@ local function CreateMainFrame()
         local EG = ELLESMERE_GREEN
         local label = MakeFont(row, 15, nil, EG.r, EG.g, EG.b, 1)
         label:SetPoint("LEFT", row, "LEFT", NAV_LEFT, 0)
-        label:SetText(group.label)
+        label:SetText(EllesmereUI.L(group.label))
         RegAccent({ type="callback", fn = function(r, g, b)
             label:SetTextColor(r, g, b, 1)
         end })
@@ -7023,7 +7226,7 @@ local function CreateMainFrame()
         local bg = SolidTex(btn, "BACKGROUND", DARK_BG.r, DARK_BG.g, DARK_BG.b, .92)
         bg:SetAllPoints()
         local lbl = MakeFont(btn, 13, nil, textR, textG, textB)
-        lbl:SetAlpha(textA); lbl:SetPoint("CENTER"); lbl:SetText(label)
+        lbl:SetAlpha(textA); lbl:SetPoint("CENTER"); lbl:SetText(EllesmereUI.L(label))
         btn._label = lbl
         do
             local FADE_DUR = 0.1
@@ -7082,11 +7285,28 @@ local function CreateMainFrame()
     footerFrame._resetBtn = resetBtn
 
     -- Reload UI  (next to Reset, 40px gap, same white/muted style)
-    MakeFooterBtn(footerFrame, FOOTER_BTN_W, FOOTER_BTN_H,
+    local reloadBtn = MakeFooterBtn(footerFrame, FOOTER_BTN_W, FOOTER_BTN_H,
         "BOTTOMLEFT", resetBtn, "BOTTOMRIGHT", FOOTER_BTN_GAP, 0,
         RS_TEXT_R, RS_TEXT_G, RS_TEXT_B, RS_TEXT_A, RS_TEXT_HR, RS_TEXT_HG, RS_TEXT_HB, RS_TEXT_HA,
         RS_BRD_R, RS_BRD_G, RS_BRD_B, RS_BRD_A, RS_BRD_HR, RS_BRD_HG, RS_BRD_HB, RS_BRD_HA,
         "Reload UI", function() ReloadUI() end)
+    footerFrame._reloadBtn = reloadBtn
+
+    -- Show/hide the Reset button per module. Modules without an onReset (Patch
+    -- Notes, Profiles) have nothing to reset, so Reset is hidden and Reload UI
+    -- slides left into its slot to avoid a gap. Called from SelectModule.
+    EllesmereUI._UpdateResetButtonVisible = function(hasReset)
+        local rb, rl = footerFrame._resetBtn, footerFrame._reloadBtn
+        if not rb or not rl then return end
+        rl:ClearAllPoints()
+        if hasReset then
+            rb:Show()
+            rl:SetPoint("BOTTOMLEFT", rb, "BOTTOMRIGHT", FOOTER_BTN_GAP, 0)
+        else
+            rb:Hide()
+            rl:SetPoint("BOTTOMLEFT", footerFrame, "BOTTOMLEFT", FOOTER_PAD, FOOTER_Y)
+        end
+    end
 
     -- Social icons  (to the left of Done button)
     do
@@ -7227,7 +7447,7 @@ local function CreateMainFrame()
         local bg = SolidTex(btn, "BACKGROUND", DARK_BG.r, DARK_BG.g, DARK_BG.b, .92)
         bg:SetAllPoints()
         local lbl = MakeFont(btn, 13, nil, ELLESMERE_GREEN.r, ELLESMERE_GREEN.g, ELLESMERE_GREEN.b)
-        lbl:SetAlpha(0.7); lbl:SetPoint("CENTER"); lbl:SetText("Done")
+        lbl:SetAlpha(0.7); lbl:SetPoint("CENTER"); lbl:SetText(EllesmereUI.L("Done"))
         -- Hover animation reads from ELLESMERE_GREEN live
         local FADE_DUR = 0.1
         local progress, target = 0, 0
@@ -8437,6 +8657,9 @@ function EllesmereUI:SelectModule(folderName)
         rb._label:SetWordWrap(false)
         rb._label:SetMaxLines(1)
     end
+    if EllesmereUI._UpdateResetButtonVisible then
+        EllesmereUI._UpdateResetButtonVisible(config.onReset ~= nil)
+    end
     headerFrame._desc:SetText(EllesmereUI.L(config.description or ""))
     BuildTabs(config.pages, config.disabledPages, config.disabledPageTooltips)
     local savedPage = _lastPagePerModule[folderName]
@@ -8839,7 +9062,7 @@ end
 -------------------------------------------------------------------------------
 --  Slash commands
 -------------------------------------------------------------------------------
-EllesmereUI.VERSION = "8.2.1"
+EllesmereUI.VERSION = "8.2.7"
 
 -- Register this addon's version into a shared global table (taint-free at load time)
 if not _G._EUI_AddonVersions then _G._EUI_AddonVersions = {} end
@@ -9019,6 +9242,7 @@ EllesmereUI._RunConflictCheck = function()
             { addon = "TellMeWhen",               label = "TellMeWhen",                 targets = "all",                              message = "TellMeWhen overlaps with EllesmereUI's core positional architecture. If you ONLY use for sound alerts it should be okay but may still cause issues." },
             { addon = "Bartender4",               label = "Bartender4",                 targets = { "EllesmereUIActionBars" } },
             { addon = "Dominos",                  label = "Dominos",                    targets = { "EllesmereUIActionBars" } },
+            { addon = "ImprovedTalentLoadouts",   label = "Improved Talent Loadouts",   targets = { "EllesmereUIActionBars" } },
             { addon = "UnhaltedUnitFrames",       label = "Unhalted Unit Frames",       targets = { "EllesmereUIUnitFrames" } },
             { addon = "Platynator",               label = "Platynator",                 targets = { "EllesmereUINameplates" } },
             { addon = "Plater",                   label = "Plater Nameplates",          targets = { "EllesmereUINameplates" } },
@@ -9358,6 +9582,101 @@ SlashCmdList.EUIDEV = function()
     end
     local state = newVal == "1" and "ON" or "OFF"
     EllesmereUI.Print("|cff00ff00[EllesmereUI]|r Dev mode: all addon restriction CVars " .. state .. ".")
+    if EllesmereUI.UpdateDevModeIndicator then EllesmereUI.UpdateDevModeIndicator() end
+end
+
+-------------------------------------------------------------------------------
+--  Dev Mode badge: a small top-left indicator shown while /euidev is active
+--  (the addon-restriction-forced CVars are on, so the restricted / secret-value
+--  environment is being forced for testing). Toggled by /euidev and re-checked
+--  on login, since the CVars persist across sessions.
+-------------------------------------------------------------------------------
+do
+    local DEV_CVAR = "addonChallengeModeRestrictionsForced"
+
+    function EllesmereUI.IsDevModeActive()
+        return GetCVar(DEV_CVAR) == "1"
+    end
+
+    local badge
+
+    local function CreateDevBadge()
+        if badge then return badge end
+        local PP = EllesmereUI.PP
+        local accent = EllesmereUI.ELLESMERE_GREEN or { r = 0.05, g = 0.82, b = 0.62 }
+
+        local f = CreateFrame("Frame", "EllesmereUIDevModeBadge", UIParent)
+        f:SetFrameStrata("HIGH")
+        f:SetHeight(26)
+        f:SetPoint("TOPLEFT", UIParent, "TOPLEFT", 16, -16)
+        f:EnableMouse(false)
+        f:Hide()
+
+        -- Dark base + faint accent wash for an on-brand tint
+        local bg = f:CreateTexture(nil, "BACKGROUND")
+        bg:SetAllPoints()
+        bg:SetColorTexture(0.02, 0.02, 0.03, 0.62)
+        local wash = f:CreateTexture(nil, "BORDER")
+        wash:SetAllPoints()
+        wash:SetColorTexture(accent.r, accent.g, accent.b, 0.06)
+
+        -- Accent 1px border (our own frame, safe)
+        if PP and PP.CreateBorder then
+            PP.CreateBorder(f, accent.r, accent.g, accent.b, 0.9, 1, "OVERLAY", 7)
+        end
+
+        -- Pulsing accent "LED" dot (recording-indicator vibe)
+        local dot = f:CreateTexture(nil, "ARTWORK")
+        dot:SetTexture("Interface\\Buttons\\WHITE8x8")
+        dot:SetVertexColor(accent.r, accent.g, accent.b, 1)
+        dot:SetSize(7, 7)
+        dot:SetPoint("LEFT", f, "LEFT", 9, 0)
+        if dot.SetSnapToPixelGrid then dot:SetSnapToPixelGrid(false); dot:SetTexelSnappingBias(0) end
+        local ag = dot:CreateAnimationGroup()
+        ag:SetLooping("BOUNCE")
+        local pulse = ag:CreateAnimation("Alpha")
+        pulse:SetFromAlpha(1); pulse:SetToAlpha(0.1)
+        pulse:SetDuration(0.7); pulse:SetSmoothing("IN_OUT")
+        f._pulse = ag
+
+        -- Label
+        local label = f:CreateFontString(nil, "OVERLAY")
+        label:SetFont(EllesmereUI.EXPRESSWAY, 11,
+            (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE")
+        label:SetText("DEV MODE ACTIVE")
+        label:SetTextColor(accent.r, accent.g, accent.b, 1)
+        label:SetPoint("LEFT", dot, "RIGHT", 8, 0)
+
+        -- Size to content: dotPad(9) + dot(7) + gap(8) + text + rightPad(12)
+        f:SetWidth(9 + 7 + 8 + label:GetStringWidth() + 12)
+
+        badge = f
+        return f
+    end
+
+    function EllesmereUI.UpdateDevModeIndicator()
+        if not EllesmereUI.IsDevModeActive() then
+            if badge then
+                if badge._pulse then badge._pulse:Stop() end
+                badge:Hide()
+            end
+            return
+        end
+        local f = CreateDevBadge()
+        f:Show()
+        if f._pulse then f._pulse:Play() end
+    end
+
+    -- CVars persist across sessions: check on login (deferred so the theme accent
+    -- is fully resolved). PLAYER_LOGIN re-fires on /reload, so this covers both.
+    local ev = CreateFrame("Frame")
+    ev:RegisterEvent("PLAYER_LOGIN")
+    ev:SetScript("OnEvent", function(self)
+        self:UnregisterAllEvents()
+        C_Timer.After(2, function()
+            if EllesmereUI.UpdateDevModeIndicator then EllesmereUI.UpdateDevModeIndicator() end
+        end)
+    end)
 end
 
 -- Open the panel with a specific addon's tab selected
@@ -9996,14 +10315,6 @@ initFrame:SetScript("OnEvent", function(self, event)
     end
 end)
 
--- Re-bind after PLAYER_LOGIN init closure: tail-of-file visibility/cast-bar code
--- can compile outside the main local EllesmereUI scope when the chunk nears the
--- Lua 200-local limit, so ensure the global/table reference exists here.
-if not EllesmereUI then
-    EllesmereUI = _G.EllesmereUI or {}
-end
-_G.EllesmereUI = EllesmereUI
-
 -------------------------------------------------------------------------------
 --  Shared Visibility System
 --  Unified visibility dropdown values, checkbox dropdown items, and runtime
@@ -10025,11 +10336,11 @@ EllesmereUI.VIS_ORDER = { "never", "always", "mouseover", "in_combat", "out_of_c
 
 -- Checkbox dropdown items for multi-select visibility modes (action bars).
 EllesmereUI.VIS_MODE_ITEMS = {}
-for _, key in ipairs(EllesmereUI.VIS_ORDER) do
-    if key ~= "---" then
+for _, modeKey in ipairs(EllesmereUI.VIS_ORDER) do
+    if modeKey ~= "---" then
         EllesmereUI.VIS_MODE_ITEMS[#EllesmereUI.VIS_MODE_ITEMS + 1] = {
-            key = key,
-            label = EllesmereUI.VIS_VALUES[key],
+            key = modeKey,
+            label = EllesmereUI.VIS_VALUES[modeKey],
         }
     end
 end
@@ -10167,6 +10478,23 @@ function EllesmereUI.CheckVisibilityMode(mode, state)
     return true
 end
 
+-- Read visibility mode array from settings, falling back to legacy single-mode fields.
+function EllesmereUI.GetVisibilityModes(opts)
+    if not opts then return { "always" } end
+    local modes = opts.barVisibilityModes
+    if type(modes) == "table" and #modes > 0 then
+        return modes
+    end
+    if opts.barVisibility then
+        return { opts.barVisibility }
+    end
+    if opts.alwaysHidden then return { "never" } end
+    if opts.mouseoverEnabled then return { "mouseover" } end
+    if opts.combatShowEnabled then return { "in_combat" } end
+    if opts.combatHideEnabled then return { "out_of_combat" } end
+    return { "always" }
+end
+
 function EllesmereUI.VisibilityModesContains(modes, mode)
     if not modes or not mode then return false end
     for i = 1, #modes do
@@ -10175,91 +10503,118 @@ function EllesmereUI.VisibilityModesContains(modes, mode)
     return false
 end
 
-function EllesmereUI.VisibilityModesEqual(a, b)
-    if not a or not b then return false end
-    if #a ~= #b then return false end
-    for i = 1, #a do
-        if a[i] ~= b[i] then return false end
-    end
-    return true
-end
-
--- Read visibility modes from settings; falls back to legacy single-string field.
-function EllesmereUI.GetVisibilityModes(settings, modesKey, legacyKey)
-    modesKey = modesKey or "barVisibilityModes"
-    legacyKey = legacyKey or "barVisibility"
-    if settings then
-        local modes = settings[modesKey]
-        if type(modes) == "table" and #modes > 0 then
-            return modes
-        end
-        local legacy = settings[legacyKey] or settings.visibility
-        if legacy and legacy ~= "" then
-            return { legacy }
-        end
-    end
-    return { "always" }
-end
-
--- OR evaluation: returns true when any selected mode matches.
-function EllesmereUI.CheckVisibilityModes(modes, state, opts)
-    opts = opts or {}
+-- OR evaluation: show when any selected mode matches. Macro/state modes are
+-- checked before mouseover (mouseover requires isHovered == true).
+function EllesmereUI.CheckVisibilityModes(modes, state, isHovered)
     if not modes or #modes == 0 then return true end
-    if EllesmereUI.VisibilityModesContains(modes, "never") then return false end
-    if EllesmereUI.VisibilityModesContains(modes, "always") then return true end
-    -- Macro/state modes take precedence over mouseover.
+
+    for i = 1, #modes do
+        if modes[i] == "never" then return false end
+    end
+    for i = 1, #modes do
+        if modes[i] == "always" then return true end
+    end
+
+    state = state or {}
     for i = 1, #modes do
         local mode = modes[i]
         if mode ~= "mouseover" and mode ~= "always" and mode ~= "never" then
-            if EllesmereUI.CheckVisibilityMode(mode, state) then return true end
+            if EllesmereUI.CheckVisibilityMode(mode, state) then
+                return true
+            end
         end
     end
-    if EllesmereUI.VisibilityModesContains(modes, "mouseover") and opts.isHovered then
-        return true
+    if isHovered then
+        for i = 1, #modes do
+            if modes[i] == "mouseover" then return true end
+        end
     end
     return false
 end
 
-function EllesmereUI.ModeToMacroClause(mode)
-    if mode == "in_combat" then return "[combat] show"
-    elseif mode == "out_of_combat" then return "[nocombat] show"
-    elseif mode == "in_raid" then return "[group:raid] show"
-    elseif mode == "in_party" then return "[group:party] show; [group:raid] show"
-    elseif mode == "solo" then return "[nogroup] show"
-    end
-    return nil
-end
-
--- Build the macro suffix for OR-combined visibility modes.
+-- Build OR-chained macro suffix for secure state-visibility drivers.
+-- Skips mouseover (handled via alpha in Lua). Returns "show", "hide", or
+-- e.g. "[combat] show; [group:raid] show; hide".
 function EllesmereUI.BuildMacroVisibilitySuffix(modes)
     if not modes or #modes == 0 then return "show" end
-    if EllesmereUI.VisibilityModesContains(modes, "never") then return "hide" end
-    if EllesmereUI.VisibilityModesContains(modes, "always") then return "show" end
-    if EllesmereUI.VisibilityModesContains(modes, "mouseover") then return "show" end
-    local parts = {}
-    for i = 1, #modes do
-        local clause = EllesmereUI.ModeToMacroClause(modes[i])
-        if clause then parts[#parts + 1] = clause end
-    end
-    if #parts == 0 then return "show" end
-    parts[#parts + 1] = "hide"
-    return table.concat(parts, "; ")
-end
 
-function EllesmereUI.VisibilityModesHasMacroCondition(modes)
     for i = 1, #modes do
-        local m = modes[i]
-        if m ~= "always" and m ~= "never" and m ~= "mouseover" then
-            return true
+        if modes[i] == "never" then return "hide" end
+    end
+    for i = 1, #modes do
+        if modes[i] == "always" then return "show" end
+    end
+
+    local clauses = {}
+    for i = 1, #modes do
+        local mode = modes[i]
+        if mode == "in_combat" then
+            clauses[#clauses + 1] = "[combat] show"
+        elseif mode == "out_of_combat" then
+            clauses[#clauses + 1] = "[nocombat] show"
+        elseif mode == "in_raid" then
+            clauses[#clauses + 1] = "[group:raid] show"
+        elseif mode == "in_party" then
+            clauses[#clauses + 1] = "[group:party] show"
+            clauses[#clauses + 1] = "[group:raid] show"
+        elseif mode == "solo" then
+            clauses[#clauses + 1] = "[nogroup] show"
         end
     end
-    return false
+
+    if #clauses == 0 then
+        return "show"
+    end
+    return table.concat(clauses, "; ") .. "; hide"
 end
 
-function EllesmereUI.VisibilityModesHasCondition(modes)
-    if not modes or #modes == 0 then return false end
-    if #modes == 1 and modes[1] == "always" then return false end
+-- Order-independent set comparison for sync UI.
+function EllesmereUI.VisibilityModesEqual(a, b)
+    if a == b then return true end
+    if not a or not b or #a ~= #b then return false end
+    local counts = {}
+    for i = 1, #a do
+        local k = a[i]
+        counts[k] = (counts[k] or 0) + 1
+    end
+    for i = 1, #b do
+        local k = b[i]
+        if not counts[k] or counts[k] == 0 then return false end
+        counts[k] = counts[k] - 1
+    end
     return true
+end
+
+-------------------------------------------------------------------------------
+--  External weak-keyed lookup table for frame state (prevents tainting Blizzard
+--  frames). Stored on EllesmereUI to avoid the 200-local cap in this file.
+-------------------------------------------------------------------------------
+EllesmereUI._FFD = EllesmereUI._FFD or setmetatable({}, { __mode = "k" })
+function EllesmereUI._GetFFD(frame)
+    local d = EllesmereUI._FFD[frame]
+    if not d then d = {}; EllesmereUI._FFD[frame] = d end
+    return d
+end
+
+-------------------------------------------------------------------------------
+--  Alpha-Zero Visibility Helper
+--  For anchor-participating container frames: use alpha 0 + EnableMouse(false)
+--  instead of :Hide() so the frame stays in the layout engine with valid bounds.
+--  Sub-widgets (icons, text, glows) inside these frames still use :Hide()/:Show().
+-------------------------------------------------------------------------------
+function EllesmereUI.SetElementVisibility(frame, visible)
+    if not frame then return end
+    if visible then
+        frame:SetAlpha(EllesmereUI._GetFFD(frame).restoreAlpha or 1)
+        frame:EnableMouse(EllesmereUI._GetFFD(frame).restoreMouse or false)
+    else
+        if frame:GetAlpha() > 0 then
+            EllesmereUI._GetFFD(frame).restoreAlpha = frame:GetAlpha()
+        end
+        EllesmereUI._GetFFD(frame).restoreMouse = frame:IsMouseEnabled()
+        frame:SetAlpha(0)
+        frame:EnableMouse(false)
+    end
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -1334,6 +1334,30 @@ EllesmereUI.ADDON_ROSTER = ADDON_ROSTER
 EllesmereUI.LOCALE_FONT_FALLBACK = LOCALE_FONT_FALLBACK
 EllesmereUI.EXPRESSWAY = LOCALE_FONT_FALLBACK or EXPRESSWAY
 
+-- Weak-keyed per-frame state (defined early -- used by PLAYER_LOGIN init below).
+EllesmereUI._FFD = EllesmereUI._FFD or setmetatable({}, { __mode = "k" })
+function EllesmereUI._GetFFD(frame)
+    local d = EllesmereUI._FFD[frame]
+    if not d then d = {}; EllesmereUI._FFD[frame] = d end
+    return d
+end
+
+-- Alpha-zero visibility for anchor-participating frames (defined early for child addons).
+function EllesmereUI.SetElementVisibility(frame, visible)
+    if not frame then return end
+    if visible then
+        frame:SetAlpha(EllesmereUI._GetFFD(frame).restoreAlpha or 1)
+        frame:EnableMouse(EllesmereUI._GetFFD(frame).restoreMouse or false)
+    else
+        if frame:GetAlpha() > 0 then
+            EllesmereUI._GetFFD(frame).restoreAlpha = frame:GetAlpha()
+        end
+        EllesmereUI._GetFFD(frame).restoreMouse = frame:IsMouseEnabled()
+        frame:SetAlpha(0)
+        frame:EnableMouse(false)
+    end
+end
+
 -- Taint-safe print. Uses AddMessage instead of the global print(), which
 -- routes through Blizzard's C-side handler and taints the chat frame
 -- execution context. Silently drops the message inside protected instances
@@ -9972,6 +9996,14 @@ initFrame:SetScript("OnEvent", function(self, event)
     end
 end)
 
+-- Re-bind after PLAYER_LOGIN init closure: tail-of-file visibility/cast-bar code
+-- can compile outside the main local EllesmereUI scope when the chunk nears the
+-- Lua 200-local limit, so ensure the global/table reference exists here.
+if not EllesmereUI then
+    EllesmereUI = _G.EllesmereUI or {}
+end
+_G.EllesmereUI = EllesmereUI
+
 -------------------------------------------------------------------------------
 --  Shared Visibility System
 --  Unified visibility dropdown values, checkbox dropdown items, and runtime
@@ -9990,6 +10022,17 @@ EllesmereUI.VIS_VALUES = {
     solo       = "Solo",
 }
 EllesmereUI.VIS_ORDER = { "never", "always", "mouseover", "in_combat", "out_of_combat", "---", "in_raid", "in_party", "solo" }
+
+-- Checkbox dropdown items for multi-select visibility modes (action bars).
+EllesmereUI.VIS_MODE_ITEMS = {}
+for _, key in ipairs(EllesmereUI.VIS_ORDER) do
+    if key ~= "---" then
+        EllesmereUI.VIS_MODE_ITEMS[#EllesmereUI.VIS_MODE_ITEMS + 1] = {
+            key = key,
+            label = EllesmereUI.VIS_VALUES[key],
+        }
+    end
+end
 
 -- CDM variant (no mouseover -- CDM bars don't support mouseover visibility)
 EllesmereUI.VIS_VALUES_CDM = {
@@ -10124,36 +10167,99 @@ function EllesmereUI.CheckVisibilityMode(mode, state)
     return true
 end
 
--------------------------------------------------------------------------------
---  External weak-keyed lookup table for frame state (prevents tainting Blizzard
---  frames). Stored on EllesmereUI to avoid the 200-local cap in this file.
--------------------------------------------------------------------------------
-EllesmereUI._FFD = EllesmereUI._FFD or setmetatable({}, { __mode = "k" })
-function EllesmereUI._GetFFD(frame)
-    local d = EllesmereUI._FFD[frame]
-    if not d then d = {}; EllesmereUI._FFD[frame] = d end
-    return d
+function EllesmereUI.VisibilityModesContains(modes, mode)
+    if not modes or not mode then return false end
+    for i = 1, #modes do
+        if modes[i] == mode then return true end
+    end
+    return false
 end
 
--------------------------------------------------------------------------------
---  Alpha-Zero Visibility Helper
---  For anchor-participating container frames: use alpha 0 + EnableMouse(false)
---  instead of :Hide() so the frame stays in the layout engine with valid bounds.
---  Sub-widgets (icons, text, glows) inside these frames still use :Hide()/:Show().
--------------------------------------------------------------------------------
-function EllesmereUI.SetElementVisibility(frame, visible)
-    if not frame then return end
-    if visible then
-        frame:SetAlpha(EllesmereUI._GetFFD(frame).restoreAlpha or 1)
-        frame:EnableMouse(EllesmereUI._GetFFD(frame).restoreMouse or false)
-    else
-        if frame:GetAlpha() > 0 then
-            EllesmereUI._GetFFD(frame).restoreAlpha = frame:GetAlpha()
-        end
-        EllesmereUI._GetFFD(frame).restoreMouse = frame:IsMouseEnabled()
-        frame:SetAlpha(0)
-        frame:EnableMouse(false)
+function EllesmereUI.VisibilityModesEqual(a, b)
+    if not a or not b then return false end
+    if #a ~= #b then return false end
+    for i = 1, #a do
+        if a[i] ~= b[i] then return false end
     end
+    return true
+end
+
+-- Read visibility modes from settings; falls back to legacy single-string field.
+function EllesmereUI.GetVisibilityModes(settings, modesKey, legacyKey)
+    modesKey = modesKey or "barVisibilityModes"
+    legacyKey = legacyKey or "barVisibility"
+    if settings then
+        local modes = settings[modesKey]
+        if type(modes) == "table" and #modes > 0 then
+            return modes
+        end
+        local legacy = settings[legacyKey] or settings.visibility
+        if legacy and legacy ~= "" then
+            return { legacy }
+        end
+    end
+    return { "always" }
+end
+
+-- OR evaluation: returns true when any selected mode matches.
+function EllesmereUI.CheckVisibilityModes(modes, state, opts)
+    opts = opts or {}
+    if not modes or #modes == 0 then return true end
+    if EllesmereUI.VisibilityModesContains(modes, "never") then return false end
+    if EllesmereUI.VisibilityModesContains(modes, "always") then return true end
+    -- Macro/state modes take precedence over mouseover.
+    for i = 1, #modes do
+        local mode = modes[i]
+        if mode ~= "mouseover" and mode ~= "always" and mode ~= "never" then
+            if EllesmereUI.CheckVisibilityMode(mode, state) then return true end
+        end
+    end
+    if EllesmereUI.VisibilityModesContains(modes, "mouseover") and opts.isHovered then
+        return true
+    end
+    return false
+end
+
+function EllesmereUI.ModeToMacroClause(mode)
+    if mode == "in_combat" then return "[combat] show"
+    elseif mode == "out_of_combat" then return "[nocombat] show"
+    elseif mode == "in_raid" then return "[group:raid] show"
+    elseif mode == "in_party" then return "[group:party] show; [group:raid] show"
+    elseif mode == "solo" then return "[nogroup] show"
+    end
+    return nil
+end
+
+-- Build the macro suffix for OR-combined visibility modes.
+function EllesmereUI.BuildMacroVisibilitySuffix(modes)
+    if not modes or #modes == 0 then return "show" end
+    if EllesmereUI.VisibilityModesContains(modes, "never") then return "hide" end
+    if EllesmereUI.VisibilityModesContains(modes, "always") then return "show" end
+    if EllesmereUI.VisibilityModesContains(modes, "mouseover") then return "show" end
+    local parts = {}
+    for i = 1, #modes do
+        local clause = EllesmereUI.ModeToMacroClause(modes[i])
+        if clause then parts[#parts + 1] = clause end
+    end
+    if #parts == 0 then return "show" end
+    parts[#parts + 1] = "hide"
+    return table.concat(parts, "; ")
+end
+
+function EllesmereUI.VisibilityModesHasMacroCondition(modes)
+    for i = 1, #modes do
+        local m = modes[i]
+        if m ~= "always" and m ~= "never" and m ~= "mouseover" then
+            return true
+        end
+    end
+    return false
+end
+
+function EllesmereUI.VisibilityModesHasCondition(modes)
+    if not modes or #modes == 0 then return false end
+    if #modes == 1 and modes[1] == "always" then return false end
+    return true
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -107,6 +107,20 @@ initFrame:SetScript("OnEvent", function(self)
         end
     end
 
+    -- Allow Unlock Mode's "Element Options" to pre-select a specific bar before
+    -- the Bar Display page builds (mirrors the unit-frame path): a direct setter
+    -- for when this module has already built, plus a pending value consumed at
+    -- page-build time. Both ignore keys that are not Bar Display dropdown bars
+    -- (Micro/Bag/XP/Rep live on their own tab) so the selector never goes blank.
+    EllesmereUI._setActionBarKey = function(key)
+        if barLabels[key] then _selectedBarKey = key end
+    end
+    EllesmereUI._consumePendingActionBarSelect = function()
+        local pending = EllesmereUI._pendingActionBarSelect
+        EllesmereUI._pendingActionBarSelect = nil
+        if pending and barLabels[pending] then _selectedBarKey = pending end
+    end
+
     ---------------------------------------------------------------------------
     --  Edit Overlay System
     --  Shows a non-draggable unlock-mode-style overlay on the actual bar
@@ -529,7 +543,7 @@ initFrame:SetScript("OnEvent", function(self)
             -- Macro name text (bottom-center, mirrors real button Name position)
             local macroFS = bf:CreateFontString(nil, "OVERLAY")
             if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(macroFS, false) end
-            macroFS:SetFont(DEFAULT_FONT, 12, "OUTLINE, SLUG")
+            macroFS:SetFont(DEFAULT_FONT, 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
             macroFS:SetTextColor(1, 1, 1)
             macroFS:SetPoint("BOTTOMLEFT", bf, "BOTTOMLEFT", 1, 4)
             macroFS:SetPoint("BOTTOMRIGHT", bf, "BOTTOMRIGHT", -1, 4)
@@ -1015,7 +1029,7 @@ initFrame:SetScript("OnEvent", function(self)
                             macroFS:SetText(mcText)
                         end
                         if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(macroFS, false) end
-                        macroFS:SetFont(fontPath, scaledMCSize, "OUTLINE, SLUG")
+                        macroFS:SetFont(fontPath, scaledMCSize, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
                         macroFS:SetTextColor(mcColor.r, mcColor.g, mcColor.b)
                         local mcOX = (settings.macroOffsetX or 0) * totalScale
                         local mcOY = (settings.macroOffsetY or 0) * totalScale
@@ -1096,6 +1110,9 @@ initFrame:SetScript("OnEvent", function(self)
 
     -- Multi-select visibility modes; legacy single-mode fields stay derived.
     local function GetVisibilityModes(s)
+        if VisibilityCompat then
+            return VisibilityCompat.GetModes(s)
+        end
         return EllesmereUI.GetVisibilityModes(s)
     end
 
@@ -1106,7 +1123,7 @@ initFrame:SetScript("OnEvent", function(self)
         end
         s.barVisibilityModes = modes
         s.barVisibility = modes[1] or "always"
-        s.alwaysHidden = (#modes == 1 and modes[1] == "never")
+        s.alwaysHidden = EllesmereUI.VisibilityModesContains(modes, "never")
         local wasMouseover = s.mouseoverEnabled
         s.mouseoverEnabled = EllesmereUI.VisibilityModesContains(modes, "mouseover")
         if s.mouseoverEnabled then
@@ -1169,7 +1186,7 @@ initFrame:SetScript("OnEvent", function(self)
         EAB:ApplyCombatVisibility()
     end
 
-    local function InstallVisibilityModesDropdown(region, getSettings, disabledFn)
+    local function InstallVisibilityModesDropdown(region, getSettings, onApplied)
         if region._control then region._control:Hide() end
         local PP = EllesmereUI.PanelPP
         local cbDD, cbDDRefresh = EllesmereUI.BuildVisOptsCBDropdown(
@@ -1181,6 +1198,7 @@ initFrame:SetScript("OnEvent", function(self)
             end,
             function(mode, on)
                 ToggleVisibilityMode(getSettings(), mode, on)
+                if onApplied then onApplied() end
                 RefreshVisibilityRuntime()
                 EllesmereUI:RefreshPage()
             end)
@@ -1227,7 +1245,7 @@ initFrame:SetScript("OnEvent", function(self)
 
             InstallVisibilityModesDropdown(visRow._leftRegion, function()
                 return EAB.db.profile.bars[barKey]
-            end, disabledFn)
+            end)
 
             -- Replace the dummy right dropdown with checkbox dropdown
             local rightRgn = visRow._rightRegion
@@ -1424,6 +1442,31 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         -----------------------------------------------------------------------
+        --  Bar 10 / Moonkin Form caution
+        -----------------------------------------------------------------------
+        -- Action page 10 (the slots Bar 10 displays) is the Druid Moonkin Form
+        -- bonus bar, so a Druid editing Bar 10 also edits their Moonkin Form
+        -- bar and vice versa. Surface that at the top of the page so it is not
+        -- a surprise. Shown for all classes; the text self-qualifies to Druids.
+        if SelectedKey() == "Bar10" then
+            local PP = EllesmereUI.PanelPP
+            local PAD = EllesmereUI.CONTENT_PAD
+            local warnW = parent:GetWidth() - PAD * 2
+            y = y - 5  -- 5px spacing above the caution
+            local warnHost = CreateFrame("Frame", nil, parent)
+            PP.Point(warnHost, "TOPLEFT", parent, "TOPLEFT", PAD, y)
+            local warnFS = EllesmereUI.MakeFont(warnHost, 14, nil, 1, 0.82, 0)
+            warnFS:SetWidth(warnW)
+            warnFS:SetWordWrap(true)
+            warnFS:SetJustifyH("CENTER")
+            warnFS:SetPoint("TOPLEFT", warnHost, "TOPLEFT", 0, 0)
+            warnFS:SetText(EllesmereUI.L("This Action Bar is also used as the Moonkin Form bar.\nChanging spells on a Druid for this bar will also change them on your Moonkin Form bar."))
+            local warnH = math.ceil(warnFS:GetStringHeight()) + 4
+            PP.Size(warnHost, warnW, warnH)
+            y = y - (warnH + 12)
+        end
+
+        -----------------------------------------------------------------------
         --  VISIBILITY
         -----------------------------------------------------------------------
         _, h = W:SectionHeader(parent, SECTION_VISIBILITY, y);  y = y - h
@@ -1448,7 +1491,10 @@ initFrame:SetScript("OnEvent", function(self)
                   getValue=function() return "__placeholder" end,
                   setValue=function() end });  y = y - h
 
-            InstallVisibilityModesDropdown(visRow1._leftRegion, function() return SB() end, _visBlizzDis)
+            InstallVisibilityModesDropdown(visRow1._leftRegion, function() return SB() end, function()
+                if EAB.ClearVisToggleOverride then EAB:ClearVisToggleOverride(SelectedKey()) end
+                if EAB.RebuildVisToggleBindings then EAB:RebuildVisToggleBindings() end
+            end)
 
             -- Replace the dummy right dropdown with checkbox dropdown
             do
@@ -1604,6 +1650,166 @@ initFrame:SetScript("OnEvent", function(self)
                     end,
                 },
             })
+        end
+
+        -- Row 3: Toggle Action Bar keybind | Click Through  (hidden for vis-only bars)
+        if not visOnly then
+            local ctRow
+            ctRow, h = W:DualRow(parent, y,
+                { type="label", text="Toggle Action Bar Visibility" },
+                { type="toggle", text="Click Through",
+                  getValue=function()
+                      return SGet("clickThrough")
+                  end,
+                  setValue=function(v)
+                      SSet("clickThrough", v, function(k) EAB:ApplyClickThroughForBar(k) end)
+                  end });  y = y - h
+            -- Keybind button for "Toggle Action Bar" (left region). Pressing the
+            -- bound key flips this bar between shown and hidden at runtime without
+            -- writing the saved visibility. Enabled only when Visibility is Always
+            -- or Never; the toggle itself only works out of combat.
+            do
+                local rgn = ctRow._leftRegion
+                local kbBtn = CreateFrame("Button", nil, rgn)
+                PP.Size(kbBtn, 126, 29)
+                PP.Point(kbBtn, "RIGHT", rgn, "RIGHT", -20, 0)
+                kbBtn:SetFrameLevel(rgn:GetFrameLevel() + 4)
+                kbBtn:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+                local kbBg = EllesmereUI.SolidTex(kbBtn, "BACKGROUND", EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
+                kbBg:SetAllPoints()
+                kbBtn._border = EllesmereUI.MakeBorder(kbBtn, 1, 1, 1, EllesmereUI.DD_BRD_A, EllesmereUI.PanelPP)
+                local kbLbl = EllesmereUI.MakeFont(kbBtn, 12, nil, 1, 1, 1)
+                kbLbl:SetAlpha(EllesmereUI.DD_TXT_A)
+                kbLbl:SetPoint("CENTER")
+
+                local listening = false
+
+                local function FormatKey(key)
+                    if not key then return EllesmereUI.L("Not Bound") end
+                    local parts = {}
+                    for mod in key:gmatch("(%u+)%-") do
+                        parts[#parts + 1] = mod:sub(1, 1) .. mod:sub(2):lower()
+                    end
+                    parts[#parts + 1] = key:match("[^%-]+$") or key
+                    return table.concat(parts, " + ")
+                end
+
+                local function IsDisabled()
+                    return not VisibilityCompat.IsToggleEligible(SB())
+                end
+
+                local function RefreshLabel()
+                    if listening then return end
+                    kbLbl:SetText(FormatKey(SB().toggleVisKey))
+                end
+
+                local function RefreshState()
+                    local off = IsDisabled()
+                    kbBtn:SetAlpha(off and 0.3 or 1)
+                    kbBtn:EnableMouse(not off)
+                    if rgn._label then rgn._label:SetAlpha(off and 0.3 or 1) end
+                    if off and listening then
+                        listening = false
+                        kbBtn:EnableKeyboard(false)
+                    end
+                    RefreshLabel()
+                end
+
+                kbBtn:SetScript("OnClick", function(self, button)
+                    if IsDisabled() then return end
+                    if button == "RightButton" then
+                        if listening then listening = false; self:EnableKeyboard(false) end
+                        SB().toggleVisKey = nil
+                        EAB:RebuildVisToggleBindings()
+                        RefreshLabel()
+                        return
+                    end
+                    if listening then return end
+                    listening = true
+                    kbLbl:SetText(EllesmereUI.L("Press a key..."))
+                    self:EnableKeyboard(true)
+                end)
+
+                kbBtn:SetScript("OnKeyDown", function(self, key)
+                    if not listening then self:SetPropagateKeyboardInput(true); return end
+                    if key == "LSHIFT" or key == "RSHIFT" or key == "LCTRL" or key == "RCTRL"
+                       or key == "LALT" or key == "RALT" then
+                        self:SetPropagateKeyboardInput(true); return
+                    end
+                    self:SetPropagateKeyboardInput(false)
+                    if key == "ESCAPE" then
+                        listening = false; self:EnableKeyboard(false); RefreshLabel(); return
+                    end
+                    local mods = ""
+                    if IsShiftKeyDown() then mods = mods .. "SHIFT-" end
+                    if IsControlKeyDown() then mods = mods .. "CTRL-" end
+                    if IsAltKeyDown() then mods = mods .. "ALT-" end
+                    SB().toggleVisKey = mods .. key
+                    EAB:RebuildVisToggleBindings()
+                    listening = false
+                    self:EnableKeyboard(false)
+                    RefreshLabel()
+                end)
+
+                kbBtn:SetScript("OnEnter", function(self)
+                    if IsDisabled() then
+                        EllesmereUI.ShowWidgetTooltip(self, EllesmereUI.DisabledTooltip("Visibility set to Always or Never"))
+                        return
+                    end
+                    kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_HA)
+                    if kbBtn._border and kbBtn._border.SetColor then kbBtn._border:SetColor(1, 1, 1, 0.3) end
+                    EllesmereUI.ShowWidgetTooltip(self, "Toggling action bar visibility is only available out of combat\n\nLeft-click to set a keybind.\nRight-click to unbind.")
+                end)
+                kbBtn:SetScript("OnLeave", function()
+                    if listening then return end
+                    kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
+                    if kbBtn._border and kbBtn._border.SetColor then kbBtn._border:SetColor(1, 1, 1, EllesmereUI.DD_BRD_A) end
+                    EllesmereUI.HideWidgetTooltip()
+                end)
+                kbBtn:SetScript("OnHide", function()
+                    if listening then listening = false; kbBtn:EnableKeyboard(false); RefreshLabel() end
+                end)
+
+                RefreshState()
+                EllesmereUI.RegisterWidgetRefresh(RefreshState)
+            end
+            -- Sync icon: Click Through (right)
+            do
+                local rgn = ctRow._rightRegion
+                EllesmereUI.BuildSyncIcon({
+                    region  = rgn,
+                    tooltip = "Apply Click Through to all Bars",
+                    onClick = function()
+                        local v = SB().clickThrough or false
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            EAB.db.profile.bars[key].clickThrough = v
+                            EAB:ApplyClickThroughForBar(key)
+                        end
+                        EllesmereUI:RefreshPage()
+                    end,
+                    isSynced = function()
+                        local v = SB().clickThrough or false
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            if (EAB.db.profile.bars[key].clickThrough or false) ~= v then return false end
+                        end
+                        return true
+                    end,
+                    flashTargets = function() return { rgn } end,
+                    multiApply = {
+                        elementKeys   = GROUP_BAR_ORDER,
+                        elementLabels = SHORT_LABELS,
+                        getCurrentKey = function() return SelectedKey() end,
+                        onApply       = function(checkedKeys)
+                            local v = SB().clickThrough or false
+                            for _, key in ipairs(checkedKeys) do
+                                EAB.db.profile.bars[key].clickThrough = v
+                                EAB:ApplyClickThroughForBar(key)
+                            end
+                            EllesmereUI:RefreshPage()
+                        end,
+                    },
+                })
+            end
         end
 
         -----------------------------------------------------------------------
@@ -2085,6 +2291,17 @@ initFrame:SetScript("OnEvent", function(self)
                     end)
                 end
             end
+
+            -- Row 4: Reverse Icon Order | (empty)
+            _, h = W:DualRow(parent, y,
+                { type="toggle", text="Reverse Icon Order",
+                  tooltip="Reverse the order of buttons on this bar.",
+                  getValue=function() return SVal("reverseIconOrder", false) end,
+                  setValue=function(v)
+                      SSet("reverseIconOrder", v, function(k) EAB:ApplyIconRowOverrides(k) end)
+                      SUpdatePreviewAndResize()
+                  end },
+                { type="label", text="" });  y = y - h
 
             -------------------------------------------------------------------
             --  ICON APPEARANCE
@@ -2776,40 +2993,23 @@ initFrame:SetScript("OnEvent", function(self)
             -------------------------------------------------------------------
             _, h = W:SectionHeader(parent, "ICON EFFECTS", y);  y = y - h
 
-            -- Row 1: Desaturate on Cooldown | Reverse Icon Order
-            _, h = W:DualRow(parent, y,
+            -- Row 1: Desaturate on Cooldown | Disable Tooltips
+            local dtRow
+            dtRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Desaturate on Cooldown",
                   tooltip="Desaturates (grays out) action button icons while the ability is on cooldown. GCD-only cooldowns are excluded.",
                   getValue=function() return EAB.db.profile.desaturateOnCooldown or false end,
                   setValue=function(v) EAB.db.profile.desaturateOnCooldown = v end },
-                { type="toggle", text="Reverse Icon Order",
-                  tooltip="Reverse the order of buttons on this bar.",
-                  getValue=function() return SVal("reverseIconOrder", false) end,
-                  setValue=function(v)
-                      SSet("reverseIconOrder", v, function(k) EAB:ApplyIconRowOverrides(k) end)
-                      SUpdatePreviewAndResize()
-                  end });  y = y - h
-
-            -- Row 2: Disable Tooltips | Click Through
-            local dtCtRow
-            dtCtRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Disable Tooltips",
                   getValue=function()
                       return SGet("disableTooltips") or false
                   end,
                   setValue=function(v)
                       SSet("disableTooltips", v)
-                  end },
-                { type="toggle", text="Click Through",
-                  getValue=function()
-                      return SGet("clickThrough")
-                  end,
-                  setValue=function(v)
-                      SSet("clickThrough", v, function(k) EAB:ApplyClickThroughForBar(k) end)
                   end });  y = y - h
-            -- Sync icon: Disable Tooltips (left)
+            -- Sync icon: Disable Tooltips (right)
             do
-                local rgn = dtCtRow._leftRegion
+                local rgn = dtRow._rightRegion
                 EllesmereUI.BuildSyncIcon({
                     region  = rgn,
                     tooltip = "Apply Disable Tooltips to all Bars",
@@ -2836,43 +3036,6 @@ initFrame:SetScript("OnEvent", function(self)
                             local v = SB().disableTooltips or false
                             for _, key in ipairs(checkedKeys) do
                                 EAB.db.profile.bars[key].disableTooltips = v
-                            end
-                            EllesmereUI:RefreshPage()
-                        end,
-                    },
-                })
-            end
-            -- Sync icon: Click Through (right)
-            do
-                local rgn = dtCtRow._rightRegion
-                EllesmereUI.BuildSyncIcon({
-                    region  = rgn,
-                    tooltip = "Apply Click Through to all Bars",
-                    onClick = function()
-                        local v = SB().clickThrough or false
-                        for _, key in ipairs(GROUP_BAR_ORDER) do
-                            EAB.db.profile.bars[key].clickThrough = v
-                            EAB:ApplyClickThroughForBar(key)
-                        end
-                        EllesmereUI:RefreshPage()
-                    end,
-                    isSynced = function()
-                        local v = SB().clickThrough or false
-                        for _, key in ipairs(GROUP_BAR_ORDER) do
-                            if (EAB.db.profile.bars[key].clickThrough or false) ~= v then return false end
-                        end
-                        return true
-                    end,
-                    flashTargets = function() return { rgn } end,
-                    multiApply = {
-                        elementKeys   = GROUP_BAR_ORDER,
-                        elementLabels = SHORT_LABELS,
-                        getCurrentKey = function() return SelectedKey() end,
-                        onApply       = function(checkedKeys)
-                            local v = SB().clickThrough or false
-                            for _, key in ipairs(checkedKeys) do
-                                EAB.db.profile.bars[key].clickThrough = v
-                                EAB:ApplyClickThroughForBar(key)
                             end
                             EllesmereUI:RefreshPage()
                         end,
@@ -3148,6 +3311,17 @@ initFrame:SetScript("OnEvent", function(self)
                           getValue=function() return GetPagingVal("alt") end,
                           setValue=function(v) SetPagingVal("alt", v) end });  y = y - h
 
+                    -- Row 3: Friendly Target | Hostile Target
+                    _, h = W:DualRow(parent, y,
+                        { type="dropdown", text="Friendly Target",
+                          values=pagingValues, order=pagingOrder,
+                          getValue=function() return GetPagingVal("help") end,
+                          setValue=function(v) SetPagingVal("help", v) end },
+                        { type="dropdown", text="Hostile Target",
+                          values=pagingValues, order=pagingOrder,
+                          getValue=function() return GetPagingVal("harm") end,
+                          setValue=function(v) SetPagingVal("harm", v) end });  y = y - h
+
                     -- Class form dropdowns (paired into DualRows)
                     local classStatesLocal = PG_STATES.class and PG_STATES.class[playerClass]
                     if classStatesLocal then
@@ -3191,7 +3365,7 @@ initFrame:SetScript("OnEvent", function(self)
                       SSet("hideKeybind", v, function(k) EAB:ApplyFontsForBar(k) end)
                       SUpdatePreview()
                   end },
-                { type="slider", text="Keybind Text Size", min=6, max=24, step=1, trackWidth=120,
+                { type="slider", text="Keybind Text Size", min=6, max=30, step=1, trackWidth=120,
                   getValue=function() return SVal("keybindFontSize", 12) end,
                   setValue=function(v)
                       SSet("keybindFontSize", v, function(k) EAB:ApplyFontsForBar(k) end)
@@ -3349,7 +3523,7 @@ initFrame:SetScript("OnEvent", function(self)
                       SSet("hideMacroText", v, function(k) EAB:ApplyFontsForBar(k) end)
                       SUpdatePreview()
                   end },
-                { type="slider", text="Macro Text Size", min=6, max=24, step=1, trackWidth=120,
+                { type="slider", text="Macro Text Size", min=6, max=30, step=1, trackWidth=120,
                   getValue=function() return SVal("macroFontSize", 12) end,
                   setValue=function(v)
                       SSet("macroFontSize", v, function(k) EAB:ApplyFontsForBar(k) end)
@@ -3497,13 +3671,13 @@ initFrame:SetScript("OnEvent", function(self)
 
             -- Row 3: Charges Text Size slider + inline swatch (left) | Cooldown Text Size slider + inline swatch (right)
             chargesRow, h = W:DualRow(parent, y,
-                { type="slider", text="Charges Text Size", min=6, max=24, step=1, trackWidth=120,
+                { type="slider", text="Charges Text Size", min=6, max=30, step=1, trackWidth=120,
                   getValue=function() return SVal("countFontSize", 12) end,
                   setValue=function(v)
                       SSet("countFontSize", v, function(k) EAB:ApplyFontsForBar(k) end)
                       SUpdatePreview()
                   end },
-                { type="slider", text="Cooldown Text Size", min=6, max=24, step=1, trackWidth=120,
+                { type="slider", text="Cooldown Text Size", min=6, max=30, step=1, trackWidth=120,
                   getValue=function() return SVal("cooldownFontSize", 12) end,
                   setValue=function(v)
                       SSet("cooldownFontSize", v, function(k) EAB:ApplyCooldownFontsForBar(k) end)
@@ -3890,6 +4064,9 @@ initFrame:SetScript("OnEvent", function(self)
         local _, h
 
         activePreview = nil
+
+        -- Consume any pending bar selection from Element Options navigation.
+        if EllesmereUI._consumePendingActionBarSelect then EllesmereUI._consumePendingActionBarSelect() end
 
         -- Show edit overlay for the currently selected bar
         ShowEditOverlay(SelectedKey())

--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -1094,27 +1094,22 @@ initFrame:SetScript("OnEvent", function(self)
         RepBar   = "Rep",
     }
 
-    -- Keep the legacy boolean flags and the newer visibility-mode dropdown in
-    -- sync. The runtime still reads both shapes in different code paths.
-    local function GetVisibilityKey(s)
-        if not VisibilityCompat then
-            return s.barVisibility or "always"
-        end
-        return VisibilityCompat.Normalize(s)
+    -- Multi-select visibility modes; legacy single-mode fields stay derived.
+    local function GetVisibilityModes(s)
+        return EllesmereUI.GetVisibilityModes(s)
     end
 
-    local function ApplyVisibilityKey(s, v)
+    local function ApplyVisibilityModes(s, modes)
         if VisibilityCompat then
-            VisibilityCompat.ApplyMode(s, v)
+            VisibilityCompat.ApplyModes(s, modes)
             return
         end
-
-        s.barVisibility = v
-        s.alwaysHidden = (v == "never")
-
+        s.barVisibilityModes = modes
+        s.barVisibility = modes[1] or "always"
+        s.alwaysHidden = (#modes == 1 and modes[1] == "never")
         local wasMouseover = s.mouseoverEnabled
-        s.mouseoverEnabled = (v == "mouseover")
-        if v == "mouseover" then
+        s.mouseoverEnabled = EllesmereUI.VisibilityModesContains(modes, "mouseover")
+        if s.mouseoverEnabled then
             if not wasMouseover then
                 s._savedBarAlpha = s.mouseoverAlpha or 1
             end
@@ -1123,9 +1118,36 @@ initFrame:SetScript("OnEvent", function(self)
             s.mouseoverAlpha = s._savedBarAlpha
             s._savedBarAlpha = nil
         end
+        s.combatHideEnabled = EllesmereUI.VisibilityModesContains(modes, "out_of_combat")
+        s.combatShowEnabled = EllesmereUI.VisibilityModesContains(modes, "in_combat")
+    end
 
-        s.combatHideEnabled = (v == "out_of_combat")
-        s.combatShowEnabled = (v == "in_combat")
+    local function ToggleVisibilityMode(s, mode, on)
+        local modes = GetVisibilityModes(s)
+        local new = {}
+        if on then
+            if mode == "never" then
+                new = { "never" }
+            elseif mode == "always" then
+                new = { "always" }
+            else
+                for i = 1, #modes do
+                    local m = modes[i]
+                    if m ~= "never" and m ~= "always" then
+                        new[#new + 1] = m
+                    end
+                end
+                if not EllesmereUI.VisibilityModesContains(new, mode) then
+                    new[#new + 1] = mode
+                end
+            end
+        else
+            for i = 1, #modes do
+                if modes[i] ~= mode then new[#new + 1] = modes[i] end
+            end
+            if #new == 0 then new = { "always" } end
+        end
+        ApplyVisibilityModes(s, new)
     end
 
     local function CopyVisibilitySettings(dst, src)
@@ -1133,15 +1155,40 @@ initFrame:SetScript("OnEvent", function(self)
             VisibilityCompat.Copy(dst, src)
             return
         end
-
-        local v = src.barVisibility or "always"
-        dst.barVisibility = v
-        dst.alwaysHidden = src.alwaysHidden
-        dst.mouseoverEnabled = src.mouseoverEnabled
+        local srcModes = GetVisibilityModes(src)
+        local modes = {}
+        for i = 1, #srcModes do modes[i] = srcModes[i] end
+        ApplyVisibilityModes(dst, modes)
         dst.mouseoverAlpha = src.mouseoverAlpha
         dst._savedBarAlpha = src._savedBarAlpha
-        dst.combatHideEnabled = src.combatHideEnabled
-        dst.combatShowEnabled = src.combatShowEnabled
+    end
+
+    local function RefreshVisibilityRuntime()
+        EAB:RefreshRuntimeVisibility()
+        EAB:RefreshMouseover()
+        EAB:ApplyCombatVisibility()
+    end
+
+    local function InstallVisibilityModesDropdown(region, getSettings, disabledFn)
+        if region._control then region._control:Hide() end
+        local PP = EllesmereUI.PanelPP
+        local cbDD, cbDDRefresh = EllesmereUI.BuildVisOptsCBDropdown(
+            region, 210, region:GetFrameLevel() + 2,
+            EllesmereUI.VIS_MODE_ITEMS,
+            function(mode)
+                local s = getSettings()
+                return s and EllesmereUI.VisibilityModesContains(GetVisibilityModes(s), mode) or false
+            end,
+            function(mode, on)
+                ToggleVisibilityMode(getSettings(), mode, on)
+                RefreshVisibilityRuntime()
+                EllesmereUI:RefreshPage()
+            end)
+        PP.Point(cbDD, "RIGHT", region, "RIGHT", -20, 0)
+        region._control = cbDD
+        region._lastInline = nil
+        EllesmereUI.RegisterWidgetRefresh(cbDDRefresh)
+        return cbDD
     end
 
 
@@ -1165,24 +1212,22 @@ initFrame:SetScript("OnEvent", function(self)
         local BLIZZ_DIS_TIP = "This option does not work with Blizzard Bars. Please use Blizzard Edit Mode."
         local function _blizzDis() return EAB.db.profile.useBlizzardDataBars end
 
-        -- Shared visibility row: left vis dropdown + right "Visibility Options" checkbox dropdown
+        -- Shared visibility row: left vis modes + right "Visibility Options" checkbox dropdown
         local function BuildVisRow(barKey, leftLabel, disabledFn, disTip)
             local visRow, visH = W:DualRow(parent, y,
                 { type="dropdown", text=leftLabel,
-                  values=EllesmereUI.VIS_VALUES, order=EllesmereUI.VIS_ORDER,
+                  values={ __placeholder = "..." }, order={ "__placeholder" },
                   disabled=disabledFn, disabledTooltip=disTip, rawTooltip=disTip and true or nil,
-                  getValue=function() return GetVisibilityKey(EAB.db.profile.bars[barKey]) end,
-                  setValue=function(v)
-                      ApplyVisibilityKey(EAB.db.profile.bars[barKey], v)
-                      EAB:RefreshRuntimeVisibility()
-                      EAB:RefreshMouseover()
-                      EAB:ApplyCombatVisibility()
-                      EllesmereUI:RefreshPage()
-                  end },
+                  getValue=function() return "__placeholder" end,
+                  setValue=function() end },
                 { type="dropdown", text="Visibility Options",
                   values={ __placeholder = "..." }, order={ "__placeholder" },
                   getValue=function() return "__placeholder" end,
                   setValue=function() end });  y = y - visH
+
+            InstallVisibilityModesDropdown(visRow._leftRegion, function()
+                return EAB.db.profile.bars[barKey]
+            end, disabledFn)
 
             -- Replace the dummy right dropdown with checkbox dropdown
             local rightRgn = visRow._rightRegion
@@ -1383,7 +1428,7 @@ initFrame:SetScript("OnEvent", function(self)
         -----------------------------------------------------------------------
         _, h = W:SectionHeader(parent, SECTION_VISIBILITY, y);  y = y - h
 
-        -- Row 1: Bar Visibility (dropdown) | Visibility Options
+        -- Row 1: Bar Visibility (multi-select) | Visibility Options
         do
             local _visBlizzDis
             local _VIS_BLIZZ_TIP = "This option does not work with Blizzard Bars. Please use Blizzard Edit Mode."
@@ -1394,22 +1439,16 @@ initFrame:SetScript("OnEvent", function(self)
             local visRow1
             visRow1, h = W:DualRow(parent, y,
                 { type="dropdown", text="Visibility",
-                  values=EllesmereUI.VIS_VALUES, order=EllesmereUI.VIS_ORDER,
+                  values={ __placeholder = "..." }, order={ "__placeholder" },
                   disabled=_visBlizzDis, disabledTooltip=_visBlizzDis and _VIS_BLIZZ_TIP or nil, rawTooltip=true,
-                  getValue=function()
-                      return GetVisibilityKey(SB())
-                  end,
-                  setValue=function(v)
-                      ApplyVisibilityKey(SB(), v)
-                      EAB:RefreshRuntimeVisibility()
-                      EAB:RefreshMouseover()
-                      EAB:ApplyCombatVisibility()
-                      EllesmereUI:RefreshPage()
-                  end },
+                  getValue=function() return "__placeholder" end,
+                  setValue=function() end },
                 { type="dropdown", text="Visibility Options",
                   values={ __placeholder = "..." }, order={ "__placeholder" },
                   getValue=function() return "__placeholder" end,
                   setValue=function() end });  y = y - h
+
+            InstallVisibilityModesDropdown(visRow1._leftRegion, function() return SB() end, _visBlizzDis)
 
             -- Replace the dummy right dropdown with checkbox dropdown
             do
@@ -1442,15 +1481,17 @@ initFrame:SetScript("OnEvent", function(self)
                             local dst = EAB.db.profile.bars[key]
                             CopyVisibilitySettings(dst, src)
                         end
-                        EAB:RefreshRuntimeVisibility()
-                        EAB:RefreshMouseover()
-                        EAB:ApplyCombatVisibility()
+                        RefreshVisibilityRuntime()
                         EllesmereUI:RefreshPage()
                     end,
                     isSynced = function()
-                        local v = SB().barVisibility or "always"
+                        local srcModes = GetVisibilityModes(SB())
                         for _, key in ipairs(GROUP_BAR_ORDER) do
-                            if (EAB.db.profile.bars[key].barVisibility or "always") ~= v then return false end
+                            if not EllesmereUI.VisibilityModesEqual(
+                                GetVisibilityModes(EAB.db.profile.bars[key]), srcModes
+                            ) then
+                                return false
+                            end
                         end
                         return true
                     end,
@@ -1465,9 +1506,7 @@ initFrame:SetScript("OnEvent", function(self)
                                 local dst = EAB.db.profile.bars[key]
                                 CopyVisibilitySettings(dst, src)
                             end
-                            EAB:RefreshRuntimeVisibility()
-                            EAB:RefreshMouseover()
-                            EAB:ApplyCombatVisibility()
+                            RefreshVisibilityRuntime()
                             EllesmereUI:RefreshPage()
                         end,
                     },

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -154,16 +154,22 @@ ns.BAR_LOOKUP          = BAR_LOOKUP
 ns.ALL_BARS            = ALL_BARS
 ns.EXTRA_BARS          = EXTRA_BARS
 
-function EAB.VisibilityCompat.ApplyMode(settings, mode)
-    if not settings then return "always" end
+function EAB.VisibilityCompat.ApplyModes(settings, modes)
+    if not settings then return { "always" } end
 
-    mode = mode or "always"
-    settings.barVisibility = mode
-    settings.alwaysHidden = (mode == "never")
+    if not modes or #modes == 0 then
+        modes = { "always" }
+    end
+
+    settings.barVisibilityModes = modes
+    settings.barVisibility = modes[1] or "always"
+    settings.alwaysHidden = (#modes == 1 and modes[1] == "never")
 
     local wasMouseover = settings.mouseoverEnabled
-    settings.mouseoverEnabled = (mode == "mouseover")
-    if mode == "mouseover" then
+    local hasMouseover = EllesmereUI and EllesmereUI.VisibilityModesContains(modes, "mouseover")
+    settings.mouseoverEnabled = hasMouseover or false
+
+    if hasMouseover then
         if not settings._savedBarAlpha then
             settings._savedBarAlpha = settings.mouseoverAlpha or 1
         end
@@ -173,44 +179,124 @@ function EAB.VisibilityCompat.ApplyMode(settings, mode)
         settings._savedBarAlpha = nil
     end
 
-    settings.combatHideEnabled = (mode == "out_of_combat")
-    settings.combatShowEnabled = (mode == "in_combat")
-    return mode
+    settings.combatHideEnabled = EllesmereUI and EllesmereUI.VisibilityModesContains(modes, "out_of_combat")
+    settings.combatShowEnabled = EllesmereUI and EllesmereUI.VisibilityModesContains(modes, "in_combat")
+    return modes
+end
+
+function EAB.VisibilityCompat.ApplyMode(settings, mode)
+    return EAB.VisibilityCompat.ApplyModes(settings, { mode or "always" })
 end
 
 function EAB.VisibilityCompat.Normalize(settings)
-    if not settings then return "always" end
+    if not settings then return { "always" } end
+    if settings.barVisibilityModes and #settings.barVisibilityModes > 0 then
+        return EAB.VisibilityCompat.ApplyModes(settings, settings.barVisibilityModes)
+    end
     if settings.barVisibility then
-        return EAB.VisibilityCompat.ApplyMode(settings, settings.barVisibility)
+        return EAB.VisibilityCompat.ApplyModes(settings, { settings.barVisibility })
     end
     if settings.alwaysHidden then
-        return EAB.VisibilityCompat.ApplyMode(settings, "never")
+        return EAB.VisibilityCompat.ApplyModes(settings, { "never" })
     end
     if settings.mouseoverEnabled then
-        return EAB.VisibilityCompat.ApplyMode(settings, "mouseover")
+        return EAB.VisibilityCompat.ApplyModes(settings, { "mouseover" })
     end
     if settings.combatShowEnabled then
-        return EAB.VisibilityCompat.ApplyMode(settings, "in_combat")
+        return EAB.VisibilityCompat.ApplyModes(settings, { "in_combat" })
     end
     if settings.combatHideEnabled then
-        return EAB.VisibilityCompat.ApplyMode(settings, "out_of_combat")
+        return EAB.VisibilityCompat.ApplyModes(settings, { "out_of_combat" })
     end
-    return EAB.VisibilityCompat.ApplyMode(settings, "always")
+    return EAB.VisibilityCompat.ApplyModes(settings, { "always" })
 end
 
 function EAB.VisibilityCompat.Copy(dst, src)
     if not dst or not src then return end
 
-    local mode = EAB.VisibilityCompat.Normalize(src)
-    EAB.VisibilityCompat.ApplyMode(dst, mode)
+    local srcModes = EllesmereUI and EllesmereUI.GetVisibilityModes(src) or { "always" }
+    local modes = {}
+    for i = 1, #srcModes do modes[i] = srcModes[i] end
+    EAB.VisibilityCompat.ApplyModes(dst, modes)
 
-    if mode == "mouseover" then
+    if EllesmereUI and EllesmereUI.VisibilityModesContains(modes, "mouseover") then
         dst._savedBarAlpha = src._savedBarAlpha or src.mouseoverAlpha or 1
         dst.mouseoverAlpha = 0
     else
         dst.mouseoverAlpha = src.mouseoverAlpha
         dst._savedBarAlpha = nil
     end
+end
+
+function EAB.VisibilityCompat.GetBarVisibilityState()
+    local inCombat = EAB_VTABLE.ExtraBars._managedNonSecureInCombat
+    if inCombat == nil then
+        inCombat = InCombatLockdown()
+    end
+    local inRaid = IsInRaid and IsInRaid() or false
+    local inGroup = IsInGroup and IsInGroup() or false
+    return {
+        inCombat = inCombat,
+        inRaid = inRaid,
+        inParty = inGroup and not inRaid,
+    }
+end
+
+function EAB.VisibilityCompat.HasMacroCondition(modes)
+    if not modes then return false end
+    for i = 1, #modes do
+        local m = modes[i]
+        if m ~= "always" and m ~= "never" and m ~= "mouseover" then return true end
+    end
+    return false
+end
+
+function EAB.VisibilityCompat.HasCondition(modes)
+    if not modes or #modes == 0 then return false end
+    if #modes == 1 and modes[1] == "always" then return false end
+    return true
+end
+
+function EAB.VisibilityCompat.GetModes(s)
+    if EllesmereUI and EllesmereUI.GetVisibilityModes then
+        return EllesmereUI.GetVisibilityModes(s)
+    end
+    return { s and s.barVisibility or "always" }
+end
+
+function EAB.VisibilityCompat.ModesContains(modes, mode)
+    if EllesmereUI and EllesmereUI.VisibilityModesContains then
+        return EllesmereUI.VisibilityModesContains(modes, mode)
+    end
+    for i = 1, #modes do
+        if modes[i] == mode then return true end
+    end
+    return false
+end
+
+function EAB.VisibilityCompat.BuildMacroSuffix(modes)
+    if EllesmereUI and EllesmereUI.BuildMacroVisibilitySuffix then
+        return EllesmereUI.BuildMacroVisibilitySuffix(modes)
+    end
+    if not modes or #modes == 0 then return "show" end
+    if EAB.VisibilityCompat.ModesContains(modes, "never") then return "hide" end
+    if EAB.VisibilityCompat.ModesContains(modes, "always") then return "show" end
+    if EAB.VisibilityCompat.ModesContains(modes, "mouseover") then return "show" end
+    local clauses = {
+        in_combat = "[combat] show",
+        out_of_combat = "[nocombat] show",
+        in_raid = "[group:raid] show",
+        in_party = "[group:party] show; [group:raid] show",
+        solo = "[nogroup] show",
+    }
+    local parts = {}
+    for i = 1, #modes do
+        local clause = clauses[modes[i]]
+        if clause then parts[#parts + 1] = clause end
+    end
+    if #parts == 0 then return "show" end
+    parts[#parts + 1] = "hide"
+    return table.concat(parts, "; ")
 end
 
 -------------------------------------------------------------------------------
@@ -382,6 +468,7 @@ for _, info in ipairs(BAR_CONFIG) do
         combatHideEnabled = false,
         housingHideEnabled = false,
         barVisibility = "always",
+        barVisibilityModes = { "always" },
         visHideHousing = false,
         visOnlyInstances = false,
         visHideMounted = false,
@@ -444,6 +531,7 @@ for _, k in ipairs({ "Bar9", "Bar10" }) do
     local b = defaults.profile.bars[k]
     if b then
         b.barVisibility = "never"
+        b.barVisibilityModes = { "never" }
         b.alwaysHidden  = true
     end
 end
@@ -548,8 +636,8 @@ local function ShouldQuickKeybindSurfaceBar(s)
 
     -- QuickKeybind should surface bars hidden by transient runtime rules,
     -- but explicit "Never" visibility remains authoritative.
-    local vis = s.barVisibility or "always"
-    return not s.alwaysHidden and vis ~= "never"
+    local modes = EAB.VisibilityCompat.GetModes(s)
+    return not s.alwaysHidden and not (#modes == 1 and modes[1] == "never")
 end
 
 local function FadeTo(frame, toAlpha, duration)
@@ -5176,6 +5264,9 @@ function EAB_VTABLE.Hover.FadeOut(barKey, state)
     if _gridState.shown then return end  -- keep bars visible during spell drag
     local s = EAB_VTABLE.Hover.GetSettings(barKey)
     if s and s.mouseoverEnabled and state and state.fadeDir ~= "out" then
+        if EAB.VisibilityCompat.IsMacroModeActive(s) then
+            return
+        end
 
         state.fadeDir = "out"
         StopFade(state.frame)
@@ -5339,11 +5430,16 @@ function EAB:RefreshMouseover()
                     if info.visibilityOnly and not info.isDataBar and not info.isBlizzardMovable then
                         AttachExtraBarHoverHooks(info)
                     end
-                    StopFade(frame)
-                    frame:SetAlpha(0)
-                    local state = hoverStates[key]
-                    if state then state.fadeDir = "out" end
-                    if key == "MainBar" then SyncPagingAlpha(0) end
+                    local modes = EAB.VisibilityCompat.GetModes(s)
+                    if EAB.VisibilityCompat.HasMacroCondition(modes) then
+                        EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, hoverStates[key])
+                    else
+                        StopFade(frame)
+                        frame:SetAlpha(0)
+                        local state = hoverStates[key]
+                        if state then state.fadeDir = "out" end
+                        if key == "MainBar" then SyncPagingAlpha(0) end
+                    end
                 else
                     StopFade(frame)
                     frame:SetAlpha(s.mouseoverAlpha or 1)
@@ -5370,9 +5466,65 @@ end
 --    PetBar:           Hide during pet battle.  Only show when the player has
 --                      a pet and is not in a vehicle/override/possess state.
 -------------------------------------------------------------------------------
-local function BuildVisibilityString(info, s)
+function EAB.VisibilityCompat.IsMacroModeActive(s)
+    if not s then return false end
+    local modes = EAB.VisibilityCompat.GetModes(s)
+    if not EAB.VisibilityCompat.HasMacroCondition(modes) then return false end
+    local state = EAB.VisibilityCompat.GetBarVisibilityState()
+    for i = 1, #modes do
+        local mode = modes[i]
+        if mode ~= "mouseover" and mode ~= "always" and mode ~= "never" then
+            if EllesmereUI and EllesmereUI.CheckVisibilityMode and EllesmereUI.CheckVisibilityMode(mode, state) then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+function EAB.VisibilityCompat.ShouldShowBar(s, hoverState)
+    if not s or s.enabled == false then return false end
+    if s.alwaysHidden then return false end
+    local modes = EAB.VisibilityCompat.GetModes(s)
+    if #modes == 1 and modes[1] == "never" then return false end
+    if EllesmereUI and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(s) then
+        return false
+    end
+    if EllesmereUI and EllesmereUI.CheckVisibilityModes then
+        return EllesmereUI.CheckVisibilityModes(
+            modes,
+            EAB.VisibilityCompat.GetBarVisibilityState(),
+            { isHovered = hoverState and hoverState.isHovered }
+        )
+    end
+    return EAB.VisibilityCompat.IsMacroModeActive(s)
+        or (EAB.VisibilityCompat.ModesContains(modes, "mouseover") and hoverState and hoverState.isHovered)
+end
+
+function EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, hoverState)
+    if not frame or not s then return end
+    local modes = EAB.VisibilityCompat.GetModes(s)
+    if not EAB.VisibilityCompat.ModesContains(modes, "mouseover") then return end
+    if not EAB.VisibilityCompat.HasMacroCondition(modes) then return end
+
+    local shouldShow = EAB.VisibilityCompat.ShouldShowBar(s, hoverState)
+    local targetAlpha = shouldShow and (s._savedBarAlpha or 1) or 0
+
+    StopFade(frame)
+    frame:SetAlpha(targetAlpha)
+    if key == "MainBar" then SyncPagingAlpha(targetAlpha) end
+    if hoverState then
+        hoverState.fadeDir = shouldShow and "in" or "out"
+    end
+
+    if barFrames[key] and frame == barFrames[key] then
+        SafeEnableMouseMotionOnly(frame, (shouldShow or s.mouseoverEnabled) and (not s.clickThrough or s.mouseoverEnabled))
+    end
+end
+
+function EAB.VisibilityCompat.BuildVisibilityString(info, s)
     local key = info.key
-    local vis = s.barVisibility or "always"
+    local modes = EAB.VisibilityCompat.GetModes(s)
 
     -- Build visibility-option hide clauses that can be expressed as macro
     -- conditionals. These run inside the secure state driver so they work
@@ -5385,18 +5537,7 @@ local function BuildVisibilityString(info, s)
     -- Pet bar has unique logic: it only shows when a pet is active and
     -- the player is not in a vehicle/override/possess state.
     if info.isPetBar then
-        local petShow
-        if vis == "in_combat" then
-            petShow = "[combat] show; hide"
-        elseif vis == "out_of_combat" then
-            petShow = "[nocombat] show; hide"
-        elseif s.combatShowEnabled then
-            petShow = "[combat] show; hide"
-        elseif s.combatHideEnabled then
-            petShow = "[combat] hide; show"
-        else
-            petShow = "show"
-        end
+        local petShow = EAB.VisibilityCompat.BuildMacroSuffix(modes)
         return "[petbattle] hide; " .. visOptHide .. "[novehicleui,pet,nooverridebar,nopossessbar] " .. petShow .. "; hide"
     end
 
@@ -5413,21 +5554,7 @@ local function BuildVisibilityString(info, s)
     -- Inject visibility-option hide clauses after the standard hide-prefix
     hidePrefix = hidePrefix .. visOptHide
 
-    -- Append visibility mode conditions
-    if vis == "never" then
-        return hidePrefix .. "hide"
-    elseif vis == "in_combat" then
-        return hidePrefix .. "[combat] show; hide"
-    elseif vis == "out_of_combat" then
-        return hidePrefix .. "[nocombat] show; hide"
-    elseif vis == "in_raid" then
-        return hidePrefix .. "[group:raid] show; hide"
-    elseif vis == "in_party" then
-        return hidePrefix .. "[group:party] show; [group:raid] show; hide"
-    elseif vis == "solo" then
-        return hidePrefix .. "[nogroup] show; hide"
-    end
-    return hidePrefix .. "show"
+    return hidePrefix .. EAB.VisibilityCompat.BuildMacroSuffix(modes)
 end
 
 -------------------------------------------------------------------------------
@@ -5451,22 +5578,12 @@ function EAB_VTABLE.ExtraBars.GetManagedNonSecureFrame(info)
 end
 
 function EAB_VTABLE.ExtraBars.GetManagedNonSecureVisibilityState()
-    local inCombat = EAB_VTABLE.ExtraBars._managedNonSecureInCombat
-    if inCombat == nil then
-        inCombat = InCombatLockdown()
-    end
-    local inRaid = IsInRaid and IsInRaid() or false
-    local inGroup = IsInGroup and IsInGroup() or false
-    return {
-        inCombat = inCombat,
-        inRaid = inRaid,
-        inParty = inGroup and not inRaid,
-    }
+    return EAB.VisibilityCompat.GetBarVisibilityState()
 end
 
-function EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s)
+function EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s, isHovered)
     if not s then return false end
-    local vis = EAB.VisibilityCompat.Normalize(s)
+    EAB.VisibilityCompat.Normalize(s)
     if C_PetBattles and C_PetBattles.IsInBattle and C_PetBattles.IsInBattle() then
         return false
     end
@@ -5474,13 +5591,16 @@ function EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s)
     if EllesmereUI and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(s) then
         return false
     end
-    if EllesmereUI and EllesmereUI.CheckVisibilityMode then
-        return EllesmereUI.CheckVisibilityMode(
-            vis,
-            EAB_VTABLE.ExtraBars.GetManagedNonSecureVisibilityState()
+    local modes = EAB.VisibilityCompat.GetModes(s)
+    if #modes == 1 and modes[1] == "never" then return false end
+    if EllesmereUI and EllesmereUI.CheckVisibilityModes then
+        return EllesmereUI.CheckVisibilityModes(
+            modes,
+            EAB.VisibilityCompat.GetBarVisibilityState(),
+            { isHovered = isHovered }
         )
     end
-    return vis ~= "never"
+    return not (#modes == 1 and modes[1] == "never")
 end
 
 function EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, reason, suppressed)
@@ -5509,14 +5629,14 @@ function EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, reason, supp
     end
 end
 
-function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s)
+function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s, shouldShow)
     if not frame or not s or not frame:IsShown() then return end
 
     local hstate = hoverStates[info.key]
     if s.mouseoverEnabled then
-        if hstate and hstate.isHovered then
-            frame:SetAlpha(1)
-            hstate.fadeDir = "in"
+        if shouldShow ~= false then
+            frame:SetAlpha(s._savedBarAlpha or 1)
+            if hstate then hstate.fadeDir = "in" end
         else
             frame:SetAlpha(0)
             if hstate then hstate.fadeDir = "out" end
@@ -5567,7 +5687,7 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, 
     end
 
     if shouldShow then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s)
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s, shouldShow)
     end
     EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, info.blizzOwnedVisibility, s, shouldShow)
 end
@@ -5579,7 +5699,10 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureVisibility(info)
     local frame = EAB_VTABLE.ExtraBars.GetManagedNonSecureFrame(info)
     if not s or not frame then return false, frame, s end
 
-    local shouldShow = EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s)
+    local hstate = hoverStates[info.key]
+    local shouldShow = EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(
+        s, hstate and hstate.isHovered
+    )
 
     if shouldShow and info.isDataBar and frame._updateFunc then
         frame._updateFunc()
@@ -5660,6 +5783,20 @@ end
 
 --  Combat Show/Hide, Runtime Visibility, Click-Through, Housing
 -------------------------------------------------------------------------------
+function EAB.VisibilityCompat.RefreshMixedModePresentation()
+    for _, info in ipairs(ALL_BARS) do
+        local key = info.key
+        local s = EAB.db and EAB.db.profile and EAB.db.profile.bars and EAB.db.profile.bars[key]
+        local frame = barFrames[key]
+        if s and frame then
+            local modes = EAB.VisibilityCompat.GetModes(s)
+            if s.mouseoverEnabled and EAB.VisibilityCompat.HasMacroCondition(modes) then
+                EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, hoverStates[key])
+            end
+        end
+    end
+end
+
 function EAB:ApplyCombatVisibility()
     if InCombatLockdown() then return end
     for _, info in ipairs(ALL_BARS) do
@@ -5674,7 +5811,7 @@ function EAB:ApplyCombatVisibility()
                 elseif EllesmereUI.CheckVisibilityOptionsNonMacro and EllesmereUI.CheckVisibilityOptionsNonMacro(s) then
                     newStr = "hide"
                 else
-                    newStr = BuildVisibilityString(info, s)
+                    newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
                 end
                 -- Skip re-registration if driver string is unchanged (avoids blink from re-evaluation)
                 if frame._eabLastVisStr ~= newStr then
@@ -5689,6 +5826,7 @@ function EAB:ApplyCombatVisibility()
     -- data bars).  These use a dedicated secure proxy since they are not
     -- SecureHandlerStateTemplate frames themselves.
     self:ApplyExtraBarVisibility()
+    EAB.VisibilityCompat.RefreshMixedModePresentation()
 end
 
 function EAB:RefreshRuntimeVisibility()
@@ -5701,8 +5839,8 @@ function EAB:RefreshRuntimeVisibility()
         else
         local frame = barFrames[key] or (info.isDataBar and dataBarFrames[key]) or (info.isBlizzardMovable and blizzMovableHolders[key]) or (extraBarHolders[key]) or (info.visibilityOnly and _G[info.frameName])
         if frame then
-            local vis = s.barVisibility or "always"
-            local isHidden = (vis == "never") or s.alwaysHidden
+            local modes = EAB.VisibilityCompat.GetModes(s)
+            local isHidden = s.alwaysHidden or (#modes == 1 and modes[1] == "never")
             if ShouldQuickKeybindSurfaceBar(s) and barFrames[key] and frame == barFrames[key] then
                 if not InCombatLockdown() then
                     RegisterAttributeDriver(frame, "state-visibility", "show")
@@ -5738,7 +5876,7 @@ function EAB:RefreshRuntimeVisibility()
                     if EllesmereUI.CheckVisibilityOptionsNonMacro and EllesmereUI.CheckVisibilityOptionsNonMacro(s) then
                         newStr = "hide"
                     else
-                        newStr = BuildVisibilityString(info, s)
+                        newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
                     end
                     if frame._eabLastVisStr ~= newStr then
 
@@ -5747,7 +5885,8 @@ function EAB:RefreshRuntimeVisibility()
                     end
                 end
                 if not InCombatLockdown() then
-                    if vis ~= "in_combat" and vis ~= "out_of_combat" and not s.combatShowEnabled then
+                    local hasMacroModes = EAB.VisibilityCompat.HasMacroCondition(modes)
+                    if not hasMacroModes then
                         -- Only Show frames without a state-visibility driver.
                         -- Frames with a driver (any _eabLastVisStr) are managed by the driver.
                         if not info.isBlizzardMovable and not info.blizzOwnedVisibility and not frame._eabLastVisStr then
@@ -5763,6 +5902,9 @@ function EAB:RefreshRuntimeVisibility()
                     else
                         SafeEnableMouse(frame, not s.clickThrough)
                     end
+                end
+                if barFrames[key] and frame == barFrames[key] then
+                    EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, hoverStates[key])
                 end
                 if info.isDataBar and frame._updateFunc then
                     frame._updateFunc()
@@ -5897,6 +6039,7 @@ function EAB:UpdateHousingVisibility()
                 else
                     local frame = barFrames[key] or (info.isDataBar and dataBarFrames[key]) or (info.isBlizzardMovable and blizzMovableHolders[key]) or (extraBarHolders[key]) or (info.visibilityOnly and _G[info.frameName])
                 if frame then
+                    local modes = EAB.VisibilityCompat.GetModes(s)
                     -- Secure action bar frames use the state driver for
                     -- target/enemy options; mounted-like druid forms are
                     -- additionally handled in ShouldHideNonMacro().
@@ -5920,9 +6063,9 @@ function EAB:UpdateHousingVisibility()
                         else
                             frame:Hide()
                         end
-                    elseif not s.alwaysHidden and (s.barVisibility or "always") ~= "never" then
+                    elseif not s.alwaysHidden and not (#modes == 1 and modes[1] == "never") then
                         if isSecure then
-                            local newStr = BuildVisibilityString(info, s)
+                            local newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
                             if frame._eabLastVisStr ~= newStr then
 
                                 frame._eabLastVisStr = newStr
@@ -8132,9 +8275,9 @@ function EAB:FinishSetup()
             local s = EAB.db.profile.bars[key]
             local frame = barFrames[key]
             if info and s and frame then
-                local vis = s.barVisibility or "always"
-                if vis ~= "always" and vis ~= "never" then
-                    RegisterAttributeDriver(frame, "state-visibility", BuildVisibilityString(info, s))
+                local modes = EAB.VisibilityCompat.GetModes(s)
+                if EAB.VisibilityCompat.HasCondition(modes) then
+                    RegisterAttributeDriver(frame, "state-visibility", EAB.VisibilityCompat.BuildVisibilityString(info, s))
                 end
                 if s.mouseoverEnabled then
                     -- The drag has fully ended (cursor cleared, checked above). If
@@ -8148,9 +8291,8 @@ function EAB:FinishSetup()
                         frame:SetAlpha(s._savedBarAlpha or 1)
                         if key == "MainBar" then SyncPagingAlpha(s._savedBarAlpha or 1) end
                     else
-                        if state then state.isHovered = false; state.fadeDir = "out" end
-                        frame:SetAlpha(0)
-                        if key == "MainBar" then SyncPagingAlpha(0) end
+                        if state then state.isHovered = false end
+                        EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, state)
                     end
                 end
             end
@@ -8172,8 +8314,8 @@ function EAB:FinishSetup()
                         local s = EAB.db.profile.bars[info.key]
                         local frame = barFrames[info.key]
                         if s and frame and not s.alwaysHidden then
-                            local vis = s.barVisibility or "always"
-                            local hasCondition = vis ~= "always" and vis ~= "never"
+                            local modes = EAB.VisibilityCompat.GetModes(s)
+                            local hasCondition = EAB.VisibilityCompat.HasCondition(modes)
                                 or s.visHideNoTarget or s.visHideNoEnemy
                                 or s.visHideMounted or s.visOnlyInstances
                             if hasCondition then
@@ -8446,6 +8588,7 @@ function EAB:FinishSetup()
     end)
 
     self:RegisterEvent("PLAYER_REGEN_ENABLED", function()
+        EAB_VTABLE.ExtraBars._managedNonSecureInCombat = false
         -- Re-apply anything that was deferred during combat
         ApplyAll()
         -- Restore any strata changes that couldn't be done in combat
@@ -8455,7 +8598,9 @@ function EAB:FinishSetup()
     end)
 
     self:RegisterEvent("PLAYER_REGEN_DISABLED", function()
+        EAB_VTABLE.ExtraBars._managedNonSecureInCombat = true
         _quickKeybindState.ReassertButtonsAfterCombatChange()
+        EAB.VisibilityCompat.RefreshMixedModePresentation()
     end)
 
     self:RegisterEvent("PLAYER_ENTERING_WORLD", function()
@@ -8557,7 +8702,7 @@ function EAB:FinishSetup()
                             RegisterAttributeDriver(frame, "state-visibility", "hide")
                         end
                     else
-                        local newStr = BuildVisibilityString(info, s)
+                        local newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
                         if frame._eabLastVisStr ~= newStr then
                             frame._eabLastVisStr = newStr
                             RegisterAttributeDriver(frame, "state-visibility", newStr)
@@ -8593,7 +8738,7 @@ function EAB:FinishSetup()
                 if s and s.visHideNoTarget then
                     local frame = barFrames[info.key]
                     if frame then
-                        local newStr = BuildVisibilityString(info, s)
+                        local newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
                         if frame._eabLastVisStr ~= newStr then
                             frame._eabLastVisStr = newStr
                             RegisterAttributeDriver(frame, "state-visibility", newStr)
@@ -8807,7 +8952,7 @@ function EAB:FinishSetup()
             local petFrame = barFrames["PetBar"]
             local petS = self.db.profile.bars["PetBar"]
             if petInfo and petFrame and petS and not petS.alwaysHidden then
-                RegisterAttributeDriver(petFrame, "state-visibility", BuildVisibilityString(petInfo, petS))
+                RegisterAttributeDriver(petFrame, "state-visibility", EAB.VisibilityCompat.BuildVisibilityString(petInfo, petS))
             end
         end)
     end

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -154,22 +154,96 @@ ns.BAR_LOOKUP          = BAR_LOOKUP
 ns.ALL_BARS            = ALL_BARS
 ns.EXTRA_BARS          = EXTRA_BARS
 
-function EAB.VisibilityCompat.ApplyModes(settings, modes)
-    if not settings then return { "always" } end
-
-    if not modes or #modes == 0 then
-        modes = { "always" }
+function EAB.VisibilityCompat.GetModes(settings)
+    if EllesmereUI and EllesmereUI.GetVisibilityModes then
+        return EllesmereUI.GetVisibilityModes(settings)
     end
+    if not settings then return { "always" } end
+    return { settings.barVisibility or "always" }
+end
 
-    settings.barVisibilityModes = modes
+function EAB.VisibilityCompat.HasMode(settings, mode)
+    local modes = EAB.VisibilityCompat.GetModes(settings)
+    for i = 1, #modes do
+        if modes[i] == mode then return true end
+    end
+    return false
+end
+
+function EAB.VisibilityCompat.GetPrimaryMode(settings)
+    local modes = EAB.VisibilityCompat.GetModes(settings)
+    return modes[1] or "always"
+end
+
+function EAB.VisibilityCompat.IsNever(settings)
+    return EAB.VisibilityCompat.HasMode(settings, "never")
+end
+
+function EAB.VisibilityCompat.IsAlwaysOnly(settings)
+    local modes = EAB.VisibilityCompat.GetModes(settings)
+    return #modes == 1 and modes[1] == "always"
+end
+
+function EAB.VisibilityCompat.HasMacroModes(settings)
+    local modes = EAB.VisibilityCompat.GetModes(settings)
+    for i = 1, #modes do
+        local mode = modes[i]
+        if mode ~= "always" and mode ~= "never" and mode ~= "mouseover" then
+            return true
+        end
+    end
+    return false
+end
+
+function EAB.VisibilityCompat.NeedsMixedPresentation(settings)
+    return EAB.VisibilityCompat.HasMode(settings, "mouseover")
+        and EAB.VisibilityCompat.HasMacroModes(settings)
+end
+
+function EAB.VisibilityCompat.IsToggleEligible(settings)
+    local modes = EAB.VisibilityCompat.GetModes(settings)
+    return #modes == 1 and (modes[1] == "always" or modes[1] == "never")
+end
+
+function EAB.VisibilityCompat.HasConditionalVisibility(settings)
+    if not settings or settings.alwaysHidden or EAB.VisibilityCompat.IsNever(settings) then
+        return false
+    end
+    if not EAB.VisibilityCompat.IsAlwaysOnly(settings) then return true end
+    return settings.visHideNoTarget or settings.visHideNoEnemy
+        or settings.visHideMounted or settings.visOnlyInstances
+end
+
+function EAB.VisibilityCompat.ShouldShowBar(s, state, isHovered)
+    if not s then return false end
+    if s.alwaysHidden or EAB.VisibilityCompat.IsNever(s) then return false end
+    if EllesmereUI and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(s) then
+        return false
+    end
+    if EllesmereUI and EllesmereUI.CheckVisibilityModes then
+        return EllesmereUI.CheckVisibilityModes(
+            EAB.VisibilityCompat.GetModes(s),
+            state,
+            isHovered
+        )
+    end
+    return true
+end
+
+function EAB.VisibilityCompat.ApplyModes(settings, modes)
+    if not settings then return end
+    if not modes or #modes == 0 then modes = { "always" } end
+
+    settings.barVisibilityModes = {}
+    for i = 1, #modes do
+        settings.barVisibilityModes[i] = modes[i]
+    end
     settings.barVisibility = modes[1] or "always"
-    settings.alwaysHidden = (#modes == 1 and modes[1] == "never")
+    settings.alwaysHidden = EAB.VisibilityCompat.HasMode(settings, "never")
 
     local wasMouseover = settings.mouseoverEnabled
-    local hasMouseover = EllesmereUI and EllesmereUI.VisibilityModesContains(modes, "mouseover")
-    settings.mouseoverEnabled = hasMouseover or false
-
-    if hasMouseover then
+    settings.mouseoverEnabled = EAB.VisibilityCompat.HasMode(settings, "mouseover")
+    if settings.mouseoverEnabled then
         if not settings._savedBarAlpha then
             settings._savedBarAlpha = settings.mouseoverAlpha or 1
         end
@@ -179,47 +253,31 @@ function EAB.VisibilityCompat.ApplyModes(settings, modes)
         settings._savedBarAlpha = nil
     end
 
-    settings.combatHideEnabled = EllesmereUI and EllesmereUI.VisibilityModesContains(modes, "out_of_combat")
-    settings.combatShowEnabled = EllesmereUI and EllesmereUI.VisibilityModesContains(modes, "in_combat")
-    return modes
+    settings.combatHideEnabled = EAB.VisibilityCompat.HasMode(settings, "out_of_combat")
+    settings.combatShowEnabled = EAB.VisibilityCompat.HasMode(settings, "in_combat")
 end
 
 function EAB.VisibilityCompat.ApplyMode(settings, mode)
-    return EAB.VisibilityCompat.ApplyModes(settings, { mode or "always" })
+    if not settings then return mode or "always" end
+    mode = mode or "always"
+    EAB.VisibilityCompat.ApplyModes(settings, { mode })
+    return mode
 end
 
 function EAB.VisibilityCompat.Normalize(settings)
     if not settings then return { "always" } end
-    if settings.barVisibilityModes and #settings.barVisibilityModes > 0 then
-        return EAB.VisibilityCompat.ApplyModes(settings, settings.barVisibilityModes)
-    end
-    if settings.barVisibility then
-        return EAB.VisibilityCompat.ApplyModes(settings, { settings.barVisibility })
-    end
-    if settings.alwaysHidden then
-        return EAB.VisibilityCompat.ApplyModes(settings, { "never" })
-    end
-    if settings.mouseoverEnabled then
-        return EAB.VisibilityCompat.ApplyModes(settings, { "mouseover" })
-    end
-    if settings.combatShowEnabled then
-        return EAB.VisibilityCompat.ApplyModes(settings, { "in_combat" })
-    end
-    if settings.combatHideEnabled then
-        return EAB.VisibilityCompat.ApplyModes(settings, { "out_of_combat" })
-    end
-    return EAB.VisibilityCompat.ApplyModes(settings, { "always" })
+    local modes = EAB.VisibilityCompat.GetModes(settings)
+    EAB.VisibilityCompat.ApplyModes(settings, modes)
+    return modes
 end
 
 function EAB.VisibilityCompat.Copy(dst, src)
     if not dst or not src then return end
 
-    local srcModes = EllesmereUI and EllesmereUI.GetVisibilityModes(src) or { "always" }
-    local modes = {}
-    for i = 1, #srcModes do modes[i] = srcModes[i] end
+    local modes = EAB.VisibilityCompat.GetModes(src)
     EAB.VisibilityCompat.ApplyModes(dst, modes)
 
-    if EllesmereUI and EllesmereUI.VisibilityModesContains(modes, "mouseover") then
+    if EAB.VisibilityCompat.HasMode(dst, "mouseover") then
         dst._savedBarAlpha = src._savedBarAlpha or src.mouseoverAlpha or 1
         dst.mouseoverAlpha = 0
     else
@@ -228,75 +286,12 @@ function EAB.VisibilityCompat.Copy(dst, src)
     end
 end
 
-function EAB.VisibilityCompat.GetBarVisibilityState()
-    local inCombat = EAB_VTABLE.ExtraBars._managedNonSecureInCombat
-    if inCombat == nil then
-        inCombat = InCombatLockdown()
-    end
-    local inRaid = IsInRaid and IsInRaid() or false
-    local inGroup = IsInGroup and IsInGroup() or false
-    return {
-        inCombat = inCombat,
-        inRaid = inRaid,
-        inParty = inGroup and not inRaid,
-    }
-end
-
-function EAB.VisibilityCompat.HasMacroCondition(modes)
-    if not modes then return false end
-    for i = 1, #modes do
-        local m = modes[i]
-        if m ~= "always" and m ~= "never" and m ~= "mouseover" then return true end
-    end
-    return false
-end
-
-function EAB.VisibilityCompat.HasCondition(modes)
-    if not modes or #modes == 0 then return false end
-    if #modes == 1 and modes[1] == "always" then return false end
-    return true
-end
-
-function EAB.VisibilityCompat.GetModes(s)
-    if EllesmereUI and EllesmereUI.GetVisibilityModes then
-        return EllesmereUI.GetVisibilityModes(s)
-    end
-    return { s and s.barVisibility or "always" }
-end
-
-function EAB.VisibilityCompat.ModesContains(modes, mode)
-    if EllesmereUI and EllesmereUI.VisibilityModesContains then
-        return EllesmereUI.VisibilityModesContains(modes, mode)
-    end
-    for i = 1, #modes do
-        if modes[i] == mode then return true end
-    end
-    return false
-end
-
-function EAB.VisibilityCompat.BuildMacroSuffix(modes)
+function EAB.VisibilityCompat.BuildMacroSuffix(settings, modesOverride)
+    local modes = modesOverride or EAB.VisibilityCompat.GetModes(settings)
     if EllesmereUI and EllesmereUI.BuildMacroVisibilitySuffix then
         return EllesmereUI.BuildMacroVisibilitySuffix(modes)
     end
-    if not modes or #modes == 0 then return "show" end
-    if EAB.VisibilityCompat.ModesContains(modes, "never") then return "hide" end
-    if EAB.VisibilityCompat.ModesContains(modes, "always") then return "show" end
-    if EAB.VisibilityCompat.ModesContains(modes, "mouseover") then return "show" end
-    local clauses = {
-        in_combat = "[combat] show",
-        out_of_combat = "[nocombat] show",
-        in_raid = "[group:raid] show",
-        in_party = "[group:party] show; [group:raid] show",
-        solo = "[nogroup] show",
-    }
-    local parts = {}
-    for i = 1, #modes do
-        local clause = clauses[modes[i]]
-        if clause then parts[#parts + 1] = clause end
-    end
-    if #parts == 0 then return "show" end
-    parts[#parts + 1] = "hide"
-    return table.concat(parts, "; ")
+    return "show"
 end
 
 -------------------------------------------------------------------------------
@@ -636,8 +631,7 @@ local function ShouldQuickKeybindSurfaceBar(s)
 
     -- QuickKeybind should surface bars hidden by transient runtime rules,
     -- but explicit "Never" visibility remains authoritative.
-    local modes = EAB.VisibilityCompat.GetModes(s)
-    return not s.alwaysHidden and not (#modes == 1 and modes[1] == "never")
+    return not s.alwaysHidden and not EAB.VisibilityCompat.IsNever(s)
 end
 
 local function FadeTo(frame, toAlpha, duration)
@@ -1749,6 +1743,10 @@ EAB_VTABLE.PAGING_STATES = {
         { id = "shift", macro = "[mod:shift]", label = "Shift" },
         { id = "ctrl",  macro = "[mod:ctrl]",  label = "Ctrl" },
     },
+    target = {
+        { id = "help",  macro = "[help]",      label = "Friendly Target" },
+        { id = "harm",  macro = "[harm]",      label = "Hostile Target" },
+    },
     class = {
         DRUID = {
             { id = "prowl",   macro = "[bonusbar:1,stealth]", label = "Prowl" },
@@ -1813,6 +1811,16 @@ function EAB_VTABLE.BuildPagingConditions(barKey, pagingConfig, defaultPage)
         parts[#parts + 1] = "[bonusbar:5] 11"
         for i = 2, NUM_AB_PAGES do
             parts[#parts + 1] = "[bar:" .. i .. "] " .. i
+        end
+    end
+    -- Target conditions come after bonusbar/bar so dragonriding and manual
+    -- page switches always take priority over target-based switching.
+    if PG.target then
+        for _, state in ipairs(PG.target) do
+            local page = pagingConfig[state.id]
+            if page then
+                parts[#parts + 1] = state.macro .. " " .. page
+            end
         end
     end
     parts[#parts + 1] = tostring(defaultPage or 1)
@@ -1930,7 +1938,7 @@ local function SetupPagingFrame()
 
     -- Page number text
     local pageText = f:CreateFontString(nil, "OVERLAY")
-    pageText:SetFont(STANDARD_TEXT_FONT, 12, "OUTLINE, SLUG")
+    pageText:SetFont(STANDARD_TEXT_FONT, 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     pageText:SetTextColor(1, 1, 1, 0.9)
     pageText:SetText("1")
     f._pageText = pageText
@@ -1977,11 +1985,16 @@ local function SetupPagingFrame()
             local s = EAB and EAB.db and EAB.db.profile and EAB.db.profile.bars and EAB.db.profile.bars["MainBar"]
             if s and not InCombatLockdown() then
                 local inCombat = (event == "PLAYER_REGEN_DISABLED")
-                if s.combatShowEnabled then
+                local hasInCombat = EAB.VisibilityCompat.HasMode(s, "in_combat")
+                local hasOutOfCombat = EAB.VisibilityCompat.HasMode(s, "out_of_combat")
+                if hasInCombat and not hasOutOfCombat then
                     if inCombat then f:Show() else f:Hide() end
-                elseif s.combatHideEnabled then
+                elseif hasOutOfCombat and not hasInCombat then
                     if inCombat then f:Hide() else f:Show() end
                 end
+            end
+            if EAB.VisibilityCompat.RefreshAllMixedModePresentations then
+                EAB.VisibilityCompat.RefreshAllMixedModePresentations()
             end
             return
         end
@@ -2049,7 +2062,7 @@ LayoutPagingFrame = function()
 
     f._upBtn:SetSize(arrowSize, arrowSize)
     f._downBtn:SetSize(arrowSize, arrowSize)
-    f._pageText:SetFont(STANDARD_TEXT_FONT, textSize, "OUTLINE, SLUG")
+    f._pageText:SetFont(STANDARD_TEXT_FONT, textSize, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
 
     f._upBtn:ClearAllPoints()
     f._downBtn:ClearAllPoints()
@@ -4507,7 +4520,7 @@ function EAB:ApplyFontsForBar(barKey)
             else
                 nm:SetAlpha(1)
                 if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(nm, false) end
-                nm:SetFont(fontPath, macroSize, "OUTLINE, SLUG")
+                nm:SetFont(fontPath, macroSize, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
                 nm:SetTextColor(macroColor.r, macroColor.g, macroColor.b)
                 nm:ClearAllPoints()
                 nm:SetPoint("BOTTOMLEFT", btn, "BOTTOMLEFT", 1 + macroOX, 4 + macroOY)
@@ -5218,6 +5231,48 @@ end
 local hoverStates = {}  -- shared by action bars, data bars, and extra bars
 local AttachExtraBarHoverHooks  -- forward declaration; defined near SetupExtraBarHolder
 
+function EAB.VisibilityCompat.ApplyBarPresentation(info, frame, s, state, isHovered)
+    if not frame or not s then return end
+    local barKey = info and info.key
+    local targetAlpha = s._savedBarAlpha or s.mouseoverAlpha or 1
+    local shouldShow = EAB.VisibilityCompat.ShouldShowBar(s, state, isHovered)
+    local hstate = barKey and hoverStates[barKey]
+
+    if shouldShow then
+        if hstate then hstate.fadeDir = "in" end
+        StopFade(frame)
+        FadeTo(frame, targetAlpha, s.mouseoverSpeed or 0.15)
+        if barKey == "MainBar" then SyncPagingAlpha(targetAlpha) end
+    else
+        if hstate then hstate.fadeDir = "out" end
+        StopFade(frame)
+        FadeTo(frame, 0, s.mouseoverSpeed or 0.15)
+        if barKey == "MainBar" then SyncPagingAlpha(0) end
+    end
+end
+
+function EAB.VisibilityCompat.RefreshMixedModePresentation(info, frame, s)
+    if not frame or not s or not EAB.VisibilityCompat.NeedsMixedPresentation(s) then return end
+    local state = EAB_VTABLE.ExtraBars.GetManagedNonSecureVisibilityState()
+    local isHovered = info.key and hoverStates[info.key] and hoverStates[info.key].isHovered
+    EAB.VisibilityCompat.ApplyBarPresentation(info, frame, s, state, isHovered)
+end
+
+function EAB.VisibilityCompat.RefreshAllMixedModePresentations()
+    if not EAB.db or not EAB.db.profile or not EAB.db.profile.bars then return end
+    for _, info in ipairs(ALL_BARS) do
+        local s = EAB.db.profile.bars[info.key]
+        if s and EAB.VisibilityCompat.NeedsMixedPresentation(s) then
+            local frame = barFrames[info.key]
+                or (info.isDataBar and dataBarFrames[info.key])
+                or extraBarHolders[info.key]
+            if frame then
+                EAB.VisibilityCompat.RefreshMixedModePresentation(info, frame, s)
+            end
+        end
+    end
+end
+
 -- Every mouseover-enabled bar follows the same state machine: entering marks
 -- the bar hovered and fades it in, leaving schedules a guarded fade-out on the
 -- next frame. The per-bar attach functions only provide the edge-case policies
@@ -5241,38 +5296,74 @@ ns._broadcastingMouseover = false
 
 function EAB_VTABLE.Hover.FadeIn(barKey, state)
     local s = EAB_VTABLE.Hover.GetSettings(barKey)
-    if s and s.mouseoverEnabled and state and state.fadeDir ~= "in" then
-        local targetAlpha = s._savedBarAlpha or 1
-        state.fadeDir = "in"
-        StopFade(state.frame)
-        FadeTo(state.frame, targetAlpha, s.mouseoverSpeed or 0.15)
-        if barKey == "MainBar" then SyncPagingAlpha(targetAlpha) end
-        -- Broadcast to all other mouseover-enabled bars
+    if not s or not s.mouseoverEnabled or not state or state.fadeDir == "in" then return end
+
+    local info = BAR_LOOKUP[barKey]
+    if info and EAB.VisibilityCompat.NeedsMixedPresentation(s) then
+        EAB.VisibilityCompat.RefreshMixedModePresentation(info, state.frame, s)
         if not ns._broadcastingMouseover and EAB.db.profile.mouseoverShowAll then
             ns._broadcastingMouseover = true
             for otherKey, otherState in pairs(hoverStates) do
                 if otherKey ~= barKey then
-                    EAB_VTABLE.Hover.FadeIn(otherKey, otherState)
+                    local os = EAB_VTABLE.Hover.GetSettings(otherKey)
+                    local oinfo = BAR_LOOKUP[otherKey]
+                    if os and oinfo and EAB.VisibilityCompat.NeedsMixedPresentation(os) then
+                        EAB.VisibilityCompat.RefreshMixedModePresentation(oinfo, otherState.frame, os)
+                    else
+                        EAB_VTABLE.Hover.FadeIn(otherKey, otherState)
+                    end
                 end
             end
             ns._broadcastingMouseover = false
         end
+        return
+    end
+
+    local targetAlpha = s._savedBarAlpha or 1
+    state.fadeDir = "in"
+    StopFade(state.frame)
+    FadeTo(state.frame, targetAlpha, s.mouseoverSpeed or 0.15)
+    if barKey == "MainBar" then SyncPagingAlpha(targetAlpha) end
+    -- Broadcast to all other mouseover-enabled bars
+    if not ns._broadcastingMouseover and EAB.db.profile.mouseoverShowAll then
+        ns._broadcastingMouseover = true
+        for otherKey, otherState in pairs(hoverStates) do
+            if otherKey ~= barKey then
+                EAB_VTABLE.Hover.FadeIn(otherKey, otherState)
+            end
+        end
+        ns._broadcastingMouseover = false
     end
 end
 
 function EAB_VTABLE.Hover.FadeOut(barKey, state)
     if _gridState.shown then return end  -- keep bars visible during spell drag
     local s = EAB_VTABLE.Hover.GetSettings(barKey)
-    if s and s.mouseoverEnabled and state and state.fadeDir ~= "out" then
-        if EAB.VisibilityCompat.IsMacroModeActive(s) then
-            return
-        end
+    if not s or not s.mouseoverEnabled or not state or state.fadeDir == "out" then return end
 
-        state.fadeDir = "out"
-        StopFade(state.frame)
-        FadeTo(state.frame, 0, s.mouseoverSpeed or 0.15)
-        if barKey == "MainBar" then SyncPagingAlpha(0) end
+    local info = BAR_LOOKUP[barKey]
+    if info and EAB.VisibilityCompat.NeedsMixedPresentation(s) then
+        EAB.VisibilityCompat.RefreshMixedModePresentation(info, state.frame, s)
+        if EAB.db.profile.mouseoverShowAll then
+            for otherKey, otherState in pairs(hoverStates) do
+                if otherKey ~= barKey and not otherState.isHovered then
+                    local os = EAB_VTABLE.Hover.GetSettings(otherKey)
+                    local oinfo = BAR_LOOKUP[otherKey]
+                    if os and oinfo and EAB.VisibilityCompat.NeedsMixedPresentation(os) then
+                        EAB.VisibilityCompat.RefreshMixedModePresentation(oinfo, otherState.frame, os)
+                    elseif not otherState.isHovered then
+                        EAB_VTABLE.Hover.FadeOut(otherKey, otherState)
+                    end
+                end
+            end
+        end
+        return
     end
+
+    state.fadeDir = "out"
+    StopFade(state.frame)
+    FadeTo(state.frame, 0, s.mouseoverSpeed or 0.15)
+    if barKey == "MainBar" then SyncPagingAlpha(0) end
 end
 
 -- Check if any mouseover-enabled bar is currently hovered.
@@ -5430,16 +5521,11 @@ function EAB:RefreshMouseover()
                     if info.visibilityOnly and not info.isDataBar and not info.isBlizzardMovable then
                         AttachExtraBarHoverHooks(info)
                     end
-                    local modes = EAB.VisibilityCompat.GetModes(s)
-                    if EAB.VisibilityCompat.HasMacroCondition(modes) then
-                        EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, hoverStates[key])
-                    else
-                        StopFade(frame)
-                        frame:SetAlpha(0)
-                        local state = hoverStates[key]
-                        if state then state.fadeDir = "out" end
-                        if key == "MainBar" then SyncPagingAlpha(0) end
-                    end
+                    StopFade(frame)
+                    frame:SetAlpha(0)
+                    local state = hoverStates[key]
+                    if state then state.fadeDir = "out" end
+                    if key == "MainBar" then SyncPagingAlpha(0) end
                 else
                     StopFade(frame)
                     frame:SetAlpha(s.mouseoverAlpha or 1)
@@ -5450,6 +5536,7 @@ function EAB:RefreshMouseover()
             end
         end
     end
+    EAB.VisibilityCompat.RefreshAllMixedModePresentations()
 end
 
 -------------------------------------------------------------------------------
@@ -5466,65 +5553,13 @@ end
 --    PetBar:           Hide during pet battle.  Only show when the player has
 --                      a pet and is not in a vehicle/override/possess state.
 -------------------------------------------------------------------------------
-function EAB.VisibilityCompat.IsMacroModeActive(s)
-    if not s then return false end
-    local modes = EAB.VisibilityCompat.GetModes(s)
-    if not EAB.VisibilityCompat.HasMacroCondition(modes) then return false end
-    local state = EAB.VisibilityCompat.GetBarVisibilityState()
-    for i = 1, #modes do
-        local mode = modes[i]
-        if mode ~= "mouseover" and mode ~= "always" and mode ~= "never" then
-            if EllesmereUI and EllesmereUI.CheckVisibilityMode and EllesmereUI.CheckVisibilityMode(mode, state) then
-                return true
-            end
-        end
+local function BuildVisibilityString(info, s, visOverride)
+    local modes
+    if visOverride then
+        modes = { visOverride }
+    else
+        modes = EAB.VisibilityCompat.GetModes(s)
     end
-    return false
-end
-
-function EAB.VisibilityCompat.ShouldShowBar(s, hoverState)
-    if not s or s.enabled == false then return false end
-    if s.alwaysHidden then return false end
-    local modes = EAB.VisibilityCompat.GetModes(s)
-    if #modes == 1 and modes[1] == "never" then return false end
-    if EllesmereUI and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(s) then
-        return false
-    end
-    if EllesmereUI and EllesmereUI.CheckVisibilityModes then
-        return EllesmereUI.CheckVisibilityModes(
-            modes,
-            EAB.VisibilityCompat.GetBarVisibilityState(),
-            { isHovered = hoverState and hoverState.isHovered }
-        )
-    end
-    return EAB.VisibilityCompat.IsMacroModeActive(s)
-        or (EAB.VisibilityCompat.ModesContains(modes, "mouseover") and hoverState and hoverState.isHovered)
-end
-
-function EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, hoverState)
-    if not frame or not s then return end
-    local modes = EAB.VisibilityCompat.GetModes(s)
-    if not EAB.VisibilityCompat.ModesContains(modes, "mouseover") then return end
-    if not EAB.VisibilityCompat.HasMacroCondition(modes) then return end
-
-    local shouldShow = EAB.VisibilityCompat.ShouldShowBar(s, hoverState)
-    local targetAlpha = shouldShow and (s._savedBarAlpha or 1) or 0
-
-    StopFade(frame)
-    frame:SetAlpha(targetAlpha)
-    if key == "MainBar" then SyncPagingAlpha(targetAlpha) end
-    if hoverState then
-        hoverState.fadeDir = shouldShow and "in" or "out"
-    end
-
-    if barFrames[key] and frame == barFrames[key] then
-        SafeEnableMouseMotionOnly(frame, (shouldShow or s.mouseoverEnabled) and (not s.clickThrough or s.mouseoverEnabled))
-    end
-end
-
-function EAB.VisibilityCompat.BuildVisibilityString(info, s)
-    local key = info.key
-    local modes = EAB.VisibilityCompat.GetModes(s)
 
     -- Build visibility-option hide clauses that can be expressed as macro
     -- conditionals. These run inside the secure state driver so they work
@@ -5534,16 +5569,23 @@ function EAB.VisibilityCompat.BuildVisibilityString(info, s)
     if s.visHideNoTarget then visOptHide = visOptHide .. "[noexists] hide; " end
     if s.visHideNoEnemy then visOptHide = visOptHide .. "[noharm] hide; " end
 
+    local modeSuffix
+    if not visOverride and EAB.VisibilityCompat.NeedsMixedPresentation(s) then
+        -- Mouseover + macro modes: secure driver stays "show"; alpha in Lua.
+        modeSuffix = "show"
+    else
+        modeSuffix = EAB.VisibilityCompat.BuildMacroSuffix(s, modes)
+    end
+
     -- Pet bar has unique logic: it only shows when a pet is active and
     -- the player is not in a vehicle/override/possess state.
     if info.isPetBar then
-        local petShow = EAB.VisibilityCompat.BuildMacroSuffix(modes)
-        return "[petbattle] hide; " .. visOptHide .. "[novehicleui,pet,nooverridebar,nopossessbar] " .. petShow .. "; hide"
+        return "[petbattle] hide; " .. visOptHide .. "[novehicleui,pet,nooverridebar,nopossessbar] " .. modeSuffix .. "; hide"
     end
 
     -- Build the hide-prefix based on bar type
     local hidePrefix
-    if key == "MainBar" then
+    if info.key == "MainBar" then
         hidePrefix = "[petbattle] hide; "
     elseif info.isStance then
         hidePrefix = "[vehicleui][petbattle] hide; "
@@ -5554,7 +5596,7 @@ function EAB.VisibilityCompat.BuildVisibilityString(info, s)
     -- Inject visibility-option hide clauses after the standard hide-prefix
     hidePrefix = hidePrefix .. visOptHide
 
-    return hidePrefix .. EAB.VisibilityCompat.BuildMacroSuffix(modes)
+    return hidePrefix .. modeSuffix
 end
 
 -------------------------------------------------------------------------------
@@ -5578,12 +5620,21 @@ function EAB_VTABLE.ExtraBars.GetManagedNonSecureFrame(info)
 end
 
 function EAB_VTABLE.ExtraBars.GetManagedNonSecureVisibilityState()
-    return EAB.VisibilityCompat.GetBarVisibilityState()
+    local inCombat = EAB_VTABLE.ExtraBars._managedNonSecureInCombat
+    if inCombat == nil then
+        inCombat = InCombatLockdown()
+    end
+    local inRaid = IsInRaid and IsInRaid() or false
+    local inGroup = IsInGroup and IsInGroup() or false
+    return {
+        inCombat = inCombat,
+        inRaid = inRaid,
+        inParty = inGroup and not inRaid,
+    }
 end
 
-function EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s, isHovered)
+function EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s, barKey)
     if not s then return false end
-    EAB.VisibilityCompat.Normalize(s)
     if C_PetBattles and C_PetBattles.IsInBattle and C_PetBattles.IsInBattle() then
         return false
     end
@@ -5591,32 +5642,15 @@ function EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s, isHovered)
     if EllesmereUI and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(s) then
         return false
     end
-    local modes = EAB.VisibilityCompat.GetModes(s)
-    if #modes == 1 and modes[1] == "never" then return false end
+    local isHovered = barKey and hoverStates[barKey] and hoverStates[barKey].isHovered
     if EllesmereUI and EllesmereUI.CheckVisibilityModes then
         return EllesmereUI.CheckVisibilityModes(
-            modes,
-            EAB.VisibilityCompat.GetBarVisibilityState(),
-            { isHovered = isHovered }
+            EAB.VisibilityCompat.GetModes(s),
+            EAB_VTABLE.ExtraBars.GetManagedNonSecureVisibilityState(),
+            isHovered
         )
     end
-    return not (#modes == 1 and modes[1] == "never")
-end
-
--- Mouseover bars must stay shown (alpha 0) so hover hooks can reveal them.
-function EAB_VTABLE.ExtraBars.ShouldKeepManagedNonSecureBarPresent(s)
-    if not s then return false end
-    EAB.VisibilityCompat.Normalize(s)
-    if C_PetBattles and C_PetBattles.IsInBattle and C_PetBattles.IsInBattle() then
-        return false
-    end
-    if s.enabled == false or s.alwaysHidden then return false end
-    if EllesmereUI and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(s) then
-        return false
-    end
-    local modes = EAB.VisibilityCompat.GetModes(s)
-    if #modes == 1 and modes[1] == "never" then return false end
-    return s.mouseoverEnabled == true
+    return not EAB.VisibilityCompat.IsNever(s)
 end
 
 function EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, reason, suppressed)
@@ -5645,14 +5679,24 @@ function EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, reason, supp
     end
 end
 
-function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s, shouldShow)
+function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s)
     if not frame or not s or not frame:IsShown() then return end
 
     local hstate = hoverStates[info.key]
-    if s.mouseoverEnabled then
-        if shouldShow ~= false then
-            frame:SetAlpha(s._savedBarAlpha or 1)
+    if EAB.VisibilityCompat.NeedsMixedPresentation(s) then
+        local state = EAB_VTABLE.ExtraBars.GetManagedNonSecureVisibilityState()
+        local isHovered = hstate and hstate.isHovered
+        if EAB.VisibilityCompat.ShouldShowBar(s, state, isHovered) then
+            frame:SetAlpha(s._savedBarAlpha or s.mouseoverAlpha or 1)
             if hstate then hstate.fadeDir = "in" end
+        else
+            frame:SetAlpha(0)
+            if hstate then hstate.fadeDir = "out" end
+        end
+    elseif s.mouseoverEnabled then
+        if hstate and hstate.isHovered then
+            frame:SetAlpha(1)
+            hstate.fadeDir = "in"
         else
             frame:SetAlpha(0)
             if hstate then hstate.fadeDir = "out" end
@@ -5663,38 +5707,24 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s, shouldS
     end
 end
 
-function EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, blizzOwnedVisibility, s, shouldShow, keepPresent)
+function EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, blizzOwnedVisibility, s, shouldShow)
     if not frame or not s then return end
 
     shouldShow = (shouldShow ~= false)
-    keepPresent = (keepPresent ~= false)
-    -- Blizzard-owned frames (MicroMenu, QueueStatus) manage their own mouse
-    -- state; overriding it disables clicking/hovering after every refresh.
+    -- Blizzard-owned frames (QueueStatusButton) manage their own mouse
+    -- state; overriding it disables clicking/hovering after every
+    -- visibility refresh.
     if blizzOwnedVisibility then
         return
-    elseif s.mouseoverEnabled then
-        if s.clickThrough then
-            SafeEnableMouseMotionOnly(frame, keepPresent)
-        else
-            SafeEnableMouse(frame, keepPresent and not s.clickThrough)
-        end
+    elseif s.mouseoverEnabled and s.clickThrough then
+        SafeEnableMouseMotionOnly(frame, shouldShow)
     else
         SafeEnableMouse(frame, shouldShow and not s.clickThrough)
     end
 end
 
-function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, shouldShow, allowShow, forceKeepPresent)
+function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, shouldShow, allowShow)
     if not frame or not s then return end
-
-    local keepPresent
-    if forceKeepPresent ~= nil then
-        keepPresent = forceKeepPresent
-    else
-        keepPresent = shouldShow
-        if not keepPresent and s.mouseoverEnabled then
-            keepPresent = EAB_VTABLE.ExtraBars.ShouldKeepManagedNonSecureBarPresent(s)
-        end
-    end
 
     -- Show/hide the holder BEFORE the Blizzard frame so the parent has
     -- valid screen coordinates when the child's Show() triggers Blizzard
@@ -5702,13 +5732,13 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, 
     if not info.isDataBar then
         local holder = extraBarHolders[info.key]
         if holder then
-            if keepPresent then holder:Show() else holder:Hide() end
+            if shouldShow then holder:Show() else holder:Hide() end
         end
     end
 
     if info.blizzOwnedVisibility then
-        EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, "visibility", not keepPresent)
-    elseif keepPresent then
+        EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, "visibility", not shouldShow)
+    elseif shouldShow then
         if allowShow ~= false then
             frame:Show()
         end
@@ -5716,10 +5746,10 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, 
         frame:Hide()
     end
 
-    if keepPresent then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s, shouldShow)
+    if shouldShow then
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s)
     end
-    EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, info.blizzOwnedVisibility, s, shouldShow, keepPresent)
+    EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, info.blizzOwnedVisibility, s, shouldShow)
 end
 
 function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureVisibility(info)
@@ -5729,10 +5759,7 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureVisibility(info)
     local frame = EAB_VTABLE.ExtraBars.GetManagedNonSecureFrame(info)
     if not s or not frame then return false, frame, s end
 
-    local hstate = hoverStates[info.key]
-    local shouldShow = EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(
-        s, hstate and hstate.isHovered
-    )
+    local shouldShow = EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s, info.key)
 
     if shouldShow and info.isDataBar and frame._updateFunc then
         frame._updateFunc()
@@ -5813,20 +5840,6 @@ end
 
 --  Combat Show/Hide, Runtime Visibility, Click-Through, Housing
 -------------------------------------------------------------------------------
-function EAB.VisibilityCompat.RefreshMixedModePresentation()
-    for _, info in ipairs(ALL_BARS) do
-        local key = info.key
-        local s = EAB.db and EAB.db.profile and EAB.db.profile.bars and EAB.db.profile.bars[key]
-        local frame = barFrames[key]
-        if s and frame then
-            local modes = EAB.VisibilityCompat.GetModes(s)
-            if s.mouseoverEnabled and EAB.VisibilityCompat.HasMacroCondition(modes) then
-                EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, hoverStates[key])
-            end
-        end
-    end
-end
-
 function EAB:ApplyCombatVisibility()
     if InCombatLockdown() then return end
     for _, info in ipairs(ALL_BARS) do
@@ -5841,7 +5854,7 @@ function EAB:ApplyCombatVisibility()
                 elseif EllesmereUI.CheckVisibilityOptionsNonMacro and EllesmereUI.CheckVisibilityOptionsNonMacro(s) then
                     newStr = "hide"
                 else
-                    newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
+                    newStr = BuildVisibilityString(info, s)
                 end
                 -- Skip re-registration if driver string is unchanged (avoids blink from re-evaluation)
                 if frame._eabLastVisStr ~= newStr then
@@ -5856,7 +5869,9 @@ function EAB:ApplyCombatVisibility()
     -- data bars).  These use a dedicated secure proxy since they are not
     -- SecureHandlerStateTemplate frames themselves.
     self:ApplyExtraBarVisibility()
-    EAB.VisibilityCompat.RefreshMixedModePresentation()
+    if not InCombatLockdown() then
+        EAB.VisibilityCompat.RefreshAllMixedModePresentations()
+    end
 end
 
 function EAB:RefreshRuntimeVisibility()
@@ -5869,8 +5884,14 @@ function EAB:RefreshRuntimeVisibility()
         else
         local frame = barFrames[key] or (info.isDataBar and dataBarFrames[key]) or (info.isBlizzardMovable and blizzMovableHolders[key]) or (extraBarHolders[key]) or (info.visibilityOnly and _G[info.frameName])
         if frame then
-            local modes = EAB.VisibilityCompat.GetModes(s)
-            local isHidden = s.alwaysHidden or (#modes == 1 and modes[1] == "never")
+            local isHidden = EAB.VisibilityCompat.IsNever(s) or s.alwaysHidden
+            -- Runtime "Toggle Action Bar" override (keybind-driven, NOT persisted):
+            -- flips a bar between always-shown and hidden without touching the saved
+            -- barVisibility. Only ever set for bars whose saved mode is always/never.
+            local _visToggleOv = EAB._visOverride and EAB._visOverride[key]
+            if _visToggleOv then
+                isHidden = (_visToggleOv == "never")
+            end
             if ShouldQuickKeybindSurfaceBar(s) and barFrames[key] and frame == barFrames[key] then
                 if not InCombatLockdown() then
                     RegisterAttributeDriver(frame, "state-visibility", "show")
@@ -5903,10 +5924,14 @@ function EAB:RefreshRuntimeVisibility()
             else
                 if not info.visibilityOnly and not InCombatLockdown() then
                     local newStr
-                    if EllesmereUI.CheckVisibilityOptionsNonMacro and EllesmereUI.CheckVisibilityOptionsNonMacro(s) then
+                    if _visToggleOv == "always" then
+                        -- Forced-show via the toggle keybind: ignore the saved mode
+                        -- (which may be "never") and any non-macro hide options.
+                        newStr = BuildVisibilityString(info, s, "always")
+                    elseif EllesmereUI.CheckVisibilityOptionsNonMacro and EllesmereUI.CheckVisibilityOptionsNonMacro(s) then
                         newStr = "hide"
                     else
-                        newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
+                        newStr = BuildVisibilityString(info, s)
                     end
                     if frame._eabLastVisStr ~= newStr then
 
@@ -5915,8 +5940,7 @@ function EAB:RefreshRuntimeVisibility()
                     end
                 end
                 if not InCombatLockdown() then
-                    local hasMacroModes = EAB.VisibilityCompat.HasMacroCondition(modes)
-                    if not hasMacroModes then
+                    if not EAB.VisibilityCompat.HasMacroModes(s) then
                         -- Only Show frames without a state-visibility driver.
                         -- Frames with a driver (any _eabLastVisStr) are managed by the driver.
                         if not info.isBlizzardMovable and not info.blizzOwnedVisibility and not frame._eabLastVisStr then
@@ -5933,11 +5957,11 @@ function EAB:RefreshRuntimeVisibility()
                         SafeEnableMouse(frame, not s.clickThrough)
                     end
                 end
-                if barFrames[key] and frame == barFrames[key] then
-                    EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, hoverStates[key])
-                end
                 if info.isDataBar and frame._updateFunc then
                     frame._updateFunc()
+                end
+                if EAB.VisibilityCompat.NeedsMixedPresentation(s) and barFrames[key] and frame == barFrames[key] then
+                    EAB.VisibilityCompat.RefreshMixedModePresentation(info, frame, s)
                 end
             end
         end
@@ -5945,6 +5969,100 @@ function EAB:RefreshRuntimeVisibility()
     end
 end
 
+
+-------------------------------------------------------------------------------
+--  "Toggle Action Bar" visibility keybind
+--  A per-bar keybind that flips a bar between always-shown and hidden at RUNTIME
+--  only -- the saved barVisibility is never written, so the toggle does not
+--  persist across sessions (a /reload restores the saved state). Only meaningful
+--  when the bar's saved visibility is "always" or "never", and only out of combat
+--  (changing a secure frame's state-visibility driver is combat-blocked).
+--  The keybind itself IS saved per-bar (s.toggleVisKey) and re-applied on login.
+--
+--  Bindings are keyed by the PRESSED KEY, not the bar, so a single key assigned
+--  to several bars toggles them all as a synced group: one press hides every
+--  bound bar that is currently shown, the next press shows them all.
+-------------------------------------------------------------------------------
+
+-- Toggle every bar bound to `key` as a group. If any participant is currently
+-- shown, hide them all; otherwise show them all. Only bars whose saved mode is
+-- "always"/"never" participate. Runtime-only -- never writes barVisibility.
+function EAB:ToggleVisKey(key)
+    if InCombatLockdown() or not key then return end
+    local participants, anyShown = {}, false
+    for _, info in ipairs(ALL_BARS) do
+        local s = self.db.profile.bars[info.key]
+        if s and s.toggleVisKey == key then
+            if EAB.VisibilityCompat.IsToggleEligible(s) then
+                participants[#participants + 1] = info.key
+                local eff = (self._visOverride and self._visOverride[info.key])
+                    or (EAB.VisibilityCompat.IsNever(s) and "never" or "always")
+                if eff == "always" then anyShown = true end
+            end
+        end
+    end
+    if #participants == 0 then return end
+    local target = anyShown and "never" or "always"
+    self._visOverride = self._visOverride or {}
+    for _, bk in ipairs(participants) do
+        self._visOverride[bk] = target
+    end
+    self:RefreshRuntimeVisibility()
+end
+
+-- Drop a bar's runtime toggle override so its saved visibility takes effect
+-- again (called when the visibility dropdown changes in options).
+function EAB:ClearVisToggleOverride(barKey)
+    if self._visOverride then self._visOverride[barKey] = nil end
+end
+
+-- Rebuild override bindings from the saved per-bar keys: one pooled button per
+-- UNIQUE key (so a key shared by several bars drives all of them). A key is only
+-- bound if at least one bar using it has a saved always/never mode, so a shared
+-- key never dead-overrides the player's normal binding. Binding APIs are
+-- combat-protected, so defer to PLAYER_REGEN_ENABLED in combat.
+function EAB:RebuildVisToggleBindings()
+    if InCombatLockdown() then
+        if not self._visToggleCombatFrame then
+            local f = CreateFrame("Frame")
+            f:SetScript("OnEvent", function(self2)
+                self2:UnregisterEvent("PLAYER_REGEN_ENABLED")
+                EAB:RebuildVisToggleBindings()
+            end)
+            self._visToggleCombatFrame = f
+        end
+        self._visToggleCombatFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+        return
+    end
+    -- Unique keys that have at least one participating (always/never) bar.
+    local keys, seen = {}, {}
+    for _, info in ipairs(ALL_BARS) do
+        local s = self.db.profile.bars[info.key]
+        local k = s and s.toggleVisKey
+        if k and k ~= "" and not seen[k] then
+            if EAB.VisibilityCompat.IsToggleEligible(s) then
+                seen[k] = true
+                keys[#keys + 1] = k
+            end
+        end
+    end
+    -- Clear every pooled button's binding, then (re)assign one per unique key.
+    self._visToggleBtnPool = self._visToggleBtnPool or {}
+    for _, btn in ipairs(self._visToggleBtnPool) do
+        ClearOverrideBindings(btn)
+    end
+    for i, k in ipairs(keys) do
+        local btn = self._visToggleBtnPool[i]
+        if not btn then
+            btn = CreateFrame("Button", "EUIVisToggleKeyBtn" .. i, UIParent)
+            btn:Hide()
+            self._visToggleBtnPool[i] = btn
+        end
+        local thisKey = k
+        btn:SetScript("OnClick", function() EAB:ToggleVisKey(thisKey) end)
+        SetOverrideBindingClick(btn, true, k, btn:GetName())
+    end
+end
 
 function EAB:ApplySmartNumIcons(barKey)
     -- No-op: bar frame size is always determined by the user's numIcons
@@ -6069,7 +6187,6 @@ function EAB:UpdateHousingVisibility()
                 else
                     local frame = barFrames[key] or (info.isDataBar and dataBarFrames[key]) or (info.isBlizzardMovable and blizzMovableHolders[key]) or (extraBarHolders[key]) or (info.visibilityOnly and _G[info.frameName])
                 if frame then
-                    local modes = EAB.VisibilityCompat.GetModes(s)
                     -- Secure action bar frames use the state driver for
                     -- target/enemy options; mounted-like druid forms are
                     -- additionally handled in ShouldHideNonMacro().
@@ -6077,7 +6194,25 @@ function EAB:UpdateHousingVisibility()
                     -- need the full check since they have no state driver.
                     local isSecure = not info.visibilityOnly and not info.isDataBar and not info.isBlizzardMovable and barFrames[key]
                     local shouldHide = isSecure and ShouldHideNonMacro(s) or (not isSecure and EllesmereUI.CheckVisibilityOptions(s))
-                    if shouldHide then
+                    -- Runtime "Toggle Action Bar" keybind override wins over the saved
+                    -- mode and the non-macro hide checks, exactly as RefreshRuntimeVisibility
+                    -- does. Without these two branches any event routed through here
+                    -- (target change, group/mount/housing) re-applies the saved visibility
+                    -- and re-shows a bar the player toggled off with its keybind. Secure
+                    -- managed bars only (the override is never set for other frame types).
+                    local _visToggleOv = isSecure and self._visOverride and self._visOverride[key]
+                    if _visToggleOv == "never" then
+                        if frame._eabLastVisStr ~= "hide" then
+                            frame._eabLastVisStr = "hide"
+                            RegisterAttributeDriver(frame, "state-visibility", "hide")
+                        end
+                    elseif _visToggleOv == "always" then
+                        local ovStr = BuildVisibilityString(info, s, "always")
+                        if frame._eabLastVisStr ~= ovStr then
+                            frame._eabLastVisStr = ovStr
+                            RegisterAttributeDriver(frame, "state-visibility", ovStr)
+                        end
+                    elseif shouldHide then
                         if isSecure then
                             if frame._eabLastVisStr ~= "hide" then
 
@@ -6093,9 +6228,9 @@ function EAB:UpdateHousingVisibility()
                         else
                             frame:Hide()
                         end
-                    elseif not s.alwaysHidden and not (#modes == 1 and modes[1] == "never") then
+                    elseif not s.alwaysHidden and not EAB.VisibilityCompat.IsNever(s) then
                         if isSecure then
-                            local newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
+                            local newStr = BuildVisibilityString(info, s)
                             if frame._eabLastVisStr ~= newStr then
 
                                 frame._eabLastVisStr = newStr
@@ -6119,6 +6254,7 @@ function EAB:UpdateHousingVisibility()
                 end
             end
         end
+        EAB.VisibilityCompat.RefreshAllMixedModePresentations()
     end)
 end
 
@@ -8284,6 +8420,9 @@ function EAB:FinishSetup()
     -- state is restored. This ensures keybinds work on /reload in combat.
     UpdateKeybinds()
 
+    -- Re-apply saved "Toggle Action Bar" visibility keybinds.
+    EAB:RebuildVisToggleBindings()
+
     -- Initialize the showgrid monitor on ActionButton1 so that when
     -- Blizzard changes its showgrid attribute (e.g. during combat spell
     -- drag), the change propagates to all our managed buttons.
@@ -8305,9 +8444,8 @@ function EAB:FinishSetup()
             local s = EAB.db.profile.bars[key]
             local frame = barFrames[key]
             if info and s and frame then
-                local modes = EAB.VisibilityCompat.GetModes(s)
-                if EAB.VisibilityCompat.HasCondition(modes) then
-                    RegisterAttributeDriver(frame, "state-visibility", EAB.VisibilityCompat.BuildVisibilityString(info, s))
+                if EAB.VisibilityCompat.HasConditionalVisibility(s) then
+                    RegisterAttributeDriver(frame, "state-visibility", BuildVisibilityString(info, s))
                 end
                 if s.mouseoverEnabled then
                     -- The drag has fully ended (cursor cleared, checked above). If
@@ -8321,12 +8459,14 @@ function EAB:FinishSetup()
                         frame:SetAlpha(s._savedBarAlpha or 1)
                         if key == "MainBar" then SyncPagingAlpha(s._savedBarAlpha or 1) end
                     else
-                        if state then state.isHovered = false end
-                        EAB.VisibilityCompat.ApplyBarPresentation(key, s, frame, state)
+                        if state then state.isHovered = false; state.fadeDir = "out" end
+                        frame:SetAlpha(0)
+                        if key == "MainBar" then SyncPagingAlpha(0) end
                     end
                 end
             end
         end
+        EAB.VisibilityCompat.RefreshAllMixedModePresentations()
         wipe(_gridSurfacedBars)
     end
     ActionButtonController:SetScript("OnEvent", function(_, event)
@@ -8344,10 +8484,7 @@ function EAB:FinishSetup()
                         local s = EAB.db.profile.bars[info.key]
                         local frame = barFrames[info.key]
                         if s and frame and not s.alwaysHidden then
-                            local modes = EAB.VisibilityCompat.GetModes(s)
-                            local hasCondition = EAB.VisibilityCompat.HasCondition(modes)
-                                or s.visHideNoTarget or s.visHideNoEnemy
-                                or s.visHideMounted or s.visOnlyInstances
+                            local hasCondition = EAB.VisibilityCompat.HasConditionalVisibility(s)
                             if hasCondition then
                                 _gridSurfacedBars[info.key] = true
                                 RegisterAttributeDriver(frame, "state-visibility", "show")
@@ -8618,7 +8755,6 @@ function EAB:FinishSetup()
     end)
 
     self:RegisterEvent("PLAYER_REGEN_ENABLED", function()
-        EAB_VTABLE.ExtraBars._managedNonSecureInCombat = false
         -- Re-apply anything that was deferred during combat
         ApplyAll()
         -- Restore any strata changes that couldn't be done in combat
@@ -8628,9 +8764,7 @@ function EAB:FinishSetup()
     end)
 
     self:RegisterEvent("PLAYER_REGEN_DISABLED", function()
-        EAB_VTABLE.ExtraBars._managedNonSecureInCombat = true
         _quickKeybindState.ReassertButtonsAfterCombatChange()
-        EAB.VisibilityCompat.RefreshMixedModePresentation()
     end)
 
     self:RegisterEvent("PLAYER_ENTERING_WORLD", function()
@@ -8723,7 +8857,7 @@ function EAB:FinishSetup()
         local softOnly = (hasSoftInteract or hasSoftEnemy or hasSoftFriend) and not hasHardTarget
         for _, info in ipairs(ALL_BARS) do
             local s = self.db.profile.bars[info.key]
-            if s and s.visHideNoTarget then
+            if s and s.visHideNoTarget and not (self._visOverride and self._visOverride[info.key]) then
                 local frame = barFrames[info.key]
                 if frame then
                     if softOnly then
@@ -8732,7 +8866,7 @@ function EAB:FinishSetup()
                             RegisterAttributeDriver(frame, "state-visibility", "hide")
                         end
                     else
-                        local newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
+                        local newStr = BuildVisibilityString(info, s)
                         if frame._eabLastVisStr ~= newStr then
                             frame._eabLastVisStr = newStr
                             RegisterAttributeDriver(frame, "state-visibility", newStr)
@@ -8765,10 +8899,10 @@ function EAB:FinishSetup()
         regenFrame:SetScript("OnEvent", function()
             for _, info in ipairs(ALL_BARS) do
                 local s = self.db.profile.bars[info.key]
-                if s and s.visHideNoTarget then
+                if s and s.visHideNoTarget and not (self._visOverride and self._visOverride[info.key]) then
                     local frame = barFrames[info.key]
                     if frame then
-                        local newStr = EAB.VisibilityCompat.BuildVisibilityString(info, s)
+                        local newStr = BuildVisibilityString(info, s)
                         if frame._eabLastVisStr ~= newStr then
                             frame._eabLastVisStr = newStr
                             RegisterAttributeDriver(frame, "state-visibility", newStr)
@@ -8982,7 +9116,7 @@ function EAB:FinishSetup()
             local petFrame = barFrames["PetBar"]
             local petS = self.db.profile.bars["PetBar"]
             if petInfo and petFrame and petS and not petS.alwaysHidden then
-                RegisterAttributeDriver(petFrame, "state-visibility", EAB.VisibilityCompat.BuildVisibilityString(petInfo, petS))
+                RegisterAttributeDriver(petFrame, "state-visibility", BuildVisibilityString(petInfo, petS))
             end
         end)
     end
@@ -9151,7 +9285,7 @@ function EAB_VTABLE.ExtraBars.BeginManagedDataBarUpdate(barKey)
     local info = BAR_LOOKUP[barKey]
     if EAB.db.profile.useBlizzardDataBars then
         if info then
-            EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, EAB.db.profile.bars[barKey], false, true, false)
+            EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, EAB.db.profile.bars[barKey], false, true)
         else
             frame:Hide()
         end
@@ -9160,14 +9294,9 @@ function EAB_VTABLE.ExtraBars.BeginManagedDataBarUpdate(barKey)
 
     local s = EAB.db.profile.bars[barKey]
     if not s then return nil, nil end
-    local hstate = hoverStates[barKey]
-    local shouldShow = EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(
-        s, hstate and hstate.isHovered
-    )
-    local keepPresent = EAB_VTABLE.ExtraBars.ShouldKeepManagedNonSecureBarPresent(s)
-    if s.alwaysHidden or (not shouldShow and not keepPresent) then
+    if s.alwaysHidden or not EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s, barKey) then
         if info then
-            EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, false, true, false)
+            EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, false, true)
         else
             frame:Hide()
         end
@@ -9182,11 +9311,7 @@ function EAB_VTABLE.ExtraBars.FinishManagedDataBarUpdate(barKey, frame, s)
 
     local info = BAR_LOOKUP[barKey]
     if info then
-        local hstate = hoverStates[barKey]
-        local shouldShow = EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(
-            s, hstate and hstate.isHovered
-        )
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, shouldShow, true)
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, true, true)
     else
         frame:Show()
     end
@@ -9205,7 +9330,7 @@ local function UpdateXPBar()
     -- Hide at max level (or XP disabled)
     if (IsLevelAtEffectiveMaxLevel and IsLevelAtEffectiveMaxLevel(UnitLevel("player")))
         or (IsXPUserDisabled and IsXPUserDisabled()) then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["XPBar"], frame, s, false, true, false)
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["XPBar"], frame, s, false, true)
         return
     end
 
@@ -9310,7 +9435,7 @@ local function UpdateRepBar()
 
     local data = C_Reputation and C_Reputation.GetWatchedFactionData and C_Reputation.GetWatchedFactionData()
     if not data or not data.name then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true, false)
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true)
         return
     end
 
@@ -9355,7 +9480,7 @@ local function UpdateRepBar()
         if majorData then
             local hasMax = C_MajorFactions.HasMaximumRenown and C_MajorFactions.HasMaximumRenown(factionID)
             if hasMax then
-                EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true, false)
+                EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true)
                 return
             end
             reaction = 10
@@ -9375,7 +9500,7 @@ local function UpdateRepBar()
 
     -- Hide capped / maxed factions (Exalted with no paragon, max friendship, etc.)
     if nextReactionThreshold == math.huge or currentReactionThreshold == nextReactionThreshold then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true, false)
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true)
         return
     end
 
@@ -9595,6 +9720,7 @@ function EAB_VTABLE.ExtraBars.EnsureManagedDataBarRuntimeState()
         -- non-secure bars in sync with the same edge that triggered the event.
         EAB_VTABLE.ExtraBars._managedNonSecureInCombat = (event == "PLAYER_REGEN_DISABLED")
         EAB_VTABLE.ExtraBars.RefreshManagedNonSecureVisibility()
+        EAB.VisibilityCompat.RefreshAllMixedModePresentations()
     end)
 end
 

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -5603,6 +5603,22 @@ function EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s, isHovered)
     return not (#modes == 1 and modes[1] == "never")
 end
 
+-- Mouseover bars must stay shown (alpha 0) so hover hooks can reveal them.
+function EAB_VTABLE.ExtraBars.ShouldKeepManagedNonSecureBarPresent(s)
+    if not s then return false end
+    EAB.VisibilityCompat.Normalize(s)
+    if C_PetBattles and C_PetBattles.IsInBattle and C_PetBattles.IsInBattle() then
+        return false
+    end
+    if s.enabled == false or s.alwaysHidden then return false end
+    if EllesmereUI and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(s) then
+        return false
+    end
+    local modes = EAB.VisibilityCompat.GetModes(s)
+    if #modes == 1 and modes[1] == "never" then return false end
+    return s.mouseoverEnabled == true
+end
+
 function EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, reason, suppressed)
     if not frame then return end
 
@@ -5647,24 +5663,38 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s, shouldS
     end
 end
 
-function EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, blizzOwnedVisibility, s, shouldShow)
+function EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, blizzOwnedVisibility, s, shouldShow, keepPresent)
     if not frame or not s then return end
 
     shouldShow = (shouldShow ~= false)
-    -- Blizzard-owned frames (QueueStatusButton) manage their own mouse
-    -- state; overriding it disables clicking/hovering after every
-    -- visibility refresh.
+    keepPresent = (keepPresent ~= false)
+    -- Blizzard-owned frames (MicroMenu, QueueStatus) manage their own mouse
+    -- state; overriding it disables clicking/hovering after every refresh.
     if blizzOwnedVisibility then
         return
-    elseif s.mouseoverEnabled and s.clickThrough then
-        SafeEnableMouseMotionOnly(frame, shouldShow)
+    elseif s.mouseoverEnabled then
+        if s.clickThrough then
+            SafeEnableMouseMotionOnly(frame, keepPresent)
+        else
+            SafeEnableMouse(frame, keepPresent and not s.clickThrough)
+        end
     else
         SafeEnableMouse(frame, shouldShow and not s.clickThrough)
     end
 end
 
-function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, shouldShow, allowShow)
+function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, shouldShow, allowShow, forceKeepPresent)
     if not frame or not s then return end
+
+    local keepPresent
+    if forceKeepPresent ~= nil then
+        keepPresent = forceKeepPresent
+    else
+        keepPresent = shouldShow
+        if not keepPresent and s.mouseoverEnabled then
+            keepPresent = EAB_VTABLE.ExtraBars.ShouldKeepManagedNonSecureBarPresent(s)
+        end
+    end
 
     -- Show/hide the holder BEFORE the Blizzard frame so the parent has
     -- valid screen coordinates when the child's Show() triggers Blizzard
@@ -5672,13 +5702,13 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, 
     if not info.isDataBar then
         local holder = extraBarHolders[info.key]
         if holder then
-            if shouldShow then holder:Show() else holder:Hide() end
+            if keepPresent then holder:Show() else holder:Hide() end
         end
     end
 
     if info.blizzOwnedVisibility then
-        EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, "visibility", not shouldShow)
-    elseif shouldShow then
+        EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, "visibility", not keepPresent)
+    elseif keepPresent then
         if allowShow ~= false then
             frame:Show()
         end
@@ -5686,10 +5716,10 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, 
         frame:Hide()
     end
 
-    if shouldShow then
+    if keepPresent then
         EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s, shouldShow)
     end
-    EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, info.blizzOwnedVisibility, s, shouldShow)
+    EAB_VTABLE.ExtraBars.ApplyManagedMouse(frame, info.blizzOwnedVisibility, s, shouldShow, keepPresent)
 end
 
 function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureVisibility(info)
@@ -9121,7 +9151,7 @@ function EAB_VTABLE.ExtraBars.BeginManagedDataBarUpdate(barKey)
     local info = BAR_LOOKUP[barKey]
     if EAB.db.profile.useBlizzardDataBars then
         if info then
-            EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, EAB.db.profile.bars[barKey], false, true)
+            EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, EAB.db.profile.bars[barKey], false, true, false)
         else
             frame:Hide()
         end
@@ -9130,9 +9160,14 @@ function EAB_VTABLE.ExtraBars.BeginManagedDataBarUpdate(barKey)
 
     local s = EAB.db.profile.bars[barKey]
     if not s then return nil, nil end
-    if s.alwaysHidden or not EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s) then
+    local hstate = hoverStates[barKey]
+    local shouldShow = EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(
+        s, hstate and hstate.isHovered
+    )
+    local keepPresent = EAB_VTABLE.ExtraBars.ShouldKeepManagedNonSecureBarPresent(s)
+    if s.alwaysHidden or (not shouldShow and not keepPresent) then
         if info then
-            EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, false, true)
+            EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, false, true, false)
         else
             frame:Hide()
         end
@@ -9147,7 +9182,11 @@ function EAB_VTABLE.ExtraBars.FinishManagedDataBarUpdate(barKey, frame, s)
 
     local info = BAR_LOOKUP[barKey]
     if info then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, true, true)
+        local hstate = hoverStates[barKey]
+        local shouldShow = EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(
+            s, hstate and hstate.isHovered
+        )
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(info, frame, s, shouldShow, true)
     else
         frame:Show()
     end
@@ -9166,7 +9205,7 @@ local function UpdateXPBar()
     -- Hide at max level (or XP disabled)
     if (IsLevelAtEffectiveMaxLevel and IsLevelAtEffectiveMaxLevel(UnitLevel("player")))
         or (IsXPUserDisabled and IsXPUserDisabled()) then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["XPBar"], frame, s, false, true)
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["XPBar"], frame, s, false, true, false)
         return
     end
 
@@ -9271,7 +9310,7 @@ local function UpdateRepBar()
 
     local data = C_Reputation and C_Reputation.GetWatchedFactionData and C_Reputation.GetWatchedFactionData()
     if not data or not data.name then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true)
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true, false)
         return
     end
 
@@ -9316,7 +9355,7 @@ local function UpdateRepBar()
         if majorData then
             local hasMax = C_MajorFactions.HasMaximumRenown and C_MajorFactions.HasMaximumRenown(factionID)
             if hasMax then
-                EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true)
+                EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true, false)
                 return
             end
             reaction = 10
@@ -9336,7 +9375,7 @@ local function UpdateRepBar()
 
     -- Hide capped / maxed factions (Exalted with no paragon, max friendship, etc.)
     if nextReactionThreshold == math.huge or currentReactionThreshold == nextReactionThreshold then
-        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true)
+        EAB_VTABLE.ExtraBars.ApplyManagedNonSecurePresentation(BAR_LOOKUP["RepBar"], frame, s, false, true, false)
         return
     end
 

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -2228,6 +2228,36 @@ EllesmereUI.RegisterMigration({
 })
 
 EllesmereUI.RegisterMigration({
+    id          = "ab_bar_visibility_to_modes_v1",
+    scope       = "profile",
+    description = "Migrate action bar barVisibility string to barVisibilityModes array.",
+    body = function(ctx)
+        local ab = ctx.profile.addons and ctx.profile.addons.EllesmereUIActionBars
+        local abBars = ab and ab.bars
+        if not abBars then return end
+        for _, cfg in pairs(abBars) do
+            if type(cfg) == "table" and (not cfg.barVisibilityModes or #cfg.barVisibilityModes == 0) then
+                local mode = cfg.barVisibility
+                if not mode or mode == "" then
+                    if cfg.alwaysHidden then
+                        mode = "never"
+                    elseif cfg.mouseoverEnabled then
+                        mode = "mouseover"
+                    elseif cfg.combatShowEnabled then
+                        mode = "in_combat"
+                    elseif cfg.combatHideEnabled then
+                        mode = "out_of_combat"
+                    else
+                        mode = "always"
+                    end
+                end
+                cfg.barVisibilityModes = { mode }
+            end
+        end
+    end,
+})
+
+EllesmereUI.RegisterMigration({
     id          = "ab_default_grow_to_center_v1",
     scope       = "profile",
     description = "Convert AB bars with default UP growth to CENTER (UP now has real edge preservation).",

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -2228,36 +2228,6 @@ EllesmereUI.RegisterMigration({
 })
 
 EllesmereUI.RegisterMigration({
-    id          = "ab_bar_visibility_to_modes_v1",
-    scope       = "profile",
-    description = "Migrate action bar barVisibility string to barVisibilityModes array.",
-    body = function(ctx)
-        local ab = ctx.profile.addons and ctx.profile.addons.EllesmereUIActionBars
-        local abBars = ab and ab.bars
-        if not abBars then return end
-        for _, cfg in pairs(abBars) do
-            if type(cfg) == "table" and (not cfg.barVisibilityModes or #cfg.barVisibilityModes == 0) then
-                local mode = cfg.barVisibility
-                if not mode or mode == "" then
-                    if cfg.alwaysHidden then
-                        mode = "never"
-                    elseif cfg.mouseoverEnabled then
-                        mode = "mouseover"
-                    elseif cfg.combatShowEnabled then
-                        mode = "in_combat"
-                    elseif cfg.combatHideEnabled then
-                        mode = "out_of_combat"
-                    else
-                        mode = "always"
-                    end
-                end
-                cfg.barVisibilityModes = { mode }
-            end
-        end
-    end,
-})
-
-EllesmereUI.RegisterMigration({
     id          = "ab_default_grow_to_center_v1",
     scope       = "profile",
     description = "Convert AB bars with default UP growth to CENTER (UP now has real edge preservation).",
@@ -2538,6 +2508,58 @@ EllesmereUI.RegisterMigration({
     end,
 })
 
+EllesmereUI.RegisterMigration({
+    id          = "ab_bar_visibility_to_modes_v1",
+    scope       = "profile",
+    description = "Convert action bar barVisibility (and legacy boolean flags) to barVisibilityModes arrays.",
+    body = function(ctx)
+        local ab = ctx.profile.addons and ctx.profile.addons.EllesmereUIActionBars
+        local bars = ab and ab.bars
+        if not bars then return end
+
+        local function legacyMode(s)
+            if type(s.barVisibilityModes) == "table" and #s.barVisibilityModes > 0 then
+                return nil
+            end
+            if s.barVisibility then return s.barVisibility end
+            if s.alwaysHidden then return "never" end
+            if s.mouseoverEnabled then return "mouseover" end
+            if s.combatShowEnabled then return "in_combat" end
+            if s.combatHideEnabled then return "out_of_combat" end
+            return "always"
+        end
+
+        local function applyDerivedFields(s, modes)
+            s.barVisibilityModes = modes
+            s.barVisibility = modes[1] or "always"
+
+            local hasNever, hasMouseover, hasInCombat, hasOutOfCombat = false, false, false, false
+            for i = 1, #modes do
+                local mode = modes[i]
+                if mode == "never" then hasNever = true
+                elseif mode == "mouseover" then hasMouseover = true
+                elseif mode == "in_combat" then hasInCombat = true
+                elseif mode == "out_of_combat" then hasOutOfCombat = true
+                end
+            end
+
+            s.alwaysHidden = hasNever
+            s.mouseoverEnabled = hasMouseover
+            s.combatShowEnabled = hasInCombat
+            s.combatHideEnabled = hasOutOfCombat
+        end
+
+        for _, s in pairs(bars) do
+            if type(s) == "table" then
+                local mode = legacyMode(s)
+                if mode then
+                    applyDerivedFields(s, { mode })
+                end
+            end
+        end
+    end,
+})
+
 local migrationFrame = CreateFrame("Frame")
 migrationFrame:RegisterEvent("ADDON_LOADED")
 migrationFrame:SetScript("OnEvent", function(self, event, addonName)
@@ -2597,5 +2619,4 @@ migrationFrame:SetScript("OnEvent", function(self, event, addonName)
             end
         end
     end
-
 end)


### PR DESCRIPTION
# New Feature: Action Bar Multi-Select Visibility

## Summary

Action bar visibility now supports **multi-select**: a bar shows when **any** selected condition is true (e.g. **In Combat + Mouseover** → visible in combat **or** on hover). **Visibility Options** (hide when mounted, hide without target, etc.) are unchanged (they still act as **AND-style hide filters** evaluated before mode logic).
<img width="458" height="331" alt="image" src="https://github.com/user-attachments/assets/b2c2787e-4487-4dc7-acb1-48d8c30a53ca" />

---

## Feature

- **Checkbox dropdown** for visibility modes (same options as before, multi-select).
- **OR evaluation**: show if any selected mode matches current state.
- **Never** and **Always** are mutually exclusive; clearing all selections defaults to **Always**.
- **Visibility Options** dropdown unchanged and works as before.

### Examples

| Modes selected | Result |
|---|---|
| In Combat + Mouseover | Bar visible in combat **or** while hovered |
| Out of Combat + In Raid | Bar visible when not in combat **or** in a raid |
| Mouseover only | Same as before — fade on hover |
| Never | Bar always hidden |
| Always | Bar always visible

---

## Code changes

### `EllesmereUI/EllesmereUI.lua`

- **Shared visibility system** (tail of file): `VIS_MODE_ITEMS`, mode helpers, and runtime evaluators.
- **`GetVisibilityModes`**: reads `barVisibilityModes[]`, falls back to legacy `barVisibility`.
- **`CheckVisibilityModes`**: OR evaluation; macro/state modes checked **before** mouseover.
- **`BuildMacroVisibilitySuffix`**: builds OR-chained secure macro condition strings.
- **`CheckVisibilityOptions` / `CheckVisibilityOptionsNonMacro`**: unchanged AND-style hide filters.
- **`_GetFFD` / `SetElementVisibility`**: moved **early** in the file to fix load-order nil errors in child addons.
- **Re-bind guard** before the visibility block for Lua 5.1 **200-local limit** edge cases at end of the main chunk. (Might want to look into refactoring visibility logic out of main file)

### `EllesmereUIActionBars/EllesmereUIActionBars.lua`

- **`EAB.VisibilityCompat`** expanded as the action-bar visibility layer:
  - `ApplyModes`, `Normalize`, `Copy`, `GetModes`, `BuildMacroSuffix`
  - `ShouldShowBar`, `IsMacroModeActive`, `ApplyBarPresentation`, `RefreshMixedModePresentation`
- **`barVisibilityModes`** is the source of truth; legacy fields (`barVisibility`, `mouseoverEnabled`, `combatShowEnabled`, etc.) are **derived** on apply.
- **Secure bars**: macro-expressible modes use `RegisterStateDriver` with OR-chained suffixes; when mouseover is combined with macro modes, the driver stays `"show"` and **alpha is managed in Lua**.
- **Mixed-mode precedence**: macro conditions (e.g. in combat) win over mouseover fade; refreshed on combat enter/exit via `RefreshMixedModePresentation`.
- **Non-secure bars** (XP/Rep, Micro, Bags, etc.): use `CheckVisibilityModes` with hover state in the managed visibility pass.
- Helpers live on **`EAB.VisibilityCompat.*`** rather than chunk locals to avoid the **200-local variable** Lua 5.1 warning.

### `EllesmereUIActionBars/EUI_ActionBars_Options.lua`

- Replaced single-select visibility dropdown with **`BuildVisOptsCBDropdown`** multi-select UI.
- **`ToggleVisibilityMode`**: Never/Always exclusivity; empty selection → Always.
- **Sync-to-all-bars** compares full mode arrays via **`VisibilityModesEqual`** instead of a single string.

### `EllesmereUI/EllesmereUI_Migration.lua`

- Migration **`ab_bar_visibility_to_modes_v1`**: converts existing `barVisibility` (and legacy boolean flags) → `barVisibilityModes = { mode }` per bar.

---

## My Tests

Tested the following in-game:

- [x] `/reload` :  _no Lua errors on login_
- [x] Migration: _existing profiles get `barVisibilityModes` populated & behavior matches pre-migration_ 
- [x] **Single modes** (Always, Never, Mouseover, In Combat, Out of Combat): _unchanged from before_
- [x] **Combined modes**:
   - [x] In Combat + Mouseover: _visible in combat without hover; also visible on hover out of combat_
   - [x] Out of Combat + In Raid: _correct in each state_
   - [x] Mouseover + Solo: _hover works, also visible when solo_
- [x] **Visibility Options**: _still hide correctly when combined with multi-select modes (mounted, no target, instances-only, housing)_
- [x] **Sync Visibility to all Bars**: _copies full mode set to all bars_
- [x] **Per-bar types**: _Checked different mode sets on multiple bars_
- [x] **Combat transitions**: _enter/exit combat with mixed mouseover + in_combat modes, no stuck alpha_
- [x] **Pet battle / vehicle / override**: _existing bar-type hide rules still apply_
- [x] **Profile copy / import**: _modes survive round-trip during copy/import process_

---

## Additional Info

**Other modules still single-mode**
CDM, Unit Frames, Resource Bars, etc. use the shared helpers but not `barVisibilityModes` multi-select. Action bars are the scope of this PR, and unifying other modules would be a separate change.

**`EllesmereUI_Visibility.lua` dispatcher**
`EvalVisibility` still evaluates a single `cfg.visibility` string. Could be updated to call `CheckVisibilityModes` for consistency across Minimap, Friends, Quest Tracker, etc. but I wanted to keep the changes as minimal as possible as this is already a rather large single-change.

**Legacy `barVisibility` field**
Only stores the **first** mode in the array for backward compatibility. Anything reading `barVisibility` alone will not see the full multi-select state; prefer `barVisibilityModes` or `GetVisibilityModes`.

**Mode array order**
`OR` logic is order-independent for display, but macro suffix clause order follows array order. Functionally equivalent; could normalize sort order for stable diffs/sync comparisons.

**200-local limit**
Local variable limit for the rather large core `EllesmereUI.lua` file mitigated via `VisibilityCompat` table methods. Core `EllesmereUI.lua` uses a re-bind guard at end of file. A longer-term fix would move the Shared Visibility System block into `EllesmereUI_Visibility.lua` or some other module.

---

## Disclaimers

LLMS were used to assist in coding up this change and help write up this pull request. However, any code generated from an LLM was looked over and tested by me.

<!-- gk-ai-analysis-start:ead74d7d14a40a63d26a04137169188054756194 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWN0aW9uIGJhciB2aXNpYmlsaXR5IGlzIHVwZ3JhZGVkIHRvIHN1cHBvcnQgbXVsdGktc2VsZWN0IGNvbmRpdGlvbnMsIHVzaW5nIE9SLWxvZ2ljIGV2YWx1YXRpb24gd2hpbGUgcHJlc2VydmluZyBBTkQtbG9naWMgaGlkZSBmaWx0ZXJzLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IkZyYW1lIHZpc2liaWxpdHkgc3RhdGUgbWFwcGluZyBtb3ZlZCB0byBlYXJseSBpbml0aWFsaXphdGlvbiIsImRlc2NyaXB0aW9uIjoiYF9HZXRGRkRgIGFuZCBgU2V0RWxlbWVudFZpc2liaWxpdHlgIHdlcmUgbW92ZWQgaGlnaGVyIGluIHRoZSBmaWxlIHRvIGVuc3VyZSBjaGlsZCBhZGRvbnMgbG9hZCB3aXRob3V0IG5pbCBlcnJvcnMuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6IkVsbGVzbWVyZVVJLmx1YSIsImxpbmVTdGFydCI6MTMzNH0seyJ0aXRsZSI6IlJlLWJpbmRpbmcgZ2xvYmFsIHJlZmVyZW5jZSBmb3IgMjAwLWxvY2FsIGxpbWl0IiwiZGVzY3JpcHRpb24iOiJEdWUgdG8gTHVhJ3MgMjAwLWxvY2FsIHZhcmlhYmxlIGxpbWl0LCBgRWxsZXNtZXJlVUlgIGlzIGV4cGxpY2l0bHkgcmUtYm91bmQgdG8gdGhlIGdsb2JhbCBzY29wZSBiZWZvcmUgcmVhY2hpbmcgdGhlIHRhaWwtb2YtZmlsZSB2aXNpYmlsaXR5IGxvZ2ljLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJFbGxlc21lcmVVSS5sdWEiLCJsaW5lU3RhcnQiOjk5OTZ9LHsidGl0bGUiOiJBY3Rpb24gYmFycyBjb252ZXJ0ZWQgdG8gbXVsdGktbW9kZSBhcnJheSIsImRlc2NyaXB0aW9uIjoiYEVBQi5WaXNpYmlsaXR5Q29tcGF0LkFwcGx5TW9kZXNgIGFuZCBgTm9ybWFsaXplYCBub3cgdXNlIGBiYXJWaXNpYmlsaXR5TW9kZXNgIGFycmF5cyB0byBkZXJpdmUgbGVnYWN5IGZsYWdzIChgYWx3YXlzSGlkZGVuYCwgYG1vdXNlb3ZlckVuYWJsZWRgLCBldGMpLiIsInNldmVyaXR5IjoiaGlnaCIsImZpbGVQYXRoIjoiRWxsZXNtZXJlVUlBY3Rpb25CYXJzL0VsbGVzbWVyZVVJQWN0aW9uQmFycy5sdWEiLCJsaW5lU3RhcnQiOjE1NH0seyJ0aXRsZSI6IlZpc2liaWxpdHkgbXVsdGktc2VsZWN0IG9wdGlvbnMgVUkgcmVwbGFjZWQiLCJkZXNjcmlwdGlvbiI6IlRoZSBvcHRpb25zIHBhbmVsIHJlcGxhY2VkIHNpbmdsZS1zZWxlY3QgZnVuY3Rpb25zIHdpdGggYFRvZ2dsZVZpc2liaWxpdHlNb2RlYCBhbmQgYEFwcGx5VmlzaWJpbGl0eU1vZGVzYCwgbWFwcGluZyBhcnJheSBzdGF0ZXMgaW50byB0aGUgdW5kZXJseWluZyBjb25maWcuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6IkVsbGVzbWVyZVVJQWN0aW9uQmFycy9FVUlfQWN0aW9uQmFyc19PcHRpb25zLmx1YSIsImxpbmVTdGFydCI6MTA5NH0seyJ0aXRsZSI6IkRhdGFiYXNlIG1pZ3JhdGlvbiB0byBtb2RlIGFycmF5cyIsImRlc2NyaXB0aW9uIjoiQWRkZWQgYGFiX2Jhcl92aXNpYmlsaXR5X3RvX21vZGVzX3YxYCBtaWdyYXRpb24gdG8gY29udmVydCBvbGRlciBzaW5nbGUtbW9kZSBgYmFyVmlzaWJpbGl0eWAgc3RyaW5ncyBhbmQgbGVnYWN5IGJvb2xlYW5zIGludG8gdGhlIGBiYXJWaXNpYmlsaXR5TW9kZXNgIGFycmF5LiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJFbGxlc21lcmVVSV9NaWdyYXRpb24ubHVhIiwibGluZVN0YXJ0IjoyMjI3fV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbeyJ0aXRsZSI6IlJlZmFjdG9yIGdsb2JhbCByZS1iaW5kIGludG8gYSBzZXBhcmF0ZSBtb2R1bGUiLCJkZXNjcmlwdGlvbiI6IkFzIG5vdGVkIGluIGNvbW1lbnRzLCBuZWFyaW5nIHRoZSBMdWEgNS4xIDIwMC1sb2NhbCBsaW1pdCBtYWtlcyBtYWludGVuYW5jZSBlcnJvci1wcm9uZS4gQ29uc2lkZXIgbW92aW5nIHRoZSB2aXNpYmlsaXR5IHN5c3RlbSB0byBhIHNlcGFyYXRlIGZpbGUgKGUuZy4gYEVsbGVzbWVyZVVJX1Zpc2liaWxpdHkubHVhYCkgdG8gcmVtb3ZlIHRoZSBuZWVkIGZvciBnbG9iYWwgcmUtYmluZGluZy4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoiRWxsZXNtZXJlVUkubHVhIiwibGluZVN0YXJ0Ijo5OTk2fV0sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:ead74d7d14a40a63d26a04137169188054756194 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/EllesmereGaming/EllesmereUI/pull/394?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->