### PR TITLE
feat(unitframes/bags/blizzardskin/damagemeters): Extend per-category Icon Zoom to more icon surfaces

### DIFF
--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -10,6 +10,7 @@
 local BAGS_DEFAULTS = {
     profile = {
         bagScale              = 1,
+        bagItemIconZoom       = 0.08,
         bagColumns            = 12,
         bagAutoSize           = false,
         bagCatTitleSize       = 11,
@@ -155,7 +156,9 @@ initFrame:SetScript("OnEvent", function(self)
             ---------------------------------------------------------------------------
             _, h = W:SectionHeader(parent, "DISPLAY", y); y = y - h
 
-            -- Window Scale | Hide Categories with 0 Items
+            -- Window Scale | Icon Zoom (crops the item-icon border; applies to
+            -- bag AND bank item icons. Paired with Window Scale as both are
+            -- display-appearance sliders; no per-item size control exists.)
             _, h = W:DualRow(parent, y,
                 { type="slider", text="Window Scale", min=50, max=150, step=5,
                   tooltip="Scale of the bag and bank windows.",
@@ -168,17 +171,26 @@ initFrame:SetScript("OnEvent", function(self)
                       if _G.EUI_BagsWindow then _G.EUI_BagsWindow:SetScale(s) end
                       if _G.EUI_Bank and _G.EUI_Bank:IsVisible() then _G.EUI_Bank:SetScale(s) end
                   end },
+                { type="slider", text="Icon Zoom", min=0, max=0.20, step=0.01,
+                  tooltip="Crops the border of every item icon in bags and bank. 0 shows the full icon.",
+                  getValue=function() return db.profile.bagItemIconZoom or 0.08 end,
+                  setValue=function(v)
+                      db.profile.bagItemIconZoom = v
+                      if _G.EUI_Bags and _G.EUI_Bags.RefreshIconZoom then _G.EUI_Bags:RefreshIconZoom() end
+                      local bank = _G.EUI_BankFrame
+                      if bank and bank.RefreshIconZoom then bank:RefreshIconZoom() end
+                  end }
+            ); y = y - h
+
+            -- Hide Categories with 0 Items | Auto-Size to Fit
+            _, h = W:DualRow(parent, y,
                 { type="toggle", text="Hide Categories with 0 Items",
                   tooltip="Hide sidebar categories that have no items in them.",
                   getValue=function() return db.profile.bagHideEmptyCategories ~= false end,
                   setValue=function(v)
                       db.profile.bagHideEmptyCategories = v
                       if _G.EUI_Bags and _G.EUI_Bags.RefreshInventory then _G.EUI_Bags:RefreshInventory() end
-                  end }
-            ); y = y - h
-
-            -- Auto-Size to Fit | Default Bag Type
-            _, h = W:DualRow(parent, y,
+                  end },
                 { type="toggle", text="Auto-Size to Fit",
                   tooltip="Grow the bag window (more columns + taller, keeping its shape) so all of the active tab's slots are visible without scrolling. It only grows while open -- switching to a bigger tab enlarges it, smaller tabs keep the size -- and resets when you close the bags. Never smaller than your normal size.",
                   getValue=function() return db.profile.bagAutoSize == true end,
@@ -190,7 +202,11 @@ initFrame:SetScript("OnEvent", function(self)
                           _G.EUI_Bags._asMaxH = nil
                           if _G.EUI_Bags.RefreshInventory then _G.EUI_Bags:RefreshInventory() end
                       end
-                  end },
+                  end }
+            ); y = y - h
+
+            -- Default Bag Type
+            _, h = W:DualRow(parent, y,
                 { type="dropdown", text="Default Bag Type",
                   tooltip="Which view bags (and the bank) open to by default. The bank has no MultiBag view, so MultiBag opens the bank to OneBank.",
                   values = { all="All Items", onebag="OneBag", multibag="MultiBag" },
@@ -206,7 +222,8 @@ initFrame:SetScript("OnEvent", function(self)
                           _G.EUI_Bags:RefreshInventory()
                       end
                       EllesmereUI:RefreshPage()
-                  end }
+                  end },
+                { type="spacer" }
             ); y = y - h
 
             -- Category Title Size | Show Item Level (+ inline cog: Gear Track Rank)

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -2035,7 +2035,8 @@ local function GetOrCreateSlot(idx)
 
     btn:SetSize(SLOT_SIZE, SLOT_SIZE)
     if btn.icon then
-        btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+        local z = BP().bagItemIconZoom or 0.08
+        btn.icon:SetTexCoord(z, 1 - z, z, 1 - z)
         btn.icon:ClearAllPoints()
         btn.icon:SetAllPoints(btn)
     end
@@ -2151,7 +2152,8 @@ local function GetOrCreateReagentSlot(idx)
 
     btn:SetSize(SLOT_SIZE, SLOT_SIZE)
     if btn.icon then
-        btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+        local z = BP().bagItemIconZoom or 0.08
+        btn.icon:SetTexCoord(z, 1 - z, z, 1 - z)
         btn.icon:ClearAllPoints()
         btn.icon:SetAllPoints(btn)
     end
@@ -2224,7 +2226,8 @@ local function GetOrCreateBagSlot(idx)
     btn:SetAllPoints(slotParent)
     btn:RegisterForClicks("LeftButtonUp", "RightButtonUp")
     btn.icon = btn:CreateTexture(nil, "ARTWORK")
-    btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+    local z = BP().bagItemIconZoom or 0.08
+    btn.icon:SetTexCoord(z, 1 - z, z, 1 - z)
     btn.icon:SetAllPoints(btn)
     btn.Count = btn:CreateFontString(nil, "OVERLAY")
     EllesmereUI.ApplyIconTextFont(btn.Count, GetFont(), BP().bagCountFontSize or 11, "bags")
@@ -2272,6 +2275,24 @@ local function RefreshTextSizes()
     end
 end
 EUI_Bags.RefreshTextSizes = RefreshTextSizes
+
+-------------------------------------------------------------------------------
+--  Fast icon-zoom update: re-applies the item-icon crop to existing slots
+--  without a full RefreshInventory. Called by the options zoom cog.
+-------------------------------------------------------------------------------
+local function RefreshIconZoom()
+    local z = BP().bagItemIconZoom or 0.08
+    for _, btn in pairs(itemSlots) do
+        if btn.icon then btn.icon:SetTexCoord(z, 1 - z, z, 1 - z) end
+    end
+    for _, btn in pairs(reagentSlots) do
+        if btn.icon then btn.icon:SetTexCoord(z, 1 - z, z, 1 - z) end
+    end
+    for _, btn in pairs(bagSlots) do
+        if btn.icon then btn.icon:SetTexCoord(z, 1 - z, z, 1 - z) end
+    end
+end
+EUI_Bags.RefreshIconZoom = RefreshIconZoom
 
 -------------------------------------------------------------------------------
 --  Bind type text (shared by bags and bank render paths)

--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -1359,7 +1359,7 @@ local function GetOrCreateBankSlot(idx)
     if btn.newitemglowAnim then btn.newitemglowAnim:Stop() end
 
     btn:SetSize(SLOT_SIZE, SLOT_SIZE)
-    if btn.icon then btn.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92) end
+    if btn.icon then local z = BP().bagItemIconZoom or 0.08; btn.icon:SetTexCoord(z, 1 - z, z, 1 - z) end
 
     -- Remove highlight/pushed textures shape
     local ht = btn.HighlightTexture or btn:GetHighlightTexture()
@@ -1481,6 +1481,15 @@ local function RefreshBankTextSizes()
     end
 end
 EUI_Bank.RefreshTextSizes = RefreshBankTextSizes
+
+-- Fast icon-zoom update for bank slots (mirrors bags RefreshIconZoom)
+local function RefreshBankIconZoom()
+    local z = BP().bagItemIconZoom or 0.08
+    for _, btn in pairs(_bankSlots) do
+        if btn.icon then btn.icon:SetTexCoord(z, 1 - z, z, 1 - z) end
+    end
+end
+EUI_Bank.RefreshIconZoom = RefreshBankIconZoom
 
 local function CountUsedSlots(bagID, numSlots)
     local used = 0

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -826,7 +826,14 @@ initFrame:SetScript("OnEvent", function(self)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.flyoutItemLevels = v
               end },
-            { type="spacer" }
+            { type="slider", text="Icon Zoom", min=0, max=0.20, step=0.01,
+              tooltip="Crops the border of the equipment-slot item icons on the character and inspect sheets. 0 shows the full icon. Only affects the themed character sheet.",
+              getValue=function() return (EllesmereUIDB and EllesmereUIDB.charSheetIconZoom) or 0.07 end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.charSheetIconZoom = v
+                  if EllesmereUI._refreshCharSheetIconZoom then EllesmereUI._refreshCharSheetIconZoom() end
+              end }
         );  y = y - h
 
         _, h = W:Spacer(parent, y, 10);  y = y - h

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -665,7 +665,8 @@ local function PreSkinCharacterSheet()
             end
             local iconTexture = _G[slotName .. "IconTexture"]
             if iconTexture then
-                iconTexture:SetTexCoord(.07,.07,.07,.93,.93,.07,.93,.93)
+                local z = (EllesmereUIDB and EllesmereUIDB.charSheetIconZoom) or 0.07
+                iconTexture:SetTexCoord(z, z, z, 1 - z, 1 - z, z, 1 - z, 1 - z)
             end
             local normalTexture = _G[slotName .. "NormalTexture"]
             if normalTexture then
@@ -2657,7 +2658,8 @@ local function SkinCharacterSheet()
 
         -- Crop icon inward
         if slot.icon then
-            slot.icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
+            local z = (EllesmereUIDB and EllesmereUIDB.charSheetIconZoom) or 0.07
+            slot.icon:SetTexCoord(z, 1 - z, z, 1 - z)
         end
 
         -- Hide NormalTexture
@@ -5035,6 +5037,21 @@ function EllesmereUI._refreshCharacterSheetColors()
             if stat.value then
                 stat.value:SetTextColor(newColor.r, newColor.g, newColor.b, 1)
             end
+        end
+    end
+end
+
+-- Re-apply the equipment-icon crop when the Icon Zoom option changes. The
+-- texcoord persists across item swaps, so only slider changes need this.
+function EllesmereUI._refreshCharSheetIconZoom()
+    -- Only the themed sheet crops its slot icons; if it is off the slots show
+    -- Blizzard's default icons, which we must not re-crop.
+    if EllesmereUIDB and EllesmereUIDB.themedCharacterSheet == false then return end
+    local z = (EllesmereUIDB and EllesmereUIDB.charSheetIconZoom) or 0.07
+    for _, slotName in ipairs(EUI_ALL_SLOTS) do
+        local slot = _G[slotName]
+        if slot and slot.icon then
+            slot.icon:SetTexCoord(z, 1 - z, z, 1 - z)
         end
     end
 end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
@@ -660,7 +660,8 @@ local function SkinInspectSheet()
 
             -- Crop icon
             if slot.icon then
-                slot.icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
+                local z = (EllesmereUIDB and EllesmereUIDB.charSheetIconZoom) or 0.07
+                slot.icon:SetTexCoord(z, 1 - z, z, 1 - z)
             end
 
             local normalTexture = _G[slotName .. "NormalTexture"]

--- a/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
@@ -1413,8 +1413,9 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.RegisterWidgetRefresh(cbDDRefresh)
         end
 
-        -- Row 3: Icon Size | Max Icons
-        _, h = W:DualRow(parent, y,
+        -- Row 3: Icon Size (+ icon zoom cog) | Max Icons
+        local shSizeRow
+        shSizeRow, h = W:DualRow(parent, y,
             { type = "slider", text = "Icon Size",
               min = 20, max = 60, step = 1,
               disabled = iconOff, disabledTooltip = "Icon History",
@@ -1427,6 +1428,32 @@ initFrame:SetScript("OnEvent", function(self)
               getValue = function() return SHDB().iconCount or 5 end,
               setValue = function(v) SHDB().iconCount = v; RefreshSH() end }
         );  y = y - h
+        -- Inline cog on Icon Size: Icon Zoom (shared by the icon strip and the
+        -- bar window, so it stays usable whenever either display is on).
+        do
+            local rgn = shSizeRow._leftRegion
+            local shZoomOff = function() return iconOff() and barOff() end
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Icon Zoom",
+                rows = {
+                    { type = "slider", label = "Zoom", min = 0, max = 0.20, step = 0.01,
+                      get = function() return SHDB().iconZoom or 0.08 end,
+                      set = function(v) SHDB().iconZoom = v; RefreshSH() end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(shZoomOff() and 0.15 or 0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints(); cogTex:SetTexture(EllesmereUI.COGS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) if not shZoomOff() then self:SetAlpha(0.7) end end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(shZoomOff() and 0.15 or 0.4) end)
+            cogBtn:SetScript("OnClick", function(self) if not shZoomOff() then cogShow(self) end end)
+            EllesmereUI.RegisterWidgetRefresh(function() cogBtn:SetAlpha(shZoomOff() and 0.15 or 0.4) end)
+        end
 
         -- Row 4: Icon Spacing | Opacity
         _, h = W:DualRow(parent, y,

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters_SpellHistory.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters_SpellHistory.lua
@@ -32,6 +32,7 @@ local SH_DEFAULTS = {
     barEnabled      = false,
     growDirection   = "LEFT",
     iconSize        = 36,
+    iconZoom        = 0.08,
     iconSpacing     = 1,
     iconCount       = 5,
     iconOpacity     = 1,
@@ -557,7 +558,8 @@ local function MakeIcon(parent)
     ic.bg = bg
     ic.tex = ic.frame:CreateTexture(nil, "ARTWORK")
     ic.tex:SetAllPoints()
-    ic.tex:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+    local z = DB().iconZoom or 0.08
+    ic.tex:SetTexCoord(z, 1 - z, z, 1 - z)
     ic.frame:Hide()
     return ic
 end
@@ -643,6 +645,7 @@ BuildIconStrip = function()
     local iconSz = PhysicalPixels(sh.iconSize or 24)
     local gap = PhysicalPixels(sh.iconSpacing or 1)
     local dir = sh.growDirection or "LEFT"
+    local iconZoom = sh.iconZoom or 0.08
 
     local maxIcons = sh.iconCount or 5
     local histCount = min(#_history, maxIcons)
@@ -681,6 +684,10 @@ BuildIconStrip = function()
         local ic = _iconPool[i]
         if not ic then break end
         if i <= count then
+            if ic._cachedZoom ~= iconZoom then
+                ic._cachedZoom = iconZoom
+                ic.tex:SetTexCoord(iconZoom, 1 - iconZoom, iconZoom, 1 - iconZoom)
+            end
             if layoutChanged then
                 ic.frame:SetScript("OnUpdate", nil)
                 ic.frame:SetScale(1)
@@ -777,7 +784,8 @@ local function MakeHistoryBar(parent)
     bar.icon = bar.row:CreateTexture(nil, "OVERLAY")
     bar.icon:SetSize(18, 18)
     bar.icon:SetPoint("LEFT", bar.row, "LEFT", 0, 0)
-    bar.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+    local z = DB().iconZoom or 0.08
+    bar.icon:SetTexCoord(z, 1 - z, z, 1 - z)
 
     bar.fill = CreateFrame("StatusBar", nil, bar.row)
     bar.fill:SetPoint("TOPLEFT", bar.icon, "TOPRIGHT", 0, 0)
@@ -1064,6 +1072,7 @@ RefreshBarWindow = function()
 
     local total = min(#_history, sh.maxBars or 5)
     local loopEnd = max(visSlots, _lastBarVisible)
+    local barIconZoom = sh.iconZoom or 0.08
 
     -- Layout key: only rebuild positions/sizes when settings change
     local layoutKey = barH .. "|" .. barSp .. "|" .. texPath
@@ -1076,6 +1085,11 @@ RefreshBarWindow = function()
         local idx = _barScroll + i
         if i <= visSlots and idx <= total then
             local entry = _history[idx]
+
+            if bar._cachedZoom ~= barIconZoom then
+                bar._cachedZoom = barIconZoom
+                bar.icon:SetTexCoord(barIconZoom, 1 - barIconZoom, barIconZoom, 1 - barIconZoom)
+            end
 
             -- Layout: only on settings change or slot reuse
             if layoutChanged or bar._cachedSlot ~= i then

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -3107,7 +3107,7 @@ initFrame:SetScript("OnEvent", function(self)
                             if bf._iconTex then
                                 bf._iconTex:SetTexture(_previewBuffIcons[i] or 135932)
                                 -- SetTexture resets texcoord, so re-apply the crop each update.
-                                ns.SetAuraIconCrop(bf._iconTex, buffCrop, buffSize, buffH)
+                                ns.SetAuraIconCrop(bf._iconTex, buffCrop, buffSize, buffH, s.buffIconZoom or 0.07)
                             end
                         else
                             if bf:IsShown() then bf:Hide() end
@@ -3222,12 +3222,12 @@ initFrame:SetScript("OnEvent", function(self)
                     local simpleIconPt   = (simpleMode == "right") and "TOPLEFT"  or "TOPRIGHT"
                     local simpleParentPt = (simpleMode == "right") and "TOPRIGHT" or "TOPLEFT"
                     local simpleEdgeSign = (simpleMode == "right") and 1 or -1
-                    local anchorKey = justH .. am.pt .. am.ox .. am.oy .. dx .. dy .. debuffSize .. debuffH .. (useSimpleBossAnchor and "S" or "N") .. simpleMode .. dOffX .. "gx" .. debuffGapX .. "gy" .. debuffGapY
+                    local anchorKey = justH .. am.pt .. am.ox .. am.oy .. dx .. dy .. debuffSize .. debuffH .. (useSimpleBossAnchor and "S" or "N") .. simpleMode .. dOffX .. "gx" .. debuffGapX .. "gy" .. debuffGapY .. "z" .. (s.debuffIconZoom or 0.07)
                     for i, df in ipairs(debuffIcons) do
                         if i <= visibleDebuffCount then
                             if df._anchorKey ~= anchorKey then
                                 PP.Size(df, debuffSize, debuffH)
-                                if df._iconTex then ns.SetAuraIconCrop(df._iconTex, debuffCrop, debuffSize, debuffH) end
+                                if df._iconTex then ns.SetAuraIconCrop(df._iconTex, debuffCrop, debuffSize, debuffH, s.debuffIconZoom or 0.07) end
                                 df:ClearAllPoints()
                                 if i == 1 then
                                     if useSimpleBossAnchor then
@@ -9151,6 +9151,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="toggle", label="Cropped Icons",
                       get=function() return SValSupported("buffCropIcons", false) end,
                       set=function(v) SSetSupported("buffCropIcons", v) end },
+                    { type="slider", label="Icon Zoom", min=0, max=0.20, step=0.01,
+                      get=function() return SValSupported("buffIconZoom", 0.07) end,
+                      set=function(v) SSetSupported("buffIconZoom", v) end },
                 },
             })
             MakeCogBtn(leftRgn, buffCogShow, nil, nil, BuffDisabled)
@@ -9272,6 +9275,9 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="toggle", label="Cropped Icons",
                       get=function() return SValSupported("debuffCropIcons", false) end,
                       set=function(v) SSetSupported("debuffCropIcons", v) end },
+                    { type="slider", label="Icon Zoom", min=0, max=0.20, step=0.01,
+                      get=function() return SValSupported("debuffIconZoom", 0.07) end,
+                      set=function(v) SSetSupported("debuffIconZoom", v) end },
                 },
             })
             MakeCogBtn(leftRgn, debuffCogShow, nil, nil, DebuffDisabled)
@@ -12361,6 +12367,16 @@ initFrame:SetScript("OnEvent", function(self)
                 } })
                 BossCogBtn(bossAuraSizeRow._leftRegion, bSizeCog, EllesmereUI.DIRECTIONS_ICON, bossBuffSizeOff)
             end
+            do  -- Icon Zoom cog on Buff Size (gated only on buffs hidden, so it
+                -- stays adjustable in Simple Buff Display, where zoom still applies)
+                local bossBuffZoomOff = function() return db.profile.boss.showBuffs == false end
+                local _, bZoomCog = EllesmereUI.BuildCogPopup({ title = "Icon Zoom", rows = {
+                    { type="slider", label="Zoom", min=0, max=0.20, step=0.01,
+                      get=function() return db.profile.boss.buffIconZoom or 0.07 end,
+                      set=function(v) db.profile.boss.buffIconZoom = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
+                } })
+                BossCogBtn(bossAuraSizeRow._leftRegion, bZoomCog, nil, bossBuffZoomOff)
+            end
             do  -- Directions cog on Debuff Size (X/Y cluster offset)
                 local _, dSizeCog = EllesmereUI.BuildCogPopup({ title = "Debuff Position", rows = {
                     { type="slider", label="Offset X", min=-200, max=200, step=1,
@@ -12375,6 +12391,15 @@ initFrame:SetScript("OnEvent", function(self)
                       set=function(v) db.profile.boss.debuffSpacing = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                 } })
                 BossCogBtn(bossAuraSizeRow._rightRegion, dSizeCog, EllesmereUI.DIRECTIONS_ICON, bossDebuffSizeOff)
+            end
+            do  -- Icon Zoom cog on Debuff Size
+                local bossDebuffZoomOff = function() return (db.profile.boss.debuffAnchor or "bottomleft") == "none" end
+                local _, dZoomCog = EllesmereUI.BuildCogPopup({ title = "Icon Zoom", rows = {
+                    { type="slider", label="Zoom", min=0, max=0.20, step=0.01,
+                      get=function() return db.profile.boss.debuffIconZoom or 0.07 end,
+                      set=function(v) db.profile.boss.debuffIconZoom = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
+                } })
+                BossCogBtn(bossAuraSizeRow._rightRegion, dZoomCog, nil, bossDebuffZoomOff)
             end
 
             -- Per-unit DEBUFF filter for boss frames (NOT synced). Boss BUFFS are

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -5301,15 +5301,18 @@ end
 -- after the height is rounded to whole pixels.
 local AURA_CROP_HEIGHT = 0.80
 local AURA_ZOOM = 0.07
-local function SetAuraIconCrop(icon, cropped, w, h)
+-- zoom (optional) overrides the default AURA_ZOOM crop; per-unit/per-category
+-- Icon Zoom values flow in here, defaulting to AURA_ZOOM so unset = unchanged.
+local function SetAuraIconCrop(icon, cropped, w, h, zoom)
     if not icon then return end
+    local z = zoom or AURA_ZOOM
     if cropped and w and h and w > 0 then
-        local uSpan = 1 - 2 * AURA_ZOOM
+        local uSpan = 1 - 2 * z
         local vSpan = uSpan * (h / w)
         local v0 = 0.5 - vSpan / 2
-        icon:SetTexCoord(AURA_ZOOM, 1 - AURA_ZOOM, v0, 1 - v0)
+        icon:SetTexCoord(z, 1 - z, v0, 1 - v0)
     else
-        icon:SetTexCoord(AURA_ZOOM, 1 - AURA_ZOOM, AURA_ZOOM, 1 - AURA_ZOOM)
+        icon:SetTexCoord(z, 1 - z, z, 1 - z)
     end
 end
 -- Exposed so the options live preview can apply the exact same crop math
@@ -5339,7 +5342,7 @@ function ns.ApplyStackAnchor(fs, parent, pos, offX, offY)
     fs:SetPoint(point, parent, point, baseX + (offX or 0), offY or 0)
 end
 
-local function ApplyAuraCooldownText(container, showCD, cdSize, stackSize, cdOffX, cdOffY, stackOffX, stackOffY, auraSize, cropped, stackPos, cdTextColor, stackTextColor)
+local function ApplyAuraCooldownText(container, showCD, cdSize, stackSize, cdOffX, cdOffY, stackOffX, stackOffY, auraSize, cropped, stackPos, cdTextColor, stackTextColor, iconZoom)
     if not container then return end
     -- Cropped style: make the buttons rectangular (height = 80% of width). oUF
     -- sizes each button to element.width x element.height and uses them for the
@@ -5362,7 +5365,7 @@ local function ApplyAuraCooldownText(container, showCD, cdSize, stackSize, cdOff
     end
     for i = 1, (container.createdButtons or 0) do
         local btn = container[i]
-        if btn and btn.Icon then SetAuraIconCrop(btn.Icon, cropped, cropW, cropH) end
+        if btn and btn.Icon then SetAuraIconCrop(btn.Icon, cropped, cropW, cropH, iconZoom) end
         if btn and btn.Cooldown then
             btn.Cooldown:SetHideCountdownNumbers(not showCD)
             local cdText = btn.Cooldown:GetRegions()
@@ -5499,11 +5502,11 @@ local function CreateTargetAuras(frame, unit)
         local s = GetSettingsForUnit(unit or "target")
         if button.Icon then
             -- Cropped icons trim the texture top/bottom to keep aspect ratio.
-            local cropped, aSize
-            if isBuff then cropped = s and s.buffCropIcons; aSize = (s and s.buffSize) or 22
-            else cropped = s and s.debuffCropIcons; aSize = (s and s.debuffSize) or 22 end
+            local cropped, aSize, zoom
+            if isBuff then cropped = s and s.buffCropIcons; aSize = (s and s.buffSize) or 22; zoom = s and s.buffIconZoom
+            else cropped = s and s.debuffCropIcons; aSize = (s and s.debuffSize) or 22; zoom = s and s.debuffIconZoom end
             local cH = cropped and math.floor(aSize * AURA_CROP_HEIGHT + 0.5) or aSize
-            SetAuraIconCrop(button.Icon, cropped, aSize, cH)
+            SetAuraIconCrop(button.Icon, cropped, aSize, cH, zoom)
         end
 
         if button.Cooldown then
@@ -8608,7 +8611,7 @@ local function ReloadFrames()
                                     frame.Buffs:ForceUpdate()
                                 end
                             end
-                            ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition)
+                            ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition, nil, nil, settings.buffIconZoom or 0.07)
                         else
                             if frame:IsElementEnabled("Buffs") then
                                 frame:DisableElement("Buffs")
@@ -8658,7 +8661,7 @@ local function ReloadFrames()
                                     frame.Debuffs:ForceUpdate()
                                 end
                             end
-                            ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition)
+                            ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition, nil, nil, settings.debuffIconZoom or 0.07)
                         end
                     end
 
@@ -9036,7 +9039,7 @@ local function ReloadFrames()
                             frame.Buffs:Hide()
                             frame.Buffs.num = 0
                         end
-                        ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition)
+                        ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition, nil, nil, settings.buffIconZoom or 0.07)
                     end
 
                     -- Debuffs
