### PR TITLE
fix(gcd-bar): stop GCD bar dropping while spamming + add Deplete Fill option

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -7316,6 +7316,16 @@ initFrame:SetScript("OnEvent", function(self)
               setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.showSpark = v; RefreshGCD() end }
         );  y = y - h
 
+        -- Row: Deplete Fill (left half only)
+        _, h = W:DualRow(parent, y,
+            { type = "toggle", text = "Deplete Fill",
+              tooltip = "Start the bar full and drain it as the global cooldown elapses, instead of filling it up.",
+              disabled = gcdOff, disabledTooltip = "GCD Bar",
+              getValue = function() local p = DB(); return p and p.gcdBar.depleteFill end,
+              setValue = function(v) local p = DB(); if not p then return end; p.gcdBar.depleteFill = v; RefreshGCD() end },
+            { type = "spacer" }
+        );  y = y - h
+
         return math.abs(y)
     end
 

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -896,6 +896,7 @@ local DEFAULTS = {
             gradientDir   = "HORIZONTAL",  -- "HORIZONTAL","VERTICAL"
             texture       = "none",
             showSpark     = false,
+            depleteFill   = false,  -- start full and deplete instead of filling up
             borderSize    = 1,
             borderR       = 0, borderG = 0, borderB = 0, borderA = 1,
             borderTexture = "solid",
@@ -5585,6 +5586,7 @@ BuildGCDBar = function()
             gcdBarFrame._gcdStart = nil
             gcdBarFrame._gcdDur = nil
             gcdBarFrame._gcdActualStart = nil
+            gcdBarFrame._barActive = nil
         end
         return
     end
@@ -5647,7 +5649,12 @@ BuildGCDBar = function()
                         local d, s = cd.duration, cd.startTime
                         return (d and d > 0 and d <= 1.6 and s and s > 0) and true or false
                     end)
-                    stillActive = ok and act
+                    -- If the read succeeded, trust it. If it FAILED (the GCD
+                    -- cooldown came back as a secret value -- common in combat),
+                    -- assume the GCD is still active and keep the bar. Otherwise a
+                    -- single secret read on one of the many FAILED events that
+                    -- spamming generates would wrongly wipe a running GCD.
+                    stillActive = (not ok) or act
                 end
                 if not stillActive then
                     self._gcdStart = nil
@@ -5694,10 +5701,16 @@ BuildGCDBar = function()
                 end)
                 if ok and elapsed and not (issecretvalue and (issecretvalue(elapsed) or issecretvalue(dur))) then
                     local actualStart = GetTime() - elapsed
-                    -- Only (re)start for a freshly started GCD (elapsed near 0).
-                    -- This stops an off-GCD / succeeded spell from restarting the
-                    -- running GCD.
-                    if elapsed < 0.3 and ((not self._gcdActualStart) or actualStart > (self._gcdActualStart + 0.05)) then
+                    -- (Re)start whenever this is a genuinely NEWER GCD than the one we
+                    -- last captured. Do NOT gate on how far the GCD has elapsed:
+                    -- while spamming, the next ability is queued and its SUCCEEDED
+                    -- lands partway into the fresh GCD (elapsed ~0.4-0.7s observed),
+                    -- so an "elapsed near 0" gate rejected every queued cast and the
+                    -- bar stayed dropped for the rest of combat. The newer-start check
+                    -- still stops an off-GCD spell from restarting the running GCD: it
+                    -- reads the SAME start, so actualStart is not newer. The remaining
+                    -- check just skips an already-finished GCD.
+                    if (dur - elapsed) > 0.05 and ((not self._gcdActualStart) or actualStart > (self._gcdActualStart + 0.05)) then
                         self._gcdActualStart = actualStart
                         -- Fill starts visually at 0 fills over the time remaining
                         -- (Using the true start would open the bar at the
@@ -5851,6 +5864,7 @@ UpdateGCDBar = function(_dt)
 
     if g.instanceOnly and not IsInInstance() then
         bar:SetValue(0)
+        gcdBarFrame._barActive = nil
         EllesmereUI.SetElementVisibility(gcdBarFrame, false)
         return
     end
@@ -5872,7 +5886,9 @@ UpdateGCDBar = function(_dt)
 
     if not active then
         -- No GCD running: empty, and invisible unless Always Show is on.
+        -- (In deplete mode "empty" = depleted, which is the right idle state.)
         bar:SetValue(0)
+        gcdBarFrame._barActive = nil
         local visible = false
         if g.alwaysShow then visible = true end
         EllesmereUI.SetElementVisibility(gcdBarFrame, visible)
@@ -5880,7 +5896,18 @@ UpdateGCDBar = function(_dt)
     end
 
     EllesmereUI.SetElementVisibility(gcdBarFrame, true)
-    bar:SetValue(elapsed / dur, bar._castInterp)
+    -- Deplete mode starts full (1) and drains to empty (0); normal mode fills 0->1.
+    local progress = elapsed / dur
+    local value = g.depleteFill and (1 - progress) or progress
+    if gcdBarFrame._barActive then
+        bar:SetValue(value, bar._castInterp)
+    else
+        -- First frame of a fresh GCD: snap to the start value (no interpolation).
+        -- Otherwise deplete mode would briefly ease UP from the empty idle state
+        -- before reversing, flashing a fill at the start of every GCD.
+        bar:SetValue(value)
+        gcdBarFrame._barActive = true
+    end
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Bug

The GCD bar drops out while spamming abilities in combat and **stays gone** for the rest of the fight (e.g. disappears around the 6th–8th cast, never returns until you stop).

Bug report: https://discord.com/channels/585577383847788554/1520554339482075176

## Cause

`captureGCD` only (re)started the bar when the GCD read as "freshly started" — `elapsed < 0.3s`. While spamming, the next ability is queued and its `UNIT_SPELLCAST_SUCCEEDED` lands **partway into** the fresh GCD, so the read shows it already 0.4–0.7s elapsed. That tripped the `< 0.3` gate, so every queued cast was rejected and the bar never re-armed.

Confirmed in-game with a temporary diagnostic: the cooldown reads were **clean (not secret)**, with `elapsed ≈ 0.44s` (range 0.39–0.66) and `bar=nil` on every spammed cast.

## Fix

Re-arm whenever the read is a genuinely **newer GCD** than the last captured one (`actualStart > _gcdActualStart`), instead of gating on how far it has elapsed:

- **Latency / spell-queue independent** — it keys off the GCD's *start identity*, not timing, so it can't be defeated by queue window or network jitter.
- **Still rejects off-GCD abilities** — those read the *same* running GCD, so the start isn't newer.
- A small remaining-time check (`dur - elapsed > 0.05`) just skips an already-finished GCD.

Also keep the bar if a stop-event cooldown read fails (defensive), and the bar fills over the *remaining* GCD time when captured mid-GCD, so it stays accurate.

## New option: Deplete Fill

Adds a **Deplete Fill** toggle (default off) that starts the bar full and drains it as the GCD elapses, instead of filling up. Snaps to the start value on the first frame of a fresh GCD so deplete mode doesn't briefly ease up from the idle (empty) state.

## Notes

- `Locales/_keys.txt` regenerated — no change (these option strings aren't extracted keys, same as "Show Spark").
- Rebased on current `main`. `luac -p` clean.
- Supersedes the closed draft #494 (a larger rework on `bugfix/gcd-bar`); this is the minimal-change approach.
