### PR TITLE
Fix: localize Width/Height labels in Unlock Mode size editor

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -7517,7 +7517,7 @@ local function CreateMover(barKey)
                 lbl:SetTextColor(0.75, 0.75, 0.75, 0.9)
                 lbl:SetJustifyH("LEFT")
                 lbl:SetPoint("LEFT", rowFrame, "LEFT", 10, 0)
-                lbl:SetText(axis)
+                lbl:SetText((EllesmereUI and EllesmereUI.L and EllesmereUI.L(axis)) or axis)
 
                 local box = CreateFrame("EditBox", nil, rowFrame)
                 box:SetSize(INPUT_W, INPUT_H)


### PR DESCRIPTION
The size-input rows in the Unlock Mode cog (Width/Height edit fields) set their label via `lbl:SetText(axis)`, passing the raw internal axis string straight to the UI. As a result the labels always rendered in English even when a translation existed in the locale catalog.

Wrapped the label render in `EllesmereUI.L()` so it goes through the locale system, while leaving the `axis == "Width"` comparisons untouched (those are internal logic keys, not display text).

- EUI_UnlockMode.lua: `lbl:SetText(EllesmereUI.L(axis))`

No catalog changes needed — "Width"/"Height" keys already exist. No `_keys.txt` change either (variable arg, not a literal, so the extractor doesn't pick it up).