### PR TITLE
[RaidFrames] introducing new frame level properties for individual components

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -204,6 +204,15 @@ local function StyleIcon(icon)
     local k = raid and 1 or (ns._partyIndicatorScale or 1)
     local sz = Setting(raid, "IconSize", 24) * k
     icon:SetSize(sz, sz)
+    -- Frame level: read from tsLevel/tsRaidLevel setting so the option takes effect.
+    local lvlKey = Setting(raid, "Level", "medium")
+    local parent = icon:GetParent()
+    if parent then
+        icon:SetFrameLevel(parent:GetFrameLevel() + ns.FRAMELVL[lvlKey])
+        if icon._borderFrame then
+            icon._borderFrame:SetFrameLevel(icon:GetFrameLevel() + 1)
+        end
+    end
     if icon._borderFrame then
         local PP = EllesmereUI and (EllesmereUI.PanelPP or EllesmereUI.PP)
         if PP and PP.UpdateBorder then
@@ -216,7 +225,6 @@ end
 local function CreateIcon(btn, raid)
     local icon = CreateFrame("Frame", nil, btn)
     icon._tsRaid = raid or false
-    icon:SetFrameLevel(btn:GetFrameLevel() + 12)
     icon:Hide()
 
     local tex = icon:CreateTexture(nil, "ARTWORK")

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -105,7 +105,7 @@ local FRAMELVL_VALUES = {
 }
 local FRAMELVL_ORDER = { "behindBorders", "behindText", "medium", "high", "highest" }
 local FRAMELVL_BASE = {
-    behindBorders = 7,                -- below the main border (+8)
+    behindBorders = 7,                -- below the configurable threat/dispel borders (default high = +20)
     behindText    = 11,               -- below the name/health text carrier, above borders
     medium        = ns.FRAMELVL.medium,
     high          = ns.FRAMELVL.high,
@@ -855,7 +855,7 @@ function ns.BM_CreateIndicators(button, health, d, PP)
     -- Frame effect border
     local effectBorder = CreateFrame("Frame", nil, button)
     effectBorder:SetAllPoints(button)
-    effectBorder:SetFrameLevel(button:GetFrameLevel() + 11)
+    effectBorder:SetFrameLevel(button:GetFrameLevel() + ns.FRAMELVL.highest)
     effectBorder:Hide()
     if PP then PP.CreateBorder(effectBorder, 0, 1, 0, 1, 2) end
 
@@ -2370,7 +2370,7 @@ function ns.BM_CreatePreviewIndicators(f, health, PP)
 
     local effectBorder = CreateFrame("Frame", nil, f)
     effectBorder:SetAllPoints(f)
-    effectBorder:SetFrameLevel(f:GetFrameLevel() + 11)
+    effectBorder:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL.highest)
     effectBorder:Hide()
     if PP then PP.CreateBorder(effectBorder, 0, 1, 0, 1, 2) end
 

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -105,13 +105,13 @@ local FRAMELVL_VALUES = {
 }
 local FRAMELVL_ORDER = { "behindBorders", "behindText", "medium", "high", "highest" }
 local FRAMELVL_BASE = {
-    behindBorders = 7,   -- below the main border (+8)
-    behindText    = 11,  -- below the name/health text carrier (+12), above borders
-    medium        = 13,  -- ns.LVL_AURA: the original/default band
-    high          = 14,
-    highest       = 15,
+    behindBorders = 7,                -- below the main border (+8)
+    behindText    = 11,               -- below the name/health text carrier, above borders
+    medium        = ns.FRAMELVL.medium,
+    high          = ns.FRAMELVL.high,
+    highest       = ns.FRAMELVL.highest,
 }
-local FRAMELVL_TEXT = 18  -- fixed count/duration text-carrier offset (icon/square)
+
 
 -------------------------------------------------------------------------------
 --  Healer spell database
@@ -1035,7 +1035,7 @@ local function BM_ApplyIconLevel(fr, ind, baseLvl)
     -- Set each explicitly rather than relying on child-level propagation.
     if fr._cooldown then fr._cooldown:SetFrameLevel(baseLvl + off + 1) end
     if fr._bdr then fr._bdr:SetFrameLevel(baseLvl + off + 1) end
-    if fr._textCarrier then fr._textCarrier:SetFrameLevel(baseLvl + FRAMELVL_TEXT) end
+    if fr._textCarrier then fr._textCarrier:SetFrameLevel(baseLvl + off + 2) end
 end
 
 -- Bars have no border/text sub-frames, so only the base applies. Bars default

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -1741,7 +1741,7 @@ initFrame:SetScript("OnEvent", function(self)
                 function() end, "accent", false, "Accent Color")
         end
 
-        -- Row 3: Health Text Position (+ cog for X/Y) | HealthText Size
+        -- Row 3: Health Text Position (+ cog for X/Y) | Health Text Size
         row, h = W:DualRow(parent, y,
             { type="dropdown", text="Health Text Position", values=namePositionValues, order=namePositionOrder,
               disabled=function() return SVal("healthTextMode", "none") == "none" end,
@@ -1869,7 +1869,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 1: Role Icon Style | Role Icon Size
         local ROLE_MEDIA = "Interface\\AddOns\\EllesmereUIRaidFrames\\Media\\"
         local RI_STYLES = {
-            modern = { _isTexture = true, TANK = ROLE_MEDIA .. "tank-modern.png", HEALER = ROLE_MEDIA .. "healer-modern.png", DAMAGER = ROLE_MEDIA .. "dpssymotion-linemarks)-modern.png" },
+            modern = { _isTexture = true, TANK = ROLE_MEDIA .. "tank-modern.png", HEALER = ROLE_MEDIA .. "healer-modern.png", DAMAGER = ROLE_MEDIA .. "dps-modern.png" },
             modernCircle = { TANK = "UI-LFG-RoleIcon-Tank", HEALER = "UI-LFG-RoleIcon-Healer", DAMAGER = "UI-LFG-RoleIcon-DPS" },
             styled = { TANK = "UI-LFG-RoleIcon-Tank-Background", HEALER = "UI-LFG-RoleIcon-Healer-Background", DAMAGER = "UI-LFG-RoleIcon-DPS-Background" },
             classicCircle = { TANK = "UI-LFG-RoleIcon-Tank-Micro-GroupFinder", HEALER = "UI-LFG-RoleIcon-Healer-Micro-GroupFinder", DAMAGER = "UI-LFG-RoleIcon-DPS-Micro-GroupFinder" },

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -2240,7 +2240,7 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
             cogBtn:SetAlpha(0.4)
             local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
-            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.COGS_ICON)
             cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
             cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
@@ -2263,7 +2263,7 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
             cogBtn:SetAlpha(0.4)
             local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
-            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.COGS_ICON)
             cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
             cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
@@ -4495,7 +4495,7 @@ initFrame:SetScript("OnEvent", function(self)
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsGrowDirection", "CENTER") end,
                   setValue=function(v) SSet("tsGrowDirection", v); TSApply() end });  y = y - h
-            -- Cog for targeted spells offset X/Y
+            -- Cog for targeted spells offset X/Y | Frame level dropdown
             do
                 local rgn = row._leftRegion
                 local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -4507,6 +4507,9 @@ initFrame:SetScript("OnEvent", function(self)
                         { type="slider", label="Offset Y", min=-50, max=50, step=1,
                           get=function() return SVal("tsOffsetY", 0) end,
                           set=function(v) SSet("tsOffsetY", v); TSApply() end },
+                        { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                          get=function() return SVal("tsLevel", "medium") end,
+                          set=function(v) SSet("tsLevel", v) end },
                     },
                 })
                 local cogBtn = CreateFrame("Button", nil, rgn)

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -425,6 +425,18 @@ initFrame:SetScript("OnEvent", function(self)
     end
 
     ---------------------------------------------------------------------------
+    -- Shared strata scale value tables (ns.STRATA_SCALE)
+    ---------------------------------------------------------------------------
+    local sharedStrataScaleValues = {
+      ["lowest"]  = "Lowest",
+      ["low"]     = "Low",
+      ["medium"]  = "Medium",
+      ["high"]    = "High",
+      ["highest"] = "Highest",
+    }
+    local sharedStrataScaleOrder = { "lowest", "low", "medium", "high", "highest" }
+
+    ---------------------------------------------------------------------------
     --  Health bar texture dropdown
     ---------------------------------------------------------------------------
     -- Re-append SharedMedia textures now (post-login) so the dropdown includes
@@ -1637,7 +1649,7 @@ initFrame:SetScript("OnEvent", function(self)
             { type="dropdown", text="Health Text", values=healthTextValues, order=healthTextOrder,
               getValue=function() return SVal("healthTextMode", "none") end,
               setValue=function(v) SSet("healthTextMode", v) end });  y = y - h
-        -- Cog for name offset X/Y
+        -- Cog for name offset X/Y | Frame level dropdown
         do
             local rgn = row._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -1649,6 +1661,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("nameOffsetY", 0) end,
                       set=function(v) SSet("nameOffsetY", v) end },
+                   { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("nameLevel", "lowest") end,
+                      set=function(v) SSet("nameLevel", v) end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -1726,7 +1741,7 @@ initFrame:SetScript("OnEvent", function(self)
                 function() end, "accent", false, "Accent Color")
         end
 
-        -- Row 3: Health Text Position (+ cog for X/Y) | Health Text Size
+        -- Row 3: Health Text Position (+ cog for X/Y) | HealthText Size
         row, h = W:DualRow(parent, y,
             { type="dropdown", text="Health Text Position", values=namePositionValues, order=namePositionOrder,
               disabled=function() return SVal("healthTextMode", "none") == "none" end,
@@ -1738,7 +1753,7 @@ initFrame:SetScript("OnEvent", function(self)
               disabledTooltip="Health Text",
               getValue=function() return SVal("healthTextSize", 9) end,
               setValue=function(v) SSet("healthTextSize", v) end });  y = y - h
-        -- Cog for health text offset X/Y
+        -- Cog for health text offset X/Y | Frame level dropdown
         do
             local rgn = row._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -1750,6 +1765,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("healthTextOffsetY", 0) end,
                       set=function(v) SSet("healthTextOffsetY", v) end },
+                   { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("healthTextLevel", "lowest") end,
+                      set=function(v) SSet("healthTextLevel", v) end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -1851,7 +1869,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 1: Role Icon Style | Role Icon Size
         local ROLE_MEDIA = "Interface\\AddOns\\EllesmereUIRaidFrames\\Media\\"
         local RI_STYLES = {
-            modern = { _isTexture = true, TANK = ROLE_MEDIA .. "tank-modern.png", HEALER = ROLE_MEDIA .. "healer-modern.png", DAMAGER = ROLE_MEDIA .. "dps-modern.png" },
+            modern = { _isTexture = true, TANK = ROLE_MEDIA .. "tank-modern.png", HEALER = ROLE_MEDIA .. "healer-modern.png", DAMAGER = ROLE_MEDIA .. "dpssymotion-linemarks)-modern.png" },
             modernCircle = { TANK = "UI-LFG-RoleIcon-Tank", HEALER = "UI-LFG-RoleIcon-Healer", DAMAGER = "UI-LFG-RoleIcon-DPS" },
             styled = { TANK = "UI-LFG-RoleIcon-Tank-Background", HEALER = "UI-LFG-RoleIcon-Healer-Background", DAMAGER = "UI-LFG-RoleIcon-DPS-Background" },
             classicCircle = { TANK = "UI-LFG-RoleIcon-Tank-Micro-GroupFinder", HEALER = "UI-LFG-RoleIcon-Healer-Micro-GroupFinder", DAMAGER = "UI-LFG-RoleIcon-DPS-Micro-GroupFinder" },
@@ -1963,7 +1981,7 @@ initFrame:SetScript("OnEvent", function(self)
               disabledTooltip="Role Icons",
               getValue=function() return SVal("roleIconSize", 14) end,
               setValue=function(v) SSet("roleIconSize", v) end });  y = y - h
-        -- Cog for role icon offset X/Y
+        -- Cog for role icon offset X/Y | frame level dropdown
         do
             local rgn = roleRow2._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -1975,6 +1993,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("roleIconOffsetY", 0) end,
                       set=function(v) SSet("roleIconOffsetY", v) end },
+                    { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("roleIconLevel", "low") end,
+                      set=function(v) SSet("roleIconLevel", v) end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -2025,7 +2046,7 @@ initFrame:SetScript("OnEvent", function(self)
               getValue=function() return SVal("raidMarkerSize", 16) end,
               setValue=function(v) SSet("raidMarkerSize", v) end });  y = y - h
 
-        -- Cog for marker offset X/Y
+        -- Cog for marker offset X/Y | Frame level dropdown
         do
             local rgn = row._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -2037,6 +2058,10 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("raidMarkerOffsetY", 0) end,
                       set=function(v) SSet("raidMarkerOffsetY", v) end },
