### PR TITLE
Bags: localize bag & bank window strings via EllesmereUI.L()

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -643,7 +643,7 @@ local function CreateHeader()
     header.title = header:CreateFontString(nil, "OVERLAY")
     SetBagFont(header.title, 13)
     header.title:SetPoint("LEFT", header, "LEFT", 8, 0)
-    header.title:SetText("Inventory")
+    header.title:SetText(EllesmereUI.L("Inventory"))
     header.title:SetTextColor(1, 1, 1)
 
     -- Item count (updated by RefreshInventory)
@@ -667,7 +667,7 @@ local function CreateHeader()
     local placeholder = search:CreateFontString(nil, "OVERLAY")
     SetBagFont(placeholder, 11)
     placeholder:SetPoint("LEFT", search, "LEFT", 5, 0)
-    placeholder:SetText("Search...")
+    placeholder:SetText(EllesmereUI.L("Search..."))
     placeholder:SetTextColor(0.4, 0.4, 0.4)
     EUI_Bags._searchBox = search
 
@@ -1418,13 +1418,13 @@ local function GetGoldTooltip()
     title:SetFont("Fonts\\FRIZQT__.TTF", 11, "")
     title:SetTextColor(0.80, 0.80, 0.80, 1)
     title:SetPoint("TOP", f, "TOP", 0, -GOLD_PAD)
-    title:SetText("Gold Summary")
+    title:SetText(EllesmereUI.L("Gold Summary"))
     f._title = title
 
     local hint = f:CreateFontString(nil, "OVERLAY")
     hint:SetFont("Fonts\\FRIZQT__.TTF", 10, "")
     hint:SetTextColor(1, 0.4, 0.4, 1)
-    hint:SetText("Ctrl + Right-Click: Reset all data")
+    hint:SetText(EllesmereUI.L("Ctrl + Right-Click: Reset all data"))
     f._hint = hint
 
     _goldTT = f
@@ -1508,7 +1508,7 @@ local function ShowGoldTooltip(anchor)
     if warbandGold then
         local nameFS = _goldTTRows[totalRow][0]
         local goldFS = _goldTTRows[totalRow][1]
-        nameFS:SetText("|cffffcc80Warbank|r")
+        nameFS:SetText("|cffffcc80" .. EllesmereUI.L("Warbank") .. "|r")
         goldFS:SetText(FormatGoldOnly(warbandGold))
         goldFS:SetTextColor(WARBANK_GOLD_R, WARBANK_GOLD_G, WARBANK_GOLD_B, 1)
         nameFS:Show(); goldFS:Show()
@@ -1521,7 +1521,7 @@ local function ShowGoldTooltip(anchor)
 
     local totalNameFS = _goldTTRows[totalRow][0]
     local totalGoldFS = _goldTTRows[totalRow][1]
-    totalNameFS:SetText("|cffffcc80Total|r")
+    totalNameFS:SetText("|cffffcc80" .. EllesmereUI.L("Total") .. "|r")
     totalGoldFS:SetText(FormatGoldOnly(totalGold))
     totalGoldFS:SetTextColor(1, 1, 0.5, 1)
     totalNameFS:Show(); totalGoldFS:Show()
@@ -1753,7 +1753,7 @@ local function CreateReagentBagUI()
     header.title = header:CreateFontString(nil, "OVERLAY")
     SetBagFont(header.title, 13)
     header.title:SetPoint("LEFT", 15, 0)
-    header.title:SetText("REAGENTS")
+    header.title:SetText(EllesmereUI.L("REAGENTS"))
     header.title:SetTextColor(1, 1, 1)
     local close = CreateFrame("Button", nil, header)
     close:SetSize(20, 20)
@@ -3636,7 +3636,7 @@ local function CreateSidebar()
     sidebarHdr._label = sidebarHdr:CreateFontString(nil, "OVERLAY")
     SetBagFont(sidebarHdr._label, 10)
     sidebarHdr._label:SetPoint("LEFT", sidebarHdr, "LEFT", 8, 0)
