### PR TITLE
Tooltip: Add guild rank

### DIFF
--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -1411,7 +1411,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.uberTooltipsManual = nil
                 EllesmereUIDB.tooltipHideHealthStrip = nil
                 EllesmereUIDB.showItemMaxStack= nil
-                EllesmereUIDB.stooltipShowGuildRank = nil
+                EllesmereUIDB.tooltipShowGuildRank = nil
                 EllesmereUIDB.reskinQueuePopup = nil
                 EllesmereUIDB.reskinGameMenu = nil
                 EllesmereUIDB.reskinGreatVault = nil

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -358,7 +358,13 @@ initFrame:SetScript("OnEvent", function(self)
                     EllesmereUIDB.showItemMaxStacks = v
                     EllesmereUI:RefreshPage()  -- update the Use Modifier cog disabled state
                 end },
-            { type="label", text="" }
+            { type="toggle", text="Show Guild Rank",
+                disabled=ttReskinOff, disabledTooltip="Reskin Tooltip",
+                getValue=function() return not (EllesmereUIDB and EllesmereUIDB.tooltipShowGuildRank == false) end,
+                setValue=function(v)
+                    if not EllesmereUIDB then EllesmereUIDB = {} end
+                    EllesmereUIDB.tooltipShowGuildRank = v
+                end },
         ); y = y - h
 
 

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -360,11 +360,11 @@ initFrame:SetScript("OnEvent", function(self)
                 end },
             { type="toggle", text="Show Guild Rank",
                 disabled=ttReskinOff, disabledTooltip="Reskin Tooltip",
-                getValue=function() return not (EllesmereUIDB and EllesmereUIDB.tooltipShowGuildRank == false) end,
+                getValue=function() return EllesmereUIDB and EllesmereUIDB.tooltipShowGuildRank or false end,
                 setValue=function(v)
                     if not EllesmereUIDB then EllesmereUIDB = {} end
                     EllesmereUIDB.tooltipShowGuildRank = v
-                end },
+                end }
         ); y = y - h
 
 
@@ -1410,6 +1410,8 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.uberTooltips = nil
                 EllesmereUIDB.uberTooltipsManual = nil
                 EllesmereUIDB.tooltipHideHealthStrip = nil
+                EllesmereUIDB.showItemMaxStack= nil
+                EllesmereUIDB.stooltipShowGuildRank = nil
                 EllesmereUIDB.reskinQueuePopup = nil
                 EllesmereUIDB.reskinGameMenu = nil
                 EllesmereUIDB.reskinGreatVault = nil

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -28,6 +28,7 @@ end
     local _GameTooltip = GameTooltip
     local _RAID_CC = RAID_CLASS_COLORS
     local _nameL1 = nil  -- cached ref to GameTooltipTextLeft1
+    local _guildL = nil -- cached ref to GameTooltipTextLeftX where X is the line for the guild name
 
     local function _enabled()
         return not EllesmereUIDB or EllesmereUIDB.customTooltips ~= false

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -317,6 +317,28 @@ end
                 GameTooltipStatusBar:SetStatusBarColor(cc.r, cc.g, cc.b)
             end
         end
+        -- Add guild rank next to guild name : Name-Realm [Rank]
+        if unit and db and db.tooltipShowGuildRank ~= false then
+            local guildName, guildRankName = GetGuildInfo(unit)
+            if guildName and guildRankName and not (_isSecret and _isSecret(guildRankName)) then
+                -- Find the line once then cache it
+                if not _guildL then
+                    for i = 2, nLinesBefore do
+                        local line = _G["GameTooltipTextLeft" .. i]
+                        if line then
+                            local text = line:GetText()
+                            if text and string.find(text, guildName, 1, true) then
+                                _guildL = line
+                                break
+                            end
+                        end
+                    end
+                end
+                if _guildL then
+                    _guildL:SetText(_guildL:GetText() .. " [" .. guildRankName .. "]")
+                end
+            end
+        end
         -- M+ Score (append-only, deduped against any equivalent foreign line).
         if unit and db and db.tooltipMythicScore ~= false
             and C_PlayerInfo and C_PlayerInfo.GetPlayerMythicPlusRatingSummary then


### PR DESCRIPTION
Add the guild rank in the tooltip

Name-Realm [Rank] or Name [Rank] if the Realm is the same as the player realm (default behavior).

<img width="928" height="382" alt="image" src="https://github.com/user-attachments/assets/34f776da-680b-466d-af24-d87ad1c3d107" />

<img width="316" height="104" alt="image" src="https://github.com/user-attachments/assets/96b4ad55-1a97-498f-a321-3f86765ec861" />
