### PR TITLE
feat(resourcebars): Add out-of-combat opacity fade for Power, Class Resource, and Health bars

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -2965,6 +2965,48 @@ initFrame:SetScript("OnEvent", function(self)
             UpdateCogDisGrad()
         end
 
+        -- Out of Combat Opacity: inline cog on the Opacity slider. Dims the Health
+        -- bar to this alpha while out of combat (100 = no fade). Applied via
+        -- ns.ResolveBarAlpha in UpdateVisibility; reacts to combat.
+        do
+            local rgn = healthBorderRow._leftRegion
+            local _, oocCogShow = EllesmereUI.BuildCogPopup({
+                title = "Out of Combat Opacity",
+                rows = {
+                    { type = "toggle", label = "Fade Out of Combat",
+                      get = function() local c = cfg(); return c and c.oocFadeEnabled == true end,
+                      set = function(v)
+                          local c = cfg(); if not c then return end
+                          c.oocFadeEnabled = v; RefreshHealth()
+                      end },
+                    { type = "slider", label = "Opacity",
+                      min = 0, max = 100, step = 1,
+                      disabled = function() local c = cfg(); return not (c and c.oocFadeEnabled) end,
+                      get = function() local c = cfg(); return math.floor(((c and c.oocAlpha) or 0.5) * 100 + 0.5) end,
+                      set = function(v)
+                          local c = cfg(); if not c then return end
+                          c.oocAlpha = v / 100; RefreshHealth()
+                      end },
+                },
+            })
+            local oocCog = MakeCogBtn(rgn, oocCogShow)
+            local oocCogDis = CreateFrame("Frame", nil, rgn)
+            oocCogDis:SetAllPoints(oocCog)
+            oocCogDis:SetFrameLevel(oocCog:GetFrameLevel() + 5)
+            oocCogDis:EnableMouse(true)
+            oocCogDis:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(oocCog, EllesmereUI.DisabledTooltip("Health Bar"))
+            end)
+            oocCogDis:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            local function UpdateOocCogDis()
+                local c = cfg()
+                if c and not c.enabled then oocCogDis:Show(); oocCog:SetAlpha(0.15) else oocCogDis:Hide(); oocCog:SetAlpha(0.4) end
+            end
+            oocCog:HookScript("OnShow", UpdateOocCogDis)
+            EllesmereUI.RegisterWidgetRefresh(UpdateOocCogDis)
+            UpdateOocCogDis()
+        end
+
         -- Text Color disable: bar off OR Health Text is None.
         local function healthTextDis()
             local c = cfg()
@@ -3716,6 +3758,48 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:HookScript("OnShow", UpdateCogDisGrad)
             EllesmereUI.RegisterWidgetRefresh(UpdateCogDisGrad)
             UpdateCogDisGrad()
+        end
+
+        -- Out of Combat Opacity: inline cog on the Opacity slider. Dims the Power
+        -- bar to this alpha while out of combat (100 = no fade). Applied via
+        -- ns.ResolveBarAlpha in UpdateVisibility; reacts to combat.
+        do
+            local rgn = powerBorderRow._leftRegion
+            local _, oocCogShow = EllesmereUI.BuildCogPopup({
+                title = "Out of Combat Opacity",
+                rows = {
+                    { type = "toggle", label = "Fade Out of Combat",
+                      get = function() local c = cfg(); return c and c.oocFadeEnabled == true end,
+                      set = function(v)
+                          local c = cfg(); if not c then return end
+                          c.oocFadeEnabled = v; RefreshPower()
+                      end },
+                    { type = "slider", label = "Opacity",
+                      min = 0, max = 100, step = 1,
+                      disabled = function() local c = cfg(); return not (c and c.oocFadeEnabled) end,
+                      get = function() local c = cfg(); return math.floor(((c and c.oocAlpha) or 0.5) * 100 + 0.5) end,
+                      set = function(v)
+                          local c = cfg(); if not c then return end
+                          c.oocAlpha = v / 100; RefreshPower()
+                      end },
+                },
+            })
+            local oocCog = MakeCogBtn(rgn, oocCogShow)
+            local oocCogDis = CreateFrame("Frame", nil, rgn)
+            oocCogDis:SetAllPoints(oocCog)
+            oocCogDis:SetFrameLevel(oocCog:GetFrameLevel() + 5)
+            oocCogDis:EnableMouse(true)
+            oocCogDis:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(oocCog, EllesmereUI.DisabledTooltip(powerDisTip))
+            end)
+            oocCogDis:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            local function UpdateOocCogDis()
+                local c = cfg()
+                if c and not c.enabled then oocCogDis:Show(); oocCog:SetAlpha(0.15) else oocCogDis:Hide(); oocCog:SetAlpha(0.4) end
+            end
+            oocCog:HookScript("OnShow", UpdateOocCogDis)
+            EllesmereUI.RegisterWidgetRefresh(UpdateOocCogDis)
+            UpdateOocCogDis()
         end
 
         -- Text Color disable: bar off OR Power Text is None.