+                    { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("raidMarkerLevel", "highest") end,
+                      set=function(v) SSet("raidMarkerLevel", v) end },
+
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -2074,7 +2099,7 @@ initFrame:SetScript("OnEvent", function(self)
             { type="slider", text="Text Size", min=6, max=24, step=1,
               getValue=function() return SVal("statusTextSize", 14) end,
               setValue=function(v) SSet("statusTextSize", v) end });  y = y - h
-        -- Cog for status text offset X/Y
+        -- Cog for status text offset X/Y | Frame level dropdown
         do
             local rgn = stRow._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -2089,6 +2114,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("statusTextOffsetY", 0) end,
                       set=function(v) SSet("statusTextOffsetY", v) end },
+                    { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("statusTextLevel", "low") end,
+                      set=function(v) SSet("statusTextLevel", v) end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -2155,7 +2183,7 @@ initFrame:SetScript("OnEvent", function(self)
               disabledTooltip="Leader Icon",
               getValue=function() return SVal("leaderIconSize", 14) end,
               setValue=function(v) SSet("leaderIconSize", v) end });  y = y - h
-        -- Cog for leader icon offset X/Y
+        -- Cog for leader icon offset X/Y | Frame level dropdown
         do
             local rgn = row._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -2167,6 +2195,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("leaderIconOffsetY", 0) end,
                       set=function(v) SSet("leaderIconOffsetY", v) end },
+                    { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("leaderIconLevel", "low") end,
+                      set=function(v) SSet("leaderIconLevel", v) end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -3165,7 +3196,7 @@ initFrame:SetScript("OnEvent", function(self)
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsRaidGrowDirection", "CENTER") end,
                   setValue=function(v) SSet("tsRaidGrowDirection", v); TSApply() end });  y = y - h
-            -- Cog for targeted spells offset X/Y
+            -- Cog for targeted spells offset X/Y | Frame level dropdown
             do
                 local rgn = row._leftRegion
                 local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -3177,6 +3208,9 @@ initFrame:SetScript("OnEvent", function(self)
                         { type="slider", label="Offset Y", min=-50, max=50, step=1,
                           get=function() return SVal("tsRaidOffsetY", 0) end,
                           set=function(v) SSet("tsRaidOffsetY", v); TSApply() end },
+                        { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                          get=function() return SVal("tsLevel", "medium") end,
+                          set=function(v) SSet("tsLevel", v) end },
                     },
                 })
                 local cogBtn = CreateFrame("Button", nil, rgn)
@@ -4628,7 +4662,7 @@ initFrame:SetScript("OnEvent", function(self)
             rgn._control = cbDD
             rgn._lastInline = nil
         end
-        -- Cog for position offset X/Y
+        -- Cog for position offset X/Y | Frame level dropdown
         do
             local rgn = defShowRow._rightRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -4640,6 +4674,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("defOffsetY", 0) end,
                       set=function(v) SSet("defOffsetY", v) end },
+                    { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("defLevel", "medium") end,
+                      set=function(v) SSet("defLevel", v) end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -4848,7 +4885,7 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v) SSet("paGrowDirection", v) end });  y = y - h
         ns._editTargets = ns._editTargets or {}
         ns._editTargets.privateAuras = paRow1
-        -- Cog for position offset X/Y
+        -- Cog for position offset X/Y | Frame level dropdown
         do
             local rgn = paRow1._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -4860,6 +4897,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("paOffsetY", 0) end,
                       set=function(v) SSet("paOffsetY", v) end },
+                    { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("paLevel", "medium") end,
+                      set=function(v) SSet("paLevel", v) end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -5014,7 +5054,7 @@ initFrame:SetScript("OnEvent", function(self)
               disabledTooltip="Show Debuffs",
               getValue=function() return SVal("debuffGrowDirection", "RIGHT") end,
               setValue=function(v) SSet("debuffGrowDirection", v) end });  y = y - h
-        -- Cog for debuff offset X/Y
+        -- Cog for debuff offset X/Y | Frame level dropdown
         do
             local rgn = row._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -5026,6 +5066,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Offset Y", min=-50, max=50, step=1,
                       get=function() return SVal("debuffOffsetY", 0) end,
                       set=function(v) SSet("debuffOffsetY", v) end },
+                   { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("debuffLevel", "medium") end,
+                      set=function(v) SSet("debuffLevel", v) end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -436,6 +436,9 @@ initFrame:SetScript("OnEvent", function(self)
     }
     local sharedStrataScaleOrder = { "lowest", "low", "medium", "high", "highest" }
 
+    local borderLevelValues = sharedStrataScaleValues
+    local borderLevelOrder  = sharedStrataScaleOrder
+
     ---------------------------------------------------------------------------
     --  Health bar texture dropdown
     ---------------------------------------------------------------------------
@@ -1032,6 +1035,29 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v) SSet("threatBorderSize", v) end });  y = y - h
         ns._editTargets.threat = smoothThreatRow
         ns._editTargets.animateBars = smoothThreatRow
+        -- Cog: threatBorderLevel
+        do
+            local rgn = smoothThreatRow._rightRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Threat Border",
+                rows = {
+                    { type="dropdown", label="Frame Level", values=borderLevelValues, order=borderLevelOrder,
+                      get=function() return SVal("threatBorderLevel", "medium") end,
+                      set=function(v) SSet("threatBorderLevel", v) end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.COGS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+        end
 
         -------------------------------------------------------------------
         --  ABSORBS
@@ -2448,6 +2474,29 @@ initFrame:SetScript("OnEvent", function(self)
                   end
                   EllesmereUI:RefreshPage()
               end });  y = y - h
+        -- Cog: dispelBorderLevel
+        do
+            local rgn = row._leftRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Dispel Border",
+                rows = {
+                    { type="dropdown", label="Frame Level", values=borderLevelValues, order=borderLevelOrder,
+                      get=function() return SVal("dispelBorderLevel", "high") end,
+                      set=function(v) SSet("dispelBorderLevel", v) end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.COGS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+        end
         -- Cog for dispel icon offset X/Y
         do
             local rgn = row._rightRegion

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -2213,6 +2213,62 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
         end
 
+        -- Show Ready Check | Show Summon Pending
+        local rcRow
+        rcRow, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Ready Check",
+              getValue=function() return SVal("showReadyCheck", true) end,
+              setValue=function(v) SSet("showReadyCheck", v) end },
+            { type="toggle", text="Show Summon Pending",
+              getValue=function() return SVal("showSummonPending", true) end,
+              setValue=function(v) SSet("showSummonPending", v) end });  y = y - h
+        -- Cog: readyCheckLevel
+        do
+            local rgn = rcRow._leftRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Ready Check",
+                rows = {
+                    { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("readyCheckLevel", "low") end,
+                      set=function(v) SSet("readyCheckLevel", v) end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+        end
+        -- Cog: summonPendingLevel
+        do
+            local rgn = rcRow._rightRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Summon Pending",
+                rows = {
+                    { type="dropdown", label="Frame Level", values=sharedStrataScaleValues, order=sharedStrataScaleOrder,
+                      get=function() return SVal("summonPendingLevel", "low") end,
+                      set=function(v) SSet("summonPendingLevel", v) end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+        end
+
         -- Show Group Numbers | Number Size (+ inline color swatch with alpha).
         -- Raid only: party frames have no groups. The size + color also drive the
         -- always-on preview group labels; the toggle gates only the real frames.

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -1042,7 +1042,7 @@ initFrame:SetScript("OnEvent", function(self)
                 title = "Threat Border",
                 rows = {
                     { type="dropdown", label="Frame Level", values=borderLevelValues, order=borderLevelOrder,
-                      get=function() return SVal("threatBorderLevel", "medium") end,
+                      get=function() return SVal("threatBorderLevel", "high") end,
                       set=function(v) SSet("threatBorderLevel", v) end },
                 },
             })

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -425,7 +425,7 @@ initFrame:SetScript("OnEvent", function(self)
     end
 
     ---------------------------------------------------------------------------
-    -- Shared strata scale value tables (ns.STRATA_SCALE)
+    -- Shared frame level value tables (ns.FRAMELVL)
     ---------------------------------------------------------------------------
     local sharedStrataScaleValues = {
       ["lowest"]  = "Lowest",

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -35,7 +35,7 @@ ns.LVL_RAISE  = 20   -- main border while hovered/targeted (PP container at +1)
 ns.LVL_MARKER = 22   -- raid marker icon (always on top)
 
 -- TODO: remove old scale.
-ns.STRATA_SCALE = {
+ns.FRAMELVL = {
     lowest  = 12,  -- offset level for name/health text
     low     = 13,  -- offset level for indicators (except Raid Markers at "highest")
     medium  = 14, -- offset level for every aura icon/bar
@@ -2330,9 +2330,9 @@ local function StyleButton(button)
 
     local function UpdateTextCarriersLevel()
         local pl = button:GetFrameLevel()
-        nameTextCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.nameLevel])
-        healthTextCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.healthTextLevel])
-        statusTextCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.statusTextLevel])
+        nameTextCarrier:SetFrameLevel(pl + ns.FRAMELVL[s.nameLevel])
+        healthTextCarrier:SetFrameLevel(pl + ns.FRAMELVL[s.healthTextLevel])
+        statusTextCarrier:SetFrameLevel(pl + ns.FRAMELVL[s.statusTextLevel])
     end
     UpdateTextCarriersLevel()
     d.UpdateTextCarriersLevel = UpdateTextCarriersLevel
@@ -2442,11 +2442,11 @@ local function StyleButton(button)
 
     local function UpdateIndicatorsLevel()
         local pl = button:GetFrameLevel()
-        roleCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.roleIconLevel])
-        markerCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.raidMarkerLevel])
-        readyCheckCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.readyCheckLevel])
-        summonPendingCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.summonPendingLevel])
-        d.leaderHost:SetFrameLevel(pl + ns.STRATA_SCALE[s.leaderIconLevel])
+        roleCarrier:SetFrameLevel(pl + ns.FRAMELVL[s.roleIconLevel])
+        markerCarrier:SetFrameLevel(pl + ns.FRAMELVL[s.raidMarkerLevel])
+        readyCheckCarrier:SetFrameLevel(pl + ns.FRAMELVL[s.readyCheckLevel])
+        summonPendingCarrier:SetFrameLevel(pl + ns.FRAMELVL[s.summonPendingLevel])
+        d.leaderHost:SetFrameLevel(pl + ns.FRAMELVL[s.leaderIconLevel])
     end
     UpdateIndicatorsLevel()
     d.UpdateIndicatorsLevel = UpdateIndicatorsLevel
