### PR TITLE
fix: recognize flex Mythic raid difficulty (233) across gates

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIABR_TalentReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIABR_TalentReminders.lua
@@ -62,6 +62,7 @@ local TALENT_REMINDER_ZONES = {
     { name="The Voidspire",           type="raid" },
     { name="The Dreamrift",           type="raid" },
     { name="March on Quel'Danas",     type="raid" },
+    { name="Sporefall",               type="raid" },
 
     { name="Magister's Terrace",      type="dungeon", mapID=2515 },
     { name="Maisara Caverns",         type="dungeon", mapID=2501 },

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -142,18 +142,24 @@ local function InMythicZeroDungeon()
     return false
 end
 
+-- Mythic raid difficulty: fixed 20-player (16, PrimaryRaidMythic) or
+-- flexible (233, RaidMythicFlexible, added in 12.0.x). Add future Mythic
+-- raid difficulty IDs here so every gate below stays correct.
+local function IsMythicRaidDiff(d)
+    return d == 16 or d == 233
+end
 
--- Mythic 0 dungeon (party, normal difficulty 1) or Mythic raid (difficulty 16)
+-- Mythic 0 dungeon (party, normal difficulty 1) or Mythic raid (fixed or flex)
 local function InMythicZeroDungeonOrMythicRaid()
     if InMythicZeroDungeon() then return true end
-    if IsInRaid() and _cachedDiffID == 16 then return true end
+    if IsInRaid() and IsMythicRaidDiff(_cachedDiffID) then return true end
     return false
 end
 
 -- Heroic+ content (heroic dungeon/raid or mythic dungeon/raid/M+)
 local function InHeroicOrMythicContent()
     if _cachedIType == "party" and (_cachedDiffID == 2 or _cachedDiffID == 23 or _cachedDiffID == 8) then return true end
-    if _cachedIType == "raid" and (_cachedDiffID == 5 or _cachedDiffID == 6 or _cachedDiffID == 15 or _cachedDiffID == 16) then return true end
+    if _cachedIType == "raid" and (_cachedDiffID == 5 or _cachedDiffID == 6 or _cachedDiffID == 15 or IsMythicRaidDiff(_cachedDiffID)) then return true end
     return false
 end
 
@@ -1981,10 +1987,10 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
         end
 
         -- Consumables (weapon enchants, flask, food) only in Mythic dungeons
-        -- (M0/M+) and Normal/Heroic/Mythic raids.
+        -- (M0/M+) and Normal/Heroic/Mythic raids (fixed 16 or flex 233).
         if inInstance and (InMythicPlusKey()
             or (_cachedIType == "party" and (_cachedDiffID == 23 or _cachedDiffID == 8))
-            or (_cachedIType == "raid" and (_cachedDiffID == 14 or _cachedDiffID == 15 or _cachedDiffID == 16))) then
+            or (_cachedIType == "raid" and (_cachedDiffID == 14 or _cachedDiffID == 15 or IsMythicRaidDiff(_cachedDiffID)))) then
 
         -- Weapon Enchants (temp weapon enchant items)
         -- Skip if the player knows any imbue spell (Shaman imbues, Paladin rites).

--- a/EllesmereUI_PartyMode.lua
+++ b/EllesmereUI_PartyMode.lua
@@ -461,11 +461,12 @@ pmInit:SetScript("OnEvent", function(self, event, ...)
         local encounterID, encounterName, difficultyID, groupSize, success = ...
         if success ~= 1 then return end
         local diffMap = {
-            [16] = "partyModeTriggerMythicBoss",
-            [15] = "partyModeTriggerHeroicBoss",
-            [14] = "partyModeTriggerNormalBoss",
-            [17] = "partyModeTriggerLFRBoss",
-            [23] = "partyModeTriggerMythic0",
+            [16]  = "partyModeTriggerMythicBoss",
+            [233] = "partyModeTriggerMythicBoss",  -- flex Mythic (RaidMythicFlexible)
+            [15]  = "partyModeTriggerHeroicBoss",
+            [14]  = "partyModeTriggerNormalBoss",
+            [17]  = "partyModeTriggerLFRBoss",
+            [23]  = "partyModeTriggerMythic0",
         }
         local key = diffMap[difficultyID]
         if not key then return end


### PR DESCRIPTION
## Summary

Flex Mythic (`DifficultyUtil.ID.RaidMythicFlexible = 233`) is a new raid difficulty introduced in 12.0.x. Several gates classified "is this a Mythic raid?" by hardcoded `== 16` (`PrimaryRaidMythic`), so in **Mythic Sporefall** (which reports `233`) those features silently broke.

Reported in Discord: https://discord.com/channels/585577383847788554/1517756363600691271 (flask/food reminders not working in Mythic Sporefall).

## Root cause

Old fixed Mythic (`16`) still coexists with flex Mythic (`233`), and the `== 16` allowlists didn't include `233`, so the affected `if` branches all failed.

## Changes

- **`EllesmereUIAuraBuffReminders.lua`** — added a single `IsMythicRaidDiff(d)` helper (`16` or `233`) and routed every Mythic-raid gate through it:
  - flask / food / weapon-enchant consumable gate (the reported bug)
  - augment-rune gates (`InMythicZeroDungeonOrMythicRaid`, `InHeroicOrMythicContent`)
- **`EllesmereUI_PartyMode.lua`** — `ENCOUNTER_END` diffMap now maps `233 -> partyModeTriggerMythicBoss`, so the Mythic-boss celebration fires on flex Mythic.
- **`EllesmereUIABR_TalentReminders.lua`** — added `Sporefall` to `TALENT_REMINDER_ZONES`.

Centralizing the IDs means the next new difficulty is a one-line change in `IsMythicRaidDiff` rather than another hunt across files.

## Out of scope (already handled)

Combat logging (`EllesmereUIQoL_AutoLogging.lua`) already whitelists Sporefall (mapID `1592`) and maps `233 -> logMythic` on `main`; no change needed there.

## Verification

- `233` confirmed against the 12.0.7 export (`DifficultyUtil.ID.RaidMythicFlexible = 233`).
- Swept the whole addon for difficulty-ID checks; remaining ones are pure "in instance" (`diffID > 0`), delve (`208`/`204`), or group-size (`tier == 15`) — unaffected.
- In-client: walked into Mythic Sporefall and confirmed both the talent reminder and the food/flask reminders now show.