### PR TITLE
Add ready check / summon icon position & size customization to raid frames

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -2253,6 +2253,61 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
         end
 
+        -- Ready Check / Summon icon position + size (the two indicators share a
+        -- single texture, so one set of controls drives both).
+        local readyCheckPositionValues = {
+            topleft     = "Top Left",
+            top         = "Top",
+            topright    = "Top Right",
+            left        = "Left",
+            center      = "Center",
+            right       = "Right",
+            bottomleft  = "Bottom Left",
+            bottom      = "Bottom",
+            bottomright = "Bottom Right",
+        }
+        local readyCheckPositionOrder = { "topleft", "top", "topright", "left", "center", "right", "bottomleft", "bottom", "bottomright" }
+        local rcRow
+        rcRow, h = W:DualRow(parent, y,
+            { type="dropdown", text="Ready Check", values=readyCheckPositionValues, order=readyCheckPositionOrder,
+              getValue=function() return SVal("readyCheckPosition", "center") end,
+              setValue=function(v) SSet("readyCheckPosition", v) end },
+            { type="slider", text="Icon Size", min=8, max=40, step=1,
+              getValue=function() return SVal("readyCheckSize", 18) end,
+              setValue=function(v) SSet("readyCheckSize", v) end });  y = y - h
+        -- Cog for ready check / summon toggles + offset X/Y
+        do
+            local rgn = rcRow._leftRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Ready Check / Summon",
+                rows = {
+                    { type="toggle", label="Show Ready Check",
+                      get=function() return SVal("showReadyCheck", true) end,
+                      set=function(v) SSet("showReadyCheck", v) end },
+                    { type="toggle", label="Show Incoming Summon",
+                      get=function() return SVal("showSummonPending", true) end,
+                      set=function(v) SSet("showSummonPending", v) end },
+                    { type="slider", label="Offset X", min=-50, max=50, step=1,
+                      get=function() return SVal("readyCheckOffsetX", 0) end,
+                      set=function(v) SSet("readyCheckOffsetX", v) end },
+                    { type="slider", label="Offset Y", min=-50, max=50, step=1,
+                      get=function() return SVal("readyCheckOffsetY", 0) end,
+                      set=function(v) SSet("readyCheckOffsetY", v) end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+        end
+
         -- Status Text Position (+ cog for X/Y) | Text Size (+ inline color swatch)
         local statusTextPositionValues = {
             none        = "None",

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -519,6 +519,10 @@ local defaults = {
         raidMarkerOffsetY  = 0,
         showReadyCheck   = true,
         showSummonPending = true,
+        readyCheckSize   = 18,
+        readyCheckPosition = "center",  -- "topleft", "top", "topright", "left", "center", "right", "bottomleft", "bottom"
+        readyCheckOffsetX  = 0,
+        readyCheckOffsetY  = 0,
         threatBorderSize = 2,    -- aggro warning border thickness; 0 = off
         showLeaderIcon   = false,
         leaderIconPosition = "top",
@@ -2819,12 +2823,39 @@ local function StyleButton(button)
     AnchorRaidMarker()
     d.AnchorRaidMarker = AnchorRaidMarker
 
-    -- Ready check icon
+    -- Ready check icon (shared with the incoming-summon indicator)
     local readyCheck = health:CreateTexture(nil, "OVERLAY", nil, 3)
-    readyCheck:SetSize(18, 18)
-    readyCheck:SetPoint("CENTER", health, "CENTER", 0, 0)
+    readyCheck:SetSize(PixelSnap(s.readyCheckSize or 18), PixelSnap(s.readyCheckSize or 18))
     readyCheck:Hide()
     d.readyCheck = readyCheck
+
+    local function AnchorReadyCheck()
+        readyCheck:ClearAllPoints()
+        local pos = s.readyCheckPosition or "center"
+        local ox = s.readyCheckOffsetX or 0
+        local oy = s.readyCheckOffsetY or 0
+        if pos == "topleft" then
+            readyCheck:SetPoint("TOPLEFT", health, "TOPLEFT", 2 + ox, -2 + oy)
+        elseif pos == "top" then
+            readyCheck:SetPoint("TOP", health, "TOP", ox, -2 + oy)
+        elseif pos == "topright" then
+            readyCheck:SetPoint("TOPRIGHT", health, "TOPRIGHT", -2 + ox, -2 + oy)
+        elseif pos == "left" then
+            readyCheck:SetPoint("LEFT", health, "LEFT", 2 + ox, oy)
+        elseif pos == "right" then
+            readyCheck:SetPoint("RIGHT", health, "RIGHT", -2 + ox, oy)
+        elseif pos == "bottomleft" then
+            readyCheck:SetPoint("BOTTOMLEFT", health, "BOTTOMLEFT", 2 + ox, 2 + oy)
+        elseif pos == "bottom" then
+            readyCheck:SetPoint("BOTTOM", health, "BOTTOM", ox, 2 + oy)
+        elseif pos == "bottomright" then
+            readyCheck:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", -2 + ox, 2 + oy)
+        else -- center
+            readyCheck:SetPoint("CENTER", health, "CENTER", ox, oy)
+        end
+    end
+    AnchorReadyCheck()
+    d.AnchorReadyCheck = AnchorReadyCheck
 
     -- Debuff icons (pre-created, anchored dynamically)
     d.debuffIcons = {}
@@ -4782,23 +4813,23 @@ local function UpdateReadyCheck(button, unit)
     local tex = d.readyCheck
     if not tex then return end
 
+    local sz = PixelSnap(db.profile.readyCheckSize or 18)
+    tex:SetSize(sz, sz)
+
     -- Ready check (priority)
     if db.profile.showReadyCheck and readyCheckActive then
         local status = GetReadyCheckStatus(unit)
         if status == "ready" then
-            tex:SetSize(18, 18)
             tex:SetTexCoord(0, 1, 0, 1)
             tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-Ready")
             tex:Show()
             return
         elseif status == "notready" then
-            tex:SetSize(18, 18)
             tex:SetTexCoord(0, 1, 0, 1)
             tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-NotReady")
             tex:Show()
             return
         elseif status == "waiting" then
-            tex:SetSize(18, 18)
             tex:SetTexCoord(0, 1, 0, 1)
             tex:SetTexture("Interface\\RaidFrame\\ReadyCheck-Waiting")
             tex:Show()
@@ -4810,17 +4841,14 @@ local function UpdateReadyCheck(button, unit)
     if db.profile.showSummonPending and unit and C_IncomingSummon.HasIncomingSummon(unit) then
         local sStatus = C_IncomingSummon.IncomingSummonStatus(unit)
         if sStatus == SUMMON_STATUS_PENDING then
-            tex:SetSize(20, 20)
             tex:SetAtlas("RaidFrame-Icon-SummonPending")
             tex:Show()
             return
         elseif sStatus == SUMMON_STATUS_ACCEPTED then
-            tex:SetSize(20, 20)
             tex:SetAtlas("RaidFrame-Icon-SummonAccepted")
             tex:Show()
             return
         elseif sStatus == SUMMON_STATUS_DECLINED then
-            tex:SetSize(20, 20)
             tex:SetAtlas("RaidFrame-Icon-SummonDeclined")
             tex:Show()
             return
@@ -6019,6 +6047,11 @@ XF.Layout = function()
             d.raidMarker:SetSize(rmSz, rmSz)
             if d.AnchorRaidMarker then d.AnchorRaidMarker() end
         end
+        if d.readyCheck then
+            local rcSz = PixelSnap(xs.readyCheckSize or 18)
+            d.readyCheck:SetSize(rcSz, rcSz)
+            if d.AnchorReadyCheck then d.AnchorReadyCheck() end
+        end
         if d.debuffIcons then
             for _, icon in ipairs(d.debuffIcons) do
                 icon:SetSize(xs.debuffSize or 18, xs.debuffSize or 18)
@@ -7140,6 +7173,13 @@ local function ReloadFrames()
             local rmSz = PixelSnap(s.raidMarkerSize or 16)
             d.raidMarker:SetSize(rmSz, rmSz)
             if d.AnchorRaidMarker then d.AnchorRaidMarker() end
+        end
+
+        -- Ready check / summon size + position
+        if d.readyCheck then
+            local rcSz = PixelSnap(s.readyCheckSize or 18)
+            d.readyCheck:SetSize(rcSz, rcSz)
+            if d.AnchorReadyCheck then d.AnchorReadyCheck() end
         end
 
         -- Border
@@ -8387,6 +8427,7 @@ do
             "showRoleForTank", "showRoleForHealer", "showRoleForDPS",
             "showRaidMarker", "raidMarkerSize", "raidMarkerPosition", "raidMarkerOffsetX", "raidMarkerOffsetY",
             "showReadyCheck", "showSummonPending",
+            "readyCheckSize", "readyCheckPosition", "readyCheckOffsetX", "readyCheckOffsetY",
             "statusTextPosition", "statusTextOffsetX", "statusTextOffsetY", "statusTextSize", "statusTextColor",
             "showLeaderIcon", "leaderIconPosition", "leaderIconSize", "leaderIconOffsetX", "leaderIconOffsetY",
             "borderSize", "borderColor", "borderAlpha", "borderTexture",
@@ -9108,6 +9149,13 @@ ns.ReloadPartyFrames = function()
             local rmSz = PixelSnap(pp.raidMarkerSize or 16)
             d.raidMarker:SetSize(rmSz, rmSz)
             if d.AnchorRaidMarker then d.AnchorRaidMarker() end
+        end
+
+        -- Ready check / summon
+        if d.readyCheck then
+            local rcSz = PixelSnap(pp.readyCheckSize or 18)
+            d.readyCheck:SetSize(rcSz, rcSz)
+            if d.AnchorReadyCheck then d.AnchorReadyCheck() end
         end
 
         -- Border
@@ -10589,9 +10637,9 @@ local function CreatePreviewFrame(index)
     raidMarker:SetSize(rmSz, rmSz)
     raidMarker:Hide()
 
-    -- Ready check icon
+    -- Ready check icon (position/size re-applied in the preview indicator pass)
     local readyCheck = health:CreateTexture(nil, "OVERLAY", nil, 3)
-    readyCheck:SetSize(18, 18)
+    readyCheck:SetSize(PixelSnap(s.readyCheckSize or 18), PixelSnap(s.readyCheckSize or 18))
     readyCheck:SetPoint("CENTER", health, "CENTER", 0, 0)
     readyCheck:Hide()
 
@@ -11664,7 +11712,6 @@ local function ApplyPreviewData(f, index)
     -- Ready check icon
     if f._readyCheck then
         local rcStatuses = previewRoles._readyCheck
-        local rcStatuses = previewRoles._readyCheck
         local rcStatus = rcStatuses and rcStatuses[index]
         local isSummon = rcStatus and rcStatus:sub(1, 6) == "summon"
         local showRC = indVis and rcStatus and (
@@ -11672,10 +11719,31 @@ local function ApplyPreviewData(f, index)
             (isSummon and s.showSummonPending)
         )
         if showRC then
-            if isSummon then
-                f._readyCheck:SetSize(20, 20)
-            else
-                f._readyCheck:SetSize(18, 18)
+            local rcSz = PixelSnap(s.readyCheckSize or 18)
+            f._readyCheck:SetSize(rcSz, rcSz)
+            -- Anchor based on ready-check position setting
+            f._readyCheck:ClearAllPoints()
+            local pos = s.readyCheckPosition or "center"
+            local ox = s.readyCheckOffsetX or 0
+            local oy = s.readyCheckOffsetY or 0
+            if pos == "topleft" then
+                f._readyCheck:SetPoint("TOPLEFT", f._health, "TOPLEFT", 2 + ox, -2 + oy)
+            elseif pos == "top" then
+                f._readyCheck:SetPoint("TOP", f._health, "TOP", ox, -2 + oy)
+            elseif pos == "topright" then
+                f._readyCheck:SetPoint("TOPRIGHT", f._health, "TOPRIGHT", -2 + ox, -2 + oy)
+            elseif pos == "left" then
+                f._readyCheck:SetPoint("LEFT", f._health, "LEFT", 2 + ox, oy)
+            elseif pos == "right" then
+                f._readyCheck:SetPoint("RIGHT", f._health, "RIGHT", -2 + ox, oy)
+            elseif pos == "bottomleft" then
+                f._readyCheck:SetPoint("BOTTOMLEFT", f._health, "BOTTOMLEFT", 2 + ox, 2 + oy)
+            elseif pos == "bottom" then
+                f._readyCheck:SetPoint("BOTTOM", f._health, "BOTTOM", ox, 2 + oy)
+            elseif pos == "bottomright" then
+                f._readyCheck:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", -2 + ox, 2 + oy)
+            else -- center
+                f._readyCheck:SetPoint("CENTER", f._health, "CENTER", ox, oy)
             end
             if rcStatus == "ready" then
                 f._readyCheck:SetTexture("Interface\\RaidFrame\\ReadyCheck-Ready")

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -43,7 +43,6 @@ Are you sure you want to reset all %1$s settings to their defaults? This will re
 Assign to Spec
 Back
 Brightness
-Buff Bar
 CDM Buttons can have all their glow and active\nstates changed on a per icon (or synced to the bar)\nbasis. Click on a button to show that button's settings.
 Cancel
 Choose Zones
@@ -67,6 +66,7 @@ Custom Spell ID
 Dark Overlays\nDisabled
 Dark Overlays\nEnabled
 Deactivate Party Mode
+Delete Spell
 Delete \
 Deselect All
 Disable


### PR DESCRIPTION
## Summary
The ready check and incoming-summon icons on raid/party frames shared a single texture **hardcoded to the health-bar center**, with no way to move or resize them. They show in the Indicators preview but had no control. This adds one.

## What's new
A **Ready Check** control in the raid/party frame **Indicators** section, matching the existing Raid Marker control:
- **Position dropdown** — 9 anchors (Top Left … Center … Bottom Right)
- **Icon Size slider** — 8–40 (was fixed at 18/20)
- **Cog popup** — X/Y offset sliders, plus *Show Ready Check* and *Show Incoming Summon* toggles (previously always-on with no UI)

The two icons share a texture, so one set of controls drives both (shared position).

## Implementation
- **Defaults**: `readyCheckSize` (18), `readyCheckPosition` ("center"), `readyCheckOffsetX/Y` (0) — renders identically to before by default. New keys added to the `indicators` party-sync section.
- **Real frames**: replaced the hardcoded `SetPoint` with an `AnchorReadyCheck()` closure (same 9-position pattern as `AnchorRaidMarker`); `UpdateReadyCheck` uses the configured size; the three settings-refresh sites re-apply size + anchor live.
- **Preview**: applies configured size + position so changes update live in the eye preview. Also fixed a pre-existing duplicate `local rcStatuses` line.
- **Options**: new dropdown + size slider + cog row after the Raid Marker row.

## Notes
- At the default size (18) the summon icon now renders at 18px instead of its old 20px — a 2px change visible only during an actual summon.
- Both files pass `luac -p`. Verified by inspection/compile; not yet smoke-tested in-client.