### PR TITLE
[RaidFrames] animated clock border and cast countdown timer for targeted spell icons

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -413,7 +413,7 @@ local function LayoutButton(btn)
     local ox = Setting(raid, "OffsetX", 0) * k
     local oy = Setting(raid, "OffsetY", 0) * k
     local anchor = btn._health or btn
-    local spc = 2 * k
+    local spc = Setting(raid, "IconSpacing", 2) * k
     local spacing = sz + spc
 
     local shown = 0
@@ -878,6 +878,30 @@ local function PreviewTick(icons)
     end
 end
 
+-- Shared 2-icon placement for previews. Mirrors LayoutButton for 2 shown
+-- icons so grow direction, spacing, and offsets all behave identically.
+local function PvPlaceIcons(icons, host, pos, ox, oy, sz, spc, grow)
+    local spacing = sz + spc
+    local centerOff = grow == "CENTER" and -spacing / 2 or 0
+    for i = 1, #icons do
+        icons[i]:ClearAllPoints()
+        if i == 1 then
+            Place(icons[i], host._health or host, pos, ox + centerOff, oy)
+        else
+            local prev = icons[i - 1]
+            if grow == "RIGHT" or grow == "CENTER" then
+                icons[i]:SetPoint("LEFT", prev, "RIGHT", spc, 0)
+            elseif grow == "LEFT" then
+                icons[i]:SetPoint("RIGHT", prev, "LEFT", -spc, 0)
+            elseif grow == "UP" then
+                icons[i]:SetPoint("BOTTOM", prev, "TOP", 0, spc)
+            else
+                icons[i]:SetPoint("TOP", prev, "BOTTOM", 0, -spc)
+            end
+        end
+    end
+end
+
 -- ---- Party preview --------------------------------------------------------
 local pvIcons = {}
 local pvTicker
@@ -911,34 +935,33 @@ function ns.TS_RefreshPreview()
         end
         return
     end
-    -- Preview mirrors the real frames 1:1: same scale factor, Place() anchor
-    -- and offsets.
+    -- Both icons are placed on the same host so icon spacing is visible.
     local k = ns._partyIndicatorScale or 1
     local pos = lower((s and s.tsPosition) or "center")
     local ox = ((s and s.tsOffsetX) or 0) * k
     local oy = ((s and s.tsOffsetY) or 0) * k
-    for i = 1, #PV_HOSTS do
-        local host = frames[PV_HOSTS[i]]
-        local icon = pvIcons[i]
-        if host then
-            if not icon or icon:GetParent() ~= host then
-                if icon then icon:Hide() end
-                icon = CreateIcon(host)
-                pvIcons[i] = icon
-            end
-            icon._tsCaster = "preview"
-            StyleIcon(icon)
-            icon._tex:SetTexture(PV_TEX[i])
-            icon:ClearAllPoints()
-            Place(icon, host._health or host, pos, ox, oy)
-            icon._pvExp = nil  -- force a fresh random swipe on next tick
-            icon:Show()
-        elseif icon then
-            icon._tsCaster = nil
-            icon._pvExp = nil
-            icon:Hide()
-        end
+    local sz = ((s and s.tsIconSize) or 24) * k
+    local spc = ((s and s.tsIconSpacing) or 2) * k
+    local grow = (s and s.tsGrowDirection) or "CENTER"
+    local host = frames[PV_HOSTS[1]]
+    if not host then
+        for i = 1, #pvIcons do if pvIcons[i] then pvIcons[i]:Hide() end end
+        return
     end
+    for i = 1, #PV_HOSTS do
+        local icon = pvIcons[i]
+        if not icon or icon:GetParent() ~= host then
+            if icon then icon:Hide() end
+            icon = CreateIcon(host)
+            pvIcons[i] = icon
+        end
+        icon._tsCaster = "preview"
+        StyleIcon(icon)
+        icon._tex:SetTexture(PV_TEX[i])
+        icon._pvExp = nil
+        icon:Show()
+    end
+    PvPlaceIcons(pvIcons, host, pos, ox, oy, sz, spc, grow)
     PvTick()
     if not pvTicker then
         pvTicker = C_Timer.NewTicker(0.5, PvTick)
@@ -982,32 +1005,33 @@ function ns.TS_RefreshRaidPreview()
         end
         return
     end
-    -- Raid icons do not auto-resize (factor 1), so offsets are used raw.
+    -- Both icons on the same host so icon spacing is visible. Raid icons do
+    -- not auto-resize (factor 1), so offsets and sizes are used raw.
     local pos = lower((s and s.tsRaidPosition) or "center")
     local ox = (s and s.tsRaidOffsetX) or 0
     local oy = (s and s.tsRaidOffsetY) or 0
-    for i = 1, #PV_HOSTS do
-        local host = frames[PV_HOSTS[i]]
-        local icon = rPvIcons[i]
-        if host then
-            if not icon or icon:GetParent() ~= host then
-                if icon then icon:Hide() end
-                icon = CreateIcon(host, true)
-                rPvIcons[i] = icon
-            end
-            icon._tsCaster = "preview"
-            StyleIcon(icon)
-            icon._tex:SetTexture(PV_TEX[i])
-            icon:ClearAllPoints()
-            Place(icon, host._health or host, pos, ox, oy)
-            icon._pvExp = nil
-            icon:Show()
-        elseif icon then
-            icon._tsCaster = nil
-            icon._pvExp = nil
-            icon:Hide()
-        end
+    local sz = (s and s.tsRaidIconSize) or 24
+    local spc = (s and s.tsRaidIconSpacing) or 2
+    local grow = (s and s.tsRaidGrowDirection) or "CENTER"
+    local host = frames[PV_HOSTS[1]]
+    if not host then
+        for i = 1, #rPvIcons do if rPvIcons[i] then rPvIcons[i]:Hide() end end
+        return
     end
+    for i = 1, #PV_HOSTS do
+        local icon = rPvIcons[i]
+        if not icon or icon:GetParent() ~= host then
+            if icon then icon:Hide() end
+            icon = CreateIcon(host, true)
+            rPvIcons[i] = icon
+        end
+        icon._tsCaster = "preview"
+        StyleIcon(icon)
+        icon._tex:SetTexture(PV_TEX[i])
+        icon._pvExp = nil
+        icon:Show()
+    end
+    PvPlaceIcons(rPvIcons, host, pos, ox, oy, sz, spc, grow)
     RPvTick()
     if not rPvTicker then
         rPvTicker = C_Timer.NewTicker(0.5, RPvTick)

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -844,6 +844,7 @@ local PV_TEX = { 135807, 136197 }  -- fireball / shadow bolt
 -- when an icon's random swipe expires, re-arm it with a fresh random duration.
 local function PreviewTick(icons)
     local now = GetTime()
+    local raid = IsInRaid()
     for i = 1, #icons do
         local icon = icons[i]
         if icon and icon._tsCaster and icon._cooldown then
@@ -852,6 +853,26 @@ local function PreviewTick(icons)
                 icon._pvExp = now + dur
                 icon._cooldown:SetCooldown(now, dur)
                 icon._cooldown:Show()
+                if icon._clockRing and Setting(raid, "ShowClockBorder", false) then
+                    local s = S()
+                    local c = s and s[(raid and "tsRaid" or "ts") .. "ClockBorderColor"]
+                    local r, g, b = c and c.r or 1, c and c.g or 1, c and c.b or 1
+                    icon._clockRing:SetDrawSwipe(true)
+                    icon._clockRing:SetCooldown(now, dur)
+                    icon._clockRing:SetSwipeTexture(WHITE_TEX)
+                    icon._clockRing:SetSwipeColor(r, g, b, 1)
+                    icon._clockRing:Show()
+                    if icon._clockBg then icon._clockBg:Show() end
+                elseif icon._clockRing then
+                    icon._clockRing:Hide()
+                    if icon._clockBg then icon._clockBg:Hide() end
+                end
+                if icon._timerCd and Setting(raid, "ShowTimer", false) then
+                    icon._timerCd:SetCooldown(now, dur)
+                    icon._timerCd:Show()
+                elseif icon._timerCd then
+                    icon._timerCd:Hide()
+                end
             end
         end
     end

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -220,46 +220,52 @@ local function StyleIcon(icon)
         end
     end
     if icon._clockRing then
-        -- Re-anchor whenever the icon is resized so the border pad scales correctly.
-        local bdrPad = Setting(raid, "ClockBorderSize", 3)
-        icon._clockRing:ClearAllPoints()
-        icon._clockRing:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -bdrPad,  bdrPad)
-        icon._clockRing:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  bdrPad, -bdrPad)
-        if icon._clockBg then
-            icon._clockBg:ClearAllPoints()
-            icon._clockBg:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -bdrPad,  bdrPad)
-            icon._clockBg:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  bdrPad, -bdrPad)
-        end
         if clockBorderOn then
+            -- Re-anchor to pick up any icon resize; skip when feature is off to avoid overhead for non-users.
+            local bdrPad = Setting(raid, "ClockBorderSize", 3)
+            icon._clockRing:ClearAllPoints()
+            icon._clockRing:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -bdrPad,  bdrPad)
+            icon._clockRing:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  bdrPad, -bdrPad)
+            if icon._clockBg then
+                icon._clockBg:ClearAllPoints()
+                icon._clockBg:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -bdrPad,  bdrPad)
+                icon._clockBg:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  bdrPad, -bdrPad)
+            end
             local s = S()
             local c = s and s[(raid and "tsRaid" or "ts") .. "ClockBorderColor"]
             local r, g, b = c and c.r or 1, c and c.g or 1, c and c.b or 1
             icon._clockRing:SetSwipeTexture(WHITE_TEX)
             icon._clockRing:SetSwipeColor(r, g, b, 1)
