### PR TITLE
feat(DamageMeters): add Force English Units (K/M/B) number format option

### DIFF
--- a/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
@@ -1000,6 +1000,19 @@ initFrame:SetScript("OnEvent", function(self)
         end
         y = y - h
 
+        -- Force English Number Units (K/M/B) | (spacer)
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Force English Units (K/M/B)",
+              tooltip = "Always use K/M/B instead of localized units.",
+              getValue = function() return Cfg("forceEnglishUnits") or false end,
+              setValue = function(v)
+                  Set("forceEnglishUnits", v)
+                  if ns.RebuildNumberFormat then ns.RebuildNumberFormat() end
+                  Refresh()
+              end },
+            { type="spacer" })
+        y = y - h
+
         -- Left Text Size (+ inline custom/class swatches) | Right Text Size (+ inline custom/class swatches)
         local btRow
         btRow, h = W:DualRow(parent, y,

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -187,6 +187,7 @@ local DM_DEFAULTS = {
             barHeight       = 18,
             barSpacing      = 2,
             numberFormat    = 2,
+            forceEnglishUnits = false, -- force K/M/B units, ignoring CJK locale's 萬/億 (opt-in; default keeps localized units)
             iconStyle       = "spec",
             iconColorUseAccent = false,
             iconColor       = { r = 1, g = 1, b = 1 },
@@ -948,27 +949,43 @@ local CJK = ({
     zhTW = { thousand = "千", wan = "萬", yi = "億" },
     koKR = { thousand = "천", wan = "만", yi = "억" },
 })[GetLocale()]
-do
-    local opts
-    if CJK then
-        opts = {
+-- Choose the abbreviation breakpoint table. CJK clients normally group by
+-- 萬/억; when the user opts into forceEnglish we fall through to K/M/B even on
+-- a CJK locale. Non-CJK clients always get K/M/B (forceEnglish is a no-op).
+local function BuildAbbrevOpts(forceEnglish)
+    if CJK and not forceEnglish then
+        return {
             { breakpoint = 100000000, abbreviation = CJK.yi,       significandDivisor = 1000000, fractionDivisor = 100, abbreviationIsGlobal = false },
             { breakpoint = 10000,     abbreviation = CJK.wan,      significandDivisor = 100,      fractionDivisor = 100, abbreviationIsGlobal = false },
             { breakpoint = 1000,      abbreviation = CJK.thousand, significandDivisor = 100,      fractionDivisor = 10,  abbreviationIsGlobal = false },
             { breakpoint = 1,         abbreviation = "",           significandDivisor = 1,        fractionDivisor = 1,   abbreviationIsGlobal = false },
         }
     else
-        opts = {
+        return {
             { breakpoint = 1000000000, abbreviation = "B", significandDivisor = 10000000, fractionDivisor = 100, abbreviationIsGlobal = false },
             { breakpoint = 1000000,    abbreviation = "M", significandDivisor = 10000,    fractionDivisor = 100, abbreviationIsGlobal = false },
             { breakpoint = 1000,       abbreviation = "K", significandDivisor = 100,      fractionDivisor = 10,  abbreviationIsGlobal = false },
             { breakpoint = 1,          abbreviation = "",  significandDivisor = 1,         fractionDivisor = 1,   abbreviationIsGlobal = false },
         }
     end
+end
+
+-- Rebuild _abbreviateCfg from the current saved setting. Runs once at load
+-- (DB not yet ready -> reads false -> identical to the previous behavior), once
+-- after the DB is created, and again whenever the options toggle flips. Cheap:
+-- just rebuilds one config object, never touches per-bar/per-refresh work.
+local function RebuildAbbrevCfg()
+    local forceEnglish = false
+    if ns.EDM and ns.EDM.DB then
+        local db = ns.EDM.DB()
+        if db and db.forceEnglishUnits then forceEnglish = true end
+    end
     if CreateAbbreviateConfig then
-        _abbreviateCfg = { config = CreateAbbreviateConfig(opts) }
+        _abbreviateCfg = { config = CreateAbbreviateConfig(BuildAbbrevOpts(forceEnglish)) }
     end
 end
+RebuildAbbrevCfg()
+ns.RebuildNumberFormat = RebuildAbbrevCfg
 
 local function AbbrevNumber(n)
     if n == nil then return "0" end
@@ -4810,6 +4827,9 @@ initFrame:SetScript("OnEvent", function(self)
     end
 
     EnsureDB()
+    -- DB is now available; rebuild number format so a saved forceEnglishUnits
+    -- preference is applied at login (load-time build ran before the DB existed).
+    if ns.RebuildNumberFormat then ns.RebuildNumberFormat() end
     -- Disable Blizzard's built-in damage meter UI; C_DamageMeter API still works
     SetCVarSafe("damageMeterEnabled", 0)
     AppendDMSharedMedia()


### PR DESCRIPTION
## Summary

Adds an **opt-in** toggle to Damage Meters that lets CJK-locale users (zhCN / zhTW / koKR) display numbers as English **K/M/B** units instead of the localized wan/eok (ten-thousand / hundred-million) grouping.

The default is **off**, so nothing changes for any existing user unless they explicitly enable it.

## Why

On CJK clients the abbreviation config is built from locale-specific breakpoints. Some users find K/M/B easier to read at a glance than wan/eok, but there was no way to choose. This adds a per-user switch without touching the default behavior.

## What changed

**`EllesmereUIDamageMeters.lua`**
- `DM_DEFAULTS.profile.dm`: add `forceEnglishUnits = false` (opt-in default).
- Refactor the load-time abbreviation-config `do...end` block into `BuildAbbrevOpts(forceEnglish)` + `RebuildAbbrevCfg()`. The CJK branch is now gated on `CJK and not forceEnglish`, so enabling the flag falls through to the existing K/M/B table even on a CJK locale.
- Expose `ns.RebuildNumberFormat` so the options panel can rebuild the config live, and rebuild once after `EnsureDB()` on `PLAYER_LOGIN` so a saved preference is applied at login.

**`EUI_DamageMeters_Options.lua`**
- Add a "Force English Units (K/M/B)" toggle under the Number Format row. Its `setValue` writes the flag, calls `RebuildNumberFormat()`, then `Refresh()` so bars repaint immediately (no `/reload` required).

## Behavior & performance

- **No behavior change by default.** With the flag off, CJK users still see localized units and non-CJK users still see K/M/B — byte-for-byte identical to before. Only users who flip the toggle see a change.
- **No hot-path cost.** `AbbrevNumber()` is unchanged and still runs one `AbbreviateNumbers()` call per format. The config is rebuilt only at load, at login, and when the toggle changes — never per-bar or per-refresh.

## Notes

- The legacy fallback in `AbbrevNumber()` (used only when the `AbbreviateNumbers` API is unavailable) still follows the client locale and is intentionally left unchanged to keep this minimal.
- Localization: new strings are passed as English source text (the widget applies `EllesmereUI.L` automatically); zhTW/zhCN/koKR catalog entries can be added separately.

## Testing

- zhTW client, default (off): bars still show localized units, identical to before.
- zhTW client, toggle on: bars switch to K/M/B immediately, no `/reload`; persists across relog.
- Toggling off restores localized units immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
