### PR TITLE
Add cast icon offset sliders

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -1093,6 +1093,8 @@ initFrame:SetScript("OnEvent", function(self)
             local onRight = (icdb and icdb.castIconOnRight) or false
             local fullSize = (icdb and icdb.castIconFullSize) or false
             local iconScale = (icdb and icdb.castIconScale) or defaults.castIconScale
+            local iconXOff = (icdb and icdb.castIconOffsetX) or defaults.castIconOffsetX or 0
+            local iconYOff = (icdb and icdb.castIconOffsetY) or defaults.castIconOffsetY or 0
             local castIconLeftPush, castIconRightPush = 0, 0
             if showIcon then
                 if fullSize then
@@ -1193,17 +1195,17 @@ initFrame:SetScript("OnEvent", function(self)
                     local fs = barH + castH
                     castParts.iconFrame:SetSize(fs, fs)
                     if onRight then
-                        castParts.iconFrame:SetPoint("BOTTOMLEFT", cast, "BOTTOMRIGHT", 0, 0)
+                        castParts.iconFrame:SetPoint("BOTTOMLEFT", cast, "BOTTOMRIGHT", iconXOff, iconYOff)
                     else
-                        castParts.iconFrame:SetPoint("BOTTOMRIGHT", cast, "BOTTOMLEFT", 0, 0)
+                        castParts.iconFrame:SetPoint("BOTTOMRIGHT", cast, "BOTTOMLEFT", iconXOff, iconYOff)
                     end
                 else
                     local scaledH = castH * iconScale
                     castParts.iconFrame:SetSize(scaledH, scaledH)
                     if onRight then
-                        castParts.iconFrame:SetPoint("TOPLEFT", cast, "TOPRIGHT", 0, 0)
+                        castParts.iconFrame:SetPoint("TOPLEFT", cast, "TOPRIGHT", iconXOff, iconYOff)
                     else
-                        castParts.iconFrame:SetPoint("TOPRIGHT", cast, "TOPLEFT", 0, 0)
+                        castParts.iconFrame:SetPoint("TOPRIGHT", cast, "TOPLEFT", iconXOff, iconYOff)
                     end
                 end
                 castParts.iconFrame:Show()
@@ -5688,6 +5690,20 @@ initFrame:SetScript("OnEvent", function(self)
                                 plate.castIconFrame:SetScale(v)
                             end
                         end
+                        UpdatePreview()
+                      end },
+                    { type="slider", label="X Offset", min=-50, max=50, step=1,
+                      get=function() return DBVal("castIconOffsetX") or defaults.castIconOffsetX or 0 end,
+                      set=function(v)
+                        DB().castIconOffsetX = v
+                        ns.RefreshAllSettings()
+                        UpdatePreview()
+                      end },
+                    { type="slider", label="Y Offset", min=-50, max=50, step=1,
+                      get=function() return DBVal("castIconOffsetY") or defaults.castIconOffsetY or 0 end,
+                      set=function(v)
+                        DB().castIconOffsetY = v
+                        ns.RefreshAllSettings()
                         UpdatePreview()
                       end },
                     { type="toggle", label="Make Icon Part of the Bar",

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -132,10 +132,12 @@ function ns._appendDisplayPresetKeys(t)
         "targetArrowDouble", "targetArrowStyle", "targetArrowColor", "targetArrowClassColor",
         "auraStackTextSize", "auraStackTextColor",
         "auraStackTextPosition", "auraStackTextX", "auraStackTextY",
+        "auraDurationTextSize", "auraDurationTextColor",
         "buffTextSize", "buffTextColor", "ccTextSize", "ccTextColor",
         "raidMarkerPos", "classificationSlot",
         "debuffCropIcons", "buffCropIcons", "ccCropIcons",
         "showCastLockoutAsCrowdControl",
+        "castIconOffsetX", "castIconOffsetY",
         "targetGlowEllesmereUI", "targetGlowBorderColor", "targetGlowHighlight", "targetBorderColor",
     }) do t[#t + 1] = k end
 end
@@ -397,6 +399,8 @@ local defaults = {
     questObjectiveTextSize = 14,
     showCastIcon = true,
     castIconScale = 1,
+    castIconOffsetX = 0,
+    castIconOffsetY = 0,
     castbarIconInWidth = false,
     castIconOnRight = false,
     castIconFullSize = false,
@@ -969,6 +973,8 @@ end
 function ns.LayoutCastIcon(plate, castH)
     local icon = plate.castIconFrame
     local onRight = ns.GetCastIconOnRight()
+    local xOff = (p and p.castIconOffsetX) or defaults.castIconOffsetX
+    local yOff = (p and p.castIconOffsetY) or defaults.castIconOffsetY
     icon:ClearAllPoints()
     if ns.GetCastIconFullSize() then
         local side = GetHealthBarHeight() + castH
@@ -982,19 +988,19 @@ function ns.LayoutCastIcon(plate, castH)
         -- the icon square (its height is fixed by the top/bottom anchors = side).
         icon:SetWidth(side)
         if onRight then
-            icon:SetPoint("TOPLEFT", plate.health, "TOPRIGHT", 0, 0)
-            icon:SetPoint("BOTTOMLEFT", plate.cast, "BOTTOMRIGHT", 0, 0)
+            icon:SetPoint("TOPLEFT", plate.health, "TOPRIGHT", xOff, yOff)
+            icon:SetPoint("BOTTOMLEFT", plate.cast, "BOTTOMRIGHT", xOff, yOff)
         else
-            icon:SetPoint("TOPRIGHT", plate.health, "TOPLEFT", 0, 0)
-            icon:SetPoint("BOTTOMRIGHT", plate.cast, "BOTTOMLEFT", 0, 0)
+            icon:SetPoint("TOPRIGHT", plate.health, "TOPLEFT", xOff, yOff)
+            icon:SetPoint("BOTTOMRIGHT", plate.cast, "BOTTOMLEFT", xOff, yOff)
         end
     else
         icon:SetScale(GetCastIconScale() or 1)
         icon:SetSize(castH, castH)
         if onRight then
-            icon:SetPoint("TOPLEFT", plate.cast, "TOPRIGHT", 0, 0)
+            icon:SetPoint("TOPLEFT", plate.cast, "TOPRIGHT", xOff, yOff)
         else
-            icon:SetPoint("TOPRIGHT", plate.cast, "TOPLEFT", 0, 0)
+            icon:SetPoint("TOPRIGHT", plate.cast, "TOPLEFT", xOff, yOff)
         end
     end
 end
@@ -8717,7 +8723,6 @@ do
         "debuffYOffset", "sideAuraXOffset", "auraSpacing",
         "debuffSpacing", "buffSpacing", "ccSpacing",
         "debuffTimerPosition", "buffTimerPosition", "ccTimerPosition",
-        "auraDurationTextSize", "auraDurationTextColor",
     }
     ns._displayPresetKeys[#ns._displayPresetKeys + 1] = "auraDurationTextX"
     ns._displayPresetKeys[#ns._displayPresetKeys + 1] = "auraDurationTextY"


### PR DESCRIPTION
Summary:
- Add cast bar spell icon X/Y offset sliders in Spell Icon Settings.
- Apply offsets to live nameplate icon layout and preview.
- Include offsets in display presets.

<img width="513" height="291" alt="image" src="https://github.com/user-attachments/assets/1680400b-1e7b-4855-bfbf-29f24bd2ab55" />
