### PR TITLE
fix(bags): guard nil slot buttons during combat to prevent RefreshInv…

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -5252,10 +5252,12 @@ function EUI_Bags:RefreshInventory()
             for j, data in ipairs(pinItems) do
                 slotIdx = slotIdx + 1
                 local btn = GetOrCreateSlot(slotIdx)
-                btn:GetParent():SetParent(child)
-                local col = (j - 1) % columns
-                local row = math.floor((j - 1) / columns)
-                RenderButton(btn, data, slotIdx, col, row, startX, curY, columns)
+                if btn then  -- nil during combat (avoids minting tainted secure buttons)
+                    btn:GetParent():SetParent(child)
+                    local col = (j - 1) % columns
+                    local row = math.floor((j - 1) / columns)
+                    RenderButton(btn, data, slotIdx, col, row, startX, curY, columns)
+                end
             end
             -- Pin "+" button
             local pinItemCount = #pinItems
@@ -5263,16 +5265,18 @@ function EUI_Bags:RefreshInventory()
                 local pinIdx = pinItemCount + 1
                 slotIdx = slotIdx + 1
                 local pinSlot = GetOrCreateSlot(slotIdx)
-                pinSlot:GetParent():SetParent(child)
-                local col = (pinIdx - 1) % columns
-                local row = math.floor((pinIdx - 1) / columns)
-                RenderButton(pinSlot, { bag = 0, slot = 0 }, slotIdx, col, row, startX, curY, columns)
-                local ov = GetOrCreatePinOverlay()
-                ov:SetParent(child)
-                ov:ClearAllPoints()
-                ov:SetAllPoints(pinSlot)
-                ov:Show()
-                pinItemCount = pinItemCount + 1
+                if pinSlot then  -- nil during combat (avoids minting tainted secure buttons)
+                    pinSlot:GetParent():SetParent(child)
+                    local col = (pinIdx - 1) % columns
+                    local row = math.floor((pinIdx - 1) / columns)
+                    RenderButton(pinSlot, { bag = 0, slot = 0 }, slotIdx, col, row, startX, curY, columns)
+                    local ov = GetOrCreatePinOverlay()
+                    ov:SetParent(child)
+                    ov:ClearAllPoints()
+                    ov:SetAllPoints(pinSlot)
+                    ov:Show()
+                    pinItemCount = pinItemCount + 1
+                end
             end
             -- Pad remaining slots in last row
             local pinRemainder = pinItemCount % columns
@@ -5342,10 +5346,12 @@ function EUI_Bags:RefreshInventory()
             for j, data in ipairs(recentItems) do
                 slotIdx = slotIdx + 1
                 local btn = GetOrCreateSlot(slotIdx)
-                btn:GetParent():SetParent(child)
-                local col = (j - 1) % columns
-                local row = math.floor((j - 1) / columns)
-                RenderButton(btn, data, slotIdx, col, row, startX, curY, columns)
+                if btn then  -- nil during combat (avoids minting tainted secure buttons)
+                    btn:GetParent():SetParent(child)
+                    local col = (j - 1) % columns
+                    local row = math.floor((j - 1) / columns)
+                    RenderButton(btn, data, slotIdx, col, row, startX, curY, columns)
+                end
             end
             local recItemCount = #recentItems
             local recRemainder = recItemCount % columns
@@ -5455,10 +5461,12 @@ function EUI_Bags:RefreshInventory()
                 local _t0RB = ProfBegin("RenderButton")
                 slotIdx = slotIdx + 1
                 local btn = GetOrCreateSlot(slotIdx)
