### PR TITLE
fix(raidframes): honor class color in live health-bar background

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -1179,8 +1179,11 @@ function ns._ApplyHealthBg(d, health, s, unit)
     if s.healthColorMode == "dark" then
         bg:SetColorTexture(DARK_BG_R, DARK_BG_G, DARK_BG_B, 1)
     else
-        local bgc = s.customBgColor
-        bg:SetColorTexture(bgc.r, bgc.g, bgc.b, (s.bgDarkness or 50) / 100)
+        -- Class-colored when bgClassColored is set, else the custom bg color.
+        -- GetBgColor returns r,g,b,a (a = bgDarkness) and is secret-safe; routing
+        -- through it keeps this live path in lockstep with the preview/reload
+        -- paths, which otherwise repaint custom color over the class tint.
+        bg:SetColorTexture(ns.GetBgColor(unit, s))
     end
 end
 


### PR DESCRIPTION
## Problem

The class-color background option (**Raid Frames → Health Bar → Background**) shows correctly in the options preview but reverts to the **Custom Background Color** on live party/raid frames in-game (reproduced in a dungeon).

## Cause

The preview and reload paths use `ns.GetBgColor`, which honors the `bgClassColored` toggle. But the live update paths — `UpdateButton` and `_UpdateButtonHealth` — both call `ns._ApplyHealthBg`, which hardcoded `s.customBgColor` and never checked `bgClassColored`.

Because `UNIT_HEALTH` fires constantly in combat, `_ApplyHealthBg` repaints the custom color over the class tint that the reload path had set — so the frame never holds the class color while you're actually playing.

## Fix

Route the alive/online branch of `_ApplyHealthBg` through `ns.GetBgColor(unit, s)`, keeping the live path in lockstep with the preview/reload paths. `GetBgColor` returns `r,g,b,a` (alpha = `bgDarkness`) and is secret-value safe.

Both `_ApplyHealthBg` call sites already pass the correctly-resolved settings proxy (`ns._scaledPartyProxy` for party, `ns._scaledProfile` for raid), so this fixes **both party and raid** with one change. The dark health-color mode and dead/offline status tints are untouched.

## Testing

- [x] Lua syntax check (`luac -p`) passes
- [ ] Party class color holds on live frames in a dungeon (taking damage)
- [ ] Raid frames in a raid group
- [ ] `bgDarkness` slider still affects the class-colored bg
- [ ] Toggle OFF cleanly reverts to custom color on live frames
- [ ] Dead/offline → resurrect restores class color
- [ ] Dark health-color mode still uses dark bg (not class color)
- [ ] Out-of-range / uninspectable units fall back gracefully (no Lua error)

---

**Bug report:** https://discord.com/channels/585577383847788554/1517963435776671774
