### PR TITLE
QoL: Add exclude warbound containers to auto open containers

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -1673,7 +1673,9 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        _, h = W:DualRow(parent, y,
+        -- Auto Unwrap Collections | Auto Open Containers
+        local autoOpenContainerRow
+        autoOpenContainerRow, h = W:DualRow(parent, y,
             { type="toggle", text="Auto Unwrap Collections",
               tooltip="Automatically dismisses the 'new mount/pet/toy' fanfare notification when you receive one, so you don't have to click through the collections journal.",
               getValue=function()
@@ -1695,8 +1697,61 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.autoOpenContainers = v
+                  EllesmereUI:RefreshPage()
               end }
         );  y = y - h
+
+        -- Cog on Auto Open Containers (right region)
+        do
+            local rightRgn = autoOpenContainerRow._rightRegion
+            local function autoOpenContainerOff()
+                return not (EllesmereUIDB and EllesmereUIDB.autoOpenContainers == true)
+            end
+
+            local _, autoOpenContainerCogShow = EllesmereUI.BuildCogPopup({
+                title = "Auto Open Containers Settings",
+                rows = {
+                    { type="toggle", label="Exclude Warbound Containers",
+                      get=function()
+                          if not EllesmereUIDB then return true end
+                          return EllesmereUIDB.autoOpenContainersExcludeWarbound ~= false
+                      end,
+                      set=function(v)
+                          if not EllesmereUIDB then EllesmereUIDB = {} end
+                          EllesmereUIDB.autoOpenContainersExcludeWarbound = v
+                      end },
+                },
+            })
+
+            local autoOpenContainerCogBtn = CreateFrame("Button", nil, rightRgn)
+            autoOpenContainerCogBtn:SetSize(26, 26)
+            autoOpenContainerCogBtn:SetPoint("RIGHT", rightRgn._lastInline or rightRgn._control, "LEFT", -9, 0)
+            rightRgn._lastInline = autoOpenContainerCogBtn
+            autoOpenContainerCogBtn:SetFrameLevel(rightRgn:GetFrameLevel() + 5)
+            autoOpenContainerCogBtn:SetAlpha(autoOpenContainerOff() and 0.15 or 0.4)
+            local autoOpenContainerCogTex = autoOpenContainerCogBtn:CreateTexture(nil, "OVERLAY")
+            autoOpenContainerCogTex:SetAllPoints()
+            autoOpenContainerCogTex:SetTexture(EllesmereUI.COGS_ICON)
+            autoOpenContainerCogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            autoOpenContainerCogBtn:SetScript("OnLeave", function(self) self:SetAlpha(autoOpenContainerOff() and 0.15 or 0.4) end)
+            autoOpenContainerCogBtn:SetScript("OnClick", function(self) autoOpenContainerCogShow(self) end)
+
+            local autoOpenContainerCogBlock = CreateFrame("Frame", nil, autoOpenContainerCogBtn)
+            autoOpenContainerCogBlock:SetAllPoints()
+            autoOpenContainerCogBlock:SetFrameLevel(autoOpenContainerCogBtn:GetFrameLevel() + 10)
+            autoOpenContainerCogBlock:EnableMouse(true)
+            autoOpenContainerCogBlock:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(autoOpenContainerCogBtn, EllesmereUI.DisabledTooltip("Auto Open Containers"))
+            end)
+            autoOpenContainerCogBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = autoOpenContainerOff()
+                autoOpenContainerCogBtn:SetAlpha(off and 0.15 or 0.4)
+                if off then autoOpenContainerCogBlock:Show() else autoOpenContainerCogBlock:Hide() end
+            end)
+            if autoOpenContainerOff() then autoOpenContainerCogBlock:Show() else autoOpenContainerCogBlock:Hide() end
+        end
 
         return math.abs(y)
     end
@@ -1746,6 +1801,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.trainAllButton = false
                 EllesmereUIDB.autoUnwrapCollections = false
                 EllesmereUIDB.autoOpenContainers = false