@@ -9082,7 +9085,7 @@ local function ReloadFrames()
                                 end
                             end
                         end
-                        ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition)
+                        ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition, nil, nil, settings.debuffIconZoom or 0.07)
                     end
 
                     UpdateBordersForScale(frame, unit)
@@ -9399,7 +9402,7 @@ local function ReloadFrames()
                                 frame.Debuffs:ForceUpdate()
                             end
                         end
-                        ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition)
+                        ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition, nil, nil, settings.debuffIconZoom or 0.07)
                     end
                 end
 
@@ -9448,7 +9451,7 @@ local function ReloadFrames()
                         frame.Buffs:Hide()
                         frame.Buffs.num = 0
                     end
-                    ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition)
+                    ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition, nil, nil, settings.buffIconZoom or 0.07)
                 end
 
                 UpdateBordersForScale(frame, unit)
@@ -9779,9 +9782,9 @@ local function ReloadFrames()
                     -- Use simple debuff cooldown text settings when simple display
                     -- is active, regular debuff settings otherwise.
                     if simpleOn then
-                        ApplyAuraCooldownText(frame.Debuffs, settings.simpleDebuffShowCooldownText, settings.simpleDebuffCooldownTextSize or 14, settings.debuffStackTextSize, settings.simpleDebuffCooldownTextOffsetX, settings.simpleDebuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, nil, nil, settings.debuffStackTextPosition, settings.debuffCooldownTextColor, settings.debuffStackTextColor)
+                        ApplyAuraCooldownText(frame.Debuffs, settings.simpleDebuffShowCooldownText, settings.simpleDebuffCooldownTextSize or 14, settings.debuffStackTextSize, settings.simpleDebuffCooldownTextOffsetX, settings.simpleDebuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, nil, nil, settings.debuffStackTextPosition, settings.debuffCooldownTextColor, settings.debuffStackTextColor, settings.debuffIconZoom or 0.07)
                     else