@@ -4708,6 +4792,48 @@ initFrame:SetScript("OnEvent", function(self)
                     flashTargets = function() return { ctx.syncRows.classOpacity, ctx.syncRows.powerOpacity, ctx.syncRows.healthOpacity } end,
                 })
             end
+        end
+
+        -- Out of Combat Opacity: inline cog on the Opacity slider. Dims the Class
+        -- Resource bar to this alpha while out of combat (100 = no fade). Applied
+        -- via ns.ResolveBarAlpha in UpdateVisibility; reacts to combat.
+        do
+            local rgn = classBorderRow._leftRegion
+            local _, oocCogShow = EllesmereUI.BuildCogPopup({
+                title = "Out of Combat Opacity",
+                rows = {
+                    { type = "toggle", label = "Fade Out of Combat",
+                      get = function() local c = cfg(); return c and c.oocFadeEnabled == true end,
+                      set = function(v)
+                          local c = cfg(); if not c then return end
+                          c.oocFadeEnabled = v; RefreshClass()
+                      end },
+                    { type = "slider", label = "Opacity",
+                      min = 0, max = 100, step = 1,
+                      disabled = function() local c = cfg(); return not (c and c.oocFadeEnabled) end,
+                      get = function() local c = cfg(); return math.floor(((c and c.oocAlpha) or 0.5) * 100 + 0.5) end,
+                      set = function(v)
+                          local c = cfg(); if not c then return end
+                          c.oocAlpha = v / 100; RefreshClass()
+                      end },
+                },
+            })
+            local oocCog = MakeCogBtn(rgn, oocCogShow)
+            local oocCogDis = CreateFrame("Frame", nil, rgn)
+            oocCogDis:SetAllPoints(oocCog)
+            oocCogDis:SetFrameLevel(oocCog:GetFrameLevel() + 5)
+            oocCogDis:EnableMouse(true)
+            oocCogDis:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(oocCog, EllesmereUI.DisabledTooltip("Class Resource"))
+            end)
+            oocCogDis:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            local function UpdateOocCogDis()
+                local c = cfg()
+                if c and not c.enabled then oocCogDis:Show(); oocCog:SetAlpha(0.15) else oocCogDis:Hide(); oocCog:SetAlpha(0.4) end
+            end
+            oocCog:HookScript("OnShow", UpdateOocCogDis)
+            EllesmereUI.RegisterWidgetRefresh(UpdateOocCogDis)
+            UpdateOocCogDis()
         end
 
         -- Resource Text + the bespoke threshold popup below operate purely on the

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1052,6 +1052,8 @@ local DEFAULTS = {
             offsetX     = 0,
             offsetY     = -64,
             barAlpha    = 1.0,
+            oocFadeEnabled = false,  -- "Fade Out of Combat" toggle (off by default)
+            oocAlpha    = 0.5,       -- alpha the bar fades to while out of combat
             visibility  = "always",  -- "always","combat","target","mouseover","never","in_combat","in_raid","in_party","solo"
             visHideHousing = false,
             visOnlyInstances = false,
@@ -1094,6 +1096,8 @@ local DEFAULTS = {
             offsetX     = 0,
             offsetY     = -54,
             barAlpha    = 1.0,
+            oocFadeEnabled = false,  -- "Fade Out of Combat" toggle (off by default)
+            oocAlpha    = 0.5,       -- alpha the bar fades to while out of combat
             visibility  = "always",  -- "always","combat","target","mouseover","never","in_combat","in_raid","in_party","solo"
             visHideHousing = false,
             visOnlyInstances = false,
@@ -1176,7 +1180,8 @@ local DEFAULTS = {
             visHideMounted = false,
             visHideNoTarget = false,
             visHideNoEnemy = false,
-            oocAlpha    = 1.0,
+            oocFadeEnabled = false,  -- "Fade Out of Combat" toggle (off by default)
+            oocAlpha    = 0.5,       -- alpha the bar fades to while out of combat
             offsetX     = 0,
             offsetY     = -38,
             -- Shift elements anchored to the class resource bar when the spec
@@ -1293,6 +1298,19 @@ local _erbEventFrame        -- file-scoped ref to the event frame (assigned in O
 local isInCombat = false
 local currentAlpha = 1
 local targetAlpha = 1
+
+-- Effective bar alpha. When "Fade Out of Combat" is enabled and the player is
+-- out of combat, the bar shows its chosen oocAlpha; otherwise its normal
+-- opacity. Off by default. Every SetAlpha site routes through this -- BuildBars
+-- sets bar alpha too, and some events (UNIT_MAXHEALTH/UNIT_MAXPOWER) rebuild
+-- without a following UpdateVisibility, so folding the fade in here keeps a
+-- rebuild from clobbering it. On ns (not a new local) to respect the 200-cap.
+function ns.ResolveBarAlpha(cfg)
+    if cfg and cfg.oocFadeEnabled and not isInCombat then
+        return cfg.oocAlpha or 0.5
+    end
+    return (cfg and cfg.barAlpha) or 1
+end
 local cachedClass
 local cachedPrimary
 local cachedSecondary
@@ -2618,7 +2636,7 @@ local function BuildBars()
             healthBar._text:SetTextColor(hp.textFillR or 1, hp.textFillG or 1, hp.textFillB or 1, hp.textFillA or 1)
         end
         healthBar:Show()
-        healthBar:SetAlpha(hp.barAlpha or 1)
+        healthBar:SetAlpha(ns.ResolveBarAlpha(hp))
         ApplyBarOrientation(healthBar, hpOri)
         if IsSpecDisabled(hp) then
             EllesmereUI.SetElementVisibility(healthBar, false)
@@ -2795,7 +2813,7 @@ local function BuildBars()
         if hidePower then
             EllesmereUI.SetElementVisibility(primaryBar, false)
         else
-            primaryBar:SetAlpha(pp.barAlpha or 1)
+            primaryBar:SetAlpha(ns.ResolveBarAlpha(pp))
         end
         ApplyBarOrientation(primaryBar, ppOri)
         if IsSpecDisabled(pp) then
@@ -3264,7 +3282,7 @@ local function BuildBars()
         end
 
         secondaryFrame:Show()
-        secondaryFrame:SetAlpha(sp.barAlpha or 1)
+        secondaryFrame:SetAlpha(ns.ResolveBarAlpha(sp))
     elseif secondaryFrame then
         -- Enabled but no resource for this spec: keep the frame positioned
         -- at zero alpha so anchored elements have a valid target.
@@ -4963,7 +4981,7 @@ local function UpdateVisibility()
         if hp and hp.enabled and not IsSpecDisabled(hp) and ShouldShowBar(hp) and not inVehicle then
             healthBar:Show()
             EllesmereUI.SetElementVisibility(healthBar, true)
-            healthBar:SetAlpha(hp.barAlpha or 1)
+            healthBar:SetAlpha(ns.ResolveBarAlpha(hp))
         else
             EllesmereUI.SetElementVisibility(healthBar, false)
         end
@@ -4979,7 +4997,7 @@ local function UpdateVisibility()
         if not hidePower and pp and pp.enabled ~= false and not IsSpecDisabled(pp) and cachedPrimary and ShouldShowBar(pp) and not inVehicle then
             primaryBar:Show()
             EllesmereUI.SetElementVisibility(primaryBar, true)
-            primaryBar:SetAlpha(pp.barAlpha or 1)
+            primaryBar:SetAlpha(ns.ResolveBarAlpha(pp))
         else
             EllesmereUI.SetElementVisibility(primaryBar, false)
         end
@@ -4991,9 +5009,7 @@ local function UpdateVisibility()
         if sp and sp.enabled ~= false and not IsSpecDisabled(sp) and cachedSecondary and ShouldShowSecondary() and not inVehicle then
             secondaryFrame:Show()
             EllesmereUI.SetElementVisibility(secondaryFrame, true)
-            local base = sp.barAlpha or 1
-            local ooc = isInCombat and 1 or (sp.oocAlpha or 1)
-            secondaryFrame:SetAlpha(base * ooc)
+            secondaryFrame:SetAlpha(ns.ResolveBarAlpha(sp))
         else
             EllesmereUI.SetElementVisibility(secondaryFrame, false)
         end
@@ -6921,6 +6937,9 @@ function ERB:ApplyAll()
     cachedClass = classFile
     cachedPrimary = GetPrimaryPowerType()
     cachedSecondary = GetSecondaryResource()
+    -- Seed combat state so a /reload mid-combat doesn't apply the OOC fade
+    -- during the fight (isInCombat otherwise only flips on PLAYER_REGEN).
+    isInCombat = InCombatLockdown()
 
     BuildMainFrame()
     BuildBars()

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -1605,6 +1605,7 @@ L["Only Color At/Above Threshold"] = "仅在阈值及以上着色"
 L["Show Power Bar"] = "显示能量条"
 L["Show Health Bar"] = "显示生命条"
 L["Enable Player Cast Bar"] = "启用玩家施法条"
+L["Out of Combat Opacity"] = "战斗外不透明度"
 L["When enabled, EUI relinquishes full control of friendly player nameplates to Blizzard."] = "启用后，EUI 会将友方玩家姓名板的控制权完全交还给暴雪。"
 
 -- == Unit Labels (from EUI_UnitFrames_Options.lua) ============================


### PR DESCRIPTION
## Overview

Adds a per-bar **out-of-combat fade** to the Resource Bars, so the Power, Class Resource, and Health bars can dim while you're out of combat and return to full opacity in combat.

Follows [#609](https://github.com/EllesmereGaming/EllesmereUI/pull/609), which added the same out-of-combat fade to the Cooldown Manager — this mirrors that behavior for the Resource Bars.

A cog on each bar's **Opacity** slider holds:

- **Fade Out of Combat** - toggle, off by default.
- **Opacity** - the alpha to fade to while out of combat (0–100%, default 50%). Greyed out until the toggle is on.

Both bars are independent, so you can set them to match.


## Background

Some setups keep the resource/power bars dimmed while idle and only bring them to full while fighting, to stay unobtrusive. It's a common WeakAuras setup (alpha conditions tied to combat state), and the Cooldown Manager already has an equivalent fade.

## Summary of Changes

### New per-bar properties

| Property | Default | Read by |
|---|---|---|
| `oocFadeEnabled` | `false` | `ns.ResolveBarAlpha` |
| `oocAlpha` | `0.5` | `ns.ResolveBarAlpha` |

Added to the `health`, `primary` (Power), and `secondary` (Class Resource) config blocks.

### Implementation details

- New accessor `ns.ResolveBarAlpha(cfg)` returns the fade alpha when `oocFadeEnabled` is on and the player is out of combat, otherwise the bar's `barAlpha`. When the fade is off (default) it returns exactly `barAlpha or 1`, so bars not using it render identically to before.
- Every place that set a bar's alpha now routes through this accessor — both `UpdateVisibility` and `BuildBars`. `BuildBars` also sets bar alpha and runs on some events (`UNIT_MAXHEALTH`/`UNIT_MAXPOWER`) without a following `UpdateVisibility`, so routing it through the accessor keeps a rebuild from clobbering the fade.
- Reacts to combat via the existing `PLAYER_REGEN_DISABLED/ENABLED → UpdateVisibility` path; no new events. Combat state is seeded in `ApplyAll` so a `/reload` mid-combat doesn't dim the bars during the fight.
- The UI is a cog on each Opacity slider (toggle + gated slider), matching the Cooldown Manager fade. `ns.ResolveBarAlpha` is exposed on `ns` (not a new local) to respect the file's 200-local cap. zhCN included.

## Testing

Tested in-game (retail):

- [x] Enable Fade Out of Combat on Health / Power / Class Resource, set opacity: bar dims out of combat, snaps to full in combat
- [x] All 3 bars independent; set to the same value to match
- [x] Toggle off (default): bars behave exactly as before, in and out of combat
- [x] Slider greyed until the toggle is on
- [x] Per-spec Advanced overrides apply; settings persist through /reload
- [x] Clean load, no Lua errors


## Example
<img width="1336" height="714" alt="resource bar" src="https://github.com/user-attachments/assets/c7c35682-7b21-4dd3-a964-5605594d53b7" />