### PR TITLE
Feature: add the option to scale the quest tracker and keep the font size visually constant

### DIFF
--- a/EllesmereUIQuestTracker/EUI_QuestTracker_Options.lua
+++ b/EllesmereUIQuestTracker/EUI_QuestTracker_Options.lua
@@ -47,6 +47,7 @@ initFrame:SetScript("OnEvent", function(self)
         if EQT.UpdateVisibility   then EQT.UpdateVisibility()   end
         if EQT.RestyleAll         then EQT.RestyleAll()         end
         if EQT.ApplyBackground    then EQT.ApplyBackground()    end
+        if EQT.ApplyTrackerScale then EQT.ApplyTrackerScale() end
     end
 
     local function BuildPage(_, parent, yOffset)
@@ -210,7 +211,7 @@ initFrame:SetScript("OnEvent", function(self)
         end
         y = y - h
 
-        -- Row 5: Hide When In Raid | blank
+        -- Row 5: Hide When In Raid | Quest Tracker Scale
         _, h = W:DualRow(parent, y,
             { type="dropdown", text="Hide When In Raid",
               tooltip="Always: hide the tracker the whole time you are in a raid.\nBoss Combat: keep it visible and only hide during boss encounters.",
@@ -218,6 +219,11 @@ initFrame:SetScript("OnEvent", function(self)
               order  = { "always", "boss" },
               getValue=function() return Cfg("hideInRaidMode") or "boss" end,
               setValue=function(v) Set("hideInRaidMode", v); if EQT.UpdateVisibility then EQT.UpdateVisibility() end end },
+            { type="slider", text="Quest Tracker Scale",
+              tooltip="Scales the whole quest tracker. 1.0 = Blizzard's default size.\nFont sizes are kept visually constant automatically.\nQuest tracker height needs to be adjusted via Blizzard Edit Mode.",
+              min = 0.5, max = 2.0, step = 0.05,
+              getValue=function() return Cfg("trackerScale") or 1.0 end,
+              setValue=function(v) Set("trackerScale", v); if EQT.ApplyTrackerScale then EQT.ApplyTrackerScale() end; if EQT.ApplyForceOnScreen then EQT.ApplyForceOnScreen() end end },
             { type="label", text="" })
         y = y - h
 

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker.lua
@@ -35,6 +35,11 @@ local QT_DEFAULTS = {
             -- you are in a raid; "boss" (default) only hides it during boss encounters.
             hideInRaidMode       = "boss",
 
+            -- Tracker scale override. 1.0 = native Blizzard size, no
+            -- override. Applied via EQT.ApplyTrackerScale() (SetScale-based,
+            -- see that function's comment for why scale and not SetWidth).
+            trackerScale         = 1.0,
+
             -- Skin toggles
             skinHeaders          = true,
             accentHeaders        = true,
@@ -114,6 +119,41 @@ end
 function EQT.IsSuppressed() return next(_qtSuppressors) ~= nil end
 
 -------------------------------------------------------------------------------
+-- Tracker scale. Implemented via SetScale rather than SetWidth: Blizzard's
+-- ObjectiveTracker modules wrap FontStrings using hardcoded internal
+-- constants, not frame:GetWidth(), so a plain SetWidth() leaves the wrap
+-- point unchanged and breaks embedded elements (quest item buttons,
+-- progress bars). Scaling the whole frame keeps Blizzard's internal layout
+-- self-consistent -- nothing wraps differently, it's just uniformly
+-- bigger/smaller.
+--
+-- Deliberately NOT derived from a target pixel width anymore: that required
+-- measuring ObjectiveTrackerFrame's native width at runtime (GetWidth()),
+-- which is timing-sensitive (login race, layout not finalized yet) and, once
+-- cached wrong, stayed wrong for the rest of the session/reload. The DB
+-- value is the scale factor itself -- no measurement, no cache to go stale.
+-------------------------------------------------------------------------------
+function EQT.GetTrackerScale()
+    local scale = EQT.Cfg("trackerScale")
+    if not scale or scale <= 0 then return 1 end
+    return scale
+end
+
+function EQT.ApplyTrackerScale()
+    local frame = _G.ObjectiveTrackerFrame
+    if not frame then return end
+    frame:SetScale(EQT.GetTrackerScale())
+    -- Re-apply fonts now that the scale changed, so title/objective font
+    -- sizes stay visually constant regardless of tracker scale. See
+    -- EQT.GetTrackerScale() and GetTitleSize()/GetObjSize() in the skin file.
+    if EQT.RefreshFonts then EQT.RefreshFonts() end
+    -- Font sizes changing alone doesn't make Blizzard re-measure block
+    -- heights, so force a layout pass or lines overlap until the next
+    -- quest event / reload.
+    if EQT.ForceLayoutUpdate then EQT.ForceLayoutUpdate() end
+end
+
+-------------------------------------------------------------------------------
 -- Loader
 -------------------------------------------------------------------------------
 local loader = CreateFrame("Frame")
@@ -135,6 +175,7 @@ local function TryInit()
     if EQT.InitSkin       then EQT.InitSkin()       end
     if EQT.InitVisibility then EQT.InitVisibility() end
     if EQT.InitQoL        then EQT.InitQoL()        end
+    if EQT.ApplyTrackerScale then EQT.ApplyTrackerScale() end
     loader:UnregisterAllEvents()
 end
 
@@ -155,6 +196,7 @@ _G._EQT_RefreshAll = function()
     if EQT.UpdateVisibility then EQT.UpdateVisibility() end
     if EQT.RestyleAll then EQT.RestyleAll() end
     if EQT.ApplyBackground then EQT.ApplyBackground() end
+    if EQT.ApplyTrackerScale then EQT.ApplyTrackerScale() end
     if EQT.ApplyForceOnScreen then EQT.ApplyForceOnScreen() end
 end
 

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -56,8 +56,31 @@ local SUB_TRACKERS = {
 
 -- Shared font sizes -- read from DB so the options panel can tweak them.
 -- Defaults are seeded in the loader's QT_DEFAULTS table.
-local function GetTitleSize() return EQT.Cfg("titleFontSize")     or 13 end
-local function GetObjSize()   return EQT.Cfg("objectiveFontSize") or 11 end
+--
+-- Divided by the tracker's current scale (EQT.GetTrackerScale, see
+-- EllesmereUIQuestTracker.lua / EQT.ApplyTrackerScale) and rounded to a
+-- whole pixel: the tracker frame gets SetScale()'d directly from the DB
+-- value (deliberately not derived from a measured pixel width anymore --
+-- see EQT.GetTrackerScale's comment), so on-screen font size = raw size *
+-- scale. Pre-dividing here cancels that out, keeping the configured font
+-- size visually constant regardless of tracker scale. Rounding avoids
+-- feeding SetFont a fractional size.
+local function RoundFontSize(v)
+    if not v or v <= 0 then return 1 end
+    return math.floor(v + 0.5)
+end
+local function GetTitleSize()
+    local size = EQT.Cfg("titleFontSize") or 13
+    local scale = (EQT.GetTrackerScale and EQT.GetTrackerScale()) or 1
+    if not scale or scale <= 0 then scale = 1 end
+    return RoundFontSize(size / scale)
+end
+local function GetObjSize()
+    local size = EQT.Cfg("objectiveFontSize") or 11
+    local scale = (EQT.GetTrackerScale and EQT.GetTrackerScale()) or 1
+    if not scale or scale <= 0 then scale = 1 end
+    return RoundFontSize(size / scale)
+end
 
 -------------------------------------------------------------------------------
 -- External weak-keyed flag tables. Never write custom fields onto Blizzard-
@@ -119,12 +142,16 @@ local function ApplyShadow(fs)
 end
 
 -- Registry of every FontString we've styled. Lets us re-template in bulk
--- when the user changes font path / outline / shadow settings.
+-- when the user changes font path / outline / shadow settings, or when the
+-- tracker's scale changes (see EQT.RefreshFonts below). Maps
+-- fs -> "title" | "objective" | "generic", so a bulk refresh can recompute
+-- the correct target size per string instead of just re-applying whatever
+-- size happened to already be set.
 local _eqtFontRegistry = setmetatable({}, { __mode = "k" })
 
 -- Reapplies EUI font path with explicit size + outline + shadow.
 -- If `size` is nil, preserves Blizzard's current size.
-local function StyleFontStringSized(fs, size)
+local function StyleFontStringSized(fs, size, kind)
     if not fs or not fs.GetFont then return end
     if not size then
         local _, cur = fs:GetFont()
@@ -133,32 +160,52 @@ local function StyleFontStringSized(fs, size)
     local ok = pcall(fs.SetFont, fs, GetFont(), size, GetOutline())
     if not ok then fs:SetFont("Fonts/FRIZQT__.TTF", size, GetOutline()) end
     ApplyShadow(fs)
-    _eqtFontRegistry[fs] = true
+    _eqtFontRegistry[fs] = kind or "generic"
 end
 
 -- Convenience wrappers so every title / objective uses the shared sizes.
-local function StyleFontString(fs)     StyleFontStringSized(fs, nil)            end
-local function StyleTitleFS(fs)        StyleFontStringSized(fs, GetTitleSize()) end
-local function StyleObjectiveFS(fs)    StyleFontStringSized(fs, GetObjSize())   end
+local function StyleFontString(fs)     StyleFontStringSized(fs, nil, "generic")             end
+local function StyleTitleFS(fs)        StyleFontStringSized(fs, GetTitleSize(), "title")     end
+local function StyleObjectiveFS(fs)    StyleFontStringSized(fs, GetObjSize(), "objective")   end
 
 -- Walk every FontString region on a frame (top-level only) and restyle it.
 -- No recursion: child frames each go through their own skin call.
+--
+-- Skips regions already registered as "title"/"objective": those were just
+-- sized via StyleTitleFS/StyleObjectiveFS (e.g. from StyleObjectiveLine),
+-- and this generic sweep would otherwise immediately downgrade them back to
+-- "generic" in the registry -- which makes EQT.RefreshFonts stop recomputing
+-- their size against the current tracker scale and freeze them at whatever
+-- pixel size happened to be set at that moment.
 local function StyleAllFontStrings(frame)
     if not frame or not frame.GetRegions then return end
     for _, region in ipairs({ frame:GetRegions() }) do
         if region and region:GetObjectType() == "FontString" then
-            StyleFontString(region)
+            local existingKind = _eqtFontRegistry[region]
+            if existingKind ~= "title" and existingKind ~= "objective" then
+                StyleFontString(region)
+            end
         end
     end
 end
 
 -- Bulk re-template everything we've touched. Called when user changes font
--- settings in options.
+-- settings in options, AND whenever the tracker's scale changes (via
+-- EQT.ApplyTrackerScale), so title/objective sizes get recomputed against
+-- the new scale rather than keeping whatever size was last baked in.
 function EQT.RefreshFonts()
-    for fs in pairs(_eqtFontRegistry) do
+    for fs, kind in pairs(_eqtFontRegistry) do
         if fs and fs.GetFont then
-            local _, size = fs:GetFont()
-            pcall(fs.SetFont, fs, GetFont(), size or 12, GetOutline())
+            local size
+            if kind == "title" then
+                size = GetTitleSize()
+            elseif kind == "objective" then
+                size = GetObjSize()
+            else
+                local _, cur = fs:GetFont()
+                size = cur or 12
+            end
+            pcall(fs.SetFont, fs, GetFont(), size, GetOutline())
             ApplyShadow(fs)
         end
     end
@@ -1034,6 +1081,31 @@ EQT._SuppressAllPOIs = function()
                 end
             end
         end
+    end)
+end
+
+-- Forces every Blizzard sub-tracker to immediately recompute its layout
+-- (block/line heights and positions) against current font metrics. Plain
+-- SetFont() changes glyph size but doesn't make Blizzard re-measure block
+-- heights -- that only happens on Blizzard's own Update pass, which
+-- otherwise only runs on quest/scenario events. Without this, a live font
+-- or scale change leaves stale (too-short/too-tall) block heights until the
+-- next such event or a /reload, and lines visibly overlap in the meantime.
+--
+-- Deferred one frame via C_Timer.After(0), same pattern as the dirty-flag
+-- Update hook above: calling tracker:Update() directly from our own call
+-- stack could carry taint into any secure code Blizzard's layout touches;
+-- a fresh timer callback starts a clean stack instead.
+function EQT.ForceLayoutUpdate()
+    if InCombatLockdown and InCombatLockdown() then return end
+    C_Timer.After(0, function()
+        if InCombatLockdown and InCombatLockdown() then return end
+        EachTracker(function(tracker)
+            if tracker.Update then
+                pcall(tracker.Update, tracker)
+            end
+        end)
+        if EQT.QueueResize then EQT.QueueResize() end
     end)
 end
 


### PR DESCRIPTION
# Summary

Introduces configurable scaling support for the Blizzard Quest Tracker.

This implementation adds native tracker scaling based on `SetScale()` while keeping all configurable font sizes visually constant across every scale factor. This is a more robust implementation than changing the Objective Tracker's width, since Blizzard's internal wrapping, progress bars, timer bars and other layout calculations are not driven by the frame width.

Unlike the initial implementation, which derived the scale from a target pixel width measured at runtime, the final solution stores the scale factor directly. This removes the dependency on Blizzard's runtime layout initialization, eliminates measurement races during login, and produces deterministic scaling behavior across all sessions.

Additionally, the tracker now performs an explicit layout refresh whenever scaling or font sizes change to ensure Blizzard immediately recalculates cached block heights and text layout.

# Changes

## Native Tracker Scaling

Added a complete scaling system for the Blizzard Objective Tracker.

The tracker can now be scaled independently of Blizzard's Edit Mode while preserving all existing functionality and without modifying Blizzard's internal layout logic.

Implementation details:

* Added persistent `trackerScale` profile setting.
* Added `EQT.GetTrackerScale()`.
* Added `EQT.ApplyTrackerScale()`.
* Tracker scaling is applied through:

```lua
ObjectiveTrackerFrame:SetScale(scale)
```

instead of resizing the frame.

Using `SetScale()` preserves Blizzard's internal wrapping calculations, progress bars, timer bars and quest item positioning, all of which rely on Blizzard's fixed internal layout constants rather than the frame width.

## Font Scale Compensation

Scaling the tracker also scales every child FontString.

To preserve the user-configured font sizes, title and objective fonts now compensate for the tracker scale before calling `SetFont()`.

The font size is calculated using:

```lua
math.floor(size / scale + 0.5)
```

This keeps the rendered font size visually constant while avoiding fractional font sizes that could otherwise introduce inconsistent rendering.

## Immediate Blizzard Layout Refresh

Changing font sizes alone does not cause Blizzard to rebuild Objective Tracker block layouts.

Without an explicit layout pass, Blizzard continues using previously cached block heights until another Objective Tracker event occurs, which can result in overlapping objective text after changing scale or font settings.

To solve this, a new layout refresh pipeline has been implemented.

Added:

* `EQT.ForceLayoutUpdate()`

This function:

* iterates all Objective Tracker sub-trackers
* schedules a deferred `tracker:Update()` using `C_Timer.After(0, ...)`
* recalculates Blizzard's cached block heights
* immediately rebuilds text layout using the updated font metrics

The implementation follows the existing taint prevention strategy already used by the addon:

* deferred execution through `C_Timer.After()`
* `InCombatLockdown()` validation before and after scheduling
* avoids executing Blizzard layout code directly from the addon's call stack

`ForceLayoutUpdate()` is automatically invoked by `EQT.ApplyTrackerScale()`, ensuring that every existing code path applying tracker scaling—including profile changes, profile resets and font size updates—also performs a complete Blizzard layout refresh.

## Options

Added the Quest Tracker options UI:

* added **Tracker Scale**
* slider range: **0.50 – 2.00**
* step size: **0.05**
* added option descriptions

## Font Registry

Retained the previously introduced font registry fix.

Title and objective FontStrings now preserve their registry type during refreshes instead of being downgraded to generic entries, ensuring that font sizes continue to be recomputed correctly whenever the tracker scale changes.

# Result

The Blizzard Quest Tracker now supports configurable scaling independent of Blizzard Edit Mode while maintaining consistent visual font sizes across every scale factor. This is the better version of changing the width for the objective tracker since that can break easily.