+        else
+            icon._clockRing:Hide()
+            if icon._clockBg then icon._clockBg:Hide() end
         end
     end
     if icon._timerCd then
-        local timerSz = Setting(raid, "TimerSize", 10)
-        local timerOffX = Setting(raid, "TimerOffsetX", 0)
-        local timerOffY = Setting(raid, "TimerOffsetY", 0)
-        icon._timerCd:ClearAllPoints()
-        icon._timerCd:SetSize(sz, sz)
-        icon._timerCd:SetPoint("CENTER", icon, "CENTER", timerOffX, timerOffY)
-        if icon._timerCdFS then
-            local face, _, flags = icon._timerCdFS:GetFont()
-            if face then
-                icon._timerCdFS:SetFont(face, timerSz, flags or "")
+        if Setting(raid, "ShowTimer", false) then
+            local timerSz = Setting(raid, "TimerSize", 10)
+            local timerOffX = Setting(raid, "TimerOffsetX", 0)
+            local timerOffY = Setting(raid, "TimerOffsetY", 0)
+            icon._timerCd:ClearAllPoints()
+            icon._timerCd:SetSize(sz, sz)
+            icon._timerCd:SetPoint("CENTER", icon, "CENTER", timerOffX, timerOffY)
+            if icon._timerCdFS then
+                local face, _, flags = icon._timerCdFS:GetFont()
+                if face then
+                    icon._timerCdFS:SetFont(face, timerSz, flags or "")
+                end
+                -- Re-anchor directly to icon to bypass template pixel-snapping offset.
+                icon._timerCdFS:ClearAllPoints()
+                icon._timerCdFS:SetPoint("CENTER", icon, "CENTER", timerOffX, timerOffY)
+                local s = S()
+                local tc = s and s[(raid and "tsRaid" or "ts") .. "TimerColor"]
+                local tr = tc and tc.r or 1
+                local tg_c = tc and tc.g or 1
+                local tb = tc and tc.b or 1
+                icon._timerCdFS:SetTextColor(tr, tg_c, tb)
             end
-            -- Re-anchor directly to the icon so Blizzard's template offset
-            -- and any accumulated pixel-snapping error are bypassed.
-            icon._timerCdFS:ClearAllPoints()
-            icon._timerCdFS:SetPoint("CENTER", icon, "CENTER", timerOffX, timerOffY)
-            local s = S()
-            local tc = s and s[(raid and "tsRaid" or "ts") .. "TimerColor"]
-            local tr = tc and tc.r or 1
-            local tg_c = tc and tc.g or 1
-            local tb = tc and tc.b or 1
-            icon._timerCdFS:SetTextColor(tr, tg_c, tb)
+        else
+            icon._timerCd:Hide()
         end
     end
 end
@@ -298,11 +304,7 @@ local function CreateIcon(btn, raid)
     end
     icon._borderFrame = bdr
 
-    -- Square clock border: a CooldownFrame positioned 3 px outside the icon edges
-    -- so the standard pie-sweep is only visible in that border zone.  The spell
-    -- texture (a child of icon, rendered at a higher frame level) masks the interior,
-    -- so only the colored border depletes clock-style as the cast progresses.
-    -- SetReverse(false) = depleting: full border at cast start, empty at cast end.
+    -- CooldownFrame outside the icon; spell texture at a higher level masks the interior, leaving only the ring depleting clock-style.
     local clockBdr = CreateFrame("Cooldown", nil, icon, "CooldownFrameTemplate")
     local BDR_PAD = 3
     clockBdr:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -BDR_PAD,  BDR_PAD)
@@ -315,10 +317,7 @@ local function CreateIcon(btn, raid)
     clockBdr:SetReverse(false)
     clockBdr:SetSwipeColor(1, 1, 1, 1)
     clockBdr:SetSwipeTexture(WHITE_TEX)
-    -- Background lives on a separate frame below clockBdr so the Cooldown
-    -- swipe renders above it (WoW draws the swipe before standard textures
-    -- on the same frame, meaning a BACKGROUND texture on clockBdr itself
-    -- would cover the swipe).
+    -- Separate frame below clockBdr: WoW draws the swipe before standard textures on the same frame, so a BACKGROUND texture on clockBdr itself would cover the swipe.
     local clockBg = CreateFrame("Frame", nil, icon)
     clockBg:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -BDR_PAD,  BDR_PAD)
     clockBg:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  BDR_PAD, -BDR_PAD)
@@ -331,10 +330,7 @@ local function CreateIcon(btn, raid)
     clockBdr:Hide()
     icon._clockRing = clockBdr
 
-    -- Timer: a CooldownFrameTemplate with the swipe hidden and the built-in
-    -- countdown numbers shown.  WoW's C code handles the secret timing values
-    -- from SetCooldownFromDurationObject internally, so no Lua arithmetic on
-    -- tainted values is needed.
+    -- CooldownFrame with swipe disabled and countdown numbers shown; SetCooldownFromDurationObject handles secret timing on the C side.
     local timerCd = CreateFrame("Cooldown", nil, icon, "CooldownFrameTemplate")
     timerCd:SetAllPoints()
     timerCd:SetFrameLevel(icon:GetFrameLevel() + 3)
@@ -549,16 +545,13 @@ local function ShowFor(caster, matches, texture, durObj, endTimeMS, startTimeMS)
                 local cr = icon._clockRing
                 if cr then
                     if Setting(raid, "ShowClockBorder", false) then
-                        -- Read the user's colour here; it must be re-applied AFTER
-                        -- SetCooldownFromDurationObject because that call resets the
-                        -- swipe colour to the CooldownFrame default.
+                        -- Colour must be re-applied after SetCooldownFromDurationObject, which resets the swipe colour.
                         local s = S()
                         local bc = s and s[(raid and "tsRaid" or "ts") .. "ClockBorderColor"]
                         local br = bc and bc.r or 1
                         local cg = bc and bc.g or 1
                         local bb = bc and bc.b or 1
-                        -- Use durObj (same source as the face swipe) so the ring is
-                        -- immune to the cast timestamp taint that affects raw endTimeMS.
+                        -- Prefer durObj over raw endTimeMS/startTimeMS to avoid taint from secret cast timestamps.
                         if durObj and cr.SetCooldownFromDurationObject then
                             cr:SetDrawSwipe(true)
                             cr:SetCooldownFromDurationObject(durObj)

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -33,8 +33,10 @@ local type          = type
 local wipe          = wipe
 local lower         = string.lower
 local random        = math.random
+local floor         = math.floor
+local max           = math.max
 local issecret      = issecretvalue or function() return false end
-
+local WHITE_TEX     = "Interface\\Buttons\\WHITE8X8"
 -- Roster token lists per context. Units() picks the active one so the roster
 -- cache and classifier iterate raid1-40 in a raid and the party list otherwise.
 local ROSTER_UNITS = { "player", "party1", "party2", "party3", "party4" }
@@ -204,11 +206,36 @@ local function StyleIcon(icon)
     local k = raid and 1 or (ns._partyIndicatorScale or 1)
     local sz = Setting(raid, "IconSize", 24) * k
     icon:SetSize(sz, sz)
+    local clockBorderOn = Setting(raid, "ShowClockBorder", true)
     if icon._borderFrame then
-        local PP = EllesmereUI and (EllesmereUI.PanelPP or EllesmereUI.PP)
-        if PP and PP.UpdateBorder then
-            PP.UpdateBorder(icon._borderFrame, 1, 0, 0, 0, 1)
-            icon._borderFrame:Show()
+        if clockBorderOn then
+            -- Clock ring replaces the static PP border; hide it to avoid visual clutter.
+            icon._borderFrame:Hide()
+        else
+            local PP = EllesmereUI and (EllesmereUI.PanelPP or EllesmereUI.PP)
+            if PP and PP.UpdateBorder then
+                PP.UpdateBorder(icon._borderFrame, 1, 0, 0, 0, 1)
+                icon._borderFrame:Show()
+            end
+        end
+    end
+    if icon._clockRing then
+        -- Re-anchor whenever the icon is resized so the border pad scales correctly.
+        local bdrPad = max(2, floor(sz * 0.12))
+        icon._clockRing:ClearAllPoints()
+        icon._clockRing:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -bdrPad,  bdrPad)
+        icon._clockRing:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  bdrPad, -bdrPad)
+        if icon._clockBg then
+            icon._clockBg:ClearAllPoints()
+            icon._clockBg:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -bdrPad,  bdrPad)
+            icon._clockBg:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  bdrPad, -bdrPad)
+        end
+        if clockBorderOn then
+            local s = S()
+            local c = s and s[(raid and "tsRaid" or "ts") .. "ClockBorderColor"]
+            local r, g, b = c and c.r or 1, c and c.g or 1, c and c.b or 1
+            icon._clockRing:SetSwipeTexture(WHITE_TEX)
+            icon._clockRing:SetSwipeColor(r, g, b, 1)
         end
     end
 end
@@ -218,6 +245,11 @@ local function CreateIcon(btn, raid)
     icon._tsRaid = raid or false
     icon:SetFrameLevel(btn:GetFrameLevel() + 12)
     icon:Hide()
+
+    -- Solid black backdrop so spell-texture transparent edges look clean.
+    local iconBg = icon:CreateTexture(nil, "BACKGROUND")
+    iconBg:SetAllPoints()
+    iconBg:SetColorTexture(0, 0, 0, 1)
 
     local tex = icon:CreateTexture(nil, "ARTWORK")
     tex:SetAllPoints()
