### PR TITLE
Add combat-only option for CDM bar glows

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -678,6 +678,7 @@ initFrame:SetScript("OnEvent", function(self)
                         glowColor = { r = 1, g = 0.82, b = 0.1 },
                         classColor = false,
                         mode = "ACTIVE",
+                        onlyInCombat = false,
                     }
                     local prefix = BAR_BUTTON_PREFIXES[barIdx]
                     local realBtn = prefix and _G[prefix .. btnIdx]
@@ -1407,7 +1408,7 @@ initFrame:SetScript("OnEvent", function(self)
                     -- Section header per buff
                     _, h = W:SectionHeader(parent, btnSpellName .. " x " .. buffName, y);  y = y - h
 
-                    -- Row 1: Glow When | Remove Glow
+                    -- Row 1: Glow When | Only In Combat
                     local modeRow
                     local removeAIdx = aIdx
                     modeRow, h = W:DualRow(parent, y,
@@ -1419,6 +1420,18 @@ initFrame:SetScript("OnEvent", function(self)
                               Refresh()
                           end,
                         },
+                        { type = "toggle", text = "Only In Combat",
+                          getValue = function() return entry.onlyInCombat == true end,
+                          setValue = function(v)
+                              entry.onlyInCombat = v or nil
+                              Refresh()
+                          end,
+                        }
+                    );  y = y - h
+
+                    local removeRow
+                    removeRow, h = W:DualRow(parent, y,
+                        { type = "spacer" },
                         { type = "labeledButton", text = "Remove Glow", buttonText = "Remove", width = 150,
                           onClick = function()
                               table.remove(buffList, removeAIdx)
@@ -1433,7 +1446,7 @@ initFrame:SetScript("OnEvent", function(self)
 
                     -- Buff icon next to the Remove button
                     do
-                        local rightRgn = modeRow._rightRegion
+                        local rightRgn = removeRow._rightRegion
                         if rightRgn and rightRgn._control then
                             local btn = rightRgn._control
                             local btnH = btn:GetHeight()

--- a/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
@@ -236,6 +236,7 @@ local function UpdateOverlayVisuals()
             local entry = overlay._assignEntry
             local spellID = entry.spellID
             local mode = entry.mode or "ACTIVE"
+            local onlyInCombat = entry.onlyInCombat == true
 
             local auraActive = false
             if spellID and spellID > 0 then
@@ -250,6 +251,10 @@ local function UpdateOverlayVisuals()
                 shouldGlow = not auraActive
             else
                 shouldGlow = auraActive
+            end
+
+            if shouldGlow and onlyInCombat then
+                shouldGlow = (InCombatLockdown and InCombatLockdown()) or UnitAffectingCombat("player") or false
             end
 
             -- Only update on state change (avoids restarting animations)
@@ -303,4 +308,3 @@ ns.RequestUpdate = ns.RequestBarGlowUpdate
 function ns.InitBarGlows()
     SetupOverlays()
 end
-

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -193,6 +193,7 @@ Not Included
 Not Loaded
 OK
 Okay
+Only In Combat
 PER-SPELL OPTIONS
 Paste your profile string here...
 Patch Notes


### PR DESCRIPTION
# Problem

Any glows assigned in the CDM glow unconditionally, with only the option to toggle the entire bar and not glow state based on combat. This leads to a lot of glows perpetually happening for missing buffs, which only matters in combat.

# Solution

Add an Only In Combat toggle to CDM bar glow assignments and gate the runtime glow state on player combat. This lets a glow trigger only while its aura condition matches and the player is in combat.

Also add the new UI label to the locale key list for translation coverage.

# Images
## Out of Combat
<img width="1454" height="1069" alt="image" src="https://github.com/user-attachments/assets/57de099d-7b50-497e-a8b2-2b2699e4ffc7" />
<img width="1342" height="976" alt="image" src="https://github.com/user-attachments/assets/1dba5a28-0b6e-4648-b141-7d047f9dfdc9" />

## Only in Combat
<img width="1314" height="960" alt="image" src="https://github.com/user-attachments/assets/aa941e66-9e60-4d7c-91c0-2ecc93b61266" />
<img width="1474" height="957" alt="image" src="https://github.com/user-attachments/assets/863671dd-f2b7-4726-948e-63dc562ed6af" />
<img width="1474" height="957" alt="image" src="https://github.com/user-attachments/assets/6f90b945-a906-478e-a7ce-451ea44bbffc" />



