### PR TITLE
Add koKR to CJK number abbreviation (천/만/억)

### DIFF
--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -899,6 +899,7 @@ local _abbreviateCfg
 local CJK = ({
     zhCN = { thousand = "千", wan = "万", yi = "亿" },
     zhTW = { thousand = "千", wan = "萬", yi = "億" },
+    koKR = { thousand = "천", wan = "만", yi = "억" },
 })[GetLocale()]
 do
     local opts


### PR DESCRIPTION
## Summary

Korean (koKR) clients group large numbers by ten-thousands (만) and hundred-millions (억) — the same math and column layout already used for zhCN/zhTW — but koKR was missing from the `CJK` table, so Korean players saw K/M/B instead.

This adds a single locale row so `AbbrevNumber` produces native Korean units. No other change is needed: all bar values already route through `AbbrevNumber` → the CJK path via `FormatBarValue`.

## Change

`EllesmereUIDamageMeters.lua`, in the `CJK` locale table:

```lua
 zhCN = { thousand = "千", wan = "万", yi = "亿" },
 zhTW = { thousand = "千", wan = "萬", yi = "億" },
+koKR = { thousand = "천", wan = "만", yi = "억" },