### PR TITLE
feat(cooldown-manager): add smooth bar fill animation to tracking bars

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -3674,6 +3674,17 @@ initFrame:SetScript("OnEvent", function(self)
               tooltip = "Only show this bar while the tracked buff/cooldown is active. Turn off to keep an empty bar on screen at all times." }
         );  y = y - h
 
+        -- Smooth Bars
+        _, h = W:DualRow(parent, y,
+            { type = "toggle", text = "Smooth Bars",
+              getValue = function() local bd = SelectedTBB(); return bd and bd.smoothBars ~= false end,
+              setValue = function(v)
+                  local bd = SelectedTBB(); if not bd then return end
+                  bd.smoothBars = v; RefreshTBB()
+              end },
+            { type = "label", text = "" }
+        );  y = y - h
+
         -----------------------------------------------------------------------
         --  EXTRAS
         -----------------------------------------------------------------------

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -223,6 +223,7 @@ local TBB_DEFAULT_BAR = {
     pandemicGlowLines = 8,
     pandemicGlowThickness = 2,
     pandemicGlowSpeed = 4,
+    smoothBars = true,
 }
 ns.TBB_DEFAULT_BAR = TBB_DEFAULT_BAR
 
@@ -1339,11 +1340,19 @@ local function UpdateLustBar(bar, cfg)
         if bar:IsShown() then bar:Hide() end
         return
     end
-    if not bar:IsShown() then bar:Show() end
+    local wasShown = bar:IsShown()
+    if not wasShown then bar:Show() end
     local sb = bar._bar
     if sb then
         sb:SetMinMaxValues(0, 40)
-        sb:SetValue(remaining)
+        local smooth = wasShown and cfg.smoothBars ~= false
+            and Enum and Enum.StatusBarInterpolation
+            and Enum.StatusBarInterpolation.ExponentialEaseOut
+        if smooth then
+            sb:SetValue(remaining, smooth)
+        else
+            sb:SetValue(remaining)
+        end
         if cfg.showSpark and bar._spark then bar._spark:Show() end
     end
     if cfg.showTimer and bar._timerText then
@@ -1416,7 +1425,8 @@ function ns.UpdateTrackedBuffBarTimers()
             local blizzBar = blzChild and blzChild.Bar
 
             if isActive then
-                if not bar:IsShown() then bar:Show() end
+                local wasShown = bar:IsShown()
+                if not wasShown then bar:Show() end
                 local sb = bar._bar
 
                 -- Stacks (gated)
@@ -1426,7 +1436,14 @@ function ns.UpdateTrackedBuffBarTimers()
                     -- Mirror Blizzard's bar onto ours. Secret values pass
                     -- through natively to widget setters -- no Lua comparison.
                     sb:SetMinMaxValues(blizzBar:GetMinMaxValues())
-                    sb:SetValue(blizzBar:GetValue())
+                    local smooth = wasShown and cfg.smoothBars ~= false
+                        and Enum and Enum.StatusBarInterpolation
+                        and Enum.StatusBarInterpolation.ExponentialEaseOut
+                    if smooth then
+                        sb:SetValue(blizzBar:GetValue(), smooth)
+                    else
+                        sb:SetValue(blizzBar:GetValue())
+                    end
                     if cfg.showSpark and bar._spark then bar._spark:Show() end
 
                     -- Auto fill color from Blizzard's bar texture


### PR DESCRIPTION
## Summary

Tracking Bars in the Cooldown Manager currently snap bar values directly from Blizzard's CDM StatusBar with no interpolation. On fast-moving bars (short durations), the discrete frame-to-frame jumps are visible as judder.

This PR adds smooth bar fill animation using `Enum.StatusBarInterpolation.ExponentialEaseOut`, the same native WoW API already used by the Raid Frames module for health and power bars.

## Changes

**`EllesmereUICdmBuffBars.lua`:**
- `TBB_DEFAULT_BAR`: add `smoothBars = true` (default on)
- `UpdateTrackedBuffBarTimers`: pass `ExponentialEaseOut` to `SetValue` for Blizzard-mirrored bars, with a `wasShown` snap on hidden→shown transitions (prevents animating from stale values on first frame after a bar appears, same pattern as Raid Frames power bars)
- `UpdateLustBar`: same smoothing applied to self-driven 40s lust bars

**`EUI_CooldownManager_Options.lua`:**
- New "Smooth Bars" toggle in the Display section (between "Hide When Inactive" and "Extras")

## Approach

Uses the native `StatusBar:SetValue(value, interpolationType)` API rather than a manual Lua lerp. This keeps the implementation minimal, one extra argument to `SetValue`, and delegates the easing to the C engine. The `wasShown` guard ensures bars snap to their current value on first appearance rather than animating from zero, matching the existing Raid Frames pattern for power bars.

## Files changed

`2 files changed, 32 insertions(+), 4 deletions(-)`
