### PR TITLE
Fix CDM custom-frame tooltips with Anchor to Cursor

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -1444,6 +1444,20 @@ do
         return cursorFrame
     end
 
+    -- Show + position the tracking frame at the pointer right now. The OnUpdate
+    -- alone only repositions it on the NEXT frame, so a tooltip anchored to it
+    -- and shown synchronously this frame (as the custom CDM frames do) would have
+    -- no valid rect yet -- and nothing renders.
+    local function PositionCursorFrameNow(cf)
+        cf:Show()
+        local scale = UIParent:GetEffectiveScale()
+        if scale > 0 then
+            local x, y = GetCursorPosition()
+            cf:ClearAllPoints()
+            cf:SetPoint("CENTER", UIParent, "BOTTOMLEFT", x / scale, y / scale)
+        end
+    end
+
     local function ApplyCursorAnchor(tooltip, parent)
         if tooltip ~= GameTooltip then return end
         -- Gated by the "Reskin Tooltip" master (matches the grayed-out option), so
@@ -1461,9 +1475,32 @@ do
             return
         end
         local cf = EnsureCursorFrame()
-        cf:Show()
+        PositionCursorFrameNow(cf)
         local point = POINT_FOR_POS[EllesmereUIDB.tooltipCursorPosition or "top"] or "BOTTOM"
         tooltip:SetOwner(parent, "ANCHOR_NONE")
+        tooltip:ClearAllPoints()
+        tooltip:SetPoint(point, cf, "CENTER",
+            EllesmereUIDB.tooltipCursorOffsetX or 0,
+            EllesmereUIDB.tooltipCursorOffsetY or 0)
+    end
+
+    -- Re-assert the cursor anchor on GameTooltip WITHOUT re-owning it (SetOwner
+    -- would wipe the content). A custom frame whose tooltip content-setter
+    -- (e.g. SetItemByID) clears/hides the tip mid-build can fire GameTooltip's
+    -- OnHide -- which hides the tracking frame -- leaving the tip anchored to a
+    -- hidden/unpositioned frame so it never appears. Calling this AFTER the
+    -- content is set (and before Show) re-shows + repositions the tracking frame
+    -- and re-points the tooltip so it reliably renders at the cursor. No-op when
+    -- the cursor anchor (or the reskin master) is off, so callers can call it
+    -- unconditionally.
+    EllesmereUI._repointTooltipAtCursor = function(tooltip)
+        if tooltip ~= GameTooltip then return end
+        if EllesmereUIDB and EllesmereUIDB.customTooltips == false then return end
+        if not (EllesmereUIDB and EllesmereUIDB.tooltipAnchorCursor) then return end
+        if tooltip:IsForbidden() then return end
+        local cf = EnsureCursorFrame()
+        PositionCursorFrameNow(cf)
+        local point = POINT_FOR_POS[EllesmereUIDB.tooltipCursorPosition or "top"] or "BOTTOM"
         tooltip:ClearAllPoints()
         tooltip:SetPoint(point, cf, "CENTER",
             EllesmereUIDB.tooltipCursorOffsetX or 0,

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2047,11 +2047,26 @@ local function GetOrCreateTrinketFrame(slotID)
         local itemID = GetInventoryItemID("player", self._trinketSlot)
         if itemID then
             GameTooltip_SetDefaultAnchor(GameTooltip, self)
-            -- Use SetItemByID rather than SetInventoryItem: on an equipped item the
-            -- latter triggers Blizzard's item-comparison (shopping tooltip) anchoring,
-            -- which misbehaves under the cursor anchor. SetItemByID shows the same
-            -- trinket tooltip and matches the item-preset (potion/healthstone) frames.
-            GameTooltip:SetItemByID(itemID)
+            -- Prefer the equipped item's link so the tooltip reflects the actual
+            -- upgrade/bonus IDs (real item level + stats) rather than the base item.
+            -- SetItemByID is only a fallback if no link is available.
+            local link = GetInventoryItemLink("player", self._trinketSlot)
+            if link then
+                -- Suppress the equipped-item comparison (shopping) tooltips: this is
+                -- our own already-equipped trinket, so a side-by-side compare is just
+                -- noise. Temporarily disable auto-compare while the tooltip is built,
+                -- then restore the user's setting.
+                local prevCompare = GetCVar("alwaysCompareItems")
+                if prevCompare and prevCompare ~= "0" then
+                    SetCVar("alwaysCompareItems", "0")
+                end
+                GameTooltip:SetHyperlink(link)
+                if prevCompare and prevCompare ~= "0" then
+                    SetCVar("alwaysCompareItems", prevCompare)
+                end
+            else
+                GameTooltip:SetItemByID(itemID)
+            end
             -- Re-assert the cursor anchor after content is set (see helper notes):
             -- the item content-setter can drop the tip's cursor anchor, so without
             -- this it never appears while "Anchor to Cursor" is on. No-op otherwise.
@@ -2059,6 +2074,11 @@ local function GetOrCreateTrinketFrame(slotID)
                 EllesmereUI._repointTooltipAtCursor(GameTooltip)
             end
             GameTooltip:Show()
+            -- Belt-and-suspenders: hide any comparison tooltips that still slipped
+            -- through (e.g. when the compare modifier key is held down).
+            if GameTooltip_HideShoppingTooltips then
+                GameTooltip_HideShoppingTooltips(GameTooltip)
+            end
         end
     end)
     f:SetScript("OnLeave", GameTooltip_Hide)

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2039,10 +2039,26 @@ local function GetOrCreateTrinketFrame(slotID)
         local ffc = _ecmeFC[self]
         local bd2 = ffc and ffc.barKey and barDataByKey[ffc.barKey]
         if not bd2 or not bd2.showTooltip then return end