@@ -2708,9 +2708,9 @@ local function StyleButton(button)
 
     local function UpdateAuraLevels()
         local pl = button:GetFrameLevel()
-        local debuffOff = ns.STRATA_SCALE[s.debuffLevel]
-        local defOff    = ns.STRATA_SCALE[s.defLevel]
-        local paOff     = ns.STRATA_SCALE[s.paLevel]
+        local debuffOff = ns.FRAMELVL[s.debuffLevel]
+        local defOff    = ns.FRAMELVL[s.defLevel]
+        local paOff     = ns.FRAMELVL[s.paLevel]
 
         for _, icon in ipairs(d.debuffIcons) do
             icon:SetFrameLevel(pl + debuffOff)
@@ -4162,7 +4162,7 @@ local function RegisterPrivateAuraSlots(button, unit)
         paFrame:SetScale(ts)
         paFrame:SetSize(slotSz / ts, slotSz / ts)
         paFrame:SetFrameStrata(fixedStrata)
-        paFrame:SetFrameLevel(button:GetFrameLevel() + ns.STRATA_SCALE[s.paLevel])
+        paFrame:SetFrameLevel(button:GetFrameLevel() + ns.FRAMELVL[s.paLevel])
         paFrame:ClearAllPoints()
 
         if i == 1 then
@@ -10171,7 +10171,7 @@ local function CreatePreviewFrame(index)
     -- Marker carrier: raid marker host.
     local markerCarrier = CreateFrame("Frame", nil, f)
     markerCarrier:SetAllPoints(health)
-    markerCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.raidMarkerLevel])
+    markerCarrier:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.raidMarkerLevel])
     f._markerCarrier = markerCarrier
 
     -- Raid marker (on marker carrier, above the border)
@@ -10183,7 +10183,7 @@ local function CreatePreviewFrame(index)
     -- Ready check icon
     local readyCheckCarrier = CreateFrame("Frame", nil, f)
     readyCheckCarrier:SetAllPoints(health)
-    readyCheckCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.readyCheckLevel])
+    readyCheckCarrier:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.readyCheckLevel])
     f._readyCheckCarrier = readyCheckCarrier
 
     local readyCheck = readyCheckCarrier:CreateTexture(nil, "OVERLAY", nil, 3)
@@ -10194,7 +10194,7 @@ local function CreatePreviewFrame(index)
     -- Summon pending icon
     local summonPendingCarrier = CreateFrame("Frame", nil, f)
     summonPendingCarrier:SetAllPoints(health)
-    summonPendingCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.summonPendingLevel])
+    summonPendingCarrier:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.summonPendingLevel])
     f._summonPendingCarrier = summonPendingCarrier
 
     local summonPending = summonPendingCarrier:CreateTexture(nil, "OVERLAY", nil, 3)
@@ -10211,11 +10211,11 @@ local function CreatePreviewFrame(index)
     textCarrier:SetAllPoints(health)
 
     local nameTextCarrier = CreateFrame("Frame", nil, textCarrier)
-    nameTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.nameLevel])
+    nameTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.nameLevel])
     f._nameTextCarrier = nameTextCarrier
 
     local healthTextCarrier = CreateFrame("Frame", nil, textCarrier)
-    healthTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.healthTextLevel])
+    healthTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.healthTextLevel])
     f._healthTextCarrier = healthTextCarrier
 
     -- Name text
@@ -10233,7 +10233,7 @@ local function CreatePreviewFrame(index)
     healthFS:SetTextColor(1, 1, 1, 0.9)
 
     local statusTextCarrier = CreateFrame("Frame", nil, textCarrier)
-    statusTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.statusTextLevel])
+    statusTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.statusTextLevel])
     f._statusTextCarrier = statusTextCarrier
 
     -- Status text (DEAD / OFFLINE / AFK)
@@ -10247,7 +10247,7 @@ local function CreatePreviewFrame(index)
     -- Role icon carrier
     local roleCarrier = CreateFrame("Frame", nil, f)
     roleCarrier:SetAllPoints(health)
-    roleCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.roleIconLevel])
+    roleCarrier:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.roleIconLevel])
     f._roleCarrier = roleCarrier
     local roleIcon = roleCarrier:CreateTexture(nil, "OVERLAY")
     local riSz = PixelSnap(s.roleIconSize or 14)
@@ -10256,7 +10256,7 @@ local function CreatePreviewFrame(index)
     -- Leader icon host
     local leaderHost = CreateFrame("Frame", nil, f)
     leaderHost:SetAllPoints(health)
-    leaderHost:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.leaderIconLevel])
+    leaderHost:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.leaderIconLevel])
     f._leaderHost = leaderHost
     local leaderIcon = leaderHost:CreateTexture(nil, "OVERLAY")
     local liSz = PixelSnap(s.leaderIconSize or 14)
@@ -11469,9 +11469,9 @@ local function ApplyPreviewData(f, index)
         end
     end
     local fpl = f:GetFrameLevel()
-    if f._nameTextCarrier   then f._nameTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.nameLevel])         end
-    if f._healthTextCarrier then f._healthTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.healthTextLevel]) end
-    if f._statusTextCarrier then f._statusTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.statusTextLevel]) end
+    if f._nameTextCarrier   then f._nameTextCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.nameLevel])         end
+    if f._healthTextCarrier then f._healthTextCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.healthTextLevel]) end
+    if f._statusTextCarrier then f._statusTextCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.statusTextLevel]) end
 
     -- Aura icon pool levels
     local function RelevelAuraPool(pool, baseOff)
@@ -11482,9 +11482,9 @@ local function ApplyPreviewData(f, index)
             if icon._durCarrier  then icon._durCarrier:SetFrameLevel(fpl + baseOff + 2) end
         end
     end
-    local pvDebuffOff = ns.STRATA_SCALE[s.debuffLevel]
-    local pvDefOff    = ns.STRATA_SCALE[s.defLevel]
-    local pvPaOff     = ns.STRATA_SCALE[s.paLevel]
+    local pvDebuffOff = ns.FRAMELVL[s.debuffLevel]
+    local pvDefOff    = ns.FRAMELVL[s.defLevel]
+    local pvPaOff     = ns.FRAMELVL[s.paLevel]
     RelevelAuraPool(f._pvDebuffs, pvDebuffOff)
     RelevelAuraPool(f._pvDefs, pvDefOff)
     RelevelAuraPool(f._pvPA, pvPaOff)
@@ -11578,11 +11578,11 @@ local function ApplyPreviewData(f, index)
     -- Debuff/defensive preview icons managed by PvAuraTicker (cycling system)
 
     local fpl = f:GetFrameLevel()
-    if f._roleCarrier          then f._roleCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.roleIconLevel])            end
-    if f._markerCarrier        then f._markerCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.raidMarkerLevel])        end
-    if f._readyCheckCarrier    then f._readyCheckCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.readyCheckLevel])    end
-    if f._summonPendingCarrier then f._summonPendingCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.summonPendingLevel]) end
-    if f._leaderHost           then f._leaderHost:SetFrameLevel(fpl + ns.STRATA_SCALE[s.leaderIconLevel])           end
+    if f._roleCarrier          then f._roleCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.roleIconLevel])            end
+    if f._markerCarrier        then f._markerCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.raidMarkerLevel])        end
+    if f._readyCheckCarrier    then f._readyCheckCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.readyCheckLevel])    end
+    if f._summonPendingCarrier then f._summonPendingCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.summonPendingLevel]) end
+    if f._leaderHost           then f._leaderHost:SetFrameLevel(fpl + ns.FRAMELVL[s.leaderIconLevel])           end
 
     f:Show()
 end

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -512,7 +512,7 @@ local defaults = {
         summonPendingLevel = "low",
         showSummonPending  = true,
         threatBorderSize   = 2,    -- aggro warning border thickness; 0 = off
-        threatBorderLevel  = "medium",
+        threatBorderLevel  = "high",
         showLeaderIcon     = false,
         leaderIconSize     = 14,
         leaderIconLevel    = "low",

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -36,10 +36,10 @@ ns.LVL_MARKER = 22   -- raid marker icon (always on top)
 
 -- TODO: remove old scale.
 ns.STRATA_SCALE = {
-    lowest  = 7,  -- base level for name/health text
-    low     = 8,  -- base level for indicators (except Raid Markers at "highest")
-    medium  = 13, -- base level for every aura icon/bar
-    high    = 20, -- main border while hovered/targeted (PP container at +1)
+    lowest  = 12,  -- offset level for name/health text
+    low     = 13,  -- offset level for indicators (except Raid Markers at "highest")
+    medium  = 14, -- offset level for every aura icon/bar
+    high    = 20, -- offset level for main border while hovered/targeted (PP container at +1)
     highest = 22, -- highest priority, sits above main frame border
 }
 
@@ -2221,20 +2221,26 @@ local function StyleButton(button)
 
     -- Text carrier: name + health text sit ABOVE the base/threat/dispel borders
     -- (+8/+10/+11) and the BM frame-border effect (+11) so they stay readable,
-    -- but BELOW the aura layer (ns.LVL_AURA = +13) so debuffs/buffs draw over them.
+    -- but BELOW the indicator (+13) and the aura (+14) layers, as to allow these to
+    -- draw over them (assuming the user does not manually override these).
+
     local textCarrier = CreateFrame("Frame", nil, button)
     textCarrier:SetAllPoints(health)
-    textCarrier:SetFrameLevel(button:GetFrameLevel() + 12)
+
+    local nameTextCarrier = CreateFrame("Frame", nil, textCarrier)
+    d.nameTextCarrier = nameTextCarrier
+    local healthTextCarrier = CreateFrame("Frame", nil, textCarrier)
+    d.healthTextCarrier = healthTextCarrier
 
     -- Name text
-    local nameFS = textCarrier:CreateFontString(nil, "OVERLAY")
+    local nameFS = nameTextCarrier:CreateFontString(nil, "OVERLAY")
     ApplyFont(nameFS, s.nameSize or 10)
     nameFS:SetJustifyH("CENTER")
     nameFS:SetWordWrap(false)
     d.nameText = nameFS
 
     -- Health deficit text
-    local healthFS = textCarrier:CreateFontString(nil, "OVERLAY")
+    local healthFS = healthTextCarrier:CreateFontString(nil, "OVERLAY")
     ApplyFont(healthFS, s.healthTextSize or 9)
     healthFS:SetTextColor(1, 1, 1, 0.9)
     d.healthText = healthFS
@@ -2282,7 +2288,10 @@ local function StyleButton(button)
     d.AnchorHealthText = AnchorHealthText
 
     -- Status text (DEAD / OFFLINE / AFK -- always shown, own position/size/color)
-    local statusFS = health:CreateFontString(nil, "OVERLAY")
+    local statusTextCarrier = CreateFrame("Frame", nil, textCarrier)
+    d.statusTextCarrier = statusTextCarrier
+
+    local statusFS = statusTextCarrier:CreateFontString(nil, "OVERLAY")
     local stc = s.statusTextColor or { r = 1, g = 1, b = 1 }
     ApplyFont(statusFS, s.statusTextSize or 14)
     statusFS:SetJustifyH("CENTER")
@@ -2317,6 +2326,15 @@ local function StyleButton(button)
     end
     AnchorStatusText()
     d.AnchorStatusText = AnchorStatusText
+
+    local function UpdateTextCarriersLevel()
+        local pl = button:GetFrameLevel()
+        nameTextCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.nameLevel])
+        healthTextCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.healthTextLevel])
+        statusTextCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.statusTextLevel])
+    end
+    UpdateTextCarriersLevel()
+    d.UpdateTextCarriersLevel = UpdateTextCarriersLevel
 
     -- Role icon (carrier frame above power bar + its border so icon renders on top)
     local roleCarrier = CreateFrame("Frame", nil, button)
