### PR TITLE
Localization: translate tracking-bar unlock labels

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -3361,8 +3361,8 @@ function ns.RegisterTBBUnlockElements()
             elements[#elements + 1] = MK({
                 key   = "TBB_" .. posKey,
                 label = isGroupMover
-                    and (ns.TBBGroupName(barGid) or ("Tracking Bar Group " .. barGid))
-                    or ("Tracking Bar: " .. (cfg.name or ("Bar " .. idx))),
+                    and (ns.TBBGroupName(barGid) or EllesmereUI.Lf("Tracking Bar Group %d", barGid))
+                    or EllesmereUI.Lf("Tracking Bar: %s", cfg.name or EllesmereUI.Lf("Bar %d", idx)),
                 group = "Cooldown Manager",
                 order = 650,
                 noResize = true,


### PR DESCRIPTION
In unlock mode the tracking-bar movers were labeled by string concatenation ("Tracking Bar Group " .. gid, "Tracking Bar: " .. name), so they stayed English regardless of locale. Built the labels through EllesmereUI.Lf(...) instead:

label = isGroupMover
    and (ns.TBBGroupName(barGid) or EllesmereUI.Lf("Tracking Bar Group %d", barGid))
    or EllesmereUI.Lf("Tracking Bar: %s", cfg.name or EllesmereUI.Lf("Bar %d", idx))
File: EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua Identity on enUS — no behavior change.
Locale: only one new key needed (Tracking Bar Group %d); Tracking Bar: %s and Bar %d already existed.