### PR TITLE
feat: Arms Warrior Sweeping Strikes charges as class resource

### DIFF
--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -3530,6 +3530,7 @@ initFrame:SetScript("OnEvent", function(self)
                 { key = "MaelstromWeapon", label = "Maelstrom Weapon" },
                 { key = "TipOfTheSpear",   label = "Tip of the Spear" },
                 { key = "WhirlwindStacks", label = "Whirlwind Stacks" },
+                { key = "SweepingStrikes", label = "Sweeping Strikes" },
             }
             local resourceItems = {}
             for _, it in ipairs(items) do

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2946,6 +2946,7 @@ EllesmereUI.DEFAULT_CLASS_RESOURCE_COLORS = {
     MaelstromWeapon = { r = 0.0,    g = 0.4392, b = 0.8706 },
     TipOfTheSpear   = { r = 0.6667, g = 0.8275, b = 0.4471 },
     WhirlwindStacks = { r = 0.7765, g = 0.6078, b = 0.4275 },
+    SweepingStrikes = { r = 0.8510, g = 0.4157, b = 0.3373 },
 }
 
 -- Get a class-resource color (custom override or default), keyed by resource.
@@ -4002,6 +4003,157 @@ do
             stacks, expiresAt = 0, nil
         end
         return stacks, MAX
