### PR TITLE
Feat: Add GCD bar in resource bars

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -8,6 +8,7 @@ local abs = math.abs
 
 local PAGE_DISPLAY   = "Class, Power and Health Bars"
 local PAGE_CASTBAR   = "Cast Bar"
+local PAGE_GCD       = "GCD Bar"
 local PAGE_TOTEM     = "Totem Bar"
 local PAGE_UNLOCK    = "Unlock Mode"
 
@@ -5390,6 +5391,7 @@ initFrame:SetScript("OnEvent", function(self)
                 p.secondary.offsetX = 0; p.secondary.offsetY = -38; p.secondary.unlockPos = nil
                 p.secondary.countTextUnlockPos = nil
                 p.castBar.unlockPos = nil; p.castBar.anchorX = 0; p.castBar.anchorY = -50
+                p.gcdBar.unlockPos = nil; p.gcdBar.anchorX = 0; p.gcdBar.anchorY = -78
                 Refresh()
             end,
             nil,
@@ -6936,17 +6938,379 @@ initFrame:SetScript("OnEvent", function(self)
     end
 
     ---------------------------------------------------------------------------
+    --  GCD Bar page
+    ---------------------------------------------------------------------------
+    local function BuildGCDBarPage(pageName, parent, yOffset)
+        local W = EllesmereUI.Widgets
+        local y = yOffset
+        local _, h
+
+        parent._showRowDivider = true
+
+        -- Re-append SharedMedia textures (catches lazy-registered SM packs)
+        if EllesmereUI.AppendSharedMediaTextures then
+            EllesmereUI.AppendSharedMediaTextures(
+                _G._ERB_BarTextureNames or {},
+                _G._ERB_BarTextureOrder or {},
+                nil,
+                _G._ERB_BarTextures
+            )
+        end
+        -- Bar texture dropdown values (same set the renderer uses)
+        local texValues, texOrder = {}, {}
+        do
+            local texNames = _G._ERB_BarTextureNames or {}
+            local texOrder2 = _G._ERB_BarTextureOrder or {}
+            local texLookup = _G._ERB_BarTextures or {}
+            for _, key in ipairs(texOrder2) do
+                if key ~= "---" then texValues[key] = texNames[key] or key end
+                texOrder[#texOrder + 1] = key
+            end
+            texValues._menuOpts = { itemHeight = 28, background = function(key) return texLookup[key] end }
+        end
+
+        local gcdOff = function() local p = DB(); return p and not p.gcdBar.enabled end
+
+        local function RefreshGCD()
+            if _G._ERB_Apply then _G._ERB_Apply() end
+            if EllesmereUI.NotifyElementResized then
+                EllesmereUI.NotifyElementResized("ERB_GCDBar")
+            end
+        end
+
+        -----------------------------------------------------------------------
+        local _sec
+        _sec, h = W:SectionHeader(parent, "LAYOUT", y);  y = y - h
+
+        local gStrataValues = { BACKGROUND = "Background", LOW = "Low", MEDIUM = "Medium", HIGH = "High", DIALOG = "Dialog" }
+        local gStrataOrder = { "BACKGROUND", "LOW", "MEDIUM", "HIGH", "DIALOG" }
+
+        -- Row: Enable GCD Bar (+ position cog) | Frame Strata
+        local enableRow
+        enableRow, h = W:DualRow(parent, y,
+            { type = "toggle", text = "Enable GCD Bar",
+              tooltip = "Shows a bar that fills over the global cooldown.",
+              getValue = function() local p = DB(); return p and p.gcdBar.enabled end,
+              setValue = function(v)
+                  local p = DB(); if not p then return end
+                  p.gcdBar.enabled = v; RefreshGCD(); EllesmereUI:RefreshPage()
+              end },
+            { type = "dropdown", text = "Frame Strata",
+              tooltip = "Controls the order that overlapping elements display in. Set higher to show above other elements.",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              values = gStrataValues, order = gStrataOrder,
+              getValue = function() local p = DB(); return p and p.gcdBar.frameStrata or "MEDIUM" end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.frameStrata = v; RefreshGCD() end }
+        );  y = y - h
+        -- Inline position cog (X/Y + unlock) on Enable
+        do
+            local rgn = enableRow._leftRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "GCD Bar Position",
+                rows = {
+                    -- X/Y edit whichever position is in effect: the saved unlock
+                    -- position takes priority in the renderer, so once it exists
+                    -- these sliders adjust it (otherwise they adjust the CENTER offset).
+                    { type = "slider", label = "X Offset", min = -600, max = 600, step = 1,
+                      get = function()
+                          local p = DB(); if not p then return 0 end
+                          local g = p.gcdBar
+                          if g.unlockPos and g.unlockPos.point then return g.unlockPos.x or 0 end
+                          return g.anchorX or 0
+                      end,
+                      set = function(v)
+                          local p = DB(); if not p then return end
+                          local g = p.gcdBar
+                          if g.unlockPos and g.unlockPos.point then g.unlockPos.x = v else g.anchorX = v end
+                          RefreshGCD()
+                      end },
+                    { type = "slider", label = "Y Offset", min = -600, max = 600, step = 1,
+                      get = function()
+                          local p = DB(); if not p then return 0 end
+                          local g = p.gcdBar
+                          if g.unlockPos and g.unlockPos.point then return g.unlockPos.y or 0 end
+                          return g.anchorY or -78
+                      end,
+                      set = function(v)
+                          local p = DB(); if not p then return end
+                          local g = p.gcdBar
+                          if g.unlockPos and g.unlockPos.point then g.unlockPos.y = v else g.anchorY = v end
+                          RefreshGCD()
+                      end },
+                },
+                footer = { unlockKey = "ERB_GCDBar" },
+            })
+            local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.DIRECTIONS_ICON)
+            local cogDis = CreateFrame("Frame", nil, rgn)
+            cogDis:SetAllPoints(cogBtn)
+            cogDis:SetFrameLevel(cogBtn:GetFrameLevel() + 5)
+            cogDis:EnableMouse(true)
+            cogDis:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(cogBtn, EllesmereUI.DisabledTooltip("GCD Bar"))
+            end)
+            cogDis:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            local function UpdateCogDis()
+                local p = DB()
+                if p and not p.gcdBar.enabled then cogDis:Show() else cogDis:Hide() end
+            end
+            cogBtn:HookScript("OnShow", UpdateCogDis)
+            EllesmereUI.RegisterWidgetRefresh(UpdateCogDis)
+            UpdateCogDis()
+        end
+
+        -- Row: Height | Width
+        local ghDis, ghTip, ghRaw = EllesmereUI.MatchGuard("ERB_GCDBar", "Height", gcdOff, "GCD Bar")
+        local gwDis, gwTip, gwRaw = EllesmereUI.MatchGuard("ERB_GCDBar", "Width", gcdOff, "GCD Bar")
+        _, h = W:DualRow(parent, y,
+            { type = "slider", text = "Height", min = 1, max = 60, step = 1,
+              disabled = ghDis, disabledTooltip = ghTip, rawTooltip = ghRaw,
+              getValue = function() local p = DB(); return p and p.gcdBar.height or 12 end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.height = v; RefreshGCD() end },
+            { type = "slider", text = "Width", min = 50, max = 500, step = 1,
+              disabled = gwDis, disabledTooltip = gwTip, rawTooltip = gwRaw,
+              getValue = function() local p = DB(); return p and p.gcdBar.width or 220 end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.width = v; RefreshGCD() end }
+        );  y = y - h
+
+        -- Row: Orientation | Instance Only
+        _, h = W:DualRow(parent, y,
+            { type = "dropdown", text = "Orientation",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              values = { HORIZONTAL = "Horizontal (Right)", HORIZONTAL_LEFT = "Horizontal (Left)", VERTICAL_UP = "Vertical (Up)", VERTICAL_DOWN = "Vertical (Down)" },
+              order = { "HORIZONTAL", "HORIZONTAL_LEFT", "VERTICAL_UP", "VERTICAL_DOWN" },
+              getValue = function() local p = DB(); return p and p.gcdBar.orientation or "HORIZONTAL" end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.orientation = v; RefreshGCD(); EllesmereUI:RefreshPage() end },
+            { type = "toggle", text = "Instance Only",
+              tooltip = "Only show the GCD bar while in a dungeon, raid, arena or battleground.",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              getValue = function() local p = DB(); return p and p.gcdBar.instanceOnly end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.instanceOnly = v; RefreshGCD() end }
+        );  y = y - h
+
+        -- Row: Only Instant Casts | Always Show
+        _, h = W:DualRow(parent, y,
+            { type = "toggle", text = "Only Instant Casts",
+              tooltip = "Only show the GCD bar for instant-cast abilities. While hard-casting or channeling a spell, the bar stays hidden (the cast bar already shows that progress).",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              getValue = function() local p = DB(); return p and p.gcdBar.instantOnly end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.instantOnly = v; RefreshGCD() end },
+            { type = "toggle", text = "Always Show",
+              tooltip = "Keep the GCD bar visible (sitting empty) when no global cooldown is running, instead of hiding it.",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              getValue = function() local p = DB(); return p and p.gcdBar.alwaysShow end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.alwaysShow = v; RefreshGCD() end }
+        );  y = y - h
+
+        _, h = W:Spacer(parent, y, 16);  y = y - h
+
+        -----------------------------------------------------------------------
+        _sec, h = W:SectionHeader(parent, "DISPLAY", y);  y = y - h
+
+        -- Row: Border Style | Border Size (+ inline color swatch + offset cog)
+        do
+            local btValues, btOrder = EllesmereUI.GetBorderTextureDropdown()
+            local bsRow
+            bsRow, h = W:DualRow(parent, y,
+                { type="dropdown", text="Border Style",
+                  disabled = gcdOff, disabledTooltip = "GCD Bar",
+                  values=btValues, order=btOrder,
+                  getValue=function() local p = DB(); return p and p.gcdBar.borderTexture or "solid" end,
+                  setValue=function(v)
+                      local p = DB(); if not p then return end
+                      p.gcdBar.borderTexture = v; p.gcdBar.borderTextureOffset = nil; p.gcdBar.borderTextureOffsetY = nil; p.gcdBar.borderTextureShiftX = nil; p.gcdBar.borderTextureShiftY = nil
+                      local _bcol, _bbehind = EllesmereUI.GetBorderStyleSelectDefaults(v)
+                      p.gcdBar.borderR = _bcol.r; p.gcdBar.borderG = _bcol.g; p.gcdBar.borderB = _bcol.b; p.gcdBar.borderA = 1
+                      p.gcdBar.borderBehind = _bbehind
+                      local defSz = EllesmereUI.GetBorderDefaultSize("resourcebars", v)
+                      if defSz then p.gcdBar.borderSize = defSz end
+                      RefreshGCD(); EllesmereUI:RefreshPage()
+                  end },
+                { type = "slider", text = "Border Size", min = 0, max = 4, step = 1,
+                  disabled = gcdOff, disabledTooltip = "GCD Bar",
+                  getValue = function() local p = DB(); return p and (p.gcdBar.borderSize or 0) or 0 end,
+                  setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.borderSize = v; RefreshGCD(); EllesmereUI:RefreshPage() end });  y = y - h
+            -- Border color swatch on the size slider (right region)
+            do
+                local rgn = bsRow._rightRegion
+                local ctrl = rgn._control
+                local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
+                    rgn, bsRow:GetFrameLevel() + 3,
+                    function()
+                        local p = DB()
+                        return (p and p.gcdBar.borderR or 0), (p and p.gcdBar.borderG or 0),
+                               (p and p.gcdBar.borderB or 0), (p and p.gcdBar.borderA or 1)
+                    end,
+                    function(r, g, b, a)
+                        local p = DB(); if not p then return end
+                        p.gcdBar.borderR, p.gcdBar.borderG, p.gcdBar.borderB, p.gcdBar.borderA = r, g, b, a
+                        RefreshGCD(); EllesmereUI:RefreshPage()
+                    end, true, 20)
+                PP.Point(swatch, "RIGHT", ctrl, "LEFT", -8, 0)
+                local block = CreateFrame("Frame", nil, swatch)
+                block:SetAllPoints()
+                block:SetFrameLevel(swatch:GetFrameLevel() + 10)
+                block:EnableMouse(true)
+                block:SetScript("OnEnter", function()
+                    EllesmereUI.ShowWidgetTooltip(swatch, EllesmereUI.DisabledTooltip("This option requires a Border Size above 0."))
+                end)
+                block:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                local function UpdateSwatchState()
+                    local p = DB()
+                    local noBorder = not p or (p.gcdBar.borderSize or 0) == 0
+                    if noBorder then swatch:SetAlpha(0.3); block:Show() else swatch:SetAlpha(1); block:Hide() end
+                end
+                EllesmereUI.RegisterWidgetRefresh(function() updateSwatch(); UpdateSwatchState() end)
+                UpdateSwatchState()
+            end
+            -- Offset cog on Border Style (left region), hidden for "solid"
+            do
+                local rgn = bsRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Border Offset",
+                    rows = {
+                        { type = "slider", label = "Offset X", min = -10, max = 10, step = 1,
+                          get = function() local p = DB(); if not p then return 0 end; local v = p.gcdBar.borderTextureOffset; if v then return v end; local dox = EllesmereUI.GetBorderDefaults("resourcebars", p.gcdBar.borderTexture or "solid", p.gcdBar.borderSize or 0); return dox end,
+                          set = function(v) local p = DB(); if not p then return end; p.gcdBar.borderTextureOffset = v; RefreshGCD(); EllesmereUI:RefreshPage() end },
+                        { type = "slider", label = "Offset Y", min = -10, max = 10, step = 1,
+                          get = function() local p = DB(); if not p then return 0 end; local v = p.gcdBar.borderTextureOffsetY; if v then return v end; local _, doy = EllesmereUI.GetBorderDefaults("resourcebars", p.gcdBar.borderTexture or "solid", p.gcdBar.borderSize or 0); return doy end,
+                          set = function(v) local p = DB(); if not p then return end; p.gcdBar.borderTextureOffsetY = v; RefreshGCD(); EllesmereUI:RefreshPage() end },
+                        { type = "slider", label = "Shift X", min = -10, max = 10, step = 1,
+                          get = function() local p = DB(); if not p then return 0 end; local v = p.gcdBar.borderTextureShiftX; if v then return v end; local _, _, dsx = EllesmereUI.GetBorderDefaults("resourcebars", p.gcdBar.borderTexture or "solid", p.gcdBar.borderSize or 0); return dsx end,
+                          set = function(v) local p = DB(); if not p then return end; p.gcdBar.borderTextureShiftX = v == 0 and nil or v; RefreshGCD(); EllesmereUI:RefreshPage() end },
+                        { type = "slider", label = "Shift Y", min = -10, max = 10, step = 1,
+                          get = function() local p = DB(); if not p then return 0 end; local v = p.gcdBar.borderTextureShiftY; if v then return v end; local _, _, _, dsy = EllesmereUI.GetBorderDefaults("resourcebars", p.gcdBar.borderTexture or "solid", p.gcdBar.borderSize or 0); return dsy end,
+                          set = function(v) local p = DB(); if not p then return end; p.gcdBar.borderTextureShiftY = v == 0 and nil or v; RefreshGCD(); EllesmereUI:RefreshPage() end },
+                        { type = "toggle", label = "Show Behind",
+                          get = function() local p = DB(); return p and p.gcdBar.borderBehind or false end,
+                          set = function(v) local p = DB(); if not p then return end; p.gcdBar.borderBehind = v == false and nil or v; RefreshGCD(); EllesmereUI:RefreshPage() end },
+                    },
+                })
+                local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.DIRECTIONS_ICON)
+                local function UpdateCogVis()
+                    local p = DB()
+                    local tex = p and p.gcdBar.borderTexture or "solid"
+                    if tex == "solid" then cogBtn:Hide() else cogBtn:Show() end
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateCogVis)
+                UpdateCogVis()
+            end
+        end
+
+        -- Row: Color (gradient end / custom / class + gradient cog) | Background (+ bg swatch)
+        local colorRow
+        colorRow, h = W:DualRow(parent, y,
+            { type = "multiSwatch", text = "Color",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              swatches = {
+                  { tooltip = "Gradient End Color", hasAlpha = true,
+                    getValue = function() local p = DB(); if not p then return 0.20, 0.20, 0.80, 1 end; return p.gcdBar.gradientR, p.gcdBar.gradientG, p.gcdBar.gradientB, p.gcdBar.gradientA end,
+                    setValue = function(r, g, b, a) local p = DB(); if not p then return end; p.gcdBar.gradientR, p.gcdBar.gradientG, p.gcdBar.gradientB, p.gcdBar.gradientA = r, g, b, a; RefreshGCD() end },
+                  { tooltip = "Custom Colored", hasAlpha = true,
+                    getValue = function() local p = DB(); if not p then local _, cf = UnitClass("player"); local cc = CLASS_COLORS[cf]; return cc and cc[1] or 1, cc and cc[2] or 0.70, cc and cc[3] or 0, 1 end; return p.gcdBar.fillR, p.gcdBar.fillG, p.gcdBar.fillB, p.gcdBar.fillA end,
+                    setValue = function(r, g, b, a) local p = DB(); if not p then return end; p.gcdBar.fillR, p.gcdBar.fillG, p.gcdBar.fillB, p.gcdBar.fillA = r, g, b, a; if p.gcdBar.classColored then p.gcdBar.classColored = false end; RefreshGCD(); EllesmereUI:RefreshPage() end,
+                    onClick = function(self) local p = DB(); if not p then return end; if p.gcdBar.classColored then p.gcdBar.classColored = false; RefreshGCD(); EllesmereUI:RefreshPage(); return end; if self._eabOrigClick then self._eabOrigClick(self) end end,
+                    refreshAlpha = function() local p = DB(); return (p and not p.gcdBar.classColored) and 1 or 0.3 end },
+                  { tooltip = "Class Colored",
+                    getValue = function() local _, classFile = UnitClass("player"); local cc = classFile and RAID_CLASS_COLORS and RAID_CLASS_COLORS[classFile]; if cc then return cc.r, cc.g, cc.b, 1 end; return 1, 0.70, 0, 1 end,
+                    setValue = function() end,
+                    onClick = function() local p = DB(); if not p then return end; p.gcdBar.classColored = true; RefreshGCD(); EllesmereUI:RefreshPage() end,
+                    refreshAlpha = function() local p = DB(); return (not p or p.gcdBar.classColored == true) and 1 or 0.3 end },
+              } },
+            { type = "slider", text = "Background", min = 0, max = 100, step = 1,
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              getValue = function() local p = DB(); return math.floor(((p and p.gcdBar.bgA or 0.7) * 100) + 0.5) end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.bgA = v / 100; RefreshGCD() end }
+        );  y = y - h
+        -- Gradient cog on Color
+        do
+            local rgn = colorRow._leftRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Gradient Settings",
+                rows = {
+                    { type = "toggle", label = "Enable Gradient",
+                      get = function() local p = DB(); return p and p.gcdBar.gradientEnabled end,
+                      set = function(v) local p = DB(); if not p then return end; p.gcdBar.gradientEnabled = v; RefreshGCD(); EllesmereUI:RefreshPage() end },
+                    { type = "dropdown", label = "Gradient Direction",
+                      values = { HORIZONTAL = "Horizontal", VERTICAL = "Vertical" }, order = { "HORIZONTAL", "VERTICAL" },
+                      get = function() local p = DB(); return p and p.gcdBar.gradientDir or "HORIZONTAL" end,
+                      set = function(v) local p = DB(); if not p then return end; p.gcdBar.gradientDir = v; RefreshGCD() end },
+                },
+            })
+            local cogBtn = MakeCogBtn(rgn, cogShow)
+            local cogDis = CreateFrame("Frame", nil, rgn)
+            cogDis:SetAllPoints(cogBtn)
+            cogDis:SetFrameLevel(cogBtn:GetFrameLevel() + 5)
+            cogDis:EnableMouse(true)
+            cogDis:SetScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(cogBtn, EllesmereUI.DisabledTooltip("GCD Bar")) end)
+            cogDis:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            local function UpdateCogDisGrad() local p = DB(); if p and not p.gcdBar.enabled then cogDis:Show() else cogDis:Hide() end end
+            cogBtn:HookScript("OnShow", UpdateCogDisGrad)
+            EllesmereUI.RegisterWidgetRefresh(UpdateCogDisGrad)
+            UpdateCogDisGrad()
+        end
+        -- Gradient end-color swatch enable/disable
+        do
+            local swatch = colorRow._leftRegion._control
+            local function UpdateGradientSwatch()
+                local p = DB()
+                if not p or not p.gcdBar.enabled then swatch:SetAlpha(0.15); swatch:Disable(); swatch._disabledTooltip = "GCD Bar"
+                elseif not p.gcdBar.gradientEnabled then swatch:SetAlpha(0.15); swatch:Disable(); swatch._disabledTooltip = "Gradient"
+                else swatch:SetAlpha(1); swatch:Enable(); swatch._disabledTooltip = nil end
+            end
+            UpdateGradientSwatch()
+            EllesmereUI.RegisterWidgetRefresh(UpdateGradientSwatch)
+        end
+        -- Background color swatch on the Background slider (right region)
+        do
+            local rgn = colorRow._rightRegion
+            local ctrl = rgn._control
+            local bgSwatch, bgUpdateSwatch = EllesmereUI.BuildColorSwatch(
+                rgn, colorRow:GetFrameLevel() + 3,
+                function() local p = DB(); return (p and p.gcdBar.bgR or 0), (p and p.gcdBar.bgG or 0), (p and p.gcdBar.bgB or 0) end,
+                function(r, g, b) local p = DB(); if not p then return end; p.gcdBar.bgR, p.gcdBar.bgG, p.gcdBar.bgB = r, g, b; RefreshGCD() end,
+                nil, 20)
+            PP.Point(bgSwatch, "RIGHT", ctrl, "LEFT", -8, 0)
+            local function UpdateBgSwatch()
+                local p = DB()
+                if not p or not p.gcdBar.enabled then bgSwatch:SetAlpha(0.15); bgSwatch:Disable(); bgSwatch._disabledTooltip = "GCD Bar"
+                else bgSwatch:SetAlpha(1); bgSwatch:Enable(); bgSwatch._disabledTooltip = nil end
+                bgUpdateSwatch()
+            end
+            UpdateBgSwatch()
+            EllesmereUI.RegisterWidgetRefresh(UpdateBgSwatch)
+        end
+
+        -- Row: Bar Texture | Show Spark
+        _, h = W:DualRow(parent, y,
+            { type = "dropdown", text = "Bar Texture",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              values = texValues, order = texOrder,
+              getValue = function() local p = DB(); return p and p.gcdBar.texture or "none" end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.texture = v; RefreshGCD() end },
+            { type = "toggle", text = "Show Spark",
+              tooltip = "Show a small glowing spark that moves along the leading edge of the fill.",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              getValue = function() local p = DB(); return p and p.gcdBar.showSpark end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.showSpark = v; RefreshGCD() end }
+        );  y = y - h
+
+        return math.abs(y)
+    end
+
+    ---------------------------------------------------------------------------
     --  Register the module
     ---------------------------------------------------------------------------
     EllesmereUI:RegisterModule("EllesmereUIResourceBars", {
         title       = "Resource Bars",
         description = "Custom class resource, health, and mana bar display.",
-        pages       = { PAGE_DISPLAY, PAGE_CASTBAR, PAGE_TOTEM },
+        pages       = { PAGE_DISPLAY, PAGE_CASTBAR, PAGE_GCD, PAGE_TOTEM },
         buildPage   = function(pageName, parent, yOffset)
             if pageName == PAGE_DISPLAY then
                 return BuildBarDisplayPage(pageName, parent, yOffset)
             elseif pageName == PAGE_CASTBAR then
                 return BuildCastBarPage(pageName, parent, yOffset)
+            elseif pageName == PAGE_GCD then
+                return BuildGCDBarPage(pageName, parent, yOffset)
             elseif pageName == PAGE_TOTEM then
                 return BuildTotemBarPage(pageName, parent, yOffset)
             end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -882,6 +882,30 @@ local DEFAULTS = {
             latencyShowText   = false,
             latencyR = 0.835, latencyG = 0.290, latencyB = 0.290, latencyA = 1.0,
         },
+        gcdBar = {
+            enabled       = false,
+            width         = 220,
+            height        = 12,
+            anchorX       = 0,
+            anchorY       = 0,
+            orientation   = "HORIZONTAL",  -- "HORIZONTAL","VERTICAL_UP","VERTICAL_DOWN"
+            classColored  = false,
+            fillR         = 0.267, fillG = 0.729, fillB = 0.898, fillA = 1,
+            gradientEnabled = false,
+            gradientR     = 0.20, gradientG = 0.20, gradientB = 0.80, gradientA = 1,
+            gradientDir   = "HORIZONTAL",  -- "HORIZONTAL","VERTICAL"
+            texture       = "none",
+            showSpark     = false,
+            borderSize    = 1,
+            borderR       = 0, borderG = 0, borderB = 0, borderA = 1,
+            borderTexture = "solid",
+            bgR           = 0, bgG = 0, bgB = 0, bgA = 0.7,
+            frameStrata   = "MEDIUM",
+            instanceOnly  = false,
+            instantOnly   = false,
+            alwaysShow    = false,
+            unlockPos     = nil,
+        },
         totemBar = {
             iconSize      = 30,
             spacing       = 2,
@@ -915,6 +939,7 @@ local secondaryBar  -- bar-style secondary (e.g. Devourer soul fragments, Elemen
 local secondaryBarTicks = {}  -- tick mark texture cache for bar-type secondary
 local secondaryPipTicks = {}  -- tick mark texture cache for pip-type secondary hash lines
 local castBarFrame
+local gcdBarFrame
 local totemBarFrame
 local _totemBorderOverlays = setmetatable({}, { __mode = "k" })
 local _totemHooked = false
@@ -935,6 +960,8 @@ local RefreshAnchoredBarsForUnlockTarget
 -- Forward declarations
 local UpdateCastBar
 local BuildCastBar
+local UpdateGCDBar
+local BuildGCDBar
 local OnCastStart, OnChannelStart, OnChannelUpdate, OnCastStop, OnEmpowerStart, OnEmpowerUpdate
 local ShowChannelTicks, HideChannelTicks
 
@@ -1561,6 +1588,69 @@ local function RegisterUnlockElements()
         })
     end
 
+    -- GCD Bar
+    do
+        local function S() return ERB.db.profile.gcdBar end
+        local function gcdSave(key, point, relPoint, x, y)
+            if not point then return end
+            local g = S()
+            g.unlockPos = { point = point, relPoint = relPoint or point, x = x, y = y }
+            if not EllesmereUI._unlockActive and gcdBarFrame then
+                gcdBarFrame:ClearAllPoints()
+                gcdBarFrame:SetPoint(point, UIParent, relPoint or point, x, y)
+            end
+        end
+        local function gcdLoad()
+            local pos = S().unlockPos
+            if not pos then return nil end
+            local pt = pos.point
+            return { point = pt, relPoint = pos.relPoint or pt, x = pos.x, y = pos.y }
+        end
+        local function gcdClear()
+            local g = S()
+            g.unlockPos = nil
+            g.anchorX = 0; g.anchorY = -78
+        end
+        local function gcdApply()
+            local pos = S().unlockPos
+            if not pos then return end
+            if gcdBarFrame then
+                local pt = pos.point
+                local sx, sy = SnapXY(pos.x, pos.y, gcdBarFrame, pos)
+                gcdBarFrame:ClearAllPoints()
+                gcdBarFrame:SetPoint(pt, UIParent, pos.relPoint or pt, sx, sy)
+            end
+        end
+        elements[#elements + 1] = MK({
+            key = "ERB_GCDBar", label = "GCD Bar", group = "Resource Bars", order = 506,
+            noAnchorTarget = true,
+            getFrame = function() return gcdBarFrame end,
+            getSize  = function()
+                local g = S()
+                return OrientedSize(g.width, g.height, g.orientation or "HORIZONTAL")
+            end,
+            setWidth = function(_, w)
+                local g = S()
+                if IsVerticalOrientation(g.orientation) then
+                    g.height = PP.Snap(math.max(w, 4))
+                else
+                    g.width = PP.Snap(math.max(w, 10))
+                end
+                Rebuild()
+            end,
+            setHeight = function(_, h)
+                local g = S()
+                if IsVerticalOrientation(g.orientation) then
+                    g.width = PP.Snap(math.max(h, 10))
+                else
+                    g.height = PP.Snap(math.max(h, 4))
+                end
+                Rebuild()
+            end,
+            savePos = gcdSave, loadPos = gcdLoad, clearPos = gcdClear, applyPos = gcdApply,
+        })
+    end
+
     -- Totem Bar
     do
         local function S() return ERB.db.profile.totemBar end
@@ -1629,6 +1719,7 @@ local ERB_ANCHOR_FRAMES = {
     erb_powerbar      = function() return primaryBar end,
     erb_health        = function() return healthBar end,
     erb_castbar       = function() return castBarFrame end,
+    erb_gcdbar        = function() return gcdBarFrame end,
     erb_cdm           = function() return _G._ECME_GetBarFrame and _G._ECME_GetBarFrame("cooldowns") end,
     mouse             = nil,  -- handled separately
     partyframe        = nil,  -- handled separately
@@ -1823,6 +1914,7 @@ local UNLOCK_TARGET_TO_ERB_ANCHOR = {
     ERB_Power = "erb_powerbar",
     ERB_ClassResource = "erb_classresource",
     ERB_CastBar = "erb_castbar",
+    ERB_GCDBar = "erb_gcdbar",
 }
 
 local function GetAnchorOffsets(settings)
@@ -4358,6 +4450,9 @@ local function OnUpdate(self, dt)
     -- Cast bar update
     UpdateCastBar(dt)
 
+    -- GCD bar update
+    UpdateGCDBar(dt)
+
     -- Throttled poll for Vengeance soul fragments (GetSpellCastCount has no
     -- discrete event) and as a safety net for other custom/bar resources.
     if cachedSecondary and (cachedSecondary.type == "custom" or cachedSecondary.type == "bar") then
@@ -5448,6 +5543,296 @@ OnEmpowerUpdate = function()
 end
 
 -------------------------------------------------------------------------------
+--  GCD Bar
+--  Uses the same detection logic as the cursor GCD Circle
+-------------------------------------------------------------------------------
+BuildGCDBar = function()
+    local g = ERB.db.profile.gcdBar
+
+    if not g.enabled then
+        if gcdBarFrame then
+            EllesmereUI.SetElementVisibility(gcdBarFrame, false)
+            gcdBarFrame:UnregisterAllEvents()
+            gcdBarFrame._gcdStart = nil
+            gcdBarFrame._gcdDur = nil
+            gcdBarFrame._gcdActualStart = nil
+        end
+        return
+    end
+
+    if not gcdBarFrame then
+        gcdBarFrame = CreateFrame("Frame", "ERB_GCDBarFrame", UIParent)
+        gcdBarFrame:SetFrameStrata(g.frameStrata or "MEDIUM")
+        gcdBarFrame:SetFrameLevel(15)
+
+        -- Background
+        local bg = gcdBarFrame:CreateTexture(nil, "BACKGROUND")
+        bg:SetAllPoints()
+        gcdBarFrame._bg = bg
+
+        -- Border frame
+        local bdrFrame = CreateFrame("Frame", nil, gcdBarFrame)
+        bdrFrame:SetAllPoints(gcdBarFrame)
+        bdrFrame:SetFrameLevel(gcdBarFrame:GetFrameLevel() + 5)
+        gcdBarFrame._border = bdrFrame
+		local PP = EllesmereUI and EllesmereUI.PP
+        if PP then PP.CreateBorder(bdrFrame, 0, 0, 0, 1, 1) end
+
+        -- Clip frame
+        local clipFrame = CreateFrame("Frame", nil, gcdBarFrame)
+        clipFrame:SetClipsChildren(true)
+        gcdBarFrame._barClip = clipFrame
+
+        -- Status bar
+        local bar = CreateFrame("StatusBar", "ERB_GCDBar", clipFrame)
+        bar:SetMinMaxValues(0, 1)
+        bar:SetValue(0)
+        gcdBarFrame._bar = bar
+		-- Smooth, always on
+		bar._castInterp = Enum and Enum.StatusBarInterpolation and Enum.StatusBarInterpolation.ExponentialEaseOut
+
+        -- Spark (same texture/approach as the cast bar)
+        local sparkFrame = CreateFrame("Frame", nil, clipFrame)
+        sparkFrame:SetAllPoints(bar)
+        sparkFrame:SetFrameLevel(bar:GetFrameLevel() + 2)
+        local spark = sparkFrame:CreateTexture(nil, "OVERLAY", nil, 1)
+        spark:SetTexture(SPARK_TEX)
+        spark:SetBlendMode("ADD")
+        gcdBarFrame._spark = spark
+
+        -- Event-driven GCD capture (like the cursor GCD ring)
+        gcdBarFrame:SetScript("OnEvent", function(self, event, unit, castGUID)
+            if unit ~= "player" then return end
+            local gc = ERB.db.profile.gcdBar
+            if not gc or not gc.enabled then return end
+
+            local getCD = C_Spell and C_Spell.GetSpellCooldown
+
+            -- Stop events: clear the bar the moment the GCD is no longer active.
+            if event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_INTERRUPTED"
+               or event == "UNIT_SPELLCAST_STOP" then
+                local cd = getCD and getCD(61304)
+                local stillActive = false
+                if cd and cd.startTime then
+                    local ok, act = pcall(function()
+                        local d, s = cd.duration, cd.startTime
+                        return (d and d > 0 and d <= 1.6 and s and s > 0) and true or false
+                    end)
+                    stillActive = ok and act
+                end
+                if not stillActive then
+                    self._gcdStart = nil
+                    self._gcdDur = nil
+                    self._gcdActualStart = nil
+                end
+                return
+            end
+
+            if event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_CHANNEL_START"
+               or event == "UNIT_SPELLCAST_EMPOWER_START" then
+                self._hardCastGUID = castGUID  -- remember this cast had a cast time
+                if gc.instantOnly then return end  -- instant-only: don't fill for hard casts
+            elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+                -- instant-only: skip the SUCCEEDED that ends a hard cast (same GUID)
+                if gc.instantOnly and castGUID == self._hardCastGUID then return end
+            else
+                return
+            end
+
+            local cd = getCD and getCD(61304)
+            if not cd or not cd.startTime then return end
+            local ok, elapsed, dur = pcall(function()
+                local d, s = cd.duration, cd.startTime
+                if d and d > 0 and d <= 1.6 and s and s > 0 then return GetTime() - s, d end
+                return nil
+            end)
+            if ok and elapsed and not (issecretvalue and (issecretvalue(elapsed) or issecretvalue(dur))) then
+                local actualStart = GetTime() - elapsed
+                -- Only (re)start for a freshly started GCD (elapsed near 0).
+                -- This stops an off-GCD / succeeded spell from restarting the
+                -- running GCD.
+                if elapsed < 0.3 and ((not self._gcdActualStart) or actualStart > (self._gcdActualStart + 0.05)) then
+                    self._gcdActualStart = actualStart
+                    -- Fill starts visually at 0 fills over the time remaining
+                    -- (Using the true start would open the bar at the
+                    -- already-elapsed %, e.g. ~30% on a hasted GCD.)
+                    self._gcdStart = GetTime()
+                    self._gcdDur = math.max(dur - elapsed, 0.05)
+                end
+            end
+        end)
+    end
+
+    -- register the cast events that start a GCD.
+    gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+    gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_START", "player")
+	gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_FAILED", "player")
+    gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_INTERRUPTED", "player")
+    gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_STOP", "player")
+    gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_START", "player")
+    gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_START", "player")
+
+    -- Size (orientation swaps width/height for vertical) + position
+    local ori = g.orientation or "HORIZONTAL"
+    local w, h = OrientedSize(g.width, g.height, ori)
+    gcdBarFrame:SetFrameStrata(g.frameStrata or "MEDIUM")
+
+    if g.unlockPos and g.unlockPos.point then
+        gcdBarFrame:SetSize(w, h)
+        if not EllesmereUI._unlockActive then
+            local anchored = EllesmereUI.IsUnlockAnchored("ERB_GCDBar")
+            if not (anchored and gcdBarFrame:GetLeft()) then
+                local rp = g.unlockPos.relPoint or g.unlockPos.point
+                gcdBarFrame:ClearAllPoints()
+                gcdBarFrame:SetPoint(g.unlockPos.point, UIParent, rp, g.unlockPos.x or 0, g.unlockPos.y or 0)
+            end
+        end
+    else
+        gcdBarFrame:SetSize(w, h)
+        if not EllesmereUI._unlockActive then
+            gcdBarFrame:ClearAllPoints()
+            gcdBarFrame:SetPoint("CENTER", UIParent, "CENTER", g.anchorX or 0, g.anchorY or 0)
+        end
+    end
+
+    -- Border styling
+    if gcdBarFrame._border then
+        local bs = g.borderSize or 0
+        local pl = gcdBarFrame:GetFrameLevel()
+        gcdBarFrame._border:SetFrameLevel(g.borderBehind and math.max(0, pl - 1) or (pl + 5))
+        EllesmereUI.ApplyBorderStyle(gcdBarFrame._border, bs,
+            g.borderR or 0, g.borderG or 0, g.borderB or 0, g.borderA or 1,
+            g.borderTexture or "solid", g.borderTextureOffset, g.borderTextureOffsetY,
+            g.borderTextureShiftX, g.borderTextureShiftY, "resourcebars", bs)
+    end
+
+    -- Clip + bar layout. The 1px inset keeps the fill from bleeding past the
+    -- border; with no border there's nothing to clip to, so skip it -- otherwise
+    -- it eats the whole height of very thin bars (height 1-2 -> nothing visible).
+    local clipFrame = gcdBarFrame._barClip
+    local bar = gcdBarFrame._bar
+    local bdrInset = ((g.borderSize or 0) > 0 and PP and PP.mult) or 0
+    clipFrame:ClearAllPoints()
+    clipFrame:SetPoint("TOPLEFT", gcdBarFrame, "TOPLEFT", bdrInset, -bdrInset)
+    clipFrame:SetPoint("BOTTOMRIGHT", gcdBarFrame, "BOTTOMRIGHT", -bdrInset, bdrInset)
+    clipFrame:SetFrameLevel(gcdBarFrame:GetFrameLevel() + 1)
+    bar:ClearAllPoints()
+    bar:SetAllPoints(clipFrame)
+
+    -- Texture + background
+    local texPath = EllesmereUI.ResolveTexturePath(_G._ERB_BarTextures, g.texture, "Interface\\Buttons\\WHITE8x8")
+    bar:SetStatusBarTexture(texPath)
+    gcdBarFrame._bg:SetTexture(nil)
+    gcdBarFrame._bg:SetColorTexture(g.bgR, g.bgG, g.bgB, g.bgA)
+
+    ApplyBarOrientation(bar, ori)
+    -- HORIZONTAL_LEFT = horizontal, but the fill grows right->left (reverse).
+    -- ApplyBarOrientation treats any non-vertical key as normal horizontal, so
+    -- flip reverse-fill here for the left variant.
+    if ori == "HORIZONTAL_LEFT" then bar:SetReverseFill(true) end
+
+    -- Fill color / gradient
+    local fillTex = bar:GetStatusBarTexture()
+    local fR, fG, fB, fA = g.fillR, g.fillG, g.fillB, g.fillA
+    if g.classColored then
+        local cc = CLASS_COLORS[cachedClass]
+        if cc then fR, fG, fB = cc[1], cc[2], cc[3] end
+    end
+    if g.gradientEnabled then
+        ApplyBarGradient(fillTex, g.gradientDir or "HORIZONTAL", fR, fG, fB, fA,
+            g.gradientR, g.gradientG, g.gradientB, g.gradientA)
+    else
+        ApplyBarFlat(fillTex, fR, fG, fB, fA)
+    end
+
+    -- Leading-edge spark: anchored to the fill texture's moving edge so it tracks
+    -- the fill. Edge depends on orientation (right / top / bottom for down-fill).
+    local spark = gcdBarFrame._spark
+    if spark then
+        if g.showSpark then
+            spark:ClearAllPoints()
+            if ori == "VERTICAL_UP" then
+                spark:SetSize(w, 8)
+                spark:SetPoint("CENTER", fillTex, "TOP", 0, 0)
+            elseif ori == "VERTICAL_DOWN" then
+                spark:SetSize(w, 8)
+                spark:SetPoint("CENTER", fillTex, "BOTTOM", 0, 0)
+            elseif ori == "HORIZONTAL_LEFT" then
+                spark:SetSize(8, h)
+                spark:SetPoint("CENTER", fillTex, "LEFT", 0, 0)
+            else
+                spark:SetSize(8, h)
+                spark:SetPoint("CENTER", fillTex, "RIGHT", 0, 0)
+            end
+            spark:Show()
+        else
+            spark:Hide()
+        end
+    end
+
+    -- Visibility
+    gcdBarFrame:Show()
+    -- if EllesmereUI._unlockActive then
+    --     -- bar:SetValue(0.65)
+    --     -- gcdBarFrame:SetAlpha(1)
+    -- else
+	if g.alwaysShow and not (g.instanceOnly and not IsInInstance()) then
+        bar:SetValue(0)
+		EllesmereUI.SetElementVisibility(gcdBarFrame, true)
+        -- gcdBarFrame:SetAlpha(1)
+    else
+        bar:SetValue(0)
+		EllesmereUI.SetElementVisibility(gcdBarFrame, false)
+        -- gcdBarFrame:SetAlpha(0)
+    end
+end
+
+UpdateGCDBar = function(_dt)
+    if not gcdBarFrame or not gcdBarFrame:IsShown() then return end
+    local g = ERB.db.profile.gcdBar
+    if not g or not g.enabled then return end
+    -- if EllesmereUI._unlockActive then return end
+
+    -- Frame stays shown; visibility is via alpha to avoid the Hide->Show fill
+    -- flash. (Re-showing a hidden StatusBar renders its fill full for a frame.)
+    -- if not gcdBarFrame:IsShown() then gcdBarFrame:Show() end
+    local bar = gcdBarFrame._bar
+
+    if g.instanceOnly and not IsInInstance() then
+        bar:SetValue(0)
+        EllesmereUI.SetElementVisibility(gcdBarFrame, false)
+        return
+    end
+
+    -- Animate from the start/duration captured at the cast event (set in the
+    -- OnEvent handler). No per-frame cooldown polling.
+    local startT, dur = gcdBarFrame._gcdStart, gcdBarFrame._gcdDur
+    local active = startT and dur
+    local elapsed
+    if active then
+        elapsed = GetTime() - startT
+        if elapsed < 0 or elapsed >= dur then
+            gcdBarFrame._gcdStart = nil
+            gcdBarFrame._gcdDur = nil
+            gcdBarFrame._gcdActualStart = nil
+            active = false
+        end
+    end
+
+    if not active then
+        -- No GCD running: empty, and invisible unless Always Show is on.
+        bar:SetValue(0)
+		local visible = false
+		if g.alwaysShow then visible = true end
+		EllesmereUI.SetElementVisibility(gcdBarFrame, visible)
+        return
+    end
+
+	EllesmereUI.SetElementVisibility(gcdBarFrame, true)
+    bar:SetValue(elapsed / dur)
+end
+
+-------------------------------------------------------------------------------
 --  Totem Bar
 --  Reparents Blizzard TotemFrame, repositions buttons in a clean row, and
 --  adds overlay border frames (our own frames, never written to Blizzard).
@@ -5730,6 +6115,7 @@ function ERB:ApplyAll()
     BuildMainFrame()
     BuildBars()
     BuildCastBar()
+    BuildGCDBar()
     BuildTotemBar()
 
     -- Apply frame strata to all existing bar frames (covers live changes)
@@ -5743,6 +6129,8 @@ function ERB:ApplyAll()
     if totemBarFrame then totemBarFrame:SetFrameStrata(tb and tb.frameStrata or "MEDIUM") end
     local cb = ERB.db.profile.castBar
     if castBarFrame then castBarFrame:SetFrameStrata(cb and cb.frameStrata or "MEDIUM") end
+    local gb = ERB.db.profile.gcdBar
+    if gcdBarFrame then gcdBarFrame:SetFrameStrata(gb and gb.frameStrata or "MEDIUM") end
     UpdateHealthBar()
     UpdatePrimaryBar()
     UpdateSecondaryResource()


### PR DESCRIPTION
Add GCD bar to resource bars. Configurable, anchorable to others (cannot be anchored to, mirrors cast bar).
Majority of implementation taken from cast bar/gcd circle so have high confidence.

Tested:
- all different UI options
- profiles/export/import
- anchoring
- w/h matching 
- in raid and with /euidev


<img width="346" height="93" alt="image" src="https://github.com/user-attachments/assets/10179481-d144-456b-a3e9-cc309b942793" />
<img width="943" height="527" alt="image" src="https://github.com/user-attachments/assets/084d975f-50b0-4832-aff2-9b149a43fe02" />