-                btn:GetParent():SetParent(child)
-                local col = (i - 1) % columns
-                local row = math.floor((i - 1) / columns)
-                RenderButton(btn, data, slotIdx, col, row, startX, curY, columns, true)
+                if btn then  -- nil during combat (avoids minting tainted secure buttons)
+                    btn:GetParent():SetParent(child)
+                    local col = (i - 1) % columns
+                    local row = math.floor((i - 1) / columns)
+                    RenderButton(btn, data, slotIdx, col, row, startX, curY, columns, true)
+                end
                 ProfEnd("RenderButton", _t0RB)
             end
             local reagRows = math.ceil(#reagentSlotList / columns)
@@ -5497,10 +5505,12 @@ function EUI_Bags:RefreshInventory()
                 local _t0RB = ProfBegin("RenderButton")
                 slotIdx = slotIdx + 1
                 local btn = GetOrCreateSlot(slotIdx)
-                btn:GetParent():SetParent(child)
-                local col = (j - 1) % columns
-                local row = math.floor((j - 1) / columns)
-                RenderButton(btn, data, slotIdx, col, row, startX, curY, columns)
+                if btn then  -- nil during combat (avoids minting tainted secure buttons)
+                    btn:GetParent():SetParent(child)
+                    local col = (j - 1) % columns
+                    local row = math.floor((j - 1) / columns)
+                    RenderButton(btn, data, slotIdx, col, row, startX, curY, columns)
+                end
                 ProfEnd("RenderButton", _t0RB)
             end
             local remainder = n % columns
@@ -5844,17 +5854,19 @@ function EUI_Bags:RefreshInventory()
                     local aIdx = memberItemCount + 1
                     slotIdx = slotIdx + 1
                     local aSlot = GetOrCreateSlot(slotIdx)
-                    aSlot:GetParent():SetParent(child)
-                    local col = (aIdx - 1) % columns
-                    local row = math.floor((aIdx - 1) / columns)
-                    RenderButton(aSlot, { bag = 0, slot = 0 }, slotIdx, col, row, startX, curY, columns)
-                    local aOv = GetOrCreateAssignOverlay()
-                    aOv._assignCatKey = memberCat._defaultName
-                    aOv:SetParent(child)
-                    aOv:ClearAllPoints()
-                    aOv:SetAllPoints(aSlot)
-                    aOv:Show()
-                    memberItemCount = memberItemCount + 1
+                    if aSlot then  -- nil during combat (avoids minting tainted secure buttons)
+                        aSlot:GetParent():SetParent(child)
+                        local col = (aIdx - 1) % columns
+                        local row = math.floor((aIdx - 1) / columns)
+                        RenderButton(aSlot, { bag = 0, slot = 0 }, slotIdx, col, row, startX, curY, columns)
+                        local aOv = GetOrCreateAssignOverlay()
+                        aOv._assignCatKey = memberCat._defaultName
+                        aOv:SetParent(child)
+                        aOv:ClearAllPoints()
+                        aOv:SetAllPoints(aSlot)
+                        aOv:Show()
+                        memberItemCount = memberItemCount + 1
+                    end
                 end
 
                 local remainder = memberItemCount % columns
@@ -6136,6 +6148,7 @@ function EUI_BagsReagent:RefreshInventory()
     local REAGENT_COLUMNS = 4
     for i, data in ipairs(tempItems) do
         local btn = GetOrCreateReagentSlot(i)
+        if btn then  -- nil during combat (avoids minting tainted secure buttons)
         local parent = btn:GetParent()
         parent:ClearAllPoints()
         parent:Show()
@@ -6190,6 +6203,7 @@ function EUI_BagsReagent:RefreshInventory()
         local col = (i - 1) % REAGENT_COLUMNS
         local row = math.floor((i - 1) / REAGENT_COLUMNS)
         parent:SetPoint("TOPLEFT", startX + (col * (SLOT_SIZE + SPACING)), startY - (row * (SLOT_SIZE + SPACING)))
+        end
     end
 
     EUI_BagsReagent:SetWidth((REAGENT_COLUMNS * (SLOT_SIZE + SPACING)) + 30)


### PR DESCRIPTION
## Summary
Fixes a Lua error (`attempt to index local 'btn' (a nil value)`) that could crash bag rendering when bags refreshed while in combat — most reliably triggered by `/reload` (or a reconnect) happening mid-combat, before the button pool had a chance to pre-warm.

## Root Cause
`GetOrCreateSlot()` and `GetOrCreateReagentSlot()` intentionally return `nil` while `InCombatLockdown()` is true, to avoid minting new tainted secure buttons during combat. Several render loops in `RefreshInventory` called these functions and used the returned button immediately without checking for `nil`, assuming a button was always created successfully.

## Changes

**`EllesmereUIBags/EllesmereUIBags.lua`**

- `EUI_Bags:RefreshInventory()` — added `if btn then ... end` guards around 6 previously-unguarded render sites: Pinned Items loop, Pin "+" button, Recent Items loop, Reagent Bag loop, main `RenderItemBlock` loop, and the group-view "assign +" slot.
- `EUI_BagsReagent:RefreshInventory()` — wrapped a separate, entirely unguarded ~55-line render loop (using `GetOrCreateReagentSlot`) in the same nil-check.

## Bug Fixes
- Fixed a crash in bag rendering when `RefreshInventory` ran during combat and a slot button wasn't available yet (pool not pre-warmed for that session), instead of erroring out mid-render.

## Verification
- Reproduced pre-fix by attacking a Training Dummy, `/reload`-ing while still in combat, then immediately opening bags — confirmed this reliably hit the crash.
- Re-tested with the fix applied using the same repro (combat → `/reload` mid-combat → open bags) — no error, bags render correctly with whatever slots are available and backfill normally once combat ends.