### PR TITLE
Nameplates: add Class Resource shapes, border, and resource icons

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -718,14 +718,18 @@ initFrame:SetScript("OnEvent", function(self)
                                 [251] = { Enum.PowerType.Runes, 6 },
                                 [252] = { Enum.PowerType.Runes, 6 } },
             },
+            WHITE = "Interface\\Buttons\\WHITE8X8",
+            SQUARE_SHAPE = { square = true, circle = true, diamond = true, hexagon = true, shield = true },
         }
         CP.pips = {}
         for i = 1, CP.MAX_POSSIBLE do
             local bg = pf:CreateTexture(nil, "OVERLAY", nil, 2)
-            bg:SetColorTexture(0.082, 0.082, 0.082, 1)
+            bg:SetTexture(CP.WHITE)
+            bg:SetVertexColor(0.082, 0.082, 0.082, 1)
             bg:Hide()
             local pip = pf:CreateTexture(nil, "OVERLAY", nil, 3)
-            pip:SetColorTexture(1, 1, 1, 1)
+            pip:SetTexture(CP.WHITE)
+            pip:SetVertexColor(1, 1, 1, 1)
             pip:SetSize(CP.PIP_W, CP.PIP_H)
             pip:Hide()
             pip._bg = bg
@@ -1871,6 +1875,7 @@ initFrame:SetScript("OnEvent", function(self)
                     for i = 1, CP.MAX_POSSIBLE do
                         CP.pips[i]:Hide()
                         if CP.pips[i]._bg then CP.pips[i]._bg:Hide() end
+                        ns.HidePipDecor(CP.pips[i])
                     end
                     local cpScale = DBVal("classPowerScale") or defaults.classPowerScale
                     local cpYOff  = DBVal("classPowerYOffset") or defaults.classPowerYOffset
@@ -1910,6 +1915,7 @@ initFrame:SetScript("OnEvent", function(self)
                     for i = 1, CP.MAX_POSSIBLE do
                         CP.pips[i]:Hide()
                         if CP.pips[i]._bg then CP.pips[i]._bg:Hide() end
+                        ns.HidePipDecor(CP.pips[i])
                     end
                     CP.bar:Hide()
                 else
@@ -1919,8 +1925,14 @@ initFrame:SetScript("OnEvent", function(self)
                     local cpXOff  = DBVal("classPowerXOffset") or defaults.classPowerXOffset
                     local cpPos   = DBVal("classPowerPos") or defaults.classPowerPos
                     local cpGap   = DBVal("classPowerGap") or defaults.classPowerGap
+                    local cpShape     = DBVal("classPowerShape") or defaults.classPowerShape
+                    local cpBorderOn  = DBVal("classPowerBorder") == true
+                    local cpBorderCol = (DB() and DB().classPowerBorderColor) or defaults.classPowerBorderColor
+                    local cpBorderPx  = cpBorderOn and Snap(DBVal("classPowerBorderSize") or defaults.classPowerBorderSize) or 0
+                    local cpIconKind  = ns.GetPipIconKind(cpShape)
+                    local cpSquare    = CP.SQUARE_SHAPE[cpShape] or (cpIconKind ~= nil)
                     local scaledW   = Snap(CP.PIP_W * cpScale)
-                    local scaledH   = Snap(CP.PIP_H * cpScale)
+                    local scaledH   = cpSquare and scaledW or Snap(CP.PIP_H * cpScale)
                     local scaledGap = Snap(cpGap * cpScale)
                     local totalPipW = cpMax * scaledW + (cpMax - 1) * scaledGap
 
@@ -1966,20 +1978,60 @@ initFrame:SetScript("OnEvent", function(self)
                             if bg then
                                 bg:ClearAllPoints()
                                 bg:SetAllPoints(pip)
-                                bg:SetColorTexture(cpBgCol.r, cpBgCol.g, cpBgCol.b, cpBgCol.a)
+                                bg:SetTexture(CP.WHITE)
+                                bg:SetTexCoord(0, 1, 0, 1)
+                                bg:SetDesaturated(false)
+                                bg:SetVertexColor(cpBgCol.r, cpBgCol.g, cpBgCol.b, cpBgCol.a)
                                 bg:Show()
                             end
 
-                            if i <= cpCur then
-                                pip:SetColorTexture(cpColor[1], cpColor[2], cpColor[3], 1)
+                            ns.ApplyPipShape(pf, pip, cpShape, cpBorderOn, cpBorderCol, cpBorderPx)
+
+                            if cpIconKind == "holypower" then
+                                local n = (i - 1) % 5 + 1
+                                local flip = (n == 5)
+                                local idx = flip and 4 or n
+                                if bg then
+                                    bg:SetAtlas("nameplates-holypower" .. idx .. "-off")
+                                    bg:SetDesaturated(true)
+                                    if flip then bg:SetTexCoord(1, 0, 0, 1) end
+                                    bg:SetVertexColor(1, 1, 1, cpBgCol.a)
+                                    bg:Show()
+                                end
+                                if i <= cpCur then
+                                    pip:SetAtlas("nameplates-holypower" .. idx .. "-on")
+                                    if flip then pip:SetTexCoord(1, 0, 0, 1) end
+                                    pip:SetVertexColor(1, 1, 1, 1)
+                                    UnsnapTex(pip)
+                                    pip:Show()
+                                else
+                                    pip:Hide()
+                                end
+                            elseif cpIconKind then
+                                pip:SetAtlas(ns.GetPipIconAtlas(cpIconKind, i <= cpCur, i))
+                                if (i > cpCur) and ns.CP_ICON_DIM_EMPTY[cpIconKind] then
+                                    pip:SetVertexColor(0.35, 0.35, 0.35, 1)
+                                else
+                                    pip:SetVertexColor(1, 1, 1, 1)
+                                end
+                                UnsnapTex(pip)
+                                pip:Show()
                             else
-                                pip:SetColorTexture(cpEmptyCol.r, cpEmptyCol.g, cpEmptyCol.b, cpEmptyCol.a)
+                                pip:SetTexture(CP.WHITE)
+                                pip:SetTexCoord(0, 1, 0, 1)
+                                if i <= cpCur then
+                                    pip:SetVertexColor(cpColor[1], cpColor[2], cpColor[3], 1)
+                                else
+                                    pip:SetVertexColor(cpEmptyCol.r, cpEmptyCol.g, cpEmptyCol.b, cpEmptyCol.a)
+                                end
+                                UnsnapTex(pip)
+                                pip:Show()
                             end
-                            UnsnapTex(pip)
-                            pip:Show()
                         else
                             pip:Hide()
                             if pip._bg then pip._bg:Hide() end
+                            if pip._border then pip._border:Hide() end
+                            if pip._borderBox then pip._borderBox:Hide() end
                         end
                     end
                     -- Extra height only when pips are below the cast bar
@@ -1991,6 +2043,7 @@ initFrame:SetScript("OnEvent", function(self)
                 for i = 1, CP.MAX_POSSIBLE do
                     CP.pips[i]:Hide()
                     if CP.pips[i]._bg then CP.pips[i]._bg:Hide() end
+                    ns.HidePipDecor(CP.pips[i])
                 end
                 CP.bar:Hide()
             end
@@ -6390,7 +6443,7 @@ initFrame:SetScript("OnEvent", function(self)
                 DB().classPowerPos = v
                 ns.RefreshClassPower(); UpdatePreview()
               end, order={ "top", "bottom" } },
-            { type="slider", text="Size", min=0.5, max=3.0, step=0.1,
+            { type="slider", text="Size", min=0.5, max=4.0, step=0.1,
               disabled=classPowerDisabled,
               disabledTooltip="Show Class Resource",
               getValue=function() return DBVal("classPowerScale") or defaults.classPowerScale end,
@@ -6459,6 +6512,81 @@ initFrame:SetScript("OnEvent", function(self)
                 DB().classPowerBgColor = { r=r, g=g, b=b, a=a }
                 ns.RefreshClassPower(); UpdatePreview()
               end });  y = y - h
+
+        -- Row 4: Shape | Border (inline color swatch + thickness cog on Border)
+        local classResourceRow4
+        classResourceRow4, h = W:DualRow(parent, y,
+            { type="dropdown", text="Shape",
+              disabled=classPowerDisabled,
+              disabledTooltip="Show Class Resource",
+              values={ rectangle="Rectangle", square="Square", circle="Circle",
+                       diamond="Diamond", hexagon="Hexagon", shield="Shield",
+                       rune="Rune", holypower="Holy Power", shard="Soul Shard",
+                       combo="Combo Points", chi="Chi", arcane="Arcane Charges",
+                       essence="Essence" },
+              order={ "rectangle", "square", "circle", "diamond", "hexagon", "shield",
+                      "rune", "holypower", "shard", "combo", "chi", "arcane", "essence" },
+              getValue=function() return DBVal("classPowerShape") or defaults.classPowerShape end,
+              setValue=function(v)
+                DB().classPowerShape = v
+                ns.RefreshClassPower(); UpdatePreview()
+              end },
+            { type="toggle", text="Border",
+              disabled=classPowerDisabled,
+              disabledTooltip="Show Class Resource",
+              getValue=function() return DBVal("classPowerBorder") == true end,
+              setValue=function(v)
+                DB().classPowerBorder = v
+                ns.RefreshClassPower(); UpdatePreview()
+                EllesmereUI:RefreshPage()
+              end });  y = y - h
+
+        -- Inline border color swatch + thickness cog on the Border toggle
+        do
+            local rgn = classResourceRow4._rightRegion
+            local function borderOff()
+                return classPowerDisabled() or DBVal("classPowerBorder") ~= true
+            end
+            local colorGet = function()
+                local c = (DB() and DB().classPowerBorderColor) or defaults.classPowerBorderColor
+                return c.r, c.g, c.b
+            end
+            local colorSet = function(r, g, b)
+                DB().classPowerBorderColor = { r = r, g = g, b = b, a = 1 }
+                ns.RefreshClassPower(); UpdatePreview()
+            end
+            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5, colorGet, colorSet, nil, 20)
+            PP.Point(swatch, "RIGHT", rgn._control, "LEFT", -12, 0)
+            rgn._lastInline = swatch
+            EllesmereUI.RegisterWidgetRefresh(function()
+                updateSwatch()
+                swatch:SetAlpha(borderOff() and 0.3 or 1)
+            end)
+
+            local _, showCog = EllesmereUI.BuildCogPopup({
+                title = "Border Settings",
+                rows = {
+                    { type="slider", label="Thickness", min=1, max=4, step=1,
+                      get=function() return DBVal("classPowerBorderSize") or defaults.classPowerBorderSize end,
+                      set=function(v) DB().classPowerBorderSize = v; ns.RefreshClassPower(); UpdatePreview() end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -9, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints()
+            cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
+            cogBtn:SetScript("OnEnter", function(self) if not borderOff() then self:SetAlpha(0.7) end end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) if not borderOff() then showCog(self) end end)
+            EllesmereUI.RegisterWidgetRefresh(function()
+                cogBtn:SetAlpha(borderOff() and 0.15 or 0.4)
+            end)
+        end
 
         -- Invisible frame spanning the entire CLASS RESOURCE section for glow targeting
         local classResourceSection = CreateFrame("Frame", nil, parent)

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -231,6 +231,10 @@ local defaults = {
     classPowerBgColor = { r = 0.082, g = 0.082, b = 0.082, a = 1.0 },
     classPowerEmptyColor = { r = 0.2, g = 0.2, b = 0.2, a = 1.0 },
     classPowerGap = 2,
+    classPowerShape = "rectangle",  -- rectangle | square | circle | diamond | hexagon | shield
+    classPowerBorder = false,
+    classPowerBorderColor = { r = 0, g = 0, b = 0, a = 1.0 },
+    classPowerBorderSize = 1,
     healthBarWidth = 6,
     nameplateOverlapV = 1.10,
     stackSpacingScale = 100,
@@ -1237,26 +1241,23 @@ local function GetShowClassPower()
     return defaults.showClassPower
 end
 ns.GetShowClassPower = GetShowClassPower
-local function GetClassPowerPos()
+-- These getters live on ns (not file locals) to keep the main chunk under Lua's
+-- 200-local limit; callers in this file use ns.GetClassPower*().
+ns.GetClassPowerPos = function()
     return (p and p.classPowerPos) or defaults.classPowerPos
 end
-ns.GetClassPowerPos = GetClassPowerPos
-local function GetClassPowerYOffset()
+ns.GetClassPowerYOffset = function()
     return (p and p.classPowerYOffset) or defaults.classPowerYOffset
 end
-ns.GetClassPowerYOffset = GetClassPowerYOffset
-local function GetClassPowerXOffset()
+ns.GetClassPowerXOffset = function()
     return (p and p.classPowerXOffset) or defaults.classPowerXOffset
 end
-ns.GetClassPowerXOffset = GetClassPowerXOffset
-local function GetClassPowerScale()
+ns.GetClassPowerScale = function()
     return (p and p.classPowerScale) or defaults.classPowerScale
 end
-ns.GetClassPowerScale = GetClassPowerScale
-local function GetClassPowerGap()
+ns.GetClassPowerGap = function()
     return (p and p.classPowerGap) or defaults.classPowerGap
 end
-ns.GetClassPowerGap = GetClassPowerGap
 local function GetClassPowerClassColors()
     if p and p.classPowerClassColors ~= nil then return p.classPowerClassColors end
     return defaults.classPowerClassColors
@@ -1267,16 +1268,29 @@ local function GetClassPowerCustomColor()
     return c
 end
 ns.GetClassPowerCustomColor = GetClassPowerCustomColor
-local function GetClassPowerBgColor()
+ns.GetClassPowerBgColor = function()
     local c = (p and p.classPowerBgColor) or defaults.classPowerBgColor
     return c
 end
-ns.GetClassPowerBgColor = GetClassPowerBgColor
-local function GetClassPowerEmptyColor()
+ns.GetClassPowerEmptyColor = function()
     local c = (p and p.classPowerEmptyColor) or defaults.classPowerEmptyColor
     return c
 end
-ns.GetClassPowerEmptyColor = GetClassPowerEmptyColor
+-- Defined on ns (not as file locals) to stay under Lua's 200 main-chunk local limit.
+function ns.GetClassPowerShape()
+    return (p and p.classPowerShape) or defaults.classPowerShape
+end
+function ns.GetClassPowerBorder()
+    local v = p and p.classPowerBorder
+    if v == nil then return defaults.classPowerBorder end
+    return v
+end
+function ns.GetClassPowerBorderColor()
+    return (p and p.classPowerBorderColor) or defaults.classPowerBorderColor
+end
+function ns.GetClassPowerBorderSize()
+    return (p and p.classPowerBorderSize) or defaults.classPowerBorderSize
+end
 local function IsBorderEnabled()
     local v = p and p.showBorder
     if v == nil then return defaults.showBorder end
@@ -3411,6 +3425,61 @@ local classPowerMax = 0  -- max pips for the resource
 local classPowerFormReq  -- required GetShapeshiftFormID() value, or nil if no form check needed
 local CP_PIP_W, CP_PIP_H, CP_PIP_GAP = 8, 3, 2  -- pip geometry
 
+-- Optional pip shapes. Rectangle (default) and square are plain boxes (no mask);
+-- the rest are carved from a square fill by a portrait-set mask, with a matching
+-- border texture. Reuses the same shape art the Cooldown Manager uses.
+-- Packed onto ns (not file locals) to stay under Lua's 200 main-chunk local limit.
+ns.CP_SHAPE = {
+    WHITE = "Interface\\Buttons\\WHITE8X8",
+    MASKS = {
+        circle  = "Interface\\AddOns\\EllesmereUI\\media\\portraits\\circle_mask.tga",
+        diamond = "Interface\\AddOns\\EllesmereUI\\media\\portraits\\diamond_mask.tga",
+        hexagon = "Interface\\AddOns\\EllesmereUI\\media\\portraits\\hexagon_mask.tga",
+        shield  = "Interface\\AddOns\\EllesmereUI\\media\\portraits\\shield_mask.tga",
+    },
+    BORDERS = {
+        circle  = "Interface\\AddOns\\EllesmereUI\\media\\portraits\\circle_border.tga",
+        diamond = "Interface\\AddOns\\EllesmereUI\\media\\portraits\\diamond_border.tga",
+        hexagon = "Interface\\AddOns\\EllesmereUI\\media\\portraits\\hexagon_border.tga",
+        shield  = "Interface\\AddOns\\EllesmereUI\\media\\portraits\\shield_border.tga",
+    },
+    -- Shapes drawn on a 1:1 (square) footprint instead of the wide pip rectangle.
+    SQUARE = { square = true, circle = true, diamond = true, hexagon = true, shield = true },
+}
+
+-- Resource-icon shapes: real Blizzard atlas art instead of a tinted shape.
+-- Each draws a class's resource art (rune, holy power, soul shard, combo
+-- points, chi, arcane charges, essence). All on ns (no main-chunk locals).
+ns.CP_ICON_SHAPE = { rune = true, holypower = true, shard = true,
+                     combo = true, chi = true, arcane = true, essence = true }
+-- Single-atlas resources have no distinct empty art, so dim their empty pips.
+ns.CP_ICON_DIM_EMPTY = { arcane = true }
+ns.CP_RUNE_SPEC = { [250] = "Blood", [251] = "Frost", [252] = "Unholy" }
+-- Icon kind for a shape ("rune", "holypower", "essence", etc.), or nil if geometric.
+function ns.GetPipIconKind(shape)
+    return ns.CP_ICON_SHAPE[shape] and shape or nil
+end
+-- Atlas for a pip of the given icon kind, filled (active) or empty (background).
+function ns.GetPipIconAtlas(kind, filled, index)
+    if kind == "shard" then
+        return filled and "Warlock-ReadyShard" or "Warlock-EmptyShard"
+    elseif kind == "rune" then
+        if not filled then return "DK-Rune-CD" end
+        local spec = C_SpecializationInfo and C_SpecializationInfo.GetSpecialization()
+        local specID = spec and C_SpecializationInfo.GetSpecializationInfo(spec)
+        return "DK-" .. (ns.CP_RUNE_SPEC[specID or 0] or "Blood") .. "-Rune-Ready"
+    elseif kind == "combo" then
+        return filled and "uf-roguecp-icon-red" or "uf-roguecp-bg"
+    elseif kind == "chi" then
+        return filled and "uf-chi-icon" or "uf-chi-bg"
+    elseif kind == "arcane" then
+        return "Mage-ArcaneCharge"  -- one atlas for both states; empty is dimmed by the caller
+    elseif kind == "essence" then
+        return filled and "UF-Essence-Icon-Active" or "UF-Essence-BG"
+    end
+    return nil
+end
+
 -- Resolve class/power color from EUI global system.
 -- For bar-type power keys (_BAR suffix), returns power color.
 -- For class resources, returns resource color > class color.
@@ -3455,6 +3524,80 @@ local CLASS_POWER_MAP = {
                     [252] = { Enum.PowerType.Runes, 6 } },
 }
 
+-- Apply the configured shape + optional border to one pip (and its bg).
+-- rectangle/square: plain box, no mask; border (if on) is a single solid box
+-- behind the pip. Other shapes: carve fill+bg with a mask and frame with the
+-- matching border texture. Idempotent; safe to call every refresh. bSize is in
+-- pip-local (already pixel-snapped) units.
+function ns.ApplyPipShape(plate, pip, shape, borderOn, bc, bSize)
+    local bg = pip._bg
+    -- Icon shapes draw real atlas art (set in the render): drop mask, borders,
+    -- and the dark bg so the art stands alone.
+    if ns.CP_ICON_SHAPE[shape] then
+        if pip._shapeMask then
+            pcall(pip.RemoveMaskTexture, pip, pip._shapeMask)
+            if bg then pcall(bg.RemoveMaskTexture, bg, pip._shapeMask) end
+            pip._shapeMask:Hide()
+        end
+        if pip._border then pip._border:Hide() end
+        if pip._borderBox then pip._borderBox:Hide() end
+        if bg then bg:Hide() end
+        return
+    end
+    local maskPath = ns.CP_SHAPE.MASKS[shape]
+    if maskPath then
+        if not pip._shapeMask then pip._shapeMask = plate:CreateMaskTexture() end
+        local m = pip._shapeMask
+        m:SetTexture(maskPath, "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+        m:ClearAllPoints()
+        m:SetAllPoints(pip)
+        m:Show()
+        pcall(pip.RemoveMaskTexture, pip, m); pip:AddMaskTexture(m)
+        if bg then pcall(bg.RemoveMaskTexture, bg, m); bg:AddMaskTexture(m) end
+    elseif pip._shapeMask then
+        pcall(pip.RemoveMaskTexture, pip, pip._shapeMask)
+        if bg then pcall(bg.RemoveMaskTexture, bg, pip._shapeMask) end
+        pip._shapeMask:Hide()
+    end
+
+    local borderPath = ns.CP_SHAPE.BORDERS[shape]
+    if borderOn and borderPath then
+        -- Masked shapes: matching outline texture, sized to the pip.
+        if not pip._border then pip._border = plate:CreateTexture(nil, "OVERLAY", nil, 4) end
+        local b = pip._border
+        b:SetTexture(borderPath)
+        b:SetVertexColor(bc.r, bc.g, bc.b, bc.a or 1)
+        b:ClearAllPoints()
+        b:SetAllPoints(pip)
+        b:Show()
+        if pip._borderBox then pip._borderBox:Hide() end
+    elseif borderOn then
+        -- Boxy shapes (rectangle/square): one solid box behind the pip, poking
+        -- out bSize on every side as a uniform outline. A single texture rounds
+        -- as one piece (no per-edge shimmer), staying crisp like the fill.
+        if pip._border then pip._border:Hide() end
+        if not pip._borderBox then
+            pip._borderBox = plate:CreateTexture(nil, "OVERLAY", nil, 1)
+            pip._borderBox:SetTexture(ns.CP_SHAPE.WHITE)
+        end
+        local box = pip._borderBox
+        box:SetVertexColor(bc.r, bc.g, bc.b, bc.a or 1)
+        box:ClearAllPoints()
+        box:SetPoint("TOPLEFT", pip, "TOPLEFT", -bSize, bSize)
+        box:SetPoint("BOTTOMRIGHT", pip, "BOTTOMRIGHT", bSize, -bSize)
+        box:Show()
+    else
+        if pip._border then pip._border:Hide() end
+        if pip._borderBox then pip._borderBox:Hide() end
+    end
+end
+
+-- Hide a pip's shape decorations (textured border + solid border box).
+function ns.HidePipDecor(pip)
+    if pip._border then pip._border:Hide() end
+    if pip._borderBox then pip._borderBox:Hide() end
+end
+
 -- Lazy-create pip textures on a plate (done once, then reused via show/hide)
 local function EnsureClassPowerPips(plate)
     if plate._cpPips then return end
@@ -3462,10 +3605,12 @@ local function EnsureClassPowerPips(plate)
     local maxPossible = 10  -- safe upper bound (Maelstrom Weapon = 10)
     for i = 1, maxPossible do
         local bg = plate:CreateTexture(nil, "OVERLAY", nil, 2)
-        bg:SetColorTexture(0.082, 0.082, 0.082, 1)
+        bg:SetTexture(ns.CP_SHAPE.WHITE)
+        bg:SetVertexColor(0.082, 0.082, 0.082, 1)
         bg:Hide()
         local pip = plate:CreateTexture(nil, "OVERLAY", nil, 3)
-        pip:SetColorTexture(1, 1, 1, 1)
+        pip:SetTexture(ns.CP_SHAPE.WHITE)
+        pip:SetVertexColor(1, 1, 1, 1)
         PP.Size(pip, CP_PIP_W, CP_PIP_H)
         pip:Hide()
         pip._bg = bg
@@ -3501,11 +3646,11 @@ local function UpdateClassPowerOnPlate(plate)
         return
     end
 
-    local cpScale = GetClassPowerScale()
-    local cpYOff = GetClassPowerYOffset()
-    local cpXOff = GetClassPowerXOffset()
-    local cpPos = GetClassPowerPos()
-    local bgCol = GetClassPowerBgColor()
+    local cpScale = ns.GetClassPowerScale()
+    local cpYOff = ns.GetClassPowerYOffset()
+    local cpXOff = ns.GetClassPowerXOffset()
+    local cpPos = ns.GetClassPowerPos()
+    local bgCol = ns.GetClassPowerBgColor()
 
     -- Determine anchor: top or bottom of health bar, with cast bar avoidance
     local anchorPoint, anchorRelPoint, anchorFrame, yDir
@@ -3742,11 +3887,22 @@ local function UpdateClassPowerOnPlate(plate)
     -- scale is what determines screen pixels). PP.Scale snaps to UIParent's
     -- pixel grid, which is wrong here because nameplates have their own
     -- scale stack (nameplate scale * cast/target scale).
+    local cpShape     = ns.GetClassPowerShape()
+    local cpBorderOn  = ns.GetClassPowerBorder()
+    local cpBorderCol = ns.GetClassPowerBorderColor()
+    -- isSecret (DH Vengeance partial fill) keeps a plain rectangle: its StatusBar
+    -- overlay can't follow a shape mask cleanly.
+    if isSecret then cpShape = "rectangle" end
+    -- Icon shapes (rune/holypower/shard) draw real Blizzard art.
+    local iconKind = ns.GetPipIconKind(cpShape)
+    local squareShape = ns.CP_SHAPE.SQUARE[cpShape] or (iconKind ~= nil)
     local plateES = plate:GetEffectiveScale()
     local onePx = (plateES and plateES > 0) and (PP.perfect / plateES) or PP.mult or 1
     local pipWPx   = math.floor((CP_PIP_W * cpScale) / onePx + 0.5)
-    local pipHPx   = math.floor((CP_PIP_H * cpScale) / onePx + 0.5)
-    local pipGapPx = math.floor((GetClassPowerGap() * cpScale) / onePx + 0.5)
+    -- Non-rectangle shapes render on a square footprint (1:1).
+    local pipHPx   = squareShape and pipWPx or math.floor((CP_PIP_H * cpScale) / onePx + 0.5)
+    local pipGapPx = math.floor((ns.GetClassPowerGap() * cpScale) / onePx + 0.5)
+    local borderPx = cpBorderOn and (ns.GetClassPowerBorderSize() * onePx) or 0
     local scaledW   = pipWPx   * onePx
     local scaledH   = pipHPx   * onePx
     local scaledGap = pipGapPx * onePx
@@ -3762,7 +3918,7 @@ local function UpdateClassPowerOnPlate(plate)
         cpColor = { cc.r, cc.g, cc.b }
     end
 
-    local emptyCol = GetClassPowerEmptyColor()
+    local emptyCol = ns.GetClassPowerEmptyColor()
 
     local leftAnchor = (anchorPoint == "BOTTOM") and "BOTTOMLEFT" or "TOPLEFT"
 
@@ -3782,9 +3938,16 @@ local function UpdateClassPowerOnPlate(plate)
             if bg then
                 bg:ClearAllPoints()
                 bg:SetAllPoints(pip)
-                bg:SetColorTexture(bgCol.r, bgCol.g, bgCol.b, bgCol.a)
+                -- Reset from any prior icon socket; holy power re-sets these below.
+                bg:SetTexture(ns.CP_SHAPE.WHITE)
+                bg:SetTexCoord(0, 1, 0, 1)
+                bg:SetDesaturated(false)
+                bg:SetVertexColor(bgCol.r, bgCol.g, bgCol.b, bgCol.a)
                 bg:Show()
             end
+
+            -- Shape mask + optional border (size/anchor are final by now)
+            ns.ApplyPipShape(plate, pip, cpShape, cpBorderOn, cpBorderCol, borderPx)
 
             if isSecret then
                 if not pip._secretBar then
@@ -3800,21 +3963,58 @@ local function UpdateClassPowerOnPlate(plate)
                 sb:SetValue(cur)
                 sb:SetStatusBarColor(cpColor[1], cpColor[2], cpColor[3], 1)
                 sb:Show()
-                pip:SetColorTexture(emptyCol.r, emptyCol.g, emptyCol.b, emptyCol.a)
+                pip:SetTexture(ns.CP_SHAPE.WHITE)
+                pip:SetTexCoord(0, 1, 0, 1)
+                pip:SetVertexColor(emptyCol.r, emptyCol.g, emptyCol.b, emptyCol.a)
                 pip:Show()
             else
                 if pip._secretBar then pip._secretBar:Hide() end
-                if i <= cur then
-                    pip:SetColorTexture(cpColor[1], cpColor[2], cpColor[3], 1)
+                if iconKind == "holypower" then
+                    -- Desaturated socket as the (alpha-controlled) background, lit
+                    -- rune on top when filled. Point 5 reuses point 4 mirrored.
+                    local n = (i - 1) % 5 + 1
+                    local flip = (n == 5)
+                    local idx = flip and 4 or n
+                    if bg then
+                        bg:SetAtlas("nameplates-holypower" .. idx .. "-off")
+                        bg:SetDesaturated(true)
+                        if flip then bg:SetTexCoord(1, 0, 0, 1) end
+                        bg:SetVertexColor(1, 1, 1, bgCol.a)
+                        bg:Show()
+                    end
+                    if i <= cur then
+                        pip:SetAtlas("nameplates-holypower" .. idx .. "-on")
+                        if flip then pip:SetTexCoord(1, 0, 0, 1) end
+                        pip:SetVertexColor(1, 1, 1, 1)
+                        pip:Show()
+                    else
+                        pip:Hide()
+                    end
+                elseif iconKind then
+                    -- Real resource art: the atlas defines the look, no tint.
+                    pip:SetAtlas(ns.GetPipIconAtlas(iconKind, i <= cur, i))
+                    if (i > cur) and ns.CP_ICON_DIM_EMPTY[iconKind] then
+                        pip:SetVertexColor(0.35, 0.35, 0.35, 1)  -- dim single-atlas empties
+                    else
+                        pip:SetVertexColor(1, 1, 1, 1)
+                    end
+                    pip:Show()
                 else
-                    pip:SetColorTexture(emptyCol.r, emptyCol.g, emptyCol.b, emptyCol.a)
+                    pip:SetTexture(ns.CP_SHAPE.WHITE)
+                    pip:SetTexCoord(0, 1, 0, 1)
+                    if i <= cur then
+                        pip:SetVertexColor(cpColor[1], cpColor[2], cpColor[3], 1)
+                    else
+                        pip:SetVertexColor(emptyCol.r, emptyCol.g, emptyCol.b, emptyCol.a)
+                    end
+                    pip:Show()
                 end
-                pip:Show()
             end
         else
             pip:Hide()
             if pip._bg then pip._bg:Hide() end
             if pip._secretBar then pip._secretBar:Hide() end
+            ns.HidePipDecor(pip)
         end
     end
 end
@@ -3826,6 +4026,7 @@ local function HideClassPowerOnPlate(plate)
         plate._cpPips[i]:Hide()
         if plate._cpPips[i]._bg then plate._cpPips[i]._bg:Hide() end
         if plate._cpPips[i]._secretBar then plate._cpPips[i]._secretBar:Hide() end
+        ns.HidePipDecor(plate._cpPips[i])
     end
     if plate._cpBar then plate._cpBar:Hide() end
 end
@@ -3834,11 +4035,13 @@ end
 -- the class power pips (when pips are on top and visible on this plate).
 GetClassPowerTopPush = function(plate)
     if not GetShowClassPower() or not classPowerType then return 0 end
-    if GetClassPowerPos() ~= "top" then return 0 end
+    if ns.GetClassPowerPos() ~= "top" then return 0 end
     if not plate or not plate.unit or not UnitIsUnit(plate.unit, "target") then return 0 end
-    local cpScale = GetClassPowerScale()
-    local cpYOff = GetClassPowerYOffset()
-    return CP_PIP_H * cpScale + cpYOff
+    local cpScale = ns.GetClassPowerScale()
+    local cpYOff = ns.GetClassPowerYOffset()
+    -- Square-footprint shapes are taller than the flat rectangle pip.
+    local h = ns.CP_SHAPE.SQUARE[ns.GetClassPowerShape()] and CP_PIP_W or CP_PIP_H
+    return h * cpScale + cpYOff
 end
 
 -- Find the target plate and update pips
@@ -8187,6 +8390,7 @@ do
         "showBorder", "borderSize", "borderColor", "castBorderSize", "castBorderColor", "targetGlowStyle", "showTargetArrows",
         "showClassPower", "classPowerPos", "classPowerYOffset", "classPowerXOffset", "classPowerScale",
         "classPowerClassColors", "classPowerCustomColor", "classPowerGap",
+        "classPowerShape", "classPowerBorder", "classPowerBorderColor", "classPowerBorderSize",
         "textSlotTop", "textSlotRight", "textSlotLeft", "textSlotCenter",
         "nameYOffset",
         "healthBarHeight", "healthBarWidth", "castBarHeight",


### PR DESCRIPTION
Class Resource pips were rectangle-only. Adds a Shape option with geometric shapes (square, circle, diamond, hexagon, shield) and an optional border with configurable color and thickness, plus resource-icon shapes from Blizzard atlas art: Rune (spec-colored), Holy Power (per-point socket art with alpha-controlled background), Soul Shard, Combo Points, Chi, Arcane Charges, and Essence. 