-                        ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition, settings.debuffCooldownTextColor, settings.debuffStackTextColor)
+                        ApplyAuraCooldownText(frame.Debuffs, settings.debuffShowCooldownText, settings.debuffCooldownTextSize or 10, settings.debuffStackTextSize, settings.debuffCooldownTextOffsetX, settings.debuffCooldownTextOffsetY, settings.debuffStackTextOffsetX, settings.debuffStackTextOffsetY, settings.debuffSize or 22, settings.debuffCropIcons, settings.debuffStackTextPosition, settings.debuffCooldownTextColor, settings.debuffStackTextColor, settings.debuffIconZoom or 0.07)
                     end
                 end
 
@@ -9876,9 +9879,9 @@ local function ReloadFrames()
                     -- Cooldown/stack text: simple uses the simpleBuff* keys (sharing the
                     -- regular buff stack settings), regular buff keys otherwise.
                     if simpleBuffOn then
-                        ApplyAuraCooldownText(frame.Buffs, settings.simpleBuffShowCooldownText, settings.simpleBuffCooldownTextSize or 14, settings.buffStackTextSize, settings.simpleBuffCooldownTextOffsetX, settings.simpleBuffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, nil, nil, settings.buffStackTextPosition, settings.buffCooldownTextColor, settings.buffStackTextColor)
+                        ApplyAuraCooldownText(frame.Buffs, settings.simpleBuffShowCooldownText, settings.simpleBuffCooldownTextSize or 14, settings.buffStackTextSize, settings.simpleBuffCooldownTextOffsetX, settings.simpleBuffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, nil, nil, settings.buffStackTextPosition, settings.buffCooldownTextColor, settings.buffStackTextColor, settings.buffIconZoom or 0.07)
                     else
