### PR TITLE
feat(cooldownmanager): Add 'Show Tooltip on Hover’ toggle for the Buffs bar

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -15557,8 +15557,20 @@ initFrame:SetScript("OnEvent", function(self)
         if not isCustomBuffBar and not isFocusKick then
         _, h = W:SectionHeader(parent, "EXTRAS", y);  y = y - h
 
-        -- Show Tooltip | Show Keybind (not for buff bars)
-        if not isAnyBuffBar then
+        -- Buffs get "Show Tooltip on Hover" only (auras aren't cast -> no keybind);
+        -- cooldown/utility icon bars get the Tooltip | Keybind pair below.
+        if isAnyBuffBar then
+        local _, tth = W:DualRow(parent, y,
+            { type="toggle", text="Show Tooltip on Hover",
+              getValue=function() return BD().showTooltip == true end,
+              setValue=function(v)
+                  BD().showTooltip = v
+                  ns.ApplyCDMTooltipState(BD().key)
+                  Refresh()
+              end },
+            { type="spacer" }
+        );  y = y - tth
+        else
         local kbRow
         kbRow, h = W:DualRow(parent, y,
             { type="toggle", text="Show Tooltip on Hover",
@@ -15640,7 +15652,7 @@ initFrame:SetScript("OnEvent", function(self)
                 end)
             end
         end
-        end -- tooltip/keybind buff bar guard
+        end -- if isAnyBuffBar (tooltip only) / else (tooltip + keybind)
 
         -- Pandemic Glow
         do


### PR DESCRIPTION
## Overview

Exposes the **Show Tooltip on Hover** toggle on the **Buffs** bar, which Cooldowns and Utility already have. With it on, hovering a buff icon shows its tooltip. Default **off**.

## Summary of Changes

No new properties - reuses the existing per-bar `showTooltip`.

- Buffs get a tooltip-only row; Cooldowns/Utility keep the Tooltip | Keybind pair.
- The buffs row uses a `{ type = "spacer" }` for its right half so the toggle stays half-width, instead of `nil` which stretched it across the whole row.

## Testing

Tested in-game (retail):

- [x] Buffs bar shows the half-width toggle (no keybind control)
- [x] Toggle on -> hovering a buff shows its tooltip; off -> none
- [x] Cooldowns/Utility unchanged (Tooltip | Keybind pair intact)
- [x] Default off; persists through /reload
- [x] Clean load, no Lua errors

## Example
<img width="800" height="340" alt="Buff-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/090b254b-2d87-493e-ba2a-efcaff6d30f6" />
