### PR TITLE
feat(nameplates): raid marker opacity and friendly plate markers

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -3800,6 +3800,13 @@ initFrame:SetScript("OnEvent", function(self)
                         ns.RefreshAllSettings()
                         UpdatePreview()
                       end },
+                    { type="slider", label="Opacity", min=0.1, max=1, step=0.05,
+                      get=function() return DBVal("nameRaidMarkerAlpha") or defaults.nameRaidMarkerAlpha or 1 end,
+                      set=function(v)
+                        DB().nameRaidMarkerAlpha = v
+                        ns.RefreshAllSettings()
+                        UpdatePreview()
+                      end },
                 },
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
@@ -4801,6 +4808,20 @@ initFrame:SetScript("OnEvent", function(self)
                 spTrack:Hide(); spValBox:Hide()
                 pf._spTrack = spTrack; pf._spValBox = spValBox
 
+                local opLabel = MakeFont(pf, 12, nil, 1, 1, 1)
+                opLabel:SetAlpha(0.6); opLabel:SetText(EllesmereUI.L("Opacity"))
+                opLabel:SetPoint("LEFT", pf, "TOPLEFT", SIDE_PAD, SP_ROW_Y - SLIDER_H / 2)
+                opLabel:Hide()
+                pf._opLabel = opLabel
+                local opTrack, opValBox = BuildSliderCore(pf, SLIDER_W, 4, 12, INPUT_W, SLIDER_H, 11, SL_INPUT_A,
+                    0.1, 1, 0.05,
+                    function() return pf._opGet and pf._opGet() or 1 end,
+                    function(v) if pf._opSet then pf._opSet(v) end end, true)
+                opTrack:SetPoint("TOPLEFT", pf, "TOPLEFT", SLIDER_LEFT, SP_ROW_Y - 2)
+                opValBox:ClearAllPoints(); opValBox:SetPoint("TOPRIGHT", pf, "TOPRIGHT", -SIDE_PAD, SP_ROW_Y)
+                opTrack:Hide(); opValBox:Hide()
+                pf._opTrack = opTrack; pf._opValBox = opValBox
+
                 -- Width % slider row (hidden unless a width-fit text element: enemy
                 -- name, cast spell name, cast target). Fixed range, built once; the
                 -- row is reordered/repositioned per show via the seq block below.
@@ -5019,6 +5040,7 @@ initFrame:SetScript("OnEvent", function(self)
             local hasSize = opts.sizeGet ~= nil
             local hasWidth = opts.widthGet ~= nil
             local hasSpacing = opts.spacingGet ~= nil
+            local hasOpacity = opts.opacityGet ~= nil
             local hasGrowth = opts.growthGet ~= nil
             local hasToggle = opts.toggleGet ~= nil
             local hasCrop = opts.cropGet ~= nil
@@ -5063,6 +5085,20 @@ initFrame:SetScript("OnEvent", function(self)
                 cogPopup._spLabel:Hide()
                 cogPopup._spTrack:Hide()
                 cogPopup._spValBox:Hide()
+            end
+
+            if hasOpacity then
+                cogPopup._opGet = opts.opacityGet
+                cogPopup._opSet = opts.opacitySet
+                cogPopup._opLabel:Show()
+                cogPopup._opTrack:Show()
+                cogPopup._opValBox:Show()
+            else
+                cogPopup._opGet = nil
+                cogPopup._opSet = nil
+                cogPopup._opLabel:Hide()
+                cogPopup._opTrack:Hide()
+                cogPopup._opValBox:Hide()
             end
 
             -- Show/hide width % row
@@ -5193,6 +5229,7 @@ initFrame:SetScript("OnEvent", function(self)
                 local seq = {}
                 if hasSize and opts.sizeFirst then
                     seq[#seq + 1] = { p._sLabel, p._sTrack, p._sValBox }
+                    if hasOpacity then seq[#seq + 1] = { p._opLabel, p._opTrack, p._opValBox } end
                     if hasSpacing then seq[#seq + 1] = { p._spLabel, p._spTrack, p._spValBox } end
                     seq[#seq + 1] = { p._xLabel, p._xTrack, p._xValBox }
                     seq[#seq + 1] = { p._yLabel, p._yTrack, p._yValBox }
@@ -5200,6 +5237,7 @@ initFrame:SetScript("OnEvent", function(self)
                     seq[#seq + 1] = { p._xLabel, p._xTrack, p._xValBox }
                     seq[#seq + 1] = { p._yLabel, p._yTrack, p._yValBox }
                     if hasSize    then seq[#seq + 1] = { p._sLabel, p._sTrack, p._sValBox } end
+                    if hasOpacity then seq[#seq + 1] = { p._opLabel, p._opTrack, p._opValBox } end
                     if hasSpacing then seq[#seq + 1] = { p._spLabel, p._spTrack, p._spValBox } end
                 end
                 for i, r in ipairs(seq) do
@@ -5280,6 +5318,7 @@ initFrame:SetScript("OnEvent", function(self)
                 if hasSize    then h = h + gap + rowH end
                 if hasWidth   then h = h + gap + rowH end
                 if hasSpacing then h = h + gap + rowH end
+                if hasOpacity then h = h + gap + rowH end
                 if hasGrowth then h = h + gap + p._GROWTH_ROW_H end
                 -- Grow and toggle are mutually exclusive and share the same slot.
                 if hasToggle then h = h + gap + p._GROWTH_ROW_H end
@@ -5385,6 +5424,9 @@ initFrame:SetScript("OnEvent", function(self)
                     spacingKey = "buffSpacing"; cropKey = "buffCropIcons"
                 elseif element == "ccs" then
                     spacingKey = "ccSpacing"; cropKey = "ccCropIcons"
+                elseif element == "raidmarker" then
+                    opts.opacityGet = function() return DBVal("raidMarkerAlpha") or defaults.raidMarkerAlpha or 1 end
+                    opts.opacitySet = function(v) DB().raidMarkerAlpha = v; RefreshAllSlots(); UpdatePreview() end
                 end
                 if spacingKey then
                     opts.spacingGet = function() return DBVal(spacingKey) or defaults[spacingKey] end

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -137,7 +137,7 @@ function ns._appendDisplayPresetKeys(t)
         "buffDurationTextSize", "buffDurationTextX", "buffDurationTextY", "buffDurationTextColor",
         "ccDurationTextSize", "ccDurationTextX", "ccDurationTextY", "ccDurationTextColor",
         "buffTextSize", "buffTextColor", "ccTextSize", "ccTextColor",
-        "raidMarkerPos", "classificationSlot",
+        "raidMarkerPos", "raidMarkerAlpha", "classificationSlot",
         "castNameSize", "castNameColor", "castTargetSize", "castTargetClassColor", "castTargetColor",
         "showCastTimer", "castTimerSize", "castTimerColor", "targetScale",
         "castNameSide", "castTargetSide", "castTimerSide",
@@ -335,8 +335,10 @@ local defaults = {
     targetHighlightAlpha = 0.20,
     nameRaidMarkerEnabled = false,
     nameRaidMarkerSize = 14,
+    nameRaidMarkerAlpha = 1,
     raidMarkerPos = "topright",
     raidMarkerSize = 24,
+    raidMarkerAlpha = 1,
     classificationSlot = "topleft",
     rareEliteIconSize = 20,
     castBarHeight = 17,
@@ -1098,6 +1100,17 @@ local function GetRaidMarkerSize()
     return (p and p[pos .. "SlotSize"]) or defaults[pos .. "SlotSize"] or 24
 end
 ns.GetRaidMarkerSize = GetRaidMarkerSize
+local function GetRaidMarkerAlpha()
+    return (p and p.raidMarkerAlpha) or defaults.raidMarkerAlpha or 1
+end
+ns.GetRaidMarkerAlpha = GetRaidMarkerAlpha
+local function GetNameRaidMarkerCfg()
+    local enabled = (p and p.nameRaidMarkerEnabled) == true
+    local size = (p and p.nameRaidMarkerSize) or defaults.nameRaidMarkerSize or 14
+    local alpha = (p and p.nameRaidMarkerAlpha) or defaults.nameRaidMarkerAlpha or 1
+    return enabled, size, alpha
+end
+ns.GetNameRaidMarkerCfg = GetNameRaidMarkerCfg
 local function GetRaidMarkerYOffset()
     return 0
 end
@@ -3371,6 +3384,7 @@ function ns.RefreshAllSettings()
         end
     end
     if ns.ApplyClassPowerSetting then ns.ApplyClassPowerSetting() end
+    if ns.RefreshFriendlyRaidIcons then ns.RefreshFriendlyRaidIcons() end
     -- 12.1 aura containers: fingerprint-guarded, near-free when no aura
     -- settings changed.
     if ns.NPC_ReloadAll then ns.NPC_ReloadAll() end
@@ -6465,6 +6479,7 @@ function NameplateFrame:RefreshNamePosition(localOnly)
         else
             SetRaidTargetIconTexture(self.nameRaid, idx)
             PP.Size(self.nameRaidFrame, nameMarkerSize, nameMarkerSize)
+            self.nameRaidFrame:SetAlpha((p and p.nameRaidMarkerAlpha) or defaults.nameRaidMarkerAlpha or 1)
             self._nameRaidMarkerShown = true
             self.nameRaidFrame:Show()
             nameMarkerShown = true
@@ -6561,6 +6576,7 @@ function NameplateFrame:UpdateRaidIcon()
     SetRaidTargetIconTexture(self.raid, idx)
     local sz = GetRaidMarkerSize()
     PP.Size(self.raidFrame, sz, sz)
+    self.raidFrame:SetAlpha(GetRaidMarkerAlpha())
     local cpPush = GetClassPowerTopPush(self)
     local rxOff, ryOff = GetAuraSlotOffsets("raidMarker")
     self.raidFrame:ClearAllPoints()

--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -527,6 +527,12 @@ hooksecurefunc(NamePlateDriverFrame, "OnNamePlateAdded", function(_, unit)
         end
     end
 
+    if IsNameOnlyMode() then
+        C_Timer.After(0, function()
+            if ns.RefreshNameOnlyMarkers then ns.RefreshNameOnlyMarkers() end
+        end)
+    end
+
     -- Name-only mode (players): remove Blizzard's width constraint on the
     -- name FontString so long names are never truncated with "...".
     if IsNameOnlyMode() and UnitIsPlayer(unit) then
@@ -551,6 +557,71 @@ hooksecurefunc(NamePlateDriverFrame, "OnNamePlateAdded", function(_, unit)
     end
 end)
 
+local nameOnlyMarkers = {}
+
+local function GetNameOnlyNameFS(nameplate)
+    local overlay = npcOverlays[nameplate]
+    if overlay and overlay.name then return overlay.name, overlay end
+    local uf = nameplate.UnitFrame
+    if uf and uf.name then return uf.name, nameplate end
+    return nil
+end
+
+local function UpdateNameOnlyMarker(nameplate, unit)
+    local mk = nameOnlyMarkers[nameplate]
+    local enabled, size, alpha
+    if ns.GetNameRaidMarkerCfg then enabled, size, alpha = ns.GetNameRaidMarkerCfg() end
+    local idx
+    if enabled and IsNameOnlyMode() and unit and GetRaidTargetIndex then
+        idx = GetRaidTargetIndex(unit)
+    end
+    if not idx then
+        if mk then mk:Hide() end
+        return
+    end
+    local nameFS, parent = GetNameOnlyNameFS(nameplate)
+    if not nameFS or not nameFS:IsShown() then
+        if mk then mk:Hide() end
+        return
+    end
+    if not mk then
+        mk = CreateFrame("Frame", nil, UIParent)
+        mk.tex = mk:CreateTexture(nil, "OVERLAY")
+        mk.tex:SetAllPoints()
+        mk.tex:SetTexture("Interface\\TargetingFrame\\UI-RaidTargetingIcons")
+        nameOnlyMarkers[nameplate] = mk
+    end
+    mk:SetParent(parent)
+    mk:SetFrameLevel(((parent.GetFrameLevel and parent:GetFrameLevel()) or 0) + 6)
+    mk:ClearAllPoints()
+    mk:SetPoint("RIGHT", nameFS, "LEFT", -3, 0)
+    mk:SetSize(size, size)
+    mk:SetAlpha(alpha)
+    SetRaidTargetIconTexture(mk.tex, idx)
+    mk:Show()
+end
+
+local function HideNameOnlyMarker(nameplate)
+    local mk = nameOnlyMarkers[nameplate]
+    if mk then mk:Hide(); mk:SetParent(UIParent); mk:ClearAllPoints() end
+end
+
+function ns.RefreshNameOnlyMarkers()
+    if not (C_NamePlate and C_NamePlate.GetNamePlates) then return end
+    for _, nameplate in ipairs(C_NamePlate.GetNamePlates()) do
+        local unit = nameplate.namePlateUnitToken
+        if unit and not UnitCanAttack("player", unit) and not UnitIsUnit(unit, "player") then
+            UpdateNameOnlyMarker(nameplate, unit)
+        end
+    end
+end
+
+local nameOnlyMarkerWatcher = CreateFrame("Frame")
+nameOnlyMarkerWatcher:RegisterEvent("RAID_TARGET_UPDATE")
+nameOnlyMarkerWatcher:SetScript("OnEvent", function()
+    ns.RefreshNameOnlyMarkers()
+end)
+
 hooksecurefunc(NamePlateDriverFrame, "OnNamePlateRemoved", function(_, unit)
     -- Guard: Blizzard settings panel can fire this with "preview" which is not a valid unit
     if not unit or not unit:find("^nameplate") then return end
@@ -558,6 +629,7 @@ hooksecurefunc(NamePlateDriverFrame, "OnNamePlateRemoved", function(_, unit)
     local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
     if nameplate then
         HideNPCOverlay(nameplate)
+        HideNameOnlyMarker(nameplate)
         nameOnlyNPCSuppressed[nameplate] = nil
     end
     if modifiedUFs[unit] then
@@ -808,6 +880,7 @@ function FriendlyFrame:ClearUnit()
     self.glow:Hide()
     if ns.HideHoverEffect then ns.HideHoverEffect(self) else self.highlight:Hide() end
     self.raidFrame:Hide()
+    if self.nameRaidFrame then self.nameRaidFrame:Hide() end
     self.leftArrow:Hide()
     self.rightArrow:Hide()
     self:Hide()
@@ -849,8 +922,25 @@ function FriendlyFrame:UpdateName()
     self.name:SetText(unitName or "")
 end
 
+function FriendlyFrame:UpdateNameRaidIcon()
+    local nrf = self.nameRaidFrame
+    if not nrf then return end
+    local enabled, size, alpha
+    if ns.GetNameRaidMarkerCfg then enabled, size, alpha = ns.GetNameRaidMarkerCfg() end
+    local idx
+    if enabled and self.unit then
+        idx = GetRaidTargetIndex and GetRaidTargetIndex(self.unit)
+    end
+    if not idx then nrf:Hide(); return end
+    SetRaidTargetIconTexture(self.nameRaid, idx)
+    nrf:SetSize(size, size)
+    nrf:SetAlpha(alpha)
+    nrf:Show()
+end
+
 function FriendlyFrame:UpdateRaidIcon()
     if not self.unit then return end
+    self:UpdateNameRaidIcon()
     local pos = ns.GetRaidMarkerPos()
     if pos == "none" then self.raidFrame:Hide(); return end
     local idx = GetRaidTargetIndex and GetRaidTargetIndex(self.unit)
@@ -859,6 +949,7 @@ function FriendlyFrame:UpdateRaidIcon()
     local sz = ns.GetRaidMarkerSize()
     local rmY = ns.GetRaidMarkerYOffset()
     self.raidFrame:SetSize(sz, sz)
+    if ns.GetRaidMarkerAlpha then self.raidFrame:SetAlpha(ns.GetRaidMarkerAlpha()) end
     self.raidFrame:ClearAllPoints()
     if pos == "top" then
         self.raidFrame:SetPoint("BOTTOM", self.health, "TOP", 0, ns.GetDebuffYOffset())
@@ -979,6 +1070,7 @@ function ns.RemoveFriendlyPlateNoRestore(unit)
     plate.glow:Hide()
     if ns.HideHoverEffect then ns.HideHoverEffect(plate) else plate.highlight:Hide() end
     plate.raidFrame:Hide()
+    if plate.nameRaidFrame then plate.nameRaidFrame:Hide() end
     plate.leftArrow:Hide()
     plate.rightArrow:Hide()
     plate:Hide()
@@ -1052,6 +1144,13 @@ function ns.RefreshFriendlyHealthText()
     for _, plate in pairs(friendlyPlates) do
         plate:UpdateHealth()
     end
+end
+
+function ns.RefreshFriendlyRaidIcons()
+    for _, plate in pairs(friendlyPlates) do
+        plate:UpdateRaidIcon()
+    end
+    if ns.RefreshNameOnlyMarkers then ns.RefreshNameOnlyMarkers() end
 end
 
 function ns.RefreshFriendlyColors()


### PR DESCRIPTION
Adds opacity sliders for both the name raid marker and the slot raid marker, and shows the name marker on friendly plates: in health-bar mode it attaches to the custom friendly plate, in name-only mode a standalone marker anchors to the visible name text and stays in sync via RAID_TARGET_UPDATE. Shared enable/size/opacity settings drive all cases. Includes locale entries.