### PR TITLE
Fix: debuff position Y offset ignored in unit frame preview

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -3000,11 +3000,11 @@ initFrame:SetScript("OnEvent", function(self)
                     -- uses its own key); other units keep the 1px schematic gap.
                     local debuffGap = (unitKey == "boss") and ns.GetBossDebuffSpacing(s, simpleOn) or 1
                     local dOffX = s.debuffOffsetX or 0
-                    -- Simple mode uses its own X offset (falling back to the regular
-                    -- debuff offset for existing users) to match the live column.
-                    if simpleOn then dOffX = (ns.GetBossSimpleDebuffOffset(s)) end
-                    -- Preview intentionally ignores the Y offset (real frames still honor it).
-                    local dOffY = 0
+                    -- Preview now mirrors the real frame's Y offset too.
+                    local dOffY = s.debuffOffsetY or 0
+                    -- Simple mode uses its own X/Y offsets (falling back to the regular
+                    -- debuff offsets for existing users) to match the live column.
+                    if simpleOn then dOffX, dOffY = ns.GetBossSimpleDebuffOffset(s) end
                     local dg = s.debuffGrowth or "auto"
 
                     local autoGrowth = {


### PR DESCRIPTION
## Summary

The unit frame **options preview** hardcoded the debuff **Y offset to `0`**, so dragging the *Debuff Position* **Y** slider produced no visible change in the live preview thumbnail, while the **X** offset worked. The real in-game frames already honored the Y offset, so the preview disagreed with the actual result and looked broken.

## Change

In `EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua` (debuff preview repositioning):

- Use `s.debuffOffsetY` for `dOffY` instead of the hardcoded `0`.
- For Boss *Simple Debuff Display* mode, read both X and Y from `ns.GetBossSimpleDebuffOffset(s)` (it already returns `x, y`).

`dOffY` now flows into `anchorMap` (the per-anchor `oy`) and the `anchorKey` cache, so the preview repositions live and matches the real frames.

## Testing

Verified in-game: dragging the Debuff Position Y slider now moves the debuff icons in the options preview, consistent with the actual unit frame.