### PR TITLE
fix(pandemic-glow): keep glow in sync across CDM bars, tracking bars, and nameplates

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -241,67 +241,10 @@ initFrame:SetScript("OnEvent", function(self)
     local PAN_GLOW_BAR_VALUES = { [0] = "None", [1] = "Pixel Glow", [4] = "Auto-Cast Shine" }
     local PAN_GLOW_BAR_ORDER  = { 0, 1, 4 }
 
-    -- Get nameplate profile from central DB
-    local function GetNPProfile()
-        if not EllesmereUIDB or not EllesmereUIDB.profiles then return nil end
-        local pName = EllesmereUIDB.activeProfile or "Default"
-        local prof = EllesmereUIDB.profiles[pName]
-        return prof and prof.addons and prof.addons.EllesmereUINameplates
-    end
-
-    -- Copy pandemic fields from one table to another
-    local function CopyPandemicFields(src, dst)
-        dst.pandemicGlow = src.pandemicGlow
-        dst.pandemicGlowStyle = src.pandemicGlowStyle
-        dst.pandemicGlowColor = src.pandemicGlowColor and CopyTable(src.pandemicGlowColor) or nil
-        dst.pandemicGlowLines = src.pandemicGlowLines
-        dst.pandemicGlowThickness = src.pandemicGlowThickness
-        dst.pandemicGlowSpeed = src.pandemicGlowSpeed
-    end
-
-    -- Compare pandemic fields between two tables
-    local function PandemicFieldsMatch(a, b)
-        if (a.pandemicGlow or false) ~= (b.pandemicGlow or false) then return false end
-        if (a.pandemicGlowStyle or 1) ~= (b.pandemicGlowStyle or 1) then return false end
-        local ac = a.pandemicGlowColor or {}
-        local bc = b.pandemicGlowColor or {}
-        if (ac.r or 1) ~= (bc.r or 1) or (ac.g or 1) ~= (bc.g or 1) or (ac.b or 0) ~= (bc.b or 0) then return false end
-        if (a.pandemicGlowLines or 8) ~= (b.pandemicGlowLines or 8) then return false end
-        if (a.pandemicGlowThickness or 2) ~= (b.pandemicGlowThickness or 2) then return false end
-        if (a.pandemicGlowSpeed or 4) ~= (b.pandemicGlowSpeed or 4) then return false end
-        return true
-    end
-
-    -- Apply pandemic settings to all targets (NP, CDM bars) except skipKey
-    local function ApplyPandemicToAll(src, skipCdmKey)
-        local np = GetNPProfile()
-        if np then CopyPandemicFields(src, np) end
-        local pdb = DB()
-        if pdb and pdb.cdmBars and pdb.cdmBars.bars then
-            for _, b in ipairs(pdb.cdmBars.bars) do
-                if b.key ~= skipCdmKey and not b.isGhostBar and b.barType ~= "custom_buff" then
-                    CopyPandemicFields(src, b)
-                end
-            end
-        end
-        ns.BuildAllCDMBars()
-        if _G._ENP_RefreshAllSettings then _G._ENP_RefreshAllSettings() end
-        Refresh()
-    end
-
-    -- Check if pandemic settings are synced across all targets
-    local function IsPandemicSyncedEverywhere(src, skipCdmKey)
-        local np = GetNPProfile()
-        if np and not PandemicFieldsMatch(src, np) then return false end
-        local pdb = DB()
-        if pdb and pdb.cdmBars and pdb.cdmBars.bars then
-            for _, b in ipairs(pdb.cdmBars.bars) do
-                if b.key ~= skipCdmKey and not b.isGhostBar and b.barType ~= "custom_buff"
-                   and not PandemicFieldsMatch(src, b) then return false end
-            end
-        end
-        return true
-    end
+    -- Pandemic-glow cross-surface sync (CDM bars + Nameplates) lives in the CDM
+    -- core as EllesmereUI.ApplyPandemicGlowToAll / IsPandemicGlowSyncedToAll
+    -- (best-effort, name-based so styles never shift across surfaces). Callers
+    -- build a payload with EllesmereUI.PandemicPayloadFrom* and pass it.
 
     -- Create a pandemic glow preview icon in a DualRow right-half
     local function BuildPandemicPreview(row, isOffFn, getDataFn)
@@ -3988,17 +3931,18 @@ initFrame:SetScript("OnEvent", function(self)
             BuildPandemicCogButton(tbbPanRow, tbbAntsOff, SelectedTBB, function() RefreshTBB() end)
 
             -- Apply All
-            if EllesmereUI.BuildSyncIcon then
+            if EllesmereUI.BuildSyncIcon and EllesmereUI.ApplyPandemicGlowToAll then
                 EllesmereUI.BuildSyncIcon({
                     region = tbbPanRow._leftRegion,
-                    tooltip = "Apply Pandemic Glow settings to all (Nameplates, CDM Bars)",
+                    tooltip = "Apply this pandemic glow to Nameplates, all CDM bars, and other tracking bars. A surface that can't show a style uses its closest match.",
                     isSynced = function()
                         local src = SelectedTBB(); if not src then return true end
-                        return IsPandemicSyncedEverywhere(src, nil, _tbbSelectedBar)
+                        return EllesmereUI.IsPandemicGlowSyncedToAll(EllesmereUI.PandemicPayloadFromRectBar(src), { skipTbbBar = src })
                     end,
                     onClick = function()
                         local src = SelectedTBB(); if not src then return end
-                        ApplyPandemicToAll(src, nil, _tbbSelectedBar)
+                        EllesmereUI.ApplyPandemicGlowToAll(EllesmereUI.PandemicPayloadFromRectBar(src), { skipTbbBar = src })
+                        RefreshTBB()
                     end,
                 })
             end
@@ -11640,15 +11584,16 @@ initFrame:SetScript("OnEvent", function(self)
 
             BuildPandemicCogButton(panGlowRow, antsOff, BD, function() ns.BuildAllCDMBars() end)
 
-            if EllesmereUI.BuildSyncIcon then
+            if EllesmereUI.BuildSyncIcon and EllesmereUI.ApplyPandemicGlowToAll then
                 EllesmereUI.BuildSyncIcon({
                     region = panGlowRow._leftRegion,
-                    tooltip = "Apply Pandemic Glow settings to all (Nameplates, CDM Bars)",
+                    tooltip = "Apply this pandemic glow to Nameplates, all CDM bars, and tracking bars. A surface that can't show a style uses its closest match.",
                     isSynced = function()
-                        return IsPandemicSyncedEverywhere(BD(), barKey)
+                        return EllesmereUI.IsPandemicGlowSyncedToAll(EllesmereUI.PandemicPayloadFromCdmBar(BD()), { skipCdmKey = barKey })
                     end,
                     onClick = function()
-                        ApplyPandemicToAll(BD(), barKey)
+                        EllesmereUI.ApplyPandemicGlowToAll(EllesmereUI.PandemicPayloadFromCdmBar(BD()), { skipCdmKey = barKey })
+                        Refresh()
                     end,
                 })
             end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -1335,6 +1335,198 @@ local GLOW_STYLES = {
 }
 ns.GLOW_STYLES = GLOW_STYLES
 
+-------------------------------------------------------------------------------
+--  Cross-surface Pandemic Glow sync (CDM bars + Nameplates) -- BEST EFFORT
+--  Glow styles are identified by NAME, never by raw index: CDM, Nameplates and
+--  the shared engine order their lists differently, so the same integer means a
+--  different style on each surface (this silently swapped styles). Each surface
+--  also advertises a different subset, so the sync is best-effort: a style a
+--  surface can't render is coerced to its nearest supported one, and the coerced
+--  value is what gets STORED -- so the dropdown name and the preview image always
+--  match what is actually displayed.
+--    - CDM icon bars  : full set + "Blizzard Default" (-1 = Blizzard's own glow)
+--    - Nameplate icons: same set MINUS "Blizzard Default" (no native glow there)
+-------------------------------------------------------------------------------
+local PG_BLIZZ_NAME = "Blizzard Default"
+
+-- CDM icon-bar style index <-> canonical name
+local function PG_CdmNameFromIndex(idx)
+    if idx == -1 then return PG_BLIZZ_NAME end
+    local e = GLOW_STYLES[idx]
+    return (e and e.name) or "Pixel Glow"
+end
+local function PG_CdmIndexFromName(name)
+    if name == PG_BLIZZ_NAME then return -1 end
+    for i = 1, #GLOW_STYLES do
+        if GLOW_STYLES[i].name == name then return i end
+    end
+    return 1  -- Pixel Glow
+end
+
+-- Nameplate style index <-> canonical name (no Blizzard Default; coerce to Pixel)
+local function PG_NameplateNameFromIndex(idx)
+    local list = EllesmereUI.NameplatePandemicGlowStyles
+    local e = list and list[idx]
+    return (e and e.name) or "Pixel Glow"
+end
+local function PG_NameplateIndexFromName(name)
+    local list = EllesmereUI.NameplatePandemicGlowStyles
+    if name and name ~= PG_BLIZZ_NAME and list then
+        for i = 1, #list do
+            if list[i].name == name then return i end
+        end
+    end
+    return 1  -- Pixel Glow (covers Blizzard Default / anything unsupported)
+end
+
+-- Tracked Buff Bars render as rectangles: only Pixel(1)/Auto-Cast(4) work there.
+local function PG_TbbIndexFromName(name)
+    return (name == "Auto-Cast Shine") and 4 or 1
+end
+-- A TBB may STORE a non-renderable style (e.g. -1 default) but DISPLAYS it as
+-- Pixel; compare what's shown, not what's stored.
+local function PG_TbbEffectiveStyle(dst)
+    return (dst.pandemicGlowStyle == 4) and 4 or 1
+end
+
+local function PG_GetNPProfile()
+    if not EllesmereUIDB or not EllesmereUIDB.profiles then return nil end
+    local pName = EllesmereUIDB.activeProfile or "Default"
+    local prof = EllesmereUIDB.profiles[pName]
+    return prof and prof.addons and prof.addons.EllesmereUINameplates
+end
+
+-- Write a canonical payload into a destination, coercing the style through the
+-- destination's own name->index resolver (so the stored index is renderable).
+local function PG_Write(dst, payload, indexFromName)
+    dst.pandemicGlow          = payload.on
+    dst.pandemicGlowStyle     = indexFromName(payload.styleName or "Pixel Glow")
+    dst.pandemicGlowColor     = payload.color and CopyTable(payload.color) or nil
+    dst.pandemicGlowLines     = payload.lines
+    dst.pandemicGlowThickness = payload.thickness
+    dst.pandemicGlowSpeed     = payload.speed
+end
+
+-- True when dst already displays what PG_Write(dst, payload) would store. When
+-- both are off nothing is shown, so leftover style/color is irrelevant.
+-- actualStyleFn lets a surface report its EFFECTIVE (displayed) style when that
+-- differs from the raw stored value (e.g. rectangle TBBs); defaults to stored.
+local function PG_Matches(dst, payload, indexFromName, actualStyleFn)
+    if (dst.pandemicGlow or false) ~= (payload.on or false) then return false end
+    if not payload.on then return true end
+    local actual = actualStyleFn and actualStyleFn(dst) or (dst.pandemicGlowStyle or 1)
+    if actual ~= indexFromName(payload.styleName or "Pixel Glow") then return false end
+    local dc = dst.pandemicGlowColor or {}
+    local pc = payload.color or {}
+    if (dc.r or 1) ~= (pc.r or 1) or (dc.g or 1) ~= (pc.g or 1) or (dc.b or 0) ~= (pc.b or 0) then return false end
+    if (dst.pandemicGlowLines or 8) ~= (payload.lines or 8) then return false end
+    if (dst.pandemicGlowThickness or 2) ~= (payload.thickness or 2) then return false end
+    if (dst.pandemicGlowSpeed or 4) ~= (payload.speed or 4) then return false end
+    return true
+end
+
+-- Build a canonical payload from a CDM icon bar.
+function EllesmereUI.PandemicPayloadFromCdmBar(bd)
+    return {
+        on        = bd.pandemicGlow == true,
+        styleName = PG_CdmNameFromIndex(bd.pandemicGlowStyle or 1),
+        color     = bd.pandemicGlowColor,
+        lines     = bd.pandemicGlowLines,
+        thickness = bd.pandemicGlowThickness,
+        speed     = bd.pandemicGlowSpeed,
+    }
+end
+
+-- Build a payload from a rectangle bar (Tracked Buff Bar): rectangles only
+-- render Pixel/Auto-Cast, so report the EFFECTIVE displayed style, not the raw
+-- stored one (which may be e.g. -1 "Blizzard Default", shown there as Pixel).
+function EllesmereUI.PandemicPayloadFromRectBar(bd)
+    return {
+        on        = bd.pandemicGlow == true,
+        styleName = (bd.pandemicGlowStyle == 4) and "Auto-Cast Shine" or "Pixel Glow",
+        color     = bd.pandemicGlowColor,
+        lines     = bd.pandemicGlowLines,
+        thickness = bd.pandemicGlowThickness,
+        speed     = bd.pandemicGlowSpeed,
+    }
+end
+
+-- Build a payload from the nameplate profile.
+function EllesmereUI.PandemicPayloadFromNameplate(np)
+    return {
+        on        = np.pandemicGlow == true,
+        styleName = PG_NameplateNameFromIndex(np.pandemicGlowStyle or 1),
+        color     = np.pandemicGlowColor,
+        lines     = np.pandemicGlowLines,
+        thickness = np.pandemicGlowThickness,
+        speed     = np.pandemicGlowSpeed,
+    }
+end
+
+-- Apply a canonical payload to all sync surfaces (CDM icon bars, Tracked Buff
+-- Bars, Nameplates), best-effort. opts.skipCdmKey / opts.skipNameplates exclude
+-- the source surface; opts.skipTbbBar excludes one TBB (its source bar table).
+function EllesmereUI.ApplyPandemicGlowToAll(payload, opts)
+    opts = opts or {}
+    if not opts.skipNameplates then
+        local np = PG_GetNPProfile()
+        if np and EllesmereUI.NameplatePandemicGlowStyles then
+            PG_Write(np, payload, PG_NameplateIndexFromName)
+        end
+    end
+    local p = ECME.db and ECME.db.profile
+    if p and p.cdmBars and p.cdmBars.bars then
+        for _, b in ipairs(p.cdmBars.bars) do
+            if b.key ~= opts.skipCdmKey and not b.isGhostBar and b.barType ~= "custom_buff" then
+                PG_Write(b, payload, PG_CdmIndexFromName)
+            end
+        end
+    end
+    -- Tracked Buff Bars (active spec) -- rectangles, so style coerces to Pixel/Auto-Cast.
+    local tbb = ns.GetTrackedBuffBars and ns.GetTrackedBuffBars()
+    if tbb and tbb.bars then
+        for _, b in ipairs(tbb.bars) do
+            if b ~= opts.skipTbbBar then
+                PG_Write(b, payload, PG_TbbIndexFromName)
+            end
+        end
+    end
+    if ns.BuildAllCDMBars then ns.BuildAllCDMBars() end
+    if ns.BuildTrackedBuffBars then ns.BuildTrackedBuffBars() end
+    if _G._ENP_RefreshAllSettings then _G._ENP_RefreshAllSettings() end
+end
+
+-- True when every (non-skipped) surface already matches the payload.
+function EllesmereUI.IsPandemicGlowSyncedToAll(payload, opts)
+    opts = opts or {}
+    if not opts.skipNameplates then
+        local np = PG_GetNPProfile()
+        if np and EllesmereUI.NameplatePandemicGlowStyles
+           and not PG_Matches(np, payload, PG_NameplateIndexFromName) then
+            return false
+        end
+    end
+    local p = ECME.db and ECME.db.profile
+    if p and p.cdmBars and p.cdmBars.bars then
+        for _, b in ipairs(p.cdmBars.bars) do
+            if b.key ~= opts.skipCdmKey and not b.isGhostBar and b.barType ~= "custom_buff"
+               and not PG_Matches(b, payload, PG_CdmIndexFromName) then
+                return false
+            end
+        end
+    end
+    local tbb = ns.GetTrackedBuffBars and ns.GetTrackedBuffBars()
+    if tbb and tbb.bars then
+        for _, b in ipairs(tbb.bars) do
+            if b ~= opts.skipTbbBar
+               and not PG_Matches(b, payload, PG_TbbIndexFromName, PG_TbbEffectiveStyle) then
+                return false
+            end
+        end
+    end
+    return true
+end
+
 StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
     if not overlay then return end
     local styleIdx = tonumber(style) or 1

--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -2749,7 +2749,13 @@ initFrame:SetScript("OnEvent", function(self)
                     previewLabel:SetAlpha(off and 0.3 or 1)
                 end
             end
-            EllesmereUI.RegisterWidgetRefresh(UpdatePreviewGrayOut)
+            EllesmereUI.RegisterWidgetRefresh(function()
+                UpdatePreviewGrayOut()
+                -- Re-render the glow so external changes (e.g. the CDM
+                -- "Apply to: All" sync) update the preview, not just the
+                -- dropdown label. Mirrors the CDM pandemic preview.
+                RefreshPandemicPreview()
+            end)
             UpdatePreviewGrayOut()
         end
 
@@ -2777,6 +2783,25 @@ initFrame:SetScript("OnEvent", function(self)
             end)
             swatch:SetAlpha(pandemicOff() and 0.15 or 1)
             swatch:EnableMouse(not pandemicOff())
+        end
+
+        -- Apply-to-All: push this nameplate pandemic glow out to all CDM bars.
+        -- The coordinator lives in the CDM core, so the link only appears when
+        -- that module is loaded (otherwise there's nothing to sync to).
+        if EllesmereUI.BuildSyncIcon and EllesmereUI.ApplyPandemicGlowToAll then
+            EllesmereUI.BuildSyncIcon({
+                region = glowStyleRow._leftRegion,
+                tooltip = "Apply this pandemic glow to all CDM bars and tracking bars. A surface that can't show a style uses its closest match.",
+                isSynced = function()
+                    return EllesmereUI.IsPandemicGlowSyncedToAll(
+                        EllesmereUI.PandemicPayloadFromNameplate(DB()), { skipNameplates = true })
+                end,
+                onClick = function()
+                    EllesmereUI.ApplyPandemicGlowToAll(
+                        EllesmereUI.PandemicPayloadFromNameplate(DB()), { skipNameplates = true })
+                    C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
+                end,
+            })
         end
 
         -- Pixel Glow sub-options: only enabled when style is "Pixel Glow" (index 1)

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -669,6 +669,12 @@ local PANDEMIC_GLOW_STYLES = {
       rows = 5, columns = 5, frames = 25, duration = 0.3, frameW = 48, frameH = 48, scale = 1.47, previewScale = 1.47 },
 }
 ns.PANDEMIC_GLOW_STYLES = PANDEMIC_GLOW_STYLES
+-- Expose the nameplate glow-style list cross-addon so other modules (e.g. the
+-- CDM "Apply Pandemic Glow to all" sync) can translate a style by NAME instead
+-- of copying a raw index. Nameplates order their styles differently from CDM
+-- (their list omits "Custom Shape Glow"), so a raw index means a different
+-- style on each side.
+if EllesmereUI then EllesmereUI.NameplatePandemicGlowStyles = PANDEMIC_GLOW_STYLES end
 
 local function GetPandemicGlowStyle()
     local raw = p and p.pandemicGlowStyle

--- a/EllesmereUI_Widgets.lua
+++ b/EllesmereUI_Widgets.lua
@@ -5535,10 +5535,12 @@ local function BuildSyncIcon(opts)
     allBtn:SetScript("OnEnter", function()
         local r, g, b = EllesmereUI.GetAccentColor()
         allText:SetTextColor(r, g, b, 1)
+        if opts.tooltip then ShowWidgetTooltip(allBtn, opts.tooltip, opts.tooltipOpts) end
     end)
     allBtn:SetScript("OnLeave", function()
         local r, g, b = EllesmereUI.GetAccentColor()
         allText:SetTextColor(r, g, b, 0.65)
+        if opts.tooltip then HideWidgetTooltip() end
     end)
 
     -- " | Multiple" link (only when multiApply opts are provided)


### PR DESCRIPTION
Addresses the desync report in https://discord.com/channels/585577383847788554/1519485795860348948

## Problem

In **Nameplates → Extra Aura Options → Pandemic Glow Style**, the dropdown would reset to the wrong entry (e.g. "Auto-Cast Shine") after reloads/logins, while the preview kept showing the previously-set style.

**Root cause:** the "Apply to: All" pandemic-glow sync copied the raw `pandemicGlowStyle` *index* between surfaces, but CDM bars, nameplate icons, and the shared glow engine order their style lists differently (CDM's "Custom Shape" entry shifts every later index by one). Copying the integer silently shifted the style on the other surface; the nameplate dropdown then re-read that shifted index and displayed the wrong name.

Repro: set a nameplate pandemic style → go to Cooldown Manager → Extras → click "Apply to: All" → return to Nameplates and the dropdown now shows a different style.

## Fix

Replace the divergent per-surface index-copy helpers with a single **name-based coordinator** in the CDM core:

- `EllesmereUI.ApplyPandemicGlowToAll` / `IsPandemicGlowSyncedToAll`
- `PandemicPayloadFromCdmBar` / `PandemicPayloadFromRectBar` / `PandemicPayloadFromNameplate`

Styles are identified by **name**, and each surface coerces to its nearest supported entry on write — storing the coerced value — so the dropdown label and preview image always match what's actually drawn (best-effort, since each surface supports a different subset).

Also in this change:
- Added an **"Apply to: All"** control to the Nameplates pandemic row (previously CDM-only).
- Included **Tracked Buff Bars** (active spec) as a best-effort sync target; rectangles render Pixel/Auto-Cast only, so other styles coerce to Pixel.
- The nameplate preview now re-renders on external syncs (registered as a widget refresh, mirroring CDM) so the image updates, not just the label.
- Tooltips on each "Apply to: All" spell out the best-effort behavior.

Net effect is a simplification: the options file shrank (~57 lines of duplicated copy/compare helpers removed) in favor of one shared coordinator.

## Notes / scope
- **"Blizzard Default"** remains CDM-only (it defers to Blizzard's native `PandemicIcon`, which has no nameplate/rectangle equivalent); it coerces to Pixel Glow elsewhere.
- Apply-to-All / sync-detection covers the **active spec's** tracking bars, consistent with how TBBs are edited per-spec everywhere else.

## Testing
- All changed files pass `luac5.1 -p`.
- No new locale keys (tooltips are literal English); `Locales/_keys.txt` regenerated, unchanged.
- In-client smoke test for the live glow rendering still recommended.