+        -- Honor the global "Show Tooltips" visibility mode (Blizzard Skin); a
+        -- custom frame's explicit content population would otherwise re-show the
+        -- tip after the global suppression hook hid it.
+        if EllesmereUI and EllesmereUI._tooltipSuppressedByMode
+           and EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
         local itemID = GetInventoryItemID("player", self._trinketSlot)
         if itemID then
             GameTooltip_SetDefaultAnchor(GameTooltip, self)
-            GameTooltip:SetInventoryItem("player", self._trinketSlot)
+            -- Use SetItemByID rather than SetInventoryItem: on an equipped item the
+            -- latter triggers Blizzard's item-comparison (shopping tooltip) anchoring,
+            -- which misbehaves under the cursor anchor. SetItemByID shows the same
+            -- trinket tooltip and matches the item-preset (potion/healthstone) frames.
+            GameTooltip:SetItemByID(itemID)
+            -- Re-assert the cursor anchor after content is set (see helper notes):
+            -- the item content-setter can drop the tip's cursor anchor, so without
+            -- this it never appears while "Anchor to Cursor" is on. No-op otherwise.
+            if EllesmereUI and EllesmereUI._repointTooltipAtCursor then
+                EllesmereUI._repointTooltipAtCursor(GameTooltip)
+            end
+            GameTooltip:Show()
         end
     end)
     f:SetScript("OnLeave", GameTooltip_Hide)
@@ -2253,8 +2269,14 @@ local function GetOrCreatePlaceholderFrame(barKey, spellID, iconID)
             local bd2 = ffc and ffc.barKey and barDataByKey[ffc.barKey]
             if not bd2 or not bd2.showTooltip then return end
             if not self._phSpellID then return end
+            -- Honor the global "Show Tooltips" visibility mode (Blizzard Skin).
+            if EllesmereUI and EllesmereUI._tooltipSuppressedByMode
+               and EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
             GameTooltip_SetDefaultAnchor(GameTooltip, self)
             GameTooltip:SetSpellByID(self._phSpellID)
+            if EllesmereUI and EllesmereUI._repointTooltipAtCursor then
+                EllesmereUI._repointTooltipAtCursor(GameTooltip)
+            end
             GameTooltip:Show()
         end)
         f:SetScript("OnLeave", GameTooltip_Hide)