@@ -6729,6 +6747,7 @@ local function ReloadFrames()
             d.statusText:SetTextColor(stc.r, stc.g, stc.b)
             if d.AnchorStatusText then d.AnchorStatusText() end
         end
+        if d.UpdateTextCarriersLevel then d.UpdateTextCarriersLevel() end
 
         -- Role icon size + position
         if d.roleIcon then
@@ -8662,6 +8681,7 @@ ns.ReloadPartyFrames = function()
             d.statusText:SetTextColor(stc.r, stc.g, stc.b)
             if d.AnchorStatusText then d.AnchorStatusText() end
         end
+        if d.UpdateTextCarriersLevel then d.UpdateTextCarriersLevel() end
 
         -- Role icon
         if d.roleIcon then
@@ -10115,27 +10135,42 @@ local function CreatePreviewFrame(index)
     readyCheck:SetPoint("CENTER", health, "CENTER", 0, 0)
     readyCheck:Hide()
 
-    -- Text carrier: above borders (+8/+10/+11), below the aura layer (+13).
+    -- Text carrier: name + health text sit ABOVE the base/threat/dispel borders
+    -- (+8/+10/+11) and the BM frame-border effect (+11) so they stay readable,
+    -- but BELOW the indicator (+13) and the aura (+14) layers, as to allow these to
+    -- draw over them (assuming the user does not manually override these).
+
     local textCarrier = CreateFrame("Frame", nil, f)
     textCarrier:SetAllPoints(health)
-    textCarrier:SetFrameLevel(f:GetFrameLevel() + 12)
 
-    -- Name text (anchoring done by ApplyPreviewData on every refresh)
-    local nameFS = textCarrier:CreateFontString(nil, "OVERLAY")
+    local nameTextCarrier = CreateFrame("Frame", nil, textCarrier)
+    nameTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.nameLevel])
+    f._nameTextCarrier = nameTextCarrier
+
+    local healthTextCarrier = CreateFrame("Frame", nil, textCarrier)
+    healthTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.healthTextLevel])
+    f._healthTextCarrier = healthTextCarrier
+
+    -- Name text
+    local nameFS = nameTextCarrier:CreateFontString(nil, "OVERLAY")
     ApplyFont(nameFS, s.nameSize or 10)
     nameFS:SetJustifyH("CENTER")
     nameFS:SetWordWrap(false)
     nameFS:SetPoint("CENTER", health, "CENTER", 0, 0)
 
-    -- Health text
-    local healthFS = textCarrier:CreateFontString(nil, "OVERLAY")
+    -- Health deficit text
+    local healthFS = healthTextCarrier:CreateFontString(nil, "OVERLAY")
     ApplyFont(healthFS, s.healthTextSize or 9)
     healthFS:SetJustifyH("CENTER")
     healthFS:SetPoint("CENTER", health, "CENTER", 0, 0)
     healthFS:SetTextColor(1, 1, 1, 0.9)
 
+    local statusTextCarrier = CreateFrame("Frame", nil, textCarrier)
+    statusTextCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.statusTextLevel])
+    f._statusTextCarrier = statusTextCarrier
+
     -- Status text (DEAD / OFFLINE / AFK)
-    local statusFS = textCarrier:CreateFontString(nil, "OVERLAY")
+    local statusFS = statusTextCarrier:CreateFontString(nil, "OVERLAY")
     local pvStc = s.statusTextColor or { r = 1, g = 1, b = 1 }
     ApplyFont(statusFS, s.statusTextSize or 14)
     statusFS:SetJustifyH("CENTER")
@@ -11318,7 +11353,6 @@ local function ApplyPreviewData(f, index)
             f._healthText:SetText("")
         end
     end
-
     -- Status text (DEAD / OFFLINE / AFK)
     if f._statusText then
         local pvStc = s.statusTextColor or { r = 1, g = 1, b = 1 }
@@ -11360,6 +11394,10 @@ local function ApplyPreviewData(f, index)
             f._statusText:Hide()
         end
     end
+    local fpl = f:GetFrameLevel()
+    if f._nameTextCarrier   then f._nameTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.nameLevel])         end
+    if f._healthTextCarrier then f._healthTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.healthTextLevel]) end
+    if f._statusTextCarrier then f._statusTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.statusTextLevel]) end
 
     -- Dead/DC overlay (mirror the live-frame status tint: full-cover bg)
     if isDead then

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -2487,6 +2487,7 @@ local function StyleButton(button)
         local dbDurCarrier = CreateFrame("Frame", nil, icon)
         dbDurCarrier:SetAllPoints()
         dbDurCarrier:SetFrameLevel(dbTextLevel)
+        icon._durCarrier = dbDurCarrier
 
         -- Stack count text
         local dbCountFS = dbDurCarrier:CreateFontString(nil, "OVERLAY")
@@ -2635,6 +2636,7 @@ local function StyleButton(button)
         local defDurCarrier = CreateFrame("Frame", nil, defIcon)
         defDurCarrier:SetAllPoints()
         defDurCarrier:SetFrameLevel(defCD:GetFrameLevel() + 2)
+        defIcon._durCarrier = defDurCarrier
         local defDurFontPath = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("raidFrames")) or "Fonts\\FRIZQT__.TTF"
         local defDurFS = defDurCarrier:CreateFontString(nil, "OVERLAY")
         defDurFS:SetPoint("CENTER", defIcon, "CENTER", 0, 0)
@@ -2703,6 +2705,37 @@ local function StyleButton(button)
     end
     AnchorDefensives()
     d.AnchorDefensives = AnchorDefensives
+
+    local function UpdateAuraLevels()
+        local pl = button:GetFrameLevel()
+        local debuffOff = ns.STRATA_SCALE[s.debuffLevel]
+        local defOff    = ns.STRATA_SCALE[s.defLevel]
+        local paOff     = ns.STRATA_SCALE[s.paLevel]
+
+        for _, icon in ipairs(d.debuffIcons) do
+            icon:SetFrameLevel(pl + debuffOff)
+            if icon._borderFrame then icon._borderFrame:SetFrameLevel(pl + debuffOff + 1) end
+            if icon._durCarrier  then icon._durCarrier:SetFrameLevel(pl + debuffOff + 2) end
+        end
+
+        for _, icon in ipairs(d.defIcons) do
+            icon:SetFrameLevel(pl + defOff)
+            if icon._borderFrame then icon._borderFrame:SetFrameLevel(pl + defOff + 1) end
+            if icon._durCarrier  then icon._durCarrier:SetFrameLevel(pl + defOff + 2) end
+        end
+
+        if d.privateAuraFrames then
+            for _, paFrame in ipairs(d.privateAuraFrames) do
+                paFrame:SetFrameLevel(pl + paOff)
+            end
+        end
+
+        if d.dispelContainer then
+            d.dispelContainer:SetFrameLevel(pl + paOff)
+        end
+    end
+    UpdateAuraLevels()
+    d.UpdateAuraLevels = UpdateAuraLevels
 
     -- Anchor name text based on position setting
     -- Uses two-point anchoring (LEFT+RIGHT) for width constraint, with
@@ -4129,7 +4162,7 @@ local function RegisterPrivateAuraSlots(button, unit)
         paFrame:SetScale(ts)
         paFrame:SetSize(slotSz / ts, slotSz / ts)
         paFrame:SetFrameStrata(fixedStrata)
-        paFrame:SetFrameLevel(button:GetFrameLevel() + ns.LVL_AURA)
+        paFrame:SetFrameLevel(button:GetFrameLevel() + ns.STRATA_SCALE[s.paLevel])
         paFrame:ClearAllPoints()
 
         if i == 1 then
@@ -6817,6 +6850,8 @@ local function ReloadFrames()
             end
         end
 
+        if d.UpdateAuraLevels then d.UpdateAuraLevels() end
+
         -- Buff manager indicators
         if d.bmIconPool and d.health and ns.BM_AnchorIndicators then
             ns.BM_AnchorIndicators(d, d.health, s)
@@ -8751,6 +8786,8 @@ ns.ReloadPartyFrames = function()
             end
         end
 
+        if d.UpdateAuraLevels then d.UpdateAuraLevels() end
+
         -- Buff manager indicators (pass the scaled proxy: BM picks the party
         -- indicator scale by recognizing this exact table)
         if d.bmIconPool and d.health and ns.BM_AnchorIndicators then
@@ -10286,6 +10323,7 @@ local function CreatePreviewFrame(index)
         local countCarrier = CreateFrame("Frame", nil, di)
         countCarrier:SetAllPoints()
         countCarrier:SetFrameLevel(math.max(cd:GetFrameLevel() + 2, dbdr:GetFrameLevel() + 1))
+        di._durCarrier = countCarrier
         local fpInit = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("raidFrames")) or "Fonts\\FRIZQT__.TTF"
         local countFS = countCarrier:CreateFontString(nil, "OVERLAY")
         countFS:SetPoint("BOTTOMRIGHT", di, "BOTTOMRIGHT", 1, -1)
