### PR TITLE
fix(cdm,power): Cooldown Manager and smart power text fixes (8.2.2)

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -3649,7 +3649,13 @@ initFrame:SetScript("OnEvent", function(self)
                         bd.bgR, bd.bgG, bd.bgB, bd.bgA = r, g, b, a; RefreshTBB()
                     end },
               } },
-            { type = "label", text = "" }
+            { type = "toggle", text = "Hide When Inactive",
+              getValue = function() local bd = SelectedTBB(); return bd and bd.hideWhenInactive ~= false end,
+              setValue = function(v)
+                  local bd = SelectedTBB(); if not bd then return end
+                  bd.hideWhenInactive = v and true or false; RefreshTBB()
+              end,
+              tooltip = "Only show this bar while the tracked buff/cooldown is active. Turn off to keep an empty bar on screen at all times." }
         );  y = y - h
 
         -----------------------------------------------------------------------
@@ -3839,7 +3845,11 @@ initFrame:SetScript("OnEvent", function(self)
             local function tbbAntsOff()
                 if tbbPandemicOff() then return true end
                 local bd = SelectedTBB()
-                return not bd or type(bd.pandemicGlowStyle) ~= "number" or bd.pandemicGlowStyle ~= 1
+                -- Pixel-glow "ants" settings apply for every bar style except
+                -- Auto-Cast Shine (4). Any non-{1,4} stored value (e.g. the legacy
+                -- -1 "Blizzard Default", which is meaningless on a rectangle)
+                -- renders as Pixel Glow, so its ants settings stay editable.
+                return not bd or bd.pandemicGlowStyle == 4
             end
 
             local tbbPanRow
@@ -3849,7 +3859,13 @@ initFrame:SetScript("OnEvent", function(self)
                   getValue = function()
                       local bd = SelectedTBB(); if not bd then return 0 end
                       if bd.pandemicGlow ~= true then return 0 end
-                      return bd.pandemicGlowStyle or 1
+                      -- Bars only render Pixel Glow (1) or Auto-Cast Shine (4).
+                      -- Any other stored style (e.g. the -1 "Blizzard Default"
+                      -- default, which has no meaning on a rectangle) renders as
+                      -- Pixel Glow, so show it as Pixel Glow instead of a raw -1.
+                      local style = bd.pandemicGlowStyle
+                      if style ~= 4 then style = 1 end
+                      return style
                   end,
                   setValue = function(v)
                       local bd = SelectedTBB(); if not bd then return end
@@ -4872,6 +4888,14 @@ initFrame:SetScript("OnEvent", function(self)
 
                                 -- Swatch click: open color picker
                                 swatchBtn:SetScript("OnClick", function()
+                                    -- Persist before mutating: for a spell with
+                                    -- no saved settings yet (e.g. a freshly added
+                                    -- Hero-talent spell like Wither / Celestial
+                                    -- Conduit), `ss` is a throwaway {} -- without
+                                    -- EnsureSS the picked colour is written to a
+                                    -- temporary table and lost, so the swipe never
+                                    -- changes and reverts to default on reopen.
+                                    EnsureSS()
                                     -- Ensure custom mode is selected
                                     ss.activeSwipeMode = nil
                                     ss.activeSwipeClassColor = nil
@@ -9392,10 +9416,14 @@ initFrame:SetScript("OnEvent", function(self)
                     end)
                     classBorderSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
 
+                    local UpdateBorderState
                     local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
                         leftRgn, buffBsRow:GetFrameLevel() + 3,
                         function() return BD().borderR or 0, BD().borderG or 0, BD().borderB or 0 end,
                         function(r, g, b)
+                            -- Picking a color always switches off class color so the
+                            -- chosen custom color actually applies.
+                            BD().borderClassColor = false
                             BD().borderR, BD().borderG, BD().borderB = r, g, b
                             ns.RefreshCDMIconAppearance(BD().key); Refresh(); UpdateCDMPreview()
                         end,
@@ -9406,21 +9434,23 @@ initFrame:SetScript("OnEvent", function(self)
                     end)
                     swatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
 
-                    -- Click the dimmed custom swatch to switch back from class color (no block overlay)
+                    -- Clicking the custom swatch switches off class color (if on) AND
+                    -- opens the color picker in the same click -- previously the first
+                    -- click only toggled class color off, leaving the border black and
+                    -- making it look like the swatch was stuck.
                     local origClick = swatch:GetScript("OnClick")
                     swatch:SetScript("OnClick", function(self, ...)
+                        -- No border selected: don't open the color picker
+                        if (BD().borderThickness or "thin") == "none" then return end
                         if BD().borderClassColor then
                             BD().borderClassColor = false
                             ns.RefreshCDMIconAppearance(BD().key); Refresh(); UpdateCDMPreview()
-                            EllesmereUI:RefreshPage()
-                            return
+                            updateSwatch(); UpdateBorderState()
                         end
-                        -- No border selected: allow swapping boxes but do not open the color picker
-                        if (BD().borderThickness or "thin") == "none" then return end
                         if origClick then origClick(self, ...) end
                     end)
 
-                    local function UpdateBorderState()
+                    function UpdateBorderState()
                         local isClassColored = BD().borderClassColor
                         local isNone = (BD().borderThickness or "thin") == "none"
                         swatch:SetAlpha((isClassColored or isNone) and 0.3 or 1)

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -182,6 +182,7 @@ local TBB_DEFAULT_BAR = {
     spellID   = 0,
     name      = "New Bar",
     enabled   = true,
+    hideWhenInactive = true,  -- hide the bar unless the tracked aura is active
     grouped   = true,   -- per-bar "Group Tracking Bars" checkbox; checked bars chain + share width/height
     height    = 24,
     width     = 270,
@@ -1376,7 +1377,20 @@ function ns.UpdateTrackedBuffBarTimers()
             local blzChild = FindChild(cfg)
             if blzChild then ns.HookPandemicState(blzChild) end
 
-            local isActive = blzChild and blzChild.IsShown and blzChild:IsShown() or false
+            -- Active state must come from the CooldownViewer item's IsActive()
+            -- (real aura state: expirationTime > now, or infinite auras), NOT
+            -- IsShown(). A buff-bar item stays SHOWN even while inactive unless
+            -- the user enabled Blizzard's "Hide When Inactive" edit-mode option
+            -- (off by default), so IsShown() would make our mirrored bar visible
+            -- 100% of the time. Fall back to IsShown() only if IsActive is absent.
+            local isActive = false
+            if blzChild then
+                if blzChild.IsActive then
+                    isActive = blzChild:IsActive() and true or false
+                elseif blzChild.IsShown then
+                    isActive = blzChild:IsShown() or false
+                end
+            end
 
             -- Read Blizzard's StatusBar (the data source for fill/timer)
             local blizzBar = blzChild and blzChild.Bar
@@ -1530,14 +1544,24 @@ function ns.UpdateTrackedBuffBarTimers()
                     end
                 end
             else
-                -- Inactive: clear state and hide
-                bar._nameSet = nil
+                -- Inactive: clear transient state
                 bar._cachedBlizzFillTex = nil
                 bar._cachedOurFillTex = nil
                 if _anyPandemic and bar._pandemicGlowActive then ClearPandemic(bar) end
                 if bar._stacksText then bar._stacksText:Hide() end
                 bar._stackCount = 0
-                if bar:IsShown() then bar:Hide() end
+                if cfg.hideWhenInactive == false then
+                    -- "Hide When Inactive" off: keep the bar on screen as an
+                    -- empty idle bar (name visible, no fill / timer / spark).
+                    if not bar:IsShown() then bar:Show() end
+                    local sb = bar._bar
+                    if sb then sb:SetMinMaxValues(0, 1); sb:SetValue(0) end
+                    if bar._timerText then bar._timerText:Hide() end
+                    if bar._spark then bar._spark:Hide() end
+                else
+                    bar._nameSet = nil
+                    if bar:IsShown() then bar:Hide() end
+                end
             end
         end
     end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -174,6 +174,78 @@ local function ResolveFrameSpellID(frame)
 end
 ns.ResolveFrameSpellID = ResolveFrameSpellID
 
+-- Resolve the per-spell settings table for a CDM frame. Settings are keyed by
+-- the spell the user added (assignedSpells / spellSettings[id]). The live frame
+-- can report SEVERAL different ids for the same logical spell, and which one
+-- matches the stored key varies by talent state:
+--   * sid2          -- ResolveFrameSpellID's cooldownInfo base. For some
+--                      Hero-talent slots this is an UNRELATED spell (observed:
+--                      a Hellcaller Wither slot whose cooldownInfo base is
+--                      Immolate 348 while the displayed spell is Wither 445468).
+--   * canon         -- GetCanonicalSpellIDForFrame: the displayed/castable id
+--                      the picker keys settings by (GetSpellID-first, clean-read
+--                      cached so it survives the active/secret state).
+--   * resolvedSid   -- cached override/display id.
+--   * baseSpellID   -- cached base id.
+-- Match a stored key against the frame's FULL identity set, by direct hit,
+-- linkedSpellIDs, and override resolution in BOTH directions (the assigned
+-- spell may be the base whose active override is one of the identity ids -- e.g.
+-- assigned Corruption 172, frame shows Wither 445468 = FindSpellOverrideByID(172)
+-- -- or an identity id may be the base whose override is the assigned spell).
+local function ResolveSpellSettings(frame, sid2, sd2)
+    local settings = sd2 and sd2.spellSettings
+    if not settings or not sid2 then return nil end
+
+    local fc2 = _ecmeFC[frame]
+
+    -- Build the frame's identity-id set (deduped).
+    local ids = { sid2 }
+    local function addId(id)
+        if not id or id <= 0 then return end
+        for i = 1, #ids do if ids[i] == id then return end end
+        ids[#ids + 1] = id
+    end
+    if ns.GetCanonicalSpellIDForFrame then addId(ns.GetCanonicalSpellIDForFrame(frame)) end
+    if fc2 then
+        addId(fc2.resolvedSid)
+        addId(fc2.baseSpellID)
+    end
+
+    -- 1. Direct hit on any identity id.
+    for i = 1, #ids do
+        local s = settings[ids[i]]
+        if s then return s end
+    end
+
+    -- 2. linkedSpellIDs reported by the cooldown info.
+    if fc2 and fc2.linkedSpellIDs then
+        for _, lid in ipairs(fc2.linkedSpellIDs) do
+            if settings[lid] then return settings[lid] end
+        end
+    end
+
+    -- 3. Override resolution across assignedSpells, both directions, against the
+    --    full identity set.
+    local FindOvr = C_SpellBook and C_SpellBook.FindSpellOverrideByID
+    if FindOvr and sd2.assignedSpells then
+        local idOvr = {}
+        for i = 1, #ids do idOvr[i] = FindOvr(ids[i]) end
+        for _, asid in ipairs(sd2.assignedSpells) do
+            if asid and asid > 0 and settings[asid] then
+                local asidOvr = FindOvr(asid)
+                for i = 1, #ids do
+                    if asidOvr == ids[i] or idOvr[i] == asid then
+                        return settings[asid]
+                    end
+                end
+            end
+        end
+    end
+
+    return nil
+end
+ns.ResolveSpellSettings = ResolveSpellSettings
+
 -------------------------------------------------------------------------------
 --  Spell Routing State
 --
@@ -624,30 +696,7 @@ local function DecorateFrame(frame, barData)
                 -- Check per-spell settings
                 local ss2
                 if sid2 and bk2 then
-                    local sd2 = ns.GetBarSpellData(bk2)
-                    ss2 = sd2 and sd2.spellSettings and sd2.spellSettings[sid2]
-                    -- Fallback: sid2 may be a base/override variant while
-                    -- settings are stored under the assigned spell ID.
-                    if not ss2 and sd2 and sd2.spellSettings and sd2.assignedSpells then
-                        local fc2 = _ecmeFC[frame]
-                        -- Try linkedSpellIDs
-                        if fc2 and fc2.linkedSpellIDs then
-                            for _, lid in ipairs(fc2.linkedSpellIDs) do
-                                if sd2.spellSettings[lid] then ss2 = sd2.spellSettings[lid]; break end
-                            end
-                        end
-                        -- Try override resolution
-                        if not ss2 and C_SpellBook and C_SpellBook.FindSpellOverrideByID then
-                            for _, asid in ipairs(sd2.assignedSpells) do
-                                if asid and asid > 0 and asid ~= sid2
-                                   and sd2.spellSettings[asid] then
-                                    if C_SpellBook.FindSpellOverrideByID(asid) == sid2 then
-                                        ss2 = sd2.spellSettings[asid]; break
-                                    end
-                                end
-                            end
-                        end
-                    end
+                    ss2 = ResolveSpellSettings(frame, sid2, ns.GetBarSpellData(bk2))
                 end
                 -- Detect active state from swipe color
                 local swipeColor = frame.cooldownSwipeColor
@@ -852,22 +901,7 @@ local function DecorateFrame(frame, barData)
                 if bk2:sub(1, 7) == "__ghost" then return end
                 -- FocusKick icon alpha is owned by SetFocusKickAlpha only.
                 if bk2 == ns.FOCUSKICK_BAR_KEY then return end
-                local sd2 = ns.GetBarSpellData(bk2)
-                local ss2 = sd2 and sd2.spellSettings and sd2.spellSettings[sid2]
-                -- Fallback: sid2 may be a spell override while settings are
-                -- stored under the base ID. Scan assignedSpells for a match.
-                if not ss2 and sd2 and sd2.spellSettings and sd2.assignedSpells
-                   and C_SpellBook and C_SpellBook.FindSpellOverrideByID then
-                    for _, asid in ipairs(sd2.assignedSpells) do
-                        if asid and asid > 0 and asid ~= sid2
-                           and sd2.spellSettings[asid] then
-                            if C_SpellBook.FindSpellOverrideByID(asid) == sid2 then
-                                ss2 = sd2.spellSettings[asid]
-                                break
-                            end
-                        end
-                    end
-                end
+                local ss2 = ResolveSpellSettings(frame, sid2, ns.GetBarSpellData(bk2))
                 local cse = ss2 and ss2.cdStateEffect
                 if not cse then
                     if fd._cdStateGlowOn then
@@ -969,21 +1003,7 @@ local function DecorateFrame(frame, barData)
                 local sid2 = fc2 and fc2.spellID
                 local bk2 = fc2 and fc2.barKey
                 if not sid2 or not bk2 then return end
-                local sd2 = ns.GetBarSpellData(bk2)
-                local ss2 = sd2 and sd2.spellSettings and sd2.spellSettings[sid2]
-                -- Override fallback: sid2 may be a transformed/override variant
-                -- while settings live under the assigned base ID (matches cdState).
-                if not ss2 and sd2 and sd2.spellSettings and sd2.assignedSpells
-                   and C_SpellBook and C_SpellBook.FindSpellOverrideByID then
-                    for _, asid in ipairs(sd2.assignedSpells) do
-                        if asid and asid > 0 and asid ~= sid2
-                           and sd2.spellSettings[asid]
-                           and C_SpellBook.FindSpellOverrideByID(asid) == sid2 then
-                            ss2 = sd2.spellSettings[asid]
-                            break
-                        end
-                    end
-                end
+                local ss2 = ResolveSpellSettings(frame, sid2, ns.GetBarSpellData(bk2))
                 if not (ss2 and ss2.desatNotActive) then return end
                 local isAct = false
                 local sc = frame.cooldownSwipeColor

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3413,10 +3413,18 @@ local function RefreshCDMIconAppearance(barKey)
             tex:SetAllPoints(icon)
             tex:SetTexCoord(zoom, 1 - zoom, zoom, 1 - zoom)
         end
-        -- Update cooldown (full frame so swipe covers the entire icon)
+        -- Update cooldown (full frame so swipe covers the entire icon). The swipe
+        -- and the countdown number both live on the Cooldown widget, so raise the
+        -- whole widget ABOVE our border (icon+13) so the number renders on top of
+        -- it -- it previously sat below the border and got drawn over (most visible
+        -- when the text is offset to an edge). Anchoring the number to cd (below)
+        -- keeps the X/Y offset working. Side effect: the dark swipe now sits over
+        -- the thin border, lightly tinting it during an active cooldown.
         if cd then
             cd:ClearAllPoints()
             cd:SetAllPoints(icon)
+            -- Above the border (icon+13); still below glow (icon+16) / text (icon+23).
+            pcall(cd.SetFrameLevel, cd, icon:GetFrameLevel() + 14)
             cd:SetSwipeColor(0, 0, 0, barData.swipeAlpha or 0.7)
             cd:SetHideCountdownNumbers(not barData.showCooldownText)
             -- Apply cooldown text font directly (old tick loop is gone)
@@ -3428,15 +3436,17 @@ local function RefreshCDMIconAppearance(barKey)
                 local cdB = barData.cooldownTextB or 1
                 local cdX = barData.cooldownTextX or 0
                 local cdY = barData.cooldownTextY or 0
-                -- Find Blizzard's countdown text FontString on the Cooldown widget
+                -- Find Blizzard's countdown text FontString on the Cooldown widget.
+                -- Keep it on the Cooldown widget (anchored to cd) so the user's
+                -- X/Y offset works -- reparenting it makes Blizzard's engine
+                -- re-center and ignore the offset. CENTER anchor also overrides
+                -- the engine's stale baseline (raw SetFont vs SetCountdownFont).
                 for _, rgn in pairs({ cd:GetRegions() }) do
                     if rgn and rgn.GetObjectType and rgn:GetObjectType() == "FontString" then
                         EllesmereUI.ApplyIconTextFont(rgn, cdFont, cdSize, "cdm")
                         rgn:SetTextColor(cdR, cdG, cdB)
-                        if cdX ~= 0 or cdY ~= 0 then
-                            rgn:ClearAllPoints()
-                            rgn:SetPoint("CENTER", cd, "CENTER", cdX, cdY)
-                        end
+                        rgn:ClearAllPoints()
+                        rgn:SetPoint("CENTER", cd, "CENTER", cdX, cdY)
                     end
                 end
             end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -2858,7 +2858,7 @@ local function UpdatePrimaryBar()
         local percentText = format("%d", pctRaw) .. percentSuffix
         local txt
         if fmt == "smart" then
-            local isPercent = EllesmereUI.IsSmartPowerPercent and EllesmereUI.IsSmartPowerPercent()
+            local isPercent = EllesmereUI.IsSmartPowerPercent and EllesmereUI.IsSmartPowerPercent(cachedPrimary)
             txt = isPercent and percentText or AbbreviateNumbers(cur)
         elseif fmt == "both" then
             txt = AbbreviateNumbers(cur) .. " | " .. percentText

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1184,20 +1184,25 @@ ns.ApplyDarkTheme = ApplyDarkTheme
 
 -- Smart power text: percent for healers/prot pally/arcane mage, numeric for everyone else.
 -- Shared helper used by both the oUF tag and the resource bars renderer.
-local function EUI_IsSmartPowerPercent()
+-- `displayedPowerType` (optional, an Enum.PowerType value) is the power the
+-- caller's bar is actually showing. For form/spec-shifting classes (Druid,
+-- Monk) the decision must follow the displayed power, NOT UnitPowerType: a
+-- Balance druid's UnitPowerType is Astral Power even while the power bar shows
+-- Mana, so without this the mana number would render raw instead of percent.
+local function EUI_IsSmartPowerPercent(displayedPowerType)
     local _, cls = UnitClass("player")
     if not cls then return false end
-    -- Druids: Restoration always uses percent (mana healer, % is always
-    -- what matters -- including Incarnation: Tree of Life, which lands on
-    -- a form index that varies by spec/talent loadout). Other specs use
-    -- percent in caster/travel form and raw value in cat/bear.
-    if cls == "DRUID" then
-        local spec = GetSpecialization()
-        if spec == 4 then return true end
-        local form = GetShapeshiftForm()
-        return form == nil or form == 0 or form == 3
+    -- Druid / Monk both shift their displayed power with form/spec. Percent
+    -- only while the bar shows Mana (Druid caster/Tree/travel + Mistweaver),
+    -- raw value otherwise (Cat=Energy, Bear=Rage, Moonkin=Astral, WW/BRM=Energy).
+    -- This is consistent across every spec, including Restoration weaving
+    -- Cat/Bear where the bar is really Energy/Rage. Prefer the caller-supplied
+    -- displayed power; fall back to the live primary power type.
+    if cls == "DRUID" or cls == "MONK" then
+        local pt = displayedPowerType or UnitPowerType("player")
+        return pt == Enum.PowerType.Mana
     end
-    if cls == "PRIEST" or cls == "SHAMAN" or cls == "MONK" then
+    if cls == "PRIEST" or cls == "SHAMAN" then
         return true
     end
     -- Paladin: Holy and Protection (mana-based specs)


### PR DESCRIPTION
## Summary

A batch of 8.2.2 bug fixes for the Cooldown Manager and resource bars, addressing reported issues (Discord [#1](https://discord.com/channels/585577383847788554/1517713558199210057), [#2](https://discord.com/channels/585577383847788554/1517597561026908262), among others).

### Cooldown Manager
- **Tracking bars were visible 100% of the time.** Active state now reads the CooldownViewer item's `IsActive()` (real aura state) instead of `IsShown()`, which stays true unless Blizzard's "Hide When Inactive" edit-mode option is on (off by default). Adds a per-bar **Hide When Inactive** toggle (default on); turning it off keeps an empty idle bar on screen.
- **Pandemic Glow dropdown showed a raw `-1`.** Bars only render Pixel Glow or Auto-Cast Shine, so any other stored style (e.g. the legacy `-1` "Blizzard Default", meaningless on a rectangle) now displays as Pixel Glow and its ant settings stay editable.
- **Active-state cooldown swipe color didn't apply to Hero-talent override spells** (e.g. Wither/Hellcaller, Celestial Conduit/Mistweaver). Per-spell settings are now resolved against the frame's full identity set with bidirectional override matching via a shared `ns.ResolveSpellSettings`, plus an `EnsureSS()` fix so a freshly-added spell's first color pick persists.
- **Countdown text rendered behind the icon border.** The countdown number and swipe share Blizzard's `Cooldown` widget, so the widget is raised just above the border; the number now draws on top while the user's X/Y offset still applies.
- **Border color swatch looked stuck on black.** One click now switches off class color *and* opens the picker (was a confusing two-click), and a picked color always clears class color so it applies.

### Smart power text
- **Smart Text showed Energy/Rage as a percent** (Monk Windwalker/Brewmaster, Druid Cat/Bear) and **Mana as a raw value** (Balance). The percent-vs-raw decision now follows the bar's actually-displayed power type (Mana → percent) instead of spec/form indices, so it's correct across every form/spec and follows swaps immediately.

## Testing
Each fix verified in-game across the affected classes/specs (Druid all forms & specs, Monk WW/BRM/MW, override-spell swipe colors, CDM border/countdown rendering).
