### PR TITLE
Add [help]/[harm] target conditions to action bar paging

### DIFF
--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -3268,6 +3268,17 @@ initFrame:SetScript("OnEvent", function(self)
                           getValue=function() return GetPagingVal("alt") end,
                           setValue=function(v) SetPagingVal("alt", v) end });  y = y - h
 
+                    -- Row 3: Friendly Target | Hostile Target
+                    _, h = W:DualRow(parent, y,
+                        { type="dropdown", text="Friendly Target",
+                          values=pagingValues, order=pagingOrder,
+                          getValue=function() return GetPagingVal("help") end,
+                          setValue=function(v) SetPagingVal("help", v) end },
+                        { type="dropdown", text="Hostile Target",
+                          values=pagingValues, order=pagingOrder,
+                          getValue=function() return GetPagingVal("harm") end,
+                          setValue=function(v) SetPagingVal("harm", v) end });  y = y - h
+
                     -- Class form dropdowns (paired into DualRows)
                     local classStatesLocal = PG_STATES.class and PG_STATES.class[playerClass]
                     if classStatesLocal then

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -1661,6 +1661,10 @@ EAB_VTABLE.PAGING_STATES = {
         { id = "shift", macro = "[mod:shift]", label = "Shift" },
         { id = "ctrl",  macro = "[mod:ctrl]",  label = "Ctrl" },
     },
+    target = {
+        { id = "help",  macro = "[help]",      label = "Friendly Target" },
+        { id = "harm",  macro = "[harm]",      label = "Hostile Target" },
+    },
     class = {
         DRUID = {
             { id = "prowl",   macro = "[bonusbar:1,stealth]", label = "Prowl" },
@@ -1725,6 +1729,16 @@ function EAB_VTABLE.BuildPagingConditions(barKey, pagingConfig, defaultPage)
         parts[#parts + 1] = "[bonusbar:5] 11"
         for i = 2, NUM_AB_PAGES do
             parts[#parts + 1] = "[bar:" .. i .. "] " .. i
+        end
+    end
+    -- Target conditions come after bonusbar/bar so dragonriding and manual
+    -- page switches always take priority over target-based switching.
+    if PG.target then
+        for _, state in ipairs(PG.target) do
+            local page = pagingConfig[state.id]
+            if page then
+                parts[#parts + 1] = state.macro .. " " .. page
+            end
         end
     end
     parts[#parts + 1] = tostring(defaultPage or 1)


### PR DESCRIPTION
Hello,
First of all congratulations on a great addon you've created! Been enjoying the simplicity alot!

I'm proposing a small quality-of-life addition to the paging system that I personally needed to fully drop Bartender, and i think some people might find usefull.

The paging section already lets you set modifier keys (Alt/Ctrl/Shift) to flip your bar to a different page on the fly. This PR adds two more conditions: **Friendly Target** and **Hostile Target** — which map to WoW's native `[help]` and `[harm]` macro conditions.
One thing worth noting on the implementation: these conditions are evaluated **after** dragonriding (`[bonusbar:5]`) and manual bar switching (`[bar:N]`) in the condition string, so they sit at the lowest priority. If you're mounted on a dragon and have a target, page 11 still wins. Felt like the right call since target-based switching is passive — you probably don't want it overriding explicit mode changes.

Bartender has had this via its paging system for years and I got too used to it. Now EllesmereUI might have it too, hopefully.

Disclaimer: Im a programer professionally, but i used claude to orient me in the code base, since im not very proficient in LUA,

I hope this meets your standards, if not just tell me what to improve (if you're interested in the feature).

Keep up the good work