### PR TITLE
fix(party-frames): align Real Preview with edit-mode location when flipping growth

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -12985,10 +12985,26 @@ local function RefreshPartyPreview()
         ns._partyOC:Show()
     end
 
-    -- Real mode: anchor frames to the actual party container position
+    -- Real mode: anchor frames to the actual party container, mirroring the
+    -- real layout's basePoint logic (_PositionPartySlots). Slot 0 sits at the
+    -- container corner the growth direction moves AWAY from, so Flip Frame
+    -- Growth keeps the stack bounded by the container instead of growing past
+    -- it. A plain TOPLEFT anchor misaligned the flipped preview by a full
+    -- stack height/width versus the edit-mode location.
     if mode == "real" and ns._partyContainerFrame then
         local pos = s.partyUnlockPos
         if pos then
+            local stepX, stepY = 0, 0
+            local basePoint = "TOPLEFT"
+            if unitGrowth == "RIGHT" then
+                stepX = w + spacing
+            elseif unitGrowth == "LEFT" then
+                stepX = -(w + spacing); basePoint = "TOPRIGHT"
+            elseif unitGrowth == "UP" then
+                stepY = h + spacing; basePoint = "BOTTOMLEFT"
+            else -- DOWN
+                stepY = -(h + spacing)
+            end
             local idx = 0  -- running position; skips the hidden player frame
             for i = 1, 5 do
                 local f = ns._partyPvFrames[i]
@@ -12997,15 +13013,8 @@ local function RefreshPartyPreview()
                         f:Hide()
                     else
                         f:ClearAllPoints()
-                        local ox, oy = 0, 0
-                        if isVert then
-                            oy = idx * (h + spacing)
-                            if unitGrowth == "UP" then oy = -oy end
-                        else
-                            ox = idx * (w + spacing)
-                            if unitGrowth == "LEFT" then ox = -ox end
-                        end
-                        f:SetPoint("TOPLEFT", ns._partyContainerFrame, "TOPLEFT", ox, -oy)
+                        f:SetPoint(basePoint, ns._partyContainerFrame, basePoint,
+                            PixelSnap(stepX * idx), PixelSnap(stepY * idx))
                         idx = idx + 1
                     end
                 end


### PR DESCRIPTION
## Problem

In **Core Addons → Raid Frames / Party Frames**, with **Real Preview** mode enabled, toggling **Flip Frame Growth** caused the party preview frames to drift away from where the real frames actually sit (the edit-mode container location). The misalignment was a full stack height (vertical) or width (horizontal).

Bug report: https://discord.com/channels/585577383847788554/1517747088392323072

## Cause

The Real Preview path in `RefreshPartyPreview` anchored every preview frame to the container's `TOPLEFT` corner and only flipped the *sign* of the offset for UP/LEFT growth.

The live layout (`_PositionPartySlots`) instead anchors slot 0 to the corner the growth direction moves **away** from — `TOPRIGHT` for LEFT, `BOTTOMLEFT` for UP — so the container always bounds the visual stack. Because the preview didn't mirror that `basePoint`, a flipped stack grew out of the wrong corner.

## Fix

Derive `basePoint` and the per-slot step exactly the way `_PositionPartySlots` does, so the preview and the real frames share one positioning rule across all four growth directions.

The overlay preview path and the raid-frame preview (which normalizes into a bounding box) were already correct and are untouched.

## Testing

Verified in-client that Real Preview now aligns with the edit-mode location:
- Both vertical and horizontal orientations, flipped and unflipped.
- **Hide Self** on: the preview's reflow (remaining members close ranks to the anchor corner) matches the live frames' behavior.