### PR TITLE
feat: add max stack size to item tooltips

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -10521,7 +10521,7 @@ initFrame:SetScript("OnEvent", function(self, event)
         ELLESMERE_GREEN.r, ELLESMERE_GREEN.g, ELLESMERE_GREEN.b = EllesmereUI.ResolveActiveAccent()
     end
 
-    -- Spell ID / Item ID + Icon ID on Tooltip (developer option)
+    -- Spell ID / Item ID + Icon ID / Max Item Stack on Tooltip (developer option)
     if TooltipDataProcessor and TooltipDataProcessor.AddTooltipPostCall then
         -- Register per-type callbacks instead of AllTypes to avoid firing on
         -- every unit/currency tooltip in the game (major CPU savings).
@@ -10539,10 +10539,22 @@ initFrame:SetScript("OnEvent", function(self, event)
             return IsShiftKeyDown()
         end
 
-        -- Shared dedup check: only scan last 4 lines (we add at most 2)
+        -- The Max Item Stack lines can be gated behind a held modifier (the
+        -- "Use Modifier" cog: none | shift | control | alt, default none). "none"
+        -- shows them whenever Show Max Stack for items is on (the original
+        -- behavior); the others only surface the lines while that key is held.
+        local function IsItemStackModifierHeld()
+        local mod = (EllesmereUIDB and EllesmereUIDB.itemStackModifier) or "none"
+        if mod == "none" then return true end
+            if mod == "control" then return IsControlKeyDown() end
+                if mod == "alt" then return IsAltKeyDown() end
+                    return IsShiftKeyDown()
+                    end
+
+        -- Shared dedup check: only scan last 5 lines (we add at most 3)
         local function hasDupLine(tooltip, name, tag)
             local n = tooltip:NumLines()
-            local start = n - 3
+            local start = n - 4
             if start < 1 then start = 1 end
             for i = n, start, -1 do
                 local fs = _G[name .. "TextLeft" .. i]
@@ -10593,6 +10605,30 @@ initFrame:SetScript("OnEvent", function(self, event)
             tooltip:Show()
         end
 
+
+        local function ItemIdMaxStackHook(tooltip, data)
+            if not (EllesmereUIDB and EllesmereUIDB.showItemMaxStacks) then return end
+            if not IsItemStackModifierHeld() then return end
+            if not data or not data.id then return end
+            if _isSecret and _isSecret(data.id) then return end
+            if not tooltip or not tooltip.GetName then return end
+            local ok, name = pcall(tooltip.GetName, tooltip)
+            if not ok or not name then return end
+            if hasDupLine(tooltip, name, "Max Stack") then return end
+
+            local itemID = data.id
+            if itemID then
+                -- Retrieve the 8th value from GetItemInfo, which is the native Max Stack Size
+                local _, _, _, _, _, _, _, maxStack = C_Item.GetItemInfo(itemID)
+
+            -- Only print if the item is actually stackable (greater than 1)
+            if maxStack and maxStack > 1 then
+                tooltip:AddDoubleLine("Max Stack", tostring(maxStack), 1, 1, 1, 1, 1, 1)
+                end
+            end
+            tooltip:Show()
+        end
+
         -- Macros surface as their own tooltip type, so the Spell hook above never
         -- fires for them. GetSpell() also returns nil on a macro tooltip. The
         -- spell #showtooltip resolved to (honoring conditionals) is exposed as the
@@ -10628,6 +10664,7 @@ initFrame:SetScript("OnEvent", function(self, event)
         if Enum.TooltipDataType.Macro then
             TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Macro, MacroSpellIDTooltipHook)
         end
+        TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, ItemIdMaxStackHook)
 
         -- Live toggle: when the selected modifier is pressed/released while a
         -- tooltip is hovered, re-process the shown GameTooltip so the ID lines

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -343,6 +343,77 @@ initFrame:SetScript("OnEvent", function(self)
             UpdateSidModState()
         end
 
+        -- Show Max Stack for Items is independent of the EUI tooltip
+        -- skin (usable with default Blizzard tooltips), so it is NOT grayed by
+        -- "Reskin Tooltip" and live at the bottom of the section.
+        local iStackRow
+        iStackRow, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Max Stack for Items",
+                tooltip="Appends an item's max stack count on tooltip.",
+                getValue=function()
+                    return EllesmereUIDB and EllesmereUIDB.showItemMaxStacks or false
+                end,
+                setValue=function(v)
+                    if not EllesmereUIDB then EllesmereUIDB = {} end
+                    EllesmereUIDB.showItemMaxStacks = v
+                    EllesmereUI:RefreshPage()  -- update the Use Modifier cog disabled state
+                end },
+            { type="label", text="" }
+        ); y = y - h
+
+
+        -- "Use Modifier" cog on Show Max Item Stack (left region): the Max Stacks
+        -- line only shows while the chosen modifier is held. Disabled (blocked +
+        -- dimmed) when Show Max Item Stack is off, mirroring the cursor-position cog.
+        do
+            local leftRgn = iStackRow._leftRegion
+            local function iStacksOff()
+            return not (EllesmereUIDB and EllesmereUIDB.showItemMaxStacks)
+            end
+            local _, iStacksModShow = EllesmereUI.BuildCogPopup({
+                title = "Item Stacks",
+                rows = {
+                    { type="dropdown", label="Use Modifier",
+                        values={ none="None", shift="Shift", control="Control", alt="Alt" },
+                        order={ "none", "shift", "control", "alt" },
+                        get=function() return (EllesmereUIDB and EllesmereUIDB.itemStackModifier) or "none" end,
+                        set=function(v)
+                            if not EllesmereUIDB then EllesmereUIDB = {} end
+                                EllesmereUIDB.itemStackModifier = v
+                        end },
+                },
+            })
+            local iStacksModBtn = CreateFrame("Button", nil, leftRgn)
+            iStacksModBtn:SetSize(26, 26)
+            iStacksModBtn:SetPoint("RIGHT", leftRgn._lastInline or leftRgn._control, "LEFT", -8, 0)
+            leftRgn._lastInline = iStacksModBtn
+            iStacksModBtn:SetFrameLevel(leftRgn:GetFrameLevel() + 5)
+            iStacksModBtn:SetAlpha(iStacksOff() and 0.15 or 0.4)
+            local iStacksModTex = iStacksModBtn:CreateTexture(nil, "OVERLAY")
+            iStacksModTex:SetAllPoints()
+            iStacksModTex:SetTexture(EllesmereUI.COGS_ICON)
+            iStacksModBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            iStacksModBtn:SetScript("OnLeave", function(self) self:SetAlpha(iStacksOff() and 0.15 or 0.4) end)
+            iStacksModBtn:SetScript("OnClick", function(self) iStacksModShow(self) end)
+
+            -- Blocking overlay + disabled tooltip when Show Max Item Stack is off
+            local iStacksModBlock = CreateFrame("Frame", nil, iStacksModBtn)
+            iStacksModBlock:SetAllPoints()
+            iStacksModBlock:SetFrameLevel(iStacksModBtn:GetFrameLevel() + 10)
+            iStacksModBlock:EnableMouse(true)
+            iStacksModBlock:SetScript("OnEnter", function()
+            EllesmereUI.ShowWidgetTooltip(iStacksModBtn, EllesmereUI.DisabledTooltip("Show Item Max Stacks on Tooltip"))
+            end)
+            iStacksModBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            local function UpdateIStacksModState()
+                local off = iStacksOff()
+                iStacksModBtn:SetAlpha(off and 0.15 or 0.4)
+                if off then iStacksModBlock:Show() else iStacksModBlock:Hide() end
+            end
+            EllesmereUI.RegisterWidgetRefresh(UpdateIStacksModState)
+            UpdateIStacksModState()
+        end
+
         -- Border: size slider with an inline colour + opacity swatch. Part of the
         -- tooltip reskin, so it grays with "Reskin Tooltip". Defaults to the
         -- historical hardcoded look (white @ 18% alpha, 1px) -- unset = unchanged.


### PR DESCRIPTION
# Summary
Adds an optional "Show Max Stack for items" toggle to _UI Reskin Addons > Blizz UI Enhanced > Tooltips, Menus & Popups_.

<img width="974" height="710" alt="image" src="https://github.com/user-attachments/assets/2b4e5f6f-594f-4511-b9e0-b32482ca9962" />

<p></p>
The toggle has an additional "Use Modifier" option, in the same style as the "Show Spell ID on Tooltip" feature.
<p></p>

<img width="454" height="264" alt="image" src="https://github.com/user-attachments/assets/b650697b-5112-4e36-823c-3caae28b509b" />

<p></p>
The feature is independent of whether the "Reskin Tooltip" option is enabled, working on both the EUI tooltip and default Blizzard tooltip.
<p></p>

<img width="257" height="316" alt="image" src="https://github.com/user-attachments/assets/8eef1bc0-5b01-426b-bf85-fe76d54ed57a" />
<img width="283" height="346" alt="image" src="https://github.com/user-attachments/assets/1d23927a-70c4-4e71-a8d4-d7fe943993ed" />

