### PR TITLE
feat: raise width slider max to 800 for health/power/class resource/cast bars

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -2516,7 +2516,7 @@ initFrame:SetScript("OnEvent", function(self)
                   EllesmereUI:RefreshPage()
               end },
             { type = "slider", text = "Width",
-              min = 50, max = 500, step = 1,
+              min = 50, max = 800, step = 1,
               disabled = hwDis, disabledTooltip = hwTip, rawTooltip = hwRaw,
               getValue = function() local c = cfg(); return c and c.width or 220 end,
               setValue = function(v)
@@ -3277,7 +3277,7 @@ initFrame:SetScript("OnEvent", function(self)
                   EllesmereUI:RefreshPage()
               end },
             { type = "slider", text = "Width",
-              min = 50, max = 500, step = 1,
+              min = 50, max = 800, step = 1,
               disabled = pwDis, disabledTooltip = pwTip, rawTooltip = pwRaw,
               getValue = function() local c = cfg(); return c and c.width or 220 end,
               setValue = function(v)
@@ -4145,7 +4145,7 @@ initFrame:SetScript("OnEvent", function(self)
                   EllesmereUI:RefreshPage()
               end },
             { type = "slider", text = "Width",
-              min = 10, max = 500, step = 1,
+              min = 10, max = 800, step = 1,
               disabled = cwDis, disabledTooltip = cwTip, rawTooltip = cwRaw,
               getValue = function() local c = cfg(); return c and c.pipWidth or 214 end,
               setValue = function(v)
@@ -7587,7 +7587,7 @@ initFrame:SetScript("OnEvent", function(self)
                   p.castBar.height = v; RefreshCast()
               end },
             { type = "slider", text = "Width",
-              min = 50, max = 500, step = 1,
+              min = 50, max = 800, step = 1,
               disabled = cbwDis, disabledTooltip = cbwTip, rawTooltip = cbwRaw,
               getValue = function() local p = DB(); return p and p.castBar.width or 220 end,
               setValue = function(v)


### PR DESCRIPTION
## Summary
Raises the Width slider maximum from 500 to 800 for four Resource Bars elements:
- Health Bar (50–800)
- Power Bar (50–800)
- Class Resource (10–800)
- Player Cast Bar (50–800)
  
## Why
500px is limiting on wide/ultrawide layouts where users want the resource bars to span a larger portion of the screen.

## Testing
- Tested in-game: dragged each of the four Width sliders up to 800 and the bars render correctly at the new maximum.
- No Lua errors.