### PR TITLE
Bags: Desaturate junk items

### DIFF
--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -38,6 +38,7 @@ local BAGS_DEFAULTS = {
         enableGoldTracking    = true,
         detachReagentBag      = false,
         enhancedBags          = true,
+        bagDesaturateJunkItems = false,
     },
 }
 local db = EllesmereUI.Lite.NewDB("EllesmereUIBagsDB", BAGS_DEFAULTS)
@@ -632,9 +633,9 @@ initFrame:SetScript("OnEvent", function(self)
             _, h = W:DualRow(parent, y,
                 { type="toggle", text="Grey Out Junk Items",
                   tooltip="Display junk items in a greyed-out style.",
-                  getValue=function() return db.profile.bagGreyOutJunk == true end,
+                  getValue=function() return db.profile.bagDesaturateJunkItems == true end,
                   setValue=function(v)
-                      db.profile.bagGreyOutJunk = v
+                      db.profile.bagDesaturateJunkItems = v
                       if _G.EUI_Bags and _G.EUI_Bags.RefreshInventory then _G.EUI_Bags:RefreshInventory() end
                   end },
                 { type="label", text="" }

--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -629,9 +629,9 @@ initFrame:SetScript("OnEvent", function(self)
                   end }
             ); y = y - h
 
-            -- Grey Out Junk Items
+            -- Desaturate Junk Items
             _, h = W:DualRow(parent, y,
-                { type="toggle", text="Grey Out Junk Items",
+                { type="toggle", text="Desaturate Junk Items",
                   tooltip="Display junk items in a greyed-out style.",
                   getValue=function() return db.profile.bagDesaturateJunkItems == true end,
                   setValue=function(v)

--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -628,6 +628,18 @@ initFrame:SetScript("OnEvent", function(self)
                   end }
             ); y = y - h
 
+            -- Grey Out Junk Items
+            _, h = W:DualRow(parent, y,
+                { type="toggle", text="Grey Out Junk Items",
+                  tooltip="Display junk items in a greyed-out style.",
+                  getValue=function() return db.profile.bagGreyOutJunk == true end,
+                  setValue=function(v)
+                      db.profile.bagGreyOutJunk = v
+                      if _G.EUI_Bags and _G.EUI_Bags.RefreshInventory then _G.EUI_Bags:RefreshInventory() end
+                  end },
+                { type="label", text="" }
+            ); y = y - h
+
             _, h = W:Spacer(parent, y, 20); y = y - h
             return math.abs(y)
             end) -- end pcall

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -2293,7 +2293,12 @@ local function RenderButton(btn, data, _, col, row, startX, currentY, _, interac
         btn:SetItemButtonTexture(data.info.iconFileID)
         btn:SetItemButtonCount(data._mergedCount or data.info.stackCount)
         btn._isMerged = data._mergedCount and true or nil
-        SetItemButtonDesaturated(btn, data.info.isLocked)
+        
+        -- Desature: 1) locked items 2) junk items if option is active
+        local quality = data.info.quality or 1
+        local isJunk = BP().bagDesaturateJunkItems and quality == 0
+        SetItemButtonDesaturated(btn, data.info.isLocked or isJunk)
+        
         local filtered = data.info.isFiltered
         btn:SetAlpha(filtered and 0.2 or 1)
         if btn._textOverlay then btn._textOverlay:SetAlpha(filtered and 0.2 or 1) end
@@ -2350,7 +2355,6 @@ local function RenderButton(btn, data, _, col, row, startX, currentY, _, interac
 
         -- Profession quality overlay: let Blizzard decide via SetItemButtonQuality
         -- (handles all item types, not just ones we think are "profession")
-        local quality = data.info.quality or 1
         if data.itemLink then
             btn:SetItemButtonQuality(quality, data.itemLink, false, false)
         end


### PR DESCRIPTION
Add a simple option to desaturate junk items so they are immediately visible at a glance.

<img width="258" height="130" alt="image" src="https://github.com/user-attachments/assets/4f4b2247-b4aa-4624-96f9-1b6c51655226" />
