### PR TITLE
Localize tooltip Item Level label via EllesmereUI.L()

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -263,9 +263,9 @@ end
         if cached and _GameTooltip:IsShown() and _tipShownGUID == guid
             and not ttd.ilvlShown
             and EllesmereUIDB and EllesmereUIDB.tooltipItemLevel ~= false
-            and not _tipHasLine(_GameTooltip, "Item Level") then
+            and not _tipHasLine(_GameTooltip, EllesmereUI.L("Item Level")) then
             local nBefore = _GameTooltip:NumLines() or 0
-            _GameTooltip:AddDoubleLine("Item Level:", cached.ilvl, 1, 1, 1, 1, 1, 1)
+            _GameTooltip:AddDoubleLine(EllesmereUI.L("Item Level:"), cached.ilvl, 1, 1, 1, 1, 1, 1)
             _ttFonts(_GameTooltip, nBefore + 1)
             _GameTooltip:Show()
             ttd.ilvlShown = true
@@ -498,8 +498,8 @@ end
                     end
                 end
             end
-            if ilvl and not _tipHasLine(tt, "Item Level") then
-                tt:AddDoubleLine("Item Level:", ilvl, 1, 1, 1, 1, 1, 1)
+            if ilvl and not _tipHasLine(tt, EllesmereUI.L("Item Level")) then
+                tt:AddDoubleLine(EllesmereUI.L("Item Level:"), ilvl, 1, 1, 1, 1, 1, 1)
                 ttd.ilvlShown = true
             end
         end


### PR DESCRIPTION
## Summary

Localizes the inspect **Item Level** tooltip label through `EllesmereUI.L()` instead of the hardcoded English string.

The item level line was hardcoded as `Item Level:` on both the live `OnEvent` append and the tooltip re-render paths, so it always showed in English regardless of client locale. This wraps the label in `EllesmereUI.L()`, resolving it to the localized string (e.g. `物品等級:` on zhTW) via the already-existing locale keys.

The `_tipHasLine()` dedup guard is localized to the same string, so on localized clients the guard still matches its own line and does not add a duplicate Item Level row.

## Changes

- `EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua` — wrap the `AddDoubleLine` label and its matching `_tipHasLine` check in `EllesmereUI.L()` on both tooltip paths (4 lines).

## Testing

Verified in-game on a zhTW client: hovering other players shows the localized Item Level line with no duplicate rows.