+    end
+end
+
+-- Sweeping Strikes tracker (Arms Warrior, Midnight charge rework)
+-- Sweeping Strikes (260708) grants 12 charges (18 with Improved Sweeping
+-- Strikes 383155). Single-target damaging abilities consume charges to
+-- strike an additional enemy within ~8 yd; a charge is only consumed when a
+-- sweep partner is actually in range ("less waste" rework design).
+-- Broad Strokes (1261049): Colossus Smash / Warbreaker also activate
+-- Sweeping Strikes. Buff duration: 30 seconds, cooldown: 30 seconds.
+-- 12.1: charges from the ability and Broad Strokes stack; we track only up
+-- to the visual cap, so either source simply refreshes to max.
+-- Fervor of Battle (202316): Cleave/Whirlwind hitting 3+ targets also Slam
+-- the primary target -- that Slam sweeps and consumes a charge.
+do
+    local stacks, expiresAt = 0, nil
+    local BASE_MAX     = 12
+    local IMPROVED_MAX = 18
+    local DURATION = 30
+    local SWEEP    = 260708
+    local IMPROVED = 383155   -- Improved Sweeping Strikes: 12 -> 18 charges
+    local BROAD    = 1261049  -- Broad Strokes: Colossus Smash activates Sweep
+    local FERVOR   = 202316   -- Fervor of Battle: Cleave/WW on 3+ targets Slams
+
+    local function MaxStacks()
+        return C_SpellBook.IsSpellKnown(IMPROVED) and IMPROVED_MAX or BASE_MAX
+    end
+
+    -- Broad Strokes generators (only count with the talent known)
+    local CS_GENERATORS = {
+        [167105] = true,  -- Colossus Smash
+        [262161] = true,  -- Warbreaker (replaces Colossus Smash)
+    }
+
+    -- Single-target damaging cast IDs whose damage effects sit in the
+    -- Sweeping Strikes affected-spells list (wowhead spell=260708), mapped
+    -- to how many charges each cast consumes.
+    -- Rend and Storm Bolt do NOT sweep and are deliberately absent.
+    local SPENDERS = {
+        [12294]   = 1,  -- Mortal Strike
+        [7384]    = 1,  -- Overpower
+        [1464]    = 1,  -- Slam
+        [163201]  = 1,  -- Execute (Arms)
+        [5308]    = 1,  -- Execute (base)
+        [260643]  = 1,  -- Skullsplitter
+        [34428]   = 1,  -- Victory Rush
+        [202168]  = 1,  -- Impending Victory
+        [1715]    = 1,  -- Hamstring
+        [1269383] = 1,  -- Heroic Strike (replaces Slam via Master of Warfare)
+        [436358]  = 2,  -- Demolish: the channel sweeps twice (damage IDs
+                        -- 440884/440886) -- confirmed in-game, 2 per cast
+    }
+
+    -- Fervor of Battle: the triggered Slam happens on Cleave/Whirlwind casts
+    local FOB_TRIGGERS = {
+        [1680] = true,  -- Whirlwind (Arms)
+        [845]  = true,  -- Cleave
+    }
+    local fobWindow = 0  -- suppress a possibly-echoed Slam cast event
+
+    -- Deduplicate cast events via GUID
+    local seenGUID = {}
+    local guidCount = 0
+
+    -- A charge is only consumed when the strike can sweep onto a second
+    -- enemy (~8 yd). Count the hostile target plus enemy nameplates inside
+    -- the index-2 interact probe (~11 yd, slightly generous; same probe as
+    -- the Whirlwind tracker above). `need` = how many enemies must be in
+    -- reach (2 for a sweep partner, 3 for a Fervor of Battle trigger).
+    -- NOTE: relies on enemy nameplates showing for off-target enemies.
+    local function EnemiesInReach(need)
+        local function InReach(u)
+            if not (UnitExists(u) and UnitCanAttack("player", u) and not UnitIsDead(u)) then
+                return false
+            end
+            return CheckInteractDistance(u, 2) or false
+        end
+        local count, targetPlated = 0, false
+        for i = 1, 40 do
+            local u = "nameplate" .. i
+            if InReach(u) then
+                count = count + 1
+                if UnitIsUnit(u, "target") then targetPlated = true end
+                if count >= need then return true end
+            end
+        end
+        -- Target without a visible nameplate still counts as one body
+        if not targetPlated and InReach("target") then count = count + 1 end
+        return count >= need
+    end
+
+    function EllesmereUI.HandleSweepingStrikes(event, unit, castGUID, spellID)
+        if event == "PLAYER_DEAD" or event == "PLAYER_ALIVE" then
+            stacks, expiresAt = 0, nil
+            fobWindow = 0
+            wipe(seenGUID)
+            guidCount = 0
+            return
+        end
+        if event == "PLAYER_REGEN_ENABLED" then
+            -- Clean up GUID cache on combat end to prevent unbounded growth
+            wipe(seenGUID)
+            guidCount = 0
+            return
+        end
+        if event ~= "UNIT_SPELLCAST_SUCCEEDED" or unit ~= "player" then return end
+        if not (C_SpellBook and C_SpellBook.IsSpellKnown(SWEEP)) then return end
+
+        if castGUID and seenGUID[castGUID] then return end
+        if castGUID then
+            seenGUID[castGUID] = true
+            guidCount = guidCount + 1
+            -- Safety: flush if table grows too large (shouldn't happen normally)
+            if guidCount > 200 then wipe(seenGUID); guidCount = 0 end
+        end
+
+        if spellID == SWEEP
+           or (CS_GENERATORS[spellID] and C_SpellBook.IsSpellKnown(BROAD)) then
+            stacks = MaxStacks()
+            expiresAt = GetTime() + DURATION
+        elseif FOB_TRIGGERS[spellID] and stacks > 0
+               and C_SpellBook.IsSpellKnown(FERVOR) then
+            -- Fervor of Battle: Cleave/Whirlwind hitting 3+ targets also
+            -- Slams the primary target; that Slam sweeps and consumes a
+            -- charge. The trigger itself is not a player cast event, so it
+            -- is counted here off the Cleave/WW cast, gated on 3 enemies in
+            -- reach (with 3+ up, a sweep partner necessarily exists).
+            if not EnemiesInReach(3) then return end
+            fobWindow = GetTime() + 0.3
+            stacks = max(0, stacks - 1)
+            if stacks == 0 then expiresAt = nil end
+        elseif SPENDERS[spellID] and stacks > 0 then
+            -- If the game echoes the Fervor-of-Battle Slam as a real cast
+            -- event, skip it -- the charge was already counted above. A
+            -- player-pressed Slam can't land inside the 0.3 s window (GCD).
+            if spellID == 1464 and GetTime() < fobWindow then return end
+            -- No sweep partner in range -> the game doesn't consume a charge
+            if not EnemiesInReach(2) then return end
+            stacks = max(0, stacks - SPENDERS[spellID])
+            if stacks == 0 then expiresAt = nil end
+        end
+    end
+
+    function EllesmereUI.GetSweepingStrikes()
+        if not (C_SpellBook and C_SpellBook.IsSpellKnown(SWEEP)) then
+            return 0, 0
+        end
+        if expiresAt and GetTime() >= expiresAt then
+            stacks, expiresAt = 0, nil
+        end
+        return stacks, MaxStacks()
     end
 end
 

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -3918,6 +3918,35 @@ do
 
     local CRACKLING = 203201  -- Crackling Thunder: widens Thunder Clap / Thunder Blast
 
+    -- Cached IsSpellKnown flags. GetWhirlwindStacks is polled every 0.1 s by
+    -- the resource bar, unit frame and nameplate readouts, and
+    -- HandleWhirlwindStacks runs on every player cast for every class;
+    -- C_SpellBook.IsSpellKnown is a C call and talents cannot change in
+    -- combat, so resolve the flags once per login/spec/talent event instead
+    -- (same pattern as the Sweeping Strikes tracker below). Non-warriors
+    -- never register the watcher: the flags stay false and both entry
+    -- points early-out on a plain upvalue read.
+    local requiredKnown, crashingKnown, unhingedKnown, cracklingKnown = false, false, false, false
+    do
+        local _, cls = UnitClass("player")
+        if cls == "WARRIOR" then
+            local function RefreshKnown()
+                local sb = C_SpellBook
+                requiredKnown  = (sb and sb.IsSpellKnown(REQUIRED)) or false
+                crashingKnown  = (sb and sb.IsSpellKnown(CRASHING)) or false
+                unhingedKnown  = (sb and sb.IsSpellKnown(UNHINGED)) or false
+                cracklingKnown = (sb and sb.IsSpellKnown(CRACKLING)) or false
+            end
+            local watcher = CreateFrame("Frame")
+            watcher:RegisterEvent("PLAYER_LOGIN")
+            watcher:RegisterEvent("PLAYER_ENTERING_WORLD")
+            watcher:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+            watcher:RegisterEvent("TRAIT_CONFIG_UPDATED")
+            watcher:RegisterEvent("PLAYER_TALENT_UPDATE")
+            watcher:SetScript("OnEvent", RefreshKnown)
+        end
+    end
+
     -- Improved Whirlwind grants stacks only when the swing connects with an enemy,
     -- but UNIT_SPELLCAST_SUCCEEDED fires even when it hits nothing (swung at empty
     -- air, no target, out of combat). Gate the award on an attackable, living enemy
@@ -3927,17 +3956,19 @@ do
     -- Resolved synchronously at cast time, so a kill that ends combat is still
     -- counted (the victim is present the instant the cast succeeds).
     -- NOTE: when no hostile target is set this relies on enemy nameplates showing.
-    local function EnemyInStrikeRange(spellID)
-        local wide = (spellID == 6343 or spellID == 435222) and C_SpellBook.IsSpellKnown(CRACKLING)
-        local function InReach(u)
-            if not (UnitExists(u) and UnitCanAttack("player", u) and not UnitIsDead(u)) then
-                return false
-            end
-            return CheckInteractDistance(u, 2) or (wide and CheckInteractDistance(u, 1)) or false
+    -- InReach is block-scoped (wide passed as a parameter, no upvalues from
+    -- the call) so EnemyInStrikeRange allocates no closure per cast.
+    local function InReach(u, wide)
+        if not (UnitExists(u) and UnitCanAttack("player", u) and not UnitIsDead(u)) then
+            return false
         end
-        if InReach("target") then return true end
+        return CheckInteractDistance(u, 2) or (wide and CheckInteractDistance(u, 1)) or false
+    end
+    local function EnemyInStrikeRange(spellID)
+        local wide = (spellID == 6343 or spellID == 435222) and cracklingKnown
+        if InReach("target", wide) then return true end
         for i = 1, 40 do
-            if InReach("nameplate" .. i) then return true end
+            if InReach("nameplate" .. i, wide) then return true end
         end
         return false
     end
@@ -3957,7 +3988,7 @@ do
             return
         end
         if event ~= "UNIT_SPELLCAST_SUCCEEDED" or unit ~= "player" then return end
-        if not (C_SpellBook and C_SpellBook.IsSpellKnown(REQUIRED)) then return end
+        if not requiredKnown then return end
 
         if castGUID and seenGUID[castGUID] then return end
         if castGUID then
@@ -3975,8 +4006,7 @@ do
 
         if GENERATORS[spellID] then
             -- Thunder Clap / Thunder Blast only count with Crashing Thunder
-            if (spellID == 6343 or spellID == 435222)
-               and not C_SpellBook.IsSpellKnown(CRASHING) then
+            if (spellID == 6343 or spellID == 435222) and not crashingKnown then
                 return
             end
             -- Only award if the swing actually had an enemy to land on.
@@ -3985,8 +4015,7 @@ do
             expiresAt = GetTime() + DURATION
         elseif SPENDERS[spellID] and stacks > 0 then
             -- Unhinged: Bloodthirst/Bloodbath don't consume during Bladestorm
-            if UNHINGED_EXEMPT[spellID]
-               and C_SpellBook.IsSpellKnown(UNHINGED)
+            if UNHINGED_EXEMPT[spellID] and unhingedKnown
                and GetTime() < bladestormEndsAt then
                 return
             end
@@ -3996,9 +4025,7 @@ do
     end
 
     function EllesmereUI.GetWhirlwindStacks()
-        if not (C_SpellBook and C_SpellBook.IsSpellKnown(REQUIRED)) then
-            return 0, 0
-        end
+        if not requiredKnown then return 0, 0 end
         if expiresAt and GetTime() >= expiresAt then
             stacks, expiresAt = 0, nil
         end

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4027,8 +4027,37 @@ do
     local BROAD    = 1261049  -- Broad Strokes: Colossus Smash activates Sweep
     local FERVOR   = 202316   -- Fervor of Battle: Cleave/WW on 3+ targets Slams
 
+    -- Cached IsSpellKnown flags. GetSweepingStrikes is polled every 0.1 s by
+    -- the resource bar, unit frame and nameplate readouts, and
+    -- HandleSweepingStrikes runs on every player cast for every class;
+    -- C_SpellBook.IsSpellKnown is a C call and talents cannot change in
+    -- combat, so resolve once per login/spec/talent event instead (same
+    -- rationale as the cached spec ID above GetSoulFragments). Non-warriors
+    -- never register the watcher: the flags stay false and both entry
+    -- points early-out on a plain upvalue read.
+    local sweepKnown, improvedKnown, broadKnown, fervorKnown = false, false, false, false
+    do
+        local _, cls = UnitClass("player")
+        if cls == "WARRIOR" then
+            local function RefreshKnown()
+                local sb = C_SpellBook
+                sweepKnown    = (sb and sb.IsSpellKnown(SWEEP)) or false
+                improvedKnown = (sb and sb.IsSpellKnown(IMPROVED)) or false
+                broadKnown    = (sb and sb.IsSpellKnown(BROAD)) or false
+                fervorKnown   = (sb and sb.IsSpellKnown(FERVOR)) or false
+            end
+            local watcher = CreateFrame("Frame")
+            watcher:RegisterEvent("PLAYER_LOGIN")
+            watcher:RegisterEvent("PLAYER_ENTERING_WORLD")
+            watcher:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+            watcher:RegisterEvent("TRAIT_CONFIG_UPDATED")
+            watcher:RegisterEvent("PLAYER_TALENT_UPDATE")
+            watcher:SetScript("OnEvent", RefreshKnown)
+        end
+    end
+
     local function MaxStacks()
-        return C_SpellBook.IsSpellKnown(IMPROVED) and IMPROVED_MAX or BASE_MAX
+        return improvedKnown and IMPROVED_MAX or BASE_MAX
     end
 
     -- Broad Strokes generators (only count with the talent known)
@@ -4073,13 +4102,15 @@ do
     -- the Whirlwind tracker above). `need` = how many enemies must be in
     -- reach (2 for a sweep partner, 3 for a Fervor of Battle trigger).
     -- NOTE: relies on enemy nameplates showing for off-target enemies.
