### PR TITLE
CDM trinket: drop CVar toggle, use HideShoppingTooltips only

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2052,18 +2052,7 @@ local function GetOrCreateTrinketFrame(slotID)
             -- SetItemByID is only a fallback if no link is available.
             local link = GetInventoryItemLink("player", self._trinketSlot)
             if link then
-                -- Suppress the equipped-item comparison (shopping) tooltips: this is
-                -- our own already-equipped trinket, so a side-by-side compare is just
-                -- noise. Temporarily disable auto-compare while the tooltip is built,
-                -- then restore the user's setting.
-                local prevCompare = GetCVar("alwaysCompareItems")
-                if prevCompare and prevCompare ~= "0" then
-                    SetCVar("alwaysCompareItems", "0")
-                end
                 GameTooltip:SetHyperlink(link)
-                if prevCompare and prevCompare ~= "0" then
-                    SetCVar("alwaysCompareItems", prevCompare)
-                end
             else
                 GameTooltip:SetItemByID(itemID)
             end
@@ -2074,8 +2063,8 @@ local function GetOrCreateTrinketFrame(slotID)
                 EllesmereUI._repointTooltipAtCursor(GameTooltip)
             end
             GameTooltip:Show()
-            -- Belt-and-suspenders: hide any comparison tooltips that still slipped
-            -- through (e.g. when the compare modifier key is held down).
+            -- This is the player's own already-equipped trinket, so the side-by-side
+            -- equipped-item comparison is just noise -- hide the shopping tooltips.
             if GameTooltip_HideShoppingTooltips then
                 GameTooltip_HideShoppingTooltips(GameTooltip)
             end


### PR DESCRIPTION
## Summary

Follow-up to #515. The CDM trinket tooltip previously suppressed the equipped-item comparison (shopping) tooltips by temporarily flipping the `alwaysCompareItems` CVar on the user's behalf. Per review feedback (avoid setting CVars for users), this drops the CVar toggle entirely and relies solely on `GameTooltip_HideShoppingTooltips` to hide the comparison for the player's own equipped trinket.

## Changes

- Removed the `GetCVar`/`SetCVar("alwaysCompareItems")` save/disable/restore blocks around `SetHyperlink` in the trinket frame `OnEnter` handler.
- Keep `GameTooltip_HideShoppingTooltips(GameTooltip)` after `Show()` to hide the comparison tooltips.

## Test plan
- [x] Hover CDM Trinket Slot 1/2 → equipped trinket tooltip shows real item level/stats, no comparison tooltip
- [x] Anchor to Cursor ON and OFF both behave correctly
- [x] `alwaysCompareItems` CVar is left untouched (normal item comparisons elsewhere unaffected)
