### PR TITLE
Bug fix for action bars show with soft target

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -9088,15 +9088,53 @@ function EAB:FinishSetup()
         end
     end
     self:RegisterEvent("PLAYER_TARGET_CHANGED", function()
-        ImmediateSoftTargetCheck()
-        self:UpdateHousingVisibility()
+        -- Defer: UnitExists("target") is not always updated at the exact
+        -- moment PLAYER_TARGET_CHANGED fires, so an immediate check can
+        -- wrongly see no hard target and keep the bar hidden. Run next frame.
+        C_Timer.After(0, function()
+            ImmediateSoftTargetCheck()
+            self:UpdateHousingVisibility()
+        end)
     end)
     self:RegisterEvent("PLAYER_SOFT_INTERACT_CHANGED", function()
         ImmediateSoftTargetCheck()
+        self:UpdateHousingVisibility()
+    end)
+    local function RegisterIfValid(event, fn)
+        if C_EventUtils and C_EventUtils.IsEventValid and C_EventUtils.IsEventValid(event) then
+            self:RegisterEvent(event, fn)
+        end
+    end
+    RegisterIfValid("PLAYER_SOFT_ENEMY_CHANGED", function()
+        ImmediateSoftTargetCheck()
+        self:UpdateHousingVisibility()
+    end)
+    RegisterIfValid("PLAYER_SOFT_FRIEND_CHANGED", function()
+        ImmediateSoftTargetCheck()
+        self:UpdateHousingVisibility()
     end)
     self:RegisterEvent("GROUP_ROSTER_UPDATE", function()
         self:UpdateHousingVisibility()
     end)
+    -- Polling fallback: some soft-target transitions (notably Action Targeting
+    -- walking into range) do not reliably fire the dedicated soft-target events
+    -- on every client/patch. Check the soft-target unit tokens every 0.1s and
+    -- sync visibility only when the state actually changes. This is cheap because
+    -- the heavy work is skipped when state is unchanged.
+    local lastSoftState
+    local function PollSoftTargetState()
+        if InCombatLockdown() then return end
+        local state = (UnitExists("softinteract") and "I" or "")
+            .. (UnitExists("softenemy") and "E" or "")
+            .. (UnitExists("softfriend") and "F" or "")
+            .. (UnitExists("target") and "T" or "")
+        if state ~= lastSoftState then
+            lastSoftState = state
+            ImmediateSoftTargetCheck()
+            self:UpdateHousingVisibility()
+        end
+    end
+    C_Timer.NewTicker(0.1, PollSoftTargetState)
     -- Combat exit: synchronously restore all visHideNoTarget bar state drivers.
     -- During combat, ImmediateSoftTargetCheck and UpdateHousingVisibility are
     -- blocked by InCombatLockdown. If a bar's driver was overridden to "hide"


### PR DESCRIPTION
# Summary

Fixes action bars configured with "Hide when No Target" failing to show or hide correctly around soft-target interactions (soft interact, soft enemy, soft friend).

Blizzard's macro conditionals treat soft-target unit tokens as "target exists", but `UnitExists("target")` does not. The existing `ImmediateSoftTargetCheck` already handled this mismatch, but it was only triggered reliably on `PLAYER_SOFT_INTERACT_CHANGED` and an immediate `PLAYER_TARGET_CHANGED`  the immediate target check could read stale unit state, and dedicated soft enemy/friend events plus a polling fallback were missing.

This change defers the hard-target check to the next frame, registers the optional soft-enemy and soft-friend events when available, and adds a lightweight 0.1s polling fallback so bars stay in sync during Action Targeting transitions that don't fire events.

# Details

The soft-target visibility path now reacts to more events and avoids reading stale target state:

- Hard target changes are deferred by one frame so the target unit is fully updated before deciding whether to hide or show the bar.
- Soft interact changes now trigger the same visibility refresh as hard target changes.
- Soft enemy and soft friend transitions are handled on clients that expose those events.
- A polling fallback keeps bars synchronized when soft-target transitions happen without firing an event, comparing a compact state token each tick and refreshing only when something actually changes. The poll is paused during combat lockdown.

# Test plan

- Enable "Hide without Target" and "Hide when Mounted" in EUI Action Bars settings under the Visibility options.
- Enable "Hide when No Target" on an action bar; clear your hard target and walk near a soft-interact object. Confirm the bar hides on soft interact and reappears when you walk away.
- Target a soft enemy (Action Targeting) with no hard target and confirm the bar shows; clear the soft enemy and confirm it hides again.
- Repeat for soft friend interactions.
- Hard-target an NPC and verify the bar still follows normal target-based visibility.
- Enter combat near a soft target and confirm no taint or secure-frame errors occur.
