### PR TITLE
fix(cdm): trinket CD-ready sound in Mythic+; add Audio on Buff Loss

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -6607,6 +6607,25 @@ initFrame:SetScript("OnEvent", function(self)
                                 AddSoundPreview,
                                 { searchable = true })
                         end
+                        -- "Audio on Buff Loss": stored per-icon as ss.buffLostSoundKey.
+                        -- Blizzard-tracked buffs fire it on the real drop edge
+                        -- (TriggerAuraRemovedAlert); self-timed preset/custom buffs have
+                        -- no such alert, so it fires when the displayed timer runs out
+                        -- (UpdateCustomBuffBars in CdmHooks), off the SAME stored key.
+                        local function AddBuffLossRow()
+                            MakeSubnavRow("Audio on Buff Loss", AUDIO_ITEMS,
+                                function() return ss.buffLostSoundKey or "none" end,
+                                function(v)
+                                    EnsureSS()
+                                    ss.buffLostSoundKey = (v ~= "none" and v) or nil
+                                    -- Same 0-cost gate covers both edges; the hook reads
+                                    -- each key independently.
+                                    if ss.buffLostSoundKey then ns._cdmAnyBuffSound = true end
+                                end,
+                                function() return ss.buffLostSoundKey == nil end,
+                                AddSoundPreview,
+                                { searchable = true })
+                        end
 
                         -- Always Show Buffs + Desaturate Inactive apply only to
                         -- Blizzard-tracked buffs (inactive placeholders); injected
@@ -6658,30 +6677,18 @@ initFrame:SetScript("OnEvent", function(self)
                                 function() return ss.desatInactive == nil end)
 
                             AddBuffGainRow()
-
-                            -- Audio on Buff Loss: Blizzard-tracked buffs fire a real drop
-                            -- edge (TriggerAuraRemovedAlert), so the loss sound is offered
-                            -- here only. Stored per-icon as ss.buffLostSoundKey.
-                            MakeSubnavRow("Audio on Buff Loss", AUDIO_ITEMS,
-                                function() return ss.buffLostSoundKey or "none" end,
-                                function(v)
-                                    EnsureSS()
-                                    ss.buffLostSoundKey = (v ~= "none" and v) or nil
-                                    -- Same 0-cost gate covers both edges; the hook reads
-                                    -- each key independently.
-                                    if ss.buffLostSoundKey then ns._cdmAnyBuffSound = true end
-                                end,
-                                function() return ss.buffLostSoundKey == nil end,
-                                AddSoundPreview,
-                                { searchable = true })
+                            -- Blizzard-tracked buffs fire a real drop edge
+                            -- (TriggerAuraRemovedAlert), so the loss sound is exact here.
+                            AddBuffLossRow()
                         else
                             -- Self-timed preset/custom buffs (Bloodlust/Heroism, Light's
                             -- Potential, potions, and user-added custom buff IDs with a
                             -- duration) are shown on a cast/edge for a fixed window. The
-                            -- real aura is secret/other-cast, so only the GAIN edge is
-                            -- knowable -- offer the gain sound only. It is fired from the
-                            -- cast timer in UpdateCustomBuffBars (CdmHooks).
+                            -- real aura is secret/other-cast, so both edges are driven off
+                            -- the displayed timer in UpdateCustomBuffBars (CdmHooks): gain
+                            -- on the cast, loss when the shown countdown runs out.
                             AddBuffGainRow()
+                            AddBuffLossRow()
                         end
 
                         -- Reverse Swipe (buffs / custom buffs / buff presets):
@@ -6851,6 +6858,56 @@ initFrame:SetScript("OnEvent", function(self)
                                 if ns.FakeActive_Rearm then ns.FakeActive_Rearm() end
                             end,
                             function() return not (cas and (cas.reverseSwipe or cas.hideCDSwipe)) end)