@@ -11434,6 +11472,27 @@ local function ApplyPreviewData(f, index)
     if f._nameTextCarrier   then f._nameTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.nameLevel])         end
     if f._healthTextCarrier then f._healthTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.healthTextLevel]) end
     if f._statusTextCarrier then f._statusTextCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.statusTextLevel]) end
+
+    -- Aura icon pool levels
+    local function RelevelAuraPool(pool, baseOff)
+        if not pool then return end
+        for _, icon in ipairs(pool) do
+            icon:SetFrameLevel(fpl + baseOff)
+            if icon._borderFrame then icon._borderFrame:SetFrameLevel(fpl + baseOff + 1) end
+            if icon._durCarrier  then icon._durCarrier:SetFrameLevel(fpl + baseOff + 2) end
+        end
+    end
+    local pvDebuffOff = ns.STRATA_SCALE[s.debuffLevel]
+    local pvDefOff    = ns.STRATA_SCALE[s.defLevel]
+    local pvPaOff     = ns.STRATA_SCALE[s.paLevel]
+    RelevelAuraPool(f._pvDebuffs, pvDebuffOff)
+    RelevelAuraPool(f._pvDefs, pvDefOff)
+    RelevelAuraPool(f._pvPA, pvPaOff)
+    if f._pvDispelDebuff then
+        f._pvDispelDebuff:SetFrameLevel(fpl + pvDebuffOff)
+        if f._pvDispelDebuff._borderFrame then f._pvDispelDebuff._borderFrame:SetFrameLevel(fpl + pvDebuffOff + 1) end
+        if f._pvDispelDebuff._durCarrier  then f._pvDispelDebuff._durCarrier:SetFrameLevel(fpl + pvDebuffOff + 2) end
+    end
 
     -- Dead/DC overlay (mirror the live-frame status tint: full-cover bg)
     if isDead then

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -34,6 +34,15 @@ ns.LVL_AURA   = 13   -- base level for every aura icon/bar (children at +1..+5);
 ns.LVL_RAISE  = 20   -- main border while hovered/targeted (PP container at +1)
 ns.LVL_MARKER = 22   -- raid marker icon (always on top)
 
