### PR TITLE
fix(abr): Inky Black Potion reminder not clearing + last-used consumable tracking

### DIFF
--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -198,6 +198,21 @@ initFrame:SetScript("OnEvent", function(self)
             icons[#icons+1] = { texture = 134062, label = "Food", cat = "consumable", itemKey = "food" }
         end
 
+        -- Augment Rune
+        if co and co.enabled and co.enabled.augment_rune then
+            icons[#icons+1] = { texture = C_Item.GetItemIconByID(259085) or 134400, label = "Rune", cat = "consumable", itemKey = "augment_rune" }
+        end
+
+        -- Healthstone (default-on: treat nil as enabled, matching the toggle)
+        if co and co.enabled and co.enabled.healthstone ~= false then
+            icons[#icons+1] = { texture = C_Item.GetItemIconByID(5512) or 134400, label = "Stone", cat = "consumable", itemKey = "healthstone" }
+        end
+
+        -- Inky Black Potion
+        if co and co.enabled and co.enabled.inky_black then
+            icons[#icons+1] = { texture = C_Item.GetItemIconByID(124640) or 136122, label = "Inky", cat = "consumable", itemKey = "inky_black" }
+        end
+
         return icons
     end
 
@@ -477,7 +492,12 @@ initFrame:SetScript("OnEvent", function(self)
                 end
             end
             UpdatePreviewHeader()
-            return
+            -- Must return the header height. A bare `return` (nil) made
+            -- SetContentHeader collapse the content header to 0px, so the whole
+            -- preview vanished whenever a toggle left the icon count unchanged
+            -- (inky/healthstone, augment rune, pet, or a raid buff/aura not for
+            -- this class). Match the full-build height (base 80 + hint row).
+            return 80 + ((not IsPreviewHintDismissed()) and 35 or 0)
         end
 
         -- Container for icons (centered within hardcoded 80px header)
@@ -1246,7 +1266,8 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         -- Augment Rune toggle | Display In dropdown
-        _, h = W:DualRow(parent, y,
+        local runeRow
+        runeRow, h = W:DualRow(parent, y,
             { type="toggle", text="Augment Rune",
               getValue=function() local c = CDB(); return c and c.enabled and c.enabled.augment_rune end,
               setValue=function(v) local c = CDB(); if c and c.enabled then c.enabled.augment_rune = v; RefreshAll(); RebuildPreviewHeader() end end },
@@ -1266,18 +1287,11 @@ initFrame:SetScript("OnEvent", function(self)
             { type="toggle", text="Inky Black Potion",
               getValue=function() local c = CDB(); return c and c.enabled and c.enabled.inky_black end,
               setValue=function(v)
-                  local c = CDB(); if not (c and c.enabled) then return end
-                  c.enabled.inky_black = v
-                  RefreshAll()
-                  -- Update widget refreshes (e.g. the "Choose Zones" disabled overlay)
-                  -- BEFORE rebuilding the preview header, so the preview rebuild is the
-                  -- final action. Calling RefreshPage AFTER RebuildPreviewHeader tears
-                  -- down the freshly-built preview (it vanished until /reload). The
-                  -- working Healthstone toggle likewise rebuilds the preview last.
+                  local c = CDB(); if c and c.enabled then c.enabled.inky_black = v; RefreshAll(); RebuildPreviewHeader() end
                   EllesmereUI:RefreshPage()
-                  RebuildPreviewHeader()
               end }
         );  y = y - h
+        local healthstoneRow = row
 
         -- Inline "Choose Zones" button on the right region (Inky Black)
         do
@@ -1389,6 +1403,11 @@ initFrame:SetScript("OnEvent", function(self)
         if flaskRow then _eabrClickMappings["item:flask"] = { section = flaskRow, target = flaskRow } end
         if foodRow then _eabrClickMappings["item:food"] = { section = foodRow, target = foodRow } end
         if weaponEnchantRow then _eabrClickMappings["item:weapon_enchant"] = { section = weaponEnchantRow, target = weaponEnchantRow } end
+        if runeRow then _eabrClickMappings["item:augment_rune"] = { section = runeRow, target = runeRow } end
+        if healthstoneRow then
+            _eabrClickMappings["item:healthstone"] = { section = healthstoneRow, target = healthstoneRow }
+            _eabrClickMappings["item:inky_black"] = { section = healthstoneRow, target = healthstoneRow }
+        end
 
         return math.abs(y)
     end

--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -1266,8 +1266,16 @@ initFrame:SetScript("OnEvent", function(self)
             { type="toggle", text="Inky Black Potion",
               getValue=function() local c = CDB(); return c and c.enabled and c.enabled.inky_black end,
               setValue=function(v)
-                  local c = CDB(); if c and c.enabled then c.enabled.inky_black = v; RefreshAll(); RebuildPreviewHeader() end
+                  local c = CDB(); if not (c and c.enabled) then return end
+                  c.enabled.inky_black = v
+                  RefreshAll()
+                  -- Update widget refreshes (e.g. the "Choose Zones" disabled overlay)
+                  -- BEFORE rebuilding the preview header, so the preview rebuild is the
+                  -- final action. Calling RefreshPage AFTER RebuildPreviewHeader tears
+                  -- down the freshly-built preview (it vanished until /reload). The
+                  -- working Healthstone toggle likewise rebuilds the preview last.
                   EllesmereUI:RefreshPage()
+                  RebuildPreviewHeader()
               end }
         );  y = y - h
 

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1081,7 +1081,7 @@ local RUNE_BUFF_IDS = {1264426, 453250, 1234969, 1242347, 393438, 347901}
 
 -- Inky Black Potion
 local INKY_BLACK_ITEM = 124640
-local INKY_BLACK_BUFF = 242783  -- buff applied by Inky Black Potion
+local INKY_BLACK_BUFF = 185394  -- "Inky Blackness" buff (icon 136122); detected by aura scan, see PlayerHasInkyBlackness
 
 -------------------------------------------------------------------------------
 --  Helpers: Well Fed / Flask buff detection (by name, not spell ID secret)
@@ -1137,6 +1137,27 @@ local function PlayerHasFlaskBuff()
         _AC.ensureNames()
         for aName in pairs(_AC.byName) do
             if FLASK_NAME_SET[aName] then return true end
+        end
+    end
+    return false
+end
+
+local function PlayerHasInkyBlackness()
+    -- Aura API is restricted in PvP and M+ keystones; suppress since the buff
+    -- can't be read there and the player can't act on it mid-key (mirrors flask/food).
+    if InPvPInstance() then return true end
+    if InMythicPlusKey() then return true end
+    for i = 1, AURA_SCAN_LIMIT do
+        local aura = C_UnitAuras.GetAuraDataByIndex("player", i, "HELPFUL")
+        if not aura then break end
+        local sid = aura.spellId
+        local ic = aura.icon
+        if (sid and not isSecret(sid) and sid == INKY_BLACK_BUFF)
+        or (ic and not isSecret(ic) and ic == 136122) then
+            if IsUnderDuration(aura.duration, aura.expirationTime) then
+                return false
+            end
+            return true
         end
     end
     return false
@@ -1270,7 +1291,7 @@ end
 --  Resolve bag/equip-derived consumable display items. This is the costly part
 --  of the consumable check (Find*Item data-table walks + GetWeaponCategory) and
 --  depends ONLY on bags, equipped weapon type, and the preferred-item settings
---  (+ db.char.lastUsed*), none of which change between refreshes. Rebuilt lazily
+--  (+ db.profile.lastUsed*), none of which change between refreshes. Rebuilt lazily
 --  when one of those changes; CollectConsumables reads the resolved records each
 --  refresh and derives the icon at emit. Preserves every branch's exact item
 --  selection, fallback ordering, and hasBags/desaturated behavior.
@@ -1296,9 +1317,9 @@ function EABR.ResolveConsumables()
     R.dirty = false
     sig.pf, sig.pfd, sig.pwe = pf, pfd, pwe
 
-    local luf  = db.char and db.char.lastUsedFlask or nil
-    local lufd = db.char and db.char.lastUsedFood or nil
-    local luwe = db.char and db.char.lastUsedWeaponEnchant or nil
+    local luf  = db.profile and db.profile.lastUsedFlask or nil
+    local lufd = db.profile and db.profile.lastUsedFood or nil
+    local luwe = db.profile and db.profile.lastUsedWeaponEnchant or nil
 
     -- Augment Rune: void preferred over ethereal; nil if neither in bags.
     local runeItem = nil
@@ -1492,11 +1513,6 @@ local defaults = {
         unlockPos = nil,
         talentReminders = {},  -- array of {zoneIDs={}, zoneNames={}, spellID=number, spellName=string, showNotNeeded=bool}
         talentReminderYOffset = -50,
-    },
-    char = {
-        lastUsedFlask = nil,
-        lastUsedFood = nil,
-        lastUsedWeaponEnchant = nil,
     },
 }
 
@@ -2362,8 +2378,9 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                 local currentZone = tostring(C_Map.GetBestMapForUnit("player") or 0)
                 if co._inkyZoneSet[currentZone] then
                     local hasPotion = EABR._resolved.inky.hasPotion
-                    local hasBuff = PlayerHasAuraByID({INKY_BLACK_BUFF})
-                    if not hasBuff and hasPotion then
+                    -- Detect the "Inky Blackness" buff by scanning auras (see PlayerHasInkyBlackness),
+                    -- mirroring flask/food. Suppressed in M+/PvP there since the aura is unreadable.
+                    if not PlayerHasInkyBlackness() and hasPotion then
                         local e = AcquireEntry()
                         e.mode = "item"; e.itemID = INKY_BLACK_ITEM
                         e.texture = GetItemIcon(INKY_BLACK_ITEM)
@@ -2957,10 +2974,11 @@ do
     for _, f in ipairs(FOOD_ITEMS) do foodSet[f.itemID] = true end
     for _, we in ipairs(WEAPON_ENCHANT_ITEMS) do weSet[we.itemID] = true end
     TrackItemUse = function(itemID)
-        if not db or not db.char then return end
-        if flaskSet[itemID] then db.char.lastUsedFlask = itemID
-        elseif foodSet[itemID] then db.char.lastUsedFood = itemID
-        elseif weSet[itemID] then db.char.lastUsedWeaponEnchant = itemID end
+        if not db or not db.profile then return end
+        -- All persistent use-tracking lives in db.profile (this DB layer has no `char` namespace).
+        if flaskSet[itemID] then db.profile.lastUsedFlask = itemID
+        elseif foodSet[itemID] then db.profile.lastUsedFood = itemID
+        elseif weSet[itemID] then db.profile.lastUsedWeaponEnchant = itemID end
     end
 end
 
@@ -3611,6 +3629,13 @@ mainFrame:SetScript("OnEvent", function(_, e, arg1, arg2, arg3)
         return
     end
 
+    if e == "PLAYER_DEAD" then
+        -- Inky Blackness (and other buffs) drop on death; refresh so the aura-based
+        -- reminders re-evaluate and reappear once the buff is lost.
+        RequestRefresh()
+        return
+    end
+
     if e == "PLAYER_ENTERING_WORLD" then
         wipe(_dismissedUntilLoad)
         RequestRefresh()
@@ -3712,7 +3737,7 @@ end)
 local _prevBagCounts = {}
 
 local function DetectUsedItem()
-    if not db or not db.char then return end
+    if not db then return end
     RebuildBagCounts()
     for itemID, oldCount in pairs(_prevBagCounts) do
         if (_bagCounts[itemID] or 0) < oldCount then


### PR DESCRIPTION
## Summary
Fixes the Inky Black Potion buff reminder never disappearing after the potion is used, plus related issues found along the way.

Original bug report: https://discord.com/channels/585577383847788554/1519882588439711786

### 1. Inky Black reminder never cleared
- The buff ID was wrong (`242783`). The real buff is **"Inky Blackness" (`185394`, icon `136122`)**.
- Replaced the by-ID check with `PlayerHasInkyBlackness()`, which scans the player's auras for the spell ID or icon (secret-guarded) and — like the existing flask/food helpers — suppresses in active M+ keystones and PvP where the aura is unreadable.
- The reminder now hides when buffed and reappears on buff cancel / expiry / death across M0, raids (incl. flex difficulty 233), scenarios, and pre-key dungeons. In an active key it suppresses, consistent with flask/food.

### 2. Last-used consumable tracking was a silent no-op
- "Last used" flask/food/weapon-enchant tracking read/wrote `db.char`, but this addon's DB layer (`EUILite.NewDB`) only provides `db.profile` — so nothing persisted and the `last_used` preferred-item option did nothing.
- Moved all reads/writes to `db.profile`, removed the dead `char` defaults block, and fixed `DetectUsedItem`, which bailed early on the missing `db.char`.

### 3. Options preview collapsed when toggling reminders
- The live options preview vanished (until `/reload`) whenever a reminder toggle left the preview icon count unchanged. `_previewHeaderBuilder`'s reuse fast-path ended in a bare `return` (nil), so `SetContentHeader` set the content-header height to 0 and collapsed it. This hit any count-unchanged toggle: inky, healthstone, augment rune, pet, or a raid buff/aura not for the player's class (e.g. Skyfury on a non-Warrior).
- Fixed by returning the proper header height from the reuse path.

### 4. Added Augment Rune / Healthstone / Inky Black Potion to the live preview
- These reminders now appear as icons in the options preview when enabled, with click-to-navigate to their option rows — same treatment as Flask/Food/Weapon. Short labels ("Rune"/"Stone"/"Inky") to avoid text overlap.

## Testing
- `luac -p` clean on both changed files.
- `Locales/_keys.txt` regenerated — no change (no new literal keys).
- In-game (dev mode off): reminder hides on potion use, stays hidden through `/reload`, reappears on manual cancel / death; preview survives toggling any reminder; new preview icons render and navigate correctly. Confirmed by the reporter.

## Notes
- No new localizable strings.
- `/euidev` dev mode forces the restricted/secret-value environment globally; the aura-check is intended to be validated with dev mode off.