### PR TITLE
[WIP]  feat(raidframes): incoming resurrection indicator on raid/party frames

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -2561,8 +2561,8 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
         end
 
-        -- Ready Check / Summon icon position + size (the two indicators share a
-        -- single texture, so one set of controls drives both).
+        -- Ready Check / Summon / Rez icon position + size (the three indicators
+        -- share a single texture, so one set of controls drives all of them).
         local readyCheckPositionValues = {
             topleft     = "Top Left",
             top         = "Top",
@@ -2577,7 +2577,7 @@ initFrame:SetScript("OnEvent", function(self)
         local readyCheckPositionOrder = { "topleft", "top", "topright", "left", "center", "right", "bottomleft", "bottom", "bottomright" }
         local rcRow
         rcRow, h = W:DualRow(parent, y,
-            { type="dropdown", text="Ready Check & Summon", values=readyCheckPositionValues, order=readyCheckPositionOrder,
+            { type="dropdown", text="Ready Check / Summon / Rez", values=readyCheckPositionValues, order=readyCheckPositionOrder,
               getValue=function() return SVal("readyCheckPosition", "center") end,
               setValue=function(v) SSet("readyCheckPosition", v) end },
             { type="slider", text="Icon Size", min=8, max=40, step=1,
@@ -2587,7 +2587,7 @@ initFrame:SetScript("OnEvent", function(self)
         do
             local rgn = rcRow._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
-                title = "Ready Check / Summon",
+                title = "Ready Check / Summon / Rez",
                 rows = {
                     { type="toggle", label="Show Ready Check",
                       get=function() return SVal("showReadyCheck", true) end,
@@ -2595,6 +2595,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="toggle", label="Show Incoming Summon",
                       get=function() return SVal("showSummonPending", true) end,
                       set=function(v) SSet("showSummonPending", v) end },
+                    { type="toggle", label="Show Incoming Resurrection",
+                      get=function() return SVal("showIncomingRez", true) end,
+                      set=function(v) SSet("showIncomingRez", v) end },
                     { type="slider", label="Offset X", min=-50, max=50, step=1,
                       get=function() return SVal("readyCheckOffsetX", 0) end,
                       set=function(v) SSet("readyCheckOffsetX", v) end },

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -185,6 +185,7 @@ local UnitExists            = UnitExists
 local UnitIsConnected       = UnitIsConnected
 local UnitIsVisible         = UnitIsVisible
 local UnitIsDeadOrGhost     = UnitIsDeadOrGhost
+local UnitHasIncomingResurrection = UnitHasIncomingResurrection
 local UnitGroupRolesAssigned = UnitGroupRolesAssigned
 local UnitThreatSituation   = UnitThreatSituation
 local UnitIsUnit            = UnitIsUnit
@@ -548,6 +549,7 @@ local defaults = {
         raidMarkerOffsetY  = 0,
         showReadyCheck   = true,
         showSummonPending = true,
+        showIncomingRez  = true,
         readyCheckSize   = 20,
         readyCheckPosition = "center",  -- "topleft", "top", "topright", "left", "center", "right", "bottomleft", "bottom"
         readyCheckOffsetX  = 0,
@@ -4134,6 +4136,10 @@ local function UpdateButton(button)
         local stc = s.statusTextColor or { r = 1, g = 1, b = 1 }
         if s.statusTextPosition == "none" then
             d.statusText:Hide()
+        elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
+            -- Being resurrected: hide DEAD so the incoming-rez icon (shown in the same
+            -- spot by UpdateReadyCheck) isn't covered by the status text.
+            d.statusText:Hide()
         elseif UnitIsDeadOrGhost(unit) then
             d.statusText:SetText(EllesmereUI.L("DEAD"))
             d.statusText:SetTextColor(stc.r, stc.g, stc.b)
@@ -5509,9 +5515,10 @@ end
 -------------------------------------------------------------------------------
 local readyCheckActive = false
 
--- The d.readyCheck texture is shared between the ready-check and incoming-summon
--- indicators (they almost never overlap). Ready check takes priority while a check
--- is active; otherwise the summon status is shown.
+-- The d.readyCheck texture is shared between the ready-check, incoming-summon and
+-- incoming-resurrection indicators (they almost never overlap -- rez only shows on
+-- dead units, the other two on living ones). Priority: an active ready check wins,
+-- then a pending summon, then an incoming rez.
 local function UpdateReadyCheck(button, unit)
     local d = GetFFD(button)
     local tex = d.readyCheck
@@ -5557,6 +5564,16 @@ local function UpdateReadyCheck(button, unit)
             tex:Show()
             return
         end
+    end
+
+    -- Incoming resurrection ("someone is casting a rez / rez waiting to be
+    -- accepted"). Lowest priority; only meaningful on a dead unit. Lets healers
+    -- see a body is already being picked up so they don't all rez the same one.
+    if db.profile.showIncomingRez and unit and UnitHasIncomingResurrection(unit) then
+        tex:SetTexCoord(0, 1, 0, 1)
+        tex:SetTexture("Interface\\RaidFrame\\Raid-Icon-Rez")
+        tex:Show()
+        return
     end
 
     tex:Hide()
@@ -5824,6 +5841,9 @@ ns._UpdateButtonHealth = function(button)
     if d.statusText then
         local stc = s.statusTextColor or { r = 1, g = 1, b = 1 }
         if s.statusTextPosition == "none" then
+            d.statusText:Hide()
+        elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
+            -- Being resurrected: hide DEAD so the incoming-rez icon isn't covered.
             d.statusText:Hide()
         elseif UnitIsDeadOrGhost(unit) then
             d.statusText:SetText(EllesmereUI.L("DEAD"))
@@ -9122,6 +9142,15 @@ local function OnEvent(self, event, arg1, ...)
             local u = btn:GetAttribute("unit")
             if u and btn:IsVisible() then UpdateReadyCheck(btn, u) end
         end
+    elseif event == "INCOMING_RESURRECT_CHANGED" then
+        -- Fires with a unit payload when a rez starts/stops on that unit. Refresh the
+        -- status text (so DEAD hides while rezzing / reappears after) as well as the
+        -- shared rez icon.
+        local btn = unitToButton[arg1] or ns._partyUnitToButton[arg1]
+        if btn and btn:IsVisible() then
+            if ns._UpdateButtonHealth then ns._UpdateButtonHealth(btn) end
+            UpdateReadyCheck(btn, arg1)
+        end
     elseif event == "PLAYER_SPECIALIZATION_CHANGED" then
         if ns.BM_RebuildLookup then ns.BM_RebuildLookup(db) end
         -- BM_RebuildLookup only rebuilds the global spell-lookup tables for the
@@ -9273,7 +9302,7 @@ do
             "roleIconStyle", "roleIconSize", "roleIconPosition", "roleIconOffsetX", "roleIconOffsetY", "roleIconHideInCombat",
             "showRoleForTank", "showRoleForHealer", "showRoleForDPS",
             "showRaidMarker", "raidMarkerSize", "raidMarkerPosition", "raidMarkerOffsetX", "raidMarkerOffsetY",
-            "showReadyCheck", "showSummonPending",
+            "showReadyCheck", "showSummonPending", "showIncomingRez",
             "readyCheckSize", "readyCheckPosition", "readyCheckOffsetX", "readyCheckOffsetY",
             "statusTextPosition", "statusTextOffsetX", "statusTextOffsetY", "statusTextSize", "statusTextColor",
             "showLeaderIcon", "showLeaderIconInCombat", "leaderIconPosition", "leaderIconSize", "leaderIconOffsetX", "leaderIconOffsetY",
@@ -11848,18 +11877,29 @@ local function BuildPreviewRoles()
         end
         previewRoles._dispelMap = dispelMap
 
-        -- Dead/offline: one of each, random non-player slots
+        -- Dead/offline/rez: one of each, random non-player slots. Two of them are
+        -- corpses -- a plain dead body and a separate one that's being resurrected --
+        -- so the showcase shows both states side by side.
         local statePool = {}
         for i = 2, 20 do statePool[#statePool + 1] = i end
         for i = #statePool, 2, -1 do
             local j = math.random(i)
             statePool[i], statePool[j] = statePool[j], statePool[i]
         end
-        previewRoles._deadSlot    = statePool[1]
+        previewRoles._deadSlot    = statePool[1]  -- plain corpse
         previewRoles._offlineSlot = statePool[2]
-        -- Clear readycheck on dead/offline slots
+        previewRoles._rezSlot     = statePool[3]  -- corpse with an incoming-rez icon
+        -- Plain dead + offline bodies carry no readycheck/summon icon (looks wrong there).
         if rcStatuses[statePool[1]] then rcStatuses[statePool[1]] = nil end
         if rcStatuses[statePool[2]] then rcStatuses[statePool[2]] = nil end
+        -- The rez corpse gets the incoming-rez icon. But markers win the shared icon
+        -- slot (same as the readycheck de-confliction above): if the rez slot landed
+        -- on a marker slot, skip the icon (the frame is still shown as a dead body).
+        if statePool[3] ~= ms1 and statePool[3] ~= ms2 then
+            rcStatuses[statePool[3]] = "rez"
+        else
+            rcStatuses[statePool[3]] = nil
+        end
     end
 end
 
@@ -12611,9 +12651,11 @@ local function ApplyPreviewData(f, index)
         local rcStatuses = previewRoles._readyCheck
         local rcStatus = rcStatuses and rcStatuses[index]
         local isSummon = rcStatus and rcStatus:sub(1, 6) == "summon"
+        local isRez    = rcStatus == "rez"
         local showRC = indVis and rcStatus and (
-            (not isSummon and s.showReadyCheck) or
-            (isSummon and s.showSummonPending)
+            (isRez and s.showIncomingRez) or
+            (isSummon and s.showSummonPending) or
+            (not isSummon and not isRez and s.showReadyCheck)
         )
         if showRC then
             local rcSz = PixelSnap(s.readyCheckSize or 20)
@@ -12657,6 +12699,9 @@ local function ApplyPreviewData(f, index)
                 f._readyCheck:SetAtlas("RaidFrame-Icon-SummonAccepted")
             elseif rcStatus == "summon_declined" then
                 f._readyCheck:SetAtlas("RaidFrame-Icon-SummonDeclined")
+            elseif rcStatus == "rez" then
+                f._readyCheck:SetTexture("Interface\\RaidFrame\\Raid-Icon-Rez")
+                f._readyCheck:SetTexCoord(0, 1, 0, 1)
             end
             f._readyCheck:Show()
         else
@@ -12724,9 +12769,12 @@ local function ApplyPreviewData(f, index)
         end -- pos ~= "none"
     end
 
-    -- Dead/offline/AFK states (only when indicators eyeball is on)
-    local isDead    = indVis and index == previewRoles._deadSlot
-    local isOffline = indVis and index == previewRoles._offlineSlot
+    -- Dead/offline/AFK states (only when indicators eyeball is on). The rez slot is
+    -- a second corpse (dimmed, no "DEAD" text) that shows an incoming-rez icon in
+    -- place of the status text -- mirrors the live "hide DEAD while rezzing" behavior.
+    local isRezCorpse = indVis and index == previewRoles._rezSlot
+    local isDead      = indVis and (index == previewRoles._deadSlot or isRezCorpse)
+    local isOffline   = indVis and index == previewRoles._offlineSlot
     -- Mark dead/offline preview frames so the animated-preview ticker skips them
     -- (their health bar is emptied and health text hidden -- never animated).
     f._pvHideHealthText = (isDead or isOffline) or nil
@@ -12872,7 +12920,10 @@ local function ApplyPreviewData(f, index)
         else
             f._statusText:SetPoint("CENTER", f._health, "CENTER", stOX, stOY)
         end
-        if isDead then
+        if isRezCorpse then
+            -- Being resurrected: the rez icon takes this spot, so no DEAD text.
+            f._statusText:Hide()
+        elseif isDead then
             f._statusText:SetText(EllesmereUI.L("DEAD"))
             f._statusText:Show()
         elseif isOffline then
@@ -13911,8 +13962,11 @@ local function BuildPartyPreviewRoles()
         local dispelTypes = { "Magic", "Curse", "Disease", "Poison", "" }
         ns._partyPvRoles._dispelMap = {}
         for i, dt in ipairs(dispelTypes) do ns._partyPvRoles._dispelMap[i] = dt end
-        -- Status showcase: 1 dead, 1 offline, 1 AFK, 1 summon-accepted, one each
-        -- on the four non-player slots (2-5). No ready-check ticks.
+        -- Status showcase: 1 dead, 1 offline, 1 AFK, 1 summon-accepted, one each on
+        -- the four non-player slots (2-5). No ready-check ticks. (Incoming-rez isn't
+        -- previewed here: a 5-man has only four non-player slots and they're all
+        -- taken, so there's no room for a separate rez corpse the way the raid
+        -- preview has one. The live indicator still shows on party frames.)
         local statusSlots = { 2, 3, 4, 5 }
         for i = #statusSlots, 2, -1 do
             local j = math.random(i)
@@ -14538,6 +14592,7 @@ function ERF:OnEnable()
     eventFrame:RegisterEvent("READY_CHECK_CONFIRM")
     eventFrame:RegisterEvent("READY_CHECK_FINISHED")
     eventFrame:RegisterEvent("INCOMING_SUMMON_CHANGED")
+    eventFrame:RegisterEvent("INCOMING_RESURRECT_CHANGED")
     eventFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
     eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
     eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")


### PR DESCRIPTION
## Overview

Adds an **Incoming Resurrection** indicator to raid and party frames. When a dead unit has a rez incoming (`UnitHasIncomingResurrection`), Blizzard's rez icon appears on their frame so healers can see the body is already being picked up — no more three healers rezzing the same corpse.

**What's new:**

- Rez icon on dead units, driven by `INCOMING_RESURRECT_CHANGED`. Reuses the shared Ready Check / Summon slot at lowest priority (ready check > summon > rez).
- While a rez is incoming, the "DEAD" text hides so it doesn't cover the icon (matches Blizzard's `CompactUnitFrame`).
- New toggle **Show Incoming Resurrection** in the renamed *Ready Check / Summon / Rez* cog, on by default; shares position/size/offset with the other two.
- New property `showIncomingRez` (default `true`). Works on raid + party frames; indicator preview shows a second, being-rezzed corpse.

## Summary of Changes

### New per-profile property

| Property | Default | Read by |
|----------|---------|---------|
| `showIncomingRez` | `true` | `UpdateReadyCheck`, `UpdateButton` / `_UpdateButtonHealth` status text, preview |

## Testing

Validated in-game (retail):

- [x] Rez on a dead member → icon shows, DEAD hides, clears on accept/decline/expire
- [x] Ready check + summon still take priority on the shared slot
- [x] Toggle off = pre-PR behavior
- [x] Persists through `/reload`; clean load, no Lua errors

## Example

<img width="1568" height="731" alt="image" src="https://github.com/user-attachments/assets/02477dd4-f9ae-4302-b555-93663f6dd10b" />
