### PR TITLE
fix(nameplates): measure localized labels in options layout

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -4730,13 +4730,12 @@ initFrame:SetScript("OnEvent", function(self)
                 titleFS:SetPoint("TOP", pf, "TOP", 0, -TOP_PAD)
                 pf._titleFS = titleFS
 
-                -- Measure label widths to compute layout BEFORE creating sliders
                 local tmpFS = pf:CreateFontString(nil, "OVERLAY")
                 tmpFS:SetFont(EllesmereUI.EXPRESSWAY or "Fonts\\FRIZQT__.TTF", 12, GetNPOptOutline())
-                local labelTexts = {"X Offset", "Y Offset", "Size", "Width %"}
+                local labelTexts = {"X Offset", "Y Offset", "Size", "Width %", "Spacing", "Opacity"}
                 local maxLblW = 0
                 for _, txt in ipairs(labelTexts) do
-                    tmpFS:SetText(txt)
+                    tmpFS:SetText(EllesmereUI.L(txt))
                     local w = tmpFS:GetStringWidth()
                     if w > maxLblW then maxLblW = w end
                 end


### PR DESCRIPTION
The Blizzard-settings popup laid out its rows using hardcoded English label widths, so longer translations overlapped the controls. The layout now measures the rendered FontString width instead.