### PR TITLE
fix vengeance threshold not filling due to secret value

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -3686,6 +3686,9 @@ local function UpdateSecondaryResource()
             -- The StatusBar accepts the secret number natively; when the
             -- value falls within [i-1, i] the bar fills proportionally,
             -- giving us a binary active/inactive look for integer counts.
+            -- Threshold coloring via a second, threshold-colored
+            -- StatusBar overlay per pip.
+            local _useThresh = _tsEntry and _tsThreshCount and _tsThreshCount > 0
             for i = 1, maxC do
                 local pip = pips[i]
                 if pip and pip:IsShown() then
@@ -3706,6 +3709,31 @@ local function UpdateSecondaryResource()
                     pip._secretBar:SetValue(cur)
                     pip._secretBar:SetStatusBarColor(r, g, b, a)
                     pip._secretBar:Show()
+
+                    -- Threshold overlay (drawn on top of the base fill)
+                    -- Partial-only: pips below the threshold index never recolor.
+                    local showThresh = _useThresh and not (_tsPartialOnly and i < _tsThreshCount)
+                    if showThresh then
+                        if not pip._secretThreshBar then
+                            local tb = CreateFrame("StatusBar", nil, pip)
+                            tb:SetAllPoints(pip._fill)
+                            tb:SetStatusBarTexture(texPath)
+                            tb:SetFrameLevel(pip:GetFrameLevel() + 1)
+                            pip._secretThreshBar = tb
+                        else
+                            pip._secretThreshBar:SetStatusBarTexture(texPath)
+                        end
+                        -- Fills only when cur >= max(i, threshCount): the pip is
+                        -- active AND the threshold has been reached.
+                        local tlo = (i > _tsThreshCount) and i or _tsThreshCount
+                        pip._secretThreshBar:SetMinMaxValues(tlo - 1, tlo)
+                        pip._secretThreshBar:SetValue(cur)
+                        pip._secretThreshBar:SetStatusBarColor(_tsR or 1, _tsG or 0.2, _tsB or 0.2, a)
+                        pip._secretThreshBar:Show()
+                    elseif pip._secretThreshBar then
+                        pip._secretThreshBar:Hide()
+                    end
+
                     -- Hide the normal fill; the StatusBar replaces it
                     pip._fill:Hide()
                 end


### PR DESCRIPTION
Vengeance pip threshold was not working due to secret value logic - it was only adding an overlay for amount of pips. Add a second overlay that checks for threshold and colours only according to the setting.

Testing (in dungeon with /euidev):
With threshold enabled -
<img width="345" height="89" alt="Screenshot 2026-06-21 124000" src="https://github.com/user-attachments/assets/630ccb59-6a73-4cca-a5c5-77e1ea094dea" />
<img width="316" height="100" alt="Screenshot 2026-06-21 124007" src="https://github.com/user-attachments/assets/e6a68247-87b8-46be-8f7f-c40aa062f7f2" />
<img width="388" height="157" alt="image" src="https://github.com/user-attachments/assets/96a72120-6462-44be-bf1d-8f40b1c9817d" />


With threshold disabled -
<img width="322" height="85" alt="Screenshot 2026-06-21 124024" src="https://github.com/user-attachments/assets/f742d017-77bb-4459-bbc3-7cffeeee92eb" />
