### PR TITLE
feat(raidframes): hover tooltips on buff/HoT aura icons

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -776,6 +776,60 @@ local DD_SPELL_ICON_SIZE = 17  -- icon size in ability/own-only dropdown menus
 local BAR_POOL_SIZE  = 4
 local BMSIMPLE_CAP   = 10  -- max buffs the Simple Setup grid can show per button
 
+-- Hover tooltips for BuffManager aura icons/bars. Mirrors the Debuff Display
+-- tooltip pattern (see EllesmereUIRaidFrames StyleButton): OnEnter renders the
+-- aura by its instance ID, which is secret-safe — it works for fingerprinted
+-- secret auras too (Blizzard renders the real name we can't read). Mouse is
+-- enabled only when the buff "Hide Tooltips" setting is off; motion and clicks
+-- propagate to the parent button so click-casting keeps working underneath.
+local function BM_TooltipOnEnter(self)
+    local u, iid = self._tipUnit, self._tipIID
+    if not u or not iid or issecretvalue(iid) then return end
+    -- Honor the same "Show Raid Frames Tooltip" combat-visibility mode as the
+    -- unit/debuff tooltips so one setting governs every raid-frame hover tip.
+    if ns.RaidFrameTooltipAllowed and not ns.RaidFrameTooltipAllowed(self._ownerButton) then return end
+    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+    if GameTooltip.SetUnitAuraByAuraInstanceID then
+        GameTooltip:SetUnitAuraByAuraInstanceID(u, iid)
+    elseif GameTooltip.SetUnitBuffByAuraInstanceID then
+        GameTooltip:SetUnitBuffByAuraInstanceID(u, iid)
+    end
+    GameTooltip:Show()
+end
+
+local function BM_TooltipOnLeave()
+    GameTooltip:Hide()
+end
+
+-- Wire a pooled aura frame for hover tooltips once, at creation. Mouse starts
+-- disabled (transparent); BM_SetTipTarget toggles it live per the setting.
+local function BM_WireTooltip(f, button)
+    f._ownerButton = button
+    f:EnableMouse(false)
+    if f.SetPropagateMouseMotion then f:SetPropagateMouseMotion(true) end
+    if f.SetPropagateMouseClicks then f:SetPropagateMouseClicks(true) end
+    f:SetScript("OnEnter", BM_TooltipOnEnter)
+    f:SetScript("OnLeave", BM_TooltipOnLeave)
+end
+
+-- Stash the hover target (unit + aura instance) as a frame is assigned an aura,
+-- and toggle mouse interactivity to match the buff "Hide Tooltips" setting. Read
+-- live so a combat-time toggle applies on the next aura event. Default (nil) =
+-- tooltips shown. A missing/secret instance id disables the hover.
+local function BM_SetTipTarget(f, unit, iid)
+    f._tipUnit = unit
+    f._tipIID  = iid
+    -- db is a per-call parameter elsewhere in this file, not a file upvalue;
+    -- read the profile off the addon namespace so this file-scope helper is safe.
+    local prof = ns.db and ns.db.profile
+    local wantMouse = (not prof or prof.buffHideTooltips ~= true)
+        and iid ~= nil and not issecretvalue(iid)
+    if f._tipMouse ~= wantMouse then
+        f:EnableMouse(wantMouse)
+        f._tipMouse = wantMouse
+    end
+end
+
 function ns.BM_CreateIndicators(button, health, d, PP)
     if not health then return end
 
@@ -832,6 +886,7 @@ function ns.BM_CreateIndicators(button, health, d, PP)
         durFS:Hide()
         f._durText = durFS
 
+        BM_WireTooltip(f, button)
         iconPool[i] = f
     end
 
@@ -848,6 +903,7 @@ function ns.BM_CreateIndicators(button, health, d, PP)
         barBg:SetColorTexture(0, 0, 0, 0.5)
         bar._bg = barBg
 
+        BM_WireTooltip(bar, button)
         barPool[i] = bar
     end
 
@@ -910,6 +966,7 @@ function ns.BM_CreateIndicators(button, health, d, PP)
             f._borderFrame = bdr
         end
 
+        BM_WireTooltip(f, button)
         simplePool[i] = f
     end
     d.bmSimpleIcons = simplePool
@@ -1545,6 +1602,7 @@ function ns.BM_UpdateSimpleGrid(button, unit, db, updateInfo)
             shown = shown + 1
             d.bmSimpleActiveIDs[iid] = true
             local icon = d.bmSimpleIcons[shown]
+            BM_SetTipTarget(icon, unit, iid)
             icon:SetSize(sz, sz)
             icon._tex:SetTexture(tex or 136243)
             local _z = bs.iconZoom or 0.08
@@ -1820,6 +1878,7 @@ function ns.BM_UpdateIndicators(button, unit, db, updateInfo)
                     barPoolIdx = barPoolIdx + 1
                     local bar = d.bmBarPool[barPoolIdx]
                     if bar then
+                        BM_SetTipTarget(bar, unit, aura.auraInstanceID)
                         BM_ApplyBarLevel(bar, ind, buttonLvl)
                         bar:SetReverseFill(ind.reverseFill or false)
                         local c = ind.color or { r=0, g=1, b=0 }
@@ -1893,6 +1952,7 @@ function ns.BM_UpdateIndicators(button, unit, db, updateInfo)
                         iconPoolIdx = iconPoolIdx + 1
                         local f = d.bmIconPool[iconPoolIdx]
                         if f then
+                            BM_SetTipTarget(f, unit, aura.auraInstanceID)
                             BM_ApplyIconLevel(f, ind, buttonLvl)
                             -- Per-spell size offset (right-click in preview): base
                             -- size + this spell's offset, clamped to >= 1px.

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -3938,6 +3938,16 @@ initFrame:SetScript("OnEvent", function(self)
               getValue=function() return CurTooltipMode() end,
               setValue=function(v) SSet("tooltipMode", v) end });  y = y - h
 