-    local function EnemiesInReach(need)
-        local function InReach(u)
-            if not (UnitExists(u) and UnitCanAttack("player", u) and not UnitIsDead(u)) then
-                return false
-            end
-            return CheckInteractDistance(u, 2) or false
+    -- InReach is block-scoped (no upvalues from the call) so EnemiesInReach
+    -- allocates nothing -- it runs on every tracked spender cast in combat.
+    local function InReach(u)
+        if not (UnitExists(u) and UnitCanAttack("player", u) and not UnitIsDead(u)) then
+            return false
         end
+        return CheckInteractDistance(u, 2) or false
+    end
+    local function EnemiesInReach(need)
         local count, targetPlated = 0, false
         for i = 1, 40 do
             local u = "nameplate" .. i
@@ -4109,7 +4140,7 @@ do
             return
         end
         if event ~= "UNIT_SPELLCAST_SUCCEEDED" or unit ~= "player" then return end
-        if not (C_SpellBook and C_SpellBook.IsSpellKnown(SWEEP)) then return end
+        if not sweepKnown then return end
 
         if castGUID and seenGUID[castGUID] then return end
         if castGUID then
@@ -4120,11 +4151,10 @@ do
         end
 
         if spellID == SWEEP
-           or (CS_GENERATORS[spellID] and C_SpellBook.IsSpellKnown(BROAD)) then
+           or (CS_GENERATORS[spellID] and broadKnown) then
             stacks = MaxStacks()
             expiresAt = GetTime() + DURATION
