### PR TITLE
feat(raidframes): Add vertical bars for Absorb Bar and Heal Absorb Bar

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -1331,8 +1331,8 @@ initFrame:SetScript("OnEvent", function(self)
         local absorbBarRow
         absorbBarRow, h = W:DualRow(parent, y,
             { type="dropdown", text="Absorb Bar",
-              values={ none="None", aboveRight="Above Frame Right", aboveLeft="Above Frame Left", topRight="Top Right", topLeft="Top Left" },
-              order={ "none", "aboveRight", "aboveLeft", "topRight", "topLeft" },
+              values={ none="None", aboveRight="Above Frame Right", aboveLeft="Above Frame Left", topRight="Top Right", topLeft="Top Left", rightVertical="Right Edge (Vertical)", leftVertical="Left Edge (Vertical)" },
+              order={ "none", "aboveRight", "aboveLeft", "topRight", "topLeft", "rightVertical", "leftVertical" },
               getValue=function() return CurAbsorbBarPos() end,
               setValue=function(v)
                   SWrite("absorbBarEnabled", v ~= "none")  -- keep legacy flag in sync
@@ -1344,6 +1344,49 @@ initFrame:SetScript("OnEvent", function(self)
               disabledTooltip="Absorb Bar",
               getValue=function() return SVal("absorbBarHeight", 4) end,
               setValue=function(v) SSet("absorbBarHeight", v) end });  y = y - h
+        -- Inline cog: vertical grow direction (shared by both strip bars)
+        do
+            local rgn = absorbBarRow._leftRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Absorb Bar Rendering",
+                rows = {
+                    { type="dropdown", label="Vertical Grow",
+                      values = { up = "Up", down = "Down" },
+                      order = { "up", "down" },
+                      disabled = function()
+                          local p = CurAbsorbBarPos()
+                          return p ~= "rightVertical" and p ~= "leftVertical"
+                      end,
+                      disabledTooltip = "Only affects the vertical (Right/Left Edge) positions",
+                      rawTooltip = true,
+                      get=function() return SVal("absorbBarGrowDir", "up") end,
+                      set=function(v) SSet("absorbBarGrowDir", v) end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints()
+            cogTex:SetTexture(EllesmereUI.COGS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+        end
+        -- The size slider reads as width for the vertical positions; retitle live.
+        do
+            local lbl = absorbBarRow._rightRegion._label
+            local function UpdateAbsorbBarSizeLabel()
+                local p = CurAbsorbBarPos()
+                local vertical = p == "rightVertical" or p == "leftVertical"
+                lbl:SetText(EllesmereUI.L(vertical and "Bar Width" or "Bar Height"))
+            end
+            EllesmereUI.RegisterWidgetRefresh(UpdateAbsorbBarSizeLabel)
+            UpdateAbsorbBarSizeLabel()
+        end
         -- Inline color swatch for the absorb bar color
         do
             local rgn = absorbBarRow._rightRegion
@@ -1460,8 +1503,8 @@ initFrame:SetScript("OnEvent", function(self)
             local healAbsorbBarRow
             healAbsorbBarRow, h = W:DualRow(parent, y,
                 { type="dropdown", text="Heal Absorb Bar",
-                  values={ none="None", belowAbsorb="Below Absorb Bar", aboveRight="Above Frame Right", aboveLeft="Above Frame Left", topRight="Top Right", topLeft="Top Left" },
-                  order={ "none", "belowAbsorb", "aboveRight", "aboveLeft", "topRight", "topLeft" },
+                  values={ none="None", belowAbsorb="Below Absorb Bar", aboveRight="Above Frame Right", aboveLeft="Above Frame Left", topRight="Top Right", topLeft="Top Left", rightVertical="Right Edge (Vertical)", leftVertical="Left Edge (Vertical)" },
+                  order={ "none", "belowAbsorb", "aboveRight", "aboveLeft", "topRight", "topLeft", "rightVertical", "leftVertical" },
                   getValue=function() return CurHealAbsorbBarPos() end,
                   setValue=function(v) SSet("healAbsorbBarPosition", v); EllesmereUI:RefreshPage() end },
                 { type="slider", text="Bar Height", min=1, max=20, step=1,
@@ -1490,6 +1533,49 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 EllesmereUI.RegisterWidgetRefresh(UpdateHealAbsorbBarSwatchVis)
                 UpdateHealAbsorbBarSwatchVis()
+            end
+            -- Inline cog: heal absorb bar vertical grow direction
+            do
+                local rgn = healAbsorbBarRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Heal Absorb Bar Rendering",
+                    rows = {
+                        { type="dropdown", label="Vertical Grow",
+                          values = { up = "Up", down = "Down" },
+                          order = { "up", "down" },
+                          disabled = function()
+                              local p = CurHealAbsorbBarPos()
+                              return p ~= "rightVertical" and p ~= "leftVertical"
+                          end,
+                          disabledTooltip = "Only affects the vertical (Right/Left Edge) positions",
+                          rawTooltip = true,
+                          get=function() return SVal("healAbsorbBarGrowDir", "up") end,
+                          set=function(v) SSet("healAbsorbBarGrowDir", v) end },
+                    },
+                })
+                local cogBtn = CreateFrame("Button", nil, rgn)
+                cogBtn:SetSize(26, 26)
+                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = cogBtn
+                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+                cogBtn:SetAlpha(0.4)
+                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+                cogTex:SetAllPoints()
+                cogTex:SetTexture(EllesmereUI.COGS_ICON)
+                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+            end
+            -- The size slider reads as width for the vertical positions; retitle live.
+            do
+                local lbl = healAbsorbBarRow._rightRegion._label
+                local function UpdateHealAbsorbBarSizeLabel()
+                    local p = CurHealAbsorbBarPos()
+                    local vertical = p == "rightVertical" or p == "leftVertical"
+                    lbl:SetText(EllesmereUI.L(vertical and "Bar Width" or "Bar Height"))
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateHealAbsorbBarSizeLabel)
+                UpdateHealAbsorbBarSizeLabel()
             end
         end
 

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -523,10 +523,13 @@ local defaults = {
         absorbBarEnabled = false,
         absorbBarHeight  = 4,
         absorbBarColor   = { r = 1, g = 1, b = 1 },
+        -- Fill direction for the vertical (Right/Left Edge) positions.
+        absorbBarGrowDir = "up",
         -- Heal Absorb Bar: separate strip showing the heal-absorb amount
         healAbsorbBarPosition = "none",
         healAbsorbBarHeight   = 4,
         healAbsorbBarColor    = { r = 200/255, g = 29/255, b = 29/255 },
+        healAbsorbBarGrowDir  = "up",
 
         -- Indicators
         roleIconStyle    = "modern",  -- none/modern/modernCircle/styled/classicCircle/classic/blizzDefault/blizzLight
@@ -2247,7 +2250,9 @@ end
 
 -------------------------------------------------------------------------------
 --  Absorb Bar position (replaces the old on/off toggle)
---  Positions: none / aboveRight / aboveLeft / topRight / topLeft.
+--  Positions: none / aboveRight / aboveLeft / topRight / topLeft /
+--  rightVertical / leftVertical (vertical side bar; fill direction comes
+--  from the per-bar grow-direction setting, default up).
 --  Legacy: the old boolean (absorbBarEnabled) maps to "aboveRight" when on and
 --  "none" when off. The new key (absorbBarPosition) takes precedence once the
 --  user picks one, so existing settings carry over with no migration.
@@ -2271,10 +2276,28 @@ end
 -- absorb-style texture. "belowAbsorb" (heal bar only) sits flush below the
 -- Absorb Bar's bottom edge, derived from the Absorb Bar's POSITION -- not its
 -- live visibility, so it never shifts up. "*Right" fills from the right edge.
-ns.ApplyStripBarLayout = function(stripBar, ab, button, position, height, absorbPos, absorbHeight)
+-- "*Vertical" hug the health bar's left/right edge as a vertical bar
+-- (Grid2-style side bar); "height" acts as its width and vertGrowDir
+-- ("up" default / "down", per bar) picks the fill direction.
+ns.ApplyStripBarLayout = function(stripBar, ab, button, position, height, absorbPos, absorbHeight, vertGrowDir)
     if not stripBar then return end
     local hp = ab._hpBar or button
     stripBar:ClearAllPoints()
+    if position == "rightVertical" or position == "leftVertical" then
+        stripBar:SetOrientation("VERTICAL")
+        stripBar:SetReverseFill(vertGrowDir == "down")
+        stripBar:SetWidth(PixelSnap(height or 4))
+        if position == "rightVertical" then
+            stripBar:SetPoint("TOPRIGHT", hp, "TOPRIGHT", 0, 0)
+            stripBar:SetPoint("BOTTOMRIGHT", hp, "BOTTOMRIGHT", 0, 0)
+        else
+            stripBar:SetPoint("TOPLEFT", hp, "TOPLEFT", 0, 0)
+            stripBar:SetPoint("BOTTOMLEFT", hp, "BOTTOMLEFT", 0, 0)
+        end
+        stripBar:SetFrameLevel(ab:GetFrameLevel() + 1)
+        return
+    end
+    stripBar:SetOrientation("HORIZONTAL")
     stripBar:SetHeight(PixelSnap(height or 4))
     if position == "belowAbsorb" then
         absorbPos = absorbPos or "none"
@@ -2359,10 +2382,11 @@ local function UpdateAbsorb(button, unit)
         if barOn then
             local bc = s.absorbBarColor or { r = 1, g = 1, b = 1 }
             local bh = s.absorbBarHeight or 4
-            -- Re-layout only when position/height changes (no per-update SetPoint churn).
-            if topBar._lpPos ~= barPos or topBar._lpH ~= bh then
-                topBar._lpPos = barPos; topBar._lpH = bh
-                ns.ApplyStripBarLayout(topBar, ab, button, barPos, bh)
+            local gd = s.absorbBarGrowDir or "up"
+            -- Re-layout only when position/height/direction changes (no per-update SetPoint churn).
+            if topBar._lpPos ~= barPos or topBar._lpH ~= bh or topBar._lpGD ~= gd then
+                topBar._lpPos = barPos; topBar._lpH = bh; topBar._lpGD = gd
+                ns.ApplyStripBarLayout(topBar, ab, button, barPos, bh, nil, nil, gd)
             end
             topBar:SetStatusBarColor(bc.r, bc.g, bc.b, bc.a or 1)
             topBar:SetMinMaxValues(0, maxHealth)
@@ -2381,12 +2405,15 @@ local function UpdateAbsorb(button, unit)
             local hbc = s.healAbsorbBarColor or { r = 200/255, g = 29/255, b = 29/255 }
             local hbh = s.healAbsorbBarHeight or 4
             local abh = s.absorbBarHeight or 4
+            local hgd = s.healAbsorbBarGrowDir or "up"
             -- Re-layout only when its or the Absorb Bar's position/height changes.
             if healTopBar._lpPos ~= healBarPos or healTopBar._lpH ~= hbh
-               or healTopBar._lpAP ~= barPos or healTopBar._lpAH ~= abh then
+               or healTopBar._lpAP ~= barPos or healTopBar._lpAH ~= abh
+               or healTopBar._lpGD ~= hgd then
                 healTopBar._lpPos = healBarPos; healTopBar._lpH = hbh
                 healTopBar._lpAP = barPos; healTopBar._lpAH = abh
-                ns.ApplyStripBarLayout(healTopBar, ab, button, healBarPos, hbh, barPos, abh)
+                healTopBar._lpGD = hgd
+                ns.ApplyStripBarLayout(healTopBar, ab, button, healBarPos, hbh, barPos, abh, hgd)
             end
             healTopBar:SetStatusBarColor(hbc.r, hbc.g, hbc.b, hbc.a or 1)
             healTopBar:SetMinMaxValues(0, maxHealth)
@@ -9214,7 +9241,9 @@ do
         absorbs = {
             "absorbStyle", "absorbOpacity", "absorbColor", "absorbEdgeMode", "showOvershield",
             "absorbBarEnabled", "absorbBarPosition", "absorbBarHeight", "absorbBarColor",
+            "absorbBarGrowDir",
             "healAbsorbBarPosition", "healAbsorbBarHeight", "healAbsorbBarColor",
+            "healAbsorbBarGrowDir",
             "healAbsorbStyle", "healAbsorbOpacity", "healAbsorbColor", "healAbsorbEdgeMode",
             "healAbsorbBgOpacity",
             "maxHealthStyle", "maxHealthOpacity", "maxHealthColor", "maxHealthBgOpacity",
@@ -11963,7 +11992,7 @@ local function ApplyPreviewData(f, index)
             end
             if barOn and absorbAmt > 0 then
                 local bc = s.absorbBarColor or { r = 1, g = 1, b = 1 }
-                ns.ApplyStripBarLayout(topBar, f._absorbBar, f, barPos, s.absorbBarHeight or 4)
+                ns.ApplyStripBarLayout(topBar, f._absorbBar, f, barPos, s.absorbBarHeight or 4, nil, nil, s.absorbBarGrowDir or "up")
                 topBar:SetStatusBarColor(bc.r, bc.g, bc.b, bc.a or 1)
                 topBar:SetValue(absorbAmt)
                 topBar:Show()
@@ -11986,7 +12015,7 @@ local function ApplyPreviewData(f, index)
                 local haAmtPv = ns.previewHealAbsorbValues[index] or 0
                 if healBarOn and haAmtPv > 0 then
                     local hbc = s.healAbsorbBarColor or { r = 200/255, g = 29/255, b = 29/255 }
-                    ns.ApplyStripBarLayout(healTopBarPv, f._absorbBar, f, healBarPos, s.healAbsorbBarHeight or 4, ns.GetAbsorbBarPosition(s), s.absorbBarHeight or 4)
+                    ns.ApplyStripBarLayout(healTopBarPv, f._absorbBar, f, healBarPos, s.healAbsorbBarHeight or 4, ns.GetAbsorbBarPosition(s), s.absorbBarHeight or 4, s.healAbsorbBarGrowDir or "up")
                     healTopBarPv:SetStatusBarColor(hbc.r, hbc.g, hbc.b, hbc.a or 1)
                     healTopBarPv:SetValue(haAmtPv)
                     healTopBarPv:Show()


### PR DESCRIPTION
## Overview

This PR adds a vertical mode to the raid frame **Absorb Bar** and **Heal Absorb Bar**, so shields and heal absorbs can be displayed as a vertical side bar - a display style commonly offered by other raid frame addons.

**What's new:**

- Two new position options in both the **Absorb Bar** and **Heal Absorb Bar** dropdowns: **Right Edge (Vertical)** and **Left Edge (Vertical)**. The bar hugs the health bar's edge as a vertical side bar and fills bottom/top, with its length proportional to shield / max health. (The bar's height is anchored to the health bar's top and bottom edges, so it automatically follows any frame height, scales with frame resizing, and stays clear of the power bar when one is shown. The fill level is a plain value/max ratio (shield / max health), so no manual size math is involved anywhere.)
- A new **Vertical Grow** setting (Up / Down, default Up) in a cog popup on each bar's options row. Each bar is configured independently, and the cog is disabled with a hint while that bar isn't on a vertical position.
- The size slider adapts to the selected position: it controls the bar's thickness in vertical mode and its label switches between **Bar Height** and **Bar Width** accordingly.
- Works in the options preview and with party frames (including per-section party sync), same as the existing positions. Existing profiles carry over unchanged — no migration needed.

Overview:

<img width="660" height="299" alt="image" src="https://github.com/user-attachments/assets/094c2209-ee22-4229-8523-ef3d437f17aa" />

---

## Background

Currently the Absorb Bar can only be anchored horizontally (above the frame or inside the top edge). A vertical side bar for shields is compact, doesn't overlap the name/health text, and is easy to read at a glance across the whole raid grid. This display style is already available in other raid frame addons such as Grid2 (via its vertical bar indicators), so it also makes switching over to EllesmereUI easier for players used to that layout.

---

## Summary of Changes

### New profile properties

| Property | Default | Function |
|---|---|---|
| `absorbBarGrowDir` | `"up"` | `UpdateAbsorb` → `ApplyStripBarLayout` |
| `healAbsorbBarGrowDir` | `"up"` | `UpdateAbsorb` → `ApplyStripBarLayout` |

### Extended values on existing properties

| Property | New accepted values |
|---|---|
| `absorbBarPosition` | `rightVertical`, `leftVertical` |
| `healAbsorbBarPosition` | `rightVertical`, `leftVertical` |

All layout goes through the existing `ns.ApplyStripBarLayout`, which gains a vertical branch: `SetOrientation("VERTICAL")`, anchored TOP+BOTTOM to the health bar's edge (height follows the frame automatically), size setting applied as width, grow direction via `SetReverseFill`. Non-vertical positions explicitly reset to `HORIZONTAL`; the re-layout cache gains a direction key, so nothing is re-anchored unless a setting actually changes. The options UI uses the standard `SVal`/`SSet` + `BuildCogPopup` patterns, the preview shares the same layout function, and both new keys are registered for party-section sync.

---

## Testing

Tested in-game (retail) with live shields/heal absorbs and in the options preview:

- [x] **Vertical positions**: Absorb Bar and Heal Absorb Bar on both **Right Edge (Vertical)** and **Left Edge (Vertical)**; the bar spans the health bar's height and its fill tracks the shield / heal-absorb amount proportionally (partial shields render as a partial bar, zero renders as empty).
- [x] **Grow direction**: flipped **Vertical Grow** between Up and Down on each bar via its cog popup; direction applies immediately, and each bar's setting is independent of the other's.
- [x] **Position switching**: switched between horizontal and vertical positions back and forth with no reload needed; all existing horizontal positions (Above Frame, Top Right/Left, Below Absorb Bar) still render as before.
- [x] **Slider label**: the size slider reads **Bar Width** on vertical positions and **Bar Height** on horizontal ones, updating live when the position changes; the value keeps controlling thickness/height as expected.
- [x] **Cog disabled state**: the Vertical Grow dropdown is disabled with its hint tooltip while the bar is on a non-vertical position.
- [x] **Options preview**: the preview frames mirror all of the above with test absorb values, without touching live frames.
- [x] **Regression**: with both bars set back to their previous horizontal positions, behavior and rendering are unchanged from before the patch.

---

## Example Screenshots

**Absorb Bar**
Shield amount shown as a vertical bar on the right edge of each frame; bar length is proportional to shield / max health.

**Vertical Grow: Up** - the bar fills from the bottom of the frame upward:
<img width="1479" height="325" alt="image" src="https://github.com/user-attachments/assets/a32d52f4-dbc3-4898-9e4c-b0cce93304d2" />

**Vertical Grow: Down** - the same setup flipped via the cog popup; the bar fills from the top downward:
<img width="1488" height="370" alt="image" src="https://github.com/user-attachments/assets/39b280c9-5250-4995-b187-bde084cc59c8" />

**Heal Absorb Bar**

**Vertical Grow: Up** - the bar fills from the bottom of the frame upward:
<img width="975" height="221" alt="image" src="https://github.com/user-attachments/assets/282d6901-6046-47e5-930b-edb1379e8be2" />

**Vertical Grow: Down** - the same setup flipped via the cog popup; the bar fills from the top downward:
<img width="1029" height="195" alt="image" src="https://github.com/user-attachments/assets/6a902e78-eca8-4c4b-9cf6-dadf6ebcea34" />

**Options UI**
The size slider's label follows the selected position: it reads **Bar Width** for the vertical positions and stays **Bar Height** for the horizontal ones  here the Absorb Bar is on *Left Edge (Vertical)* (Bar Width) while the Heal Absorb Bar is on *Below Absorb Bar* (Bar Height):

<img width="942" height="266" alt="image" src="https://github.com/user-attachments/assets/1550bfb5-5391-4f9e-be18-e092b234b6fe" />