+-- TODO: remove old scale.
+ns.STRATA_SCALE = {
+    lowest  = 7,  -- base level for name/health text
+    low     = 8,  -- base level for indicators (except Raid Markers at "highest")
+    medium  = 13, -- base level for every aura icon/bar
+    high    = 20, -- main border while hovered/targeted (PP container at +1)
+    highest = 22, -- highest priority, sits above main frame border
+}
+
 -------------------------------------------------------------------------------
 --  Chat-strata host: lowers a frame onto the chat frame's strata, one level
 --  above it, so its contents render on the SAME layer as chat (just above chat
@@ -433,6 +442,7 @@ local defaults = {
         nameSize         = 10,
         nameColorMode    = "custom",  -- "class", "accent", "custom"
         nameCustomColor  = { r = 1, g = 1, b = 1 },
+        nameLevel        = "lowest",
         namePosition     = "topleft", -- "topleft", "top", "topright", "left", "center", "right", "bottomleft", "bottom"
         nameOffsetX      = 0,
         nameOffsetY      = 0,
@@ -440,6 +450,7 @@ local defaults = {
         healthTextColorMode   = "custom",  -- "class", "accent", "custom"
         healthTextCustomColor = { r = 1, g = 1, b = 1 },
         healthTextSize   = 9,
+        healthTextLevel    = "lowest",
         healthTextPosition = "center",
         healthTextOffsetX  = 0,
         healthTextOffsetY  = 0,
@@ -482,6 +493,7 @@ local defaults = {
         -- Indicators
         roleIconStyle    = "modern",  -- "none", "modern", "modernCircle", "styled", "classicCircle", "classic"
         roleIconSize     = 13,
+        roleIconLevel    = "low",
         roleIconPosition = "bottomleft",  -- "topleft", "topright", "bottomleft", "bottomright"
         roleIconOffsetX  = 0,
         roleIconOffsetY  = 0,
@@ -489,19 +501,23 @@ local defaults = {
         showRoleForTank    = true,
         showRoleForHealer  = true,
         showRoleForDPS     = false,
-        showRaidMarker   = true,
-        raidMarkerSize   = 16,
+        showRaidMarker     = true,
+        raidMarkerSize     = 16,
+        raidMarkerLevel    = "highest",
         raidMarkerPosition = "center",  -- "topleft", "top", "topright", "left", "center", "right", "bottomleft", "bottom"
         raidMarkerOffsetX  = 0,
         raidMarkerOffsetY  = 0,
-        showReadyCheck   = true,
-        showSummonPending = true,
-        threatBorderSize = 2,    -- aggro warning border thickness; 0 = off
-        showLeaderIcon   = false,
+        readyCheckLevel    = "low",
+        showReadyCheck     = true,
+        showSummonPending  = true,
+        threatBorderSize   = 2,    -- aggro warning border thickness; 0 = off
+        showLeaderIcon     = false,
+        leaderIconSize     = 14,
+        leaderIconLevel    = "low",
         leaderIconPosition = "top",
-        leaderIconSize   = 14,
         leaderIconOffsetX  = 0,
         leaderIconOffsetY  = 0,
+        statusTextLevel    = "low",
         statusTextPosition = "center",
         statusTextOffsetX  = 0,
         statusTextOffsetY  = 0,
@@ -551,6 +567,7 @@ local defaults = {
         paSize           = 20,
         paShowCountdown  = false,
         paHideTooltip    = true,
+        paLevel          = "medium",
         paPosition       = "center",
         paOffsetX        = 0,
         paOffsetY        = 0,
@@ -563,6 +580,7 @@ local defaults = {
         -- Defensives & Externals
         showDefensives   = true,
         showExternals    = true,
+        defLevel         = "medium",
         defPosition      = "center",
         defOffsetX       = 0,
         defOffsetY       = 0,
@@ -605,6 +623,7 @@ local defaults = {
         debuffSize       = 18,
         debuffCap        = 3,
         debuffHideTooltips = true,
+        debuffLevel      = "medium",
         debuffPosition   = "bottomright",
         debuffOffsetX    = 0,
         debuffOffsetY    = 0,
@@ -631,6 +650,7 @@ local defaults = {
         tsEnabled   = true,   -- legacy boolean; superseded by tsMode (kept harmless)
         tsMode      = "whenHealing",  -- never | whenHealing | always
         tsIconSize  = 24,
+        tsLevel     = "medium",
         tsPosition  = "center",
         tsGrowDirection = "CENTER",
         tsOffsetX   = 0,

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -2706,7 +2706,7 @@ local function StyleButton(button)
     AnchorDefensives()
     d.AnchorDefensives = AnchorDefensives
 
-    local function UpdateAuraLevels()
+    local function UpdateAurasLevel()
         local pl = button:GetFrameLevel()
         local debuffOff = ns.FRAMELVL[s.debuffLevel]
         local defOff    = ns.FRAMELVL[s.defLevel]
@@ -2734,8 +2734,8 @@ local function StyleButton(button)
             d.dispelContainer:SetFrameLevel(pl + paOff)
         end
     end
-    UpdateAuraLevels()
-    d.UpdateAuraLevels = UpdateAuraLevels
+    UpdateAurasLevel()
+    d.UpdateAurasLevel = UpdateAurasLevel
 
     -- Anchor name text based on position setting
     -- Uses two-point anchoring (LEFT+RIGHT) for width constraint, with
@@ -6850,7 +6850,7 @@ local function ReloadFrames()
             end
         end
 
-        if d.UpdateAuraLevels then d.UpdateAuraLevels() end
+        if d.UpdateAurasLevel then d.UpdateAurasLevel() end
 
         -- Buff manager indicators
         if d.bmIconPool and d.health and ns.BM_AnchorIndicators then
@@ -8786,7 +8786,7 @@ ns.ReloadPartyFrames = function()
             end
         end
 
-        if d.UpdateAuraLevels then d.UpdateAuraLevels() end
+        if d.UpdateAurasLevel then d.UpdateAurasLevel() end
 
         -- Buff manager indicators (pass the scaled proxy: BM picks the party
         -- indicator scale by recognizing this exact table)

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -4454,58 +4454,65 @@ end
 -------------------------------------------------------------------------------
 --  Ready check handling
 -------------------------------------------------------------------------------
-local readyCheckActive = false
+local UpdateReadyCheck  -- forward-declared; assigned inside do..end below
+do
+    local readyCheckActive = false
 
--- Returns true if a ready-check icon was shown (used to suppress summon pending).
-local function ApplyReadyCheck(button, unit)
-    local d = GetFFD(button)
-    local tex = d.readyCheck
-    if not tex then return false end
-    if db.profile.showReadyCheck and readyCheckActive then
-        local status = GetReadyCheckStatus(unit)
-        if status == "ready" then
-            tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
-            tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-Ready")
-            tex:Show(); return true
-        elseif status == "notready" then
-            tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
-            tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-NotReady")
-            tex:Show(); return true
-        elseif status == "waiting" then
-            tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
-            tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-Waiting")
-            tex:Show(); return true
+    local function ApplyReadyCheck(button, unit)
+        local d = GetFFD(button)
+        local tex = d.readyCheck
+        if not tex then return false end
+        if db.profile.showReadyCheck and readyCheckActive then
+            local status = GetReadyCheckStatus(unit)
+            if status == "ready" then
+                tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
+                tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-Ready")
+                tex:Show(); return true
+            elseif status == "notready" then
+                tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
+                tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-NotReady")
+                tex:Show(); return true
+            elseif status == "waiting" then
+                tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
+                tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-Waiting")
+                tex:Show(); return true
+            end
+        end
+        tex:Hide()
+        return false
+    end
+
+    local function ApplySummonPending(button, unit)
+        local d = GetFFD(button)
+        local tex = d.summonPending
+        if not tex then return end
+        if db.profile.showSummonPending and unit and C_IncomingSummon.HasIncomingSummon(unit) then
+            local sStatus = C_IncomingSummon.IncomingSummonStatus(unit)
+            if sStatus == SUMMON_STATUS_PENDING then
+                tex:SetAtlas("RaidFrame-Icon-SummonPending"); tex:Show(); return
+            elseif sStatus == SUMMON_STATUS_ACCEPTED then
+                tex:SetAtlas("RaidFrame-Icon-SummonAccepted"); tex:Show(); return
+            elseif sStatus == SUMMON_STATUS_DECLINED then
+                tex:SetAtlas("RaidFrame-Icon-SummonDeclined"); tex:Show(); return
+            end
+        end
+        tex:Hide()
+    end
+
+    UpdateReadyCheck = function(button, unit)
+        local rcShown = ApplyReadyCheck(button, unit)
+        local d = GetFFD(button)
+        if rcShown then
+            if d.summonPending then d.summonPending:Hide() end
+        else
+            ApplySummonPending(button, unit)
         end
     end
-    tex:Hide()
-    return false
-end
 
-local function ApplySummonPending(button, unit)
-    local d = GetFFD(button)
-    local tex = d.summonPending
-    if not tex then return end
-    if db.profile.showSummonPending and unit and C_IncomingSummon.HasIncomingSummon(unit) then
-        local sStatus = C_IncomingSummon.IncomingSummonStatus(unit)
-        if sStatus == SUMMON_STATUS_PENDING then
-            tex:SetAtlas("RaidFrame-Icon-SummonPending"); tex:Show(); return
-        elseif sStatus == SUMMON_STATUS_ACCEPTED then
-            tex:SetAtlas("RaidFrame-Icon-SummonAccepted"); tex:Show(); return
-        elseif sStatus == SUMMON_STATUS_DECLINED then
-            tex:SetAtlas("RaidFrame-Icon-SummonDeclined"); tex:Show(); return
-        end
-    end
-    tex:Hide()
-end
-
-local function UpdateReadyCheck(button, unit)
-    local rcShown = ApplyReadyCheck(button, unit)
-    local d = GetFFD(button)
-    if rcShown then
-        if d.summonPending then d.summonPending:Hide() end
-    else
-        ApplySummonPending(button, unit)
-    end
+    -- Accessors so event handlers outside this block can read/write the flag
+    -- without the variable bleeding into the outer local budget.
+    ns._setReadyCheckActive = function(v) readyCheckActive = v end
+    ns._getReadyCheckActive = function()  return readyCheckActive end
 end
 
 -------------------------------------------------------------------------------
@@ -7855,7 +7862,7 @@ local function OnEvent(self, event, arg1, ...)
         local t0 = ns.ProfBegin("UpdateTargetBorders"); ns._UpdateTargetBorders(); ns.ProfEnd("UpdateTargetBorders", t0)
     elseif event == "READY_CHECK" then
         local t0 = ns.ProfBegin("ReadyCheck:START")
-        readyCheckActive = true
+        ns._setReadyCheckActive(true)
         for _, btn in ipairs(allButtons) do
             local u = btn:GetAttribute("unit")
             if u and btn:IsVisible() then UpdateReadyCheck(btn, u) end
@@ -7869,9 +7876,9 @@ local function OnEvent(self, event, arg1, ...)
         local btn = unitToButton[arg1] or ns._partyUnitToButton[arg1]
         if btn then UpdateReadyCheck(btn, arg1) end
     elseif event == "READY_CHECK_FINISHED" then
-        readyCheckActive = false
+        ns._setReadyCheckActive(false)
         C_Timer.After(5, function()
-            if not readyCheckActive then
+            if not ns._getReadyCheckActive() then
                 -- Re-evaluate rather than force-hide: a unit may have an incoming
                 -- summon active that shares the same texture.
                 for _, btn in ipairs(allButtons) do

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -512,6 +512,7 @@ local defaults = {
         summonPendingLevel = "low",
         showSummonPending  = true,
         threatBorderSize   = 2,    -- aggro warning border thickness; 0 = off
+        threatBorderLevel  = "medium",
         showLeaderIcon     = false,
         leaderIconSize     = 14,
         leaderIconLevel    = "low",
@@ -542,7 +543,8 @@ local defaults = {
         targetBorderAlpha = 1,
 
         -- Dispels
-        dispelBorderSize = 0,
+        dispelBorderSize  = 0,
+        dispelBorderLevel = "high",
         dispelOverlay    = "fill",   -- "none", "fill", "full", "gradient"
         dispelOverlayOpacity = 100,
         dispelShowAll        = true,   -- true = highlight any dispellable debuff; false = only player-dispellable
@@ -2089,7 +2091,7 @@ local function StyleButton(button)
     -- Threat border
     local threatFrame = CreateFrame("Frame", nil, button)
     threatFrame:SetAllPoints(button)
-    threatFrame:SetFrameLevel(button:GetFrameLevel() + 10)
+    threatFrame:SetFrameLevel(button:GetFrameLevel() + ns.FRAMELVL[s.threatBorderLevel])
     threatFrame:Hide()
     d.threatFrame = threatFrame
     if PP then PP.CreateBorder(threatFrame, 1, 0, 0, 1, 2) end
@@ -2097,10 +2099,18 @@ local function StyleButton(button)
     -- Dispel border (health bar only, not power bar)
     local dispelFrame = CreateFrame("Frame", nil, button)
     dispelFrame:SetAllPoints(health)
-    dispelFrame:SetFrameLevel(button:GetFrameLevel() + 10)
+    dispelFrame:SetFrameLevel(button:GetFrameLevel() + ns.FRAMELVL[s.dispelBorderLevel])
     dispelFrame:Hide()
     d.dispelFrame = dispelFrame
     if PP then PP.CreateBorder(dispelFrame, 0.2, 0.6, 1, 1, 2) end
+
+    local function UpdateBordersLevel()
+        local pl = button:GetFrameLevel()
+        if d.threatFrame then d.threatFrame:SetFrameLevel(pl + ns.FRAMELVL[s.threatBorderLevel]) end
+        if d.dispelFrame then d.dispelFrame:SetFrameLevel(pl + ns.FRAMELVL[s.dispelBorderLevel]) end
+    end
+    UpdateBordersLevel()
+    d.UpdateBordersLevel = UpdateBordersLevel
 
     -- Dispel overlay (fill / full / gradient)
     -- Texture on health bar at ARTWORK sublevel 3: above fill (0) AND above the
@@ -2450,6 +2460,14 @@ local function StyleButton(button)
     end
     UpdateIndicatorsLevel()
     d.UpdateIndicatorsLevel = UpdateIndicatorsLevel
+
+    local function UpdateBordersLevel()
+        local pl = button:GetFrameLevel()
+        if d.threatFrame then d.threatFrame:SetFrameLevel(pl + ns.FRAMELVL[s.threatBorderLevel]) end
+        if d.dispelFrame then d.dispelFrame:SetFrameLevel(pl + ns.FRAMELVL[s.dispelBorderLevel]) end
+    end
+    UpdateBordersLevel()
+    d.UpdateBordersLevel = UpdateBordersLevel
 
     -- Debuff icons (pre-created, anchored dynamically)
     d.debuffIcons = {}
@@ -6826,10 +6844,13 @@ local function ReloadFrames()
             d.raidMarker:SetSize(rmSz, rmSz)
             if d.AnchorRaidMarker then d.AnchorRaidMarker() end
         end
+
         if d.UpdateIndicatorsLevel then d.UpdateIndicatorsLevel() end
+        if d.UpdateBordersLevel    then d.UpdateBordersLevel()    end
 
         -- Border
         if d.UpdateBorder then d.UpdateBorder() end
+        if d.UpdateBordersLevel    then d.UpdateBordersLevel()    end
 
         -- Debuff size + position
         if d.debuffIcons then
@@ -8763,9 +8784,11 @@ ns.ReloadPartyFrames = function()
         end
 
         if d.UpdateIndicatorsLevel then d.UpdateIndicatorsLevel() end
+        if d.UpdateBordersLevel    then d.UpdateBordersLevel()    end
 
         -- Border
         if d.UpdateBorder then d.UpdateBorder() end
+        if d.UpdateBordersLevel    then d.UpdateBordersLevel()    end
 
         -- Debuff icons
         if d.debuffIcons then
@@ -10135,7 +10158,7 @@ local function CreatePreviewFrame(index)
     -- Threat border (aggro indicator)
     local threatFrame = CreateFrame("Frame", nil, f)
     threatFrame:SetAllPoints(f)
-    threatFrame:SetFrameLevel(f:GetFrameLevel() + 10)
+    threatFrame:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.threatBorderLevel])
     threatFrame:Hide()
     if PP then PP.CreateBorder(threatFrame, 1, 0, 0, 1, 2) end
 
@@ -10155,7 +10178,7 @@ local function CreatePreviewFrame(index)
     -- Dispel border
     local dispelBdrFrame = CreateFrame("Frame", nil, f)
     dispelBdrFrame:SetAllPoints(health)
-    dispelBdrFrame:SetFrameLevel(f:GetFrameLevel() + 10)
+    dispelBdrFrame:SetFrameLevel(f:GetFrameLevel() + ns.FRAMELVL[s.dispelBorderLevel])
     dispelBdrFrame:Hide()
     if PP then PP.CreateBorder(dispelBdrFrame, 0.2, 0.6, 1, 1, 2) end
 
@@ -11590,6 +11613,13 @@ local function ApplyPreviewData(f, index)
     if f._readyCheckCarrier    then f._readyCheckCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.readyCheckLevel])    end
     if f._summonPendingCarrier then f._summonPendingCarrier:SetFrameLevel(fpl + ns.FRAMELVL[s.summonPendingLevel]) end
     if f._leaderHost           then f._leaderHost:SetFrameLevel(fpl + ns.FRAMELVL[s.leaderIconLevel])           end
+    -- Borders (UpdateBordersLevel equivalent for preview frames)
+    if f._threatFrame    then f._threatFrame:SetFrameLevel(fpl + ns.FRAMELVL[s.threatBorderLevel])    end
+    if f._dispelBdrFrame then f._dispelBdrFrame:SetFrameLevel(fpl + ns.FRAMELVL[s.dispelBorderLevel]) end
+
+    -- Borders (UpdateBordersLevel equivalent for preview frames)
+    if f._threatFrame    then f._threatFrame:SetFrameLevel(fpl + ns.FRAMELVL[s.threatBorderLevel])    end
+    if f._dispelBdrFrame then f._dispelBdrFrame:SetFrameLevel(fpl + ns.FRAMELVL[s.dispelBorderLevel]) end
 
     f:Show()
 end

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -509,6 +509,7 @@ local defaults = {
         raidMarkerOffsetY  = 0,
         readyCheckLevel    = "low",
         showReadyCheck     = true,
+        summonPendingLevel = "low",
         showSummonPending  = true,
         threatBorderSize   = 2,    -- aggro warning border thickness; 0 = off
         showLeaderIcon     = false,
@@ -2339,7 +2340,7 @@ local function StyleButton(button)
     -- Role icon (carrier frame above power bar + its border so icon renders on top)
     local roleCarrier = CreateFrame("Frame", nil, button)
     roleCarrier:SetAllPoints(health)
-    roleCarrier:SetFrameLevel(button:GetFrameLevel() + 5)
+    d.roleCarrier = roleCarrier
     local roleIcon = roleCarrier:CreateTexture(nil, "OVERLAY")
     local riSz = PixelSnap(s.roleIconSize or 14)
     roleIcon:SetSize(riSz, riSz)
@@ -2364,22 +2365,14 @@ local function StyleButton(button)
     AnchorRoleIcon()
     d.AnchorRoleIcon = AnchorRoleIcon
 
-    -- Marker carrier: above the frame border (including the hover/target raise
-    -- at +12/+13) so the raid marker renders on top of the border instead of
-    -- being clipped behind it.
+    -- Marker carrier: raid marker host, above the frame border.
     local markerCarrier = CreateFrame("Frame", nil, button)
     markerCarrier:SetAllPoints(health)
-    markerCarrier:SetFrameLevel(button:GetFrameLevel() + ns.LVL_MARKER)
+    d.markerCarrier = markerCarrier
 
-    -- Leader/assistant icon. Hosted on its own frame lowered to the chat frame's
-    -- strata (one level above chat) so it renders on the same layer as chat,
-    -- above chat on that layer -- NOT on the marker carrier, whose high level
-    -- keeps the raid marker always on top. Parented to the button so it tracks
-    -- the frame; SetAllPoints(health) so the icon still anchors to the health
-    -- bar as before. Strata/level are re-asserted on reload (chat-relative).
+    -- Leader/assistant icon host (level driven by leaderIconLevel).
     d.leaderHost = CreateFrame("Frame", nil, button)
     d.leaderHost:SetAllPoints(health)
-    ns.ApplyChatStrata(d.leaderHost)
 
     local leaderIcon = d.leaderHost:CreateTexture(nil, "OVERLAY")
     local liSz = PixelSnap(s.leaderIconSize or 14)
@@ -2426,11 +2419,37 @@ local function StyleButton(button)
     d.AnchorRaidMarker = AnchorRaidMarker
 
     -- Ready check icon
-    local readyCheck = health:CreateTexture(nil, "OVERLAY", nil, 3)
+    local readyCheckCarrier = CreateFrame("Frame", nil, button)
+    readyCheckCarrier:SetAllPoints(health)
+    d.readyCheckCarrier = readyCheckCarrier
+
+    local readyCheck = readyCheckCarrier:CreateTexture(nil, "OVERLAY", nil, 3)
     readyCheck:SetSize(18, 18)
     readyCheck:SetPoint("CENTER", health, "CENTER", 0, 0)
     readyCheck:Hide()
     d.readyCheck = readyCheck
+
+    -- Summon pending icon (separate carrier so its level is independent of readyCheck)
+    local summonPendingCarrier = CreateFrame("Frame", nil, button)
+    summonPendingCarrier:SetAllPoints(health)
+    d.summonPendingCarrier = summonPendingCarrier
+
+    local summonPending = summonPendingCarrier:CreateTexture(nil, "OVERLAY", nil, 3)
+    summonPending:SetSize(20, 20)
+    summonPending:SetPoint("CENTER", health, "CENTER", 0, 0)
+    summonPending:Hide()
+    d.summonPending = summonPending
+
+    local function UpdateIndicatorsLevel()
+        local pl = button:GetFrameLevel()
+        roleCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.roleIconLevel])
+        markerCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.raidMarkerLevel])
+        readyCheckCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.readyCheckLevel])
+        summonPendingCarrier:SetFrameLevel(pl + ns.STRATA_SCALE[s.summonPendingLevel])
+        d.leaderHost:SetFrameLevel(pl + ns.STRATA_SCALE[s.leaderIconLevel])
+    end
+    UpdateIndicatorsLevel()
+    d.UpdateIndicatorsLevel = UpdateIndicatorsLevel
 
     -- Debuff icons (pre-created, anchored dynamically)
     d.debuffIcons = {}
@@ -4404,60 +4423,56 @@ end
 -------------------------------------------------------------------------------
 local readyCheckActive = false
 
--- The d.readyCheck texture is shared between the ready-check and incoming-summon
--- indicators (they almost never overlap). Ready check takes priority while a check
--- is active; otherwise the summon status is shown.
-local function UpdateReadyCheck(button, unit)
+-- Returns true if a ready-check icon was shown (used to suppress summon pending).
+local function ApplyReadyCheck(button, unit)
     local d = GetFFD(button)
     local tex = d.readyCheck
-    if not tex then return end
-
-    -- Ready check (priority)
+    if not tex then return false end
     if db.profile.showReadyCheck and readyCheckActive then
         local status = GetReadyCheckStatus(unit)
         if status == "ready" then
-            tex:SetSize(18, 18)
-            tex:SetTexCoord(0, 1, 0, 1)
+            tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
             tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-Ready")
-            tex:Show()
-            return
+            tex:Show(); return true
         elseif status == "notready" then
-            tex:SetSize(18, 18)
-            tex:SetTexCoord(0, 1, 0, 1)
+            tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
             tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-NotReady")
-            tex:Show()
-            return
+            tex:Show(); return true
         elseif status == "waiting" then
-            tex:SetSize(18, 18)
-            tex:SetTexCoord(0, 1, 0, 1)
+            tex:SetSize(18, 18); tex:SetTexCoord(0, 1, 0, 1)
             tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-Waiting")
-            tex:Show()
-            return
+            tex:Show(); return true
         end
     end
+    tex:Hide()
+    return false
+end
 
-    -- Incoming summon
+local function ApplySummonPending(button, unit)
+    local d = GetFFD(button)
+    local tex = d.summonPending
+    if not tex then return end
     if db.profile.showSummonPending and unit and C_IncomingSummon.HasIncomingSummon(unit) then
         local sStatus = C_IncomingSummon.IncomingSummonStatus(unit)
         if sStatus == SUMMON_STATUS_PENDING then
-            tex:SetSize(20, 20)
-            tex:SetAtlas("RaidFrame-Icon-SummonPending")
-            tex:Show()
-            return
+            tex:SetAtlas("RaidFrame-Icon-SummonPending"); tex:Show(); return
         elseif sStatus == SUMMON_STATUS_ACCEPTED then
-            tex:SetSize(20, 20)
-            tex:SetAtlas("RaidFrame-Icon-SummonAccepted")
-            tex:Show()
-            return
+            tex:SetAtlas("RaidFrame-Icon-SummonAccepted"); tex:Show(); return
         elseif sStatus == SUMMON_STATUS_DECLINED then
-            tex:SetSize(20, 20)
-            tex:SetAtlas("RaidFrame-Icon-SummonDeclined")
-            tex:Show()
-            return
+            tex:SetAtlas("RaidFrame-Icon-SummonDeclined"); tex:Show(); return
         end
     end
-
     tex:Hide()
+end
+
+local function UpdateReadyCheck(button, unit)
+    local rcShown = ApplyReadyCheck(button, unit)
+    local d = GetFFD(button)
+    if rcShown then
+        if d.summonPending then d.summonPending:Hide() end
+    else
+        ApplySummonPending(button, unit)
+    end
 end
 
 -------------------------------------------------------------------------------
@@ -6763,8 +6778,6 @@ local function ReloadFrames()
             d.leaderIcon:ClearAllPoints()
             local liPos = (s.leaderIconPosition or "top"):upper()
             d.leaderIcon:SetPoint(liPos, d.health, liPos, s.leaderIconOffsetX or 0, s.leaderIconOffsetY or 0)
-            -- Keep the leader-icon host on the chat frame's current strata/level
-            if d.leaderHost then ns.ApplyChatStrata(d.leaderHost) end
         end
 
         -- Raid marker size + position
@@ -6773,6 +6786,7 @@ local function ReloadFrames()
             d.raidMarker:SetSize(rmSz, rmSz)
             if d.AnchorRaidMarker then d.AnchorRaidMarker() end
         end
+        if d.UpdateIndicatorsLevel then d.UpdateIndicatorsLevel() end
 
         -- Border
         if d.UpdateBorder then d.UpdateBorder() end
@@ -8697,8 +8711,6 @@ ns.ReloadPartyFrames = function()
             d.leaderIcon:ClearAllPoints()
             local liPos = (raw.leaderIconPosition or "top"):upper()
             d.leaderIcon:SetPoint(liPos, d.health, liPos, pp.leaderIconOffsetX or 0, pp.leaderIconOffsetY or 0)
-            -- Keep the leader-icon host on the chat frame's current strata/level
-            if d.leaderHost then ns.ApplyChatStrata(d.leaderHost) end
         end
 
         -- Raid marker
@@ -8707,6 +8719,8 @@ ns.ReloadPartyFrames = function()
             d.raidMarker:SetSize(rmSz, rmSz)
             if d.AnchorRaidMarker then d.AnchorRaidMarker() end
         end
+
+        if d.UpdateIndicatorsLevel then d.UpdateIndicatorsLevel() end
 
         -- Border
         if d.UpdateBorder then d.UpdateBorder() end
@@ -10117,11 +10131,11 @@ local function CreatePreviewFrame(index)
     dispelIconTex:SetAllPoints()
     dispelIconTex:SetTexture("Interface\\Buttons\\WHITE8X8")
 
-    -- Marker carrier: above the frame border (incl. hover/target raise) so the
-    -- leader icon and raid marker render on top of it (mirrors real frames).
+    -- Marker carrier: raid marker host.
     local markerCarrier = CreateFrame("Frame", nil, f)
     markerCarrier:SetAllPoints(health)
-    markerCarrier:SetFrameLevel(f:GetFrameLevel() + ns.LVL_MARKER)
+    markerCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.raidMarkerLevel])
+    f._markerCarrier = markerCarrier
 
     -- Raid marker (on marker carrier, above the border)
     local raidMarker = markerCarrier:CreateTexture(nil, "OVERLAY", nil, 2)
@@ -10130,10 +10144,26 @@ local function CreatePreviewFrame(index)
     raidMarker:Hide()
 
     -- Ready check icon
-    local readyCheck = health:CreateTexture(nil, "OVERLAY", nil, 3)
+    local readyCheckCarrier = CreateFrame("Frame", nil, f)
+    readyCheckCarrier:SetAllPoints(health)
+    readyCheckCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.readyCheckLevel])
+    f._readyCheckCarrier = readyCheckCarrier
+
+    local readyCheck = readyCheckCarrier:CreateTexture(nil, "OVERLAY", nil, 3)
     readyCheck:SetSize(18, 18)
     readyCheck:SetPoint("CENTER", health, "CENTER", 0, 0)
     readyCheck:Hide()