+        -- Buff/HoT aura-icon tooltips (Buff Manager). Off by default -- matches the
+        -- long-standing behavior where buff icons showed no tooltip; opt in here.
+        -- When shown, the aura tip still follows the "Show Raid Frames Tooltip"
+        -- combat-visibility mode above (mode governs when, this governs whether).
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Hide Buff Tooltips",
+              tooltip="Hide the tooltip when hovering a buff/HoT icon on a raid or party frame.",
+              getValue=function() return SVal("buffHideTooltips", true) end,
+              setValue=function(v) SSet("buffHideTooltips", v); if ns.ReloadFrames then ns.ReloadFrames() end end });  y = y - h
+
         -- Hide Blizzard Party Panel. Shares the exact same global setting and
         -- apply function as the QoL module's toggle (EllesmereUIDB.hideBlizzardPartyFrame
         -- -> EllesmereUI._applyHideBlizzardPartyFrame); the QoL toggle is disabled

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -687,6 +687,7 @@ local defaults = {
             durTextOffsetY  = 0,
         },
 
+        buffHideTooltips = true,
         debuffSize       = 18,
         debuffCap        = 3,
         debuffHideTooltips = true,
@@ -813,6 +814,22 @@ ns._ResolveTooltipMode = function(s)
     if s.showTooltip == false then return "never" end
     if EllesmereUIDB and EllesmereUIDB.showUnitTooltipsInCombat then return "always" end
     return "outOfCombat"
+end
+
+-- Whether raid-frame hover tooltips are allowed right now, per the "Show Raid
+-- Frames Tooltip" mode + current combat state. Shared by the unit tooltip and
+-- the buff/debuff aura-icon tooltips so one setting governs every raid-frame
+-- tip (an aura tip is still gated by its own "Hide Tooltips" toggle on top).
+function ns.RaidFrameTooltipAllowed(button)
+    local fd = button and ns.GetFFD and ns.GetFFD(button)
+    local s = (fd and (fd._isParty and ns._scaledPartyProxy
+        or (fd._isExtra and ns._scaledExtraProxy) or ns._scaledProfile))
+        or ns._scaledProfile
+    local ttMode = ns._ResolveTooltipMode(s)
+    if ttMode == "never" then return false end
+    if ttMode == "outOfCombat" and inCombat then return false end
+    if ttMode == "outOfBossCombat" and ns._inBossCombat then return false end
+    return true
 end
 
 -------------------------------------------------------------------------------
