### PR TITLE
fix(unitframes): stop detached power bar rendering behind its own fra…

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2697,10 +2697,20 @@ local function ReparentBarsToClip(frame, powerPosition)
                 frame.Power:SetParent(clip)
             end
         end
-        -- Power bar must render above absorb overlay (health level + 1).
         -- SetParent resets frame level, so re-assert after every reparent.
-        local hpLevel = frame.Health and frame.Health:GetFrameLevel() or clip:GetFrameLevel()
-        frame.Power:SetFrameLevel(hpLevel + 2)
+        if detached then
+            -- Detached bars are reparented onto `frame` itself (not the bar
+            -- clip), which also holds the border (frame:GetFrameLevel() + 10,
+            -- see CreateUnifiedBorder/UpdatePowerBorder). hpLevel + 2 (below)
+            -- sits well under that and let the border render over a detached
+            -- power bar dragged onto its edge -- match CreatePowerBar's own
+            -- detached offset instead so this stays consistently above it.
+            frame.Power:SetFrameLevel(frame:GetFrameLevel() + 12)
+        else
+            -- Power bar must render above absorb overlay (health level + 1).
+            local hpLevel = frame.Health and frame.Health:GetFrameLevel() or clip:GetFrameLevel()
+            frame.Power:SetFrameLevel(hpLevel + 2)
+        end
     end
 end
 
@@ -8045,6 +8055,22 @@ local function ReloadFrames()
                     frame.BottomTextBar:SetFrameStrata(strata)
                 end
             end
+            -- Same re-lift for a detached power bar. frame:SetFrameStrata above
+            -- just reset it to the frame's strata (same reason the cast bar needs
+            -- re-lifting below), so without this a detached power bar silently
+            -- falls back to the frame's strata and can end up behind the frame's
+            -- own border, however "Detached Power Bar" strata is configured.
+            if frame.Power then
+                local us2 = GetSettingsForUnit(unitKey)
+                local ppPos = us2 and us2.powerPosition or "below"
+                if ppPos == "detached_top" or ppPos == "detached_bottom" then
+                    if profile.enableCustomBarStratas then
+                        frame.Power:SetFrameStrata(profile.detachedPowerStrata or "HIGH")
+                    else
+                        frame.Power:SetFrameStrata("MEDIUM")
+                    end
+                end
+            end
             -- The cast bar is a child of the frame, so the SetFrameStrata above
             -- reset it to the frame's strata. Lift player/target/focus cast bars
             -- to HIGH so they never hide behind other MEDIUM-strata frames -- unless
@@ -11049,6 +11075,19 @@ function InitializeFrames()
                     frame.BottomTextBar:SetFrameStrata(db.profile.detachedTextBarStrata or "DIALOG")
                 else
                     frame.BottomTextBar:SetFrameStrata(strata)
+                end
+            end
+            -- Same re-lift for a detached power bar -- see the matching comment
+            -- in the other frameStrata-apply pass above for why this is needed.
+            if frame.Power then
+                local us2 = GetSettingsForUnit(unitKey)
+                local ppPos = us2 and us2.powerPosition or "below"
+                if ppPos == "detached_top" or ppPos == "detached_bottom" then
+                    if db.profile.enableCustomBarStratas then
+                        frame.Power:SetFrameStrata(db.profile.detachedPowerStrata or "HIGH")
+                    else
+                        frame.Power:SetFrameStrata("MEDIUM")
+                    end
                 end
             end
             -- The cast bar is a child of the frame, so the SetFrameStrata above


### PR DESCRIPTION
## Summary
Fixes a bug where a detached Target UnitFrame power bar (Bar Position: Detached Top/Bottom) would render **behind** its own frame's border when dragged onto the frame's edge, instead of on top of it.

## Changes

### Unit Frames — Power Bar Frame Level & Strata
Two separate frame-level/strata bugs in `EllesmereUIUnitFrames.lua`, both causing the detached power bar to lose its place above the frame border:

- **`ReparentBarsToClip`**: re-parents a detached power bar directly onto `frame` (required, since `SetParent` resets frame level in WoW's API), then re-asserted a flat `hpLevel + 2` regardless of detached state — well under the border's `frame:GetFrameLevel() + 10`. Now uses the same `+12` offset `CreatePowerBar` already used at initial creation, so reparenting (triggered any time "Bar Position" changes) stays consistent with it.
- **`ReloadFrames` / `InitializeFrames`**: the unit-frame strata reapply passes explicitly re-lift `BottomTextBar` and the cast bar after `frame:SetFrameStrata()` resets all children's strata (a documented side effect in the existing code) — but never did the same for a detached power bar, silently dragging it back down to the frame's own strata on any strata-affecting settings change.

## Bug Fixes
- Fixed the Target UnitFrame border rendering on top of a detached power bar positioned on/near the frame's edge.
- Fixed detached power bar strata silently resetting to the frame's own strata after a `SetFrameStrata` reapply pass, even with Custom Bar Stratas configured.

## Defaults
No new settings or defaults — both fixes correct existing frame-level/strata logic; no profile data changes needed.
<img width="395" height="141" alt="EUI TargetFramePowerBarFix" src="https://github.com/user-attachments/assets/24e7995f-eb02-43cd-aefe-b18cbfbcf425" />