@@ -241,6 +273,39 @@ local function CreateIcon(btn, raid)
         PP.CreateBorder(bdr, 0, 0, 0, 1, 1)
     end
     icon._borderFrame = bdr
+
+    -- Square clock border: a CooldownFrame positioned 3 px outside the icon edges
+    -- so the standard pie-sweep is only visible in that border zone.  The spell
+    -- texture (a child of icon, rendered at a higher frame level) masks the interior,
+    -- so only the colored border depletes clock-style as the cast progresses.
+    -- SetReverse(false) = depleting: full border at cast start, empty at cast end.
+    local clockBdr = CreateFrame("Cooldown", nil, icon, "CooldownFrameTemplate")
+    local BDR_PAD = 3
+    clockBdr:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -BDR_PAD,  BDR_PAD)
+    clockBdr:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  BDR_PAD, -BDR_PAD)
+    clockBdr:SetFrameLevel(max(0, icon:GetFrameLevel() - 1))
+    clockBdr:SetHideCountdownNumbers(true)
+    clockBdr:SetDrawEdge(false)
+    clockBdr:SetDrawBling(false)
+    clockBdr:SetDrawSwipe(true)
+    clockBdr:SetReverse(false)
+    clockBdr:SetSwipeColor(1, 1, 1, 1)
+    clockBdr:SetSwipeTexture(WHITE_TEX)
+    -- Background lives on a separate frame below clockBdr so the Cooldown
+    -- swipe renders above it (WoW draws the swipe before standard textures
+    -- on the same frame, meaning a BACKGROUND texture on clockBdr itself
+    -- would cover the swipe).
+    local clockBg = CreateFrame("Frame", nil, icon)
+    clockBg:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -BDR_PAD,  BDR_PAD)
+    clockBg:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  BDR_PAD, -BDR_PAD)
+    clockBg:SetFrameLevel(max(0, icon:GetFrameLevel() - 2))
+    local clockBgTex = clockBg:CreateTexture(nil, "BACKGROUND")
+    clockBgTex:SetAllPoints()
+    clockBgTex:SetColorTexture(0, 0, 0, 1)
+    clockBg:Hide()
+    icon._clockBg = clockBg
+    clockBdr:Hide()
+    icon._clockRing = clockBdr
 
     StyleIcon(icon)
     return icon
@@ -368,6 +433,8 @@ local function ClearCaster(caster)
             icon._cooldown:Clear()
             icon._cooldown:Hide()
         end
+        if icon._clockRing then icon._clockRing:Hide() end
+        if icon._clockBg then icon._clockBg:Hide() end
         touched[icon:GetParent()] = true
     end
     for btn in pairs(touched) do LayoutButton(btn) end
@@ -378,7 +445,7 @@ local function ClearAll()
     wipe(tracked)
 end
 
-local function ShowFor(caster, matches, texture, durObj)
+local function ShowFor(caster, matches, texture, durObj, endTimeMS, startTimeMS)
     -- Pick the active context's unit->button map. The classifier already
     -- produced tokens in this context (Units()), so they line up with the map.
     local raid = IsInRaid()
@@ -416,6 +483,52 @@ local function ShowFor(caster, matches, texture, durObj)
                     cd:Clear()
                     cd:Hide()
                 end
+                local cr = icon._clockRing
+                if cr then
+                    if Setting(raid, "ShowClockBorder", true) then
+                        -- Read the user's colour here; it must be re-applied AFTER
+                        -- SetCooldownFromDurationObject because that call resets the
+                        -- swipe colour to the CooldownFrame default.
+                        local s = S()
+                        local bc = s and s[(raid and "tsRaid" or "ts") .. "ClockBorderColor"]
+                        local br = bc and bc.r or 1
+                        local cg = bc and bc.g or 1
+                        local bb = bc and bc.b or 1
+                        -- Use durObj (same source as the face swipe) so the ring is
+                        -- immune to the cast timestamp taint that affects raw endTimeMS.
+                        if durObj and cr.SetCooldownFromDurationObject then
+                            cr:SetDrawSwipe(true)
+                            cr:SetCooldownFromDurationObject(durObj)
+                            cr:SetSwipeTexture(WHITE_TEX)
+                            cr:SetSwipeColor(br, cg, bb, 1)
+                            cr:SetAlpha(1)
+                            cr:Show()
+                            if icon._clockBg then icon._clockBg:Show() end
+                        elseif startTimeMS and endTimeMS
+                                and not issecret(startTimeMS) and not issecret(endTimeMS) then
+                            local sTime = startTimeMS / 1000
+                            local dur = (endTimeMS - startTimeMS) / 1000
+                            if dur > 0 then
+                                cr:SetDrawSwipe(true)
+                                cr:SetCooldown(sTime, dur)
+                                cr:SetSwipeTexture(WHITE_TEX)
+                                cr:SetSwipeColor(br, cg, bb, 1)
+                                cr:SetAlpha(1)
+                                cr:Show()
+                                if icon._clockBg then icon._clockBg:Show() end
+                            else
+                                cr:Clear(); cr:Hide()
+                                if icon._clockBg then icon._clockBg:Hide() end
+                            end
+                        else
+                            cr:Clear(); cr:Hide()
+                            if icon._clockBg then icon._clockBg:Hide() end
+                        end
+                    else
+                        cr:Clear(); cr:Hide()
+                        if icon._clockBg then icon._clockBg:Hide() end
+                    end
+                end
                 icon:Show()
                 LayoutButton(btn)
                 shownAny = true
@@ -433,10 +546,10 @@ local function Resolve(caster, myGen)
     if gen[caster] ~= myGen then return end
     -- Re-validate the cast is still running (assign-then-type-check: these
     -- return ZERO values when not casting)
-    local castName, _, texture = UnitCastingInfo(caster)
+    local castName, _, texture, startTimeMS, endTimeMS = UnitCastingInfo(caster)
     local channeling = false
     if type(castName) == "nil" then
-        castName, _, texture = UnitChannelInfo(caster)
+        castName, _, texture, startTimeMS, endTimeMS = UnitChannelInfo(caster)
         channeling = true
     end
     if type(castName) == "nil" then return end
@@ -478,7 +591,7 @@ local function Resolve(caster, myGen)
         for btn in pairs(touched) do LayoutButton(btn) end
     end
 
-    ShowFor(caster, matches, texture, durObj)
+    ShowFor(caster, matches, texture, durObj, endTimeMS, startTimeMS)
     local list = activeIcons[caster]
     if list then list.key = newKey end
     -- No per-cast cleanup timer: STOP/CHANNEL_STOP/INTERRUPTED/plate-removal

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -535,7 +535,8 @@ local function ShowFor(caster, matches, texture, durObj, endTimeMS, startTimeMS)
                     if Setting(raid, "ShowTimer", false)
                             and durObj and timerCd.SetCooldownFromDurationObject then
                         timerCd:SetCooldownFromDurationObject(durObj)
-                        -- Re-apply: SetCooldownFromDurationObject resets SetHideCountdownNumbers.
+                        -- Re-apply: SetCooldownFromDurationObject and Clear() reset SetDrawSwipe and SetHideCountdownNumbers.
+                        timerCd:SetDrawSwipe(false)
                         timerCd:SetHideCountdownNumbers(false)
                         timerCd:SetAlpha(1)
                         timerCd:Show()
@@ -868,6 +869,7 @@ local function PreviewTick(icons)
                 end
                 if icon._timerCd and Setting(raid, "ShowTimer", false) then
                     icon._timerCd:SetCooldown(now, dur)
+                    icon._timerCd:SetDrawSwipe(false)
                     icon._timerCd:SetHideCountdownNumbers(false)
                     icon._timerCd:Show()
                 elseif icon._timerCd then

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -206,7 +206,7 @@ local function StyleIcon(icon)
     local k = raid and 1 or (ns._partyIndicatorScale or 1)
     local sz = Setting(raid, "IconSize", 24) * k
     icon:SetSize(sz, sz)
-    local clockBorderOn = Setting(raid, "ShowClockBorder", true)
+    local clockBorderOn = Setting(raid, "ShowClockBorder", false)
     if icon._borderFrame then
         if clockBorderOn then
             -- Clock ring replaces the static PP border; hide it to avoid visual clutter.
@@ -532,7 +532,7 @@ local function ShowFor(caster, matches, texture, durObj, endTimeMS, startTimeMS)
                 end
                 local timerCd = icon._timerCd
                 if timerCd then
-                    if Setting(raid, "ShowTimer", true)
+                    if Setting(raid, "ShowTimer", false)
                             and durObj and timerCd.SetCooldownFromDurationObject then
                         timerCd:SetCooldownFromDurationObject(durObj)
                         timerCd:SetAlpha(1)
@@ -544,7 +544,7 @@ local function ShowFor(caster, matches, texture, durObj, endTimeMS, startTimeMS)
                 end
                 local cr = icon._clockRing
                 if cr then
-                    if Setting(raid, "ShowClockBorder", true) then
+                    if Setting(raid, "ShowClockBorder", false) then
                         -- Read the user's colour here; it must be re-applied AFTER
                         -- SetCooldownFromDurationObject because that call resets the
                         -- swipe colour to the CooldownFrame default.

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -238,6 +238,26 @@ local function StyleIcon(icon)
             icon._clockRing:SetSwipeColor(r, g, b, 1)
         end
     end
