### PR TITLE
Add Hide Error Messages quality-of-life option

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -323,6 +323,21 @@ initFrame:SetScript("OnEvent", function(self)
             if coordInitOff then coordCogBlock:Show() else coordCogBlock:Hide() end
         end
 
+        -- Row 6: Hide Error Messages (left) |
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Hide Error Messages",
+              tooltip="Hides most red error messages (such as 'Not enough rage' or 'Ability is not ready yet'). Important errors like a full bag or quest log are still shown.",
+              getValue=function()
+                  return EllesmereUIDB and EllesmereUIDB.hideErrorMessages or false
+              end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.hideErrorMessages = v
+                  if EllesmereUI._applyHideErrorMessages then EllesmereUI._applyHideErrorMessages() end
+              end },
+            { type="label", text="" }
+        );  y = y - h
+
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
         ---------------------------------------------------------------------------
@@ -1620,11 +1635,13 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.autoRepairGuild = false
                 EllesmereUIDB.shifterEnabled = false
                 EllesmereUIDB.shifterPositions = nil
+                EllesmereUIDB.hideErrorMessages = false
             end
             EllesmereUIDB.autoLogging = nil
             if _G._EUI_ResetUpgradeCalc then _G._EUI_ResetUpgradeCalc() end
             if _G._EBS_ResetCursor then _G._EBS_ResetCursor() end
             if EllesmereUI._applyHideBlizzardPartyFrame then EllesmereUI._applyHideBlizzardPartyFrame() end
+            if EllesmereUI._applyHideErrorMessages then EllesmereUI._applyHideErrorMessages() end
             if EllesmereUI._applyQuickSignup then EllesmereUI._applyQuickSignup() end
             if EllesmereUI._applyPersistSignupNote then EllesmereUI._applyPersistSignupNote() end
             EllesmereUI:InvalidatePageCache()

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -2048,3 +2048,79 @@ do
         end
     end
 end
+
+-------------------------------------------------------------------------------
+--  Hide Error Messages
+--  Swallows the red UIErrorsFrame spam (e.g. "Not enough rage", "Ability is
+--  not ready yet") while keeping a short whitelist of genuinely useful errors
+--  visible. The OnEvent override is only installed while the option is on, so
+--  it costs nothing for anyone who leaves it off.
+-------------------------------------------------------------------------------
+do
+    local origOnEvent
+    local installed = false
+
+    -- Errors worth keeping even while the rest are hidden. Built lazily so we
+    -- only touch the ERR_* globals when someone actually enables the feature.
+    local keep
+    local function BuildKeepList()
+        if keep then return end
+        keep = {}
+        for _, msg in ipairs({
+            ERR_INV_FULL, ERR_QUEST_LOG_FULL, ERR_RAID_GROUP_ONLY,
+            ERR_PARTY_LFG_BOOT_LIMIT, ERR_PARTY_LFG_BOOT_DUNGEON_COMPLETE,
+            ERR_PARTY_LFG_BOOT_IN_COMBAT, ERR_PARTY_LFG_BOOT_IN_PROGRESS,
+            ERR_PARTY_LFG_BOOT_LOOT_ROLLS, ERR_PARTY_LFG_TELEPORT_IN_COMBAT,
+            ERR_PET_SPELL_DEAD, ERR_PLAYER_DEAD,
+            SPELL_FAILED_TARGET_NO_POCKETS, ERR_ALREADY_PICKPOCKETED,
+        }) do
+            if msg then keep[msg] = true end
+        end
+    end
+
+    -- The group-kick "not eligible" line is a format string, so it needs a
+    -- pattern match rather than a plain equality check.
+    local function IsBootNotEligible(err)
+        if type(err) ~= "string" or not ERR_PARTY_LFG_BOOT_NOT_ELIGIBLE_S then return false end
+        local ok, found = pcall(function()
+            return err:find(string.format(ERR_PARTY_LFG_BOOT_NOT_ELIGIBLE_S, ".+"))
+        end)
+        return (ok and found) and true or false
+    end
+
+    local function FilteredOnEvent(self, event, id, err, ...)
+        if event == "UI_ERROR_MESSAGE" then
+            if keep[err] or IsBootNotEligible(err) then
+                return origOnEvent(self, event, id, err, ...)
+            end
+            return
+        end
+        return origOnEvent(self, event, id, err, ...)
+    end
+
+    local function ApplyHideErrorMessages()
+        local on = EllesmereUIDB and EllesmereUIDB.hideErrorMessages
+        if on and not installed then
+            BuildKeepList()
+            origOnEvent = UIErrorsFrame:GetScript("OnEvent")
+            UIErrorsFrame:SetScript("OnEvent", FilteredOnEvent)
+            UIParent:UnregisterEvent("PING_SYSTEM_ERROR")
+            installed = true
+        elseif not on and installed then
+            UIErrorsFrame:SetScript("OnEvent", origOnEvent)
+            origOnEvent = nil
+            UIParent:RegisterEvent("PING_SYSTEM_ERROR")
+            installed = false
+        end
+    end
+    EllesmereUI._applyHideErrorMessages = ApplyHideErrorMessages
+
+    local f = CreateFrame("Frame")
+    f:RegisterEvent("PLAYER_LOGIN")
+    f:SetScript("OnEvent", function(self)
+        self:UnregisterAllEvents()
+        if EllesmereUIDB and EllesmereUIDB.hideErrorMessages then
+            ApplyHideErrorMessages()
+        end
+    end)
+end


### PR DESCRIPTION
## Summary
Adds a **Hide Error Messages** toggle to the QoL Features tab. When enabled it suppresses the red `UIErrorsFrame` spam (e.g. "Not enough rage", "Ability is not ready yet") while keeping a short whitelist of genuinely useful errors visible (full bag, full quest log, group-finder/boot messages, pet/player dead, pickpocket). Ping system errors are silenced too.

Off by default. The `UIErrorsFrame` `OnEvent` override is only installed while the option is enabled and fully restored when disabled, so it costs nothing for anyone who leaves it off.

## Files changed
- `EllesmereUIQoL/EllesmereUIQoL.lua` - runtime logic + apply hook
- `EllesmereUIQoL/EUI_QoL_Options.lua` - option toggle + reset wiring

## Screenshot
<img width="1298" height="947" alt="image" src="https://github.com/user-attachments/assets/2c6b6e3d-75f0-4d72-a527-3928a08e2927" />

## Testing
Toggled on/off live in-game (no reload needed); confirmed error spam is hidden while important errors still show