### PR TITLE
Bags: Fix border color transparency when filtered

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -2475,14 +2475,14 @@ local function RenderButton(btn, data, _, col, row, startX, currentY, _, interac
         local _bpx = (EUI and EUI.PP and EUI.PP.mult) or 1
         if data._isQuest then
             SetInsetBorderThickness(btn, _bpx * 2)
-            SetInsetBorderColor(btn, QUEST_BORDER_COLOR.r, QUEST_BORDER_COLOR.g, QUEST_BORDER_COLOR.b, 1)
+            SetInsetBorderColor(btn, QUEST_BORDER_COLOR.r, QUEST_BORDER_COLOR.g, QUEST_BORDER_COLOR.b, filtered and 0.2 or 1)
         else
             SetInsetBorderThickness(btn, _bpx)
             local c = ITEM_QUALITY_COLORS[quality]
             if c then
-                SetInsetBorderColor(btn, c.r, c.g, c.b, 1)
+                SetInsetBorderColor(btn, c.r, c.g, c.b, filtered and 0.2 or 1)
             else
-                SetInsetBorderColor(btn, 0.25, 0.25, 0.25, 1)
+                SetInsetBorderColor(btn, 0.25, 0.25, 0.25, filtered and 0.2 or 1)
             end
         end
         -- Quest marker atlas (created lazily, reused). Only shown for items that


### PR DESCRIPTION
In bags before:
<img width="676" height="116" alt="image" src="https://github.com/user-attachments/assets/c702af1d-0a2b-47f9-a731-1311c9651a8c" />

After:
<img width="676" height="126" alt="image" src="https://github.com/user-attachments/assets/f6489427-55cc-43ad-ac7c-f4392ad6c147" />

In bags with warband dim before:
<img width="678" height="120" alt="image" src="https://github.com/user-attachments/assets/922e84d4-d5d9-4194-afd3-18cd8d593966" />

After:
<img width="676" height="128" alt="image" src="https://github.com/user-attachments/assets/b82a9573-6994-4fbc-ba8f-59c8d03f703b" />

