### PR TITLE
feat(raidframes): localize full preview labels

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -6152,7 +6152,7 @@ initFrame:SetScript("OnEvent", function(self)
             cy = cy - 10
             local lbl = MakeFont(panel, 11, 1, 1, 1, 0.75)
             lbl:SetPoint("TOPLEFT", panel, "TOPLEFT", PAD, cy)
-            lbl:SetText(text)
+            lbl:SetText(EllesmereUI.L(text))
             local line = panel:CreateTexture(nil, "ARTWORK")
             line:SetHeight(1)
             line:SetPoint("LEFT", lbl, "RIGHT", 8, 0)
@@ -6208,7 +6208,7 @@ initFrame:SetScript("OnEvent", function(self)
             lblBtn:SetScript("OnClick", DoToggle)
             local lbl = MakeFont(lblBtn, 11, 1, 1, 1, 0.85)
             lbl:SetPoint("LEFT")
-            lbl:SetText(label)
+            lbl:SetText(EllesmereUI.L(label))
 
             -- Edit button
             if editTarget then


### PR DESCRIPTION
## Problem

The RaidFrames "full preview" overlay (Raid Frames → 完整預覽 / HoverCast) built its section headers and checkbox rows with hardcoded English literals, so they stayed English even with a translation catalog active — while the surrounding Edit/Close buttons (which use `L()`) were localized.

## Change

Wrap the two shared local builders — `SectionHeader` and `CheckboxRow` — in `EllesmereUI.L()`, so all three section headers (HEALTH & POWER BARS / AURAS / INDICATORS) and their twelve rows localize at once.

- Labels are display-only; nothing reads them back against English (the INDICATORS eyeball lookup targets a different header via `EnKey`), so the wrap is safe.
- Matching zhTW keys already exist in the catalog.

## Testing
`/reload` with zhTW active — the full-preview overlay headers and rows render localized; toggles still work; no Lua errors.
