### PR TITLE
Add Passive Pet Reminder to AuraBuffReminders

### DIFF
--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -1206,6 +1206,14 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v) local c = CDB(); if c and c.enabled then c.enabled.wrong_pet = v; RefreshAll(); RebuildPreviewHeader() end end }
         );  y = y - h
 
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Passive Pet Reminder",
+              tooltip="Show a reminder when your active pet is set to Passive stance. Only applies to pet classes (Hunter, Warlock, Death Knight, Mage).",
+              getValue=function() local c = CDB(); return c and c.enabled and c.enabled.pet_passive ~= false end,
+              setValue=function(v) local c = CDB(); if c and c.enabled then c.enabled.pet_passive = v; RefreshAll(); RebuildPreviewHeader() end end },
+            { type="spacer" }
+        );  y = y - h
+
         _eabrClickMappings.pet = { section = petHdr, target = petFirstRow }
 
         _, h = W:Spacer(parent, y, 10);  y = y - h

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -2678,6 +2678,31 @@ local function Refresh()
                     missing[#missing+1] = e
                 end
             end
+            -- Pet on Passive: warn when an active pet is set to Passive stance.
+            -- Combat-safe: pet command state is not part of the secret system.
+            -- Skip while mounted: the pet is forced to Passive automatically.
+            if not suppress and co.enabled.pet_passive ~= false
+               and UnitExists("pet") and not UnitIsDead("pet")
+               and not IsMounted() then
+                local passiveActive, passiveTex, passiveIsToken
+                for i = 1, (NUM_PET_ACTION_SLOTS or 10) do
+                    local nm, tx, tok, active = GetPetActionInfo(i)
+                    if nm == "PET_MODE_PASSIVE" then
+                        if not isSecret(active) then passiveActive = (active == true) end
+                        passiveTex, passiveIsToken = tx, tok
+                        break
+                    end
+                end
+                if passiveActive then
+                    local e = AcquireEntry()
+                    e.mode = "texture"
+                    e.texture = (passiveIsToken and _G[passiveTex]) or passiveTex or petIcon
+                    e.label = PET_MODE_PASSIVE or "Passive"
+                    e.cat = "consumable"; e.scale = co.scale or 1.0
+                    e.dismissKey = "consumable:pet_passive"
+                    missing[#missing+1] = e
+                end
+            end
         end
     end
 


### PR DESCRIPTION
## Summary

Adds a new **Passive Pet Reminder** to the AuraBuffReminders module. It warns when your active pet is set to Passive stance, which is an easy-to-miss state that leaves the pet doing nothing in combat.

## Details

- New toggle in the pet options section ("Passive Pet Reminder"), enabled by default.
- Detects Passive stance by reading the pet command state via `GetPetActionInfo`, matching the `PET_MODE_PASSIVE` slot. This is part of the unprotected command API, so the check is combat-safe and respects the secret system.
- The reminder is skipped while mounted, since the pet is forced to Passive automatically in that case and the warning would be a false positive.
- Applies to pet classes only (Hunter, Warlock, Death Knight, Mage), since other classes never have a pet command bar.

## Testing

- `/reload` in-game with a Hunter pet set to Passive: reminder appears.
- Set pet back to Defensive/Assist: reminder clears.
- Mount up with the pet on Passive: reminder does not appear.
- Toggle the option off: reminder no longer shows.