### PR TITLE
Feature: Add chat tab font size option

### DIFF
--- a/EllesmereUIChat/EUI_Chat_Options.lua
+++ b/EllesmereUIChat/EUI_Chat_Options.lua
@@ -27,6 +27,7 @@ initFrame:SetScript("OnEvent", function(self)
     local function RefreshAll()
         if ECHAT.ApplyBackground  then ECHAT.ApplyBackground()  end
         if ECHAT.ApplyFonts       then ECHAT.ApplyFonts()       end
+        if ECHAT.ApplyTabFontSize then ECHAT.ApplyTabFontSize() end
         if ECHAT.RefreshVisibility then ECHAT.RefreshVisibility() end
     end
 
@@ -204,6 +205,13 @@ initFrame:SetScript("OnEvent", function(self)
                                   cancelText  = "Later",
                                   onConfirm   = function() ReloadUI() end,
                               })
+                          end },
+                        { type="slider", label="Tab Font Size",
+                          min = 8, max = 20, step = 1,
+                          get=function() return Cfg("tabFontSize") or 10 end,
+                          set=function(v)
+                              Set("tabFontSize", v)
+                              if ECHAT.ApplyTabFontSize then ECHAT.ApplyTabFontSize() end
                           end },
                     },
                 })

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -1960,7 +1960,8 @@ local function UpdateTabStyle(tab)
     -- FCF_OpenTemporaryWindow's secure chain. If taint resurfaces, rip SetFont first.
     local fs = CFD(tab).tabText
     if fs then
-        fs:SetFont(GetFont(), 11, "")
+        local tabSize = ECHAT.DB().tabFontSize or 10
+        fs:SetFont(GetFont(), tabSize, "")
         fs:SetJustifyH("CENTER")
         fs:ClearAllPoints()
         fs:SetPoint("CENTER", tab, 0, 0)
@@ -1980,6 +1981,17 @@ local function UpdateTabStyle(tab)
         if isActive then ns._activeUnderline = CFD(tab).underline end
     end
 
+end
+
+-- Re-apply tab font size to all skinned chat tabs. Called live from the
+-- options page (no reload needed), same pattern as ApplyBackground.
+function ECHAT.ApplyTabFontSize()
+    for i = 1, 20 do
+        local tab = _G["ChatFrame" .. i .. "Tab"]
+        if tab and CFD(tab).skinned then
+            UpdateTabStyle(tab)
+        end
+    end
 end
 
 -- One-time reskin of a Blizzard chat tab (strip textures, add our visuals)


### PR DESCRIPTION
## Chat Tab Font Size Option

### Summary
Adds a new option letting users adjust the font size of the chat tab labels (e.g. "General", "Trade", ...) independently from the actual chat text size.

### Changes

**`EllesmereUIChat.lua`**
- `UpdateTabStyle()`: tab font size is now read from `Cfg("tabFontSize")` instead of being hardcoded to `11` (the DB default was already `10`, but was never actually used anywhere).
- New function `ECHAT.ApplyTabFontSize()`: updates the font size on all currently skinned tabs live, no reload required.

**`EUI_Chat_Options.lua`**
- New **"Tab Font Size"** slider (range 8–20) in the cog popup next to the "Font" dropdown (alongside "Outline Mode").
- `RefreshAll()` now also calls `ApplyTabFontSize()`, so the size is correctly re-applied on e.g. profile switch.

### Behavior
- Change applies instantly, no `/reload` needed.
- Only affects the tab label text, not the chat message text size (which is still controlled via Blizzard's right-click "Font Size" menu).