+    if icon._timerCd then
+        local timerSz = Setting(raid, "TimerSize", 10)
+        local timerOffX = Setting(raid, "TimerOffsetX", 0)
+        local timerOffY = Setting(raid, "TimerOffsetY", 0)
+        icon._timerCd:ClearAllPoints()
+        icon._timerCd:SetSize(sz, sz)
+        icon._timerCd:SetPoint("CENTER", icon, "CENTER", timerOffX, timerOffY)
+        if icon._timerCdFS then
+            local face, _, flags = icon._timerCdFS:GetFont()
+            if face then
+                icon._timerCdFS:SetFont(face, timerSz, flags or "")
+            end
+            local s = S()
+            local tc = s and s[(raid and "tsRaid" or "ts") .. "TimerColor"]
+            local tr = tc and tc.r or 1
+            local tg_c = tc and tc.g or 1
+            local tb = tc and tc.b or 1
+            icon._timerCdFS:SetTextColor(tr, tg_c, tb)
+        end
+    end
 end
 
 local function CreateIcon(btn, raid)
@@ -306,6 +326,29 @@ local function CreateIcon(btn, raid)
     icon._clockBg = clockBg
     clockBdr:Hide()
     icon._clockRing = clockBdr
+
+    -- Timer: a CooldownFrameTemplate with the swipe hidden and the built-in
+    -- countdown numbers shown.  WoW's C code handles the secret timing values
+    -- from SetCooldownFromDurationObject internally, so no Lua arithmetic on
+    -- tainted values is needed.
+    local timerCd = CreateFrame("Cooldown", nil, icon, "CooldownFrameTemplate")
+    timerCd:SetAllPoints()
+    timerCd:SetFrameLevel(icon:GetFrameLevel() + 3)
+    timerCd:SetHideCountdownNumbers(false)
+    timerCd:SetDrawEdge(false)
+    timerCd:SetDrawBling(false)
+    timerCd:SetDrawSwipe(false)
+    timerCd:SetReverse(false)
+    timerCd:Hide()
+    icon._timerCd = timerCd
+
+    -- Discover the countdown FontString so StyleIcon can recolour it.
+    for _, r in ipairs({timerCd:GetRegions()}) do
+        if r and r.GetObjectType and r:GetObjectType() == "FontString" then
+            icon._timerCdFS = r
+            break
+        end
+    end
 
     StyleIcon(icon)
     return icon
@@ -433,6 +476,10 @@ local function ClearCaster(caster)
             icon._cooldown:Clear()
             icon._cooldown:Hide()
         end
+        if icon._timerCd then
+            icon._timerCd:Clear()
+            icon._timerCd:Hide()
+        end
         if icon._clockRing then icon._clockRing:Hide() end
         if icon._clockBg then icon._clockBg:Hide() end
         touched[icon:GetParent()] = true
@@ -482,6 +529,18 @@ local function ShowFor(caster, matches, texture, durObj, endTimeMS, startTimeMS)
                 else
                     cd:Clear()
                     cd:Hide()
+                end
+                local timerCd = icon._timerCd
+                if timerCd then
+                    if Setting(raid, "ShowTimer", true)
+                            and durObj and timerCd.SetCooldownFromDurationObject then
+                        timerCd:SetCooldownFromDurationObject(durObj)
+                        timerCd:SetAlpha(1)
+                        timerCd:Show()
+                    else
+                        timerCd:Clear()
+                        timerCd:Hide()
+                    end
                 end
                 local cr = icon._clockRing
                 if cr then

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -250,6 +250,10 @@ local function StyleIcon(icon)
             if face then
                 icon._timerCdFS:SetFont(face, timerSz, flags or "")
             end
+            -- Re-anchor directly to the icon so Blizzard's template offset
+            -- and any accumulated pixel-snapping error are bypassed.
+            icon._timerCdFS:ClearAllPoints()
+            icon._timerCdFS:SetPoint("CENTER", icon, "CENTER", timerOffX, timerOffY)
             local s = S()
             local tc = s and s[(raid and "tsRaid" or "ts") .. "TimerColor"]
             local tr = tc and tc.r or 1

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -221,7 +221,7 @@ local function StyleIcon(icon)
     end
     if icon._clockRing then
         -- Re-anchor whenever the icon is resized so the border pad scales correctly.
-        local bdrPad = max(2, floor(sz * 0.12))
+        local bdrPad = Setting(raid, "ClockBorderSize", 3)
         icon._clockRing:ClearAllPoints()
         icon._clockRing:SetPoint("TOPLEFT",     icon, "TOPLEFT",     -bdrPad,  bdrPad)
         icon._clockRing:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT",  bdrPad, -bdrPad)

--- a/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
+++ b/EllesmereUIRaidFrames/EUI_RF_TargetedSpells.lua
@@ -535,6 +535,8 @@ local function ShowFor(caster, matches, texture, durObj, endTimeMS, startTimeMS)
                     if Setting(raid, "ShowTimer", false)
                             and durObj and timerCd.SetCooldownFromDurationObject then
                         timerCd:SetCooldownFromDurationObject(durObj)
+                        -- Re-apply: SetCooldownFromDurationObject resets SetHideCountdownNumbers.
+                        timerCd:SetHideCountdownNumbers(false)
                         timerCd:SetAlpha(1)
                         timerCd:Show()
                     else
@@ -866,6 +868,7 @@ local function PreviewTick(icons)
                 end
                 if icon._timerCd and Setting(raid, "ShowTimer", false) then
                     icon._timerCd:SetCooldown(now, dur)
+                    icon._timerCd:SetHideCountdownNumbers(false)
                     icon._timerCd:Show()
                 elseif icon._timerCd then
                     icon._timerCd:Hide()

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -3412,6 +3412,7 @@ initFrame:SetScript("OnEvent", function(self)
             local cbRaidRow
             cbRaidRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Clock Border",
+                  tooltip="Draws an animated border around the icon that sweeps away as the cast progresses.",
                   disabled=function() return SVal("tsRaidMode", "never") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsRaidShowClockBorder", true) end,
@@ -4799,6 +4800,7 @@ initFrame:SetScript("OnEvent", function(self)
             local cbPartyRow
             cbPartyRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Clock Border",
+                  tooltip="Draws an animated border around the icon that sweeps away as the cast progresses.",
                   disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsShowClockBorder", true) end,

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -3338,6 +3338,13 @@ initFrame:SetScript("OnEvent", function(self)
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsRaidIconSize", 24) end,
                   setValue=function(v) SSet("tsRaidIconSize", v); TSApply() end });  y = y - h
+            row, h = W:DualRow(parent, y,
+                { type="label", text="" },
+                { type="slider", text="Icon Spacing", min=0, max=20, step=1,
+                  disabled=function() return SVal("tsRaidMode", "never") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsRaidIconSpacing", 2) end,
+                  setValue=function(v) SSet("tsRaidIconSpacing", v); TSApply() end });  y = y - h
 
             -- Row 2: Icon Position (+ cog for X/Y) | Growth Direction
             local tsPositionValues = {
@@ -4726,6 +4733,13 @@ initFrame:SetScript("OnEvent", function(self)
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsIconSize", 24) end,
                   setValue=function(v) SSet("tsIconSize", v); TSApply() end });  y = y - h
+            row, h = W:DualRow(parent, y,
+                { type="label", text="" },
+                { type="slider", text="Icon Spacing", min=0, max=20, step=1,
+                  disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsIconSpacing", 2) end,
+                  setValue=function(v) SSet("tsIconSpacing", v); TSApply() end });  y = y - h
 
             -- Row 2: Icon Position (+ cog for X/Y) | Growth Direction
             local tsPositionValues = {

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -3407,7 +3407,7 @@ initFrame:SetScript("OnEvent", function(self)
                 cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
             end
 
-            -- Clock Border row: toggle + inline colour swatch
+            -- Clock Border (left) + Show Duration Timer (right) on one row
             local cbRaidRow
             cbRaidRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Clock Border",
@@ -3415,7 +3415,12 @@ initFrame:SetScript("OnEvent", function(self)
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsRaidShowClockBorder", true) end,
                   setValue=function(v) SSet("tsRaidShowClockBorder", v); TSApply() end },
-                { type="label", text="" });  y = y - h
+                { type="toggle", text="Show Duration Timer",
+                  disabled=function() return SVal("tsRaidMode", "never") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsRaidShowTimer", true) end,
+                  setValue=function(v) SSet("tsRaidShowTimer", v); TSApply() end });  y = y - h
+            -- Clock Border: inline colour swatch on left region
             do
                 local rgn = cbRaidRow._leftRegion
                 local swatch = EllesmereUI.BuildColorSwatch(
@@ -3437,6 +3442,61 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
                 UpdateSwatchVis()
+            end
+            -- Duration Timer: inline colour swatch + cog on right region
+            do
+                local rgn = cbRaidRow._rightRegion
+                local timerDisabled = function()
+                    return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowTimer", true)
+                end
+                local swatch = EllesmereUI.BuildColorSwatch(
+                    rgn, rgn:GetFrameLevel() + 3,
+                    function()
+                        local c = db.profile.tsRaidTimerColor
+                        if c then return c.r, c.g, c.b, 1 end
+                        return 1, 1, 1, 1
+                    end,
+                    function(r, g, b)
+                        db.profile.tsRaidTimerColor = { r=r, g=g, b=b }
+                        TSApply()
+                    end, false, 20)
+                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = swatch
+                local function UpdateTimerSwatchVis()
+                    swatch:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateTimerSwatchVis)
+                UpdateTimerSwatchVis()
+
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Duration Timer",
+                    rows = {
+                        { type="slider", label="Text Size", min=6, max=26, step=1,
+                          get=function() return SVal("tsRaidTimerSize", 10) end,
+                          set=function(v) SSet("tsRaidTimerSize", v); TSApply() end },
+                        { type="slider", label="Offset X", min=-20, max=20, step=1,
+                          get=function() return SVal("tsRaidTimerOffsetX", 0) end,
+                          set=function(v) SSet("tsRaidTimerOffsetX", v); TSApply() end },
+                        { type="slider", label="Offset Y", min=-20, max=20, step=1,
+                          get=function() return SVal("tsRaidTimerOffsetY", 0) end,
+                          set=function(v) SSet("tsRaidTimerOffsetY", v); TSApply() end },
+                    },
+                })
+                local cogBtn = CreateFrame("Button", nil, rgn)
+                cogBtn:SetSize(26, 26)
+                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = cogBtn
+                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+                cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+                cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
+                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(timerDisabled() and 0.15 or 0.4) end)
+                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+                local function UpdateCogAlpha()
+                    cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateCogAlpha)
             end
 
             _secY = y