+
+    -- Summon pending icon
+    local summonPendingCarrier = CreateFrame("Frame", nil, f)
+    summonPendingCarrier:SetAllPoints(health)
+    summonPendingCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.summonPendingLevel])
+    f._summonPendingCarrier = summonPendingCarrier
+
+    local summonPending = summonPendingCarrier:CreateTexture(nil, "OVERLAY", nil, 3)
+    summonPending:SetSize(20, 20)
+    summonPending:SetPoint("CENTER", health, "CENTER", 0, 0)
+    summonPending:Hide()
 
     -- Text carrier: name + health text sit ABOVE the base/threat/dispel borders
     -- (+8/+10/+11) and the BM frame-border effect (+11) so they stay readable,
@@ -10177,16 +10207,21 @@ local function CreatePreviewFrame(index)
     statusFS:SetTextColor(pvStc.r, pvStc.g, pvStc.b)
     statusFS:Hide()
 
-    -- Role icon (carrier frame above power bar + its border)
+    -- Role icon carrier
     local roleCarrier = CreateFrame("Frame", nil, f)
     roleCarrier:SetAllPoints(health)
-    roleCarrier:SetFrameLevel(f:GetFrameLevel() + 5)
+    roleCarrier:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.roleIconLevel])
+    f._roleCarrier = roleCarrier
     local roleIcon = roleCarrier:CreateTexture(nil, "OVERLAY")
     local riSz = PixelSnap(s.roleIconSize or 14)
     roleIcon:SetSize(riSz, riSz)
 
