### PR TITLE
Fix: localize CLASS RESOURCE COLORS labels in Global Options

### DIFF
--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -3427,7 +3427,7 @@ initFrame:SetScript("OnEvent", function(self)
             for _, it in ipairs(items) do
                 local key = it.key
                 resourceItems[#resourceItems + 1] = {
-                    label = it.label,
+                    label = EllesmereUI.L(it.label),
                     getColor = function()
                         return EllesmereUI.GetClassResourceColor(key)
                             or { r = 1, g = 1, b = 1 }


### PR DESCRIPTION
## Problem

In **Global Settings → Font & Colors**, the **CLASS RESOURCE COLORS** swatches (Combo Points, Soul Shards, Holy Power, Arcane Charges, Maelstrom Weapon, Whirlwind Stacks, etc.) always displayed in English, even under non-English locales such as zhTW.

The neighbouring **POWER COLORS** section builds its items with `label = EllesmereUI.L(lbl)`, but the CLASS RESOURCE COLORS loop passed the raw English string (`label = it.label`). `BuildColorGrid` just `SetText`s the label and does no translation, so those labels were never localized.

## Fix

Wrap `it.label` in `EllesmereUI.L()`, matching the POWER COLORS pattern.

The locale strings already exist (verified in `Locales/zhTW.lua` and other locales), so no new translation entries are needed — the labels now render translated immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)