@@ -3377,6 +3394,8 @@ local function StyleButton(button)
                 fd._hovered = true
                 if fd.ApplyBorderColor then fd.ApplyBorderColor() end
             end
+            -- Aura tooltip honors the same combat-visibility mode as the unit tip.
+            if not ns.RaidFrameTooltipAllowed(b) then return end
             GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
             if GameTooltip.SetUnitAuraByAuraInstanceID then
                 GameTooltip:SetUnitAuraByAuraInstanceID(u, iid)
@@ -3725,6 +3744,17 @@ local function StyleButton(button)
         local fd = GetFFD(self)
         fd._hovered = true
         if fd.ApplyBorderColor then fd.ApplyBorderColor() end
+        -- Aura icons (buff/debuff) enable mouse and propagate motion up to this
+        -- button, so a direct enter onto an icon fires the icon's OnEnter first
+        -- (aura tooltip) then bubbles here -- which would clobber it with the unit
+        -- tooltip. If the cursor is genuinely over one of our aura icons (marked by
+        -- a stashed _tipIID), let that icon own the tooltip and bail here.
+        local foci = (GetMouseFoci and GetMouseFoci()) or (GetMouseFocus and { GetMouseFocus() })
+        if foci then
+            for _, mf in ipairs(foci) do
+                if mf ~= self and mf._tipIID ~= nil then return end
+            end
+        end
         -- Read through the party-aware proxy (like every other render path), not
         -- raw db.profile -- otherwise party_<key> overrides written by a custom
         -- party "Range & Tooltip" section are never seen and the tooltip mode


### PR DESCRIPTION
## What

Adds hover tooltips to buff/HoT aura icons on raid & party frames (Buff Manager), and unifies aura-tooltip visibility with the existing unit tooltip.

## Details

- **Buff/HoT tooltips (new):** wired across all Buff Manager icon pools — custom indicators, squares/bars, and the Simple Setup grid — using `GameTooltip:SetUnitAuraByAuraInstanceID`, which is secret-safe (names fingerprinted secret auras in instances too, matching the existing debuff path).
- **Combat-visibility gating:** buff *and* debuff aura tooltips now honor the same "Show Raid Frames Tooltip" mode (never / out of combat / out of boss combat / always) as the unit tooltip, via a shared `ns.RaidFrameTooltipAllowed`. The mode governs *when*; each aura toggle governs *whether*.
- **Direct-entry race fix:** entering an icon straight from outside the frame previously showed the unit (player) tooltip instead of the aura, because the parent button's `OnEnter` bubbles after the icon's and clobbered it. The button now bails if the cursor is genuinely over an aura icon (covers the pre-existing debuff path too).
- **Options:** new "Hide Buff Tooltips" toggle under Raid Frames → Range & Tooltip. Both buff and debuff aura tooltips default to **hidden** (opt-in), matching prior behavior — no change for existing users unless they enable it.

## Files

- `EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua` — shared `RaidFrameTooltipAllowed` gate, debuff-tooltip combat gating, button `OnEnter` race fix, `buffHideTooltips` default.
- `EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua` — buff-icon tooltip wiring (all pools).
- `EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua` — "Hide Buff Tooltips" option + default.

## Testing

- Out of combat, hover buff/HoT and debuff icons → shows the aura name (when enabled).
- Direct-entry onto an icon from outside the frame → shows the aura, not the player.
- Combat mode respected: with "Out of Combat", aura tooltips hide in combat.
- Click-casting still works through icons (mouse motion/clicks propagate to the button).
- `luac5.1 -p` clean on all three files.

## Notes

The new option label is a dynamic (`text=`) string, so it isn't in the static `Locales/_keys.txt` (same as sibling option labels like "Hide Tooltips"); it falls back to English and can be harvested via `/euiloc`.