@@ -2354,8 +2376,16 @@ local function GetOrCreateItemPresetFrame(barKey, itemID)
         local ffc = _ecmeFC[self]
         local bd2 = ffc and ffc.barKey and barDataByKey[ffc.barKey]
         if not bd2 or not bd2.showTooltip then return end
+        -- Honor the global "Show Tooltips" visibility mode (Blizzard Skin).
+        if EllesmereUI and EllesmereUI._tooltipSuppressedByMode
+           and EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
         GameTooltip_SetDefaultAnchor(GameTooltip, self)
         GameTooltip:SetItemByID(self._presetItemID)
+        -- Re-assert the cursor anchor after content is set (item setters can drop
+        -- it under "Anchor to Cursor", leaving the tip invisible). No-op otherwise.
+        if EllesmereUI and EllesmereUI._repointTooltipAtCursor then
+            EllesmereUI._repointTooltipAtCursor(GameTooltip)
+        end
         GameTooltip:Show()
     end)
     f:SetScript("OnLeave", GameTooltip_Hide)
@@ -3553,9 +3583,18 @@ local function CollectAndReanchor()
                                             local spid = ffc and ffc.spellID
                                             local bd2 = ffc and ffc.barKey and barDataByKey[ffc.barKey]
                                             if not bd2 or not bd2.showTooltip then return end
+                                            -- Honor the global "Show Tooltips" mode (Blizzard Skin).
+                                            if EllesmereUI and EllesmereUI._tooltipSuppressedByMode
+                                               and EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
                                             if spid and spid > 0 then
                                                 GameTooltip_SetDefaultAnchor(GameTooltip, self)
                                                 GameTooltip:SetSpellByID(spid)
+                                                if EllesmereUI and EllesmereUI._repointTooltipAtCursor then
+                                                    EllesmereUI._repointTooltipAtCursor(GameTooltip)
+                                                end
+                                                -- Explicit Show(): needed when "Anchor to Cursor"
+                                                -- re-owns the tooltip to ANCHOR_NONE (see trinket).
+                                                GameTooltip:Show()
                                             end
                                         end)
                                         f:SetScript("OnLeave", GameTooltip_Hide)


### PR DESCRIPTION
## Summary

Follow-up fix to PR #512. The custom Cooldown Manager frames (Trinket Slot 1, racial/placeholder, item presets, and custom spells) did not behave correctly with the **Tooltip → Anchor to Cursor** option:

- Their tooltips bypassed the global **Show Tooltips** mode (showing/hiding inverse to the setting, e.g. visible on "Never" and hidden on "Always").
- With "Anchor to Cursor" enabled, the trinket tooltip frequently failed to render at all because `SetInventoryItem`/`SetItemByID` do not auto-show under `ANCHOR_NONE`, and the cursor-tracking frame was not yet positioned when content was set synchronously.

## Changes

**EllesmereUIBlizzardSkin**
- Added `PositionCursorFrameNow` to immediately position the cursor-tracking frame when shown/repointed (instead of waiting for the next `OnUpdate`).
- Exposed `EllesmereUI._repointTooltipAtCursor(tooltip)` so custom frames can reliably re-anchor `GameTooltip` to the cursor after setting content.

**EllesmereUICooldownManager (CdmHooks)**
- All four custom CDM frame `OnEnter` handlers now respect `EllesmereUI._tooltipSuppressedByMode` so they honor the global Show Tooltips setting.
- Trinket frame now uses `SetItemByID` (avoids equipped-item comparison conflicts with `ANCHOR_NONE`).
- Added explicit `GameTooltip:Show()` where missing and a call to `_repointTooltipAtCursor` after setting content so the tooltip reliably renders at the cursor.

## Test plan
- [x] Show Tooltips = Always, Anchor to Cursor ON → all CDM icons (incl. Trinket Slot 1) show tooltips at cursor
- [x] Show Tooltips = Never → no CDM tooltips appear
- [x] Show Tooltips = Out of Combat → CDM tooltips suppressed in combat, shown out of combat
- [x] Anchor to Cursor OFF → tooltips still behave correctly for all CDM icons
