### PR TITLE
Fix Hide Items if Missing keeping cross-linked healthstones visible

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -415,7 +415,6 @@ local CDM_ITEM_PRESETS = {
         icon     = 538745,
         itemID   = 5512,
         spellID  = 6262,
-        altItemIDs = { 224464 },
         combatLockout = true,
     },
     {
@@ -423,7 +422,6 @@ local CDM_ITEM_PRESETS = {
         name     = "Demonic Healthstone",
         itemID   = 224464,
         spellID  = 452930,
-        altItemIDs = { 5512 },
         combatLockout = true,
     },
 }


### PR DESCRIPTION
## Summary
Fixes a bug where a Cooldown Manager item button with **Hide Items if Missing** enabled stayed visible (and showed a count) when you had none of that item, as long as you carried the other healthstone variant.

## Cause
The `Healthstone` (5512) and `Demonic Healthstone` (224464) presets listed each other in `altItemIDs`. The presence/count check falls back to summing `altItemIDs` when the primary item count is zero, so e.g. a Demonic Healthstone button counted your normal Healthstones and never hid.

`altItemIDs` is meant for quality/rank variants of the *same* item (like the crafted potion ranks), but these two are different items chosen via talent, not ranks of one item.

## Fix
Removed the cross-`altItemIDs` from both healthstone presets so each button tracks only its own item. Cooldown detection still works per button (healthstones share an internal cooldown that `GetItemCooldown` reports on either item), so nothing else changes.

## Testing
With Hide Items if Missing on and only normal Healthstones in bags, the Demonic Healthstone button now correctly hides; and vice-versa. Each button's count reflects only its own item