-    -- Leader icon (on marker carrier, above the border)
-    local leaderIcon = markerCarrier:CreateTexture(nil, "OVERLAY")
+    -- Leader icon host
+    local leaderHost = CreateFrame("Frame", nil, f)
+    leaderHost:SetAllPoints(health)
+    leaderHost:SetFrameLevel(f:GetFrameLevel() + ns.STRATA_SCALE[s.leaderIconLevel])
+    f._leaderHost = leaderHost
+    local leaderIcon = leaderHost:CreateTexture(nil, "OVERLAY")
     local liSz = PixelSnap(s.leaderIconSize or 14)
     leaderIcon:SetSize(liSz, liSz)
     local liPos = (s.leaderIconPosition or "top"):upper()
@@ -10220,6 +10255,7 @@ local function CreatePreviewFrame(index)
     f._dispelIconTex = dispelIconTex
     f._raidMarker = raidMarker
     f._readyCheck = readyCheck
+    f._summonPending = summonPending
     f._nameText = nameFS
     f._topNameBar = tnb
     f._topNameBarBg = tnbBg
@@ -11164,40 +11200,40 @@ local function ApplyPreviewData(f, index)
     end
 
     -- Ready check icon
-    if f._readyCheck then
-        local rcStatuses = previewRoles._readyCheck
+    do
         local rcStatuses = previewRoles._readyCheck
         local rcStatus = rcStatuses and rcStatuses[index]
         local isSummon = rcStatus and rcStatus:sub(1, 6) == "summon"
-        local showRC = indVis and rcStatus and (
-            (not isSummon and s.showReadyCheck) or
-            (isSummon and s.showSummonPending)
-        )
-        if showRC then
-            if isSummon then
-                f._readyCheck:SetSize(20, 20)
-            else
-                f._readyCheck:SetSize(18, 18)
-            end
+        local showRC  = indVis and rcStatus and not isSummon and s.showReadyCheck
+        local showSP  = indVis and rcStatus and isSummon and s.showSummonPending
+        if showRC and f._readyCheck then
+            f._readyCheck:SetSize(18, 18)
             if rcStatus == "ready" then
                 f._readyCheck:SetTexture("Interface\\RaidFrame\\ReadyCheck-Ready")
                 f._readyCheck:SetTexCoord(0, 1, 0, 1)
             elseif rcStatus == "notready" then
                 f._readyCheck:SetTexture("Interface\\RaidFrame\\ReadyCheck-NotReady")
                 f._readyCheck:SetTexCoord(0, 1, 0, 1)
-            elseif rcStatus == "pending" then
+            else
                 f._readyCheck:SetTexture("Interface\\RaidFrame\\ReadyCheck-Waiting")
                 f._readyCheck:SetTexCoord(0, 1, 0, 1)
-            elseif rcStatus == "summon_pending" then
-                f._readyCheck:SetAtlas("RaidFrame-Icon-SummonPending")
-            elseif rcStatus == "summon_accepted" then
-                f._readyCheck:SetAtlas("RaidFrame-Icon-SummonAccepted")
-            elseif rcStatus == "summon_declined" then
-                f._readyCheck:SetAtlas("RaidFrame-Icon-SummonDeclined")
             end
             f._readyCheck:Show()
-        else
+        elseif f._readyCheck then
             f._readyCheck:Hide()
+        end
+        if showSP and f._summonPending then
+            f._summonPending:SetSize(20, 20)
+            if rcStatus == "summon_pending" then
+                f._summonPending:SetAtlas("RaidFrame-Icon-SummonPending")
+            elseif rcStatus == "summon_accepted" then
+                f._summonPending:SetAtlas("RaidFrame-Icon-SummonAccepted")
+            else
+                f._summonPending:SetAtlas("RaidFrame-Icon-SummonDeclined")
+            end
+            f._summonPending:Show()
+        elseif f._summonPending then
+            f._summonPending:Hide()
         end
     end
 
@@ -11481,6 +11517,13 @@ local function ApplyPreviewData(f, index)
     -- Buff manager indicators only shown on the BM page preview, not here
 
     -- Debuff/defensive preview icons managed by PvAuraTicker (cycling system)
+
+    local fpl = f:GetFrameLevel()
+    if f._roleCarrier          then f._roleCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.roleIconLevel])            end
+    if f._markerCarrier        then f._markerCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.raidMarkerLevel])        end
+    if f._readyCheckCarrier    then f._readyCheckCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.readyCheckLevel])    end
+    if f._summonPendingCarrier then f._summonPendingCarrier:SetFrameLevel(fpl + ns.STRATA_SCALE[s.summonPendingLevel]) end
+    if f._leaderHost           then f._leaderHost:SetFrameLevel(fpl + ns.STRATA_SCALE[s.leaderIconLevel])           end
 
     f:Show()
 end


### PR DESCRIPTION
This PR introduces user-configurable frame level control across most visual layers of the raid frames: name and health text, status overlays, indicators, aura icons, and Buff Manager indicators. 

Previously, every component's z-order was hardcoded to a fixed offset constant (such as `ns.LVL_AURA`, `ns.LVL_RAISE`), which meant users who repositioned the name text to a centre or bottom slot had no way to resolve the resulting overlap with ready-check icons, status text, or aura icons short of a source edit.

<details>
<summary>In-game example (old)</summary>

<img width="122" height="218" alt="image" src="https://github.com/user-attachments/assets/4ed17dc1-8160-4ea2-9bf1-c1f93c09b74c" />

Targeted Spells, and indicators like Ready-Check / Summon Pending would overlap with the display name. Additionally, should one prefer to have debuffs or other auras outside of frame boundary, the hover/target border would cut these off.
</details>

<details><summary>In-game example (new)</summary>
<p>
<img width="153" height="384" alt="image" src="https://github.com/user-attachments/assets/60794468-dedf-4906-a116-0ad0306a9fed" />

Every component is displayed correctly. One will also notice on frame 2 (top-down, warrior) that both a private aura and a targeted spell are rendered at the same time; I set the TS to have a higher priority than PA. 

</p>
</details> 

## New scale

<img width="495" height="320" alt="eui_rf_new_scale" src="https://github.com/user-attachments/assets/3e130bdf-faf3-4480-aa28-712f700e6ac5" />

| Key | Offset | Targets (by default) |
|--------|--------|--------|
| Lowest | +12 | Text (name, health) | 
| Low | +13 | Indicators | 
| Medium | +14 | Auras (defensives, debuffs, targeted spells) |
| High | +20 | Raised border(s) |
| Highest | +22 | Above border(s) | 

The philosophy behind the new scale was to maintain backwards compatibility as much as possible while providing some flexibility to the user. 

Text, indicators, and auras are now distributed over 3 distinct levels representative of their visual priority, +12, +13, and +14 respectively. The implication is that Indicators and auras no longer share the same `ns.LVL_AURA` level; auras still have a sufficient level buffer (from +14 to +20) to allow for flexible rendering. The ~~threat~~/hover/target border remains unchanged at +20. The raid-marker "always on top" behaviour also remains unchanged; however, the user can now set other elements to that same level (such as my debuffs in the prior section).

> Correction (21/06): threat border was originally set to +10; commit [bda1dd5](https://github.com/EllesmereGaming/EllesmereUI/commit/bda1dd535d79f3bbdd8d48d374881dd1092706b6) adds dropdowns for both threat and dispel borders, these are now set to "medium" and "high" respectively.

###   Buff Manager aligned, not redesigned. 

BM indicators already had a per-indicator frame-level dropdown (behindBorders → highest). Rather than adding a new pool-level key on top of that, `FRAMELVL_BASE`'s three shared tiers (medium, high, highest) is now aligned to `ns.FRAMELVL` (new scale), so BM indicators occupy the  same bands as every other component. The two BM-only fixed tiers (behindBorders=7, behindText=11) are intentional design positions - indicators explicitly placed there are exempt and unaffected. The text carrier offset was also made relative (off + 2) instead of pinned to the old fixed constant +18, which would have placed labels below their own icon at high or highest.

## Summary Changes

<details><summary>New profile properties</summary>

  | Property | Default | Function |
  |---|---|---|
  | `nameLevel` | `"lowest"` | `UpdateTextCarriersLevel` |
  | `healthTextLevel` | `"lowest"` | `UpdateTextCarriersLevel` |
  | `statusTextLevel` | `"low"` | `UpdateTextCarriersLevel` |
  | `roleIconLevel` | `"low"` | `UpdateIndicatorsLevel` |
  | `raidMarkerLevel` | `"highest"` | `UpdateIndicatorsLevel` |
  | `readyCheckLevel` | `"low"` | `UpdateIndicatorsLevel` |
  | `summonPendingLevel` | `"low"` | `UpdateIndicatorsLevel` |
  | `leaderIconLevel` | `"low"` | `UpdateIndicatorsLevel` |
  | `threatBorderLevel` | `"medium"` | `UpdateBordersLevel` |
  | `dispelBorderLevel` | `"high"` | `UpdateBordersLevel` |
  | `debuffLevel` | `"medium"` | `UpdateAurasLevel` |
  | `defLevel` | `"medium"` | `UpdateAurasLevel` |
  | `paLevel` | `"medium"` | `UpdateAurasLevel` |
  | `tsLevel` | `"lowest"` | `TS_ApplySettings` → `StyleIcon` |

</details> 

 Each controllable layer follows the same end-to-end flow: a new string key is added to the profile defaults using one of five named tiers that map to absolute frame level offsets via `s.FRAMELVL`. A corresponding Frame Level dropdown is added to the options UI, reading and writing that key through the standard SVal / SSet helpers and triggering a `ReloadAndUpdate`on change. 

On the render side, `StyleButton` creates a carrier frame for each layer and immediately calls a closure; `ns.FRAMELVL[s.<key>]` is read and applied relative to the unit button's current frame level. That closure is stored on `d` so both `ReloadFrames` and `ReloadPartyFrames` can re-invoke it when settings change without recreating any frames. The preview panel mirrors this: carrier frames are stored with `f._` prefixes at creation, and `ApplyPreviewData` re-levels them on every settings refresh so the panel stays in sync with the dropdowns in real time.

> [!IMPORTANT]
> Please note that `ReadyCheck` and `SummonPending` now have uncoupled texture frames.

## Screenshots

<details><summary>Settings</summary>
<img width="1166" height="850" alt="Screenshot_2026-06-20_185434" src="https://github.com/user-attachments/assets/14ec2139-1176-46f5-8b7d-bc8466940fd2" />
<img width="1171" height="846" alt="Screenshot_2026-06-20_185413" src="https://github.com/user-attachments/assets/63e42d30-3ce5-474e-8281-0e3bc6b41067" />

These patterns are repeated where applicable.
</details> 
