### PR TITLE
fix(unitframes): support custom fonts on Cyrillic and CJK locales

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -889,22 +889,10 @@ end
 
 local SOLID_BACKDROP = { bgFile = "Interface\\Buttons\\WHITE8X8" }
 
--- Locale system font override: for CJK/Cyrillic clients, bypass all custom
--- fonts and use the WoW built-in font that supports the locale's glyphs.
-local LOCALE_FONT_OVERRIDE = EllesmereUI and EllesmereUI.LOCALE_FONT_FALLBACK
-
-local cachedFontPath = LOCALE_FONT_OVERRIDE or (EllesmereUI and EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames"))
+local cachedFontPath = (EllesmereUI and EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames"))
     or "Interface\\AddOns\\EllesmereUI\\media\\fonts\\Expressway.TTF"
 local cachedFontPaths = {}  -- per-unit font cache
 local function ResolveFontPath(unitKey)
-    -- Locale override takes absolute priority ? no custom font can render CJK/Cyrillic
-    if LOCALE_FONT_OVERRIDE then
-        cachedFontPath = LOCALE_FONT_OVERRIDE
-        for _, uKey in ipairs({"player", "target", "focus", "boss", "pet", "targettarget", "focustarget"}) do
-            cachedFontPaths[uKey] = LOCALE_FONT_OVERRIDE
-        end
-        return
-    end
     -- Global font system
     local gPath = EllesmereUI and EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames")
         or "Interface\\AddOns\\EllesmereUI\\media\\fonts\\Expressway.TTF"


### PR DESCRIPTION
### Summary
This PR fixes an issue where custom fonts selected in the UnitFrames options panel are not applied on Cyrillic (Russian) and CJK (Chinese, Korean) clients.

### Cause
Previously, a hardcoded `LOCALE_FONT_OVERRIDE` in `EllesmereUIUnitFrames.lua` unconditionally hijacked the UnitFrames font path on non-Latin locales, forcing it to the default system font (e.g. `FRIZQT___CYR.TTF` for Russian). This prevented users on these locales from using custom SharedMedia fonts, even if those fonts fully supported their character sets.

### Solution
Removed the redundant `LOCALE_FONT_OVERRIDE` logic inside `EllesmereUIUnitFrames.lua` and let the module delegate path resolution to the core `ResolveFontName` system in `EllesmereUI.lua`. The core system is already equipped to handle fallback paths dynamically:
1. It allows custom SharedMedia fonts to be resolved.
2. It automatically falls back to the client's default locale-specific font when a bundled Latin-only font is chosen (preventing text from rendering as empty boxes/question marks).