### PR TITLE
Boss Frame: Add CD and stack texts color

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -3280,7 +3280,7 @@ initFrame:SetScript("OnEvent", function(self)
             -- Show Cooldown Text / Stack controls live-update here.
             do
                 local showExtras = (unitKey == "boss") and not noDebuffPreview
-                local showCDText, cdTextSize, cdTOffX, cdTOffY, stackTextSize, stackTOffX, stackTOffY
+                local showCDText, cdTextSize, cdTOffX, cdTOffY, stackTextSize, stackTextPosition, stackTOffX, stackTOffY, cdTextColor, stackTextColor
                 if showExtras then
                     if ns.GetBossSimpleDebuffMode(s) ~= "none" then
                         showCDText = s.simpleDebuffShowCooldownText
@@ -3294,8 +3294,11 @@ initFrame:SetScript("OnEvent", function(self)
                         cdTOffY = s.debuffCooldownTextOffsetY or 0
                     end
                     stackTextSize = s.debuffStackTextSize or 14
+                    stackTextPosition = s.debuffStackTextPosition or "bottomright"
                     stackTOffX = s.debuffStackTextOffsetX or 0
                     stackTOffY = s.debuffStackTextOffsetY or 0
+                    cdTextColor = s.debuffCooldownTextColor or {r=1, g=1, b=1}
+                    stackTextColor = s.debuffStackTextColor or {r=1, g=1, b=1}
                 end
                 local fontP = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames")) or "Fonts\\FRIZQT__.TTF"
                 for i = 1, #debuffIcons do
@@ -3308,6 +3311,7 @@ initFrame:SetScript("OnEvent", function(self)
                                 EllesmereUI.ApplyIconTextFont(dt, fontP, cdTextSize, "unitFrames")
                                 dt:ClearAllPoints()
                                 dt:SetPoint("CENTER", df, "CENTER", cdTOffX, cdTOffY)
+                                dt:SetTextColor(cdTextColor.r, cdTextColor.g, cdTextColor.b)
                                 dt:Show()
                             else
                                 dt:Hide()
@@ -3319,8 +3323,8 @@ initFrame:SetScript("OnEvent", function(self)
                             if i == 2 then
                                 EllesmereUI.ApplyIconTextFont(st, fontP, stackTextSize, "unitFrames")
                                 st:SetText(3)
-                                st:ClearAllPoints()
-                                st:SetPoint("BOTTOMRIGHT", df, "BOTTOMRIGHT", -1 + stackTOffX, stackTOffY)
+                                ns.ApplyStackAnchor(st, df, stackTextPosition, stackTOffX, stackTOffY)
+                                st:SetTextColor(stackTextColor.r, stackTextColor.g, stackTextColor.b)
                                 st:Show()
                             else
                                 st:Hide()
@@ -11985,14 +11989,129 @@ initFrame:SetScript("OnEvent", function(self)
             -- BUFFS AND DEBUFFS section (below DISPLAY)
             bossAuraHeader, hh = Ww:SectionHeader(pp, "Buffs and Debuffs", yy);  yy = yy - hh
 
+            -- Simple Buff Display: identical to Simple Debuff Display above but for
+            -- buffs. Defaults to None. Forces a single Left/Right column matched to
+            -- the frame height, overriding Buffs Location + Buff Size while active.
+            local simpleBuffTextOff = function()
+                return ns.db.profile.boss.showBuffs
+                or db.profile.boss.simpleBuffs == "none"
+                or not db.profile.boss.simpleBuffShowCooldownText
+            end
+            simpleBuffRow, hh = Ww:DualRow(pp, yy,
+                { type="dropdown", text="Simple Buff Display",
+                  disabled = function()
+                      return ns.db.profile.boss.showBuffs
+                  end,
+                  disabledTooltip="Buffs Location", requireState="disabled",
+                  tooltip = "Force boss buffs into a single large column matched to the frame height.",
+                  values = { none = "None", left = "Left", right = "Right" },
+                  order = { "none", "left", "right" },
+                  getValue=function() return ns.GetBossSimpleBuffMode(db.profile.boss) end,
+                  setValue=function(v)
+                      db.profile.boss.simpleBuffs = v
+                      if v ~= "none" then
+                          -- Same-side collision: if Simple Debuff Display occupies this
+                          -- side, push it off (set to None) so they never overlap.
+                          if ns.GetBossSimpleDebuffMode(db.profile.boss) == v then
+                              db.profile.boss.simpleDebuffs = "none"
+                          end
+                          -- Selecting a side takes over from the normal Buffs
+                          -- Location, so force that setting to None.
+                          db.profile.boss.showBuffs = false
+                      end
+                      ReloadAndUpdate()
+                      if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end
+                      EllesmereUI:RefreshPage()
+                  end },
+                { type="slider", text="Buff Text Size", min=6, max=30, step=1,
+                  disabled=simpleBuffTextOff, disabledTooltip="Show Duration (Inside Cog)",
+                  getValue=function() return db.profile.boss.simpleBuffCooldownTextSize or 14 end,
+                  setValue=function(v) db.profile.boss.simpleBuffCooldownTextSize = v; ReloadAndUpdate() end });  yy = yy - hh
+
+            -- Directions cog on Simple Buff Display: the simple column's own X/Y
+            -- offset (defaults to the regular buff offsets via ns.GetBossSimpleBuffOffset);
+            -- writing here makes the simple offset independent. Disabled while None.
+            do
+                local leftRgn = simpleBuffRow._leftRegion
+                local _, simpleBuffPosCogShow = EllesmereUI.BuildCogPopup({
+                    title = "Simple Buff Position",
+                    rows = {
+                        -- Max buffs shown in simple mode. Shares the boss maxBuffs key
+                        -- with Buffs Location (the two modes are mutually exclusive);
+                        -- the runtime caps frame.Buffs.num to it.
+                        { type="slider", label="Max Count", min=1, max=20, step=1,
+                          get=function() return db.profile.boss.maxBuffs or 4 end,
+                          set=function(v) db.profile.boss.maxBuffs = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
+                        { type="slider", label="Offset X", min=-200, max=200, step=1,
+                          get=function() local x = ns.GetBossSimpleBuffOffset(db.profile.boss); return x end,
+                          set=function(v) db.profile.boss.simpleBuffOffsetX = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
+                        { type="slider", label="Offset Y", min=-200, max=200, step=1,
+                          get=function() local _, y = ns.GetBossSimpleBuffOffset(db.profile.boss); return y end,
+                          set=function(v) db.profile.boss.simpleBuffOffsetY = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
+                        -- Physical-pixel-perfect gap between the simple buff icons.
+                        { type="slider", label="Spacing", min=-1, max=10, step=1,
+                          get=function() return db.profile.boss.simpleBuffSpacing or 1 end,
+                          set=function(v) db.profile.boss.simpleBuffSpacing = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
+                    },
+                })
+                BossCogBtn(leftRgn, simpleBuffPosCogShow, EllesmereUI.DIRECTIONS_ICON,
+                    function() return ns.GetBossSimpleBuffMode(db.profile.boss) == "none" end)
+            end
+
+            -- Inline cog on Simple Text Size: duration X/Y + stack size / X/Y.
+            do
+                local rightRgn = simpleBuffRow._rightRegion
+                local _, simpleBuffStackCogShow = EllesmereUI.BuildCogPopup({
+                    title = "Duration & Stack",
+                    rows = {
+                        { type="toggle", label="Show Duration",
+                          get=function() return db.profile.boss.simpleBuffShowCooldownText end,
+                          set=function(v) db.profile.boss.simpleBuffShowCooldownText = v; ReloadAndUpdate(); EllesmereUI:RefreshPage() end },
+                        { type="slider", label="Duration X", min=-100, max=100, step=1,
+                          get=function() return db.profile.boss.simpleBuffCooldownTextOffsetX or 0 end,
+                          set=function(v) db.profile.boss.simpleBuffCooldownTextOffsetX = v; ReloadAndUpdate() end },
+                        { type="slider", label="Duration Y", min=-100, max=100, step=1,
+                          get=function() return db.profile.boss.simpleBuffCooldownTextOffsetY or 0 end,
+                          set=function(v) db.profile.boss.simpleBuffCooldownTextOffsetY = v; ReloadAndUpdate() end },
+                        { type="slider", label="Stack Size", min=6, max=30, step=1,
+                          get=function() return db.profile.boss.buffStackTextSize or 14 end,
+                          set=function(v) db.profile.boss.buffStackTextSize = v; ReloadAndUpdate() end },
+                        { type="dropdown", label="Stack Position",
+                          values={ bottomright="Bottom Right", bottomleft="Bottom Left", topright="Top Right", topleft="Top Left", center="Center" },
+                          order={ "bottomright", "bottomleft", "topright", "topleft", "center" },
+                          get=function() return db.profile.boss.buffStackTextPosition or "bottomright" end,
+                          set=function(v) db.profile.boss.buffStackTextPosition = v; ReloadAndUpdate() end },
+                        { type="slider", label="Stack X", min=-100, max=100, step=1,
+                          get=function() return db.profile.boss.buffStackTextOffsetX or 0 end,
+                          set=function(v) db.profile.boss.buffStackTextOffsetX = v; ReloadAndUpdate() end },
+                        { type="slider", label="Stack Y", min=-100, max=100, step=1,
+                          get=function() return db.profile.boss.buffStackTextOffsetY or 0 end,
+                          set=function(v) db.profile.boss.buffStackTextOffsetY = v; ReloadAndUpdate() end },
+                    },
+                })
+                BossCogBtn(rightRgn, simpleBuffStackCogShow, nil, function()
+                    return ns.db.profile.boss.showBuffs or db.profile.boss.simpleBuffs == "none"
+                end)
+            end
+            -- (Show Duration toggle lives inside the Duration & Stack cog above.)
+
             -- Simple Debuff Display: forces Left anchor + debuff height =
             -- frame bar height so boss debuffs render as one large column.
             -- Row 1 slot 2 is "Simple Text Size": the cooldown-text size slider,
             -- gated by an inline Show-Cooldown-Text toggle, with an inline cog
             -- holding the stack size and stack X/Y position controls.
-            local simpleTextOff = function() return not db.profile.boss.simpleDebuffShowCooldownText end
+            
+            local simpleTextOff = function()
+                return ns.db.profile.boss.debuffAnchor ~= "none"
+                or db.profile.boss.simpleDebuffs == "none"
+                or not db.profile.boss.simpleDebuffShowCooldownText
+            end
             simpleRow, hh = Ww:DualRow(pp, yy,
                 { type="dropdown", text="Simple Debuff Display",
+                  disabled = function()
+                      return ns.db.profile.boss.debuffAnchor ~= "none"
+                  end,
+                  disabledTooltip="Debuffs Location", requireState="disabled",
                   tooltip = "Force boss debuffs into a single large column matched to the frame height.",
                   values = { none = "None", left = "Left", right = "Right" },
                   order = { "none", "left", "right" },
@@ -12080,104 +12199,9 @@ initFrame:SetScript("OnEvent", function(self)
                           set=function(v) db.profile.boss.debuffStackTextOffsetY = v; ReloadAndUpdate() end },
                     },
                 })
-                BossCogBtn(rightRgn, simpleStackCogShow)
-            end
-
-            -- (Show Duration toggle lives inside the Duration & Stack cog above.)
-
-            -- Simple Buff Display: identical to Simple Debuff Display above but for
-            -- buffs. Defaults to None. Forces a single Left/Right column matched to
-            -- the frame height, overriding Buffs Location + Buff Size while active.
-            local simpleBuffTextOff = function() return not db.profile.boss.simpleBuffShowCooldownText end
-            simpleBuffRow, hh = Ww:DualRow(pp, yy,
-                { type="dropdown", text="Simple Buff Display",
-                  tooltip = "Force boss buffs into a single large column matched to the frame height.",
-                  values = { none = "None", left = "Left", right = "Right" },
-                  order = { "none", "left", "right" },
-                  getValue=function() return ns.GetBossSimpleBuffMode(db.profile.boss) end,
-                  setValue=function(v)
-                      db.profile.boss.simpleBuffs = v
-                      if v ~= "none" then
-                          -- Same-side collision: if Simple Debuff Display occupies this
-                          -- side, push it off (set to None) so they never overlap.
-                          if ns.GetBossSimpleDebuffMode(db.profile.boss) == v then
-                              db.profile.boss.simpleDebuffs = "none"
-                          end
-                          -- Selecting a side takes over from the normal Buffs
-                          -- Location, so force that setting to None.
-                          db.profile.boss.showBuffs = false
-                      end
-                      ReloadAndUpdate()
-                      if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end
-                      EllesmereUI:RefreshPage()
-                  end },
-                { type="slider", text="Buff Text Size", min=6, max=30, step=1,
-                  disabled=simpleBuffTextOff, disabledTooltip="Show Duration (Inside Cog)",
-                  getValue=function() return db.profile.boss.simpleBuffCooldownTextSize or 14 end,
-                  setValue=function(v) db.profile.boss.simpleBuffCooldownTextSize = v; ReloadAndUpdate() end });  yy = yy - hh
-
-            -- Directions cog on Simple Buff Display: the simple column's own X/Y
-            -- offset (defaults to the regular buff offsets via ns.GetBossSimpleBuffOffset);
-            -- writing here makes the simple offset independent. Disabled while None.
-            do
-                local leftRgn = simpleBuffRow._leftRegion
-                local _, simpleBuffPosCogShow = EllesmereUI.BuildCogPopup({
-                    title = "Simple Buff Position",
-                    rows = {
-                        -- Max buffs shown in simple mode. Shares the boss maxBuffs key
-                        -- with Buffs Location (the two modes are mutually exclusive);
-                        -- the runtime caps frame.Buffs.num to it.
-                        { type="slider", label="Max Count", min=1, max=20, step=1,
-                          get=function() return db.profile.boss.maxBuffs or 4 end,
-                          set=function(v) db.profile.boss.maxBuffs = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
-                        { type="slider", label="Offset X", min=-200, max=200, step=1,
-                          get=function() local x = ns.GetBossSimpleBuffOffset(db.profile.boss); return x end,
-                          set=function(v) db.profile.boss.simpleBuffOffsetX = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
-                        { type="slider", label="Offset Y", min=-200, max=200, step=1,
-                          get=function() local _, y = ns.GetBossSimpleBuffOffset(db.profile.boss); return y end,
-                          set=function(v) db.profile.boss.simpleBuffOffsetY = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
-                        -- Physical-pixel-perfect gap between the simple buff icons.
-                        { type="slider", label="Spacing", min=-1, max=10, step=1,
-                          get=function() return db.profile.boss.simpleBuffSpacing or 1 end,
-                          set=function(v) db.profile.boss.simpleBuffSpacing = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
-                    },
-                })
-                BossCogBtn(leftRgn, simpleBuffPosCogShow, EllesmereUI.DIRECTIONS_ICON,
-                    function() return ns.GetBossSimpleBuffMode(db.profile.boss) == "none" end)
-            end
-
-            -- Inline cog on Simple Text Size: duration X/Y + stack size / X/Y.
-            do
-                local rightRgn = simpleBuffRow._rightRegion
-                local _, simpleBuffStackCogShow = EllesmereUI.BuildCogPopup({
-                    title = "Duration & Stack",
-                    rows = {
-                        { type="toggle", label="Show Duration",
-                          get=function() return db.profile.boss.simpleBuffShowCooldownText end,
-                          set=function(v) db.profile.boss.simpleBuffShowCooldownText = v; ReloadAndUpdate(); EllesmereUI:RefreshPage() end },
-                        { type="slider", label="Duration X", min=-100, max=100, step=1,
-                          get=function() return db.profile.boss.simpleBuffCooldownTextOffsetX or 0 end,
-                          set=function(v) db.profile.boss.simpleBuffCooldownTextOffsetX = v; ReloadAndUpdate() end },
-                        { type="slider", label="Duration Y", min=-100, max=100, step=1,
-                          get=function() return db.profile.boss.simpleBuffCooldownTextOffsetY or 0 end,
-                          set=function(v) db.profile.boss.simpleBuffCooldownTextOffsetY = v; ReloadAndUpdate() end },
-                        { type="slider", label="Stack Size", min=6, max=30, step=1,
-                          get=function() return db.profile.boss.buffStackTextSize or 14 end,
-                          set=function(v) db.profile.boss.buffStackTextSize = v; ReloadAndUpdate() end },
-                        { type="dropdown", label="Stack Position",
-                          values={ bottomright="Bottom Right", bottomleft="Bottom Left", topright="Top Right", topleft="Top Left", center="Center" },
-                          order={ "bottomright", "bottomleft", "topright", "topleft", "center" },
-                          get=function() return db.profile.boss.buffStackTextPosition or "bottomright" end,
-                          set=function(v) db.profile.boss.buffStackTextPosition = v; ReloadAndUpdate() end },
-                        { type="slider", label="Stack X", min=-100, max=100, step=1,
-                          get=function() return db.profile.boss.buffStackTextOffsetX or 0 end,
-                          set=function(v) db.profile.boss.buffStackTextOffsetX = v; ReloadAndUpdate() end },
-                        { type="slider", label="Stack Y", min=-100, max=100, step=1,
-                          get=function() return db.profile.boss.buffStackTextOffsetY or 0 end,
-                          set=function(v) db.profile.boss.buffStackTextOffsetY = v; ReloadAndUpdate() end },
-                    },
-                })
-                BossCogBtn(rightRgn, simpleBuffStackCogShow)
+                BossCogBtn(rightRgn, simpleStackCogShow, nil, function()
+                    return ns.db.profile.boss.debuffAnchor ~= "none" or db.profile.boss.simpleDebuffs == "none"
+                end)
             end
             -- (Show Duration toggle lives inside the Duration & Stack cog above.)
 
@@ -12216,6 +12240,9 @@ initFrame:SetScript("OnEvent", function(self)
                   end,
                   setValue=function(v)
                       SwapAuraSlot(db.profile.boss, "debuffAnchor", v)
+                      if db.profile.boss.buffAnchor == "none" then
+                          db.profile.boss.showBuffs = false
+                      end
                       ReloadAndUpdate()
                       if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end
                       -- Refresh so dependent disabled states (Debuff Size, Boss
@@ -12322,12 +12349,21 @@ initFrame:SetScript("OnEvent", function(self)
                 -- the "Show Duration" toggle at the top of its own Duration & Stack
                 -- cog (which also holds Duration X/Y + Stack size/position/X/Y).
                 -- Buff Text Size is a 1:1 mirror of Debuff Text Size.
-                local debuffTextOff = function() return not db.profile.boss.debuffShowCooldownText end
-                local buffTextOff = function() return not db.profile.boss.buffShowCooldownText end
+
+                local buffTextOff = function()
+                    return not ns.db.profile.boss.showBuffs
+                    or db.profile.boss.simpleBuffs ~= "none"
+                    or not db.profile.boss.buffShowCooldownText
+                end
+                local debuffTextOff = function()
+                    return ns.db.profile.boss.debuffAnchor == "none"
+                    or db.profile.boss.simpleDebuffs ~= "none" or
+                    not db.profile.boss.debuffShowCooldownText
+                end
                 local textSizeRow
                 textSizeRow, hh = Ww:DualRow(pp, yy,
                     { type="slider", text="Buff Text Size", min=6, max=30, step=1,
-                      disabled=buffTextOff, disabledTooltip="Show Duration",
+                      disabled=buffTextOff, disabledTooltip="Show Duration (Inside Cog)",
                       getValue=function() return db.profile.boss.buffCooldownTextSize or 10 end,
                       setValue=function(v) db.profile.boss.buffCooldownTextSize = v; ReloadAndUpdate() end },
                     { type="slider", text="Debuff Text Size", min=6, max=30, step=1,
@@ -12367,7 +12403,7 @@ initFrame:SetScript("OnEvent", function(self)
                         },
                     })
                     BossCogBtn(leftRgn, buffStackCogShow, nil,
-                        function() return ns.GetBossSimpleBuffMode(db.profile.boss) ~= "none" end)
+                        function() return ns.GetBossSimpleBuffMode(db.profile.boss) ~= "none" or not ns.db.profile.boss.showBuffs end)
                 end
                 -- Debuff Text Size cog (right): Show Duration + Duration X/Y + Stack.
                 -- Disabled while Simple Debuff Display is active.
@@ -12405,20 +12441,25 @@ initFrame:SetScript("OnEvent", function(self)
                     -- uses its own (simpleDebuff*) cooldown text, so the regular
                     -- debuff Duration & Stack controls do not apply.
                     BossCogBtn(rightRgn, debuffStackCogShow, nil,
-                        function() return ns.GetBossSimpleDebuffMode(db.profile.boss) ~= "none" end)
+                        function() return ns.GetBossSimpleDebuffMode(db.profile.boss) ~= "none" or ns.db.profile.boss.debuffAnchor == "none" end)
                 end
                 -- Boss Debuff Filter on its own row, below the text-size row (boss
-                -- buffs are never filtered, so the right slot is intentionally
+                -- buffs are never filtered, so the left slot is intentionally
                 -- blank). The multi-select checkbox dropdown is injected into the
                 -- left slot, replacing the placeholder.
                 local filterRow
+                local filterOff = function()
+                    local p = db.profile.boss
+                    return ns.GetBossSimpleDebuffMode(p) == "none" and (p.debuffAnchor or "bottomleft") == "none"
+                end
                 filterRow, hh = Ww:DualRow(pp, yy,
+                    { type="label", text="" },
                     { type="dropdown", text="Boss Debuff Filter",
+                      disabled=filterOff, disabledTooltip="Debuffs", requireState="displayed",
                       values={ __placeholder="..." }, order={ "__placeholder" },
-                      getValue=function() return "__placeholder" end, setValue=function() end },
-                    { type="label", text="" });  yy = yy - hh
+                      getValue=function() return "__placeholder" end, setValue=function() end });  yy = yy - hh
                 do
-                    local rgn = filterRow._leftRegion
+                    local rgn = filterRow._rightRegion
                     if rgn._control then rgn._control:Hide() end
                     local cbDD, cbRefresh = EllesmereUI.BuildVisOptsCBDropdown(
                         rgn, 210, rgn:GetFrameLevel() + 2, filterItems,
@@ -12436,12 +12477,11 @@ initFrame:SetScript("OnEvent", function(self)
                     filterBlock:SetFrameLevel(cbDD:GetFrameLevel() + 10)
                     filterBlock:EnableMouse(true)
                     filterBlock:SetScript("OnEnter", function()
-                        EllesmereUI.ShowWidgetTooltip(cbDD, EllesmereUI.DisabledTooltip("Debuffs Location"))
+                        EllesmereUI.ShowWidgetTooltip(cbDD, EllesmereUI.DisabledTooltip("Debuffs", "displayed"))
                     end)
                     filterBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
                     local function UpdateFilterDisabled()
-                        local p = db.profile.boss
-                        local off = ns.GetBossSimpleDebuffMode(p) == "none" and (p.debuffAnchor or "bottomleft") == "none"
+                        local off = filterOff()
                         if off then
                             cbDD:SetAlpha(0.3); filterBlock:Show()
                         else
@@ -12483,8 +12523,7 @@ initFrame:SetScript("OnEvent", function(self)
                     end)
                     cogBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
                     local function UpdateBuffCogDisabled()
-                        local p = db.profile.boss
-                        local off = ns.GetBossSimpleBuffMode(p) ~= "none" or p.showBuffs == false
+                        local off = bossBuffSizeOff()
                         if off then
                             cogBtn:SetAlpha(0.15)
                             cogBlock:Show()
@@ -12541,6 +12580,64 @@ initFrame:SetScript("OnEvent", function(self)
                     EllesmereUI.RegisterWidgetRefresh(UpdateDebuffCogDisabled)
                 end
             end
+
+            -- Buff Text Color | Debuff Text Color
+            _, h = Ww:DualRow(pp, yy,
+                { type="multiSwatch", text="Buff Text Color",
+                    disabled = function()
+                        local p = db.profile.boss
+                        return ns.GetBossSimpleBuffMode(p) == "none" and p.showBuffs == false
+                    end,
+                    disabledTooltip = "Buffs", requireState="displayed",
+                    swatches = {
+                        { tooltip = "Duration", hasAlpha = false,
+                        getValue = function()
+                            local c = db.profile.boss.buffCooldownTextColor
+                            if c then return c.r, c.g, c.b end
+                            return 1, 1, 1
+                        end,
+                        setValue = function(r, g, b)
+                            db.profile.boss.buffCooldownTextColor = { r=r, g=g, b=b }; ReloadAndUpdate()
+                        end },
+                        { tooltip = "Stack", hasAlpha = false,
+                        getValue = function()
+                            local c = db.profile.boss.buffStackTextColor
+                            if c then return c.r, c.g, c.b end
+                            return 1, 1, 1
+                        end,
+                        setValue = function(r, g, b)
+                            db.profile.boss.buffStackTextColor = { r=r, g=g, b=b }; ReloadAndUpdate()
+                        end
+                    } }
+                },
+                { type="multiSwatch", text="Debuff Text Color",
+                    disabled = function()
+                        local p = db.profile.boss
+                        return ns.GetBossSimpleDebuffMode(p) == "none" and (p.debuffAnchor or "bottomleft") == "none"
+                    end,
+                    disabledTooltip = "Debuffs", requireState="displayed",
+                    swatches = {
+                        { tooltip = "Duration", hasAlpha = false,
+                        getValue = function()
+                            local c = db.profile.boss.debuffCooldownTextColor
+                            if c then return c.r, c.g, c.b end
+                            return 1, 1, 1
+                        end,
+                        setValue = function(r, g, b)
+                            db.profile.boss.debuffCooldownTextColor = { r=r, g=g, b=b }; ReloadAndUpdate()
+                        end },
+                        { tooltip = "Stack",
+                        hasAlpha = false,
+                        getValue = function()
+                            local c = db.profile.boss.debuffStackTextColor
+                            if c then return c.r, c.g, c.b end
+                            return 1, 1, 1
+                        end,
+                        setValue = function(r, g, b)
+                            db.profile.boss.debuffStackTextColor = { r=r, g=g, b=b }; ReloadAndUpdate()
+                        end
+                    } }
+                }); yy = yy - hh
 
             return yy
         end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -834,8 +834,10 @@ local defaults = {
             debuffOffsetY = 0,
             buffShowCooldownText = false,
             buffCooldownTextSize = 10,
+            buffCooldownTextColor = {r=1, g=1, b=1},
             debuffShowCooldownText = false,
             debuffCooldownTextSize = 10,
+            debuffCooldownTextColor = {r=1, g=1, b=1},
             simpleDebuffShowCooldownText = false,
             simpleDebuffCooldownTextSize = 14,
             simpleDebuffs = "left",  -- "none"/"left"/"right": simple display forces that-side anchor + frame-height-matched debuff size (legacy boolean true=left / false=none honored at read time)
@@ -5314,7 +5316,7 @@ function ns.ApplyStackAnchor(fs, parent, pos, offX, offY)
     fs:SetPoint(point, parent, point, baseX + (offX or 0), offY or 0)
 end
 
-local function ApplyAuraCooldownText(container, showCD, cdSize, stackSize, cdOffX, cdOffY, stackOffX, stackOffY, auraSize, cropped, stackPos)
+local function ApplyAuraCooldownText(container, showCD, cdSize, stackSize, cdOffX, cdOffY, stackOffX, stackOffY, auraSize, cropped, stackPos, cdTextColor, stackTextColor)
     if not container then return end
     -- Cropped style: make the buttons rectangular (height = 80% of width). oUF
     -- sizes each button to element.width x element.height and uses them for the
@@ -5342,7 +5344,12 @@ local function ApplyAuraCooldownText(container, showCD, cdSize, stackSize, cdOff
             btn.Cooldown:SetHideCountdownNumbers(not showCD)
             local cdText = btn.Cooldown:GetRegions()
             if cdText and cdText.SetFont then
-                if showCD then EllesmereUI.ApplyIconTextFont(cdText, cachedFontPath, cdSize, "unitFrames") end
+                if showCD then
+                    EllesmereUI.ApplyIconTextFont(cdText, cachedFontPath, cdSize, "unitFrames")
+                    if cdTextColor then
+                        cdText:SetTextColor(cdTextColor.r or 1, cdTextColor.g or 1, cdTextColor.b or 1)
+                    end
+                end
                 -- Default cooldown text is centered; offset 0,0 == default.
                 cdText:ClearAllPoints()
                 cdText:SetPoint("CENTER", btn.Cooldown, "CENTER", cdOffX or 0, cdOffY or 0)
@@ -5354,6 +5361,9 @@ local function ApplyAuraCooldownText(container, showCD, cdSize, stackSize, cdOff
         -- oUF (BOTTOMRIGHT -1,0); offset 0,0 == default.
         if btn and btn.Count then
             EllesmereUI.ApplyIconTextFont(btn.Count, cachedFontPath, stackSize or 14, "unitFrames")
+            if stackTextColor then
+                btn.Count:SetTextColor(stackTextColor.r or 1, stackTextColor.g or 1, stackTextColor.b or 1)
+            end
             ns.ApplyStackAnchor(btn.Count, btn, stackPos, stackOffX, stackOffY)
         end
     end
@@ -5476,7 +5486,7 @@ local function CreateTargetAuras(frame, unit)
         if button.Cooldown then
             button.Cooldown:SetDrawEdge(false)
             button.Cooldown:SetReverse(true)
-            local showText, textSize, cdOffX, cdOffY
+            local showText, textSize, cdOffX, cdOffY, cdTextColor
             if isBuff then
                 if s and unit and unit:match("^boss") and ns.GetBossSimpleBuffMode(s) ~= "none" then
                     showText = s and s.simpleBuffShowCooldownText
@@ -5489,21 +5499,26 @@ local function CreateTargetAuras(frame, unit)
                     cdOffX = (s and s.buffCooldownTextOffsetX) or 0
                     cdOffY = (s and s.buffCooldownTextOffsetY) or 0
                 end
+                cdTextColor = (s and s.buffCooldownTextColor) or {r=1, g=1, b=1}
             elseif s and unit and unit:match("^boss") and ns.GetBossSimpleDebuffMode(s) ~= "none" then
                 showText = s and s.simpleDebuffShowCooldownText
                 textSize = s and s.simpleDebuffCooldownTextSize or 14
                 cdOffX = (s and s.debuffCooldownTextOffsetX) or 0
                 cdOffY = (s and s.debuffCooldownTextOffsetY) or 0
+                cdTextColor = (s and s.debuffCooldownTextColor) or {r=1, g=1, b=1}
             else
                 showText = s and s.debuffShowCooldownText
                 textSize = s and s.debuffCooldownTextSize or 10
                 cdOffX = (s and s.debuffCooldownTextOffsetX) or 0
                 cdOffY = (s and s.debuffCooldownTextOffsetY) or 0
+                cdTextColor = (s and s.debuffCooldownTextColor) or {r=1, g=1, b=1}
             end
             button.Cooldown:SetHideCountdownNumbers(not showText)
             local cdText = button.Cooldown:GetRegions()
             if cdText and cdText.SetFont then
                 if showText then EllesmereUI.ApplyIconTextFont(cdText, cachedFontPath, textSize, "unitFrames") end
+                cdText:SetTextColor(cdTextColor.r, cdTextColor.g, cdTextColor.b)
+
                 -- Default cooldown text is centered; offset 0,0 == default (no change).
                 cdText:ClearAllPoints()
                 cdText:SetPoint("CENTER", button.Cooldown, "CENTER", cdOffX, cdOffY)
@@ -5516,19 +5531,22 @@ local function CreateTargetAuras(frame, unit)
         -- oUF (BOTTOMRIGHT -1,0); offset 0,0 == default (no change).
         if button.Count then
             local s2 = GetSettingsForUnit(unit or "target")
-            local stackSize, sOffX, sOffY, sPos
+            local stackSize, sOffX, sOffY, sPos, sTextColor
             if container and container.filter == "HELPFUL" then
                 stackSize = s2 and s2.buffStackTextSize
                 sOffX = (s2 and s2.buffStackTextOffsetX) or 0
                 sOffY = (s2 and s2.buffStackTextOffsetY) or 0
                 sPos = s2 and s2.buffStackTextPosition
+                sTextColor = (s2 and s2.buffStackTextColor) or {r=1, g=1, b=1}
             else
                 stackSize = s2 and s2.debuffStackTextSize
                 sOffX = (s2 and s2.debuffStackTextOffsetX) or 0
                 sOffY = (s2 and s2.debuffStackTextOffsetY) or 0
                 sPos = s2 and s2.debuffStackTextPosition
+                sTextColor = (s2 and s2.debuffStackTextColor) or {r=1, g=1, b=1}
             end
             EllesmereUI.ApplyIconTextFont(button.Count, cachedFontPath, stackSize or 14, "unitFrames")
+            button.Count:SetTextColor(sTextColor.r, sTextColor.g, sTextColor.b)
             ns.ApplyStackAnchor(button.Count, button, sPos, sOffX, sOffY)
         end
 
@@ -9722,9 +9740,9 @@ local function ReloadFrames()
                     -- Use simple debuff cooldown text settings when simple display
                     -- is active, regular debuff settings otherwise.
                     if simpleOn then
-                        ApplyAuraCooldownText(frame.Debuffs, settings.simpleDebuffShowCooldownText, settings.simpleDebuffCooldownTextSize or 14, settings.debuffStackTextSize, settings.simpleDebuffCooldownTextOffsetX, settings.simpleDebuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, nil, nil, settings.debuffStackTextPosition)
+                        ApplyAuraCooldownText(frame.Debuffs, settings.simpleDebuffShowCooldownText, settings.simpleDebuffCooldownTextSize or 14, settings.debuffStackTextSize, settings.simpleDebuffCooldownTextOffsetX, settings.simpleDebuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, nil, nil, settings.debuffStackTextPosition, settings.debuffCooldownTextColor, settings.debuffStackTextColor)
                     else
-                        ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition)
+                        ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition, settings.debuffCooldownTextColor, settings.debuffStackTextColor)
                     end
                 end
 
@@ -9819,9 +9837,9 @@ local function ReloadFrames()
                     -- Cooldown/stack text: simple uses the simpleBuff* keys (sharing the
                     -- regular buff stack settings), regular buff keys otherwise.
                     if simpleBuffOn then
-                        ApplyAuraCooldownText(frame.Buffs, settings.simpleBuffShowCooldownText, settings.simpleBuffCooldownTextSize or 14, settings.buffStackTextSize, settings.simpleBuffCooldownTextOffsetX, settings.simpleBuffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, nil, nil, settings.buffStackTextPosition)
+                        ApplyAuraCooldownText(frame.Buffs, settings.simpleBuffShowCooldownText, settings.simpleBuffCooldownTextSize or 14, settings.buffStackTextSize, settings.simpleBuffCooldownTextOffsetX, settings.simpleBuffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, nil, nil, settings.buffStackTextPosition, settings.buffCooldownTextColor, settings.buffStackTextColor)
                     else
-                        ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition)
+                        ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition, settings.buffCooldownTextColor, settings.buffStackTextColor)
                     end
                 end
 
@@ -11626,6 +11644,8 @@ function SetupOptionsPanel()
         local stackOffX = settings.debuffStackTextOffsetX or 0
         local stackOffY = settings.debuffStackTextOffsetY or 0
         local stackPos = settings.debuffStackTextPosition
+        local cdTextColor = settings.debuffCooldownTextColor or {r=1, g=1, b=1}
+        local stackTextColor = settings.debuffStackTextColor or {r=1, g=1, b=1}
         local fontPath = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames")) or "Fonts\\FRIZQT__.TTF"
         local now = GetTime()
         for idx, spellID in ipairs(FAKE_DEBUFF_SPELLS) do
@@ -11669,6 +11689,7 @@ function SetupOptionsPanel()
             durText:SetDrawLayer("OVERLAY", 7)
             EllesmereUI.ApplyIconTextFont(durText, fontPath, cdSize, "unitFrames")
             durText:SetPoint("CENTER", iconFrame, "CENTER", cdOffX, cdOffY)
+            durText:SetTextColor(cdTextColor.r, cdTextColor.g, cdTextColor.b)
             durText:SetText(FAKE_DEBUFF_SECS[idx] or 10)
             if not showCD then durText:Hide() end
             -- Stack text on a single icon only (looks natural; most debuffs are
@@ -11678,6 +11699,7 @@ function SetupOptionsPanel()
                 stack:SetDrawLayer("OVERLAY", 7)
                 EllesmereUI.ApplyIconTextFont(stack, fontPath, stackSize, "unitFrames")
                 ns.ApplyStackAnchor(stack, iconFrame, stackPos, stackOffX, stackOffY)
+                stack:SetTextColor(stackTextColor.r, stackTextColor.g, stackTextColor.b)
                 stack:SetText(FAKE_DEBUFF_STACKS[idx])
             end
             -- Border just above the icon; its PP container renders at border+1


### PR DESCRIPTION
Add CD and stack texts color for the boss frame.

Maybe it could be refactored in the future to allow this on all frames ?

Other changes:
- Changed the position of the "Simple Buff Display" row with the "Simple Debuff Display" to align with the category name
- Moved Boss Debuff Filter to the right column to align with other debuff options
- "(De)buff Text Size Cog is now only enabled if relevant (De)buff display is enabled
- Fixed Stack position not working in the EUI preview (was fine in the real preview)


Before:
<img width="938" height="336" alt="image" src="https://github.com/user-attachments/assets/5991bc4f-a7c0-43f8-9f98-8c9224fb9a5a" />

After:
<img width="931" height="376" alt="image" src="https://github.com/user-attachments/assets/5523e3b4-b65e-44cd-a56f-da1a8c16789d" />
<img width="919" height="378" alt="image" src="https://github.com/user-attachments/assets/5aaac81b-9047-46f8-9c77-877ede25fd7f" />

In action in EUI preview:
<img width="394" height="92" alt="image" src="https://github.com/user-attachments/assets/abb066dc-a010-4b52-a355-3f1c21c55267" />
In action with real preview:
<img width="375" height="65" alt="image" src="https://github.com/user-attachments/assets/d1e25998-3d50-4416-b525-36953b108956" />
