### PR TITLE
fix(questtracker): force relayout after font-size change or quest focus

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -164,6 +164,53 @@ function EQT.RefreshFonts()
     end
 end
 
+-- Forces Blizzard to fully recompute block heights/positions after we
+-- resize existing FontStrings (RestyleAll) or Blizzard only partially
+-- relayouts around a focus change -- both leave stale cached block heights
+-- that overlap the next block until a full ObjectiveTrackerFrame:Update()
+-- runs (normally only happens on /reload).
+--
+-- Deferred via C_Timer.After(0) so this never runs inline inside whatever
+-- callback triggered it: the documented SplashFrame taint (see
+-- EllesmereUIQuestTracker_QoL.lua) came from calling Update() SYNCHRONOUSLY
+-- inside a Blizzard secure call chain (OnHide during a quest turn-in flow).
+-- A fresh timer tick, fired from a plain insecure options-panel action or
+-- event handler, has no such ancestor. Also combat-gated because Update()
+-- rebuilds the tracker's secure quest-item action buttons; if combat is
+-- active when the tick fires, retry once on PLAYER_REGEN_ENABLED instead of
+-- silently dropping the request.
+local _relayoutPending = false
+local _relayoutRetryFrame = nil
+local function DoTrackerRelayout()
+    if InCombatLockdown() then
+        if not _relayoutRetryFrame then
+            _relayoutRetryFrame = CreateFrame("Frame")
+            _relayoutRetryFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+            if not EQT._eventFrames then EQT._eventFrames = {} end
+            if not EQT._eventRegistrations then EQT._eventRegistrations = {} end
+            local idx = #EQT._eventFrames + 1
+            EQT._eventFrames[idx] = _relayoutRetryFrame
+            EQT._eventRegistrations[idx] = {"PLAYER_REGEN_ENABLED"}
+            _relayoutRetryFrame:SetScript("OnEvent", function()
+                if EQT.ForceTrackerRelayout then EQT.ForceTrackerRelayout() end
+            end)
+        end
+        return
+    end
+    local otf = _G.ObjectiveTrackerFrame
+    if otf and otf.Update then
+        otf:Update()
+    end
+end
+function EQT.ForceTrackerRelayout()
+    if _relayoutPending then return end
+    _relayoutPending = true
+    C_Timer.After(0, function()
+        _relayoutPending = false
+        DoTrackerRelayout()
+    end)
+end
+
 -- Physical-pixel-perfect 1px accent divider under each section header.
 -- Parented to ObjectiveTrackerFrame (NOT the header) so collapse/expand
 -- animations on the header don't drag our divider with them. Keyed by
@@ -1078,8 +1125,15 @@ function EQT.InitSkin()
     -- Quest events just need a BG resize. Block skinning is handled by
     -- AddBlock/AddObjective/GetProgressBar/GetTimerBar hooks, so we no
     -- longer need to walk the entire tracker tree on every event.
-    evt:SetScript("OnEvent", function()
+    evt:SetScript("OnEvent", function(_, event)
         if EQT.QueueResize then EQT.QueueResize() end
+        -- Focusing a quest can expand its objective text without Blizzard
+        -- relayouting sibling blocks underneath it; force a full relayout
+        -- for this event specifically (not the frequent quest-log events,
+        -- which already go through Blizzard's own native Update()).
+        if event == "SUPER_TRACKING_CHANGED" and EQT.ForceTrackerRelayout then
+            EQT.ForceTrackerRelayout()
+        end
     end)
     if not EQT._eventFrames then EQT._eventFrames = {} end
     if not EQT._eventRegistrations then EQT._eventRegistrations = {} end
@@ -1107,6 +1161,10 @@ function EQT.InitSkin()
             if t.Header then SkinHeader(t.Header) end
             SkinExistingBlocks(t)
         end)
+        -- Font/color size changes just resized existing FontStrings in
+        -- place; Blizzard's cached block heights are now stale until a
+        -- full relayout runs (see EQT.ForceTrackerRelayout above).
+        if EQT.ForceTrackerRelayout then EQT.ForceTrackerRelayout() end
     end
 
     -- Live-update headers, blocks and progress bar fills when the user


### PR DESCRIPTION
## Summary
Fixes overlapping quest tracker text that occurred when changing Objective/Title Font Size, or when focusing (super-tracking) a quest that expands its objective text. Previously only fixed by a `/reload`.

## Root Cause
Changing font size resized existing FontStrings in place, but nothing told Blizzard's `ObjectiveTrackerFrame` to recompute its cached block heights so the next block stayed anchored at its old (now-stale) offset and text overlapped it. Focusing a quest that expands its objective text hit the same gap via `SUPER_TRACKING_CHANGED`: Blizzard only partially relayouts around the focused block, so sibling blocks below it don't shift to make room.

The fix call `ObjectiveTrackerFrame:Update()` after restyling is exactly what this addon had previously removed, due to a documented taint incident: calling that function synchronously from inside a Blizzard secure call chain (originally `SplashFrame`'s `OnHide`) taints the tracker's secure quest-item action buttons downstream.

## Changes

**`EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua`**

- Added `EQT.ForceTrackerRelayout()`  calls `ObjectiveTrackerFrame:Update()` deferred via `C_Timer.After(0)` so it never runs inline inside whatever callback triggered it (breaking the call-stack link that caused the original taint), and gated on `InCombatLockdown()`  if combat is active when the deferred tick fires, it retries once on `PLAYER_REGEN_ENABLED` instead of silently dropping the request.
- Wired into `RestyleAll()` (fires after font/color settings changes reapply sizes to existing FontStrings).
- Wired into the `SUPER_TRACKING_CHANGED` event handler specifically (quest focus changes) not the frequent quest-log-update events, which already go through Blizzard's own native `Update()` and don't need this.

## Bug Fixes
- Fixed quest tracker text overlapping after changing Objective/Title Font Size, without needing a `/reload`.
- Fixed the same overlap when focusing a quest that expands its objective text.
- Fixed the same overlap while turning quest in after changing size.

## Verification
- Changed Objective Font Size with multiple quests tracked lines no longer overlap, no reload needed.
- Focused a quest that expands its text sibling blocks reflow correctly.
- Tested quest turn-ins and quest-item hotkeys after a font-size change to confirm no taint regression (the exact failure mode of the original `SplashFrame` incident this fix is designed to avoid repeating).

<img width="317" height="690" alt="Questrackerwrap" src="https://github.com/user-attachments/assets/f9866b0e-a8f8-496f-8c9d-a7b8db2bee06" />