-    sidebarHdr._label:SetText("Categories")
+    sidebarHdr._label:SetText(EllesmereUI.L("Categories"))
     sidebarHdr._label:SetTextColor(0.5, 0.5, 0.5)
 
     local ARROW_ICON = "Interface\\AddOns\\EllesmereUI\\media\\icons\\eui-arrow-left.png"
@@ -3864,9 +3864,9 @@ local function BuildSidebarButtons(categoryCounts, totalCount)
     -- Three fixed views (All Items / OneBag / MultiBag), the configured default
     -- type first, then the rest in canonical order.
     local _fixedViews = {
-        all      = { catIdx = 0,  name = "All Items", icon = 133633, count = totalCount },
-        onebag   = { catIdx = -1, name = "OneBag",    icon = 133634, count = totalCount },
-        multibag = { catIdx = -2, name = "MultiBag",  icon = 133635, count = totalCount },
+        all      = { catIdx = 0,  name = EllesmereUI.L("All Items"), icon = 133633, count = totalCount },
+        onebag   = { catIdx = -1, name = EllesmereUI.L("OneBag"),    icon = 133634, count = totalCount },
+        multibag = { catIdx = -2, name = EllesmereUI.L("MultiBag"),  icon = 133635, count = totalCount },
     }
     local _dbt = GetDefaultBagType()
     displayList[#displayList + 1] = _fixedViews[_dbt] or _fixedViews.all
@@ -4182,7 +4182,7 @@ local function BuildSidebarButtons(categoryCounts, totalCount)
             btn._label:SetWordWrap(false)
             btn._label:SetPoint("LEFT", btn._icon, "RIGHT", 6, 0)
             btn._label:SetPoint("RIGHT", btn, "RIGHT", -6, 0)
-            btn._label:SetText("Add Category")
+            btn._label:SetText(EllesmereUI.L("Add Category"))
             btn._label:SetTextColor(1, 1, 1, 0.4)
             btn:SetScript("OnEnter", function(self)
                 self._bg:SetColorTexture(1, 1, 1, 0.06)
@@ -4213,7 +4213,7 @@ local function BuildSidebarButtons(categoryCounts, totalCount)
                     SetBagFont(title, 13)
                     title:SetPoint("TOPLEFT", popup, "TOPLEFT", 10, -10)
                     title:SetTextColor(1, 1, 1, 0.9)
-                    title:SetText("New Custom Category")
+                    title:SetText(EllesmereUI.L("New Custom Category"))
 
                     -- Name editbox
                     local eb = CreateFrame("EditBox", nil, popup)
@@ -4237,7 +4237,7 @@ local function BuildSidebarButtons(categoryCounts, totalCount)
                     SetBagFont(iconLbl, 11)
                     iconLbl:SetPoint("TOPLEFT", eb, "BOTTOMLEFT", 0, -8)
                     iconLbl:SetTextColor(0.7, 0.7, 0.7, 1)
-                    iconLbl:SetText("Icon:")
+                    iconLbl:SetText(EllesmereUI.L("Icon:"))
 
                     -- Icon grid (placeholder IDs -- replace with real set)
                     local ICON_IDS = {
@@ -4318,7 +4318,7 @@ local function BuildSidebarButtons(categoryCounts, totalCount)
                     SetBagFont(customLbl, 11)
                     customLbl:SetPoint("TOPLEFT", iconLbl, "BOTTOMLEFT", 0, -(4 + lastRow * (ICON_SZ + ICON_PAD) + 6))
                     customLbl:SetTextColor(0.7, 0.7, 0.7, 1)
-                    customLbl:SetText("Custom Icon ID:")
+                    customLbl:SetText(EllesmereUI.L("Custom Icon ID:"))
 
                     -- Preview icon to the left of the editbox
                     local preview = CreateFrame("Frame", nil, popup)
@@ -4385,7 +4385,7 @@ local function BuildSidebarButtons(categoryCounts, totalCount)
                     SetBagFont(cBtnLbl, 12)
                     cBtnLbl:SetPoint("CENTER")
                     cBtnLbl:SetTextColor(1, 1, 1, 0.9)
-                    cBtnLbl:SetText("Create")
+                    cBtnLbl:SetText(EllesmereUI.L("Create"))
                     createBtn:SetScript("OnEnter", function() cBtnBg:SetColorTexture(0.2, 0.2, 0.2, 1) end)
                     createBtn:SetScript("OnLeave", function() cBtnBg:SetColorTexture(0.15, 0.15, 0.15, 1) end)
                     -- Red flash validation for empty fields
@@ -5137,7 +5137,7 @@ function EUI_Bags:RefreshInventory()
             pinHdr:SetPoint("TOPLEFT", child, "TOPLEFT", startX, curY)
             pinHdr:SetWidth(columns * (SLOT_SIZE + SPACING))
             local showTips = BP().bagShowPinRecentTips ~= false
-            pinHdr._label:SetText("Pinned Items")
+            pinHdr._label:SetText(EllesmereUI.L("Pinned Items"))
             pinHdr._hint:SetText(showTips and "(Middle Click to Add or Remove)" or "")
             if not pinHdr._hideBtn then
                 local hb = CreateFrame("Button", nil, pinHdr)
@@ -5145,7 +5145,7 @@ function EUI_Bags:RefreshInventory()
                 hb._fs = hb:CreateFontString(nil, "OVERLAY")
                 SetBagFont(hb._fs, 9)
                 hb._fs:SetAllPoints()
-                hb._fs:SetText("Hide")
+                hb._fs:SetText(EllesmereUI.L("Hide"))
                 hb._fs:SetTextColor(0.5, 0.5, 0.5, 0.7)
                 hb:SetScript("OnEnter", function(self)
                     self._fs:SetTextColor(1, 1, 1, 0.9)
@@ -5227,7 +5227,7 @@ function EUI_Bags:RefreshInventory()
             recHdr:SetPoint("TOPLEFT", child, "TOPLEFT", startX, curY)
             recHdr:SetWidth(columns * (SLOT_SIZE + SPACING))
             local showTips = BP().bagShowPinRecentTips ~= false
-            recHdr._label:SetText("Recent Items")
+            recHdr._label:SetText(EllesmereUI.L("Recent Items"))
             recHdr._hint:SetText(showTips and "(Extra quickview display, your items are also in their category)" or "")
             if not recHdr._hideBtn then
                 local hb = CreateFrame("Button", nil, recHdr)
@@ -5235,7 +5235,7 @@ function EUI_Bags:RefreshInventory()
                 hb._fs = hb:CreateFontString(nil, "OVERLAY")
                 SetBagFont(hb._fs, 9)
                 hb._fs:SetAllPoints()
-                hb._fs:SetText("Hide")
+                hb._fs:SetText(EllesmereUI.L("Hide"))
                 hb._fs:SetTextColor(0.5, 0.5, 0.5, 0.7)
                 hb:SetScript("OnEnter", function(self)
                     self._fs:SetTextColor(1, 1, 1, 0.9)
@@ -5324,14 +5324,14 @@ function EUI_Bags:RefreshInventory()
                 if a.bag ~= b.bag then return a.bag < b.bag end
                 return a.slot < b.slot
             end)
-            RenderBagGrid("Main Bags (" .. mainFilled .. " / " .. #mainSlots .. ")", mainSlots)
+            RenderBagGrid(EllesmereUI.Lf("Main Bags (%d / %d)", mainFilled, #mainSlots), mainSlots)
         else
             -- MultiBag: one section per equipped bag (0-4)
             local function BagDisplayName(bag)
-                if bag == 0 then return "Backpack" end
+                if bag == 0 then return EllesmereUI.L("Backpack") end
                 local invID = C_Container.ContainerIDToInventoryID(bag)
                 local link = invID and GetInventoryItemLink("player", invID)
-                return (link and GetItemInfo(link)) or ("Bag " .. bag)
+                return (link and GetItemInfo(link)) or EllesmereUI.Lf("Bag %d", bag)
             end
             for bag = 0, 4 do
                 local bagList = {}
@@ -5368,7 +5368,7 @@ function EUI_Bags:RefreshInventory()
             reagHdr:SetWidth(columns * (SLOT_SIZE + SPACING))
             local reagFilled = 0
             for _, d in ipairs(reagentSlotList) do if d.info then reagFilled = reagFilled + 1 end end
-            reagHdr._label:SetText("Reagent Bag (" .. reagFilled .. " / " .. #reagentSlotList .. ")")
+            reagHdr._label:SetText(EllesmereUI.Lf("Reagent Bag (%d / %d)", reagFilled, #reagentSlotList))
             reagHdr:Show()
             curY = curY - 22
 
@@ -5463,10 +5463,10 @@ function EUI_Bags:RefreshInventory()
             local showTips = BP().bagShowPinRecentTips ~= false
             if showPinAdd and showTips then
                 hdr._label:SetText(sectionName)
-                hdr._hint:SetText("(Middle Click to Add or Remove)")
+                hdr._hint:SetText(EllesmereUI.L("(Middle Click to Add or Remove)"))
             elseif alwaysShow and showTips then
                 hdr._label:SetText(sectionName)
-                hdr._hint:SetText("(Extra quickview display, your items are also in their category)")
+                hdr._hint:SetText(EllesmereUI.L("(Extra quickview display, your items are also in their category)"))
             else
                 hdr._label:SetText(sectionName .. " (" .. itemCount .. ")")
                 hdr._hint:SetText("")
@@ -5479,7 +5479,7 @@ function EUI_Bags:RefreshInventory()
                     hb._fs = hb:CreateFontString(nil, "OVERLAY")
                     SetBagFont(hb._fs, 9)
                     hb._fs:SetAllPoints()
-                    hb._fs:SetText("Hide")
+                    hb._fs:SetText(EllesmereUI.L("Hide"))
                     hb._fs:SetTextColor(0.5, 0.5, 0.5, 0.7)
                     hb:SetScript("OnEnter", function(self)
                         self._fs:SetTextColor(1, 1, 1, 0.9)
@@ -5671,7 +5671,7 @@ function EUI_Bags:RefreshInventory()
                         end
                     end
                     if #recentItems > 0 then recentItems = MergeDuplicates(recentItems) end
-                    RenderSection("Recent Items", recentItems, false, false, true)
+                    RenderSection(EllesmereUI.L("Recent Items"), recentItems, false, false, true)
                 end
             elseif cat.groupName then
                 if not renderedGroups[cat.groupName] then
@@ -5814,7 +5814,7 @@ function EUI_Bags:RefreshInventory()
                     delBtn._fs = delBtn:CreateFontString(nil, "OVERLAY")
                     SetBagFont(delBtn._fs, 10)
                     delBtn._fs:SetPoint("RIGHT", ef, "RIGHT", 0, 0)
-                    delBtn._fs:SetText("Delete")
+                    delBtn._fs:SetText(EllesmereUI.L("Delete"))
                     delBtn._fs:SetTextColor(0.5, 0.5, 0.5, 0.7)
                     delBtn:SetWidth(delBtn._fs:GetStringWidth() + 4)
                     delBtn:SetAllPoints(delBtn._fs)
@@ -5851,7 +5851,7 @@ function EUI_Bags:RefreshInventory()
                     editBtn._fs = editBtn:CreateFontString(nil, "OVERLAY")
                     SetBagFont(editBtn._fs, 10)
                     editBtn._fs:SetPoint("RIGHT", divider, "LEFT", -6, 0)
-                    editBtn._fs:SetText("Edit")
+                    editBtn._fs:SetText(EllesmereUI.L("Edit"))
                     editBtn._fs:SetTextColor(0.5, 0.5, 0.5, 0.7)
                     editBtn:SetWidth(editBtn._fs:GetStringWidth() + 4)
                     editBtn:SetAllPoints(editBtn._fs)
@@ -5904,10 +5904,10 @@ function EUI_Bags:RefreshInventory()
                 local showTips = BP().bagShowPinRecentTips ~= false
                 if selCat and selCat.isPinned and showTips then
                     hdr._label:SetText(headerName)
-                    hdr._hint:SetText("(Middle Click to Add or Remove)")
+                    hdr._hint:SetText(EllesmereUI.L("(Middle Click to Add or Remove)"))
                 elseif selCat and selCat.isRecent and showTips then
                     hdr._label:SetText(headerName)
-                    hdr._hint:SetText("(Extra quickview display, your items are also in their category)")
+                    hdr._hint:SetText(EllesmereUI.L("(Extra quickview display, your items are also in their category)"))
                 else
                     hdr._label:SetText(headerName .. " (" .. #displayItems .. ")")
                     hdr._hint:SetText("")
@@ -5995,9 +5995,9 @@ function EUI_Bags:RefreshInventory()
     if EUI_Bags.Header and EUI_Bags.Header.itemCount then
         if selectedCategoryIndex == 0 or selectedCategoryIndex == -1 or selectedCategoryIndex == -2 then
             local totalSlots = totalCount + #emptySlots
-            EUI_Bags.Header.itemCount:SetText(totalCount .. " / " .. totalSlots .. " Items")
+            EUI_Bags.Header.itemCount:SetText(EllesmereUI.Lf("%d / %d Items", totalCount, totalSlots))
         else
-            EUI_Bags.Header.itemCount:SetText(totalCount .. " Items")
+            EUI_Bags.Header.itemCount:SetText(EllesmereUI.Lf("%d Items", totalCount))
         end
     end
 

--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -226,7 +226,7 @@ local title = header:CreateFontString(nil, "OVERLAY")
 SetBankFont(title, 13)
 title:SetPoint("LEFT", header, "LEFT", 8, 0)
 title:SetTextColor(1, 1, 1)
-title:SetText("Bank")
+title:SetText(EllesmereUI.L("Bank"))
 
 local itemCount = header:CreateFontString(nil, "OVERLAY")
 SetBankFont(itemCount, 11)
@@ -249,7 +249,7 @@ if EUI and EUI.PanelPP then EUI.PanelPP.CreateBorder(bankSearch, 0.25, 0.25, 0.2
 local searchPlaceholder = bankSearch:CreateFontString(nil, "OVERLAY")
 SetBankFont(searchPlaceholder, 11)
 searchPlaceholder:SetPoint("LEFT", bankSearch, "LEFT", 5, 0)
-searchPlaceholder:SetText("Search...")
+searchPlaceholder:SetText(EllesmereUI.L("Search..."))
 searchPlaceholder:SetTextColor(0.4, 0.4, 0.4)
 EUI_Bank._searchBox = bankSearch
 
@@ -438,14 +438,14 @@ do
         local lbl = btn:CreateFontString(nil, "OVERLAY")
         SetBankFont(lbl, 9)
         lbl:SetPoint("CENTER", btn, "CENTER", 0, 0)
-        lbl:SetText(label)
+        lbl:SetText(EllesmereUI.L(label))
         lbl:SetTextColor(GOLD_R, GOLD_G, GOLD_B, 0.8)
         btn._label = lbl
 
         btn:SetScript("OnEnter", function(self)
             self._label:SetTextColor(GOLD_R, GOLD_G, GOLD_B, 1)
             if PP and PP.SetBorderColor then PP.SetBorderColor(self, GOLD_R, GOLD_G, GOLD_B, 1) end
-            if EUI.ShowWidgetTooltip then EUI.ShowWidgetTooltip(self, tooltipText) end
+            if EUI.ShowWidgetTooltip then EUI.ShowWidgetTooltip(self, EllesmereUI.L(tooltipText)) end
         end)
         btn:SetScript("OnLeave", function(self)
             self._label:SetTextColor(GOLD_R, GOLD_G, GOLD_B, 0.8)
@@ -463,8 +463,8 @@ do
     local function ShowMoneyPopup(title, onAccept)
         if not EUI.ShowInputPopup then return end
         EUI:ShowInputPopup({
-            title = title,
-            message = "Enter amount in gold:",
+            title = EllesmereUI.L(title),
+            message = EllesmereUI.L("Enter amount in gold:"),
             placeholder = "1137",
             confirmText = ACCEPT,
             cancelText = CANCEL,
@@ -531,10 +531,10 @@ do
 
     function EUI_Bank:UpdateDepositButton(isWarband)
         if isWarband then
-            depositItemsLabel:SetText("Deposit Warbound Items")
+            depositItemsLabel:SetText(EllesmereUI.L("Deposit Warbound Items"))
             depositItemsBtn._bankType = Enum.BankType.Account
         else
-            depositItemsLabel:SetText("Deposit Reagents")
+            depositItemsLabel:SetText(EllesmereUI.L("Deposit Reagents"))
             depositItemsBtn._bankType = Enum.BankType.Character
         end
         local r, g, b = GetAccentRGB()
@@ -623,7 +623,7 @@ sidebarHdr:SetPoint("TOPRIGHT", sidebar, "TOPRIGHT", 0, 0)
 sidebarHdr._label = sidebarHdr:CreateFontString(nil, "OVERLAY")
 SetBankFont(sidebarHdr._label, 10)
 sidebarHdr._label:SetPoint("LEFT", sidebarHdr, "LEFT", 8, 0)
-sidebarHdr._label:SetText("Tabs")
+sidebarHdr._label:SetText(EllesmereUI.L("Tabs"))
 sidebarHdr._label:SetTextColor(0.5, 0.5, 0.5)
 
 local ARROW_ICON = "Interface\\AddOns\\EllesmereUI\\media\\icons\\eui-arrow-left.png"
@@ -1715,7 +1715,7 @@ function BuildBankSidebar()
             btn._count:Hide()
         else
             btn._label:Show()
-            btn._label:SetText(label)
+            btn._label:SetText(EllesmereUI.L(label))
             btn._label:SetTextColor(1, 1, 1, 0.6)
             btn._count:Hide()
         end
@@ -1798,9 +1798,9 @@ function BuildBankSidebar()
     -- Update header item count
     if EUI_Bank._headerItemCount then
         if _warbandOnly then
-            EUI_Bank._headerItemCount:SetText(warbUsed .. " / " .. warbTotal .. " Items")
+            EUI_Bank._headerItemCount:SetText(EllesmereUI.Lf("%d / %d Items", warbUsed, warbTotal))
         else
-            EUI_Bank._headerItemCount:SetText((charUsed + warbUsed) .. " / " .. (charTotal + warbTotal) .. " Items")
+            EUI_Bank._headerItemCount:SetText(EllesmereUI.Lf("%d / %d Items", charUsed + warbUsed, charTotal + warbTotal))
         end
     end
 
@@ -1810,11 +1810,11 @@ function BuildBankSidebar()
     local defaultOneBag = BankDefaultsToOne()
     if not _warbandOnly then
         if defaultOneBag then
-            RenderSidebarEntry(-1, "OneBank", 1542860, charUsed, _selectedView == -1)
-            RenderSidebarEntry(0, "All Bank Tabs", 413587, charUsed, _selectedView == 0)
+            RenderSidebarEntry(-1, EllesmereUI.L("OneBank"), 1542860, charUsed, _selectedView == -1)
+            RenderSidebarEntry(0, EllesmereUI.L("All Bank Tabs"), 413587, charUsed, _selectedView == 0)
         else
-            RenderSidebarEntry(0, "All Bank Tabs", 413587, charUsed, _selectedView == 0)
-            RenderSidebarEntry(-1, "OneBank", 1542860, charUsed, _selectedView == -1)
+            RenderSidebarEntry(0, EllesmereUI.L("All Bank Tabs"), 413587, charUsed, _selectedView == 0)
+            RenderSidebarEntry(-1, EllesmereUI.L("OneBank"), 1542860, charUsed, _selectedView == -1)
         end
     end
 
@@ -1825,11 +1825,11 @@ function BuildBankSidebar()
     end
     if hasWarband then
         if defaultOneBag then
-            RenderSidebarEntry(-3, "OneWarbank", 1542854, warbUsed, _selectedView == -3)
-            RenderSidebarEntry(-2, "All Warbank Tabs", 1542854, warbUsed, _selectedView == -2)
+            RenderSidebarEntry(-3, EllesmereUI.L("OneWarbank"), 1542854, warbUsed, _selectedView == -3)
+            RenderSidebarEntry(-2, EllesmereUI.L("All Warbank Tabs"), 1542854, warbUsed, _selectedView == -2)
         else
-            RenderSidebarEntry(-2, "All Warbank Tabs", 1542854, warbUsed, _selectedView == -2)
-            RenderSidebarEntry(-3, "OneWarbank", 1542854, warbUsed, _selectedView == -3)
+            RenderSidebarEntry(-2, EllesmereUI.L("All Warbank Tabs"), 1542854, warbUsed, _selectedView == -2)
+            RenderSidebarEntry(-3, EllesmereUI.L("OneWarbank"), 1542854, warbUsed, _selectedView == -3)
         end
     end
 

--- a/EllesmereUIBags/EllesmereUIBags_Categories.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Categories.lua
@@ -158,7 +158,7 @@ function CategoryManager:InitCategories()
             local state = userState[def.name]
             cats[#cats + 1] = {
                 _defaultName      = def.name,
-                name              = (state and state.rename) or def.name,
+                name              = (state and state.rename) or EllesmereUI.L(def.name),
                 types             = def.types,
                 icon              = def.icon,
                 isAtlas           = def.isAtlas,


### PR DESCRIPTION
## Problem

The bag and bank windows render all of their chrome (titles, sidebar entries, headers, buttons, tooltips, popups) with hardcoded English literals. They never went through `EllesmereUI.L()`, so even with a translation catalog active the UI stays English.

## Change

Wrap the user-facing strings in `EllesmereUI.L()` / `EllesmereUI.Lf()` so they follow the active locale. Keys are the English source strings (consistent with existing `L()` usage); matching entries already exist in `Locales/zhTW.lua`, so most strings localize on reload with no catalog changes.

### Scope (display strings only)
- **Main window**: Inventory, Search placeholder, Categories header, Add Category, New Custom Category popup (title / Icon: / Custom Icon ID: / Create), Pinned Items, Recent Items, Hide, pin/recent hints, Delete, Edit, REAGENTS.
- **Fixed views**: All Items / OneBag / MultiBag.
- **Gold tooltip**: Gold Summary, reset hint, Warbank / Total rows (split from color codes).
- **Bank window**: Bank, Search, Tabs, Deposit / Withdraw (+ tooltips), gold deposit/withdraw popup (title + message), and the OneBank / All Bank Tabs / OneWarbank / All Warbank Tabs / Buy (War)bank Tab entries.
- **Counts** use positional `Lf` so translators can reorder: `"%d / %d Items"`, `"%d Items"`, `"Reagent Bag (%d / %d)"`, `"Main Bags (%d / %d)"`, `"Bag %d"`.
- **Default category names** localized at the resolution source — only the default side of `(state.rename) or EllesmereUI.L(def.name)`.

### Deliberately left untouched
- Bank fixed-view labels wrapped at their **call sites**, not the shared `RenderSidebarEntry` SetText, so real (game-localized) bank tab names aren't double-processed.
- User content: category renames, user-created category names, custom group names, player names.
- Auto-generated group names (e.g. `Consumables & Gear Enhancements`) double as **persisted identity keys**; translating in place would mutate stored state. Left as-is — a display/identity split is noted as follow-up.
- Non-translatable tokens: icon escapes, pure symbols, color codes.

## Testing
`/reload` with zhTW active — bag and bank windows render localized; renaming a category keeps the custom name; no Lua errors.
