### PR TITLE
Feature: Add customization options for Blizzard Aura Frames (Buff & Debuffs)

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -15212,6 +15212,150 @@ initFrame:SetScript("OnEvent", function(self)
     ---------------------------------------------------------------------------
     --  Player Buffs & Debuffs page
     ---------------------------------------------------------------------------
+    local auraTextPosValues = {
+        ["bottom"] = "Bottom",
+        ["top"]    = "Top",
+    }
+    local auraTextPosOrder = { "bottom", "top" }
+
+
+    -- Local, purpose-built copy of the general BuildColorGrid layout pattern
+    -- (that helper lives as an unexported closure inside BuildColorsPage in
+    -- EUI__General_Options.lua). This is just enough to lay out the 6
+    -- debuff-type swatches below -- not a general/reusable API, and not
+    -- wired into the global color system in any way.
+    local function HexColor(hex)
+        local r = tonumber(hex:sub(1, 2), 16) / 255
+        local g = tonumber(hex:sub(3, 4), 16) / 255
+        local b = tonumber(hex:sub(5, 6), 16) / 255
+        return r, g, b
+    end
+
+    -- Mirrors EllesmereUIUnitFrames_PlayerAuras.lua's DEBUFF_TYPE_DEFAULT_HEX
+    -- so the swatch shows the correct color before any DB value is set.
+    local DEBUFF_TYPE_DEFAULT_HEX = {
+        None = "e63333",
+        Magic = "3399ff",
+        Curse = "9900ff",
+        Disease = "996600",
+        Poison = "009900",
+        Bleed = "ff3399",
+    }
+
+    -- Order/labels/DB-prefixes match DEBUFF_TYPE_DB_PREFIX in
+    -- EllesmereUIUnitFrames_PlayerAuras.lua.
+    local DEBUFF_TYPE_GRID = {
+        { key = "None",    db = "debuffTypeColorNone" },
+        { key = "Magic",   db = "debuffTypeColorMagic" },
+        { key = "Curse",   db = "debuffTypeColorCurse" },
+        { key = "Disease", db = "debuffTypeColorDisease" },
+        { key = "Poison",  db = "debuffTypeColorPoison" },
+        { key = "Bleed",   db = "debuffTypeColorBleed" },
+    }
+
+    -- 2-column grid of debuff-type border-color swatches, built from the
+    -- same W:DualRow row system every other setting on this page uses
+    -- (rather than a bespoke frame layout) so it matches spacing, row
+    -- height, and label styling automatically.
+    -- PAGet/PASet are the same accessor closures BuildPlayerAurasPage uses
+    -- for every other playerAuras setting on this page.
+    local function BuildDebuffTypeColorGrid(parent, y, PAGet, PASet, isDisabledFn)
+        local W = EllesmereUI.Widgets
+        local totalH = 0
+        local cells = {}
+        local CB_SPLITS = { 0.333, 0.333, 0.334, rowHeight = 50 }
+
+        local function AddSwatch(rgn, entry)
+            if not (rgn and entry) then return end
+            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
+                rgn, rgn:GetFrameLevel() + 3,
+                function()
+                    local r = PAGet(entry.db .. "R")
+                    local g = PAGet(entry.db .. "G")
+                    local b = PAGet(entry.db .. "B")
+                    local a = PAGet(entry.db .. "A")
+                    if r == nil then
+                        r, g, b = HexColor(DEBUFF_TYPE_DEFAULT_HEX[entry.key])
+                    end
+                    return r or 1, g or 1, b or 1, a or 1
+                end,
+                function(r, g, b, a)
+                    PASet(entry.db .. "R", r)
+                    PASet(entry.db .. "G", g)
+                    PASet(entry.db .. "B", b)
+                    PASet(entry.db .. "A", a)
+                    if ns.InvalidateDispelCurve then ns.InvalidateDispelCurve() end
+                end,
+                true, 18)
+            PP.Point(swatch, "RIGHT", rgn, "RIGHT", -20, 0)
+            cells[#cells + 1] = { label = rgn, swatch = swatch, update = updateSwatch }
+        end
+
+        for i = 1, #DEBUFF_TYPE_GRID, 3 do
+            local leftEntry  = DEBUFF_TYPE_GRID[i]
+            local midEntry   = DEBUFF_TYPE_GRID[i + 1]
+            local rightEntry = DEBUFF_TYPE_GRID[i + 2]
+
+            local row, rh    = W:TripleRow(parent, y,
+                {
+                    type = "label",
+                    text = leftEntry.key,
+                    disabled = isDisabledFn
+                },
+                midEntry and {
+                    type = "label",
+                    text = midEntry.key,
+                    disabled = isDisabledFn
+                },
+                rightEntry and {
+                    type = "label",
+                    text = rightEntry.key,
+                    disabled = isDisabledFn
+                } or { type = "label", text = "" },
+                CB_SPLITS
+            )
+
+            y                = y - rh
+            totalH           = totalH + rh
+
+            AddSwatch(row._leftRegion, leftEntry)
+            AddSwatch(row._midRegion, midEntry)
+            AddSwatch(row._rightRegion, rightEntry)
+        end
+
+        local function Refresh()
+            local off = isDisabledFn and isDisabledFn()
+            for _, c in ipairs(cells) do
+                c.update()
+                c.swatch:SetAlpha(off and 0.3 or 1)
+                c.swatch:EnableMouse(not off)
+
+                c.label:SetAlpha(off and 0.3 or 1)
+            end
+        end
+        Refresh()
+        EllesmereUI.RegisterWidgetRefresh(Refresh)
+
+        return totalH
+    end
+    -- Local cog-button helper (mirrors the shared MakeCogBtn pattern used
+    -- elsewhere, but that helper is scoped to BuildSharedSettings only).
+    local function PAMakeCogBtn(rgn, showFn)
+        local cogBtn = CreateFrame("Button", nil, rgn)
+        cogBtn:SetSize(26, 26)
+        cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+        rgn._lastInline = cogBtn
+        cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+        local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+        cogTex:SetAllPoints()
+        cogTex:SetTexture(EllesmereUI.COGS_ICON)
+        cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+        cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+        cogBtn:SetScript("OnClick", function(self) showFn(self) end)
+        cogBtn:SetAlpha(0.4)
+        return cogBtn
+    end
+
     local function BuildPlayerAurasPage(pageName, parent, yOffset)
         local W = EllesmereUI.Widgets
         local y = yOffset
@@ -15227,6 +15371,7 @@ initFrame:SetScript("OnEvent", function(self)
             db.profile.playerAuras[key] = v
             if ns.RefreshPlayerAuras then ns.RefreshPlayerAuras() end
             if ns.ApplyPlayerAuraScale then ns.ApplyPlayerAuraScale() end
+            if ns.ApplyPlayerAuraPadding then ns.ApplyPlayerAuraPadding() end
         end
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
@@ -15238,23 +15383,34 @@ initFrame:SetScript("OnEvent", function(self)
         local function PAOff() return not PAGet("enabled") end
         local paRow1
         paRow1, h = W:DualRow(parent, y,
-            { type = "toggle", text = "Enable Styled Buffs & Debuffs",
-              setValue = EllesmereUI.SectionToggleSetValue(function(v)
-                  PASet("enabled", v)
-                  EllesmereUI:ShowConfirmPopup({
-                      title   = "Reload Required",
-                      message = "This change requires a UI reload to take effect.",
-                      confirmText = "Reload Now",
-                      cancelText  = "Later",
-                      onConfirm = function() ReloadUI() end,
-                  })
-              end),
-              getValue = function() return PAGet("enabled") or false end },
-            { type = "slider", text = "Icon Size", min = 16, max = 60, step = 1,
-              disabled = PAOff, disabledTooltip = "Enable Styled Buffs & Debuffs first", rawTooltip = true,
-              getValue = function() return PAGet("iconSize") or 32 end,
-              setValue = function(v) PASet("iconSize", v) end }
-        );  y = y - h
+            {
+                type = "toggle",
+                text = "Enable Styled Buffs & Debuffs",
+                setValue = EllesmereUI.SectionToggleSetValue(function(v)
+                    PASet("enabled", v)
+                    EllesmereUI:ShowConfirmPopup({
+                        title       = "Reload Required",
+                        message     = "This change requires a UI reload to take effect.",
+                        confirmText = "Reload Now",
+                        cancelText  = "Later",
+                        onConfirm   = function() ReloadUI() end,
+                    })
+                end),
+                getValue = function() return PAGet("enabled") or false end
+            },
+            {
+                type = "slider",
+                text = "Icon Size",
+                min = 16,
+                max = 60,
+                step = 1,
+                disabled = PAOff,
+                disabledTooltip = "Enable Styled Buffs & Debuffs first",
+                rawTooltip = true,
+                getValue = function() return PAGet("iconSize") or 32 end,
+                setValue = function(v) PASet("iconSize", v) end
+            }
+        ); y = y - h
 
         -- Inline cog: Icon Zoom (next to "Icon Size"). Buffs and debuffs
         -- crop independently.
@@ -15263,12 +15419,24 @@ initFrame:SetScript("OnEvent", function(self)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Icon Zoom",
                 rows = {
-                    { type = "slider", label = "Buff Zoom", min = 0, max = 0.20, step = 0.01,
-                      get = function() return PAGet("buffIconZoom") or 0.055 end,
-                      set = function(v) PASet("buffIconZoom", v) end },
-                    { type = "slider", label = "Debuff Zoom", min = 0, max = 0.20, step = 0.01,
-                      get = function() return PAGet("debuffIconZoom") or 0.055 end,
-                      set = function(v) PASet("debuffIconZoom", v) end },
+                    {
+                        type = "slider",
+                        label = "Buff Zoom",
+                        min = 0,
+                        max = 0.20,
+                        step = 0.01,
+                        get = function() return PAGet("buffIconZoom") or 0.055 end,
+                        set = function(v) PASet("buffIconZoom", v) end
+                    },
+                    {
+                        type = "slider",
+                        label = "Debuff Zoom",
+                        min = 0,
+                        max = 0.20,
+                        step = 0.01,
+                        get = function() return PAGet("debuffIconZoom") or 0.055 end,
+                        set = function(v) PASet("debuffIconZoom", v) end
+                    },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -15302,192 +15470,407 @@ initFrame:SetScript("OnEvent", function(self)
         -- Rows 2-4 are hidden entirely while the section is disabled (the
         -- enable toggle's SectionToggleSetValue wrapper forces the rebuild).
         if PAGet("enabled") then
-
-        -- Row 2: Show Text | Text Size (+ inline Duration Format cog)
-        local paRow2
-        paRow2, h = W:DualRow(parent, y,
-            { type = "toggle", text = "Show Text",
-              getValue = function() return PAGet("showText") ~= false end,
-              setValue = function(v) PASet("showText", v) end },
-            { type = "slider", text = "Text Size", min = 6, max = 24, step = 1,
-              getValue = function() return PAGet("textSize") or 11 end,
-              setValue = function(v) PASet("textSize", v) end }
-        );  y = y - h
-
-        -- Inline cog: Duration Format (next to "Text Size").
-        do
-            local rgn = paRow2._rightRegion
-            local _, cogShow = EllesmereUI.BuildCogPopup({
-                title = "Duration Format",
-                rows = {
-                    { type = "dropdown", label = "Format",
-                      values = {
-                          blizzard = { text = "Blizzard Default (2 min)" },
-                          compact  = { text = "Standard (5m / 32)" },
-                          colon    = { text = "Colon (5:32)" },
-                          seconds  = { text = "Seconds (152)" },
-                      },
-                      order = { "blizzard", "compact", "colon", "seconds" },
-                      get = function() return PAGet("durationFormat") or "blizzard" end,
-                      set = function(v) PASet("durationFormat", v) end },
+            -- Row 2: Show Text | Text Size (+ inline Duration Format cog)
+            _, h = W:DualRow(parent, y,
+                {
+                    type = "toggle",
+                    text = "Show Text",
+                    getValue = function() return PAGet("showText") ~= false end,
+                    setValue = function(v) PASet("showText", v) end
                 },
-            })
-            local cogBtn = CreateFrame("Button", nil, rgn)
-            cogBtn:SetSize(26, 26)
-            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-            rgn._lastInline = cogBtn
-            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
-            cogBtn:SetAlpha(0.4)
-            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
-            cogTex:SetAllPoints()
-            cogTex:SetTexture(EllesmereUI.COGS_ICON)
-            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
-            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
-            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
-        end
+                {
+                    type = "dropdown",
+                    text = "Duration Format",
+                    tooltip =
+                    "How aura duration text is written. All styles except Blizzard Default are short and locale-independent, so they never overflow the icon.",
+                    values = {
+                        blizzard = { text = "Blizzard Default (2 min)" },
+                        compact  = { text = "Standard (5m / 32)" },
+                        colon    = { text = "Colon (5:32)" },
+                        seconds  = { text = "Seconds (152)" },
+                    },
+                    order = { "blizzard", "compact", "colon", "seconds" },
+                    getValue = function() return PAGet("durationFormat") or "blizzard" end,
+                    setValue = function(v) PASet("durationFormat", v) end
+                }
+            ); y = y - h
 
-        -- Row 3: Border Style | Border Size (+ inline color swatch)
-        do
-            local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
-            local borderSizeValues = {
-                none = "None", thin = "Thin", normal = "Normal",
-                heavy = "Heavy", strong = "Strong",
-            }
-            local borderSizeOrder = { "none", "thin", "normal", "heavy", "strong" }
-            local borderSizeToNumber = { none = 0, thin = 1, normal = 2, heavy = 3, strong = 4 }
-            local borderNumberToSize = { [0] = "none", [1] = "thin", [2] = "normal", [3] = "heavy", [4] = "strong" }
-            local bsRow
-            bsRow, h = W:DualRow(parent, y,
-                { type = "dropdown", text = "Border Style",
-                  values = texValues, order = texOrder,
-                  getValue = function() return PAGet("borderTexture") or "solid" end,
-                  setValue = function(v)
-                      local color, behind = EllesmereUI.GetBorderStyleSelectDefaults(v)
-                      PASet("borderTexture", v)
-                      PASet("borderTextureOffset", nil); PASet("borderTextureOffsetY", nil)
-                      PASet("borderTextureShiftX", nil); PASet("borderTextureShiftY", nil)
-                      PASet("borderBehind", behind)
-                      PASet("borderR", color.r); PASet("borderG", color.g); PASet("borderB", color.b)
-                      PASet("borderA", 1)
-                      local defSz = EllesmereUI.GetBorderDefaultSize("unitframes", v)
-                      if defSz then PASet("borderSize", defSz) end
-                  end },
-                { type = "dropdown", text = "Border Size",
-                  values = borderSizeValues, order = borderSizeOrder,
-                  getValue = function()
-                      return borderNumberToSize[PAGet("borderSize") or 1] or "thin"
-                  end,
-                  setValue = function(v) PASet("borderSize", borderSizeToNumber[v] or 1) end }
-            );  y = y - h
-
-            -- Textured-border offset and layer controls.
+            -- Row 3: Stacks: Position (dropdown, + cog for X/Y offset) | Stacks: Text Size
             do
-                local rgn = bsRow._leftRegion
-                local _, cogShow = EllesmereUI.BuildCogPopup({
-                    title = "Border Offset",
+                local stackRow
+                stackRow, h = W:DualRow(parent, y,
+                    {
+                        type = "dropdown",
+                        text = "Stacks: Position",
+                        values = auraTextPosValues,
+                        order = auraTextPosOrder,
+                        getValue = function() return PAGet("stackPosition") or "bottom" end,
+                        setValue = function(v) PASet("stackPosition", v) end
+                    },
+                    {
+                        type = "slider",
+                        text = "Stacks: Text Size",
+                        min = 6,
+                        max = 24,
+                        step = 1,
+                        getValue = function() return PAGet("stackTextSize") or 11 end,
+                        setValue = function(v) PASet("stackTextSize", v) end
+                    }
+                ); y = y - h
+
+                local rgn = stackRow._leftRegion
+                local _, stackCogShow = EllesmereUI.BuildCogPopup({
+                    title = "Stacks Position Offsets",
                     rows = {
-                        { type = "slider", label = "Offset X", min = -10, max = 10, step = 1,
-                          get = function()
-                              local v = PAGet("borderTextureOffset")
-                              if v ~= nil then return v end
-                              return EllesmereUI.GetBorderDefaults("unitframes", PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
-                          end,
-                          set = function(v) PASet("borderTextureOffset", v) end },
-                        { type = "slider", label = "Offset Y", min = -10, max = 10, step = 1,
-                          get = function()
-                              local v = PAGet("borderTextureOffsetY")
-                              if v ~= nil then return v end
-                              local _, oy = EllesmereUI.GetBorderDefaults("unitframes", PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
-                              return oy
-                          end,
-                          set = function(v) PASet("borderTextureOffsetY", v) end },
-                        { type = "slider", label = "Shift X", min = -10, max = 10, step = 1,
-                          get = function()
-                              local v = PAGet("borderTextureShiftX")
-                              if v ~= nil then return v end
-                              local _, _, sx = EllesmereUI.GetBorderDefaults("unitframes", PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
-                              return sx
-                          end,
-                          set = function(v) PASet("borderTextureShiftX", v == 0 and nil or v) end },
-                        { type = "slider", label = "Shift Y", min = -10, max = 10, step = 1,
-                          get = function()
-                              local v = PAGet("borderTextureShiftY")
-                              if v ~= nil then return v end
-                              local _, _, _, sy = EllesmereUI.GetBorderDefaults("unitframes", PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
-                              return sy
-                          end,
-                          set = function(v) PASet("borderTextureShiftY", v == 0 and nil or v) end },
-                        { type = "toggle", label = "Show Behind",
-                          get = function() return PAGet("borderBehind") or false end,
-                          set = function(v) PASet("borderBehind", v) end },
+                        {
+                            type = "slider",
+                            label = "X Offset",
+                            min = -50,
+                            max = 50,
+                            step = 1,
+                            get = function() return PAGet("stackOffsetX") or 0 end,
+                            set = function(v) PASet("stackOffsetX", v) end
+                        },
+                        {
+                            type = "slider",
+                            label = "Y Offset",
+                            min = -50,
+                            max = 50,
+                            step = 1,
+                            get = function() return PAGet("stackOffsetY") or 0 end,
+                            set = function(v) PASet("stackOffsetY", v) end
+                        },
                     },
                 })
-                local cogBtn = CreateFrame("Button", nil, rgn)
-                cogBtn:SetSize(26, 26)
-                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-                rgn._lastInline = cogBtn
-                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
-                cogBtn:SetAlpha(0.4)
-                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
-                cogTex:SetAllPoints()
-                cogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
-                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
-                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
-                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
-                local function UpdateCogVis()
-                    if (PAGet("borderTexture") or "solid") == "solid" then cogBtn:Hide() else cogBtn:Show() end
-                end
-                EllesmereUI.RegisterWidgetRefresh(UpdateCogVis)
-                UpdateCogVis()
+                PAMakeCogBtn(rgn, stackCogShow)
             end
 
-            -- Inline border color swatch on Border Size dropdown
+            -- Row 4: Duration: Position (dropdown, + cog for X/Y offset) | Duration: Text Size
             do
-                local rgn = bsRow._rightRegion
-                local borderSwatch, updateBorderSwatch = EllesmereUI.BuildColorSwatch(
-                    rgn, bsRow:GetFrameLevel() + 3,
-                    function()
-                        return (PAGet("borderR") or 0), (PAGet("borderG") or 0),
-                               (PAGet("borderB") or 0), (PAGet("borderA") or 1)
-                    end,
-                    function(r, g, b, a)
-                        PASet("borderR", r); PASet("borderG", g); PASet("borderB", b); PASet("borderA", a)
-                    end,
-                    true, 20)
-                PP.Point(borderSwatch, "RIGHT", rgn._control, "LEFT", -8, 0)
-                -- Disable swatch when border size is 0
-                local borderSwatchBlock = CreateFrame("Frame", nil, borderSwatch)
-                borderSwatchBlock:SetAllPoints()
-                borderSwatchBlock:SetFrameLevel(borderSwatch:GetFrameLevel() + 10)
-                borderSwatchBlock:EnableMouse(true)
-                borderSwatchBlock:SetScript("OnEnter", function()
-                    EllesmereUI.ShowWidgetTooltip(borderSwatch, EllesmereUI.DisabledTooltip("This option requires a Border Size above 0."))
-                end)
-                borderSwatchBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-                local function UpdateBorderSwatchState()
-                    local noBorder = (PAGet("borderSize") or 0) == 0
-                    if noBorder then borderSwatch:SetAlpha(0.3); borderSwatchBlock:Show()
-                    else borderSwatch:SetAlpha(1); borderSwatchBlock:Hide() end
-                end
-                EllesmereUI.RegisterWidgetRefresh(function() updateBorderSwatch(); UpdateBorderSwatchState() end)
-                UpdateBorderSwatchState()
+                local durRow
+                durRow, h = W:DualRow(parent, y,
+                    {
+                        type = "dropdown",
+                        text = "Duration: Position",
+                        values = auraTextPosValues,
+                        order = auraTextPosOrder,
+                        getValue = function() return PAGet("durationPosition") or "bottom" end,
+                        setValue = function(v) PASet("durationPosition", v) end
+                    },
+                    {
+                        type = "slider",
+                        text = "Duration: Text Size",
+                        min = 6,
+                        max = 24,
+                        step = 1,
+                        getValue = function() return PAGet("durationTextSize") or 11 end,
+                        setValue = function(v) PASet("durationTextSize", v) end
+                    }
+                ); y = y - h
+
+                local rgn = durRow._leftRegion
+                local _, durCogShow = EllesmereUI.BuildCogPopup({
+                    title = "Duration Position Offsets",
+                    rows = {
+                        {
+                            type = "slider",
+                            label = "X Offset",
+                            min = -50,
+                            max = 50,
+                            step = 1,
+                            get = function() return PAGet("durationOffsetX") or 0 end,
+                            set = function(v) PASet("durationOffsetX", v) end
+                        },
+                        {
+                            type = "slider",
+                            label = "Y Offset",
+                            min = -50,
+                            max = 50,
+                            step = 1,
+                            get = function() return PAGet("durationOffsetY") or 0 end,
+                            set = function(v) PASet("durationOffsetY", v) end
+                        },
+                    },
+                })
+                PAMakeCogBtn(rgn, durCogShow)
             end
-        end
 
-        -- Row 4: Blizzard debuff borders | buff-frame expand button.
-        _, h = W:DualRow(parent, y,
-            { type = "toggle", text = "No Border on Debuffs",
-              tooltip = "When enabled, debuff icons keep Blizzard's colored border instead of using the custom border.",
-              getValue = function() return PAGet("noBorderDebuffs") ~= false end,
-              setValue = function(v) PASet("noBorderDebuffs", v) end },
-            { type = "toggle", text = "Show Expand Button",
-              getValue = function() return PAGet("showExpandButton") ~= false end,
-              setValue = function(v) PASet("showExpandButton", v) end }
-        );  y = y - h
+            -- Row 5: Border Style | Border Size (+ inline color swatch)
+            do
+                local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
+                local borderSizeValues = {
+                    none = "None",
+                    thin = "Thin",
+                    normal = "Normal",
+                    heavy = "Heavy",
+                    strong = "Strong",
+                }
+                local borderSizeOrder = { "none", "thin", "normal", "heavy", "strong" }
+                local borderSizeToNumber = { none = 0, thin = 1, normal = 2, heavy = 3, strong = 4 }
+                local borderNumberToSize = { [0] = "none", [1] = "thin", [2] = "normal", [3] = "heavy", [4] =
+                "strong" }
+                local bsRow
+                bsRow, h = W:DualRow(parent, y,
+                    {
+                        type = "dropdown",
+                        text = "Border Style",
+                        values = texValues,
+                        order = texOrder,
+                        getValue = function() return PAGet("borderTexture") or "solid" end,
+                        setValue = function(v)
+                            local color, behind = EllesmereUI.GetBorderStyleSelectDefaults(v)
+                            PASet("borderTexture", v)
+                            PASet("borderTextureOffset", nil); PASet("borderTextureOffsetY", nil)
+                            PASet("borderTextureShiftX", nil); PASet("borderTextureShiftY", nil)
+                            PASet("borderBehind", behind)
+                            PASet("borderR", color.r); PASet("borderG", color.g); PASet("borderB", color.b)
+                            PASet("borderA", 1)
+                            local defSz = EllesmereUI.GetBorderDefaultSize("unitframes", v)
+                            if defSz then PASet("borderSize", defSz) end
+                        end
+                    },
+                    {
+                        type = "dropdown",
+                        text = "Border Size",
+                        values = borderSizeValues,
+                        order = borderSizeOrder,
+                        getValue = function()
+                            return borderNumberToSize[PAGet("borderSize") or 1] or "thin"
+                        end,
+                        setValue = function(v) PASet("borderSize", borderSizeToNumber[v] or 1) end
+                    }
+                ); y = y - h
 
+                -- Textured-border offset and layer controls.
+                do
+                    local rgn = bsRow._leftRegion
+                    local _, cogShow = EllesmereUI.BuildCogPopup({
+                        title = "Border Offset",
+                        rows = {
+                            {
+                                type = "slider",
+                                label = "Offset X",
+                                min = -10,
+                                max = 10,
+                                step = 1,
+                                get = function()
+                                    local v = PAGet("borderTextureOffset")
+                                    if v ~= nil then return v end
+                                    return EllesmereUI.GetBorderDefaults("unitframes",
+                                        PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
+                                end,
+                                set = function(v) PASet("borderTextureOffset", v) end
+                            },
+                            {
+                                type = "slider",
+                                label = "Offset Y",
+                                min = -10,
+                                max = 10,
+                                step = 1,
+                                get = function()
+                                    local v = PAGet("borderTextureOffsetY")
+                                    if v ~= nil then return v end
+                                    local _, oy = EllesmereUI.GetBorderDefaults("unitframes",
+                                        PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
+                                    return oy
+                                end,
+                                set = function(v) PASet("borderTextureOffsetY", v) end
+                            },
+                            {
+                                type = "slider",
+                                label = "Shift X",
+                                min = -10,
+                                max = 10,
+                                step = 1,
+                                get = function()
+                                    local v = PAGet("borderTextureShiftX")
+                                    if v ~= nil then return v end
+                                    local _, _, sx = EllesmereUI.GetBorderDefaults("unitframes",
+                                        PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
+                                    return sx
+                                end,
+                                set = function(v) PASet("borderTextureShiftX", v == 0 and nil or v) end
+                            },
+                            {
+                                type = "slider",
+                                label = "Shift Y",
+                                min = -10,
+                                max = 10,
+                                step = 1,
+                                get = function()
+                                    local v = PAGet("borderTextureShiftY")
+                                    if v ~= nil then return v end
+                                    local _, _, _, sy = EllesmereUI.GetBorderDefaults("unitframes",
+                                        PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
+                                    return sy
+                                end,
+                                set = function(v) PASet("borderTextureShiftY", v == 0 and nil or v) end
+                            },
+                            {
+                                type = "toggle",
+                                label = "Show Behind",
+                                get = function() return PAGet("borderBehind") or false end,
+                                set = function(v) PASet("borderBehind", v) end
+                            },
+                        },
+                    })
+                    local cogBtn = CreateFrame("Button", nil, rgn)
+                    cogBtn:SetSize(26, 26)
+                    cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                    rgn._lastInline = cogBtn
+                    cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+                    cogBtn:SetAlpha(0.4)
+                    local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+                    cogTex:SetAllPoints()
+                    cogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+                    cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+                    cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+                    cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+                    local function UpdateCogVis()
+                        if (PAGet("borderTexture") or "solid") == "solid" then cogBtn:Hide() else cogBtn:Show() end
+                    end
+                    EllesmereUI.RegisterWidgetRefresh(UpdateCogVis)
+                    UpdateCogVis()
+                end
+
+                -- Inline border color swatch on Border Size dropdown
+                do
+                    local rgn = bsRow._rightRegion
+                    local borderSwatch, updateBorderSwatch = EllesmereUI.BuildColorSwatch(
+                        rgn, bsRow:GetFrameLevel() + 3,
+                        function()
+                            return (PAGet("borderR") or 0), (PAGet("borderG") or 0),
+                                (PAGet("borderB") or 0), (PAGet("borderA") or 1)
+                        end,
+                        function(r, g, b, a)
+                            PASet("borderR", r); PASet("borderG", g); PASet("borderB", b); PASet("borderA", a)
+                        end,
+                        true, 20)
+                    PP.Point(borderSwatch, "RIGHT", rgn._control, "LEFT", -8, 0)
+                    -- Disable swatch when border size is 0
+                    local borderSwatchBlock = CreateFrame("Frame", nil, borderSwatch)
+                    borderSwatchBlock:SetAllPoints()
+                    borderSwatchBlock:SetFrameLevel(borderSwatch:GetFrameLevel() + 10)
+                    borderSwatchBlock:EnableMouse(true)
+                    borderSwatchBlock:SetScript("OnEnter", function()
+                        EllesmereUI.ShowWidgetTooltip(borderSwatch,
+                            EllesmereUI.DisabledTooltip("This option requires a Border Size above 0."))
+                    end)
+                    borderSwatchBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                    local function UpdateBorderSwatchState()
+                        local noBorder = (PAGet("borderSize") or 0) == 0
+                        if noBorder then
+                            borderSwatch:SetAlpha(0.3); borderSwatchBlock:Show()
+                        else
+                            borderSwatch:SetAlpha(1); borderSwatchBlock:Hide()
+                        end
+                    end
+                    EllesmereUI.RegisterWidgetRefresh(function()
+                        updateBorderSwatch(); UpdateBorderSwatchState()
+                    end)
+                    UpdateBorderSwatchState()
+                end
+            end
+
+            _, h = W:SectionHeader(parent, "MISC", y); y = y - h
+
+            -- Row 1: Hide Blizzard Border / Skin Textures | Hide Collapsing Arrow
+            _, h = W:DualRow(parent, y,
+                {
+                    type = "toggle",
+                    text = "Hide Blizzard Border / Skin Textures",
+                    tooltip =
+                    "Removes any additional Blizzard border/skin textures. (e.g. the colored border on temporary weapon-enchant buffs).",
+                    getValue = function() return PAGet("noBlizzardBorder") ~= false end,
+                    setValue = function(v) PASet("noBlizzardBorder", v) end
+                },
+                {
+                    type = "toggle",
+                    text = "Hide Collpasing Arrow",
+                    tooltip =
+                    "Hides the arrow that appears on the right side of the player aura frame buffs/debuffs.",
+                    -- default true (hidden), matching the previous hard-coded behaviour when no
+                    -- DB value has been saved yet.
+                    getValue = function() return PAGet("hideCollapseArrow") ~= false end,
+                    setValue = function(v)
+                        PASet("hideCollapseArrow", v)
+                        C_CVar.SetCVar("collapseExpandBuffs", v and "0" or "1")
+                        EllesmereUI:ShowConfirmPopup({
+                            title       = "Reload Required",
+                            message     = "This change requires a UI reload to take effect.",
+                            confirmText = "Reload Now",
+                            cancelText  = "Later",
+                            onConfirm   = function() ReloadUI() end,
+                        })
+                    end
+                }
+            ); y = y - h
+
+            -- Row 2: Buff Padding | Debuff Padding
+            _, h = W:DualRow(parent, y,
+                {
+                    type = "slider",
+                    text = "Buffs: Padding",
+                    min = 1,
+                    max = 15,
+                    step = 1,
+                    getValue = function() return PAGet("paddingBuffs") or 5 end,
+                    setValue = function(v) PASet("paddingBuffs", v) end
+                },
+                {
+                    type = "slider",
+                    text = "Debuffs: Padding",
+                    min = 1,
+                    max = 15,
+                    step = 1,
+                    getValue = function() return PAGet("paddingDebuffs") or 5 end,
+                    setValue = function(v) PASet("paddingDebuffs", v) end
+                }
+            ); y = y - h
+
+            _, h = W:SectionHeader(parent, "DEBUFF BORDER", y); y = y - h
+
+            -- Row 1: No Border on Debuff | Color Border by Debuff Type
+            _, h = W:DualRow(parent, y,
+                {
+                    type = "toggle",
+                    text = "No Border on Debuffs",
+                    tooltip =
+                    "When enabled, debuff icons keep Blizzard's colored border instead of using the custom border.",
+                    getValue = function() return PAGet("noBorderDebuffs") ~= false end,
+                    setValue = function(v)
+                        PASet("noBorderDebuffs", v); EllesmereUI:RefreshPage()
+                    end
+                },
+                {
+                    type = "toggle",
+                    text = "Color Border by Debuff Type",
+                    tooltip =
+                    "Colors the custom border according to the debuff's dispel type (Magic, Curse, Poison, Disease, etc.), similar to Blizzard's own debuff border colors. Only applies to debuffs; has no effect when 'No Border on Debuffs' is enabled.",
+                    disabled = function() return PAGet("noBorderDebuffs") ~= false or PAGet("borderTexture") ~= "solid" end,
+                    disabledTooltip =
+                    "This option only works with the 'Solid Border Texture' setting and has no effect when 'No Border on Debuffs' is enabled, as Blizzard's default border is used instead of the custom one.",
+                    getValue = function() return PAGet("colorBorderByDebuffType") or false end,
+                    setValue = function(v) PASet("colorBorderByDebuffType", v) end
+                }
+            ); y = y - h
+
+            _, h = W:SectionHeader(parent, "DEBUFF COLOR", y); y = y - h
+
+            -- Row 2: Debuff-type color grid (None/Magic/Curse/Disease/Poison/Bleed).
+            -- Greyed out under the same conditions as the toggle above: no
+            -- effect while "No Border on Debuffs" is on, or while "Color Border
+            -- by Debuff Type" itself is off.
+            do
+                local gridDisabled = function()
+                    return (PAGet("noBorderDebuffs") ~= false) or not PAGet("colorBorderByDebuffType")
+                end
+                local gh = BuildDebuffTypeColorGrid(parent, y, PAGet, PASet, gridDisabled)
+                y = y - gh - 4
+            end
         end -- PAGet("enabled") section gate
 
-        -----------------------------------------------------------------------
+    -----------------------------------------------------------------------
         --  External Defensives Frame (our own frame; live enable, no reload)
         -----------------------------------------------------------------------
         local function EDGet(key)
@@ -15715,11 +16098,11 @@ initFrame:SetScript("OnEvent", function(self)
     end
 
     EllesmereUI:RegisterModule("EllesmereUIUnitFrames", {
-        title       = "Unit Frames",
-        description = "Configure unit frame appearance and behavior.",
-        pages       = { PAGE_DISPLAY, PAGE_BOSS, PAGE_MINI, PAGE_AURAS },
-        searchTerms = ufSearchTerms,
-        buildPage   = function(pageName, parent, yOffset)
+        title               = "Unit Frames",
+        description         = "Configure unit frame appearance and behavior.",
+        pages               = { PAGE_DISPLAY, PAGE_BOSS, PAGE_MINI, PAGE_AURAS },
+        searchTerms         = ufSearchTerms,
+        buildPage           = function(pageName, parent, yOffset)
             -- Randomize preview creature IDs on every tab switch
             RandomizePreviewCreatures()
             if pageName == PAGE_DISPLAY then
@@ -15732,7 +16115,7 @@ initFrame:SetScript("OnEvent", function(self)
                 return BuildPlayerAurasPage(pageName, parent, yOffset)
             end
         end,
-        getHeaderBuilder = function(pageName)
+        getHeaderBuilder    = function(pageName)
             if pageName == PAGE_DISPLAY then
                 return _displayHeaderBuilder
             elseif pageName == PAGE_BOSS then
@@ -15756,7 +16139,7 @@ initFrame:SetScript("OnEvent", function(self)
             end
             return nil
         end,
-        onPageCacheRestore = function(pageName)
+        onPageCacheRestore  = function(pageName)
             RandomizePreviewCreatures()
             -- Hide all UIParent-parented disabled overlays before restoring
             -- (they persist across tab switches since they're not children of pf)
@@ -15785,7 +16168,7 @@ initFrame:SetScript("OnEvent", function(self)
                 end
             end
         end,
-        onReset     = function()
+        onReset             = function()
             db:ResetProfile()
             ReloadUI()
         end,

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
@@ -10,8 +10,20 @@ local GetFFD = EllesmereUI._GetFFD
 local ICON_ZOOM = 0.055  -- fallback crop (same as totem bar); user values in profile
 local BLIZZARD_AURA_ICON_SIZE = 30 -- visible icon inside the native 32px aura button
 
--------------------------------------------------------------------------------
---  Settings helper
+-- Learned native grid step (icon size + Blizzard's built-in 5px padding),
+-- in whatever offset units SetPoint reports (already UIScale-adjusted, so
+-- not necessarily a whole number of "real" pixels). Populated lazily from
+-- the first couple of genuine Blizzard SetPoint calls per container -- see
+-- the padding hook in SkinAuraButton. Kept separate for buffs/debuffs since
+-- their icon sizes/padding can differ.
+local _paGridStep = {
+    buff   = { x = nil, y = nil },
+    debuff = { x = nil, y = nil },
+}
+local PADDING_NATIVE = 5 -- Blizzard's own Edit Mode minimum for iconPadding
+
+--  Settings helper (moved up here: DebuffTypeBorderColors below needs it
+--  for its live DB lookups).
 -------------------------------------------------------------------------------
 local function PA()
     local db = ns.db
@@ -45,6 +57,200 @@ local function FormatCompactDuration(timeLeft, style)
     return string.format("%d", math.floor(timeLeft + 0.5))
 end
 
+--  Debuff type -> border color lookup (for "Color Border by Debuff Type").
+-------------------------------------------------------------------------------
+local function HexColor(hex)
+    -- Guard against malformed/short hex strings so a bad value can't throw
+    -- (arithmetic on nil) -- falls back to white if parsing fails.
+    if type(hex) ~= "string" or #hex < 6 then
+        return 1, 1, 1
+    end
+    local rn = tonumber(hex:sub(1, 2), 16)
+    local gn = tonumber(hex:sub(3, 4), 16)
+    local bn = tonumber(hex:sub(5, 6), 16)
+    if not (rn and gn and bn) then
+        return 1, 1, 1
+    end
+    return rn / 255, gn / 255, bn / 255
+end
+
+-- Fallback defaults (identical to the previous hard-coded values). Used only
+-- when no DB value has been saved yet for a given channel, e.g. fresh
+-- profiles or profiles saved before this option existed.
+local DEBUFF_TYPE_DEFAULT_HEX = {
+    None       = "e63333",
+    Magic      = "3399ff",
+    Curse      = "9900ff",
+    Disease    = "996600",
+    Poison     = "009900",
+    Bleed      = "ff3399",
+    --["Bad Dispel"] = "0dd9f0",
+    --Stealable  = "ede88c",
+    --Energy     = "ff8000",
+}
+
+-- DB field prefix for each dispel type. Flat, scalar fields on
+-- db.profile.playerAuras (…R/…G/…B/…A), mirroring the existing
+-- borderR/borderG/borderB/borderA pattern already used in this table.
+-- This is entirely local to the Player Auras module -- no relation to the
+-- global color system (EllesmereUI.lua's GetCustomColorsDB/CLASS_COLOR_MAP/
+-- etc.), and no relation to the separate dispelColorMagic/dispelColorCurse/
+-- etc. player-frame health-overlay colors, which remain untouched.
+local DEBUFF_TYPE_DB_PREFIX = {
+    None    = "debuffTypeColorNone",
+    Magic   = "debuffTypeColorMagic",
+    Curse   = "debuffTypeColorCurse",
+    Disease = "debuffTypeColorDisease",
+    Poison  = "debuffTypeColorPoison",
+    Bleed   = "debuffTypeColorBleed",
+}
+
+-- Live-reads the current DB values (via PA()) on every index access,
+-- falling back to the static defaults above when a channel hasn't been set
+-- yet. Only ever consulted from BuildDispelTypeCurve(), which is itself
+-- cached and only rebuilt via InvalidateDispelCurve() -- so this "live
+-- lookup" cost is paid once per color change, not once per aura update.
+local DebuffTypeBorderColors = setmetatable({}, {
+    __index = function(_, key)
+        local prefix = DEBUFF_TYPE_DB_PREFIX[key]
+        if not prefix then return nil end
+
+        local defHex = DEBUFF_TYPE_DEFAULT_HEX[key]
+        local dr, dg, db_ = 1, 1, 1
+        if defHex then dr, dg, db_ = HexColor(defHex) end
+
+        local cfg = PA()
+        local r = cfg and cfg[prefix .. "R"]
+        local g = cfg and cfg[prefix .. "G"]
+        local b = cfg and cfg[prefix .. "B"]
+        local a = cfg and cfg[prefix .. "A"]
+
+        if r == nil then r = dr end
+        if g == nil then g = dg end
+        if b == nil then b = db_ end
+        if a == nil then a = 1 end
+
+        return { r, g, b, a }
+    end,
+})
+
+-------------------------------------------------------------------------------
+--  Dispel-type curve (Secret-Values-safe border coloring)
+-------------------------------------------------------------------------------
+-- Indices match Blizzard's internal dispel-type enumeration as consumed by
+-- C_UnitAuras.GetAuraDispelTypeColor's curve lookup. Bleed has no contiguous
+-- slot in that enum (it's not a "real" dispel type) -- 11 is the index
+-- Blizzard's own UI code uses for it there; verify against
+-- Enum.DispelType / the relevant Blizzard FrameXML if this ever needs
+-- re-checking on a client update.
+local DISPEL_TYPE_INDEX = {
+    None    = 0,
+    Magic   = 1,
+    Curse   = 2,
+    Disease = 3,
+    Poison  = 4,
+    Bleed = 11,
+}
+
+-- Built lazily on first use (not at file load) so a missing API on an older
+-- client can't break addon load entirely -- SkinAuraButton just falls back
+-- to the static config border color if this stays nil.
+local dispelCurve
+local dispelCurveAttempted = false
+
+-- Bumped on every InvalidateDispelCurve() call. Used by
+-- GetDebuffTypeBorderColor() to know its per-button cached color
+-- (ffd._paLastBorderColor) was computed against a now-stale curve, so it
+-- gets recomputed immediately instead of only on the next aura change.
+local dispelCurveVersion = 0
+
+local function BuildDispelTypeCurve()
+    if dispelCurveAttempted then return dispelCurve end
+    dispelCurveAttempted = true
+
+    if not (C_CurveUtil and C_CurveUtil.CreateColorCurve and C_UnitAuras and C_UnitAuras.GetAuraDispelTypeColor) then
+        return nil
+    end
+
+    local ok, curve = pcall(function()
+        local c = C_CurveUtil.CreateColorCurve()
+        c:SetType(Enum.LuaCurveType.Step) -- discrete types, no blending between them
+        for key, index in pairs(DISPEL_TYPE_INDEX) do
+            local col = DebuffTypeBorderColors[key]
+            if col then
+                c:AddPoint(index, CreateColor(col[1], col[2], col[3], col[4]))
+            end
+        end
+        return c
+    end)
+
+    if ok then
+        dispelCurve = curve
+    end
+    return dispelCurve
+end
+
+-- Forces BuildDispelTypeCurve() to rebuild (picking up current DB colors)
+-- on its next call. Called from every color setter in the Options UI so a
+-- color change is reflected immediately, without requiring /reload.
+local function InvalidateDispelCurve()
+    dispelCurve = nil
+    dispelCurveAttempted = false
+    dispelCurveVersion = dispelCurveVersion + 1
+end
+ns.InvalidateDispelCurve = InvalidateDispelCurve
+
+-------------------------------------------------------------------------------
+-- Was UpdateDebuffTypeBorderColor: now a pure color resolver, since
+-- ApplySecretSafeBorderStyle bakes r/g/b/a into its own internally-managed
+-- edge textures (state._secretBorderEdges) at call time -- there is no
+-- post-hoc SetColorTexture step to hook into anymore.
+local function GetDebuffTypeBorderColor(btn, ffd, cfg)
+    local bR, bG, bB, bA = cfg.borderR or 0, cfg.borderG or 0, cfg.borderB or 0, cfg.borderA or 1
+
+    local curve = BuildDispelTypeCurve()
+    if curve then
+        local buttonInfo = btn.buttonInfo
+        local index = buttonInfo and buttonInfo.index
+        if index then
+            local ok, auraData = pcall(C_UnitAuras.GetAuraDataByIndex, btn.unit or "player", index, "HARMFUL")
+            local auraInstanceID = ok and auraData and auraData.auraInstanceID
+            if auraInstanceID then
+                if ffd._paLastAuraInstanceID == auraInstanceID
+                    and ffd._paLastBorderColor
+                    and ffd._paLastCurveVersion == dispelCurveVersion then
+                    local c = ffd._paLastBorderColor
+                    bR, bG, bB, bA = c[1], c[2], c[3], c[4]
+                else
+                    local ok2, color = pcall(C_UnitAuras.GetAuraDispelTypeColor, btn.unit or "player", auraInstanceID, curve)
+                    if ok2 and color then
+                        -- color:GetRGBA() may return Secret Values here (in combat /
+                        -- M+ / instances). Previously this was confirmed safe because
+                        -- it went straight into SetColorTexture. It now flows into
+                        -- ApplySecretSafeBorderStyle instead (SetVertexColor for
+                        -- textured borders, ApplyBorderStyle for solid) -- NOT yet
+                        -- verified against Secret Values for either path. Test both
+                        -- border-texture modes in combat/M+ before shipping.
+                        local ok3, r, g, b, a = pcall(color.GetRGBA, color)
+                        if ok3 then
+                            bR, bG, bB, bA = r, g, b, a
+                        end
+                    end
+                    ffd._paLastAuraInstanceID = auraInstanceID
+                    ffd._paLastBorderColor = { bR, bG, bB, bA }
+                    ffd._paLastCurveVersion = dispelCurveVersion
+                end
+            else
+                ffd._paLastAuraInstanceID = nil
+                ffd._paLastBorderColor = nil
+                ffd._paLastCurveVersion = nil
+            end
+        end
+    end
+
+    return bR, bG, bB, bA
+end
+
 -------------------------------------------------------------------------------
 --  Per-button skinning
 -------------------------------------------------------------------------------
@@ -57,6 +263,97 @@ local function SkinAuraButton(btn, isDebuff)
     local ffd = GetFFD(btn)
     if not ffd then return end
 
+    -- Fingerprint of everything that influences this button's appearance.
+    -- If nothing relevant changed and the button is already skinned, bail
+    -- out immediately -- no region scans, no ClearAllPoints/SetPoint, no
+    -- texture/font calls. This is what kills both the CPU cost AND the
+    -- visible "jumping" of the duration/count text on every refresh pass.
+    --
+    -- Compared field-by-field against cached values on ffd instead of
+    -- building a table + table.concat string every call -- this avoids
+    -- two allocations per button on every single UpdateGridLayout firing,
+    -- even in the (very common) case where nothing actually changed.
+    local noBlizzBorderV  = (cfg.noBlizzardBorder ~= false) and 1 or 0
+    local noBorderDebuffsV = cfg.noBorderDebuffs and 1 or 0
+    local borderSizeV = cfg.borderSize or 1
+    local borderRV = cfg.borderR or 0
+    local borderGV = cfg.borderG or 0
+    local borderBV = cfg.borderB or 0
+    local borderAV = cfg.borderA or 1
+    local durSizeV = cfg.durationTextSize or 11
+    local durPosV = cfg.durationPosition or ""
+    local durOXV = cfg.durationOffsetX or 0
+    local durOYV = cfg.durationOffsetY or 0
+    local stackSizeV = cfg.stackTextSize or 11
+    local stackPosV = cfg.stackPosition or ""
+    local stackOXV = cfg.stackOffsetX or 0
+    local stackOYV = cfg.stackOffsetY or 0
+    local isDebuffV = isDebuff and 1 or 0
+    local colorByDebuffTypeV = cfg.colorBorderByDebuffType and 1 or 0
+    local iconZoomV = (isDebuff and cfg.debuffIconZoom or cfg.buffIconZoom) or ICON_ZOOM
+    local showTextV = cfg.showText ~= false and 1 or 0
+    -- debuffTypeV intentionally not read/compared here -- btn.buttonInfo.debuffType
+    -- is a Secret Value in tainted addon execution; comparing it (even via ==)
+    -- throws a Lua error. Border coloring by debuff type is instead done via
+    -- GetDebuffTypeBorderColor() further down, which uses the Secret-Values
+    -- -safe C_UnitAuras.GetAuraDispelTypeColor curve API.
+
+    if ffd._paSkinned
+        and ffd._paNoBlizzBorder == noBlizzBorderV
+        and ffd._paNoBorderDebuffs == noBorderDebuffsV
+        and ffd._paBorderSize == borderSizeV
+        and ffd._paBorderR == borderRV
+        and ffd._paBorderG == borderGV
+        and ffd._paBorderB == borderBV
+        and ffd._paBorderA == borderAV
+        and ffd._paDurSize == durSizeV
+        and ffd._paDurPos == durPosV
+        and ffd._paDurOX == durOXV
+        and ffd._paDurOY == durOYV
+        and ffd._paStackSize == stackSizeV
+        and ffd._paStackPos == stackPosV
+        and ffd._paStackOX == stackOXV
+        and ffd._paStackOY == stackOYV
+        and ffd._paIsDebuff == isDebuffV
+        and ffd._paColorByDebuffType == colorByDebuffTypeV
+        and ffd._paIconZoom == iconZoomV
+        and ffd._paShowText == showTextV
+    then
+        -- Everything static already matches -- but if debuff-type coloring is
+        -- active, the aura occupying this slot can still have changed (same
+        -- button/icon, different debuff) without any of the above changing.
+        -- That's a Secret Value we can't detect via fingerprint comparison,
+        -- so when this mode is on we cheaply re-apply just the border color
+        -- every pass instead of skipping entirely. This is 4 SetColorTexture
+        -- calls, not a full re-skin -- no region scans, no SetPoint, no font
+        -- calls -- so it stays in line with the 0-performance-impact goal.
+    if isDebuffV == 1 and colorByDebuffTypeV == 1 and (not cfg.borderTexture or cfg.borderTexture == "" or cfg.borderTexture == "solid") and ffd._paBorder then
+        local bR, bG, bB, bA = GetDebuffTypeBorderColor(btn, ffd, cfg)
+        EllesmereUI.SetBorderStyleColor(ffd._paBorder, bR, bG, bB, bA)
+    end
+        return
+    end
+
+    ffd._paNoBlizzBorder = noBlizzBorderV
+    ffd._paNoBorderDebuffs = noBorderDebuffsV
+    ffd._paBorderSize = borderSizeV
+    ffd._paBorderR = borderRV
+    ffd._paBorderG = borderGV
+    ffd._paBorderB = borderBV
+    ffd._paBorderA = borderAV
+    ffd._paDurSize = durSizeV
+    ffd._paDurPos = durPosV
+    ffd._paDurOX = durOXV
+    ffd._paDurOY = durOYV
+    ffd._paStackSize = stackSizeV
+    ffd._paStackPos = stackPosV
+    ffd._paStackOX = stackOXV
+    ffd._paStackOY = stackOYV
+    ffd._paIsDebuff = isDebuffV
+    ffd._paColorByDebuffType = colorByDebuffTypeV
+    ffd._paIconZoom = iconZoomV
+    ffd._paShowText = showTextV
+
     -- Icon zoom crop (btn.Icon is a Frame in Midnight; find the Texture inside)
     local iconFrame = btn.Icon
     local iconTex
@@ -65,8 +362,12 @@ local function SkinAuraButton(btn, isDebuff)
         iconTex = iconFrame.Texture or iconFrame.texture
         -- Fallback: scan for the first Texture region
         if not iconTex and iconFrame.GetRegions then
-            for i = 1, iconFrame:GetNumRegions() do
-                local r = select(i, iconFrame:GetRegions())
+            -- Snapshot regions once instead of re-calling GetRegions() inside
+            -- the loop (select(i, GetRegions()) would re-walk the full vararg
+            -- list every iteration -- O(n^2) for n regions).
+            local regions = { iconFrame:GetRegions() }
+            for i = 1, #regions do
+                local r = regions[i]
                 if r and r:IsObjectType("Texture") and r.SetTexCoord then
                     iconTex = r
                     break
@@ -85,10 +386,62 @@ local function SkinAuraButton(btn, isDebuff)
         iconTex:SetTexCoord(z, 1 - z, z, 1 - z)
     end
 
-    -- Hide Blizzard border (alpha, not Hide, to avoid taint)
-    -- Keep it visible on debuffs when noBorderDebuffs is enabled (colored border)
+    -- Hide any extra Blizzard border/skin textures nested inside the icon
+    -- frame itself. In Midnight, btn.Icon is a Frame and can contain its own
+    -- border region (this is what shows up as e.g. the purple temporary-
+    -- weapon-enchant frame) separate from btn.Border. We hide every texture
+    -- region except the icon texture we just found, so any such overlay
+    -- disappears regardless of its name. Alpha only, never Hide(), to avoid
+    -- taint on Blizzard's secure-adjacent frames.
+    local noBlizzardBorder = cfg.noBlizzardBorder ~= false
+    if iconFrame and iconFrame.GetRegions and iconFrame ~= btn then
+        -- Snapshot regions once (see comment above for why).
+        local regions = { iconFrame:GetRegions() }
+        for i = 1, #regions do
+            local r = regions[i]
+            if r and r ~= iconTex and r.IsObjectType and r:IsObjectType("Texture") and r.SetAlpha then
+                r:SetAlpha(noBlizzardBorder and 0 or 1)
+            end
+        end
+    end
+
+    -- Some border/skin textures (notably on temporary weapon-enchant
+    -- buttons, e.g. "...TempEnchant1") are parented directly to the button
+    -- itself rather than to btn.Icon. Scan the button's own regions too and
+    -- hide anything that isn't the icon texture, the Count/Duration text, or
+    -- one of our own custom edge textures.
+    if btn.GetRegions then
+        local edges = ffd._paEdges
+        -- Snapshot regions once (see comment above for why).
+        local regions = { btn:GetRegions() }
+        for i = 1, #regions do
+            local r = regions[i]
+            if r and r.IsObjectType and r:IsObjectType("Texture") and r.SetAlpha then
+                local isIcon  = (r == iconTex)
+                local isOurs  = edges and (r == edges.top or r == edges.bottom or r == edges.left or r == edges.right)
+                local isKnown = (r == btn.Icon) or (r == btn.Count) or (r == btn.Duration)
+                if not (isIcon or isOurs or isKnown) then
+                    r:SetAlpha(noBlizzardBorder and 0 or 1)
+                end
+            end
+        end
+    end
+
+    -- Some button templates also skin the button itself (Normal/Pushed/
+    -- Highlight texture) which can bleed a colored frame around the icon.
+    if btn.GetNormalTexture then
+        local nt = btn:GetNormalTexture()
+        if nt then nt:SetAlpha(noBlizzardBorder and 0 or 1) end
+    end
+
+    -- Hide Blizzard's plain border (alpha, not Hide, to avoid taint).
+    -- For debuffs we still allow keeping it, since its color communicates
+    -- the debuff type (magic/curse/poison/disease) which has gameplay value.
+    -- For buffs there is no such gameplay value, so it is always removed --
+    -- our own clean pixel border (below) is drawn in its place regardless.
     if btn.Border then
-        if isDebuff and cfg.noBorderDebuffs then
+        local keepBlizzBorder = isDebuff and cfg.noBorderDebuffs
+        if keepBlizzBorder then
             btn.Border:SetAlpha(1)
         else
             btn.Border:SetAlpha(0)
@@ -98,9 +451,11 @@ local function SkinAuraButton(btn, isDebuff)
     -- Duration text styling (btn.Duration may be a Frame containing a FontString)
     local durFS = btn.Duration
     if durFS and not durFS.SetFont and durFS.GetRegions then
-        -- Duration is a Frame; find the FontString inside
-        for i = 1, durFS:GetNumRegions() do
-            local r = select(i, durFS:GetRegions())
+        -- Duration is a Frame; find the FontString inside.
+        -- Snapshot regions once (see comment above for why).
+        local regions = { durFS:GetRegions() }
+        for i = 1, #regions do
+            local r = regions[i]
             if r and r.SetFont then durFS = r; break end
         end
     end
@@ -122,20 +477,105 @@ local function SkinAuraButton(btn, isDebuff)
     if durFS and durFS.SetFont then
         if cfg.showText then
             local fontPath = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames") or STANDARD_TEXT_FONT
-            local outline = EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("unitFrames") or "OUTLINE, SLUG"
-            if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(durFS, outline == "") end
-            durFS:SetFont(fontPath, cfg.textSize or 11, outline)
-            durFS:SetTextColor(1, 1, 1, 1)
+            -- Duration count always uses a forced OUTLINE, SLUG flag (keeps the digits
+            -- crisp regardless of the user's global font-outline setting).
+            EllesmereUI.ApplyIconTextFont(durFS, fontPath, cfg.durationTextSize or 11, "unitFrames")
+            durFS:SetDrawLayer("OVERLAY", 7)
+            if durFS and not durFS._paColorHooked then
+                durFS._paColorHooked = true
+                hooksecurefunc(durFS, "SetVertexColor", function(self, r, g, b, a)
+                    if self._paApplyingColor then return end -- Rekursionsschutz
+                    -- Live-read the config here (same pattern as the SetAlpha/
+                    -- SetPoint hooks below) instead of using the "cfg" upvalue
+                    -- captured at hook-creation time -- this hook is only
+                    -- attached once per FontString, so a stale "cfg" would
+                    -- silently stop reacting to later showText changes.
+                    local liveCfg = PA()
+                    if not liveCfg then return end
+                    self._paApplyingColor = true
+                    if liveCfg.showText then
+                        self:SetVertexColor(1, 1, 1, 1)
+                    end
+                    self._paApplyingColor = false
+                end)
+            end
+
+            -- Reposition duration text (Top/Bottom + X/Y offset) relative to the icon.
+            -- Cheap re-anchor on our own FontString reference; no taint risk.
+            local durAnchor = btn.Icon or btn
+            local durOX = cfg.durationOffsetX or 0
+            local durOY = cfg.durationOffsetY or 0
+            durFS:ClearAllPoints()
+            if cfg.durationPosition == "top" then
+                durFS:SetPoint("TOP", durAnchor, "TOP", durOX, durOY)
+            else
+                durFS:SetPoint("BOTTOM", durAnchor, "BOTTOM", durOX, durOY)
+            end
+
+            -- Alpha only, never Hide() -- Blizzard's own aura update code keeps
+            -- touching this FontString (SetText on every tick), so a Hide() call
+            -- would just get fought over every refresh. Alpha sticks regardless
+            -- of what Blizzard does to visibility/text.
+            durFS:SetAlpha(showTextV == 1 and 1 or 0)
+
+            -- Blizzard's own countdown-tick code resets alpha on this FontString
+            -- too (same mechanism that forced the SetVertexColor hook above --
+            -- it recolors/refreshes the text as the duration ticks down), which
+            -- silently undid our SetAlpha(0) a moment after we set it. Same
+            -- hook-with-recursion-guard pattern as SetPoint/SetVertexColor below
+            -- so our "showText" choice always wins, whenever Blizzard touches it.
+            if not durFS._paAlphaHooked then
+                durFS._paAlphaHooked = true
+                hooksecurefunc(durFS, "SetAlpha", function(self)
+                    if self._paApplyingAlpha then return end
+                    local liveCfg = PA()
+                    if not liveCfg then return end
+                    self._paApplyingAlpha = true
+                    self:SetAlpha(liveCfg.showText ~= false and 1 or 0)
+                    self._paApplyingAlpha = false
+                end)
+            end
+
+            -- Blizzard re-anchors this FontString on its own during zone/instance
+            -- transitions (its own UpdateGridLayout-style code runs again after
+            -- a loading screen), which silently undoes our positioning above --
+            -- this is what caused the duration text to jump back after entering
+            -- a dungeon. Rather than guess at *when* Blizzard does this and race
+            -- it with our own timing, we hook SetPoint itself (same pattern as
+            -- the SetVertexColor hook below) so that any external SetPoint call,
+            -- whenever it happens, is immediately followed by our own anchor.
+            -- The recursion guard prevents this from calling itself.
+            if not durFS._paPointHooked then
+                durFS._paPointHooked = true
+                hooksecurefunc(durFS, "SetPoint", function(self)
+                    if self._paApplyingPoint then return end
+                    local liveCfg = PA()
+                    if not liveCfg then return end
+                    self._paApplyingPoint = true
+                    self:ClearAllPoints()
+                    local anchor = btn.Icon or btn
+                    if liveCfg.durationPosition == "top" then
+                        self:SetPoint("TOP", anchor, "TOP", liveCfg.durationOffsetX or 0, liveCfg.durationOffsetY or 0)
+                    else
+                        self:SetPoint("BOTTOM", anchor, "BOTTOM", liveCfg.durationOffsetX or 0, liveCfg.durationOffsetY or 0)
+                    end
+                    self._paApplyingPoint = false
+                end)
+            end
         else
-            durFS:SetTextColor(0, 0, 0, 0)
+            -- Same alpha-only approach as the stack text below, instead of
+            -- SetTextColor -- keeps both hide mechanisms consistent.
+            durFS:SetAlpha(0)
         end
     end
 
     -- Count text styling
     local countFS = btn.Count
     if countFS and not countFS.SetFont and countFS.GetRegions then
-        for i = 1, countFS:GetNumRegions() do
-            local r = select(i, countFS:GetRegions())
+        -- Snapshot regions once (see comment above for why).
+        local regions = { countFS:GetRegions() }
+        for i = 1, #regions do
+            local r = regions[i]
             if r and r.SetFont then countFS = r; break end
         end
     end
@@ -143,11 +583,156 @@ local function SkinAuraButton(btn, isDebuff)
         local fontPath = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames") or STANDARD_TEXT_FONT
         -- Stack count always uses a forced OUTLINE, SLUG flag (keeps the digits
         -- crisp regardless of the user's global font-outline setting).
-        EllesmereUI.ApplyIconTextFont(countFS, fontPath, cfg.textSize or 11, "unitFrames")
+        EllesmereUI.ApplyIconTextFont(countFS, fontPath, cfg.stackTextSize or 11, "unitFrames")
+        countFS:SetDrawLayer("OVERLAY", 7)
+
+        -- Reposition stack count text (Top/Bottom + X/Y offset) relative to the icon.
+        -- Cheap re-anchor on our own FontString reference; no taint risk.
+        local countAnchor = btn.Icon or btn
+        local countOX = cfg.stackOffsetX or 0
+        local countOY = cfg.stackOffsetY or 0
+        countFS:ClearAllPoints()
+        if cfg.stackPosition == "top" then
+            countFS:SetPoint("TOP", countAnchor, "TOP", countOX, countOY)
+        else
+            countFS:SetPoint("BOTTOM", countAnchor, "BOTTOM", countOX, countOY)
+        end
+
+        -- Same alpha-only approach as the duration text above.
+        countFS:SetAlpha(showTextV == 1 and 1 or 0)
+
+        -- Same "Blizzard re-touches this FontString" problem as the duration
+        -- text above (alpha reset on countdown-tick-style updates, re-anchor
+        -- reset after loading screens). Same hook-with-recursion-guard
+        -- pattern, applied to the stack/count text so its position and
+        -- visibility survive Blizzard's own refresh code the same way
+        -- duration's does.
+        if not countFS._paAlphaHooked then
+            countFS._paAlphaHooked = true
+            hooksecurefunc(countFS, "SetAlpha", function(self)
+                if self._paApplyingAlpha then return end
+                local liveCfg = PA()
+                if not liveCfg then return end
+                self._paApplyingAlpha = true
+                self:SetAlpha(liveCfg.showText ~= false and 1 or 0)
+                self._paApplyingAlpha = false
+            end)
+        end
+
+        if not countFS._paPointHooked then
+            countFS._paPointHooked = true
+            hooksecurefunc(countFS, "SetPoint", function(self)
+                if self._paApplyingPoint then return end
+                local liveCfg = PA()
+                if not liveCfg then return end
+                self._paApplyingPoint = true
+                self:ClearAllPoints()
+                local anchor = btn.Icon or btn
+                if liveCfg.stackPosition == "top" then
+                    self:SetPoint("TOP", anchor, "TOP", liveCfg.stackOffsetX or 0, liveCfg.stackOffsetY or 0)
+                else
+                    self:SetPoint("BOTTOM", anchor, "BOTTOM", liveCfg.stackOffsetX or 0, liveCfg.stackOffsetY or 0)
+                end
+                self._paApplyingPoint = false
+            end)
+        end
     end
 
-    -- The shared border-style engine requires a frame we own. Keep that frame
-    -- anchored to the icon instead of applying a backdrop to Blizzard's button.
+    -- Padding compensation (bypasses Edit Mode's 5px minimum on iconPadding).
+    -- Deliberately does NOT touch AuraContainer.iconPadding or call
+    -- UpdateGridLayout() -- doing so marks AuraContainer/EditModeManager
+    -- itself as "addon-tainted" for the rest of the session, which broke
+    -- unrelated EditMode saves (e.g. the Damage Meter window) with a
+    -- "secret value" comparison error the moment EditMode's own Save/Reset
+    -- pass touched anything it manages. Hooking SetPoint on the button
+    -- itself (like the Duration/Count FontString hooks above) never
+    -- touches AuraContainer, so it carries no such taint risk.
+    --
+    -- Blizzard's own grid layout re-anchors each button with x/y offsets
+    -- that are cumulative multiples of a fixed "step" (icon size + its
+    -- built-in 5px padding) per column/row -- e.g. observed offsets of
+    -- 0, -35, -70, -105... (columns) and 0, -45, -90... (rows), NOT a
+    -- single "-5" per button as originally assumed. We learn that native
+    -- step per layout pass (from the smallest nonzero offset seen on each
+    -- axis so far in this pass), derive each button's column/row index
+    -- from its offset, then rebuild the offset using the user's desired
+    -- padding instead of Blizzard's native 5px.
+    --
+    -- The learned step is deliberately NOT cached across passes: Edit
+    -- Mode's own preview grid appears to use different native spacing
+    -- than the normal in-world grid, so a step learned once and reused
+    -- forever produced inconsistent results depending on which context
+    -- triggered first. Instead we reset it every time we see a button
+    -- anchored at (0,0) -- that's always the very first button of a
+    -- fresh pass (row 1, column 1, no offset yet), a reliable pass
+    -- boundary marker.
+    local gridKey = isDebuff and "debuff" or "buff"
+    if not btn._paPaddingHooked then
+        btn._paPaddingHooked = true
+        hooksecurefunc(btn, "SetPoint", function(self, point, relTo, relPoint, x, y)
+            if self._paApplyingPadding then return end -- Rekursionsschutz
+
+            local liveCfg = PA()
+            if not liveCfg or not liveCfg.enabled then return end
+
+            local step = _paGridStep[gridKey]
+
+            if x == 0 and y == 0 then
+                -- New pass starting -- forget whatever step we learned
+                -- during a previous (possibly different-context) pass.
+                step.x, step.y = nil, nil
+                return -- nothing to compensate on the anchor button itself
+            end
+
+            -- Learn the native step from the smallest nonzero offset seen
+            -- on each axis so far in this pass.
+            if x and x ~= 0 then
+                local ax = math.abs(x)
+                if not step.x or ax < step.x then step.x = ax end
+            end
+            if y and y ~= 0 then
+                local ay = math.abs(y)
+                if not step.y or ay < step.y then step.y = ay end
+            end
+
+            -- Blizzard's OWN current padding, read live from the container
+            -- (a plain read -- never written here, so no taint risk). This
+            -- is normally 5 (Edit Mode's minimum) but the user can raise it
+            -- higher via Blizzard's native slider; hardcoding 5 here caused
+            -- our own padding to effectively stack on top of theirs
+            -- whenever they'd set Edit Mode's slider above its minimum.
+            local container = isDebuff and DebuffFrame and DebuffFrame.AuraContainer
+                                        or BuffFrame and BuffFrame.AuraContainer
+            local nativePadding = (container and container.iconPadding) or PADDING_NATIVE
+
+            local desired = isDebuff and (liveCfg.paddingDebuffs or nativePadding)
+                                       or (liveCfg.paddingBuffs or nativePadding)
+            if desired == nativePadding then return end -- nothing to compensate
+
+            local function rebuild(offset, nativeStep)
+                -- Compensate this axis only if we've actually learned its
+                -- native step (e.g. row 1 never has a nonzero y, so
+                -- step.y stays nil for the whole row -- that's fine,
+                -- offset is 0 there anyway and needs no compensation).
+                if not offset or offset == 0 or not nativeStep then return offset end
+                local newStep = (nativeStep - nativePadding) + desired
+                local idx = math.floor(math.abs(offset) / nativeStep + 0.5)
+                if idx == 0 then return offset end
+                local sign = offset < 0 and -1 or 1
+                return sign * idx * newStep
+            end
+
+            local newX = rebuild(x, step.x)
+            local newY = rebuild(y, step.y)
+
+            if newX ~= x or newY ~= y then
+                self._paApplyingPadding = true
+                self:SetPoint(point, relTo, relPoint, newX, newY)
+                self._paApplyingPadding = false
+            end
+        end)
+    end
+
     local anchorFrame = iconFrame or btn
     local bs = cfg.borderSize or 1
     local skipBorder = isDebuff and cfg.noBorderDebuffs
@@ -158,25 +743,44 @@ local function SkinAuraButton(btn, isDebuff)
         ffd._paBorder = border
     end
     border:SetFrameLevel(cfg.borderBehind and math.max(0, btn:GetFrameLevel() - 1) or (btn:GetFrameLevel() + 10))
-    -- Never derive this frame's dimensions through SetAllPoints(anchorFrame):
-    -- Blizzard aura dimensions are secret on Midnight, and BackdropTemplate's
-    -- SetBackdrop then attempts arithmetic on that secret width. AuraContainer
-    -- applies the user's icon size as scale over Blizzard's native 32px button.
-    -- Its visible icon is 30px, so this public constant avoids both the secret
-    -- geometry read and the one-pixel gap left by sizing to the whole button.
     border:ClearAllPoints()
     border:SetPoint("CENTER", anchorFrame, "CENTER", 0, 0)
     border:SetSize(BLIZZARD_AURA_ICON_SIZE, BLIZZARD_AURA_ICON_SIZE)
+    -- Duration/Count are direct regions on btn; a child Frame's FrameLevel
+    -- always composites its entire content above ALL of the parent's own
+    -- regions, regardless of draw layer/sublevel -- so border (btn's
+    -- FrameLevel + 10) always wins against btn's own OVERLAY regions.
+    -- Reparenting the two FontStrings onto a frame above `border` is the
+    -- only way to guarantee they render on top. Same pattern as
+    -- EllesmereUIBags.lua's countFS:SetParent(textOverlay).
+    local textOverlay = ffd._paTextOverlay
+    if not textOverlay then
+        textOverlay = CreateFrame("Frame", nil, btn)
+        textOverlay:SetAllPoints()
+        ffd._paTextOverlay = textOverlay
+    end
+    textOverlay:SetFrameLevel(border:GetFrameLevel() + 1)
+    if durFS and durFS.SetParent then durFS:SetParent(textOverlay) end
+    if countFS and countFS.SetParent then countFS:SetParent(textOverlay) end
+    local isSolidBorder = not cfg.borderTexture or cfg.borderTexture == "" or cfg.borderTexture == "solid"
+
+    local bR, bG, bB, bA
+    if isDebuff and cfg.colorBorderByDebuffType and isSolidBorder then
+        bR, bG, bB, bA = GetDebuffTypeBorderColor(btn, ffd, cfg)
+    else
+        bR, bG, bB, bA = cfg.borderR or 0, cfg.borderG or 0, cfg.borderB or 0, cfg.borderA or 1
+    end
+
     EllesmereUI.ApplySecretSafeBorderStyle(border, ffd,
         (bs > 0 and not skipBorder) and bs or 0,
-        cfg.borderR or 0, cfg.borderG or 0, cfg.borderB or 0, cfg.borderA or 1,
+        bR, bG, bB, bA,
         cfg.borderTexture or "solid",
         cfg.borderTextureOffset, cfg.borderTextureOffsetY,
         cfg.borderTextureShiftX, cfg.borderTextureShiftY,
         "unitframes", bs)
 
-    ffd._paSkinned = true
-end
+        ffd._paSkinned = true
+    end
 
 -------------------------------------------------------------------------------
 --  Iterate and skin all visible aura buttons on a frame
@@ -201,58 +805,26 @@ end
 ns.RefreshPlayerAuras = RefreshAll
 
 -------------------------------------------------------------------------------
+--  Debounced refresh trigger. UpdateGridLayout can fire multiple times per
+--  frame (UNIT_AURA batches, cooldown swipe updates, mouseover, etc). Without
+--  this, every single firing would queue its own C_Timer.After(0, RefreshAll),
+--  causing several redundant skin passes per visible frame -- which is what
+--  produced the flicker/jumping text. This collapses them into exactly one.
+-------------------------------------------------------------------------------
+local refreshQueued = false
+local function QueueRefresh()
+    if refreshQueued then return end
+    refreshQueued = true
+    C_Timer.After(0, function()
+        refreshQueued = false
+        RefreshAll()
+    end)
+end
+
+-------------------------------------------------------------------------------
 --  Scale helper (applies iconSize via SetScale on AuraContainer)
 -------------------------------------------------------------------------------
 local _appliedBuffScale, _appliedDebuffScale
-local _nativeExpandEnabled
-local _appliedShowExpand
-local _savedExpandedState
-
-local function ApplyExpandButtonSetting()
-    local cfg = PA()
-    local button = BuffFrame and BuffFrame.CollapseAndExpandButton
-    if not (cfg and button) then return end
-    if _nativeExpandEnabled == nil then
-        _nativeExpandEnabled = button:IsEnabled() and true or false
-    end
-    local show = cfg.showExpandButton ~= false
-    if _appliedShowExpand == show then
-        if not show then button:Hide() end
-        return
-    end
-    -- First evaluation with the button wanted in its native shown state:
-    -- nothing to change, so leave Blizzard's model and layout untouched.
-    -- Running BuffFrame's layout functions (RefreshConsolidationFrame-
-    -- Visibility / UpdateGridLayout) from addon context stamps their
-    -- Lua-side state with addon taint, and Edit Mode's enter pass reads
-    -- that state -- the source of secret-value LUA_WARNING storms for
-    -- users with the aura reskin enabled.
-    if _appliedShowExpand == nil and show then
-        _appliedShowExpand = show
-        return
-    end
-    _appliedShowExpand = show
-    if not show then
-        _savedExpandedState = BuffFrame.isExpanded
-        -- Keep the button logically enabled: Blizzard's IsExpanded() treats a
-        -- disabled button as consolidated/collapsed in some configurations.
-        -- Force the model open and hide only the visual control.
-        button:Enable()
-        BuffFrame.isExpanded = true
-        if BuffFrame.Update then pcall(BuffFrame.Update, BuffFrame) end
-        button:Hide()
-    else
-        if _savedExpandedState ~= nil then
-            BuffFrame.isExpanded = _savedExpandedState
-            _savedExpandedState = nil
-        end
-        if _nativeExpandEnabled then button:Enable() else button:Disable() end
-        if BuffFrame.RefreshConsolidationFrameVisibility then
-            BuffFrame:RefreshConsolidationFrameVisibility()
-        end
-    end
-    if BuffFrame.UpdateGridLayout then pcall(BuffFrame.UpdateGridLayout, BuffFrame) end
-end
 
 local function ApplyScale()
     local cfg = PA()
@@ -272,9 +844,62 @@ local function ApplyScale()
             _appliedDebuffScale = scale
         end
     end
-    ApplyExpandButtonSetting()
 end
 ns.ApplyPlayerAuraScale = ApplyScale
+
+-------------------------------------------------------------------------------
+--  Padding helper.
+--  The actual padding compensation happens per-button via the
+--  hooksecurefunc(btn, "SetPoint", ...) hook registered in SkinAuraButton
+--  (see PADDING_NATIVE / btn._paPaddingHooked above). That hook only fires
+--  when Blizzard itself re-anchors a button, which only happens on a real
+--  grid rebuild (icon count/row count changing, zone transitions, Edit
+--  Mode resets) -- NOT on every simple aura tick. So a padding value
+--  changing in the DB would otherwise sit invisible until the next
+--  incidental rebuild.
+--
+--  No polling/watcher needed here: the options panel's PASet() already
+--  calls ns.ApplyPlayerAuraPadding() directly on every change (same
+--  pattern it uses for ns.RefreshPlayerAuras()/ns.ApplyPlayerAuraScale()),
+--  so this only ever runs in direct response to an actual change, with
+--  zero cost otherwise.
+--
+--  NOTE ON FORCING A LIVE REBUILD: toggling BuffFrame/DebuffFrame
+--  visibility via Hide()/Show() was tried first and confirmed (via
+--  in-game testing) to NOT force Blizzard to re-run its grid layout --
+--  padding changes only became visible after a real Blizzard-triggered
+--  rebuild (/reload, a zone transition, or opening/closing Edit Mode).
+--  Instead, this toggles the "collapseExpandBuffs" CVar (already used
+--  elsewhere in this file to control the same BuffFrame/DebuffFrame
+--  layout), since Blizzard's own layout code is what reacts to that CVar
+--  changing -- flipping it and flipping it back forces a real,
+--  Blizzard-driven relayout pass rather than us calling any
+--  AuraContainer/UpdateGridLayout method ourselves. The flip-back happens
+--  on the next frame (C_Timer.After(0, ...)) rather than immediately, in
+--  case Blizzard's CVAR_UPDATE handling only reacts once per frame and
+--  would otherwise see the two writes cancel out with no visible effect.
+--  This still needs to be confirmed in-game -- if it doesn't force a
+--  rebuild either, the padding change will keep waiting for a genuine
+--  Blizzard-triggered one, same as before.
+-------------------------------------------------------------------------------
+local function ForceAuraGridRebuild()
+    local current = C_CVar.GetCVar("collapseExpandBuffs")
+    if not current then return end
+    local flipped = (current == "1") and "0" or "1"
+    C_CVar.SetCVar("collapseExpandBuffs", flipped)
+    C_Timer.After(0, function()
+        C_CVar.SetCVar("collapseExpandBuffs", current)
+    end)
+end
+
+local function ApplyPadding()
+    local cfg = PA()
+    if not cfg or not cfg.enabled then return end
+
+    ForceAuraGridRebuild()
+    RefreshAll()
+end
+ns.ApplyPlayerAuraPadding = ApplyPadding
 
 
 -------------------------------------------------------------------------------
@@ -624,42 +1249,85 @@ initFrame:SetScript("OnEvent", function(self, event, arg1)
 
         -- Delay to let UF db initialize
         C_Timer.After(1, function()
+            -- Sync the "Hide Collapsing Arrow" CVar from the (account/profile-scoped)
+            -- DB on every login, on every character -- independent of the aura-skin
+            -- "enabled" flag below, since this is just a Blizzard CVar toggle, not
+            -- part of the reskin itself.
+            do
+                local cfg = PA()
+                if cfg then
+                    local wantHidden = cfg.hideCollapseArrow ~= false
+                    local desired = wantHidden and "0" or "1"
+                    if C_CVar.GetCVar("collapseExpandBuffs") ~= desired then
+                        C_CVar.SetCVar("collapseExpandBuffs", desired)
+                    end
+                end
+            end
+
             local cfg = PA()
             if not cfg or not cfg.enabled then return end
 
             -- Apply scale
             ApplyScale()
 
+            -- Apply padding once on login (subsequent changes come straight
+            -- from the options panel's PASet(), which already calls
+            -- ns.ApplyPlayerAuraPadding() on every change -- see comment
+            -- above ApplyPadding()).
+            --
+            -- One-time cleanup: an earlier build of this file persisted a
+            -- "_paPaddingWatcherInstalled" flag straight into the
+            -- SavedVariables profile (via rawset on cfg). That flag is
+            -- dead now but harmless -- this just removes it if present so
+            -- old profiles don't carry it forever.
+            if cfg._paPaddingWatcherInstalled ~= nil then
+                cfg._paPaddingWatcherInstalled = nil
+            end
+            ApplyPadding()
+
             -- Initial skin pass
             RefreshAll()
 
-            -- Hook aura updates to catch new/changed buttons
+            -- Hook aura updates to catch new/changed buttons. This never
+            -- writes to AuraContainer.iconPadding or calls UpdateGridLayout
+            -- itself -- it only queues our own debounced re-skin pass, so
+            -- there's no re-entrancy/recursion risk even though the hook
+            -- also fires on the UpdateGridLayout calls that Blizzard's own
+            -- layout logic (and, indirectly, our per-button SetPoint hook)
+            -- triggers. Padding itself is no longer mirrored from
+            -- AuraContainer.iconPadding -- since we never change that field
+            -- anymore, it always reads back as Blizzard's native 5px, and
+            -- writing it into cfg.paddingBuffs/paddingDebuffs here would
+            -- immediately clobber the user's own slider value on every
+            -- layout pass.
             if BuffFrame and BuffFrame.AuraContainer then
                 hooksecurefunc(BuffFrame.AuraContainer, "UpdateGridLayout", function()
-                    C_Timer.After(0, RefreshAll)
+                    QueueRefresh()
                 end)
-                if BuffFrame.RefreshConsolidationFrameVisibility then
-                    hooksecurefunc(BuffFrame, "RefreshConsolidationFrameVisibility", function()
-                        -- Deferred: this can fire inside Blizzard's secure
-                        -- buff-system refresh (incl. Edit Mode's passes);
-                        -- hiding inline there taints the rest of that
-                        -- execution.
-                        C_Timer.After(0, function()
-                            local cfgNow = PA()
-                            if cfgNow and cfgNow.showExpandButton == false
-                                and BuffFrame.CollapseAndExpandButton then
-                                BuffFrame.CollapseAndExpandButton:Hide()
-                            end
-                        end)
-                    end)
-                end
             end
             if DebuffFrame and DebuffFrame.AuraContainer then
                 hooksecurefunc(DebuffFrame.AuraContainer, "UpdateGridLayout", function()
-                    C_Timer.After(0, RefreshAll)
+                    QueueRefresh()
                 end)
             end
 
+            -- PLAYER_ENTERING_WORLD fires on every loading screen (zone/
+            -- instance change, reload, login). Blizzard's AuraContainer can
+            -- reset its scale during this transition, which is what caused
+            -- the icons to visibly "jump" back to native size right after
+            -- a zone change. ApplyScale() itself is cheap -- it early-outs
+            -- via _appliedBuffScale/_appliedDebuffScale if nothing changed --
+            -- so re-running it here on every world-enter is effectively
+            -- free in the common case and only does real work when Blizzard
+            -- actually reset something. QueueRefresh (already debounced) is
+            -- called alongside it to catch any button skin state lost in
+            -- the same rebuild.
+            self:RegisterEvent("PLAYER_ENTERING_WORLD")
         end)
+    elseif event == "PLAYER_ENTERING_WORLD" then
+        local cfg = PA()
+        if not cfg or not cfg.enabled then return end
+        ApplyScale()
+        QueueRefresh()
     end
 end)


### PR DESCRIPTION
# Summary

Expands the Blizzard Player Aura customization system with configurable borders, debuff-type border coloring, additional text customization options, and several runtime optimizations.

## Changes

### Aura Border Customization

* Added support for hiding Blizzard's default aura border/skin textures.
* Added an option to change the border based on dispel type. (see below)

### Debuff Type Border Colors

* Added optional debuff border coloring based on Blizzard's dispel type API.
* Added configurable colors for:
  * None
  * Magic
  * Curse
  * Disease
  * Poison
  * Bleed
* Added automatic cache invalidation so border color changes are applied immediately without requiring `/reload`.

### Aura Text Customization

* Split text configuration into independent Duration and Stack settings.
* Added configurable text positions (Top / Bottom).
* Added configurable X/Y offsets for both Duration and Stack text.
* Added independent font size settings for Duration and Stack text.
* Fixed "Show Text" not hiding stacks when disabled
* Fixed Duration & Stack strata to always be on top

### Options UI

* Added dedicated **Debuff Border** and **Debuff Color** sections.
* Added inline border color picker.
* Added debuff-type color picker grid.
* Added cog popups for configuring text position offsets.
* Added disabled states and contextual tooltips for dependent options.
* Added hide collpasing arrow option (CVar)
* Added padding options for buffs and debuffs
* Included duration format (new update)
* Included Border Styles (new update)
* Included Externals (new update)
<img width="1297" height="948" alt="grafik" src="https://github.com/user-attachments/assets/07518477-bd6c-4016-90e6-503a5ee1a28b" />



### Runtime

* Added Secret-Value-safe debuff border coloring using `C_UnitAuras.GetAuraDispelTypeColor()`.
* Added lazy creation and caching of the dispel color curve.
* Added runtime cache invalidation for debuff color changes.
* Added per-button appearance fingerprinting to skip unnecessary re-skinning.
* Added debounced aura refresh handling to collapse redundant `UpdateGridLayout()` refreshes.
* Reduced border updates to color-only changes when possible instead of rebuilding the entire aura.
* Added automatic refresh handling after loading screens and zone transitions.

### Defaults

* Added default border colors for all supported debuff types.
* Added default configuration values for all newly introduced Player Aura options.
* Preserved backward compatibility by falling back to default values for existing profiles.