-                        ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition, settings.buffCooldownTextColor, settings.buffStackTextColor)
+                        ApplyAuraCooldownText(frame.Buffs, settings.buffShowCooldownText, settings.buffCooldownTextSize or 10, settings.buffStackTextSize, settings.buffCooldownTextOffsetX, settings.buffCooldownTextOffsetY, settings.buffStackTextOffsetX, settings.buffStackTextOffsetY, settings.buffSize or 22, settings.buffCropIcons, settings.buffStackTextPosition, settings.buffCooldownTextColor, settings.buffStackTextColor, settings.buffIconZoom or 0.07)
                     end
                 end
 
@@ -11701,7 +11704,8 @@ function SetupOptionsPanel()
             local tex = GetSpellTexture and GetSpellTexture(spellID)
                      or (C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(spellID))
             if tex then icon:SetTexture(tex) end
-            icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
+            local z = settings.debuffIconZoom or 0.07
+            icon:SetTexCoord(z, 1 - z, z, 1 - z)
             -- Static fake cooldown swipe: a huge duration parked at a fixed
             -- fraction so the wedge never visibly moves. Native countdown
             -- numbers stay hidden; the duration text below is a manual static
@@ -11846,7 +11850,8 @@ function SetupOptionsPanel()
             local tex = GetSpellTexture and GetSpellTexture(spellID)
                      or (C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(spellID))
             if tex then icon:SetTexture(tex) end
