### PR TITLE
feat(action-bars): add /kb slash command for Quick Keybind Mode

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -8135,6 +8135,17 @@ function EAB:OnInitialize()
         end
     end
 
+    SLASH_EABQUICKKEYBIND1 = "/kb"
+    SlashCmdList["EABQUICKKEYBIND"] = function(msg)
+        if InCombatLockdown() then return end
+        if not C_AddOns.IsAddOnLoaded("Blizzard_QuickKeybind") then
+            C_AddOns.LoadAddOn("Blizzard_QuickKeybind")
+        end
+        if QuickKeybindFrame then
+            QuickKeybindFrame:Show()
+        end
+    end
+
 end
 
 function EAB:OnEnable()

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -203,7 +203,6 @@ Not Included
 Not Loaded
 OK
 Okay
-Only In Combat
 PER-SPELL OPTIONS
 Paste your profile string here...
 Patch Notes


### PR DESCRIPTION
Adds the /kb slash command to quickly open Blizzard's Quick Keybind Mode without navigating through the Action Bars options panel.