-        elseif FOB_TRIGGERS[spellID] and stacks > 0
-               and C_SpellBook.IsSpellKnown(FERVOR) then
+        elseif FOB_TRIGGERS[spellID] and stacks > 0 and fervorKnown then
             -- Fervor of Battle: Cleave/Whirlwind hitting 3+ targets also
             -- Slams the primary target; that Slam sweeps and consumes a
             -- charge. The trigger itself is not a player cast event, so it
@@ -4147,9 +4177,7 @@ do
     end
 
     function EllesmereUI.GetSweepingStrikes()
-        if not (C_SpellBook and C_SpellBook.IsSpellKnown(SWEEP)) then
-            return 0, 0
-        end
+        if not sweepKnown then return 0, 0 end
         if expiresAt and GetTime() >= expiresAt then
             stacks, expiresAt = 0, nil
         end

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -3694,7 +3694,8 @@ local CLASS_POWER_MAP = {
     SHAMAN      = { [263] = { "MAELSTROM_WEAPON", 10 } },  -- Enhancement only
     PRIEST      = { [258] = { "INSANITY_BAR", 100 } },     -- Shadow only
     HUNTER      = { [255] = { "TIP_OF_THE_SPEAR", 3 } },   -- Survival only
-    WARRIOR     = { [72]  = { "WHIRLWIND_STACKS", 4 } },    -- Fury only
+    WARRIOR     = { [72]  = { "WHIRLWIND_STACKS", 4 },     -- Fury
+                    [71]  = { "SWEEPING_STRIKES", 12 } },   -- Arms
     DEATHKNIGHT = { [250] = { Enum.PowerType.Runes, 6 },
                     [251] = { Enum.PowerType.Runes, 6 },
                     [252] = { Enum.PowerType.Runes, 6 } },
@@ -4027,6 +4028,15 @@ local function UpdateClassPowerOnPlate(plate)
             end
             return
         end
+    elseif classPowerType == "SWEEPING_STRIKES" then
+        cur, maxP = EllesmereUI.GetSweepingStrikes()
+        if not maxP or maxP <= 0 then
+            for i = 1, #plate._cpPips do
+                plate._cpPips[i]:Hide()
+                if plate._cpPips[i]._bg then plate._cpPips[i]._bg:Hide() end
+            end
+            return
+        end
     elseif classPowerType == "ICICLES" then
         local count = 0
         if C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID then
@@ -4332,6 +4342,9 @@ local function EnableClassPowerWatcher()
                     if EllesmereUI.HandleWhirlwindStacks then
                         EllesmereUI.HandleWhirlwindStacks(event, unit, castGUID, spellID)
                     end
+                    if EllesmereUI.HandleSweepingStrikes then
+                        EllesmereUI.HandleSweepingStrikes(event, unit, castGUID, spellID)
+                    end
                 end
                 RefreshClassPower()
             elseif event == "PLAYER_DEAD" or event == "PLAYER_ALIVE" then
@@ -4342,11 +4355,19 @@ local function EnableClassPowerWatcher()
                     if EllesmereUI.HandleWhirlwindStacks then
                         EllesmereUI.HandleWhirlwindStacks(event)
                     end
+                    if EllesmereUI.HandleSweepingStrikes then
+                        EllesmereUI.HandleSweepingStrikes(event)
+                    end
                 end
                 RefreshClassPower()
             elseif event == "PLAYER_REGEN_ENABLED" then
-                if not _G._ERB_AceDB and EllesmereUI and EllesmereUI.HandleWhirlwindStacks then
-                    EllesmereUI.HandleWhirlwindStacks(event)
+                if not _G._ERB_AceDB and EllesmereUI then
+                    if EllesmereUI.HandleWhirlwindStacks then
+                        EllesmereUI.HandleWhirlwindStacks(event)
+                    end
+                    if EllesmereUI.HandleSweepingStrikes then
+                        EllesmereUI.HandleSweepingStrikes(event)
+                    end
                 end
                 RefreshClassPower()
             else

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -417,6 +417,10 @@ initFrame:SetScript("OnEvent", function(self)
                             math.floor(_previewPipCount / 5 * numPips + 0.5)))
                     end
                 end