@@ -4724,7 +4784,7 @@ initFrame:SetScript("OnEvent", function(self)
                 cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
             end
 
-            -- Clock Border row: toggle + inline colour swatch
+            -- Clock Border (left) + Show Duration Timer (right) on one row
             local cbPartyRow
             cbPartyRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Clock Border",
@@ -4732,7 +4792,12 @@ initFrame:SetScript("OnEvent", function(self)
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsShowClockBorder", true) end,
                   setValue=function(v) SSet("tsShowClockBorder", v); TSApply() end },
-                { type="label", text="" });  y = y - h
+                { type="toggle", text="Show Duration Timer",
+                  disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsShowTimer", true) end,
+                  setValue=function(v) SSet("tsShowTimer", v); TSApply() end });  y = y - h
+            -- Clock Border: inline colour swatch on left region
             do
                 local rgn = cbPartyRow._leftRegion
                 local swatch = EllesmereUI.BuildColorSwatch(
@@ -4754,6 +4819,61 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
                 UpdateSwatchVis()
+            end
+            -- Duration Timer: inline colour swatch + cog on right region
+            do
+                local rgn = cbPartyRow._rightRegion
+                local timerDisabled = function()
+                    return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowTimer", true)
+                end
+                local swatch = EllesmereUI.BuildColorSwatch(
+                    rgn, rgn:GetFrameLevel() + 3,
+                    function()
+                        local c = db.profile.tsTimerColor
+                        if c then return c.r, c.g, c.b, 1 end
+                        return 1, 1, 1, 1
+                    end,
+                    function(r, g, b)
+                        db.profile.tsTimerColor = { r=r, g=g, b=b }
+                        TSApply()
+                    end, false, 20)
+                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = swatch
+                local function UpdateTimerSwatchVis()
+                    swatch:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateTimerSwatchVis)
+                UpdateTimerSwatchVis()
+
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Duration Timer",
+                    rows = {
+                        { type="slider", label="Text Size", min=6, max=26, step=1,
+                          get=function() return SVal("tsTimerSize", 10) end,
+                          set=function(v) SSet("tsTimerSize", v); TSApply() end },
+                        { type="slider", label="Offset X", min=-20, max=20, step=1,
+                          get=function() return SVal("tsTimerOffsetX", 0) end,
+                          set=function(v) SSet("tsTimerOffsetX", v); TSApply() end },
+                        { type="slider", label="Offset Y", min=-20, max=20, step=1,
+                          get=function() return SVal("tsTimerOffsetY", 0) end,
+                          set=function(v) SSet("tsTimerOffsetY", v); TSApply() end },
+                    },
+                })
+                local cogBtn = CreateFrame("Button", nil, rgn)
+                cogBtn:SetSize(26, 26)
+                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = cogBtn
+                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+                cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+                cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
+                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(timerDisabled() and 0.15 or 0.4) end)
+                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+                local function UpdateCogAlpha()
+                    cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateCogAlpha)
             end
         end
 

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -3407,6 +3407,38 @@ initFrame:SetScript("OnEvent", function(self)
                 cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
             end
 
+            -- Clock Border row: toggle + inline colour swatch
+            local cbRaidRow
+            cbRaidRow, h = W:DualRow(parent, y,
+                { type="toggle", text="Clock Border",
+                  disabled=function() return SVal("tsRaidMode", "never") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsRaidShowClockBorder", true) end,
+                  setValue=function(v) SSet("tsRaidShowClockBorder", v); TSApply() end },
+                { type="label", text="" });  y = y - h
+            do
+                local rgn = cbRaidRow._leftRegion
+                local swatch = EllesmereUI.BuildColorSwatch(
+                    rgn, rgn:GetFrameLevel() + 3,
+                    function()
+                        local c = db.profile.tsRaidClockBorderColor
+                        if c then return c.r, c.g, c.b, 1 end
+                        return 1, 1, 1, 1
+                    end,
+                    function(r, g, b)
+                        db.profile.tsRaidClockBorderColor = { r=r, g=g, b=b }
+                        TSApply()
+                    end, false, 20)
+                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = swatch
+                local function UpdateSwatchVis()
+                    local on = SVal("tsRaidMode", "never") ~= "never" and SVal("tsRaidShowClockBorder", true)
+                    swatch:SetAlpha(on and 1 or 0.3)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
+                UpdateSwatchVis()
+            end
+
             _secY = y
         end
 
@@ -4033,6 +4065,43 @@ initFrame:SetScript("OnEvent", function(self)
             UpdateHBSwatchVis()
         end
 
+        -- Hover Overlay: toggle + colour swatch (left) | Overlay Opacity slider (right)
+        local hoverOverlayRow
+        hoverOverlayRow, h = W:DualRow(parent, y,
+            { type="toggle", text="Hover Overlay",
+              tooltip="Overlay a tinted colour on the health bar while hovering the frame.",
+              getValue=function() return SVal("hoverOverlayEnabled", false) end,
+              setValue=function(v)
+                  SSet("hoverOverlayEnabled", v)
+                  ReloadAndUpdate()
+                  EllesmereUI:RefreshPage()
+              end },
+            { type="slider", text="Overlay Opacity", min=5, max=100, step=1,
+              disabled=function() return not SVal("hoverOverlayEnabled", false) end,
+              disabledTooltip="Hover Overlay",
+              getValue=function() return SVal("hoverOverlayOpacity", 30) end,
+              setValue=function(v) SSet("hoverOverlayOpacity", v); ReloadAndUpdate() end });  y = y - h
+        do
+            local rgn = hoverOverlayRow._leftRegion
+            local overlaySwatch, updOverlay = EllesmereUI.BuildColorSwatch(
+                rgn, hoverOverlayRow:GetFrameLevel() + 3,
+                function()
+                    local c = SGet("hoverOverlayColor") or { r = 1, g = 1, b = 1 }
+                    return c.r, c.g, c.b, 1
+                end,
+                function(r, g, b)
+                    SWrite("hoverOverlayColor", { r=r, g=g, b=b })
+                    ReloadAndUpdate()
+                end, false, 20)
+            overlaySwatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = overlaySwatch
+            local function UpdateOverlaySwatchVis()
+                overlaySwatch:SetAlpha(SVal("hoverOverlayEnabled", false) and 1 or 0.3)
+            end
+            EllesmereUI.RegisterWidgetRefresh(function() updOverlay(); UpdateOverlaySwatchVis() end)
+            UpdateOverlaySwatchVis()
+        end
+
         -------------------------------------------------------------------
         --  LAYOUT
         -------------------------------------------------------------------
@@ -4653,6 +4722,38 @@ initFrame:SetScript("OnEvent", function(self)
                 cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
                 cogBtn:SetScript("OnLeave", function(self) self:SetAlpha((SVal("tsMode", "whenHealing") ~= "never") and 0.4 or 0.15) end)
                 cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+            end
+
+            -- Clock Border row: toggle + inline colour swatch
+            local cbPartyRow
+            cbPartyRow, h = W:DualRow(parent, y,
+                { type="toggle", text="Clock Border",
+                  disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsShowClockBorder", true) end,
+                  setValue=function(v) SSet("tsShowClockBorder", v); TSApply() end },
+                { type="label", text="" });  y = y - h
+            do
+                local rgn = cbPartyRow._leftRegion
+                local swatch = EllesmereUI.BuildColorSwatch(
+                    rgn, rgn:GetFrameLevel() + 3,
+                    function()
+                        local c = db.profile.tsClockBorderColor
+                        if c then return c.r, c.g, c.b, 1 end
+                        return 1, 1, 1, 1
+                    end,
+                    function(r, g, b)
+                        db.profile.tsClockBorderColor = { r=r, g=g, b=b }
+                        TSApply()
+                    end, false, 20)
+                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = swatch
+                local function UpdateSwatchVis()
+                    local on = SVal("tsMode", "whenHealing") ~= "never" and SVal("tsShowClockBorder", true)
+                    swatch:SetAlpha(on and 1 or 0.3)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
+                UpdateSwatchVis()
             end
         end
 

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -3408,6 +3408,7 @@ initFrame:SetScript("OnEvent", function(self)
             end
 
             -- Clock Border (left) + Show Duration Timer (right) on one row
+            -- Row 1: Clock Border toggle (+ colour swatch) | Border Size slider
             local cbRaidRow
             cbRaidRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Clock Border",
@@ -3415,12 +3416,12 @@ initFrame:SetScript("OnEvent", function(self)
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsRaidShowClockBorder", true) end,
                   setValue=function(v) SSet("tsRaidShowClockBorder", v); TSApply() end },
-                { type="toggle", text="Show Duration Timer",
-                  disabled=function() return SVal("tsRaidMode", "never") == "never" end,
-                  disabledTooltip="Enable Targeted Spells",
-                  getValue=function() return SVal("tsRaidShowTimer", true) end,
-                  setValue=function(v) SSet("tsRaidShowTimer", v); TSApply() end });  y = y - h
-            -- Clock Border: inline colour swatch on left region
+                { type="slider", text="Border Size", min=1, max=10, step=1,
+                  disabled=function() return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowClockBorder", true) end,
+                  disabledTooltip="Enable Clock Border",
+                  getValue=function() return SVal("tsRaidClockBorderSize", 3) end,
+                  setValue=function(v) SSet("tsRaidClockBorderSize", v); TSApply() end });  y = y - h
+            -- Clock Border colour swatch (inline on left region)
             do
                 local rgn = cbRaidRow._leftRegion
                 local swatch = EllesmereUI.BuildColorSwatch(
@@ -3443,9 +3444,18 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
                 UpdateSwatchVis()
             end
-            -- Duration Timer: inline colour swatch + cog on right region
+            -- Row 2: Show Duration Timer toggle (+ colour swatch + cog) | empty
+            local timerRaidRow
+            timerRaidRow, h = W:DualRow(parent, y,
+                { type="toggle", text="Show Duration Timer",
+                  disabled=function() return SVal("tsRaidMode", "never") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsRaidShowTimer", true) end,
+                  setValue=function(v) SSet("tsRaidShowTimer", v); TSApply() end },
+                { type="label", text="" });  y = y - h
+            -- Duration Timer: colour swatch + cog (inline on left region)
             do
-                local rgn = cbRaidRow._rightRegion
+                local rgn = timerRaidRow._leftRegion
                 local timerDisabled = function()
                     return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowTimer", true)
                 end
@@ -3463,7 +3473,7 @@ initFrame:SetScript("OnEvent", function(self)
                 swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
                 rgn._lastInline = swatch
                 local function UpdateTimerSwatchVis()
-                    swatch:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                    swatch:SetAlpha(timerDisabled() and 0.15 or 1)
                 end
                 EllesmereUI.RegisterWidgetRefresh(UpdateTimerSwatchVis)
                 UpdateTimerSwatchVis()
@@ -4785,6 +4795,7 @@ initFrame:SetScript("OnEvent", function(self)
             end
 
             -- Clock Border (left) + Show Duration Timer (right) on one row
+            -- Row 1: Clock Border toggle (+ colour swatch) | Border Size slider
             local cbPartyRow
             cbPartyRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Clock Border",
@@ -4792,12 +4803,12 @@ initFrame:SetScript("OnEvent", function(self)
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsShowClockBorder", true) end,
                   setValue=function(v) SSet("tsShowClockBorder", v); TSApply() end },
-                { type="toggle", text="Show Duration Timer",
-                  disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
-                  disabledTooltip="Enable Targeted Spells",
-                  getValue=function() return SVal("tsShowTimer", true) end,
-                  setValue=function(v) SSet("tsShowTimer", v); TSApply() end });  y = y - h
-            -- Clock Border: inline colour swatch on left region
+                { type="slider", text="Border Size", min=1, max=10, step=1,
+                  disabled=function() return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowClockBorder", true) end,
+                  disabledTooltip="Enable Clock Border",
+                  getValue=function() return SVal("tsClockBorderSize", 3) end,
+                  setValue=function(v) SSet("tsClockBorderSize", v); TSApply() end });  y = y - h
+            -- Clock Border colour swatch (inline on left region)
             do
                 local rgn = cbPartyRow._leftRegion
                 local swatch = EllesmereUI.BuildColorSwatch(
@@ -4820,9 +4831,18 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
                 UpdateSwatchVis()
             end
-            -- Duration Timer: inline colour swatch + cog on right region
+            -- Row 2: Show Duration Timer toggle (+ colour swatch + cog) | empty
+            local timerPartyRow
+            timerPartyRow, h = W:DualRow(parent, y,
+                { type="toggle", text="Show Duration Timer",
+                  disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsShowTimer", true) end,
+                  setValue=function(v) SSet("tsShowTimer", v); TSApply() end },
+                { type="label", text="" });  y = y - h
+            -- Duration Timer: colour swatch + cog (inline on left region)
             do
-                local rgn = cbPartyRow._rightRegion
+                local rgn = timerPartyRow._leftRegion
                 local timerDisabled = function()
                     return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowTimer", true)
                 end
@@ -4840,7 +4860,7 @@ initFrame:SetScript("OnEvent", function(self)
                 swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
                 rgn._lastInline = swatch
                 local function UpdateTimerSwatchVis()
-                    swatch:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                    swatch:SetAlpha(timerDisabled() and 0.15 or 1)
                 end
                 EllesmereUI.RegisterWidgetRefresh(UpdateTimerSwatchVis)
                 UpdateTimerSwatchVis()

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -3415,10 +3415,10 @@ initFrame:SetScript("OnEvent", function(self)
                   tooltip="Draws an animated border around the icon that sweeps away as the cast progresses.",
                   disabled=function() return SVal("tsRaidMode", "never") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
-                  getValue=function() return SVal("tsRaidShowClockBorder", true) end,
+                  getValue=function() return SVal("tsRaidShowClockBorder", false) end,
                   setValue=function(v) SSet("tsRaidShowClockBorder", v); TSApply() end },
                 { type="slider", text="Border Size", min=1, max=10, step=1,
-                  disabled=function() return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowClockBorder", true) end,
+                  disabled=function() return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowClockBorder", false) end,
                   disabledTooltip="Enable Clock Border",
                   getValue=function() return SVal("tsRaidClockBorderSize", 3) end,
                   setValue=function(v) SSet("tsRaidClockBorderSize", v); TSApply() end });  y = y - h
@@ -3439,7 +3439,7 @@ initFrame:SetScript("OnEvent", function(self)
                 swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
                 rgn._lastInline = swatch
                 local function UpdateSwatchVis()
-                    local on = SVal("tsRaidMode", "never") ~= "never" and SVal("tsRaidShowClockBorder", true)
+                    local on = SVal("tsRaidMode", "never") ~= "never" and SVal("tsRaidShowClockBorder", false)
                     swatch:SetAlpha(on and 1 or 0.3)
                 end
                 EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
@@ -3451,14 +3451,14 @@ initFrame:SetScript("OnEvent", function(self)
                 { type="toggle", text="Show Duration Timer",
                   disabled=function() return SVal("tsRaidMode", "never") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
-                  getValue=function() return SVal("tsRaidShowTimer", true) end,
+                  getValue=function() return SVal("tsRaidShowTimer", false) end,
                   setValue=function(v) SSet("tsRaidShowTimer", v); TSApply() end },
                 { type="label", text="" });  y = y - h
             -- Duration Timer: colour swatch + cog (inline on left region)
             do
                 local rgn = timerRaidRow._leftRegion
                 local timerDisabled = function()
-                    return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowTimer", true)
+                    return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowTimer", false)
                 end
                 local swatch = EllesmereUI.BuildColorSwatch(
                     rgn, rgn:GetFrameLevel() + 3,
@@ -4803,10 +4803,10 @@ initFrame:SetScript("OnEvent", function(self)
                   tooltip="Draws an animated border around the icon that sweeps away as the cast progresses.",
                   disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
-                  getValue=function() return SVal("tsShowClockBorder", true) end,
+                  getValue=function() return SVal("tsShowClockBorder", false) end,
                   setValue=function(v) SSet("tsShowClockBorder", v); TSApply() end },
                 { type="slider", text="Border Size", min=1, max=10, step=1,
-                  disabled=function() return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowClockBorder", true) end,
+                  disabled=function() return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowClockBorder", false) end,
                   disabledTooltip="Enable Clock Border",
                   getValue=function() return SVal("tsClockBorderSize", 3) end,
                   setValue=function(v) SSet("tsClockBorderSize", v); TSApply() end });  y = y - h
@@ -4827,7 +4827,7 @@ initFrame:SetScript("OnEvent", function(self)
                 swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
                 rgn._lastInline = swatch
                 local function UpdateSwatchVis()
-                    local on = SVal("tsMode", "whenHealing") ~= "never" and SVal("tsShowClockBorder", true)
+                    local on = SVal("tsMode", "whenHealing") ~= "never" and SVal("tsShowClockBorder", false)
                     swatch:SetAlpha(on and 1 or 0.3)
                 end
                 EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
@@ -4839,14 +4839,14 @@ initFrame:SetScript("OnEvent", function(self)
                 { type="toggle", text="Show Duration Timer",
                   disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
-                  getValue=function() return SVal("tsShowTimer", true) end,
+                  getValue=function() return SVal("tsShowTimer", false) end,
                   setValue=function(v) SSet("tsShowTimer", v); TSApply() end },
                 { type="label", text="" });  y = y - h
             -- Duration Timer: colour swatch + cog (inline on left region)
             do
                 local rgn = timerPartyRow._leftRegion
                 local timerDisabled = function()
-                    return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowTimer", true)
+                    return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowTimer", false)
                 end
                 local swatch = EllesmereUI.BuildColorSwatch(
                     rgn, rgn:GetFrameLevel() + 3,

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -3327,25 +3327,84 @@ initFrame:SetScript("OnEvent", function(self)
                 end)
             end  -- close do (eyeball)
 
-            row, h = W:DualRow(parent, y,
+            local timerRaidRow
+            timerRaidRow, h = W:DualRow(parent, y,
                 { type="dropdown", text="Show Targeted Spells",
                   values={ never="Never", whenHealing="When Healing", always="Always" },
                   order={ "never", "whenHealing", "always" },
                   getValue=function() return SVal("tsRaidMode", "never") end,
                   setValue=function(v) SSet("tsRaidMode", v); TSApply(); EllesmereUI:RefreshPage() end },
+                { type="toggle", text="Duration Timer",
+                  disabled=function() return SVal("tsRaidMode", "never") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsRaidShowTimer", false) end,
+                  setValue=function(v) SSet("tsRaidShowTimer", v); TSApply() end });  y = y - h
+            -- Duration Timer: colour swatch + cog (inline on right region)
+            do
+                local rgn = timerRaidRow._rightRegion
+                local timerDisabled = function()
+                    return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowTimer", false)
+                end
+                local swatch = EllesmereUI.BuildColorSwatch(
+                    rgn, rgn:GetFrameLevel() + 3,
+                    function()
+                        local c = db.profile.tsRaidTimerColor
+                        if c then return c.r, c.g, c.b, 1 end
+                        return 1, 1, 1, 1
+                    end,
+                    function(r, g, b)
+                        db.profile.tsRaidTimerColor = { r=r, g=g, b=b }
+                        TSApply()
+                    end, false, 20)
+                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = swatch
+                local function UpdateTimerSwatchVis()
+                    swatch:SetAlpha(timerDisabled() and 0.15 or 1)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateTimerSwatchVis)
+                UpdateTimerSwatchVis()
+
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Duration Timer",
+                    rows = {
+                        { type="slider", label="Text Size", min=6, max=26, step=1,
+                          get=function() return SVal("tsRaidTimerSize", 10) end,
+                          set=function(v) SSet("tsRaidTimerSize", v); TSApply() end },
+                        { type="slider", label="Offset X", min=-20, max=20, step=1,
+                          get=function() return SVal("tsRaidTimerOffsetX", 0) end,
+                          set=function(v) SSet("tsRaidTimerOffsetX", v); TSApply() end },
+                        { type="slider", label="Offset Y", min=-20, max=20, step=1,
+                          get=function() return SVal("tsRaidTimerOffsetY", 0) end,
+                          set=function(v) SSet("tsRaidTimerOffsetY", v); TSApply() end },
+                    },
+                })
+                local cogBtn = CreateFrame("Button", nil, rgn)
+                cogBtn:SetSize(26, 26)
+                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = cogBtn
+                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+                cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+                cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
+                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(timerDisabled() and 0.15 or 0.4) end)
+                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+                local function UpdateCogAlpha()
+                    cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateCogAlpha)
+            end
+            row, h = W:DualRow(parent, y,
                 { type="slider", text="Icon Size", min=12, max=48, step=1,
                   disabled=function() return SVal("tsRaidMode", "never") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsRaidIconSize", 24) end,
-                  setValue=function(v) SSet("tsRaidIconSize", v); TSApply() end });  y = y - h
-            row, h = W:DualRow(parent, y,
-                { type="label", text="" },
+                  setValue=function(v) SSet("tsRaidIconSize", v); TSApply() end },
                 { type="slider", text="Icon Spacing", min=0, max=20, step=1,
                   disabled=function() return SVal("tsRaidMode", "never") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsRaidIconSpacing", 2) end,
                   setValue=function(v) SSet("tsRaidIconSpacing", v); TSApply() end });  y = y - h
-
             -- Row 2: Icon Position (+ cog for X/Y) | Growth Direction
             local tsPositionValues = {
                 topleft     = "Top Left",
@@ -3452,71 +3511,6 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
                 UpdateSwatchVis()
             end
-            -- Row 2: Show Duration Timer toggle (+ colour swatch + cog) | empty
-            local timerRaidRow
-            timerRaidRow, h = W:DualRow(parent, y,
-                { type="toggle", text="Show Duration Timer",
-                  disabled=function() return SVal("tsRaidMode", "never") == "never" end,
-                  disabledTooltip="Enable Targeted Spells",
-                  getValue=function() return SVal("tsRaidShowTimer", false) end,
-                  setValue=function(v) SSet("tsRaidShowTimer", v); TSApply() end },
-                { type="label", text="" });  y = y - h
-            -- Duration Timer: colour swatch + cog (inline on left region)
-            do
-                local rgn = timerRaidRow._leftRegion
-                local timerDisabled = function()
-                    return SVal("tsRaidMode", "never") == "never" or not SVal("tsRaidShowTimer", false)
-                end
-                local swatch = EllesmereUI.BuildColorSwatch(
-                    rgn, rgn:GetFrameLevel() + 3,
-                    function()
-                        local c = db.profile.tsRaidTimerColor
-                        if c then return c.r, c.g, c.b, 1 end
-                        return 1, 1, 1, 1
-                    end,
-                    function(r, g, b)
-                        db.profile.tsRaidTimerColor = { r=r, g=g, b=b }
-                        TSApply()
-                    end, false, 20)
-                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-                rgn._lastInline = swatch
-                local function UpdateTimerSwatchVis()
-                    swatch:SetAlpha(timerDisabled() and 0.15 or 1)
-                end
-                EllesmereUI.RegisterWidgetRefresh(UpdateTimerSwatchVis)
-                UpdateTimerSwatchVis()
-
-                local _, cogShow = EllesmereUI.BuildCogPopup({
-                    title = "Duration Timer",
-                    rows = {
-                        { type="slider", label="Text Size", min=6, max=26, step=1,
-                          get=function() return SVal("tsRaidTimerSize", 10) end,
-                          set=function(v) SSet("tsRaidTimerSize", v); TSApply() end },
-                        { type="slider", label="Offset X", min=-20, max=20, step=1,
-                          get=function() return SVal("tsRaidTimerOffsetX", 0) end,
-                          set=function(v) SSet("tsRaidTimerOffsetX", v); TSApply() end },
-                        { type="slider", label="Offset Y", min=-20, max=20, step=1,
-                          get=function() return SVal("tsRaidTimerOffsetY", 0) end,
-                          set=function(v) SSet("tsRaidTimerOffsetY", v); TSApply() end },
-                    },
-                })
-                local cogBtn = CreateFrame("Button", nil, rgn)
-                cogBtn:SetSize(26, 26)
-                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-                rgn._lastInline = cogBtn
-                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
-                cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
-                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
-                cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
-                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
-                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(timerDisabled() and 0.15 or 0.4) end)
-                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
-                local function UpdateCogAlpha()
-                    cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
-                end
-                EllesmereUI.RegisterWidgetRefresh(UpdateCogAlpha)
-            end
-
             _secY = y
         end
 
@@ -4143,43 +4137,6 @@ initFrame:SetScript("OnEvent", function(self)
             UpdateHBSwatchVis()
         end
 
-        -- Hover Overlay: toggle + colour swatch (left) | Overlay Opacity slider (right)
-        local hoverOverlayRow
-        hoverOverlayRow, h = W:DualRow(parent, y,
-            { type="toggle", text="Hover Overlay",
-              tooltip="Overlay a tinted colour on the health bar while hovering the frame.",
-              getValue=function() return SVal("hoverOverlayEnabled", false) end,
-              setValue=function(v)
-                  SSet("hoverOverlayEnabled", v)
-                  ReloadAndUpdate()
-                  EllesmereUI:RefreshPage()
-              end },
-            { type="slider", text="Overlay Opacity", min=5, max=100, step=1,
-              disabled=function() return not SVal("hoverOverlayEnabled", false) end,
-              disabledTooltip="Hover Overlay",
-              getValue=function() return SVal("hoverOverlayOpacity", 30) end,
-              setValue=function(v) SSet("hoverOverlayOpacity", v); ReloadAndUpdate() end });  y = y - h
-        do
-            local rgn = hoverOverlayRow._leftRegion
-            local overlaySwatch, updOverlay = EllesmereUI.BuildColorSwatch(
-                rgn, hoverOverlayRow:GetFrameLevel() + 3,
-                function()
-                    local c = SGet("hoverOverlayColor") or { r = 1, g = 1, b = 1 }
-                    return c.r, c.g, c.b, 1
-                end,
-                function(r, g, b)
-                    SWrite("hoverOverlayColor", { r=r, g=g, b=b })
-                    ReloadAndUpdate()
-                end, false, 20)
-            overlaySwatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-            rgn._lastInline = overlaySwatch
-            local function UpdateOverlaySwatchVis()
-                overlaySwatch:SetAlpha(SVal("hoverOverlayEnabled", false) and 1 or 0.3)
-            end
-            EllesmereUI.RegisterWidgetRefresh(function() updOverlay(); UpdateOverlaySwatchVis() end)
-            UpdateOverlaySwatchVis()
-        end
-
         -------------------------------------------------------------------
         --  LAYOUT
         -------------------------------------------------------------------
@@ -4722,25 +4679,84 @@ initFrame:SetScript("OnEvent", function(self)
                 end)
             end  -- close do (eyeball)
 
-            row, h = W:DualRow(parent, y,
+            local timerPartyRow
+            timerPartyRow, h = W:DualRow(parent, y,
                 { type="dropdown", text="Show Targeted Spells",
                   values={ never="Never", whenHealing="When Healing", always="Always" },
                   order={ "never", "whenHealing", "always" },
                   getValue=function() return SVal("tsMode", "whenHealing") end,
                   setValue=function(v) SSet("tsMode", v); TSApply(); EllesmereUI:RefreshPage() end },
+                { type="toggle", text="Duration Timer",
+                  disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
+                  disabledTooltip="Enable Targeted Spells",
+                  getValue=function() return SVal("tsShowTimer", false) end,
+                  setValue=function(v) SSet("tsShowTimer", v); TSApply() end });  y = y - h
+            -- Duration Timer: colour swatch + cog (inline on right region, removed separate row)
+            do
+                local rgn = timerPartyRow._rightRegion
+                local timerDisabled = function()
+                    return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowTimer", false)
+                end
+                local swatch = EllesmereUI.BuildColorSwatch(
+                    rgn, rgn:GetFrameLevel() + 3,
+                    function()
+                        local c = db.profile.tsTimerColor
+                        if c then return c.r, c.g, c.b, 1 end
+                        return 1, 1, 1, 1
+                    end,
+                    function(r, g, b)
+                        db.profile.tsTimerColor = { r=r, g=g, b=b }
+                        TSApply()
+                    end, false, 20)
+                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = swatch
+                local function UpdateTimerSwatchVis()
+                    swatch:SetAlpha(timerDisabled() and 0.15 or 1)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateTimerSwatchVis)
+                UpdateTimerSwatchVis()
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Duration Timer",
+                    rows = {
+                        { type="slider", label="Text Size", min=6, max=26, step=1,
+                          get=function() return SVal("tsTimerSize", 10) end,
+                          set=function(v) SSet("tsTimerSize", v); TSApply() end },
+                        { type="slider", label="Offset X", min=-20, max=20, step=1,
+                          get=function() return SVal("tsTimerOffsetX", 0) end,
+                          set=function(v) SSet("tsTimerOffsetX", v); TSApply() end },
+                        { type="slider", label="Offset Y", min=-20, max=20, step=1,
+                          get=function() return SVal("tsTimerOffsetY", 0) end,
+                          set=function(v) SSet("tsTimerOffsetY", v); TSApply() end },
+                    },
+                })
+                local cogBtn = CreateFrame("Button", nil, rgn)
+                cogBtn:SetSize(26, 26)
+                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = cogBtn
+                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+                cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+                cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
+                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(timerDisabled() and 0.15 or 0.4) end)
+                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+                local function UpdateCogAlpha()
+                    cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateCogAlpha)
+            end
+
+            row, h = W:DualRow(parent, y,
                 { type="slider", text="Icon Size", min=12, max=48, step=1,
                   disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsIconSize", 24) end,
-                  setValue=function(v) SSet("tsIconSize", v); TSApply() end });  y = y - h
-            row, h = W:DualRow(parent, y,
-                { type="label", text="" },
+                  setValue=function(v) SSet("tsIconSize", v); TSApply() end },
                 { type="slider", text="Icon Spacing", min=0, max=20, step=1,
                   disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
                   disabledTooltip="Enable Targeted Spells",
                   getValue=function() return SVal("tsIconSpacing", 2) end,
                   setValue=function(v) SSet("tsIconSpacing", v); TSApply() end });  y = y - h
