### PR TITLE
[codex] Reduce AuraBuff Reminders idle CPU

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -303,14 +303,29 @@ function _AC.ensureNames()
 end
 
 local function IsUnderDuration(duration, expirationTime)
-    if InMythicZeroDungeon() and db and db.profile.display.showUnderDurationDungeon > 0 and duration >= db.profile.display.showUnderDurationDungeon*60 and expirationTime - GetTime() < db.profile.display.showUnderDurationDungeon*60 then
-        return true
+    if not (db and db.profile and db.profile.display and duration and expirationTime) then return false end
+
+    local d = db.profile.display
+    local thresholdSeconds
+    if InMythicZeroDungeon() then
+        thresholdSeconds = (d.showUnderDurationDungeon or 0) * 60
+    elseif IsInRaid() then
+        thresholdSeconds = (d.showUnderDurationRaid or 0) * 60
     end
-    if IsInRaid() and db and db.profile.display.showUnderDurationRaid > 0 and duration >= db.profile.display.showUnderDurationRaid*60 and expirationTime - GetTime() < db.profile.display.showUnderDurationRaid*60 then
-        return true
+
+    if thresholdSeconds and thresholdSeconds > 0 and duration >= thresholdSeconds then
+        local now = GetTime()
+        if expirationTime - now < thresholdSeconds then
+            return true
+        end
+
+        local refreshAt = expirationTime - thresholdSeconds
+        if refreshAt > now and (not EABR._nextDurationRefreshTime or refreshAt < EABR._nextDurationRefreshTime) then
+            EABR._nextDurationRefreshTime = refreshAt
+        end
     end
-    
-    return false 
+
+    return false
 end
 
 local function PlayerHasAuraByID(spellIDs)
@@ -2266,6 +2281,7 @@ local UpdateDurationTicker  -- forward-declare; defined after RequestRefresh
 
 local function Refresh()
     _cachedOutline = nil
+    EABR._nextDurationRefreshTime = nil
     if not db then return end
     if euiPanelOpen then HideCombatIcons(); HideAllIcons(); return end
 
@@ -2566,33 +2582,26 @@ local function RequestRefresh()
     end
 end
 
--- Duration-threshold ticker: polls every 15s so expiring buffs trigger
--- reminders even when no event fires. Only runs when OOC, in a dungeon
--- or raid, not in an active keystone, and a threshold is set.
-local _durationTicker
+-- Duration-threshold timer: arm one refresh for the next known buff/enchant
+-- threshold crossing instead of polling while idle.
 UpdateDurationTicker = function()
-    local shouldTick = false
-    if db and not InCombat() and not InMythicPlusKey() then
-        local d = db.profile.display
-        if d and ((d.showUnderDurationDungeon or 0) > 0
-              or  (d.showUnderDurationRaid or 0) > 0) then
-            if (_cachedIType == "party" or _cachedIType == "raid") then
-                shouldTick = true
-            end
-        end
+    if EABR._durationTimer then
+        EABR._durationTimer:Cancel()
+        EABR._durationTimer = nil
     end
-    if shouldTick and not _durationTicker then
-        _durationTicker = C_Timer.NewTicker(15, function()
-            if InCombat() or InMythicPlusKey() then
-                if _durationTicker then _durationTicker:Cancel(); _durationTicker = nil end
-                return
-            end
-            RequestRefresh()
-        end)
-    elseif not shouldTick and _durationTicker then
-        _durationTicker:Cancel()
-        _durationTicker = nil
+
+    if not (EABR._nextDurationRefreshTime and db and not InCombat() and not InMythicPlusKey()) then
+        return
     end
+
+    local delay = EABR._nextDurationRefreshTime - GetTime() + 0.1
+    if delay < 0.1 then delay = 0.1 end
+
+    EABR._durationTimer = C_Timer.NewTimer(delay, function()
+        EABR._durationTimer = nil
+        if InCombat() or InMythicPlusKey() then return end
+        RequestRefresh()
+    end)
 end
 
 

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3221,12 +3221,10 @@ function EABR:OnEnable()
     end
 
     ---------------------------------------------------------------------------
-    --  Range polling (0.5s throttle). Runs in combat too: UnitInRange is not
-    --  protected, and the group-buff reminders gate on member range, so a
-    --  member walking in or out of range mid-fight must retrigger evaluation.
+    --  Range updates. UNIT_IN_RANGE_UPDATE mirrors the raid frames' range
+    --  path, so range changes retrigger group-buff evaluation without polling.
     ---------------------------------------------------------------------------
     local _lastRangeSet = {}   -- [unitToken] = true/false (last known in-range state)
