### PR TITLE
Action Bars: XP Bar show level and raw values

### DIFF
--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -1217,6 +1217,8 @@ initFrame:SetScript("OnEvent", function(self)
             rightRgn._control = cbDD
             rightRgn._lastInline = nil
             EllesmereUI.RegisterWidgetRefresh(cbDDRefresh)
+
+            return visRow
         end
 
         -------------------------------------------------------------------
@@ -1333,12 +1335,13 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         local function BuildDataBarSection(barKey, sectionTitle, visLabel)
+            local visRow, sizeRow
             _, h = W:SectionHeader(parent, sectionTitle, y);  y = y - h
-            BuildVisRow(barKey, visLabel, _blizzDis, BLIZZ_DIS_TIP)
+            visRow = BuildVisRow(barKey, visLabel, _blizzDis, BLIZZ_DIS_TIP)
 
             local wDis, wTip, wRaw = EllesmereUI.MatchGuard(barKey, "Width", _blizzDis, BLIZZ_DIS_TIP)
             local hDis, hTip, hRaw = EllesmereUI.MatchGuard(barKey, "Height", _blizzDis, BLIZZ_DIS_TIP)
-            _, h = W:DualRow(parent, y,
+            sizeRow, h = W:DualRow(parent, y,
                 { type="slider", text="Width", min=50, max=600, step=1,
                   disabled=wDis, disabledTooltip=wTip, rawTooltip=wRaw,
                   getValue=function() return EAB.db.profile.bars[barKey].width or 400 end,
@@ -1418,9 +1421,43 @@ initFrame:SetScript("OnEvent", function(self)
                       S().barTexture = v
                       if ns.ApplyDataBarLayout then ns.ApplyDataBarLayout(barKey) end
                   end });  y = y - h
+
+            return visRow, sizeRow
         end
 
-        BuildDataBarSection("XPBar",  "EXPERIENCE BAR", "XP Bar Visibility")
+        local xpBarRow = BuildDataBarSection("XPBar",  "EXPERIENCE BAR", "XP Bar Visibility")
+        do
+            local rgn = xpBarRow._leftRegion
+            local _, xpCogShow = EllesmereUI.BuildCogPopup({
+                title = "XP Bar Visibility",
+                rows = {
+                    { type="toggle", label="Show Raw Values",
+                        get=function() return EAB and EAB.db and EAB.db.profile and EAB.db.profile.bars and EAB.db.profile.bars["XPBar"] and EAB.db.profile.bars["XPBar"].showRawValues end,
+                        set=function(v)
+                            EAB.db.profile.bars["XPBar"].showRawValues = v
+                        end },
+                    { type="toggle", label="Show Level",
+                        get=function() return EAB and EAB.db and EAB.db.profile and EAB.db.profile.bars and EAB.db.profile.bars["XPBar"] and EAB.db.profile.bars["XPBar"].showLevel end,
+                        set=function(v)
+                            EAB.db.profile.bars["XPBar"].showLevel = v
+                        end },
+                },
+            })
+            local xpCtrl = rgn._control
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", xpCtrl or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints()
+            cogTex:SetTexture(EllesmereUI.COGS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) xpCogShow(self) end)
+        end
+
         _, h = W:Spacer(parent, y, 12);  y = y - h
         BuildDataBarSection("RepBar", "REPUTATION BAR", "Rep Bar Visibility")
         _, h = W:Spacer(parent, y, 12);  y = y - h

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -9700,6 +9700,7 @@ local function UpdateXPBar()
     local maxXP = UnitXPMax("player")
     if maxXP <= 0 then maxXP = 1 end
     local restedXP = GetXPExhaustion() or 0
+    local level = UnitLevel("player")
 
     bar:SetMinMaxValues(0, maxXP)
     bar:SetValue(currentXP)
@@ -9717,13 +9718,35 @@ local function UpdateXPBar()
         restedBar:Hide()
     end
 
-    local pct = (currentXP / maxXP) * 100
-    if restedXP > 0 then
-        local restedPct = (restedXP / maxXP) * 100
-        text:SetText(format("%.1f%% (Rested: %.1f%%)", pct, restedPct))
-    else
-        text:SetText(format("%.1f%%", pct))
+    local config = (EAB and EAB.db and EAB.db.profile and EAB.db.profile.bars and EAB.db.profile.bars["XPBar"]) or {}
+    local showLevel = config.showLevel
+    local showRawValues = config.showRawValues
+
+    local strLevel = ""
+    local strXP = ""
+    local strRested = ""
+
+    if showLevel then
+        strLevel = format("%s %d - ", LEVEL, level)
     end
+
+    if showRawValues then
+        strXP = format("%s / %s", AbbreviateLargeNumbers(currentXP), AbbreviateLargeNumbers(maxXP))
+    else
+        local pct = (currentXP / maxXP) * 100
+        strXP = format("%.1f%%", pct)
+    end
+
+    if restedXP > 0 then
+        if showRawValues then
+            strRested = format(" (Rested: %s)", AbbreviateLargeNumbers(restedXP))
+        else
+            local restedPct = (restedXP / maxXP) * 100
+            strRested = format(" (Rested: %.1f%%)", restedPct)
+        end
+    end
+
+    text:SetText(strLevel .. strXP .. strRested)
 
     EAB_VTABLE.ExtraBars.FinishManagedDataBarUpdate("XPBar", frame, s)
 end


### PR DESCRIPTION
Once the setting is toggled, the UI will update a few seconds after. Should be good enough but let me know if there is a way to update it instantly.

<img width="476" height="209" alt="image" src="https://github.com/user-attachments/assets/ced5241b-55b0-48e4-a1b3-43a5eb4a12ca" />

<img width="249" height="29" alt="image" src="https://github.com/user-attachments/assets/fb9f89fa-b5a4-48bd-856f-95fcea059805" />

<img width="249" height="32" alt="image" src="https://github.com/user-attachments/assets/1a8a0ace-477d-493e-bbfa-888ae9423c33" />

Feature request on discord: https://discord.com/channels/585577383847788554/1523149734435487764