+
+                        -- Audio Effect on CD Ready (preset / trinket / racial / custom):
+                        -- play a sound the moment the ability comes off cooldown. Presets
+                        -- have no Blizzard SetDesaturated edge, so this rides the FakeActive
+                        -- cooldown-state poll (PresetOnCD) which already handles trinket
+                        -- SLOTS via GetInventoryItemCooldown. Stored per-item/spell in the
+                        -- profile customActiveStates (cas.cdReadySoundKey), so it travels
+                        -- with the item across bars/specs like the other preset settings.
+                        local PRESET_CDR_ITEMS = {}
+                        for _, key in ipairs(ns.FOCUSKICK_SOUND_ORDER or { "none" }) do
+                            if type(key) == "string" and key:sub(1, 3) == "---" then
+                                PRESET_CDR_ITEMS[#PRESET_CDR_ITEMS + 1] = { divider = true }
+                            else
+                                PRESET_CDR_ITEMS[#PRESET_CDR_ITEMS + 1] = {
+                                    val   = key,
+                                    label = (ns.FOCUSKICK_SOUND_NAMES and ns.FOCUSKICK_SOUND_NAMES[key]) or key,
+                                }
+                            end
+                        end
+                        local function AddPresetCdrPreview(si, item)
+                            if item.val and item.val ~= "none" then
+                                local play = CreateFrame("Button", nil, si)
+                                play:SetSize(16, 16)
+                                play:SetPoint("RIGHT", si, "RIGHT", -8, 0)
+                                play:SetFrameLevel(si:GetFrameLevel() + 2)
+                                play:SetNormalAtlas("common-icon-sound")
+                                play:SetPushedAtlas("common-icon-sound-pressed")
+                                play:SetScript("OnClick", function()
+                                    local paths = ns.FOCUSKICK_SOUND_PATHS
+                                    local path = paths and paths[item.val]
+                                    if path then PlaySoundFile(path, "Master") end
+                                end)
+                                play:SetScript("OnEnter", function()
+                                    EllesmereUI.ShowWidgetTooltip(play, "Preview Sound")
+                                end)
+                                play:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                            end
+                        end
+                        MakeSubnavRow("Audio Effect on CD Ready", PRESET_CDR_ITEMS,
+                            function() return (cas and cas.cdReadySoundKey) or "none" end,
+                            function(v)
+                                local e = EnsureCAS()
+                                e.cdReadySoundKey = (v ~= "none" and v) or nil
+                                -- Re-arm so the FakeActive poll starts watching this
+                                -- preset's cooldown edge (or stops if cleared).
+                                if ns.FakeActive_Rearm then ns.FakeActive_Rearm() end
+                            end,
+                            function() return not (cas and cas.cdReadySoundKey) end,
+                            AddPresetCdrPreview,
+                            { searchable = true })
 
                         if not hasActive then
                             MakeActionRow("Add Active State", function()

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -6608,18 +6608,12 @@ initFrame:SetScript("OnEvent", function(self)
                                 { searchable = true })
                         end
                         -- "Audio on Buff Loss": stored per-icon as ss.buffLostSoundKey.
-                        -- Blizzard-tracked buffs fire it on the real drop edge
-                        -- (TriggerAuraRemovedAlert); self-timed preset/custom buffs have
-                        -- no such alert, so it fires when the displayed timer runs out
-                        -- (UpdateCustomBuffBars in CdmHooks), off the SAME stored key.
                         local function AddBuffLossRow()
                             MakeSubnavRow("Audio on Buff Loss", AUDIO_ITEMS,
                                 function() return ss.buffLostSoundKey or "none" end,
                                 function(v)
                                     EnsureSS()
                                     ss.buffLostSoundKey = (v ~= "none" and v) or nil
-                                    -- Same 0-cost gate covers both edges; the hook reads
-                                    -- each key independently.
                                     if ss.buffLostSoundKey then ns._cdmAnyBuffSound = true end
                                 end,
                                 function() return ss.buffLostSoundKey == nil end,
@@ -6677,16 +6671,10 @@ initFrame:SetScript("OnEvent", function(self)
                                 function() return ss.desatInactive == nil end)
 
                             AddBuffGainRow()
-                            -- Blizzard-tracked buffs fire a real drop edge
-                            -- (TriggerAuraRemovedAlert), so the loss sound is exact here.
                             AddBuffLossRow()
                         else
-                            -- Self-timed preset/custom buffs (Bloodlust/Heroism, Light's
-                            -- Potential, potions, and user-added custom buff IDs with a
-                            -- duration) are shown on a cast/edge for a fixed window. The
-                            -- real aura is secret/other-cast, so both edges are driven off
-                            -- the displayed timer in UpdateCustomBuffBars (CdmHooks): gain
-                            -- on the cast, loss when the shown countdown runs out.
+                            -- Self-timed preset/custom buffs: both edges driven off the
+                            -- displayed timer in UpdateCustomBuffBars (no real aura event).
                             AddBuffGainRow()
                             AddBuffLossRow()
                         end
@@ -6860,53 +6848,43 @@ initFrame:SetScript("OnEvent", function(self)
                             function() return not (cas and (cas.reverseSwipe or cas.hideCDSwipe)) end)
 
                         -- Audio Effect on CD Ready (preset / trinket / racial / custom):
-                        -- play a sound the moment the ability comes off cooldown. Presets
-                        -- have no Blizzard SetDesaturated edge, so this rides the FakeActive
-                        -- cooldown-state poll (PresetOnCD) which already handles trinket
-                        -- SLOTS via GetInventoryItemCooldown. Stored per-item/spell in the
-                        -- profile customActiveStates (cas.cdReadySoundKey), so it travels
-                        -- with the item across bars/specs like the other preset settings.
-                        local PRESET_CDR_ITEMS = {}
+                        -- fired when the ability comes off cooldown via the FakeActive
+                        -- poll (PresetOnCD). Stored in customActiveStates so it travels
+                        -- with the item. (Own list/preview: the buff-bar branch's shared
+                        -- AUDIO_ITEMS/AddSoundPreview are out of scope in this branch.)
+                        local CDR_ITEMS = {}
                         for _, key in ipairs(ns.FOCUSKICK_SOUND_ORDER or { "none" }) do
                             if type(key) == "string" and key:sub(1, 3) == "---" then
-                                PRESET_CDR_ITEMS[#PRESET_CDR_ITEMS + 1] = { divider = true }
+                                CDR_ITEMS[#CDR_ITEMS + 1] = { divider = true }
                             else
-                                PRESET_CDR_ITEMS[#PRESET_CDR_ITEMS + 1] = {
-                                    val   = key,
-                                    label = (ns.FOCUSKICK_SOUND_NAMES and ns.FOCUSKICK_SOUND_NAMES[key]) or key,
-                                }
+                                CDR_ITEMS[#CDR_ITEMS + 1] = { val = key,
+                                    label = (ns.FOCUSKICK_SOUND_NAMES and ns.FOCUSKICK_SOUND_NAMES[key]) or key }
                             end
                         end
-                        local function AddPresetCdrPreview(si, item)
-                            if item.val and item.val ~= "none" then
-                                local play = CreateFrame("Button", nil, si)
-                                play:SetSize(16, 16)
-                                play:SetPoint("RIGHT", si, "RIGHT", -8, 0)
-                                play:SetFrameLevel(si:GetFrameLevel() + 2)
-                                play:SetNormalAtlas("common-icon-sound")
-                                play:SetPushedAtlas("common-icon-sound-pressed")
-                                play:SetScript("OnClick", function()
-                                    local paths = ns.FOCUSKICK_SOUND_PATHS
-                                    local path = paths and paths[item.val]
-                                    if path then PlaySoundFile(path, "Master") end
-                                end)
-                                play:SetScript("OnEnter", function()
-                                    EllesmereUI.ShowWidgetTooltip(play, "Preview Sound")
-                                end)
-                                play:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-                            end
+                        local function AddCdrPreview(si, item)
+                            if not (item.val and item.val ~= "none") then return end
+                            local play = CreateFrame("Button", nil, si)
+                            play:SetSize(16, 16)
+                            play:SetPoint("RIGHT", si, "RIGHT", -8, 0)
+                            play:SetFrameLevel(si:GetFrameLevel() + 2)
+                            play:SetNormalAtlas("common-icon-sound")
+                            play:SetPushedAtlas("common-icon-sound-pressed")
+                            play:SetScript("OnClick", function()
+                                local path = ns.FOCUSKICK_SOUND_PATHS and ns.FOCUSKICK_SOUND_PATHS[item.val]
+                                if path then PlaySoundFile(path, "Master") end
+                            end)
+                            play:SetScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(play, "Preview Sound") end)
+                            play:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
                         end
-                        MakeSubnavRow("Audio Effect on CD Ready", PRESET_CDR_ITEMS,
+                        MakeSubnavRow("Audio Effect on CD Ready", CDR_ITEMS,
                             function() return (cas and cas.cdReadySoundKey) or "none" end,
                             function(v)
                                 local e = EnsureCAS()
                                 e.cdReadySoundKey = (v ~= "none" and v) or nil
-                                -- Re-arm so the FakeActive poll starts watching this
-                                -- preset's cooldown edge (or stops if cleared).
                                 if ns.FakeActive_Rearm then ns.FakeActive_Rearm() end
                             end,
                             function() return not (cas and cas.cdReadySoundKey) end,
-                            AddPresetCdrPreview,
+                            AddCdrPreview,
                             { searchable = true })
 
                         if not hasActive then

--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -86,6 +86,16 @@ local _cdStateRules = {}                                -- subset: cas.cdStateEf
 local _cdStateTicker
 local _hasUserRules = false                             -- any profile (user) rule armed
 
+-- CD-ready sound arm state, persisted BY ABILITY KEY (not on the rule object).
+-- FakeActive_Rearm wipes and recreates the rule objects on every CDM rebuild, so
+-- an armed flag stored on the rule is lost whenever a rebuild lands -- and in a
+-- Mythic+ / raid the CDM rebuilds far more often, so a rebuild reliably eats the
+-- on-CD -> ready edge right when the trinket comes back up (works in the open
+-- world, silent in a dungeon). Keying the armed state by the ability lets it
+-- survive rebuilds so the ready edge always fires. Empty at login/reload, so a
+-- preset already ready at login still never false-fires.
+local _cdrArmedByKey = {}
+
 -- Forward declarations
 local GetOverlay, ResolveSwipeColor, IconTexture, ApplyToFrame, ApplyRule, RaiseOverlayBorders, RestoreOverlayBorders
 local EnsureTicker, OpenWindow, CloseWindow, CloseAll, CastWindow
@@ -459,24 +469,38 @@ end
 --  throttled poll -- but only while at least one preset actually uses it.
 -- ---------------------------------------------------------------------------
 -- Unified "is this preset on a real (non-GCD) cooldown right now?" read.
+--
+-- Trinket / item presets read the ITEM cooldown, which is the source of truth for
+-- "when can I use this again" and stays readable even inside the restricted
+-- instances we tested (Mythic+). We must NOT read the item's on-use SPELL here:
+-- an on-use trinket's granted spell frequently has its own, shorter cooldown
+-- (e.g. a 30s spell lockout on top of a 90s item cooldown), so the ready edge
+-- would fire early. If a context ever hands back Secret Values we bail (returning
+-- "not on cooldown") rather than compare them -- no error, no early/false fire.
 PresetOnCD = function(key)
     local now = GetTime()
     if key > 0 then
         local ci = C_Spell and C_Spell.GetSpellCooldown and C_Spell.GetSpellCooldown(key)
         return (ci and ci.isActive and not ci.isOnGCD) or false
     end
+
     local start, dur, enable
     if key == -13 or key == -14 then
         if GetInventoryItemCooldown then start, dur, enable = GetInventoryItemCooldown("player", -key) end
-        if enable ~= nil and enable ~= 1 then return false end
     else
         local itemID = -key
         if C_Container and C_Container.GetItemCooldown then start, dur = C_Container.GetItemCooldown(itemID) end
-        if not (start and dur and dur > 1.5) and C_Item and C_Item.GetItemCooldown then
+        if (start == nil or dur == nil) and C_Item and C_Item.GetItemCooldown then
             start, dur = C_Item.GetItemCooldown(itemID)
         end
     end
-    return (start and dur and dur > 1.5 and now < start + dur) or false
+    if start == nil or dur == nil then return false end
+    if issecretvalue and (issecretvalue(start) or issecretvalue(dur)) then return false end
+    -- enable is only meaningful (and only safe to compare) when not a Secret.
+    if enable ~= nil and not (issecretvalue and issecretvalue(enable)) and enable ~= 1 then
+        return false
+    end
+    return (dur > 1.5 and now < start + dur) or false
 end
 
 -- Normal (shown) alpha for a frame, from its bar's opacity.
@@ -558,18 +582,48 @@ EvalCdStateNow = function()
     if not icons or not FCt then return end
     for r = 1, #_cdStateRules do
         local rule = _cdStateRules[r]
-        local eff = rule.cas and rule.cas.cdStateEffect
-        if eff then
+        local cas = rule.cas
+        local eff = cas and cas.cdStateEffect
+        local soundKey = cas and cas.cdReadySoundKey
+        if soundKey == "none" then soundKey = nil end
+        if eff or soundKey then
             local onCD = PresetOnCD(rule.spellID)
             local sid = rule.spellID
+            -- The sound only fires while the ability's icon is actually present on a
+            -- bar (an unequipped/absent trinket has no icon), so track that here too.
+            local hasIcon = false
             for _, list in pairs(icons) do
                 for i = 1, #list do
                     local f = list[i]
                     local fc = f and FCt[f]
                     if fc and fc.spellID == sid then
-                        ApplyCdState(f, fc, rule.cas, eff, onCD)
+                        hasIcon = true
+                        if eff then ApplyCdState(f, fc, cas, eff, onCD) end
                     end
                 end
+            end
+            -- Audio Effect on CD Ready (preset/trinket): arm while on cooldown, play
+            -- once on the on-CD -> ready edge. Armed state is persisted BY ABILITY
+            -- KEY (not on the rule object) so it survives the CDM rebuilds that wipe
+            -- and recreate rules -- otherwise a rebuild landing at cooldown-end (very
+            -- frequent in M+/raid) silently eats the ready edge. Empty at login, so a
+            -- preset already ready at login never false-fires.
+            if soundKey then
+                local akey = rule.srcKey or sid
+                -- Arm only while the icon is present AND on cooldown; fire once on
+                -- the on-CD -> ready edge. A missing icon (rebuild flicker, trinket
+                -- swapped out) leaves the persisted state untouched so a rebuild that
+                -- lands exactly at cooldown-end cannot swallow the ready edge.
+                if onCD then
+                    if hasIcon then _cdrArmedByKey[akey] = true end
+                elseif hasIcon and _cdrArmedByKey[akey] then
+                    _cdrArmedByKey[akey] = nil
+                    if not (ns._cdmSoundSuppressed and ns._cdmSoundSuppressed()) then
+                        local path = ns.FOCUSKICK_SOUND_PATHS and ns.FOCUSKICK_SOUND_PATHS[soundKey]
+                        if path then PlaySoundFile(path, "Master") end
+                    end
+                end
+                rule._cdrArmed = _cdrArmedByKey[akey]
             end
         end
     end
@@ -695,7 +749,8 @@ function ns.FakeActive_Rearm()
             if type(cas) == "table" and key ~= -13 and key ~= -14 then
                 local hasDur = (cas.duration or 0) > 0
                 local hasCd  = cas.cdStateEffect ~= nil
-                if hasDur or hasCd then
+                local hasSound = cas.cdReadySoundKey ~= nil and cas.cdReadySoundKey ~= "none"
+                if hasDur or hasCd or hasSound then
                     -- Settings are keyed by spell / item. A trinket's settings are
                     -- keyed by item, but its ICON is a slot (-13/-14) -- so route the
                     -- rule to whichever slot currently holds that item. (Cast +
@@ -707,7 +762,7 @@ function ns.FakeActive_Rearm()
                         if GetInventoryItemID("player", 13) == itemID then matchKey = -13
                         elseif GetInventoryItemID("player", 14) == itemID then matchKey = -14 end
                     end
-                    local rule = { spellID = matchKey, cas = cas, user = true }
+                    local rule = { spellID = matchKey, srcKey = key, cas = cas, user = true }
                     _rules[#_rules + 1] = rule
                     _hasUserRules = true
                     if hasDur then
@@ -715,7 +770,9 @@ function ns.FakeActive_Rearm()
                         rule.duration = cas.duration
                         MapCast(rule)
                     end
-                    if hasCd then
+                    if hasCd or hasSound then
+                        -- Both the cooldown-state effect and the CD-ready sound ride
+                        -- the same throttled cooldown poll (EvalCdStateNow).
                         _cdStateRules[#_cdStateRules + 1] = rule
                     end
                 end

--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -86,14 +86,9 @@ local _cdStateRules = {}                                -- subset: cas.cdStateEf
 local _cdStateTicker
 local _hasUserRules = false                             -- any profile (user) rule armed
 
--- CD-ready sound arm state, persisted BY ABILITY KEY (not on the rule object).
--- FakeActive_Rearm wipes and recreates the rule objects on every CDM rebuild, so
--- an armed flag stored on the rule is lost whenever a rebuild lands -- and in a
--- Mythic+ / raid the CDM rebuilds far more often, so a rebuild reliably eats the
--- on-CD -> ready edge right when the trinket comes back up (works in the open
--- world, silent in a dungeon). Keying the armed state by the ability lets it
--- survive rebuilds so the ready edge always fires. Empty at login/reload, so a
--- preset already ready at login still never false-fires.
+-- CD-ready sound "armed" state, keyed by ability so it survives the rule-object
+-- churn of FakeActive_Rearm (rebuilds are frequent in M+ and would otherwise eat
+-- the ready edge). Empty at login, so an already-ready preset never false-fires.
 local _cdrArmedByKey = {}
 
 -- Forward declarations
@@ -469,14 +464,8 @@ end
 --  throttled poll -- but only while at least one preset actually uses it.
 -- ---------------------------------------------------------------------------
 -- Unified "is this preset on a real (non-GCD) cooldown right now?" read.
---
--- Trinket / item presets read the ITEM cooldown, which is the source of truth for
--- "when can I use this again" and stays readable even inside the restricted
--- instances we tested (Mythic+). We must NOT read the item's on-use SPELL here:
--- an on-use trinket's granted spell frequently has its own, shorter cooldown
--- (e.g. a 30s spell lockout on top of a 90s item cooldown), so the ready edge
--- would fire early. If a context ever hands back Secret Values we bail (returning
--- "not on cooldown") rather than compare them -- no error, no early/false fire.
+-- Trinkets/items read the ITEM cooldown (its on-use spell can have a shorter
+-- cooldown that would fire the ready edge early). Bail on nil / Secret Values.
 PresetOnCD = function(key)
     local now = GetTime()
     if key > 0 then
@@ -495,11 +484,9 @@ PresetOnCD = function(key)
         end
     end
     if start == nil or dur == nil then return false end
-    if issecretvalue and (issecretvalue(start) or issecretvalue(dur)) then return false end
-    -- enable is only meaningful (and only safe to compare) when not a Secret.
-    if enable ~= nil and not (issecretvalue and issecretvalue(enable)) and enable ~= 1 then
-        return false
-    end
+    if issecretvalue and (issecretvalue(start) or issecretvalue(dur)
+        or (enable ~= nil and issecretvalue(enable))) then return false end
+    if enable ~= nil and enable ~= 1 then return false end
     return (dur > 1.5 and now < start + dur) or false
 end
 
@@ -589,8 +576,7 @@ EvalCdStateNow = function()
         if eff or soundKey then
             local onCD = PresetOnCD(rule.spellID)
             local sid = rule.spellID
-            -- The sound only fires while the ability's icon is actually present on a
-            -- bar (an unequipped/absent trinket has no icon), so track that here too.
+            -- Sound only fires while the ability's icon is present on a bar.
             local hasIcon = false
             for _, list in pairs(icons) do
                 for i = 1, #list do
@@ -602,18 +588,11 @@ EvalCdStateNow = function()
                     end
                 end
             end
-            -- Audio Effect on CD Ready (preset/trinket): arm while on cooldown, play
-            -- once on the on-CD -> ready edge. Armed state is persisted BY ABILITY
-            -- KEY (not on the rule object) so it survives the CDM rebuilds that wipe
-            -- and recreate rules -- otherwise a rebuild landing at cooldown-end (very
-            -- frequent in M+/raid) silently eats the ready edge. Empty at login, so a
-            -- preset already ready at login never false-fires.
+            -- Audio Effect on CD Ready: arm while on cooldown, fire once on the ready
+            -- edge. A missing icon leaves the armed state untouched so a rebuild at
+            -- cooldown-end can't swallow the edge (armed state persists by key).
             if soundKey then
                 local akey = rule.srcKey or sid
-                -- Arm only while the icon is present AND on cooldown; fire once on
-                -- the on-CD -> ready edge. A missing icon (rebuild flicker, trinket
-                -- swapped out) leaves the persisted state untouched so a rebuild that
-                -- lands exactly at cooldown-end cannot swallow the ready edge.
                 if onCD then
                     if hasIcon then _cdrArmedByKey[akey] = true end
                 elseif hasIcon and _cdrArmedByKey[akey] then
@@ -623,7 +602,6 @@ EvalCdStateNow = function()
                         if path then PlaySoundFile(path, "Master") end
                     end
                 end
-                rule._cdrArmed = _cdrArmedByKey[akey]
             end
         end
     end
@@ -771,8 +749,7 @@ function ns.FakeActive_Rearm()
                         MapCast(rule)
                     end
                     if hasCd or hasSound then
-                        -- Both the cooldown-state effect and the CD-ready sound ride
-                        -- the same throttled cooldown poll (EvalCdStateNow).
+                        -- Both effects ride the same cooldown poll (EvalCdStateNow).
                         _cdStateRules[#_cdStateRules + 1] = rule
                     end
                 end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -163,11 +163,21 @@ local function HasEnoughResources(spellID)
         if powerType then
             local cost = c.cost or 0
             if c.costPercent and c.costPercent > 0 then
+                -- UnitPowerMax/UnitPower can return a SECRET number while
+                -- execution is tainted in combat (Midnight secret values);
+                -- comparing one throws. Without a readable value we can't gate,
+                -- so treat the spell as castable (let the glow show) rather than
+                -- tainting -- consistent with the "default to enough" stance above.
                 local maxP = UnitPowerMax("player", powerType)
+                if issecretvalue and issecretvalue(maxP) then return true end
                 cost = math.max(cost, (c.costPercent / 100) * maxP)
             end
-            if cost > 0 and UnitPower("player", powerType) < cost then
-                return false
+            if cost > 0 then
+                local cur = UnitPower("player", powerType)
+                if issecretvalue and issecretvalue(cur) then return true end
+                if cur < cost then
+                    return false
+                end
             end
         end
     end
@@ -4649,6 +4659,7 @@ ns.CollectAndReanchor = CollectAndReanchor
 -- (the same flag RescanBuffSoundFlag sets from these very spellSettings) and
 -- throttled so a refresh-cast a few frames apart can't double-fire.
 local _presetGainSoundAt = {}
+local _presetLossSoundAt = {}
 local PRESET_GAIN_SOUND_GAP = 0.3
 local function PlayPresetBuffGainSound(sd, sid, now)
     if not ns._cdmAnyBuffSound then return end
@@ -4661,6 +4672,26 @@ local function PlayPresetBuffGainSound(sd, sid, now)
     local last = _presetGainSoundAt[sid]
     if last and (now - last) < PRESET_GAIN_SOUND_GAP then return end
     _presetGainSoundAt[sid] = now
+    local paths = ns.FOCUSKICK_SOUND_PATHS
+    local path = paths and paths[key]
+    if path then PlaySoundFile(path, "Master") end
+end
+-- Loss counterpart for self-timed preset/custom buffs. Fired from the displayed
+-- window end (the icon's own countdown timer running out), since these buffs get
+-- no real Blizzard aura-removed alert. Reads the SAME per-icon store as the
+-- regular-buff loss hook (ss.buffLostSoundKey) so the option is identical; kept
+-- on a separate throttle table from the gain edge so the two never suppress each
+-- other. Approximate by design: a fixed-duration window won't catch early
+-- cancels/dispels.
+local function PlayPresetBuffLossSound(sd, sid, now)
+    if not ns._cdmAnyBuffSound then return end
+    if ns._cdmSoundSuppressed and ns._cdmSoundSuppressed() then return end
+    local ss = sd and sd.spellSettings and sd.spellSettings[sid]
+    local key = ss and ss.buffLostSoundKey
+    if not key or key == "none" then return end
+    local last = _presetLossSoundAt[sid]
+    if last and (now - last) < PRESET_GAIN_SOUND_GAP then return end
+    _presetLossSoundAt[sid] = now
     local paths = ns.FOCUSKICK_SOUND_PATHS
     local path = paths and paths[key]
     if path then PlaySoundFile(path, "Master") end
@@ -4702,6 +4733,16 @@ local function UpdateCustomBuffBars()
                                 PlayPresetBuffGainSound(sd, sid, now)
                             end
 
+                            -- Loss edge: a live timer that has now run past its
+                            -- duration is the displayed window end -> play the
+                            -- per-icon loss sound once, then drop the timer so it
+                            -- can't re-fire (also reads as inactive below).
+                            if timer and (now - timer.start) >= timer.duration then
+                                PlayPresetBuffLossSound(sd, sid, now)
+                                _customAuraTimers[timerKey] = nil
+                                timer = nil
+                            end
+
                             local isActive = timer and duration > 0
                                 and (now - timer.start) < timer.duration
 
@@ -4731,7 +4772,7 @@ local function UpdateCustomBuffBars()
                                     local spInfo = C_Spell and C_Spell.GetSpellInfo and C_Spell.GetSpellInfo(sid)
                                     if spInfo and spInfo.iconID and f._tex then f._tex:SetTexture(spInfo.iconID) end
                                 end
-                                if isActive then
+                                if isActive and timer then
                                     f._cooldown:SetCooldown(timer.start, timer.duration)
                                 else
                                     f._cooldown:Clear()
@@ -4788,13 +4829,24 @@ local function UpdateCustomBuffBars()
             local durs = sd and sd.spellDurations
             if spellList and durs then
                 for _, sid in ipairs(spellList) do
-                    if type(sid) == "number" and sid > 0
-                       and (durs[sid] or 0) > 0 and _pendingCastIDs[sid] then
-                        _customAuraTimers[barData.key .. ":" .. sid] = {
-                            start = now, duration = durs[sid],
-                        }
-                        needBuffReanchor = true
-                        PlayPresetBuffGainSound(sd, sid, now)
+                    if type(sid) == "number" and sid > 0 and (durs[sid] or 0) > 0 then
+                        local tkey = barData.key .. ":" .. sid
+                        if _pendingCastIDs[sid] then
+                            _customAuraTimers[tkey] = {
+                                start = now, duration = durs[sid],
+                            }
+                            needBuffReanchor = true
+                            PlayPresetBuffGainSound(sd, sid, now)
+                        else
+                            -- Loss edge: displayed window ran out -> play the loss
+                            -- sound once and drop the timer (reanchor removes the icon).
+                            local t = _customAuraTimers[tkey]
+                            if t and (now - t.start) >= t.duration then
+                                PlayPresetBuffLossSound(sd, sid, now)
+                                _customAuraTimers[tkey] = nil
+                                needBuffReanchor = true
+                            end
+                        end
                     end
                 end
             end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -163,11 +163,8 @@ local function HasEnoughResources(spellID)
         if powerType then
             local cost = c.cost or 0
             if c.costPercent and c.costPercent > 0 then
-                -- UnitPowerMax/UnitPower can return a SECRET number while
-                -- execution is tainted in combat (Midnight secret values);
-                -- comparing one throws. Without a readable value we can't gate,
-                -- so treat the spell as castable (let the glow show) rather than
-                -- tainting -- consistent with the "default to enough" stance above.
+                -- Power can be a SECRET number in tainted combat; can't compare it,
+                -- so default to castable rather than throw.
                 local maxP = UnitPowerMax("player", powerType)
                 if issecretvalue and issecretvalue(maxP) then return true end
                 cost = math.max(cost, (c.costPercent / 100) * maxP)
@@ -175,9 +172,7 @@ local function HasEnoughResources(spellID)
             if cost > 0 then
                 local cur = UnitPower("player", powerType)
                 if issecretvalue and issecretvalue(cur) then return true end
-                if cur < cost then
-                    return false
-                end
+                if cur < cost then return false end
             end
         end
     end
@@ -4676,13 +4671,9 @@ local function PlayPresetBuffGainSound(sd, sid, now)
     local path = paths and paths[key]
     if path then PlaySoundFile(path, "Master") end
 end
--- Loss counterpart for self-timed preset/custom buffs. Fired from the displayed
--- window end (the icon's own countdown timer running out), since these buffs get
--- no real Blizzard aura-removed alert. Reads the SAME per-icon store as the
--- regular-buff loss hook (ss.buffLostSoundKey) so the option is identical; kept
--- on a separate throttle table from the gain edge so the two never suppress each
--- other. Approximate by design: a fixed-duration window won't catch early
--- cancels/dispels.
+-- Loss counterpart to PlayPresetBuffGainSound for self-timed preset/custom buffs
+-- (no real aura-removed alert): fired when the displayed timer runs out. Separate
+-- throttle table so gain/loss never suppress each other.
 local function PlayPresetBuffLossSound(sd, sid, now)
     if not ns._cdmAnyBuffSound then return end
     if ns._cdmSoundSuppressed and ns._cdmSoundSuppressed() then return end
@@ -4733,10 +4724,7 @@ local function UpdateCustomBuffBars()
                                 PlayPresetBuffGainSound(sd, sid, now)
                             end
 
-                            -- Loss edge: a live timer that has now run past its
-                            -- duration is the displayed window end -> play the
-                            -- per-icon loss sound once, then drop the timer so it
-                            -- can't re-fire (also reads as inactive below).
+                            -- Loss edge: displayed timer ran out -> fire once, drop it.
                             if timer and (now - timer.start) >= timer.duration then
                                 PlayPresetBuffLossSound(sd, sid, now)
                                 _customAuraTimers[timerKey] = nil
@@ -4838,8 +4826,7 @@ local function UpdateCustomBuffBars()
                             needBuffReanchor = true
                             PlayPresetBuffGainSound(sd, sid, now)
                         else
-                            -- Loss edge: displayed window ran out -> play the loss
-                            -- sound once and drop the timer (reanchor removes the icon).
+                            -- Loss edge: displayed window ran out -> fire once, drop timer.
                             local t = _customAuraTimers[tkey]
                             if t and (now - t.start) >= t.duration then
                                 PlayPresetBuffLossSound(sd, sid, now)

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3812,6 +3812,7 @@ ApplyShapeToCDMIcon = function(icon, shape, barData, ssb)
     local tex = fd and fd.tex or icon._tex
     local cd = fd and fd.cooldown or icon._cooldown
     local bg = fd and fd.bg or icon._bg
+
     local zoom = barData.iconZoom or 0.08
     local borderSz = barData.borderSize or 1
     local brdR = barData.borderR or 0
@@ -4330,7 +4331,7 @@ local function RefreshCDMIconAppearance(barKey)
                 end
             end
         end
-        -- Update border (PP or textured via ApplyBorderStyle)
+        -- Update border (PP or textured via ApplyBorderStyle).
         local bdrTgt = (fd and fd.borderFrame) or icon
         if fd and fd.borderFrame or EllesmereUI.PP.GetBorders(icon) then
             local textureKey = barData.borderTexture or "solid"

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3812,7 +3812,6 @@ ApplyShapeToCDMIcon = function(icon, shape, barData, ssb)
     local tex = fd and fd.tex or icon._tex
     local cd = fd and fd.cooldown or icon._cooldown
     local bg = fd and fd.bg or icon._bg
-
     local zoom = barData.iconZoom or 0.08
     local borderSz = barData.borderSize or 1
     local brdR = barData.borderR or 0
@@ -4331,7 +4330,7 @@ local function RefreshCDMIconAppearance(barKey)
                 end
             end
         end
-        -- Update border (PP or textured via ApplyBorderStyle).
+        -- Update border (PP or textured via ApplyBorderStyle)
         local bdrTgt = (fd and fd.borderFrame) or icon
         if fd and fd.borderFrame or EllesmereUI.PP.GetBorders(icon) then
             local textureKey = barData.borderTexture or "solid"


### PR DESCRIPTION
## Summary

Two Cooldown Manager audio changes:

### Fix: Trinket/item "Audio Effect on CD Ready" now fires in Mythic+ (and raid/PvP)
Previously the ready sound worked in the open world but was silent inside dungeons. Two independent causes:

- **Armed state lost on rebuild.** The CD-ready "armed" flag was stored on the per-rule object, but `FakeActive_Rearm` wipes and recreates rule objects on every CDM rebuild — which happens far more often in combat-heavy instances. A rebuild landing right at cooldown-end silently ate the on-CD → ready edge, so the sound never played. The armed state is now **persisted by ability key** so it survives rebuilds. The store is empty at login/reload, so a preset already ready at login still never false-fires.
- **Wrong cooldown source.** Readiness for trinket/item presets now reads the **item cooldown** (the true "when can I use this again" timer) instead of the item's on-use spell. An on-use trinket's granted spell often has its own, shorter cooldown, which caused the ready sound to fire early (e.g. at ~30s on a 90s trinket). A Secret-Value guard is retained purely as a safety net.

### Feature: "Audio on Buff Loss"
Adds an "Audio on Buff Loss" option mirroring the existing "Audio on Buff Gain", extended to self-timed preset/custom buffs (Bloodlust/Heroism/potions, etc.). It fires when the displayed buff timer ends.

## Files changed
- `EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua` — persist armed state by key; item-cooldown readiness read
- `EllesmereUICooldownManager/EllesmereUICdmHooks.lua` — buff-loss sound on preset/custom timer end
- `EllesmereUICooldownManager/EUI_CooldownManager_Options.lua` — "Audio on Buff Loss" option UI
- `EllesmereUICooldownManager/EllesmereUICooldownManager.lua` — minor cosmetic tidy

## Test plan
- [x] Open world: trinket CD-ready sound plays at the correct time (unchanged).
- [x] Mythic+ dungeon: trinket CD-ready sound now plays exactly when the trinket comes off its full cooldown (verified live).
- [x] No early fire mid-cooldown when the on-use spell's shorter lockout ends.
- [x] No false-fire at login/reload for an already-ready preset.
- [x] "Audio on Buff Loss" fires when a self-timed preset/custom buff's displayed timer ends.
