### PR TITLE
Add zoom option for class/spec icons in damage meter

### DIFF
--- a/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
@@ -603,10 +603,10 @@ initFrame:SetScript("OnEvent", function(self)
         y = y - h
 
         -- Bar Spacing | Icon Style
-        _, h = W:DualRow(parent, y,
+        local iconRow, h = W:DualRow(parent, y,
             { type="slider", text="Spacing", min = -1, max = 10, step = 1,
-              getValue = function() return Cfg("barSpacing") or 2 end,
-              setValue = function(v) Set("barSpacing", v); Refresh() end },
+            getValue = function() return Cfg("barSpacing") or 2 end,
+            setValue = function(v) Set("barSpacing", v); Refresh() end },
             { type="dropdown", text="Icon Style",
               values = _G._EDM_IconStyleValues or {},
               order  = _G._EDM_IconStyleOrder or {},
@@ -617,6 +617,30 @@ initFrame:SetScript("OnEvent", function(self)
                 Refresh()  
               end })
         y = y - h
+
+        -- Inline cog: Icon Zoom (rechte Region, neben "Icon Style")
+        do
+            local rgn = iconRow._rightRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Icon Zoom",
+                rows = {
+                    { type = "slider", label = "Zoom", min = 0, max = 0.20, step = 0.01,
+                    get = function() return Cfg("classIconZoom") or 0.08 end,
+                    set = function(v) Set("classIconZoom", v); Refresh() end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._control, "LEFT", -8, 0)
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints()
+            cogTex:SetTexture(EllesmereUI.COGS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+        end
 
         -- Border Style (+ cog) | Border Size (+ inline swatch)
         -- Shadow (Glow rendered behind) needs Show Behind support, which DM lacks,

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -189,6 +189,7 @@ local DM_DEFAULTS = {
             numberFormat    = 2,
             forceEnglishUnits = false, -- force K/M/B units, ignoring CJK locale's 萬/億 (opt-in; default keeps localized units)
             iconStyle       = "spec",
+            classIconZoom = 0.08,
             iconColorUseAccent = false,
             iconColor       = { r = 1, g = 1, b = 1 },
             iconBorderTexture = "solid",
@@ -1105,9 +1106,16 @@ local ICON_STYLE_ORDER = {
 _G._EDM_IconStyleValues = ICON_STYLE_VALUES
 _G._EDM_IconStyleOrder  = ICON_STYLE_ORDER
 
+local function ZoomCoords(u1, u2, v1, v2, z)
+    local du = (u2 - u1) * z
+    local dv = (v2 - v1) * z
+    return u1 + du, u2 - du, v1 + dv, v2 - dv
+end
+
 local function ResolveIcon(src, iconTex, barH)
     local cfg = DB()
     local style = cfg.iconStyle or "spec"
+    local zoom = cfg.classIconZoom or 0.08
     if style == "none" then iconTex:Hide(); return 0 end
 
     local classFile = src.classFilename
@@ -1117,7 +1125,7 @@ local function ResolveIcon(src, iconTex, barH)
         local specIcon = src.specIconID
         if specIcon and type(specIcon) == "number" and specIcon ~= 0 then
             iconTex:SetTexture(specIcon)
-            iconTex:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+            iconTex:SetTexCoord(zoom, 1 - zoom, zoom, 1 - zoom)
             iconTex:SetSize(barH, barH)
             iconTex:SetDesaturated(false)
             iconTex:SetVertexColor(1, 1, 1, 1)
@@ -1126,16 +1134,24 @@ local function ResolveIcon(src, iconTex, barH)
         end
         iconTex:SetTexture("Interface\\GLUES\\CHARACTERCREATE\\UI-CHARACTERCREATE-CLASSES")
         local coords = CLASS_ICON_TCOORDS and CLASS_ICON_TCOORDS[classFile]
-        if coords then iconTex:SetTexCoord(unpack(coords)) else iconTex:SetTexCoord(0, 1, 0, 1) end
+        if coords then
+            iconTex:SetTexCoord(ZoomCoords(coords[1], coords[2], coords[3], coords[4], zoom))
+        else
+            iconTex:SetTexCoord(zoom, 1 - zoom, zoom, 1 - zoom)
+        end
     elseif style == "blizzard" then
         iconTex:SetTexture("Interface\\GLUES\\CHARACTERCREATE\\UI-CHARACTERCREATE-CLASSES")
         local coords = CLASS_ICON_TCOORDS and CLASS_ICON_TCOORDS[classFile]
-        if coords then iconTex:SetTexCoord(unpack(coords)) else iconTex:SetTexCoord(0, 1, 0, 1) end
+        if coords then
+            iconTex:SetTexCoord(ZoomCoords(coords[1], coords[2], coords[3], coords[4], zoom))
+        else
+            iconTex:SetTexCoord(zoom, 1 - zoom, zoom, 1 - zoom)
+        end
     else
         local coords = CLASS_SPRITE_COORDS[classFile]
         if coords then
             iconTex:SetTexture(CLASS_ICON_SPRITE_TEX[style] or (CLASS_ICON_SPRITE_BASE .. style .. ".tga"))
-            iconTex:SetTexCoord(coords[1], coords[2], coords[3], coords[4])
+            iconTex:SetTexCoord(ZoomCoords(coords[1], coords[2], coords[3], coords[4], zoom))
         else
             iconTex:Hide(); return 0
         end
@@ -1981,7 +1997,8 @@ local function CreateDMWindow(winIdx)
         bar.fill:SetMinMaxValues(0, 1); bar.fill:SetValue(0); bar.fill:SetStatusBarTexture(BAR_TEX)
         bar.classIcon = bar.fill:CreateTexture(nil, "OVERLAY")
         bar.classIcon:SetSize(18, 18); bar.classIcon:SetPoint("LEFT", bar.row, "LEFT", 0, 0)
-        bar.classIcon:SetTexCoord(0.08, 0.92, 0.08, 0.92); bar.classIcon:Hide()
+        local _cz = DB().classIconZoom or 0.08
+        bar.classIcon:SetTexCoord(_cz, 1 - _cz, _cz, 1 - _cz); bar.classIcon:Hide()
         -- Per-bar border (lazy-created, only when borderSize > 0)
         function bar.ApplyBorder()
             local c = DB()
@@ -3195,7 +3212,7 @@ local function CreateDMWindow(winIdx)
         local showIcon = (c.iconStyle or "spec") ~= "none"; local showClassColor = c.showClassColor ~= false
         local texPath, texKey = GetBarTexturePath()
         -- Layout cache: only rebuild on settings change
-        local stickyCacheKey = leftFS .. "|" .. rightFS .. "|" .. texPath .. "|" .. tostring(showIcon) .. "|" .. tostring(showClassColor) .. "|" .. barH
+        local stickyCacheKey = leftFS .. "|" .. rightFS .. "|" .. texPath .. "|" .. tostring(showIcon) .. "|" .. tostring(showClassColor) .. "|" .. barH .. "|" .. tostring(c.classIconZoom)
         if stickyCacheKey ~= W._stickyCacheKey then
             W._stickyCacheKey = stickyCacheKey
             bar.row:SetHeight(barH)
@@ -3315,7 +3332,7 @@ local function CreateDMWindow(winIdx)
             count = math.min(#sources, BAR_POOL_SIZE)
             -- Cache key: detects settings changes that require full bar rebuild
             local iconStyle = c.iconStyle or "spec"
-            local cacheKey = leftFS .. "|" .. rightFS .. "|" .. texPath .. "|" .. iconStyle .. "|" .. tostring(showClassColor) .. "|" .. tostring(c.barColorUseAccent) .. "|" .. barH .. "|" .. barSp .. "|" .. tostring(c.hideNumbers) .. "|" .. tostring(c.leftTextUseClassColor) .. "|" .. tostring(c.rightTextUseClassColor) .. "|" .. tostring(c.barFillAlpha)
+            local cacheKey = leftFS .. "|" .. rightFS .. "|" .. texPath .. "|" .. iconStyle .. "|" .. tostring(showClassColor) .. "|" .. tostring(c.barColorUseAccent) .. "|" .. barH .. "|" .. barSp .. "|" .. tostring(c.hideNumbers) .. "|" .. tostring(c.leftTextUseClassColor) .. "|" .. tostring(c.rightTextUseClassColor) .. "|" .. tostring(c.barFillAlpha) .. "|" .. tostring(c.classIconZoom)
             local fullRebuild = (cacheKey ~= W._barCacheKey)
             if fullRebuild then W._barCacheKey = cacheKey end
 
@@ -3585,7 +3602,8 @@ local function CreateDMWindow(winIdx)
                         spIcon = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(spID)
                     end
                     if not spIcon then spIcon = 135274 end
-                    bar.classIcon:SetTexture(spIcon); bar.classIcon:SetTexCoord(0.065, 0.935, 0.065, 0.935); bar.classIcon:SetSize(barH, barH); bar.classIcon:Show(); iconOffset = barH
+                    local _cz = DB().classIconZoom or 0.08
+                    bar.classIcon:SetTexture(spIcon); bar.classIcon:SetTexCoord(_cz, 1 - _cz, _cz, 1 - _cz); bar.classIcon:SetSize(barH, barH); bar.classIcon:Show(); iconOffset = barH
                     bar.fill:ClearAllPoints(); bar.fill:SetPoint("TOPLEFT", bar.row, "TOPLEFT", iconOffset, 0)
                     bar.fill:SetPoint("TOPRIGHT", bar.row, "TOPRIGHT", 0, 0); bar.fill:SetHeight(barH)
                     -- Fill = HP% remaining at this event
@@ -3733,7 +3751,8 @@ local function CreateDMWindow(winIdx)
                 local iconOffset = 0
                 if spell.spellID then
                     local spIcon = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(spell.spellID)
-                    if spIcon then bar.classIcon:SetTexture(spIcon); bar.classIcon:SetTexCoord(0.065, 0.935, 0.065, 0.935); bar.classIcon:SetSize(barH, barH); bar.classIcon:Show(); iconOffset = barH
+                    local _cz = DB().classIconZoom or 0.08
+                    if spIcon then bar.classIcon:SetTexture(spIcon); bar.classIcon:SetTexCoord(_cz, 1 - _cz, _cz, 1 - _cz); bar.classIcon:SetSize(barH, barH); bar.classIcon:Show(); iconOffset = barH
                     else bar.classIcon:Hide() end
                 else bar.classIcon:Hide() end
                 bar.fill:ClearAllPoints(); bar.fill:SetPoint("TOPLEFT", bar.row, "TOPLEFT", iconOffset, 0)


### PR DESCRIPTION
## Summary
 
Adds an **Icon Zoom** option for the player/class icons shown in each Damage Meter row, matching the zoom behavior already available in the Cooldown Manager module.
 
## Changes
 
- Added a new `classIconZoom` setting (default `0.08`) to the Damage Meters DB defaults.
- `ResolveIcon` now applies the configured zoom to all icon styles:
  - **Spec icon** (real spell texture): direct `SetTexCoord` crop.
  - **Blizzard class icons** and **custom icon style presets** (sprite atlas based): zoom is applied proportionally to each style's texture-coordinate rectangle via a small `ZoomCoords` helper, so the crop stays correct regardless of the source atlas.
- Row creation and the "death log" spell-icon overlay now use the same dynamic zoom value instead of a hardcoded crop.
- The zoom value is included in the existing row/sticky-player layout cache keys, so changing the setting invalidates the icon cache and applies live on the next refresh tick — no extra apply/refresh loop needed.
- Added an **Icon Zoom** slider to the Options UI, placed as an inline cog next to the **Icon Style** dropdown.
## Testing
 
- Verified the slider updates the class/spec icon zoom live, without requiring `/reload`.
- Verified all icon styles (Spec, Blizzard, and the sprite-based presets) crop correctly at both ends of the slider range (0 and 0.20).
 
