### PR TITLE
fix(qol): always outline the Group Death alert text

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -2440,8 +2440,11 @@ do
         if not alertOverlay then return end
         local fontPath = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras"))
             or EllesmereUI.EXPRESSWAY or "Fonts\\FRIZQT__.TTF"
-        local outline = (EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("extras"))
-            or "OUTLINE"
+        -- Always keep an outline so the alert stays readable over any background.
+        local outline = (EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("extras")) or ""
+        if not outline:find("OUTLINE") then
+            outline = (outline == "") and "OUTLINE" or (outline .. ", OUTLINE")
+        end
         local size = (EllesmereUIDB and EllesmereUIDB.groupDeathTextSize) or DEFAULT_TEXT_SIZE
         alertOverlay._text:SetFont(fontPath, size, outline)
         -- Keep the frame (and therefore the unlock-mode mover) compact and sized


### PR DESCRIPTION
## Summary
- Guarantees an OUTLINE on the **Group Death Announcer** text so it stays readable over any background, regardless of the configured Extras font style.
- If the Extras font style already includes an outline it is left as-is; otherwise OUTLINE is appended. Mirrors the treatment used by the Combat Alert text.

## Test plan
- [x] With an Extras font style that has no outline, the Group Death alert text now renders with an outline.
- [x] With an outlined Extras font style, behavior is unchanged.