### PR TITLE
feat(cooldownmanager): Add per-bar out-of-combat alpha fade for CDM bars

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -13952,6 +13952,39 @@ initFrame:SetScript("OnEvent", function(self)
             MakeCogBtn(leftRgn, topRowCogShow, ctrl, EllesmereUI.COGS_ICON)
         end
 
+        -- Inline cog on Bar Opacity: fade the bar to a chosen alpha while out
+        -- of combat. Off by default.
+        if isCDOrUtilityRow3 then
+            local rgn = numRowsRow._rightRegion
+            local ctrl = rgn and rgn._control
+            local _, oocCogShow = EllesmereUI.BuildCogPopup({
+                title = "Out of Combat Alpha",
+                rows = {
+                    { type="toggle", label="Fade Out of Combat",
+                      tooltip="Dims this bar while out of combat.",
+                      rawTooltip=true,
+                      get=function() return BD().oocFadeEnabled == true end,
+                      set=function(v)
+                          BD().oocFadeEnabled = v
+                          if ns.CDMApplyVisibility then ns.CDMApplyVisibility() end
+                          UpdateCDMPreview()
+                      end },
+                    { type="slider", label="Out of Combat Alpha",
+                      min=0, max=100, step=1,
+                      disabled=function() return not BD().oocFadeEnabled end,
+                      disabledTooltip="Enable Fade Out of Combat first",
+                      rawTooltip=true,
+                      get=function() return math.floor((BD().oocFadeAlpha or 0.5) * 100 + 0.5) end,
+                      set=function(v)
+                          BD().oocFadeAlpha = v / 100
+                          if ns.CDMApplyVisibility then ns.CDMApplyVisibility() end
+                          UpdateCDMPreview()
+                      end },
+                },
+            })
+            MakeCogBtn(rgn, oocCogShow, ctrl, EllesmereUI.COGS_ICON)
+        end
+
         -- Hide Buffs When Inactive (global setting, applies to all buff bars)
         if ns.IsBarBuffFamily(barData) then
             local prof = ns.ECME and ns.ECME.db and ns.ECME.db.profile

--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -519,10 +519,11 @@ PresetOnCD = function(key)
     return (dur > 1.5 and now < start + dur) or false
 end
 
--- Normal (shown) alpha for a frame, from its bar's opacity.
+-- Normal (shown) alpha for a frame, from its bar's opacity (out-of-combat
+-- fade folded in via EffectiveBarAlpha so restores don't clobber the fade).
 local function FrameBaseAlpha(fc)
     local bd = fc and fc.barKey and ns.barDataByKey and ns.barDataByKey[fc.barKey]
-    return (bd and bd.barOpacity) or 1
+    return ns.EffectiveBarAlpha(bd)
 end
 
 -- cas is the rule's styling entry (passed in so a trinket, whose frame key is a

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2067,7 +2067,7 @@ local function DecorateFrame(frame, barData)
                     if fc2 and fc2._cdStateHidden then
                         fc2._cdStateHidden = false
                         local bd2 = barDataByKey and barDataByKey[bk2]
-                        frame:SetAlpha(bd2 and bd2.barOpacity or 1)
+                        frame:SetAlpha(ns.EffectiveBarAlpha(bd2))
                     end
                 end
                 -- For hidden cdState modes, defer the evaluation by one
@@ -2098,7 +2098,7 @@ local function DecorateFrame(frame, barData)
                         local onCD = cseInfo and cseInfo.isActive and not cseInfo.isOnGCD
                         local myCse = self.cse
                         local bd3 = barDataByKey and barDataByKey[bk3]
-                        local baseA = bd3 and bd3.barOpacity or 1
+                        local baseA = ns.EffectiveBarAlpha(bd3)
                         if myCse == "lowerAlphaOnCD" then
                             -- Lowered (not hidden): reuse _cdStateHidden as the
                             -- "cd-state owns this alpha" flag so the opacity appliers
@@ -3945,7 +3945,7 @@ local function CollectAndReanchor()
                             if barData.hidePlaceholderIcon and frame._isPlaceholderFrame then
                                 frame:SetAlpha(0)
                             else
-                                frame:SetAlpha(barHidden and 0 or (barData.barOpacity or 1))
+                                frame:SetAlpha(barHidden and 0 or ns.EffectiveBarAlpha(barData))
                             end
                         end
                     end
@@ -4471,7 +4471,7 @@ local function CollectAndReanchor()
                     if not isFKBar then
                     local fcH = _ecmeFC[frame]
                     if not (fcH and fcH._cdStateHidden) then
-                        frame:SetAlpha(barHidden and 0 or (barData.barOpacity or 1))
+                        frame:SetAlpha(barHidden and 0 or ns.EffectiveBarAlpha(barData))
                     end
                     end
                     frame:Show()

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -220,6 +220,17 @@ local _keybindDebounceTimer  = nil   -- cancellable timer for debounced keybind 
 -- Combat state tracked via events (InCombatLockdown() can lag behind PLAYER_REGEN_DISABLED)
 local _inCombat = false
 
+-- Resting alpha for a bar's icons: the out-of-combat fade value when enabled
+-- and out of combat, otherwise the bar's opacity. Callers restoring an icon's
+-- alpha go through this so the fade survives cd-state and buff re-renders.
+local function EffectiveBarAlpha(barData)
+    if barData and barData.oocFadeEnabled and not _inCombat then
+        return barData.oocFadeAlpha or 0.5
+    end
+    return (barData and barData.barOpacity) or 1
+end
+ns.EffectiveBarAlpha = EffectiveBarAlpha
+
 -- Vehicle/petbattle state proxy. Created once in CDMFinishSetup; drives
 -- _CDMApplyVisibility on state change so CDM bars hide while in vehicle UI.
 local _cdmVehicleProxy = nil
@@ -5128,19 +5139,19 @@ local function RefreshCDMIconAppearance(barKey)
                 local onCD = cseInfo and cseInfo.isActive and not cseInfo.isOnGCD
                 if cse == "hiddenOnCD" or cse == "hiddenReady" then
                     local hide = (cse == "hiddenOnCD") == onCD
-                    icon:SetAlpha(hide and 0 or (barData.barOpacity or 1))
+                    icon:SetAlpha(hide and 0 or EffectiveBarAlpha(barData))
                     if fc then fc._cdStateHidden = hide or false end
                 elseif cse == "lowerAlphaOnCD" then
                     -- Identical to hiddenOnCD but with a customizable opacity instead
                     -- of 0. Reuse the _cdStateHidden flag as "cd-state owns this alpha"
                     -- so the opacity appliers leave the lowered value alone.
-                    icon:SetAlpha(onCD and (csSs.cdStateLowerAlpha or 0.5) or (barData.barOpacity or 1))
+                    icon:SetAlpha(onCD and (csSs.cdStateLowerAlpha or 0.5) or EffectiveBarAlpha(barData))
                     if fc then fc._cdStateHidden = onCD or false end
                 else
                     -- Clear stale hidden state when switching to a glow effect
                     if fc and fc._cdStateHidden then
                         fc._cdStateHidden = false
-                        icon:SetAlpha(barData.barOpacity or 1)
+                        icon:SetAlpha(EffectiveBarAlpha(barData))
                     end
                     if not ifd or not ifd._cdStateGlowOn then
                         if (cse == "pixelGlowReady" or cse == "buttonGlowReady"
@@ -5176,7 +5187,7 @@ local function RefreshCDMIconAppearance(barKey)
                 -- so don't clear it here or the icon flashes visible.
                 if not (ns.PresetHasCdState and ns.PresetHasCdState(icon)) then
                     fc._cdStateHidden = false
-                    icon:SetAlpha(barData.barOpacity or 1)
+                    icon:SetAlpha(EffectiveBarAlpha(barData))
                 end
             end
         end
@@ -6047,8 +6058,9 @@ _CDMApplyVisibility = function()
                 end
                 frame._visHidden = false
                 -- Apply opacity to icons every pass (idempotent, handles
-                -- fresh loads where wasHidden is false).
-                local visAlpha = barData.barOpacity or 1
+                -- fresh loads where wasHidden is false). EffectiveBarAlpha folds
+                -- in the out-of-combat fade when that option is on.
+                local visAlpha = EffectiveBarAlpha(barData)
                 local icons = cdmBarIcons[barData.key]
                 local icCombat2 = InCombatLockdown()
                 if icons then
@@ -6155,7 +6167,7 @@ local function ApplyBarOpacity(barKey)
     local barData = barDataByKey[barKey]
     if not barData then return end
     if barKey == FOCUSKICK_BAR_KEY then return end
-    local a = barData.barOpacity or 1
+    local a = EffectiveBarAlpha(barData)
     local icons = cdmBarIcons[barKey]
     if icons then
         for i = 1, #icons do

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -1666,6 +1666,10 @@ L["Text Bar"]                      = "文字条"
 -- == Text Alignment ===========================================================
 
 -- == CDM Options - Missing Translations ========================================
+L["Fade Out of Combat"]           = "战斗外淡出"
+L["Out of Combat Alpha"]          = "战斗外透明度"
+L["Dims this bar while out of combat."] = "战斗外时降低此条的透明度。"
+L["Enable Fade Out of Combat first"] = "首先启用战斗外淡出"
 L["Glow When"]                    = "发光时机"
 L["Remove Glow"]                  = "移除发光"
 L["Remove"]                       = "移除"


### PR DESCRIPTION
## Overview

Adds a per-bar **out-of-combat fade** to the CDM bars - a cog on each Cooldowns / Utility / Buffs bar's **Bar Opacity** slider:

- **Fade Out of Combat** - dims the bar to a chosen alpha while out of combat; snaps back to full the moment you enter combat.
- **Out of Combat Alpha** - the alpha to fade to (0–100%, default 50%). Greyed out until the toggle is on.

## Background
Dimming cooldown/buff icons out of combat and going full-alpha only while fighting is a common WeakAuras setup (per-aura alpha conditions tied to combat state).

## Summary of Changes

### New per-bar properties

| Property | Default | Read by |
|---|---|---|
| `oocFadeEnabled` | `false` | `ns.EffectiveBarAlpha` |
| `oocFadeAlpha` | `0.5` | `ns.EffectiveBarAlpha` |

### Implementation details

- New helper `ns.EffectiveBarAlpha(barData)` returns the fade alpha when the option is on and the player is out of combat, otherwise the bar's `barOpacity`. When the fade is off it returns exactly `barOpacity or 1`, so bars not using it render identically to before.
- Every site that restored an icon to its opacity routes through this helper - `_CDMApplyVisibility`, `ApplyBarOpacity`, `RefreshCDMIconAppearance`, the CdmHooks collect/cd-state passes, and the Fake-Active restore. Without this the fade was clobbered the moment a spell cycled on/off cooldown or a buff re-rendered.
- Driven by the existing `PLAYER_REGEN_ENABLED/DISABLED` events (0.1s exit buffer against flicker).
- Per-spell "lower alpha on cooldown" is unchanged (on-CD uses its own value, ready uses the fade - they don't multiply); placeholder/hidden-cd-state icons and FocusKick untouched.

## Testing

Tested in-game:

- [x] Fade toggle + alpha slider on Cooldowns/Utility/Buffs: dims out of combat, snaps to full in combat
- [x] Self-buff cast / spells cycling on & off cooldown while out of combat: icons stay faded (no flash to full)
- [x] Per-bar independence; mounted/resting/stance stays faded
- [x] Default off on a fresh bar; slider greyed until the toggle is on
- [x] Regression - fade off with custom Bar Opacity (60%): identical to before through cd cycles and buff pops
- [x] Clean load, no Lua errors

## Note
This covers the following discord request:
- https://discord.com/channels/585577383847788554/1523956902277419038

## Example

<img width="1294" height="948" alt="image" src="https://github.com/user-attachments/assets/c65e17ef-47ec-400f-9ac1-c448e5304f75" />


<img width="800" height="396" alt="OOC-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/09ed3de8-7302-4ee4-92ae-152de9074683" />