### PR TITLE
Update EllesmereUIMinimap.lua

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -1900,7 +1900,7 @@ local function CreateMinimapPortalFlyout()
             label:SetFont(fontPath, 8, "OUTLINE")
             label:SetPoint("BOTTOM", btn, "BOTTOM", 0, 2)
             label:SetTextColor(1, 1, 1, 0.9)
-            label:SetText(short)
+            label:SetText((EllesmereUI and EllesmereUI.L and EllesmereUI.L(short)) or short)
         end
 
         local hover = btn:CreateTexture(nil, "HIGHLIGHT")


### PR DESCRIPTION
Minimap M+ portal flyout — dungeon abbreviation localization

The M+ portals flyout draws a dungeon abbreviation on each portal button (`WRS`, `MT`, `NPX`, ...) from the `PORTAL_SHORT` table, but it set the label with a raw `:SetText(short)`, so it could not be localized.

Wrapped the label in `EllesmereUI.L(...)` (guarded, matching the file's existing `EllesmereUI and EllesmereUI.X` style since the flyout can build before the locale engine is ready).

## Code (`EllesmereUIMinimap/EllesmereUIMinimap.lua`)

```lua
-- before
label:SetText(short)
-- after
label:SetText((EllesmereUI and EllesmereUI.L and EllesmereUI.L(short)) or short)
```