-
             -- Row 2: Icon Position (+ cog for X/Y) | Growth Direction
             local tsPositionValues = {
                 topleft     = "Top Left",
@@ -4846,70 +4862,6 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 EllesmereUI.RegisterWidgetRefresh(UpdateSwatchVis)
                 UpdateSwatchVis()
-            end
-            -- Row 2: Show Duration Timer toggle (+ colour swatch + cog) | empty
-            local timerPartyRow
-            timerPartyRow, h = W:DualRow(parent, y,
-                { type="toggle", text="Show Duration Timer",
-                  disabled=function() return SVal("tsMode", "whenHealing") == "never" end,
-                  disabledTooltip="Enable Targeted Spells",
-                  getValue=function() return SVal("tsShowTimer", false) end,
-                  setValue=function(v) SSet("tsShowTimer", v); TSApply() end },
-                { type="label", text="" });  y = y - h
-            -- Duration Timer: colour swatch + cog (inline on left region)
-            do
-                local rgn = timerPartyRow._leftRegion
-                local timerDisabled = function()
-                    return SVal("tsMode", "whenHealing") == "never" or not SVal("tsShowTimer", false)
-                end
-                local swatch = EllesmereUI.BuildColorSwatch(
-                    rgn, rgn:GetFrameLevel() + 3,
-                    function()
-                        local c = db.profile.tsTimerColor
-                        if c then return c.r, c.g, c.b, 1 end
-                        return 1, 1, 1, 1
-                    end,
-                    function(r, g, b)
-                        db.profile.tsTimerColor = { r=r, g=g, b=b }
-                        TSApply()
-                    end, false, 20)
-                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-                rgn._lastInline = swatch
-                local function UpdateTimerSwatchVis()
-                    swatch:SetAlpha(timerDisabled() and 0.15 or 1)
-                end
-                EllesmereUI.RegisterWidgetRefresh(UpdateTimerSwatchVis)
-                UpdateTimerSwatchVis()
-
-                local _, cogShow = EllesmereUI.BuildCogPopup({
-                    title = "Duration Timer",
-                    rows = {
-                        { type="slider", label="Text Size", min=6, max=26, step=1,
-                          get=function() return SVal("tsTimerSize", 10) end,
-                          set=function(v) SSet("tsTimerSize", v); TSApply() end },
-                        { type="slider", label="Offset X", min=-20, max=20, step=1,
-                          get=function() return SVal("tsTimerOffsetX", 0) end,
-                          set=function(v) SSet("tsTimerOffsetX", v); TSApply() end },
-                        { type="slider", label="Offset Y", min=-20, max=20, step=1,
-                          get=function() return SVal("tsTimerOffsetY", 0) end,
-                          set=function(v) SSet("tsTimerOffsetY", v); TSApply() end },
-                    },
-                })
-                local cogBtn = CreateFrame("Button", nil, rgn)
-                cogBtn:SetSize(26, 26)
-                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-                rgn._lastInline = cogBtn
-                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
-                cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
-                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
-                cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
-                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
-                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(timerDisabled() and 0.15 or 0.4) end)
-                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
-                local function UpdateCogAlpha()
-                    cogBtn:SetAlpha(timerDisabled() and 0.15 or 0.4)
-                end
-                EllesmereUI.RegisterWidgetRefresh(UpdateCogAlpha)
             end
         end
 


