### PR TITLE
CDM: localize spell-settings dropdown labels via EllesmereUI.L()

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -5697,7 +5697,7 @@ initFrame:SetScript("OnEvent", function(self)
                         lbl:SetFont(FONT_PATH, 11, GetCDMOptOutline())
                         lbl:SetPoint("LEFT", 10, 0)
                         lbl:SetJustifyH("LEFT")
-                        lbl:SetText(label)
+                        lbl:SetText(EllesmereUI.L(label))
 
                         -- Optional disabled state (opts.disabled = function -> bool):
                         -- greys the row, blocks the flyout, and shows a tooltip.
@@ -5779,7 +5779,7 @@ initFrame:SetScript("OnEvent", function(self)
                                 sLbl:SetFont(FONT_PATH, 11, GetCDMOptOutline())
                                 sLbl:SetPoint("LEFT", 10, 0)
                                 sLbl:SetJustifyH("LEFT")
-                                sLbl:SetText(item.label)
+                                sLbl:SetText(EllesmereUI.L(item.label))
 
                                 -- Highlight selected item. Charge entries are
                                 -- independent toggles (item.charge names the ss


### PR DESCRIPTION
## Problem

The per-spell right-click settings menu in the Cooldown Manager (Proc Glow, Active State, Active State Glow, Max Stacks Glow, Non Active State, Cooldown State Effect, Glow Effect Color, … and every flyout option under them) sets its text with raw English literals, so it bypasses the locale catalog and stays English even when a translation is active.

## Change

Wrap the two central `SetText` points in the menu builder — `MakeSubnavRow`'s row label and its per-item option label — so every parent row and every option label localizes at once via `EllesmereUI.L()`.

- Option values are stored in separate fields (`item.val` / `item.charge` / `item.activeBorder`); only the display label is translated, so selection logic is unaffected.
- `L()` falls back to the English string for any key not present in the catalog, so untranslated locales are unchanged.

## Testing
`/reload` with zhTW active — the spell-settings dropdown rows and their flyout options render localized; selecting options still works; no Lua errors.