+                EllesmereUIDB.autoOpenContainersExcludeWarbound = true
                 EllesmereUIDB.autoRepairGuild = false
                 EllesmereUIDB.shifterEnabled = false
                 EllesmereUIDB.shifterPositions = nil

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -212,18 +212,28 @@ qolFrame:SetScript("OnEvent", function(self)
                                 if InCombatLockdown() then wipe(_pendingOpens); return end
                                 local item = _pendingOpens[idx]
                                 local info = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                                if info and info.itemID and _openableCache[info.itemID] and not _failedItems[info.itemID] then
-                                    local prevID = info.itemID
-                                    local prevCount = info.stackCount or 1
-                                    C_Container.UseContainerItem(item.bag, item.slot)
-                                    C_Timer.After(0.5, function()
-                                        local after = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                                        if after and after.itemID == prevID and (after.stackCount or 1) >= prevCount then
-                                            _failedItems[prevID] = true
+                                if info and info.itemID then
+                                    if EllesmereUIDB and EllesmereUIDB.autoOpenContainersExcludeWarbound then
+                                        local loc = ItemLocation:CreateFromBagAndSlot(item.bag, item.slot)
+                                        local isWarbound = C_Bank.IsItemAllowedInBankType(Enum.BankType.Account, loc)
+                                        if isWarbound then
+                                            OpenNext(idx + 1)
+                                            return
                                         end
-                                        OpenNext(idx + 1)
-                                    end)
-                                    return
+                                    end
+                                    if _openableCache[info.itemID] and not _failedItems[info.itemID] then
+                                        local prevID = info.itemID
+                                        local prevCount = info.stackCount or 1
+                                        C_Container.UseContainerItem(item.bag, item.slot)
+                                        C_Timer.After(0.5, function()
+                                            local after = C_Container.GetContainerItemInfo(item.bag, item.slot)
+                                            if after and after.itemID == prevID and (after.stackCount or 1) >= prevCount then
+                                                _failedItems[prevID] = true
+                                            end
+                                            OpenNext(idx + 1)
+                                        end)
+                                        return
+                                    end
                                 end
                                 C_Timer.After(0.5, function() OpenNext(idx + 1) end)
                             end
@@ -283,18 +293,28 @@ qolFrame:SetScript("OnEvent", function(self)
                 if InCombatLockdown() then return end
                 local item = toOpen[idx]
                 local info2 = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                if info2 and info2.itemID and _openableCache[info2.itemID] and not _failedItems[info2.itemID] then
-                    local prevID = info2.itemID
-                    local prevCount = info2.stackCount or 1
-                    C_Container.UseContainerItem(item.bag, item.slot)
-                    C_Timer.After(0.5, function()
-                        local after = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                        if after and after.itemID == prevID and (after.stackCount or 1) >= prevCount then
-                            _failedItems[prevID] = true
+                if info2 and info2.itemID then
+                    if EllesmereUIDB and EllesmereUIDB.autoOpenContainersExcludeWarbound then
+                        local loc = ItemLocation:CreateFromBagAndSlot(item.bag, item.slot)
+                        local isWarbound = C_Bank.IsItemAllowedInBankType(Enum.BankType.Account, loc)
+                        if isWarbound then
+                            OpenNext(idx + 1)
+                            return
                         end
-                        OpenNext(idx + 1)
-                    end)
-                    return
+                    end
+                    if _openableCache[info2.itemID] and not _failedItems[info2.itemID] then
+                        local prevID = info2.itemID
+                        local prevCount = info2.stackCount or 1
+                        C_Container.UseContainerItem(item.bag, item.slot)
+                        C_Timer.After(0.5, function()
+                            local after = C_Container.GetContainerItemInfo(item.bag, item.slot)
+                            if after and after.itemID == prevID and (after.stackCount or 1) >= prevCount then
+                                _failedItems[prevID] = true
+                            end
+                            OpenNext(idx + 1)
+                        end)
+                        return
+                    end
                 end
                 C_Timer.After(0.5, function() OpenNext(idx + 1) end)
             end


### PR DESCRIPTION
This fixes https://github.com/EllesmereGaming/EllesmereUI/issues/493.

Default is **true** for this new option. Let me know if it is something we should disable by default instead.

<img width="499" height="123" alt="image" src="https://github.com/user-attachments/assets/9b19a595-416b-4413-8efb-8311b26ae991" />
