### PR TITLE
Tooltip: Check for guild text before updating

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -335,7 +335,7 @@ end
                         end
                     end
                 end
-                if _guildL then
+                if _guildL and _guildL:GetText() then
                     _guildL:SetText(_guildL:GetText() .. " [" .. guildRankName .. "]")
                 end
             end


### PR DESCRIPTION
Base feature: https://github.com/EllesmereGaming/EllesmereUI/pull/560

Once the cache was set, going in Edit Mode (base UI) would cause an error when hovering a player (unit frame or 3D model - basically anything that would make a player tooltip appear) who is part of a guild.