### PR TITLE
feat(aura-reminders): localize reminder labels (spell names + consumables)

### DIFF
--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -93,7 +93,7 @@ initFrame:SetScript("OnEvent", function(self)
     }
     local function ShortLabel(name, classOverride)
         if classOverride and LABEL_CLASS_OVERRIDES[classOverride] then
-            return LABEL_CLASS_OVERRIDES[classOverride]
+            return EllesmereUI.L(LABEL_CLASS_OVERRIDES[classOverride])
         end
         if LABEL_OVERRIDES[name] then return LABEL_OVERRIDES[name] end
         return name:match("^(%S+)") or name
@@ -114,7 +114,7 @@ initFrame:SetScript("OnEvent", function(self)
         for _, buff in ipairs(RAID_BUFFS) do
             if buff.class == playerClass and Known(buff.castSpell) then
                 if rb and rb.enabled and rb.enabled[buff.key] then
-                    icons[#icons+1] = { texture = Tex(buff.castSpell), label = ShortLabel(buff.name), cat = "raidbuff", itemKey = buff.key }
+                    icons[#icons+1] = { texture = Tex(buff.castSpell), label = ShortLabel(_G._EABR_SpellName(buff.castSpell, buff.name)), cat = "raidbuff", itemKey = buff.key }
                 end
             end
         end
@@ -133,11 +133,11 @@ initFrame:SetScript("OnEvent", function(self)
                     if specOk then
                         if aura.key == "bol" or aura.key == "bof" then
                             if not beaconAdded then
-                                icons[#icons+1] = { texture = Tex(aura.castSpell), label = ShortLabel(aura.name), cat = "aura", itemKey = aura.key }
+                                icons[#icons+1] = { texture = Tex(aura.castSpell), label = ShortLabel(_G._EABR_SpellName(aura.castSpell, aura.name)), cat = "aura", itemKey = aura.key }
                                 beaconAdded = true
                             end
                         else
-                            icons[#icons+1] = { texture = Tex(aura.castSpell), label = ShortLabel(aura.name), cat = "aura", itemKey = aura.key }
+                            icons[#icons+1] = { texture = Tex(aura.castSpell), label = ShortLabel(_G._EABR_SpellName(aura.castSpell, aura.name)), cat = "aura", itemKey = aura.key }
                         end
                     end
                 end
@@ -150,7 +150,7 @@ initFrame:SetScript("OnEvent", function(self)
             local POISONS = _G._EABR_ROGUE_POISONS or {}
             for _, poison in ipairs(POISONS) do
                 if Known(poison.castSpell) and co and co.enabled and co.enabled[poison.key] then
-                    icons[#icons+1] = { texture = Tex(poison.castSpell), label = ShortLabel(poison.name, "ROGUE"), cat = "consumable", itemKey = poison.key }
+                    icons[#icons+1] = { texture = Tex(poison.castSpell), label = ShortLabel(_G._EABR_SpellName(poison.castSpell, poison.name), "ROGUE"), cat = "consumable", itemKey = poison.key }
                     break
                 end
             end
@@ -161,7 +161,7 @@ initFrame:SetScript("OnEvent", function(self)
             local RITES = _G._EABR_PALADIN_RITES or {}
             for _, rite in ipairs(RITES) do
                 if Known(rite.castSpell) and co and co.enabled and co.enabled[rite.key] then
-                    icons[#icons+1] = { texture = Tex(rite.castSpell), label = ShortLabel(rite.name), cat = "consumable", itemKey = rite.key }
+                    icons[#icons+1] = { texture = Tex(rite.castSpell), label = ShortLabel(_G._EABR_SpellName(rite.castSpell, rite.name)), cat = "consumable", itemKey = rite.key }
                     break
                 end
             end
@@ -172,7 +172,7 @@ initFrame:SetScript("OnEvent", function(self)
             local IMBUES = _G._EABR_SHAMAN_IMBUES or {}
             for _, imbue in ipairs(IMBUES) do
                 if Known(imbue.castSpell) and co and co.enabled and co.enabled[imbue.key] then
-                    icons[#icons+1] = { texture = Tex(imbue.castSpell), label = ShortLabel(imbue.name, "SHAMAN_IMBUE"), cat = "consumable", itemKey = imbue.key }
+                    icons[#icons+1] = { texture = Tex(imbue.castSpell), label = ShortLabel(_G._EABR_SpellName(imbue.castSpell, imbue.name), "SHAMAN_IMBUE"), cat = "consumable", itemKey = imbue.key }
                     break
                 end
             end
@@ -190,27 +190,27 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Flask
         if co and co.enabled and co.enabled.flask then
-            icons[#icons+1] = { texture = 134830, label = "Flask", cat = "consumable", itemKey = "flask" }
+            icons[#icons+1] = { texture = 134830, label = EllesmereUI.L("Flask"), cat = "consumable", itemKey = "flask" }
         end
 
         -- Food
         if co and co.enabled and co.enabled.food then
-            icons[#icons+1] = { texture = 134062, label = "Food", cat = "consumable", itemKey = "food" }
+            icons[#icons+1] = { texture = 134062, label = EllesmereUI.L("Food"), cat = "consumable", itemKey = "food" }
         end
 
         -- Augment Rune
         if co and co.enabled and co.enabled.augment_rune then
-            icons[#icons+1] = { texture = C_Item.GetItemIconByID(259085) or 134400, label = "Rune", cat = "consumable", itemKey = "augment_rune" }
+            icons[#icons+1] = { texture = C_Item.GetItemIconByID(259085) or 134400, label = EllesmereUI.L("Rune"), cat = "consumable", itemKey = "augment_rune" }
         end
 
         -- Healthstone (default-on: treat nil as enabled, matching the toggle)
         if co and co.enabled and co.enabled.healthstone ~= false then
-            icons[#icons+1] = { texture = C_Item.GetItemIconByID(5512) or 134400, label = "Stone", cat = "consumable", itemKey = "healthstone" }
+            icons[#icons+1] = { texture = C_Item.GetItemIconByID(5512) or 134400, label = EllesmereUI.L("Stone"), cat = "consumable", itemKey = "healthstone" }
         end
 
         -- Inky Black Potion
         if co and co.enabled and co.enabled.inky_black then
-            icons[#icons+1] = { texture = C_Item.GetItemIconByID(124640) or 136122, label = "Inky", cat = "consumable", itemKey = "inky_black" }
+            icons[#icons+1] = { texture = C_Item.GetItemIconByID(124640) or 136122, label = EllesmereUI.L("Inky"), cat = "consumable", itemKey = "inky_black" }
         end
 
         return icons
@@ -1058,7 +1058,7 @@ initFrame:SetScript("OnEvent", function(self)
             local gridItems = {}
             for _, buff in ipairs(RAID_BUFFS) do
                 gridItems[#gridItems+1] = {
-                    label = buff.name,
+                    label = _G._EABR_SpellName(buff.castSpell, buff.name),
                     classToken = buff.class,
                     key = buff.key,
                     getVal = function() local r = RDB(); return r and r.enabled and r.enabled[buff.key] end,
@@ -1096,7 +1096,7 @@ initFrame:SetScript("OnEvent", function(self)
             local gridItems = {}
             for _, aura in ipairs(AURAS) do
                 gridItems[#gridItems+1] = {
-                    label = aura.name,
+                    label = _G._EABR_SpellName(aura.castSpell, aura.name),
                     classToken = aura.class,
                     key = aura.key,
                     getVal = function() local a = ADB(); return a and a.enabled and a.enabled[aura.key] end,
@@ -1119,7 +1119,7 @@ initFrame:SetScript("OnEvent", function(self)
             local gridItems = {}
             for _, poison in ipairs(POISONS) do
                 gridItems[#gridItems+1] = {
-                    label = poison.name,
+                    label = _G._EABR_SpellName(poison.castSpell, poison.name),
                     classToken = "ROGUE",
                     key = poison.key,
                     getVal = function() local c = CDB(); return c and c.enabled and c.enabled[poison.key] end,
@@ -1142,7 +1142,7 @@ initFrame:SetScript("OnEvent", function(self)
             local gridItems = {}
             for _, rite in ipairs(RITES) do
                 gridItems[#gridItems+1] = {
-                    label = rite.name,
+                    label = _G._EABR_SpellName(rite.castSpell, rite.name),
                     classToken = "PALADIN",
                     key = rite.key,
                     getVal = function() local c = CDB(); return c and c.enabled and c.enabled[rite.key] end,
@@ -1165,7 +1165,7 @@ initFrame:SetScript("OnEvent", function(self)
             local IMBUES = _G._EABR_SHAMAN_IMBUES or {}
             for _, imbue in ipairs(IMBUES) do
                 gridItems[#gridItems+1] = {
-                    label = imbue.name,
+                    label = _G._EABR_SpellName(imbue.castSpell, imbue.name),
                     classToken = "SHAMAN",
                     key = imbue.key,
                     getVal = function() local c = CDB(); return c and c.enabled and c.enabled[imbue.key] end,
@@ -1175,7 +1175,7 @@ initFrame:SetScript("OnEvent", function(self)
             local SHIELDS = _G._EABR_SHAMAN_SHIELDS or {}
             for _, shield in ipairs(SHIELDS) do
                 gridItems[#gridItems+1] = {
-                    label = shield.name,
+                    label = EllesmereUI.L(shield.name),
                     classToken = "SHAMAN",
                     key = shield.key,
                     getVal = function() local c = CDB(); return c and c.enabled and c.enabled[shield.key] end,

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -188,7 +188,7 @@ local LABEL_CLASS_OVERRIDES = {
 }
 local function ShortLabel(name, classOverride)
     if classOverride and LABEL_CLASS_OVERRIDES[classOverride] then
-        return LABEL_CLASS_OVERRIDES[classOverride]
+        return EllesmereUI.L(LABEL_CLASS_OVERRIDES[classOverride])
     end
     if LABEL_OVERRIDES[name] then return LABEL_OVERRIDES[name] end
     return name:match("^(%S+)") or name
@@ -797,6 +797,15 @@ local BUFF_BENEFICIARIES = {
 -------------------------------------------------------------------------------
 --  SPELL DATA Raid Buffs (all non-secret in 12.0, work in combat)
 -------------------------------------------------------------------------------
+-- Resolve a spell's display name from its ID in the client's locale, with
+-- an English fallback, so reminder labels follow the game client's language
+-- instead of the hardcoded English name. Exposed as _G._EABR_SpellName for
+-- the options panel.
+_G._EABR_SpellName = function(spellID, fallback)
+    local n = spellID and C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(spellID)
+    return n or fallback
+end
+
 local RAID_BUFFS = {
     { key="motw",   class="DRUID",   name="Mark of the Wild",       castSpell=1126,   buffIDs={1126,432661},    check="raid" },
     { key="bshout", class="WARRIOR", name="Battle Shout",           castSpell=6673,   buffIDs={6673},    check="raid", benefit="attackPower" },
@@ -2031,7 +2040,7 @@ if inInstance or rb.showNonInstanced then
                 if isMissing then
                     local e = AcquireEntry()
                     e.mode = "spell"; e.spellID = buff.castSpell
-                    e.label = ShortLabel(buff.name)
+                    e.label = ShortLabel(_G._EABR_SpellName(buff.castSpell, buff.name))
                     if buff.check == "huntersMark" then e.unit = "target" end
                     e.cat = "raidbuff"; e.data = buff; e.scale = rb.scale or 1.0
                     e.dismissKey = buff.key and ("raidbuff:" .. buff.key) or nil
@@ -2121,7 +2130,7 @@ if inInstance or au.showNonInstanced then
                     if isMissing then
                         local e = AcquireEntry()
                         e.mode = "spell"; e.spellID = aura.castSpell
-                        e.label = ShortLabel(aura.name)
+                        e.label = ShortLabel(_G._EABR_SpellName(aura.castSpell, aura.name))
                         e.cat = "aura"; e.data = aura; e.scale = au.scale or 1.0
                         e.dismissKey = "aura:" .. aura.key
                         missing[#missing+1] = e
@@ -2176,7 +2185,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                 if missingL and activeL < reqL then
                     local e = AcquireEntry()
                     e.mode = "spell"; e.spellID = missingL.castSpell
-                    e.label = ShortLabel(missingL.name, "ROGUE")
+                    e.label = ShortLabel(_G._EABR_SpellName(missingL.castSpell, missingL.name), "ROGUE")
                     e.cat = "consumable"; e.data = missingL; e.scale = co.scale or 1.0
                     e.dismissKey = "consumable:rogue_lethal"
                     missing[#missing+1] = e
@@ -2184,7 +2193,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                 if missingNL and activeNL < reqNL then
                     local e = AcquireEntry()
                     e.mode = "spell"; e.spellID = missingNL.castSpell
-                    e.label = ShortLabel(missingNL.name, "ROGUE")
+                    e.label = ShortLabel(_G._EABR_SpellName(missingNL.castSpell, missingNL.name), "ROGUE")
                     e.cat = "consumable"; e.data = missingNL; e.scale = co.scale or 1.0
                     e.dismissKey = "consumable:rogue_nonlethal"
                     missing[#missing+1] = e
@@ -2205,7 +2214,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                         if show then
                             local e = AcquireEntry()
                             e.mode = "spell"; e.spellID = rite.castSpell
-                            e.label = ShortLabel(rite.name)
+                            e.label = ShortLabel(_G._EABR_SpellName(rite.castSpell, rite.name))
                             e.cat = "consumable"; e.data = rite; e.scale = co.scale or 1.0
                             e.dismissKey = "consumable:" .. rite.key
                             missing[#missing+1] = e
@@ -2245,7 +2254,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                         if not found then
                             local e = AcquireEntry()
                             e.mode = "spell"; e.spellID = imbue.castSpell
-                            e.label = ShortLabel(imbue.name, "SHAMAN_IMBUE")
+                            e.label = ShortLabel(_G._EABR_SpellName(imbue.castSpell, imbue.name), "SHAMAN_IMBUE")
                             e.cat = "consumable"; e.data = imbue; e.scale = co.scale or 1.0
                             e.dismissKey = "consumable:" .. imbue.key
                             missing[#missing+1] = e
@@ -2299,7 +2308,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                     if runeItem then
                         local e = AcquireEntry()
                         e.mode = "item"; e.itemID = runeItem
-                        e.texture = GetItemIcon(runeItem); e.label = ShortLabel("Augment Rune")
+                        e.texture = GetItemIcon(runeItem); e.label = EllesmereUI.L(ShortLabel("Augment Rune"))
                         e.cat = "consumable"; e.scale = co.scale or 1.0
                         e.dismissKey = "consumable:rune"
                         missing[#missing+1] = e
@@ -2347,7 +2356,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                     e.mode = "macro"
                     e.macro = "/use item:" .. bestItemID .. "\n/use " .. si.slot
                     e.texture = GetItemIcon(bestItemID) or 134400
-                    e.label = ShortLabel(si.slot == 16 and "Main Hand" or "Off Hand")
+                    e.label = EllesmereUI.L(ShortLabel(si.slot == 16 and "Main Hand" or "Off Hand"))
                     e.tooltipItem = bestItemID
                     e.desaturated = not r.hasBags
                     e.cat = "consumable"; e.scale = co.scale or 1.0
@@ -2366,7 +2375,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                     local e = AcquireEntry()
                     e.mode = "item"; e.itemID = flaskItemID
                     e.texture = GetItemIcon(flaskItemID) or 134830
-                    e.label = "Flask"
+                    e.label = EllesmereUI.L("Flask")
                     e.desaturated = not rf.hasBags
                     e.cat = "consumable"; e.scale = co.scale or 1.0
                     e.dismissKey = "consumable:flask"
@@ -2383,7 +2392,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                     local e = AcquireEntry()
                     e.mode = "item"; e.itemID = foodItemID
                     e.texture = GetItemIcon(foodItemID) or 134062
-                    e.label = "Food"
+                    e.label = EllesmereUI.L("Food")
                     e.cat = "consumable"; e.scale = co.scale or 1.0
                     e.dismissKey = "consumable:food"
                     missing[#missing+1] = e
@@ -2412,7 +2421,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                         local e = AcquireEntry()
                         e.mode = "item"; e.itemID = INKY_BLACK_ITEM
                         e.texture = GetItemIcon(INKY_BLACK_ITEM)
-                        e.label = ShortLabel("Inky Black Potion")
+                        e.label = EllesmereUI.L(ShortLabel("Inky Black Potion"))
                         e.cat = "consumable"; e.scale = co.scale or 1.0
                         e.dismissKey = "consumable:inky_black"
                         missing[#missing+1] = e
@@ -2466,7 +2475,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
             if hasWarlock and not hasHealthstone then
                 local e = AcquireEntry()
                 e.mode = "texture"; e.texture = 538745
-                e.label = "HS"
+                e.label = EllesmereUI.L("HS")
                 e.cat = "consumable"; e.scale = co.scale or 1.0
                 e.dismissKey = "consumable:healthstone"
                 missing[#missing+1] = e
@@ -2487,7 +2496,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
             if not hasBuff then
                 local e = AcquireEntry()
                 e.mode = "texture"; e.texture = PARTNERED_TRINKET.icon
-                e.label = "Whistle"
+                e.label = EllesmereUI.L("Whistle")
                 e.cat = "consumable"; e.scale = co.scale or 1.0
                 e.dismissKey = "consumable:coaches_whistle"
                 missing[#missing+1] = e
@@ -2513,7 +2522,7 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
             if needsRune then
                 local e = AcquireEntry()
                 e.mode = "texture"; e.texture = 135957
-                e.label = "Rune"
+                e.label = EllesmereUI.L("Rune")
                 e.cat = "consumable"; e.scale = co.scale or 1.0
                 e.dismissKey = "consumable:runeforge"
                 missing[#missing+1] = e
@@ -2672,7 +2681,7 @@ local function Refresh()
                     local e = AcquireEntry()
                     e.mode = "texture"
                     e.texture = 136216
-                    e.label = "Felguard"
+                    e.label = EllesmereUI.L("Felguard")
                     e.cat = "consumable"; e.scale = co.scale or 1.0
                     e.dismissKey = "consumable:wrong_pet"
                     missing[#missing+1] = e
@@ -2743,7 +2752,7 @@ local function Refresh()
                     if safe then
                         local spellID = m.data and m.data.castSpell
                         local texture = m.texture or (spellID and Tex(spellID)) or 134400
-                        local label = m.label or (m.data and ShortLabel(m.data.name)) or ""
+                        local label = m.label or (m.data and ShortLabel(_G._EABR_SpellName(m.data.castSpell, m.data.name))) or ""
                         local f
                         if useCursor and IsImportantBuff(m) then
                             cursorIdx = cursorIdx + 1
@@ -2791,7 +2800,7 @@ local function Refresh()
                 if useCursor and IsImportantBuff(m) then
                     local spellID = m.data and m.data.castSpell
                     local texture = m.texture or (spellID and Tex(spellID)) or 134400
-                    local label = m.label or (m.data and ShortLabel(m.data.name)) or ""
+                    local label = m.label or (m.data and ShortLabel(_G._EABR_SpellName(m.data.castSpell, m.data.name))) or ""
                     cursorIdx = cursorIdx + 1
                     ShowCursorIcon(cursorIdx, spellID, texture, label)
                     local f = cursorActiveIcons[#cursorActiveIcons]


### PR DESCRIPTION
## Problem

The AuraBuff reminder icon labels were hardcoded English: spell-based labels used the hardcoded English spell name, and non-spell consumable labels (Flask, Food, HS, Whistle, Rune, Felguard, Inky, Augment Rune, Main/Off Hand) were plain English literals. So the reminders stayed English regardless of client locale.

## Change

Localize the labels in both the live reminders (`EllesmereUIAuraBuffReminders.lua`) and the options preview (`EUI_AuraBuffReminders_Options.lua`):

- **Spell names**: resolve buff / aura / poison / rite / imbue names from their spell ID in the client's locale via a new `_G._EABR_SpellName` helper (English fallback), so labels use the game's localized spell name.
- **Consumables**: wrap the non-spell labels in `EllesmereUI.L()` — Flask, Food, HS, Whistle, Rune, Felguard, plus the `ShortLabel`-derived Augment Rune / Inky Black Potion / Main Hand / Off Hand.

Labels are display-only (selection keys live in `itemKey` / `dismissKey`), so logic is unaffected; `L()` falls back to English for unkeyed strings.

## Testing
`/reload` with zhTW active — reminder icon labels (spells + consumables) render localized; click-to-buff/dismiss still works; no Lua errors.

## Note
Depends on the matching zhTW keys (added in the separate zhTW PR) to display in Traditional Chinese; until merged, unkeyed strings fall back to English.