### PR DESCRIPTION
This PR introduces animated clock border and cast countdown timer for targeted spell icons. The former is a feature I enjoyed when Cell was still around (somewhat inspired), and the latter is a nice usability addition. 

Both features are showcased [here](https://youtu.be/CyYoaB3VDS0).

> [!NOTE]
>  While I have been tinkering with these features for a few days now, the landscape of targeted spells remains experimental. I would recommend spending a bit of time independently testing either feature to be somewhat confident with their stability. I have not encountered major downsides as of yet (degradation in performance, Lua errors, etc). 
> 
> If a more informed maintainer could look at my API utilisation that would be helpful for future development. I have a couple more PRs to submit; I hope to be able to finish them in the coming days. 

## Summary Changes

### Clock Border

A `CooldownFrameTemplate` frame is placed outside the icon edges by a configurable amount (default 3 px). The spell texture, rendered at a higher frame level, masks the interior such that only the outer ring is visible. The ring depletes clockwise as the cast drains, giving an immediate visual read on urgency without obscuring the icon.

- The default pie-sweep texture ignores `SetSwipeColor`, so `WHITE8X8` is used as the swipe texture and tinted to the user's chosen colour. Colour must also be re-applied after every `SetCooldownFromDurationObject` call, as that resets both the texture and colour.
- The black background for the elapsed arc lives on a separate sibling `Frame` at frame level 2 rather than on the `CooldownFrame` itself. WoW draws the cooldown swipe before standard textures on the same frame, so a `BACKGROUND` texture directly on the `CooldownFrame` renders above the sweep and obscures it.

> [!IMPORTANT]
> When `ShowClockBorder` is enabled, the static pixel-perfect border (`_borderFrame`) is
> hidden to avoid visual conflict with the ring.

#### UI Widgets

Toggle and colour swatch on the left, border size slider (1–10 px, default 3) on the
right. Per section (raid / party).

---

### Cast Countdown Timer

A second `CooldownFrameTemplate` is placed over the icon with the swipe disabled and the built-in countdown numbers enabled. It shows the remaining cast time as a ticking number.

- Reading `UnitCastingInfo` timestamps and doing the arithmetic in Lua is not viable as those values are secret. `SetCooldownFromDurationObject` passes the duration object directly to the C side, which handles all timing internally and never surfaces taint in Lua.
- Font size and colour are user-configurable. The internal `FontString` inside the`CooldownFrame` is not exposed via a named method, so it is discovered once at creation time via `GetRegions()` and stored as `_timerCdFS` for later use in `StyleIcon`. The `FontString` is also re-anchored directly to the icon frame to bypass any pixel-snapping offset baked into the template.

#### UI Widgets

Duration Timer toggle shares a row with the Show Targeted Spells dropdown, with its colour swatch and cog popup (text size, X/Y offset) inline on the right. Icon Size and Icon Spacing share the row below. Per section (raid / party).

## Screenshots

<details><summary>Settings</summary>
<img width="1304" height="857" alt="bvbbbb" src="https://github.com/user-attachments/assets/451706c4-3ed1-45a0-acfe-abe302071a08" />
</details> 

<details><summary>Stills from demo video</summary>
<img width="1664" height="958" alt="CleanShot 2026-06-21 at 21 09 28@2x" src="https://github.com/user-attachments/assets/aad43c67-4691-453f-b82f-84df8f25403c" />
<img width="1696" height="1012" alt="CleanShot 2026-06-21 at 21 09 07@2x" src="https://github.com/user-attachments/assets/1ec72ded-6599-44ff-993f-0efbadb6b206" />
</details> 