+                -- Expose to the count-text block below so the number always
+                -- matches the lit segments
+                pc._pvShownCount = filledCount
+                pc._pvShownMax = numPips
                 local useThresh = _pvTsEnabled
 				-- use current spec threshold color if configured
 				local tr = _pvTsEntry2 and _pvTsEntry2.thresholdR or sp.thresholdR
@@ -595,10 +599,16 @@ initFrame:SetScript("OnEvent", function(self)
                     local percentSuffix = (sp.showPercent == false) and "" or "%"
                     pc._countText:SetText(tostring(_previewBarFillPct) .. percentSuffix)
                 else
-                    local _pvTsE3 = _G._ERB_ResolveThresholdSpecEntry and _G._ERB_ResolveThresholdSpecEntry(sp) or nil
-                    local _pvE3Enabled = _pvTsE3 and (_pvTsE3.thresholdEnabled ~= false) or false
-                    local filledCount = _pvE3Enabled and (_pvTsE3.thresholdCount or sp.thresholdCount) or _previewPipCount
-                    pc._countText:SetText(tostring(filledCount))
+                    -- Mirror the pip loop's filled count (threshold-resolved
+                    -- and rescaled to the spec's pip count) so the number
+                    -- always matches the lit segments; "cur / max" like the
+                    -- live bar unless Show Max Stacks is off.
+                    local shown = pc._pvShownCount or _previewPipCount
+                    if sp.showMaxStacks == false then
+                        pc._countText:SetText(tostring(shown))
+                    else
+                        pc._countText:SetText(shown .. " / " .. (pc._pvShownMax or shown))
+                    end
                 end
                 pc._countText:Show()
             elseif pc._countText then

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -186,6 +186,30 @@ initFrame:SetScript("OnEvent", function(self)
     local _previewPipCount = 3  -- randomized each page visit
     local _previewBarFillPct = 65 -- randomized each page visit (30-80)
 
+    -- Discrete pip count for the current spec's preview: use the real
+    -- resource max (Fury Whirlwind 4, Arms Sweeping Strikes 12/18, DK runes
+    -- 6, Maelstrom Weapon 5/10, ...) so the preview matches the live bar;
+    -- generic 5 as fallback when there is no discrete secondary.
+    local function PreviewPipCount()
+        local gsr = _G._ERB_GetSecondaryResource
+        local info = gsr and gsr()
+        if not info or info.type == "bar" then return 5 end
+        local m = info.max
+        -- Talent-dependent maxes come from the live trackers
+        if info.power == "SWEEPING_STRIKES" and EllesmereUI and EllesmereUI.GetSweepingStrikes then
+            local _, realMax = EllesmereUI.GetSweepingStrikes()
+            if realMax and realMax > 0 then m = realMax end
+        elseif info.power == "WHIRLWIND_STACKS" and EllesmereUI and EllesmereUI.GetWhirlwindStacks then
+            local _, realMax = EllesmereUI.GetWhirlwindStacks()
+            if realMax and realMax > 0 then m = realMax end
+        elseif info.power == "MAELSTROM_WEAPON" and EllesmereUI and EllesmereUI.GetMaelstromWeapon then
+            local _, realMax = EllesmereUI.GetMaelstromWeapon()
+            if realMax and realMax > 0 then m = realMax end
+        end
+        if type(m) == "number" and m >= 2 and m <= 20 then return m end
+        return 5
+    end
+
     local function UpdatePreviewHeader()
         local p = DB()
         if not p then return end
@@ -340,7 +364,7 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 local totalW = PipSnap(sp.pipWidth)
                 local snappedPipH = PipSnap(sp.pipHeight)
-                local numPips = 5
+                local numPips = PreviewPipCount()
                 local isVertical = false
                 local isReversed = false
 
@@ -385,6 +409,13 @@ initFrame:SetScript("OnEvent", function(self)
                     filledCount = _pvThreshCount
                 else
                     filledCount = _previewPipCount
+                    -- _previewPipCount is randomized against the generic
+                    -- 5-pip preview; rescale for specs with other pip counts
+                    -- (e.g. 12/18 Sweeping Strikes charges).
+                    if numPips ~= 5 then
+                        filledCount = math.max(1, math.min(numPips,
+                            math.floor(_previewPipCount / 5 * numPips + 0.5)))
+                    end
                 end
                 local useThresh = _pvTsEnabled
 				-- use current spec threshold color if configured
@@ -392,7 +423,21 @@ initFrame:SetScript("OnEvent", function(self)
 				local tg = _pvTsEntry2 and _pvTsEntry2.thresholdG or sp.thresholdG
 				local tb = _pvTsEntry2 and _pvTsEntry2.thresholdB or sp.thresholdB
 
-                for i, pip in ipairs(_previewFrames.pips) do
+                -- Top up pip frames if this spec needs more than were built
+                -- (pip counts differ per spec: 3-18). Styling is applied in
+                -- the loop below, so bare bg+fill textures suffice here.
+                for i = #_previewFrames.pips + 1, numPips do
+                    local pip = CreateFrame("Frame", nil, pc)
+                    local bg = pip:CreateTexture(nil, "BACKGROUND")
+                    bg:SetAllPoints()
+                    pip._bg = bg
+                    local fill = pip:CreateTexture(nil, "ARTWORK")
+                    fill:SetAllPoints()
+                    pip._fill = fill
+                    _previewFrames.pips[i] = pip
+                end
+                for i = 1, math.min(numPips, #_previewFrames.pips) do
+                    local pip = _previewFrames.pips[i]
                     if isVertical then
                         pip:SetSize(snappedPipH, pipW[i])
                         pip:ClearAllPoints()
@@ -458,7 +503,7 @@ initFrame:SetScript("OnEvent", function(self)
                             sp.textXOffset or 0, sp.textYOffset or 0)
                         if not active then
                             -- Fake durations: higher numbers for pips further right
-                            local fakeDurations = { 2, 4, 7, 9, 10 }
+                            local fakeDurations = { 2, 4, 6, 7, 9, 10 }
                             pip._pvCdText:SetText(tostring(fakeDurations[i] or ""))
                             pip._pvCdText:Show()
                         else
@@ -651,7 +696,7 @@ initFrame:SetScript("OnEvent", function(self)
         else
             -- Pips preview: pipWidth is total bar width; divide evenly across pips.
             -- Any remainder pixels go into pip widths, not spacing.
-            local numPips = 5
+            local numPips = PreviewPipCount()
             local totalW = sp.pipWidth
             local pipSp = sp.pipSpacing
             local baseW = math.floor((totalW - (numPips - 1) * pipSp) / numPips)

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -555,6 +555,10 @@ local function GetSecondaryResource()
         return { power = "IGNOREPAIN_BAR", max = mx * IP.CAP, type = "bar" }
     elseif classFile == "WARRIOR" and spec == 2 then
         return { power = "WHIRLWIND_STACKS", max = 4, type = "custom" }
+    elseif classFile == "WARRIOR" and spec == 1 then
+        -- Arms: Sweeping Strikes charges (12, or 18 with Improved Sweeping
+        -- Strikes). Base max here; BuildBars refreshes from the tracker.
+        return { power = "SWEEPING_STRIKES", max = 12, type = "custom" }
     end
 
     return nil
@@ -583,6 +587,7 @@ do
         ["MAELSTROM_WEAPON"]         = "MaelstromWeapon",
         ["TIP_OF_THE_SPEAR"]         = "TipOfTheSpear",
         ["WHIRLWIND_STACKS"]         = "WhirlwindStacks",
+        ["SWEEPING_STRIKES"]         = "SweepingStrikes",
     }
     local PKEY = {
         ["LUNAR_POWER_BAR"] = "LUNAR_POWER",
@@ -2849,6 +2854,9 @@ local function BuildBars()
             elseif powerType == "WHIRLWIND_STACKS" and EllesmereUI.GetWhirlwindStacks then
                 local _, realMax = EllesmereUI.GetWhirlwindStacks()
                 if realMax and realMax > 0 then maxPts = realMax end
+            elseif powerType == "SWEEPING_STRIKES" and EllesmereUI.GetSweepingStrikes then
+                local _, realMax = EllesmereUI.GetSweepingStrikes()
+                if realMax and realMax > 0 then maxPts = realMax end
             elseif powerType == "ICICLES" then
                 maxPts = 5
             end
@@ -4512,6 +4520,12 @@ local function UpdateSecondaryResource()
             cur, maxC = EllesmereUI.GetTipOfTheSpear()
         elseif powerType == "WHIRLWIND_STACKS" and EllesmereUI and EllesmereUI.GetWhirlwindStacks then
             cur, maxC = EllesmereUI.GetWhirlwindStacks()
+            if not maxC or maxC <= 0 then
+                for i = 1, #pips do if pips[i] then pips[i]:Hide() end end
+                return
+            end
+        elseif powerType == "SWEEPING_STRIKES" and EllesmereUI and EllesmereUI.GetSweepingStrikes then
+            cur, maxC = EllesmereUI.GetSweepingStrikes()
             if not maxC or maxC <= 0 then
                 for i = 1, #pips do if pips[i] then pips[i]:Hide() end end
                 return
@@ -7050,9 +7064,12 @@ local function OnEvent(self, event, ...)
     elseif event == "PLAYER_REGEN_ENABLED" then
         isInCombat = false
         UpdateVisibility()
-        -- Clean up Whirlwind GUID cache on combat end
+        -- Clean up Whirlwind / Sweeping Strikes GUID caches on combat end
         if EllesmereUI and EllesmereUI.HandleWhirlwindStacks then
             EllesmereUI.HandleWhirlwindStacks(event)
+        end
+        if EllesmereUI and EllesmereUI.HandleSweepingStrikes then
+            EllesmereUI.HandleSweepingStrikes(event)
         end
     elseif event == "PLAYER_TARGET_CHANGED" then
         UpdateVisibility()
@@ -7132,6 +7149,9 @@ local function OnEvent(self, event, ...)
                 if EllesmereUI.HandleWhirlwindStacks then
                     EllesmereUI.HandleWhirlwindStacks(event, unit, castGUID, spellID)
                 end
+                if EllesmereUI.HandleSweepingStrikes then
+                    EllesmereUI.HandleSweepingStrikes(event, unit, castGUID, spellID)
+                end
             end
             if cachedSecondary and (cachedSecondary.type == "custom"
                or cachedSecondary.power == "IRONFUR_BAR") then
@@ -7149,6 +7169,9 @@ local function OnEvent(self, event, ...)
             end
             if EllesmereUI.HandleWhirlwindStacks then
                 EllesmereUI.HandleWhirlwindStacks(event)
+            end
+            if EllesmereUI.HandleSweepingStrikes then
+                EllesmereUI.HandleSweepingStrikes(event)
             end
         end
     elseif event == "PLAYER_ENTERING_WORLD" then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -7375,7 +7375,8 @@ local CLASS_POWER_TYPES = {
                     [1480] = { "SOUL_FRAGMENTS_DEVOURER", 50, "bar" } },
     SHAMAN      = { [263] = { "MAELSTROM_WEAPON", 10 } },
     HUNTER      = { [255] = { "TIP_OF_THE_SPEAR", 3 } },
-    WARRIOR     = { [72]  = { "WHIRLWIND_STACKS", 4 } },
+    WARRIOR     = { [72]  = { "WHIRLWIND_STACKS", 4 },
+                    [71]  = { "SWEEPING_STRIKES", 12 } },
 }
 
 -- Returns true if the player's current spec has a class resource in CLASS_POWER_TYPES
@@ -7449,6 +7450,8 @@ local function CreateCustomClassPower(playerFrame, style)
         elseif powerType == "TIP_OF_THE_SPEAR" then
             maxPower = customMax
         elseif powerType == "WHIRLWIND_STACKS" then
+            maxPower = customMax
+        elseif powerType == "SWEEPING_STRIKES" then
             maxPower = customMax
         elseif powerType == "ICICLES" then
             maxPower = customMax or 5
@@ -7662,6 +7665,8 @@ local function CreateCustomClassPower(playerFrame, style)
                 cur, max = EllesmereUI.GetTipOfTheSpear()
             elseif powerType == "WHIRLWIND_STACKS" and EllesmereUI and EllesmereUI.GetWhirlwindStacks then
                 cur, max = EllesmereUI.GetWhirlwindStacks()
+            elseif powerType == "SWEEPING_STRIKES" and EllesmereUI and EllesmereUI.GetSweepingStrikes then
+                cur, max = EllesmereUI.GetSweepingStrikes()
             elseif powerType == "ICICLES" then
                 -- Frost Mage Icicles: stack count from the Icicles aura (205473).
                 local count = 0
@@ -7761,7 +7766,8 @@ local function CreateCustomClassPower(playerFrame, style)
         local auraDriven    = (powerType == "MAELSTROM_WEAPON" or powerType == "ICICLES")
         local needsOnUpdate = not auraDriven
         local needsAura     = auraDriven
-        local needsCasts    = (powerType == "TIP_OF_THE_SPEAR" or powerType == "WHIRLWIND_STACKS")
+        local needsCasts    = (powerType == "TIP_OF_THE_SPEAR" or powerType == "WHIRLWIND_STACKS"
+                               or powerType == "SWEEPING_STRIKES")
 
         if needsOnUpdate then
             local elapsed = 0
@@ -7784,7 +7790,7 @@ local function CreateCustomClassPower(playerFrame, style)
             eventFrame:RegisterEvent("PLAYER_DEAD")
             eventFrame:RegisterEvent("PLAYER_ALIVE")
         end
-        if powerType == "WHIRLWIND_STACKS" then
+        if powerType == "WHIRLWIND_STACKS" or powerType == "SWEEPING_STRIKES" then
             eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
         end
 
@@ -7807,6 +7813,9 @@ local function CreateCustomClassPower(playerFrame, style)
                         if EllesmereUI.HandleWhirlwindStacks then
                             EllesmereUI.HandleWhirlwindStacks(event, unit, castGUID, spellID)
                         end
+                        if EllesmereUI.HandleSweepingStrikes then
+                            EllesmereUI.HandleSweepingStrikes(event, unit, castGUID, spellID)
+                        end
                     end
                 end
             elseif event == "PLAYER_DEAD" or event == "PLAYER_ALIVE" then
@@ -7817,10 +7826,18 @@ local function CreateCustomClassPower(playerFrame, style)
                     if EllesmereUI.HandleWhirlwindStacks then
                         EllesmereUI.HandleWhirlwindStacks(event)
                     end
+                    if EllesmereUI.HandleSweepingStrikes then
+                        EllesmereUI.HandleSweepingStrikes(event)
+                    end
                 end
             elseif event == "PLAYER_REGEN_ENABLED" then
-                if not _G._ERB_AceDB and EllesmereUI and EllesmereUI.HandleWhirlwindStacks then
-                    EllesmereUI.HandleWhirlwindStacks(event)
+                if not _G._ERB_AceDB and EllesmereUI then
+                    if EllesmereUI.HandleWhirlwindStacks then
+                        EllesmereUI.HandleWhirlwindStacks(event)
+                    end
+                    if EllesmereUI.HandleSweepingStrikes then
+                        EllesmereUI.HandleSweepingStrikes(event)
+                    end
                 end
             end
             UpdatePips()


### PR DESCRIPTION
## Summary

Adds **Sweeping Strikes charges** as the Arms Warrior (spec 71) class resource, mirroring the existing Fury `WHIRLWIND_STACKS` implementation across all display surfaces: Resource Bars, Unit Frames and personal Nameplate. Also improves the options preview and optimizes talent lookups in both warrior trackers.

## Mechanics (Midnight charge rework)

- **Sweeping Strikes (260708)** grants 12 charges — 18 with Improved Sweeping Strikes (383155) — for 30 s.
- **Broad Strokes (1261049)**: Colossus Smash (167105) / Warbreaker (262161) also activate Sweeping Strikes.
- **Spenders** consume 1 charge per cast, gated on a sweep partner actually being in range (~8 yd nameplate probe, same technique as the Whirlwind tracker): Mortal Strike, Overpower, Slam, Execute, Skullsplitter, Victory Rush / Impending Victory, Hamstring, Heroic Strike (Master of Warfare).
- **Demolish (436358)** consumes **2 charges** per channel (its two sweeping damage effects 440884/440886 — confirmed in-game).
- **Fervor of Battle (202316)**: Cleave/Whirlwind hitting 3+ targets also Slam the primary target; counted off the Cleave/WW cast with a 0.3 s window suppressing a possibly-echoed Slam cast event.
- **Rend and Storm Bolt deliberately excluded** — they are not in the Sweeping Strikes affected-spells list and do not sweep.

Tracking is manual via `UNIT_SPELLCAST_SUCCEEDED` with castGUID dedup (12.0+ secret-value safe, no combat log), following the existing `HandleWhirlwindStacks` pattern. Without the talent, the pips hide (same hide-on-0 behavior as Fury).

## Changes

- **`EllesmereUI.lua`** — new `HandleSweepingStrikes` / `GetSweepingStrikes` tracker block next to the Whirlwind one; `SweepingStrikes` default in `DEFAULT_CLASS_RESOURCE_COLORS`.
- **`EllesmereUIResourceBars`** — Arms secondary resource (`SWEEPING_STRIKES`, custom pips), color key, dynamic 12↔18 max, event routing.
- **`EllesmereUIUnitFrames` / `EllesmereUINameplates`** — spec 71 entries, cur/max branches, conditional event registration, standalone routing (when Resource Bars isn't loaded).
- **`EUI__General_Options.lua`** — "Sweeping Strikes" entry in Class Resource Colors.
- **Options preview** now shows the real pip count for the current spec (Arms 12/18, Fury 4, DK runes 6, Enhancement 5/10, …) instead of a hardcoded 5, with the random fill rescaled and the count text synced to the lit segments ("cur / max", like the live bar).
- **Perf**: both warrior trackers (Sweeping Strikes and Whirlwind) now cache their `IsSpellKnown` flags, refreshed on login/spec/talent events by a watcher only registered on warriors. The getters are polled every 0.1 s by three surfaces and the handlers run on every player cast for every class — these are now plain upvalue reads. The range-probe inner closures were also hoisted so no allocation happens per tracked cast.

## Testing

- Tested in-game on Arms: charge generation (button + Broad Strokes), per-spender consumption with 2+ enemies, Demolish double consumption, Fervor of Battle on 3+ targets, 12↔18 max on talent swap, pip color via Class Resource Colors.
- Fury Whirlwind stacks re-tested after the perf commit (behavior unchanged).
- Range gating relies on enemy nameplates being visible for off-target enemies (same limitation as the Whirlwind tracker).
- The 12.1 "both sources stack" rule is modeled as refresh-to-max (the tracker caps at the visual max).