-            icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
+            local z = settings.buffIconZoom or 0.07
+            icon:SetTexCoord(z, 1 - z, z, 1 - z)
             local border = CreateFrame("Frame", nil, iconFrame)
             border:SetAllPoints(icon)
             border:SetFrameLevel(iconFrame:GetFrameLevel() + 1)


### PR DESCRIPTION
## Overview

Extends the existing Icon Zoom control from https://github.com/EllesmereGaming/EllesmereUI/pull/606 to five more surfaces. Range 0–0.20, defaults match the old hardcoded crops so nothing changes until you move a slider.

| Surface | Setting (default) | Control |
|---|---|---|
| Unit Frame auras - player/target/focus | `<unit>.buffIconZoom` / `debuffIconZoom` (0.07) | Unit Frames - Main Frames - pick a unit (Player/Target/Focus) - cog next to Buff Size / Debuff Size - Icon Zoom slider in the popup |
| Boss auras | `boss.buffIconZoom` / `debuffIconZoom` (0.07) | Unit Frames - Boss Frames - Icon Zoom cog next to Buff Size / Debuff Size |
| Bags - all item icons | `bagItemIconZoom` (0.08) | Bags - DISPLAY - Icon Zoom slider (right of Window Scale) |
| Character sheet (+ inspect) | `charSheetIconZoom` (0.07) | slider on the Gear Flyout row |
| DM spell history | `spellHistory.iconZoom` (0.08) | Damage Meters - spell history settings - Icon Zoom cog next to Icon Size |

## Notes

- Unit Frame auras share one `SetAuraIconCrop`; zoom is threaded per-unit/per-category, and combat-created buttons crop correctly.
- Character-sheet zoom is guarded to the themed sheet, so it never crops Blizzard's default icons.
- Private auras stay unzoomable (Blizzard-rendered, no Lua texture handle).

## Testing

- [x] Defaults untouched = identical to before
- [x] Each surface zooms independently; live + preview update immediately
- [x] Per-unit UF values independent; boss works in Simple Display; combat auras crop right
- [x] Bags cover main/reagent/bank/bag-bar; char + inspect sheets; no mis-crop when themed sheet off
- [x] Clean load, no Lua errors