### PR TITLE
fix(raidframes): re-enable incoming resurrection indicator

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -2577,8 +2577,7 @@ initFrame:SetScript("OnEvent", function(self)
         local readyCheckPositionOrder = { "topleft", "top", "topright", "left", "center", "right", "bottomleft", "bottom", "bottomright" }
         local rcRow
         rcRow, h = W:DualRow(parent, y,
-            -- HELD (PR #610 incoming rez, disabled for this build): text="Ready Check / Summon / Rez"
-            { type="dropdown", text="Ready Check & Summon", values=readyCheckPositionValues, order=readyCheckPositionOrder,
+            { type="dropdown", text="Ready Check / Summon / Rez", values=readyCheckPositionValues, order=readyCheckPositionOrder,
               getValue=function() return SVal("readyCheckPosition", "center") end,
               setValue=function(v) SSet("readyCheckPosition", v) end },
             { type="slider", text="Icon Size", min=8, max=40, step=1,
@@ -2588,8 +2587,7 @@ initFrame:SetScript("OnEvent", function(self)
         do
             local rgn = rcRow._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
-                -- HELD (PR #610 incoming rez, disabled for this build): title = "Ready Check / Summon / Rez"
-                title = "Ready Check / Summon",
+                title = "Ready Check / Summon / Rez",
                 rows = {
                     { type="toggle", label="Show Ready Check",
                       get=function() return SVal("showReadyCheck", true) end,
@@ -2597,10 +2595,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="toggle", label="Show Incoming Summon",
                       get=function() return SVal("showSummonPending", true) end,
                       set=function(v) SSet("showSummonPending", v) end },
-                    -- HELD (PR #610 incoming rez, disabled for this build):
-                    -- { type="toggle", label="Show Incoming Resurrection",
-                    --   get=function() return SVal("showIncomingRez", true) end,
-                    --   set=function(v) SSet("showIncomingRez", v) end },
+                    { type="toggle", label="Show Incoming Resurrection",
+                      get=function() return SVal("showIncomingRez", true) end,
+                      set=function(v) SSet("showIncomingRez", v) end },
                     { type="slider", label="Offset X", min=-50, max=50, step=1,
                       get=function() return SVal("readyCheckOffsetX", 0) end,
                       set=function(v) SSet("readyCheckOffsetX", v) end },

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -194,8 +194,7 @@ local UnitExists            = UnitExists
 local UnitIsConnected       = UnitIsConnected
 local UnitIsVisible         = UnitIsVisible
 local UnitIsDeadOrGhost     = UnitIsDeadOrGhost
--- HELD (PR #610 incoming rez, disabled for this build):
--- local UnitHasIncomingResurrection = UnitHasIncomingResurrection
+local UnitHasIncomingResurrection = UnitHasIncomingResurrection
 local UnitGroupRolesAssigned = UnitGroupRolesAssigned
 local UnitThreatSituation   = UnitThreatSituation
 local UnitIsUnit            = UnitIsUnit
@@ -559,7 +558,7 @@ local defaults = {
         raidMarkerOffsetY  = 0,
         showReadyCheck   = true,
         showSummonPending = true,
-        -- showIncomingRez  = true,  -- HELD (PR #610 incoming rez, disabled for this build)
+        showIncomingRez  = true,
         readyCheckSize   = 20,
         readyCheckPosition = "center",  -- "topleft", "top", "topright", "left", "center", "right", "bottomleft", "bottom"
         readyCheckOffsetX  = 0,
@@ -4150,11 +4149,10 @@ local function UpdateButton(button)
         local stc = s.statusTextColor or { r = 1, g = 1, b = 1 }
         if s.statusTextPosition == "none" then
             d.statusText:Hide()
-        -- HELD (PR #610 incoming rez, disabled for this build):
-        -- elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
-        --     -- Being resurrected: hide DEAD so the incoming-rez icon (shown in the same
-        --     -- spot by UpdateReadyCheck) isn't covered by the status text.
-        --     d.statusText:Hide()
+        elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
+            -- Being resurrected: hide DEAD so the incoming-rez icon (shown in the same
+            -- spot by UpdateReadyCheck) isn't covered by the status text.
+            d.statusText:Hide()
         elseif UnitIsDeadOrGhost(unit) then
             d.statusText:SetText(EllesmereUI.L("DEAD"))
             d.statusText:SetTextColor(stc.r, stc.g, stc.b)
@@ -5589,13 +5587,12 @@ local function UpdateReadyCheck(button, unit)
     -- Incoming resurrection ("someone is casting a rez / rez waiting to be
     -- accepted"). Lowest priority; only meaningful on a dead unit. Lets healers
     -- see a body is already being picked up so they don't all rez the same one.
-    -- HELD (PR #610 incoming rez, disabled for this build):
-    -- if db.profile.showIncomingRez and unit and UnitHasIncomingResurrection(unit) then
-    --     tex:SetTexCoord(0, 1, 0, 1)
-    --     tex:SetTexture("Interface\\RaidFrame\\Raid-Icon-Rez")
-    --     tex:Show()
-    --     return
-    -- end
+    if db.profile.showIncomingRez and unit and UnitHasIncomingResurrection(unit) then
+        tex:SetTexCoord(0, 1, 0, 1)
+        tex:SetTexture("Interface\\RaidFrame\\Raid-Icon-Rez")
+        tex:Show()
+        return
+    end
 
     tex:Hide()
 end
@@ -5863,10 +5860,9 @@ ns._UpdateButtonHealth = function(button)
         local stc = s.statusTextColor or { r = 1, g = 1, b = 1 }
         if s.statusTextPosition == "none" then
             d.statusText:Hide()
-        -- HELD (PR #610 incoming rez, disabled for this build):
-        -- elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
-        --     -- Being resurrected: hide DEAD so the incoming-rez icon isn't covered.
-        --     d.statusText:Hide()
+        elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
+            -- Being resurrected: hide DEAD so the incoming-rez icon isn't covered.
+            d.statusText:Hide()
         elseif UnitIsDeadOrGhost(unit) then
             d.statusText:SetText(EllesmereUI.L("DEAD"))
             d.statusText:SetTextColor(stc.r, stc.g, stc.b)
@@ -9213,16 +9209,15 @@ local function OnEvent(self, event, arg1, ...)
             local u = btn:GetAttribute("unit")
             if u and btn:IsVisible() then UpdateReadyCheck(btn, u) end
         end
-    -- HELD (PR #610 incoming rez, disabled for this build):
-    -- elseif event == "INCOMING_RESURRECT_CHANGED" then
-    --     -- Fires with a unit payload when a rez starts/stops on that unit. Refresh the
-    --     -- status text (so DEAD hides while rezzing / reappears after) as well as the
-    --     -- shared rez icon.
-    --     local btn = unitToButton[arg1] or ns._partyUnitToButton[arg1]
-    --     if btn and btn:IsVisible() then
-    --         if ns._UpdateButtonHealth then ns._UpdateButtonHealth(btn) end
-    --         UpdateReadyCheck(btn, arg1)
-    --     end
+    elseif event == "INCOMING_RESURRECT_CHANGED" then
+        -- Fires with a unit payload when a rez starts/stops on that unit. Refresh the
+        -- status text (so DEAD hides while rezzing / reappears after) as well as the
+        -- shared rez icon.
+        local btn = unitToButton[arg1] or ns._partyUnitToButton[arg1]
+        if btn and btn:IsVisible() then
+            if ns._UpdateButtonHealth then ns._UpdateButtonHealth(btn) end
+            UpdateReadyCheck(btn, arg1)
+        end
     elseif event == "PLAYER_SPECIALIZATION_CHANGED" then
         if ns.BM_RebuildLookup then ns.BM_RebuildLookup(db) end
         -- BM_RebuildLookup only rebuilds the global spell-lookup tables for the
@@ -9374,7 +9369,7 @@ do
             "roleIconStyle", "roleIconSize", "roleIconPosition", "roleIconOffsetX", "roleIconOffsetY", "roleIconHideInCombat",
             "showRoleForTank", "showRoleForHealer", "showRoleForDPS",
             "showRaidMarker", "raidMarkerSize", "raidMarkerPosition", "raidMarkerOffsetX", "raidMarkerOffsetY",
-            "showReadyCheck", "showSummonPending", --[[ HELD (PR #610): "showIncomingRez", ]]
+            "showReadyCheck", "showSummonPending", "showIncomingRez",
             "readyCheckSize", "readyCheckPosition", "readyCheckOffsetX", "readyCheckOffsetY",
             "statusTextPosition", "statusTextOffsetX", "statusTextOffsetY", "statusTextSize", "statusTextColor",
             "showLeaderIcon", "showLeaderIconInCombat", "leaderIconPosition", "leaderIconSize", "leaderIconOffsetX", "leaderIconOffsetY",
@@ -11976,20 +11971,18 @@ local function BuildPreviewRoles()
         end
         previewRoles._deadSlot    = statePool[1]  -- plain corpse
         previewRoles._offlineSlot = statePool[2]
-        -- HELD (PR #610 incoming rez, disabled for this build):
-        -- previewRoles._rezSlot     = statePool[3]  -- corpse with an incoming-rez icon
+        previewRoles._rezSlot     = statePool[3]  -- corpse with an incoming-rez icon
         -- Plain dead + offline bodies carry no readycheck/summon icon (looks wrong there).
         if rcStatuses[statePool[1]] then rcStatuses[statePool[1]] = nil end
         if rcStatuses[statePool[2]] then rcStatuses[statePool[2]] = nil end
         -- The rez corpse gets the incoming-rez icon. But markers win the shared icon
         -- slot (same as the readycheck de-confliction above): if the rez slot landed
         -- on a marker slot, skip the icon (the frame is still shown as a dead body).
-        -- HELD (PR #610 incoming rez, disabled for this build):
-        -- if statePool[3] ~= ms1 and statePool[3] ~= ms2 then
-        --     rcStatuses[statePool[3]] = "rez"
-        -- else
-        --     rcStatuses[statePool[3]] = nil
-        -- end
+        if statePool[3] ~= ms1 and statePool[3] ~= ms2 then
+            rcStatuses[statePool[3]] = "rez"
+        else
+            rcStatuses[statePool[3]] = nil
+        end
     end
 end
 
@@ -12742,16 +12735,11 @@ local function ApplyPreviewData(f, index)
         local rcStatuses = previewRoles._readyCheck
         local rcStatus = rcStatuses and rcStatuses[index]
         local isSummon = rcStatus and rcStatus:sub(1, 6) == "summon"
-        -- HELD (PR #610 incoming rez, disabled for this build):
-        -- local isRez    = rcStatus == "rez"
-        -- local showRC = indVis and rcStatus and (
-        --     (isRez and s.showIncomingRez) or
-        --     (isSummon and s.showSummonPending) or
-        --     (not isSummon and not isRez and s.showReadyCheck)
-        -- )
+        local isRez    = rcStatus == "rez"
         local showRC = indVis and rcStatus and (
-            (not isSummon and s.showReadyCheck) or
-            (isSummon and s.showSummonPending)
+            (isRez and s.showIncomingRez) or
+            (isSummon and s.showSummonPending) or
+            (not isSummon and not isRez and s.showReadyCheck)
         )
         if showRC then
             local rcSz = PixelSnap(s.readyCheckSize or 20)
@@ -12795,10 +12783,9 @@ local function ApplyPreviewData(f, index)
                 f._readyCheck:SetAtlas("RaidFrame-Icon-SummonAccepted")
             elseif rcStatus == "summon_declined" then
                 f._readyCheck:SetAtlas("RaidFrame-Icon-SummonDeclined")
-            -- HELD (PR #610 incoming rez, disabled for this build):
-            -- elseif rcStatus == "rez" then
-            --     f._readyCheck:SetTexture("Interface\\RaidFrame\\Raid-Icon-Rez")
-            --     f._readyCheck:SetTexCoord(0, 1, 0, 1)
+            elseif rcStatus == "rez" then
+                f._readyCheck:SetTexture("Interface\\RaidFrame\\Raid-Icon-Rez")
+                f._readyCheck:SetTexCoord(0, 1, 0, 1)
             end
             f._readyCheck:Show()
         else
@@ -12869,10 +12856,8 @@ local function ApplyPreviewData(f, index)
     -- Dead/offline/AFK states (only when indicators eyeball is on). The rez slot is
     -- a second corpse (dimmed, no "DEAD" text) that shows an incoming-rez icon in
     -- place of the status text -- mirrors the live "hide DEAD while rezzing" behavior.
-    -- HELD (PR #610 incoming rez, disabled for this build):
-    -- local isRezCorpse = indVis and index == previewRoles._rezSlot
-    -- local isDead      = indVis and (index == previewRoles._deadSlot or isRezCorpse)
-    local isDead      = indVis and index == previewRoles._deadSlot
+    local isRezCorpse = indVis and index == previewRoles._rezSlot
+    local isDead      = indVis and (index == previewRoles._deadSlot or isRezCorpse)
     local isOffline   = indVis and index == previewRoles._offlineSlot
     -- Mark dead/offline preview frames so the animated-preview ticker skips them
     -- (their health bar is emptied and health text hidden -- never animated).
@@ -13019,12 +13004,10 @@ local function ApplyPreviewData(f, index)
         else
             f._statusText:SetPoint("CENTER", f._health, "CENTER", stOX, stOY)
         end
-        -- HELD (PR #610 incoming rez, disabled for this build):
-        -- if isRezCorpse then
-        --     -- Being resurrected: the rez icon takes this spot, so no DEAD text.
-        --     f._statusText:Hide()
-        -- elseif isDead then
-        if isDead then
+        if isRezCorpse then
+            -- Being resurrected: the rez icon takes this spot, so no DEAD text.
+            f._statusText:Hide()
+        elseif isDead then
             f._statusText:SetText(EllesmereUI.L("DEAD"))
             f._statusText:Show()
         elseif isOffline then
@@ -14703,7 +14686,7 @@ function ERF:OnEnable()
     eventFrame:RegisterEvent("READY_CHECK_CONFIRM")
     eventFrame:RegisterEvent("READY_CHECK_FINISHED")
     eventFrame:RegisterEvent("INCOMING_SUMMON_CHANGED")
-    -- eventFrame:RegisterEvent("INCOMING_RESURRECT_CHANGED")  -- HELD (PR #610 incoming rez, disabled for this build)
+    eventFrame:RegisterEvent("INCOMING_RESURRECT_CHANGED")
     eventFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
     eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
     eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")


### PR DESCRIPTION
## Overview

Re-enables the **Incoming Resurrection** indicator (originally #610), which was commented out with `HELD` markers in the v8.4.1 release because it had shipped untested. It's since been tested, so this turns it back on.

**What changed:**
- Reverses only the rez hold-out (the `HELD (PR #610 …)` blocks). Feature logic is unchanged from #610 — restored byte-for-byte, still gated behind the `showIncomingRez` toggle (default on).
- The unrelated **unlock-anchor** work that was bundled into the same v8.4.1 release commit is left untouched.

## Testing

Tested in-game (retail):

- [x] Dead raid member being rezzed - icon shows in the shared ready-check/summon slot, "DEAD" text hidden; icon clears and "DEAD" returns on accept / decline / expire
- [x] Active ready check and incoming summon still take priority over the rez icon
- [x] "Show Incoming Resurrection" toggle off - no icon, "DEAD" shows normally
- [x] Party frames show the icon; options preview shows the rez corpse
- [x] No taint / Lua errors when triggered in combat