### PR TITLE
[wip] Add configurable nameplate class icons

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -6646,34 +6646,40 @@ initFrame:SetScript("OnEvent", function(self)
         -----------------------------------------------------------------------
         --  PLAYER CLASS ICONS
         -----------------------------------------------------------------------
+        local playerClassIconHeader
+        local playerClassIconToggleRow
+        local playerClassIconStyleRow
         do
-            _, h = W:SectionHeader(parent, "PLAYER CLASS ICONS", y);  y = y - h
+            playerClassIconHeader, h = W:SectionHeader(parent, "PLAYER CLASS ICONS", y);  y = y - h
 
             local function classIconsDisabled()
                 return DBVal("showEnemyClassIcons") ~= true and DBVal("showFriendlyClassIcons") ~= true
             end
             local classIconStyleValues = {
                 blizzard = "Blizzard",
-                accent   = "EUI Accent",
                 modern   = "Modern",
                 arcade   = "Arcade",
                 glyph    = "Glyph",
-                legend   = "Legend",
                 midnight = "Midnight",
                 pixel    = "Pixel",
                 runic    = "Runic",
             }
             local classIconStyleOrder = {
-                "blizzard", "---", "accent", "modern", "arcade", "glyph",
-                "legend", "midnight", "pixel", "runic",
+                "blizzard", "---", "modern", "arcade", "glyph",
+                "midnight", "pixel", "runic",
             }
+            local function getClassIconStyle()
+                local style = DBVal("classIconStyle") or defaults.classIconStyle
+                if classIconStyleValues[style] then return style end
+                return defaults.classIconStyle
+            end
             local function refreshClassIcons(rebuild)
                 if ns.RefreshClassIcons then ns.RefreshClassIcons() end
                 UpdatePreview()
                 if rebuild then EllesmereUI:RefreshPage() end
             end
 
-            _, h = W:DualRow(parent, y,
+            playerClassIconToggleRow, h = W:DualRow(parent, y,
                 { type="toggle", text="Enemy Player Class Icons",
                   tooltip="Shows class icons above enemy player nameplates.",
                   getValue=function() return DBVal("showEnemyClassIcons") == true end,
@@ -6689,14 +6695,14 @@ initFrame:SetScript("OnEvent", function(self)
                     refreshClassIcons(true)
                   end });  y = y - h
 
-            _, h = W:DualRow(parent, y,
+            playerClassIconStyleRow, h = W:DualRow(parent, y,
                 { type="dropdown", text="Class Icon Style",
                   tooltip="Uses Blizzard icons or EllesmereUI's existing class icon art.",
                   disabled=classIconsDisabled,
                   disabledTooltip="Enemy or Friendly Player Class Icons",
                   values=classIconStyleValues,
                   order=classIconStyleOrder,
-                  getValue=function() return DBVal("classIconStyle") or defaults.classIconStyle end,
+                  getValue=getClassIconStyle,
                   setValue=function(v)
                     DB().classIconStyle = v
                     refreshClassIcons()
@@ -7449,6 +7455,7 @@ initFrame:SetScript("OnEvent", function(self)
             castTarget   = { section = generalTextHeader, target = spellNameRow,        slotSide = "right" },
             healthBar    = { section = healthBarHeader,  target = healthBarHeightRow },
             classResource = { section = classResourceHeader, target = classResourceSection },
+            playerClassIcon = { section = playerClassIconHeader, target = playerClassIconStyleRow or playerClassIconToggleRow, slotSide = "left" },
             targetArrows = { section = tfxHeader,            target = targetGlowRow,       slotSide = "right" },
         }
 
@@ -7732,6 +7739,11 @@ initFrame:SetScript("OnEvent", function(self)
                 classOverlay = CreateHitOverlay(pv._classIcon, "classIcon")
                 if not showClassificationPreview then classOverlay:Hide() end
             end
+            local playerClassOverlay
+            if pv._playerClassIcon and pv._playerClassIcon.frame then
+                playerClassOverlay = CreateHitOverlay(pv._playerClassIcon.frame, "playerClassIcon")
+                if not pv._playerClassIcon.frame:IsShown() then playerClassOverlay:Hide() end
+            end
             -- Class resource pips wrapper button spanning all visible pips
             local cpOverlay
             if pv._cpPips then
@@ -7786,6 +7798,7 @@ initFrame:SetScript("OnEvent", function(self)
             -- Sync overlay visibility with preview toggles
             pv._raidOverlay = raidOverlay
             pv._classOverlay = classOverlay
+            pv._playerClassOverlay = playerClassOverlay
             -- Target arrows wrapper button spanning both arrow textures
             local arrowOverlay
             if pv._arrows then

--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -6594,6 +6594,104 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         -----------------------------------------------------------------------
+        --  PLAYER CLASS ICONS
+        -----------------------------------------------------------------------
+        do
+            _, h = W:SectionHeader(parent, "PLAYER CLASS ICONS", y);  y = y - h
+
+            local function classIconsDisabled()
+                return DBVal("showEnemyClassIcons") ~= true and DBVal("showFriendlyClassIcons") ~= true
+            end
+            local classIconStyleValues = {
+                blizzard = "Blizzard",
+                accent   = "EUI Accent",
+                modern   = "Modern",
+                arcade   = "Arcade",
+                glyph    = "Glyph",
+                legend   = "Legend",
+                midnight = "Midnight",
+                pixel    = "Pixel",
+                runic    = "Runic",
+            }
+            local classIconStyleOrder = {
+                "blizzard", "---", "accent", "modern", "arcade", "glyph",
+                "legend", "midnight", "pixel", "runic",
+            }
+            local function refreshClassIcons(rebuild)
+                if ns.RefreshClassIcons then ns.RefreshClassIcons() end
+                UpdatePreview()
+                if rebuild then EllesmereUI:RefreshPage() end
+            end
+
+            _, h = W:DualRow(parent, y,
+                { type="toggle", text="Enemy Player Class Icons",
+                  tooltip="Shows class icons above enemy player nameplates.",
+                  getValue=function() return DBVal("showEnemyClassIcons") == true end,
+                  setValue=function(v)
+                    DB().showEnemyClassIcons = v
+                    refreshClassIcons(true)
+                  end },
+                { type="toggle", text="Friendly Player Class Icons",
+                  tooltip="Shows class icons above EUI full friendly player nameplates. Name-only friendly nameplates stay Blizzard-controlled.",
+                  getValue=function() return DBVal("showFriendlyClassIcons") == true end,
+                  setValue=function(v)
+                    DB().showFriendlyClassIcons = v
+                    refreshClassIcons(true)
+                  end });  y = y - h
+
+            _, h = W:DualRow(parent, y,
+                { type="dropdown", text="Class Icon Style",
+                  tooltip="Uses Blizzard icons or EllesmereUI's existing class icon art.",
+                  disabled=classIconsDisabled,
+                  disabledTooltip="Enemy or Friendly Player Class Icons",
+                  values=classIconStyleValues,
+                  order=classIconStyleOrder,
+                  getValue=function() return DBVal("classIconStyle") or defaults.classIconStyle end,
+                  setValue=function(v)
+                    DB().classIconStyle = v
+                    refreshClassIcons()
+                  end },
+                { type="slider", text="Class Icon Size", min=12, max=40, step=1,
+                  disabled=classIconsDisabled,
+                  disabledTooltip="Enemy or Friendly Player Class Icons",
+                  getValue=function() return DBVal("classIconSize") or defaults.classIconSize end,
+                  setValue=function(v)
+                    DB().classIconSize = v
+                    refreshClassIcons()
+                  end });  y = y - h
+
+            _, h = W:DualRow(parent, y,
+                { type="toggle", text="Class Color Border",
+                  disabled=classIconsDisabled,
+                  disabledTooltip="Enemy or Friendly Player Class Icons",
+                  getValue=function() return DBVal("classIconClassColorBorder") ~= false end,
+                  setValue=function(v)
+                    DB().classIconClassColorBorder = v
+                    refreshClassIcons()
+                  end },
+                { type="slider", text="Class Icon X", min=-80, max=80, step=1,
+                  disabled=classIconsDisabled,
+                  disabledTooltip="Enemy or Friendly Player Class Icons",
+                  getValue=function() return DBVal("classIconXOffset") or defaults.classIconXOffset end,
+                  setValue=function(v)
+                    DB().classIconXOffset = v
+                    refreshClassIcons()
+                  end });  y = y - h
+
+            _, h = W:DualRow(parent, y,
+                { type="slider", text="Class Icon Y", min=-80, max=80, step=1,
+                  disabled=classIconsDisabled,
+                  disabledTooltip="Enemy or Friendly Player Class Icons",
+                  getValue=function() return DBVal("classIconYOffset") or defaults.classIconYOffset end,
+                  setValue=function(v)
+                    DB().classIconYOffset = v
+                    refreshClassIcons()
+                  end });  y = y - h
+
+            _, h = W:Spacer(parent, y, 20);  y = y - h
+        end
+
+        -----------------------------------------------------------------------
         --  CLASS RESOURCE
         -----------------------------------------------------------------------
         local classResourceHeader

--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -559,6 +559,17 @@ initFrame:SetScript("OnEvent", function(self)
         nameFS:SetText(EllesmereUI.L("Enemy Name Text"))
         nameFS:SetTextColor(1, 1, 1, 1)
 
+        local playerClassIconFrame = CreateFrame("Frame", nil, pf)
+        playerClassIconFrame:SetFrameLevel(health:GetFrameLevel() + 9)
+        playerClassIconFrame:Hide()
+        local playerClassIconTex = playerClassIconFrame:CreateTexture(nil, "ARTWORK")
+        playerClassIconTex:SetAllPoints()
+        UnsnapTex(playerClassIconTex)
+        if PP and PP.CreateBorder then
+            PP.CreateBorder(playerClassIconFrame, 0, 0, 0, 1, 1, "OVERLAY", 7, true)
+        end
+        pf._playerClassIcon = { frame = playerClassIconFrame, icon = playerClassIconTex, anchor = nameFS }
+
         -- Health percentage text (right-aligned inside health bar)
         local hpText = healthTextFrame:CreateFontString(nil, "OVERLAY")
         SetPVFont(hpText, FONT_PATH, 10, GetNPOptOutline())
@@ -850,6 +861,44 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Cached position values for the health bar anchor (see health block).
         local _cachedRawBarW, _cachedXOff
+
+        pf.UpdatePlayerClassIcon = function(self)
+            local ci = self._playerClassIcon
+            if not ci then return 0 end
+            local enabled = DBVal("showEnemyClassIcons") == true or DBVal("showFriendlyClassIcons") == true
+            if not enabled then
+                ci.frame:Hide()
+                return 0
+            end
+
+            local _, classToken = UnitClass("player")
+            classToken = classToken or "WARRIOR"
+            local size = DBVal("classIconSize") or defaults.classIconSize
+            local xOff = DBVal("classIconXOffset") or defaults.classIconXOffset
+            local yOff = DBVal("classIconYOffset") or defaults.classIconYOffset
+
+            ci.frame:SetSize(size, size)
+            ci.frame:ClearAllPoints()
+            ci.frame:SetPoint("BOTTOM", ci.anchor, "TOP", xOff, yOff)
+            if ns.ApplyClassIconTexture then
+                ns.ApplyClassIconTexture(ci.icon, classToken, DBVal("classIconStyle") or defaults.classIconStyle)
+            end
+
+            if PP and PP.GetBorders then
+                local border = PP.GetBorders(ci.frame)
+                if border then
+                    local c = DBVal("classIconClassColorBorder") ~= false and RAID_CLASS_COLORS and RAID_CLASS_COLORS[classToken]
+                    if c then
+                        PP.SetBorderColor(ci.frame, c.r, c.g, c.b, 1)
+                    else
+                        PP.SetBorderColor(ci.frame, 0, 0, 0, 1)
+                    end
+                    PP.ShowBorder(ci.frame)
+                end
+            end
+            ci.frame:Show()
+            return math.max(0, size + yOff)
+        end
 
         -------------------------------------------------------------------
         --  Update re-reads DB, applies to existing frames. No rebuilds.
@@ -1804,6 +1853,7 @@ initFrame:SetScript("OnEvent", function(self)
             if isTopSlot(ccSlotVal) then topExtent = math.max(topExtent, ccSz + ccYOff) end
             if isTopSlot(rmPos) and showRM then topExtent = math.max(topExtent, rmSize + rmYOff) end
             if isTopSlot(clPos) and showCL then topExtent = math.max(topExtent, reIconSz + clYOff) end
+            if self.UpdatePlayerClassIcon then topExtent = math.max(topExtent, self:UpdatePlayerClassIcon()) end
             -- Only include name text height when something is actually in the top slot
             local topTextH = (slotTop ~= "none") and (topFontSz + 4 + nameYOff + topYOff) or 0
             -- Only add debuffY gap when something occupies the center "top" position or top text slot

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -37,7 +37,7 @@ local function NP_ArmAuraCooldown(cd, durObj)
     end
     return true
 end
-local UnitName, UnitGUID = UnitName, UnitGUID
+local UnitName = UnitName
 local UnitIsUnit, UnitCanAttack = UnitIsUnit, UnitCanAttack
 local UnitIsEnemy, UnitIsTapDenied = UnitIsEnemy, UnitIsTapDenied
 
@@ -1369,9 +1369,7 @@ do
     end
 
     local function IsPlayerClassIconUnit(unit)
-        if UnitIsPlayer(unit) then return true end
-        local guid = UnitGUID(unit)
-        return type(guid) == "string" and guid:match("^Player%-") ~= nil
+        return UnitIsPlayer(unit) == true
     end
 
     local function GetClassIconClassToken(unit)

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -135,6 +135,8 @@ function ns._appendDisplayPresetKeys(t)
         "debuffCropIcons", "buffCropIcons", "ccCropIcons",
         "showCastLockoutAsCrowdControl",
         "targetGlowEllesmereUI", "targetGlowBorderColor", "targetGlowHighlight", "targetBorderColor",
+        "showEnemyClassIcons", "showFriendlyClassIcons", "classIconStyle", "classIconSize",
+        "classIconXOffset", "classIconYOffset", "classIconClassColorBorder",
     }) do t[#t + 1] = k end
 end
 
@@ -231,6 +233,13 @@ local defaults = {
     targetArrowScale = 1.0,
     targetArrowColor = { r = 1, g = 1, b = 1 },
     targetArrowClassColor = false,
+    showEnemyClassIcons = false,
+    showFriendlyClassIcons = false,
+    classIconStyle = "blizzard",
+    classIconSize = 22,
+    classIconXOffset = 0,
+    classIconYOffset = 2,
+    classIconClassColorBorder = true,
     showClassPower = false,
     classPowerPos = "bottom",
     classPowerYOffset = 1,
@@ -1326,6 +1335,174 @@ end
 function ns.GetClassPowerBorderSize()
     return (p and p.classPowerBorderSize) or defaults.classPowerBorderSize
 end
+
+-- Player class icon overlay. Uses Ellesmere's class icon sheets when selected;
+-- otherwise uses Blizzard's built-in class atlas with a legacy sheet fallback.
+do
+    local CLASS_ICON_TEX = "Interface\\GLUES\\CHARACTERCREATE\\UI-CHARACTERCREATE-CLASSES"
+    local CLASS_FULL_SPRITE_BASE = "Interface\\AddOns\\EllesmereUI\\media\\icons\\class-full\\"
+    local CLASS_ACCENT_BASE = "Interface\\AddOns\\EllesmereUI\\media\\icons\\class-accent\\"
+    local CLASS_FULL_COORDS = {
+        WARRIOR     = { 0,     0.125, 0,     0.125 },
+        MAGE        = { 0.125, 0.25,  0,     0.125 },
+        ROGUE       = { 0.25,  0.375, 0,     0.125 },
+        DRUID       = { 0.375, 0.5,   0,     0.125 },
+        EVOKER      = { 0.5,   0.625, 0,     0.125 },
+        HUNTER      = { 0,     0.125, 0.125, 0.25  },
+        SHAMAN      = { 0.125, 0.25,  0.125, 0.25  },
+        PRIEST      = { 0.25,  0.375, 0.125, 0.25  },
+        WARLOCK     = { 0.375, 0.5,   0.125, 0.25  },
+        PALADIN     = { 0,     0.125, 0.25,  0.375 },
+        DEATHKNIGHT = { 0.125, 0.25,  0.25,  0.375 },
+        MONK        = { 0.25,  0.375, 0.25,  0.375 },
+        DEMONHUNTER = { 0.375, 0.5,   0.25,  0.375 },
+    }
+    local CLASS_ACCENT_FILES = {
+        WARRIOR     = "warrior",
+        MAGE        = "mage",
+        ROGUE       = "rogue",
+        DRUID       = "druid",
+        EVOKER      = "evoker",
+        HUNTER      = "hunter",
+        SHAMAN      = "shaman",
+        PRIEST      = "priest",
+        WARLOCK     = "warlock",
+        PALADIN     = "paladin",
+        DEATHKNIGHT = "dk",
+        MONK        = "monk",
+        DEMONHUNTER = "dh",
+    }
+    local CLASS_FULL_STYLES = {
+        modern = true, arcade = true, glyph = true, legend = true,
+        midnight = true, pixel = true, runic = true,
+    }
+
+    local function ApplyEllesmereClassIconTexture(tex, classToken, style)
+        if style == "accent" then
+            local file = CLASS_ACCENT_FILES[classToken]
+            if not file then return false end
+            tex:SetTexture(CLASS_ACCENT_BASE .. file .. ".png")
+            tex:SetTexCoord(0, 1, 0, 1)
+            return true
+        end
+        if not CLASS_FULL_STYLES[style] then return false end
+        local coords = CLASS_FULL_COORDS[classToken]
+        if not coords then return false end
+        tex:SetTexture(CLASS_FULL_SPRITE_BASE .. style .. ".tga")
+        tex:SetTexCoord(coords[1], coords[2], coords[3], coords[4])
+        return true
+    end
+
+    function ns.GetClassIconStyle()
+        return (p and p.classIconStyle) or defaults.classIconStyle
+    end
+    function ns.GetClassIconSize()
+        return (p and p.classIconSize) or defaults.classIconSize
+    end
+    function ns.GetClassIconXOffset()
+        return (p and p.classIconXOffset) or defaults.classIconXOffset
+    end
+    function ns.GetClassIconYOffset()
+        return (p and p.classIconYOffset) or defaults.classIconYOffset
+    end
+    function ns.GetClassIconClassColorBorder()
+        local v = p and p.classIconClassColorBorder
+        if v == nil then return defaults.classIconClassColorBorder end
+        return v
+    end
+
+    function ns.IsClassIconEnabledForUnit(unit)
+        if not unit or not UnitIsPlayer(unit) or UnitIsUnit(unit, "player") then return false end
+        if UnitCanAttack("player", unit) then
+            return p and p.showEnemyClassIcons == true
+        end
+        return p and p.showFriendlyClassIcons == true
+    end
+
+    function ns.EnsureClassIcon(plate)
+        if plate.classIconFrame then return end
+        local frame = CreateFrame("Frame", nil, plate)
+        frame:SetFrameStrata("MEDIUM")
+        frame:SetFrameLevel(905)
+        frame:Hide()
+        plate.classIconFrame = frame
+
+        frame.icon = frame:CreateTexture(nil, "ARTWORK")
+        frame.icon:SetAllPoints()
+        if PP and PP.DisablePixelSnap then PP.DisablePixelSnap(frame.icon) end
+
+        if PP and PP.CreateBorder then
+            PP.CreateBorder(frame, 0, 0, 0, 1, 1, "OVERLAY", 7, true)
+        end
+    end
+
+    function ns.UpdateClassIcon(plate)
+        local unit = plate and plate.unit
+        if not ns.IsClassIconEnabledForUnit(unit) then
+            if plate and plate.classIconFrame then plate.classIconFrame:Hide() end
+            return
+        end
+
+        local classToken = UnitClassBase and UnitClassBase(unit)
+        if not classToken then
+            classToken = select(2, UnitClass(unit))
+        end
+        if not classToken then
+            if plate.classIconFrame then plate.classIconFrame:Hide() end
+            return
+        end
+
+        ns.EnsureClassIcon(plate)
+        local frame = plate.classIconFrame
+        local size = ns.GetClassIconSize()
+        frame:SetSize(size, size)
+        frame:ClearAllPoints()
+
+        local anchor = plate.health
+        if plate.name and plate.name:IsShown()
+           and (not plate.topTextFrame or plate.name:GetParent() == plate.topTextFrame) then
+            anchor = plate.name
+        end
+        frame:SetPoint("BOTTOM", anchor, "TOP", ns.GetClassIconXOffset(), ns.GetClassIconYOffset())
+
+        local style = ns.GetClassIconStyle()
+        if style ~= "blizzard" and ApplyEllesmereClassIconTexture(frame.icon, classToken, style) then
+            frame.icon:SetDesaturated(false)
+            frame.icon:SetVertexColor(1, 1, 1, 1)
+        else
+            local atlas = "classicon-" .. string.lower(classToken)
+            if frame.icon.SetAtlas and (not C_Texture or not C_Texture.GetAtlasInfo or C_Texture.GetAtlasInfo(atlas)) then
+                frame.icon:SetAtlas(atlas)
+                frame.icon:SetTexCoord(0, 1, 0, 1)
+            else
+                frame.icon:SetTexture(CLASS_ICON_TEX)
+                local tc = CLASS_ICON_TCOORDS and CLASS_ICON_TCOORDS[classToken]
+                if tc then
+                    frame.icon:SetTexCoord(tc[1], tc[2], tc[3], tc[4])
+                else
+                    frame.icon:SetTexCoord(0, 1, 0, 1)
+                end
+            end
+            frame.icon:SetDesaturated(false)
+            frame.icon:SetVertexColor(1, 1, 1, 1)
+        end
+
+        if PP and PP.GetBorders then
+            local border = PP.GetBorders(frame)
+            if border then
+                local c = ns.GetClassIconClassColorBorder() and RAID_CLASS_COLORS and RAID_CLASS_COLORS[classToken]
+                if c then
+                    PP.SetBorderColor(frame, c.r, c.g, c.b, 1)
+                else
+                    PP.SetBorderColor(frame, 0, 0, 0, 1)
+                end
+                PP.ShowBorder(frame)
+            end
+        end
+        frame:Show()
+    end
+end
+
 local function IsBorderEnabled()
     local v = p and p.showBorder
     if v == nil then return defaults.showBorder end
@@ -3202,6 +3379,14 @@ function ns.RefreshAllSettings()
         end
     end
     if ns.ApplyClassPowerSetting then ns.ApplyClassPowerSetting() end
+    if ns.RefreshFriendlyClassIcons then ns.RefreshFriendlyClassIcons() end
+end
+
+function ns.RefreshClassIcons()
+    for _, plate in pairs(ns.plates) do
+        if plate.UpdateClassIcon then plate:UpdateClassIcon() end
+    end
+    if ns.RefreshFriendlyClassIcons then ns.RefreshFriendlyClassIcons() end
 end
 
 function ns.HideHoverEffect(plate)
@@ -5546,6 +5731,7 @@ function NameplateFrame:SetUnit(unit, nameplate)
             self:UpdateName()
             self:UpdateClassification()
             self:UpdateRaidIcon()
+            self:UpdateClassIcon()
             self:ApplyTarget()
             self:ApplyMouseover()
             self:UpdateCast()
@@ -5650,6 +5836,7 @@ function NameplateFrame:ClearUnit()
     self.raidFrame:Hide()
     self.classFrame:Hide()
     if self.classText then self.classText:Hide() end
+    if self.classIconFrame then self.classIconFrame:Hide() end
     if self.focusLetter then self.focusLetter:Hide() end
     if self.leftArrow then self.leftArrow:Hide() end
     if self.rightArrow then self.rightArrow:Hide() end
@@ -5994,6 +6181,9 @@ function NameplateFrame:UpdateName()
         self.name:SetText(name)
     end
 end
+function NameplateFrame:UpdateClassIcon()
+    ns.UpdateClassIcon(self)
+end
 function NameplateFrame:UpdateClassification()
     if not self.unit then return end
     local slot = GetClassificationSlot()
@@ -6184,6 +6374,7 @@ function NameplateFrame:RefreshNamePosition()
     self:ApplyNameVisibility()
     self:UpdateAuras()
     self:UpdateClassification()
+    self:UpdateClassIcon()
 end
 function NameplateFrame:UpdateRaidIcon()
     if not self.unit then return end
@@ -7899,6 +8090,7 @@ function NameplateFrame:QueueAuraFallback()
 end
 function NameplateFrame:UNIT_NAME_UPDATE()
     self:UpdateName()
+    if self.classIconFrame then self:UpdateClassIcon() end
 end
 function NameplateFrame:UNIT_THREAT_LIST_UPDATE()
     self:UpdateHealthColor()

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -1341,7 +1341,6 @@ end
 do
     local CLASS_ICON_TEX = "Interface\\GLUES\\CHARACTERCREATE\\UI-CHARACTERCREATE-CLASSES"
     local CLASS_FULL_SPRITE_BASE = "Interface\\AddOns\\EllesmereUI\\media\\icons\\class-full\\"
-    local CLASS_ACCENT_BASE = "Interface\\AddOns\\EllesmereUI\\media\\icons\\class-accent\\"
     local CLASS_FULL_COORDS = {
         WARRIOR     = { 0,     0.125, 0,     0.125 },
         MAGE        = { 0.125, 0.25,  0,     0.125 },
@@ -1357,34 +1356,44 @@ do
         MONK        = { 0.25,  0.375, 0.25,  0.375 },
         DEMONHUNTER = { 0.375, 0.5,   0.25,  0.375 },
     }
-    local CLASS_ACCENT_FILES = {
-        WARRIOR     = "warrior",
-        MAGE        = "mage",
-        ROGUE       = "rogue",
-        DRUID       = "druid",
-        EVOKER      = "evoker",
-        HUNTER      = "hunter",
-        SHAMAN      = "shaman",
-        PRIEST      = "priest",
-        WARLOCK     = "warlock",
-        PALADIN     = "paladin",
-        DEATHKNIGHT = "dk",
-        MONK        = "monk",
-        DEMONHUNTER = "dh",
-    }
     local CLASS_FULL_STYLES = {
-        modern = true, arcade = true, glyph = true, legend = true,
+        modern = true, arcade = true, glyph = true,
         midnight = true, pixel = true, runic = true,
     }
 
-    local function ApplyEllesmereClassIconTexture(tex, classToken, style)
-        if style == "accent" then
-            local file = CLASS_ACCENT_FILES[classToken]
-            if not file then return false end
-            tex:SetTexture(CLASS_ACCENT_BASE .. file .. ".png")
-            tex:SetTexCoord(0, 1, 0, 1)
-            return true
+    local function NormalizeClassIconStyle(style)
+        if style == "blizzard" or CLASS_FULL_STYLES[style] then
+            return style
         end
+        return defaults.classIconStyle
+    end
+
+    local function IsPlayerClassIconUnit(unit)
+        if UnitIsPlayer(unit) then return true end
+        local guid = UnitGUID(unit)
+        return type(guid) == "string" and guid:match("^Player%-") ~= nil
+    end
+
+    local function GetClassIconClassToken(unit)
+        local classToken = UnitClassBase and UnitClassBase(unit)
+        if not classToken then
+            classToken = select(2, UnitClass(unit))
+        end
+        return classToken
+    end
+
+    local function QueueClassIconRetry(plate, unit)
+        if not plate or not unit then return end
+        plate._classIconRetryCount = (plate._classIconRetryCount or 0) + 1
+        if plate._classIconRetryCount > 5 then return end
+        C_Timer.After(0.2, function()
+            if plate.unit == unit then
+                ns.UpdateClassIcon(plate)
+            end
+        end)
+    end
+
+    local function ApplyEllesmereClassIconTexture(tex, classToken, style)
         if not CLASS_FULL_STYLES[style] then return false end
         local coords = CLASS_FULL_COORDS[classToken]
         if not coords then return false end
@@ -1395,7 +1404,7 @@ do
 
     function ns.ApplyClassIconTexture(tex, classToken, style)
         if not tex or not classToken then return false end
-        style = style or defaults.classIconStyle
+        style = NormalizeClassIconStyle(style or defaults.classIconStyle)
         if style ~= "blizzard" and ApplyEllesmereClassIconTexture(tex, classToken, style) then
             tex:SetDesaturated(false)
             tex:SetVertexColor(1, 1, 1, 1)
@@ -1420,7 +1429,7 @@ do
     end
 
     function ns.GetClassIconStyle()
-        return (p and p.classIconStyle) or defaults.classIconStyle
+        return NormalizeClassIconStyle((p and p.classIconStyle) or defaults.classIconStyle)
     end
     function ns.GetClassIconSize()
         return (p and p.classIconSize) or defaults.classIconSize
@@ -1438,7 +1447,7 @@ do
     end
 
     function ns.IsClassIconEnabledForUnit(unit)
-        if not unit or not UnitIsPlayer(unit) or UnitIsUnit(unit, "player") then return false end
+        if not unit or UnitIsUnit(unit, "player") or not IsPlayerClassIconUnit(unit) then return false end
         if UnitCanAttack("player", unit) then
             return p and p.showEnemyClassIcons == true
         end
@@ -1466,17 +1475,17 @@ do
         local unit = plate and plate.unit
         if not ns.IsClassIconEnabledForUnit(unit) then
             if plate and plate.classIconFrame then plate.classIconFrame:Hide() end
+            if plate then plate._classIconRetryCount = nil end
             return
         end
 
-        local classToken = UnitClassBase and UnitClassBase(unit)
-        if not classToken then
-            classToken = select(2, UnitClass(unit))
-        end
+        local classToken = GetClassIconClassToken(unit)
         if not classToken then
             if plate.classIconFrame then plate.classIconFrame:Hide() end
+            QueueClassIconRetry(plate, unit)
             return
         end
+        plate._classIconRetryCount = nil
 
         ns.EnsureClassIcon(plate)
         local frame = plate.classIconFrame
@@ -5820,6 +5829,7 @@ function NameplateFrame:ClearUnit()
     self._kickGeoDirty = nil
     self._castTex = nil
     self._castLockout = nil
+    self._classIconRetryCount = nil
     if ns._npDequeueAuraWork then ns._npDequeueAuraWork(self) end
     self.cast:Hide()
     self.castShieldFrame:Hide()
@@ -8350,6 +8360,7 @@ local function RefreshThreatContextAndPlateColors()
     wipe(ns._questObjText)
     for _, plate in pairs(ns.plates) do
         plate:UpdateHealthColor()
+        if plate.UpdateClassIcon then plate:UpdateClassIcon() end
     end
 end
 
@@ -8582,10 +8593,12 @@ manager:SetScript("OnEvent", function(self, event, unit)
         if oldTarget and oldTarget.unit then
             oldTarget:ApplyTarget()
             oldTarget:UpdateHealthColor()
+            if oldTarget.UpdateClassIcon then oldTarget:UpdateClassIcon() end
         end
         if ns._cachedTargetPlate and ns._cachedTargetPlate ~= oldTarget then
             ns._cachedTargetPlate:ApplyTarget()
             ns._cachedTargetPlate:UpdateHealthColor()
+            if ns._cachedTargetPlate.UpdateClassIcon then ns._cachedTargetPlate:UpdateClassIcon() end
         end
     elseif event == "PLAYER_FOCUS_CHANGED" then
         -- PERF: only update old + new focus plates instead of iterating all
@@ -8602,6 +8615,7 @@ manager:SetScript("OnEvent", function(self, event, unit)
         local function UpdateFocusPlate(plate)
             if not plate or not plate.unit then return end
             plate:UpdateHealthColor()
+            if plate.UpdateClassIcon then plate:UpdateClassIcon() end
             if focusPct ~= 100 then
                 local castH = GetCastBarHeight()
                 if UnitIsUnit(plate.unit, "focus") then

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -1393,6 +1393,32 @@ do
         return true
     end
 
+    function ns.ApplyClassIconTexture(tex, classToken, style)
+        if not tex or not classToken then return false end
+        style = style or defaults.classIconStyle
+        if style ~= "blizzard" and ApplyEllesmereClassIconTexture(tex, classToken, style) then
+            tex:SetDesaturated(false)
+            tex:SetVertexColor(1, 1, 1, 1)
+            return true
+        end
+
+        local atlas = "classicon-" .. string.lower(classToken)
+        if tex.SetAtlas and (not C_Texture or not C_Texture.GetAtlasInfo or C_Texture.GetAtlasInfo(atlas)) then
+            tex:SetAtlas(atlas)
+        else
+            tex:SetTexture(CLASS_ICON_TEX)
+            local tc = CLASS_ICON_TCOORDS and CLASS_ICON_TCOORDS[classToken]
+            if tc then
+                tex:SetTexCoord(tc[1], tc[2], tc[3], tc[4])
+            else
+                tex:SetTexCoord(0, 1, 0, 1)
+            end
+        end
+        tex:SetDesaturated(false)
+        tex:SetVertexColor(1, 1, 1, 1)
+        return true
+    end
+
     function ns.GetClassIconStyle()
         return (p and p.classIconStyle) or defaults.classIconStyle
     end
@@ -1465,27 +1491,7 @@ do
         end
         frame:SetPoint("BOTTOM", anchor, "TOP", ns.GetClassIconXOffset(), ns.GetClassIconYOffset())
 
-        local style = ns.GetClassIconStyle()
-        if style ~= "blizzard" and ApplyEllesmereClassIconTexture(frame.icon, classToken, style) then
-            frame.icon:SetDesaturated(false)
-            frame.icon:SetVertexColor(1, 1, 1, 1)
-        else
-            local atlas = "classicon-" .. string.lower(classToken)
-            if frame.icon.SetAtlas and (not C_Texture or not C_Texture.GetAtlasInfo or C_Texture.GetAtlasInfo(atlas)) then
-                frame.icon:SetAtlas(atlas)
-                frame.icon:SetTexCoord(0, 1, 0, 1)
-            else
-                frame.icon:SetTexture(CLASS_ICON_TEX)
-                local tc = CLASS_ICON_TCOORDS and CLASS_ICON_TCOORDS[classToken]
-                if tc then
-                    frame.icon:SetTexCoord(tc[1], tc[2], tc[3], tc[4])
-                else
-                    frame.icon:SetTexCoord(0, 1, 0, 1)
-                end
-            end
-            frame.icon:SetDesaturated(false)
-            frame.icon:SetVertexColor(1, 1, 1, 1)
-        end
+        ns.ApplyClassIconTexture(frame.icon, classToken, ns.GetClassIconStyle())
 
         if PP and PP.GetBorders then
             local border = PP.GetBorders(frame)

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -1337,7 +1337,7 @@ function ns.GetClassPowerBorderSize()
 end
 
 -- Player class icon overlay. Uses Ellesmere's class icon sheets when selected;
--- otherwise uses Blizzard's built-in class atlas with a legacy sheet fallback.
+-- otherwise uses Blizzard's built-in class sheet, matching other EUI modules.
 do
     local CLASS_ICON_TEX = "Interface\\GLUES\\CHARACTERCREATE\\UI-CHARACTERCREATE-CLASSES"
     local CLASS_FULL_SPRITE_BASE = "Interface\\AddOns\\EllesmereUI\\media\\icons\\class-full\\"
@@ -1411,17 +1411,12 @@ do
             return true
         end
 
-        local atlas = "classicon-" .. string.lower(classToken)
-        if tex.SetAtlas and (not C_Texture or not C_Texture.GetAtlasInfo or C_Texture.GetAtlasInfo(atlas)) then
-            tex:SetAtlas(atlas)
+        tex:SetTexture(CLASS_ICON_TEX)
+        local coords = CLASS_ICON_TCOORDS and CLASS_ICON_TCOORDS[classToken]
+        if coords then
+            tex:SetTexCoord(coords[1], coords[2], coords[3], coords[4])
         else
-            tex:SetTexture(CLASS_ICON_TEX)
-            local tc = CLASS_ICON_TCOORDS and CLASS_ICON_TCOORDS[classToken]
-            if tc then
-                tex:SetTexCoord(tc[1], tc[2], tc[3], tc[4])
-            else
-                tex:SetTexCoord(0, 1, 0, 1)
-            end
+            tex:SetTexCoord(0, 1, 0, 1)
         end
         tex:SetDesaturated(false)
         tex:SetVertexColor(1, 1, 1, 1)

--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -816,6 +816,7 @@ function FriendlyFrame:SetUnit(unit, nameplate)
     self:UpdateHealth()
     self:UpdateName()
     self:UpdateRaidIcon()
+    self:UpdateClassIcon()
     self:ApplyTarget()
     -- Re-apply the enemy border settings every spawn: a pooled plate may have
     -- been released while the user changed the border size/color/toggle.
@@ -834,6 +835,7 @@ function FriendlyFrame:ClearUnit()
     self.glow:Hide()
     if ns.HideHoverEffect then ns.HideHoverEffect(self) else self.highlight:Hide() end
     self.raidFrame:Hide()
+    if self.classIconFrame then self.classIconFrame:Hide() end
     self.leftArrow:Hide()
     self.rightArrow:Hide()
     self:Hide()
@@ -873,6 +875,10 @@ function FriendlyFrame:UpdateName()
     if not unit then return end
     local unitName = UnitName(unit)
     self.name:SetText(unitName or "")
+end
+
+function FriendlyFrame:UpdateClassIcon()
+    if ns.UpdateClassIcon then ns.UpdateClassIcon(self) end
 end
 
 function FriendlyFrame:UpdateRaidIcon()
@@ -923,7 +929,10 @@ function FriendlyFrame:ApplyTarget()
 end
 
 function FriendlyFrame:UNIT_HEALTH()  self:UpdateHealth() end
-function FriendlyFrame:UNIT_NAME_UPDATE()  self:UpdateName() end
+function FriendlyFrame:UNIT_NAME_UPDATE()
+    self:UpdateName()
+    if self.classIconFrame then self:UpdateClassIcon() end
+end
 
 -------------------------------------------------------------------------------
 --  Friendly event manager (target, mouseover, raid icons)
@@ -1007,6 +1016,7 @@ function ns.RemoveFriendlyPlateNoRestore(unit)
     plate.raidFrame:Hide()
     plate.leftArrow:Hide()
     plate.rightArrow:Hide()
+    if plate.classIconFrame then plate.classIconFrame:Hide() end
     plate:Hide()
     plate:SetParent(UIParent)
     plate:ClearAllPoints()
@@ -1109,6 +1119,13 @@ function ns.RefreshFriendlyNameTextSize()
     local size = GetFriendlyNameTextSize()
     for _, plate in pairs(friendlyPlates) do
         if plate.name then SetFSFont(plate.name, size, "OUTLINE, SLUG") end
+        if plate.UpdateClassIcon then plate:UpdateClassIcon() end
+    end
+end
+
+function ns.RefreshFriendlyClassIcons()
+    for _, plate in pairs(friendlyPlates) do
+        if plate.UpdateClassIcon then plate:UpdateClassIcon() end
     end
 end
 

--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -832,6 +832,7 @@ function FriendlyFrame:ClearUnit()
     if self.unit then RestoreBlizzardUF(self.unit) end
     self.unit = nil
     self.nameplate = nil
+    self._classIconRetryCount = nil
     self.glow:Hide()
     if ns.HideHoverEffect then ns.HideHoverEffect(self) else self.highlight:Hide() end
     self.raidFrame:Hide()
@@ -1011,6 +1012,7 @@ function ns.RemoveFriendlyPlateNoRestore(unit)
     modifiedUFs[unit] = nil
     plate.unit = nil
     plate.nameplate = nil
+    plate._classIconRetryCount = nil
     plate.glow:Hide()
     if ns.HideHoverEffect then ns.HideHoverEffect(plate) else plate.highlight:Hide() end
     plate.raidFrame:Hide()


### PR DESCRIPTION
## Summary
- Add optional player class icons above enemy and friendly EUI nameplates.
- Add Display options for enemy/friendly toggles, icon style, size, offsets, and class-colored border.
