### PR TITLE
ActionBars: Show bars immediately when dismounted in combat

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -6296,7 +6296,18 @@ function EAB:UpdateHousingVisibility()
                 end
             end
             if s.visHideMounted then
-                if EllesmereUI and EllesmereUI.IsPlayerMountedLike and EllesmereUI.IsPlayerMountedLike() then
+                -- Regular mounts are handled entirely by the secure "[mounted]
+                -- hide" clause in the state driver, which self-updates even in
+                -- combat -- so the bar reappears the instant the player is
+                -- dazed/knocked off a mount. Clobbering the driver with a
+                -- literal "hide" here would freeze it hidden until combat ends,
+                -- because this handler bails during InCombatLockdown and the
+                -- dismount event (PLAYER_MOUNT_DISPLAY_CHANGED) can no longer
+                -- re-evaluate a dead constant string. Only druid travel/flight
+                -- forms need this non-secure fallback, since [mounted] does not
+                -- match shapeshift forms.
+                if not (IsMounted and IsMounted())
+                    and EllesmereUI and EllesmereUI.IsPlayerMountedLike and EllesmereUI.IsPlayerMountedLike() then
                     return true
                 end
             end


### PR DESCRIPTION
## Problem

With **Hide when Mounted** enabled, if the player enters combat while mounted and is then dazed/knocked off the mount, the action bars stay hidden until combat ends instead of reappearing on dismount.

## Cause

The mounted hide is expressed two ways:

1. A secure `[mounted] hide` clause in the `state-visibility` driver (self-updating, works in combat).
2. A non-secure supplement (`UpdateHousingVisibility` → `ShouldHideNonMacro`) that covers druid travel/flight forms, which `[mounted]` cannot match.

The non-secure path detected *any* mount-like state (including regular mounts) and overwrote the driver with a literal `"hide"` constant. That dead string can no longer self-update, and the dismount re-check bails during `InCombatLockdown`, so the bars remain hidden until `PLAYER_REGEN_ENABLED`.

## Fix

Regular mounts are now handled entirely by the secure `[mounted]` clause, which re-evaluates in combat and reveals the bars the instant the player is dismounted. The non-secure fallback is kept only for druid travel/flight forms (`IsPlayerMountedLike()` true while `IsMounted()` is false).

No new protected calls are introduced, so this stays taint-free. Steady-state mounted visibility is unchanged; only in-combat dismount responsiveness improves.

## Testing

- Regular mount → enter combat → get dazed off the mount → bars reappear immediately (no longer wait for combat to end).
- Druid travel/flight form behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)