-    local _rangeAccum   = 0    -- seconds since last poll
 
     -- Pre-build unit token strings to avoid per-poll allocations
     local _raidTokens = {}
@@ -3235,44 +3233,85 @@ function EABR:OnEnable()
     for i = 1, 4 do _partyTokens[i] = "party" .. i end
 
     local rangeFrame = CreateFrame("Frame")
-    local _rangeChanged = false
+    local _rangeTrackers = {}
     local function _checkUnit(u)
         if not UnitExists(u) then
             if _lastRangeSet[u] ~= nil then
                 _lastRangeSet[u] = nil
-                _rangeChanged = true
+                return true
             end
-            return
+            return false
         end
         local state = _unitInRange(u)
         if _lastRangeSet[u] ~= state then
             _lastRangeSet[u] = state
-            _rangeChanged = true
+            return true
+        end
+        return false
+    end
+
+    local function _checkAllRangeUnits()
+        local changed = false
+        if IsInRaid() then
+            for i = 1, GetNumGroupMembers() do
+                if _checkUnit(_raidTokens[i]) then changed = true end
+            end
+        elseif IsInGroup() then
+            for i = 1, GetNumSubgroupMembers() do
+                if _checkUnit(_partyTokens[i]) then changed = true end
+            end
+        end
+        return changed
+    end
+
+    local function _onRangeEvent(_, event, unit)
+        if event == "UNIT_PHASE" then
+            if _checkAllRangeUnits() then RequestRefresh() end
+        elseif unit and _checkUnit(unit) then
+            RequestRefresh()
         end
     end
 
-    rangeFrame:SetScript("OnUpdate", function(_, elapsed)
-        -- Only poll while in a group. The poll just reads UnitInRange and
-        -- requests our own (insecure) refresh, so combat is safe.
-        if not IsInGroup() then
-            _rangeAccum = 0
-            return
+    local function _clearRangeTrackers()
+        for _, tracker in pairs(_rangeTrackers) do
+            tracker:UnregisterAllEvents()
         end
-        _rangeAccum = _rangeAccum + elapsed
-        if _rangeAccum < 0.5 then
-            return
-        end
-        _rangeAccum = 0
+    end
 
-        _rangeChanged = false
+    local function _trackRangeUnit(unit)
+        if UnitIsUnit(unit, "player") then return end
+        local tracker = _rangeTrackers[unit]
+        if not tracker then
+            tracker = CreateFrame("Frame")
+            tracker:SetScript("OnEvent", _onRangeEvent)
+            _rangeTrackers[unit] = tracker
+        end
+        tracker:RegisterUnitEvent("UNIT_IN_RANGE_UPDATE", unit)
+        tracker:RegisterUnitEvent("UNIT_CONNECTION", unit)
+    end
+
+    local function _rebuildRangeTracking()
+        _clearRangeTrackers()
+        wipe(_lastRangeSet)
         if IsInRaid() then
-            for i = 1, GetNumGroupMembers() do _checkUnit(_raidTokens[i]) end
-        else
-            for i = 1, GetNumSubgroupMembers() do _checkUnit(_partyTokens[i]) end
+            for i = 1, GetNumGroupMembers() do _trackRangeUnit(_raidTokens[i]) end
+        elseif IsInGroup() then
+            for i = 1, GetNumSubgroupMembers() do _trackRangeUnit(_partyTokens[i]) end
         end
+        if _checkAllRangeUnits() then RequestRefresh() end
+    end
 
-        if _rangeChanged then RequestRefresh() end
+    rangeFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+    rangeFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
+    rangeFrame:RegisterEvent("UNIT_PHASE")
+    rangeFrame:SetScript("OnEvent", function(_, event)
+        if event == "UNIT_PHASE" then
+            _onRangeEvent(nil, event)
+        else
+            _rebuildRangeTracking()
+        end
     end)
+    _rebuildRangeTracking()
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Make AuraBuff Reminders range updates event-driven instead of polling while grouped.
- Schedule duration-threshold refreshes only when tracked auras cross a relevant threshold.

## Why
AuraBuff Reminders did permanent idle work in group content even when nothing changed. The range update path and duration refresh path can both wait for game events or the next known threshold deadline.

## Validation
- Manual in-game profiling with Numi Addon Profiler.
- 30s idle dungeon sample on this branch showed AuraBuff Reminders at 0.000ms total.

<img width="1640" height="154" alt="image" src="https://github.com/user-attachments/assets/47c768ed-3d9e-477b-9db9-2abf93033ab8" />
<img width="1661" height="178" alt="image" src="https://github.com/user-attachments/assets/50f482f8-285b-4d99-bf98-6ec43ef5f1e2" />

