### PR TITLE
feat(buffreminders): label anchor option

### DIFF
--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -50,6 +50,18 @@ initFrame:SetScript("OnEvent", function(self)
         return db and db.profile
     end
     local function DDB()  local p = DB(); return p and p.display end
+
+    local PREVIEW_TEXT_ANCHORS = {
+        BOTTOM = { "TOP",    "BOTTOM" },
+        TOP    = { "BOTTOM", "TOP"    },
+        CENTER = { "CENTER", "CENTER" },
+        LEFT   = { "RIGHT",  "LEFT"   },
+        RIGHT  = { "LEFT",   "RIGHT"  },
+    }
+    local function GetPreviewTextAnchor(d)
+        local m = PREVIEW_TEXT_ANCHORS[(d and d.textAnchor) or "BOTTOM"] or PREVIEW_TEXT_ANCHORS.BOTTOM
+        return m[1], m[2]
+    end
     local function RDB()  local p = DB(); return p and p.raidBuffs end
     local function ADB()  local p = DB(); return p and p.auras end
     local function CDB()  local p = DB(); return p and p.consumables end
@@ -279,7 +291,8 @@ initFrame:SetScript("OnEvent", function(self)
                 local textYOff = d and d.textYOffset or -2
                 SetPVFont(btn._text, fontPath, textSize)
                 btn._text:ClearAllPoints()
-                btn._text:SetPoint("TOP", btn, "BOTTOM", textXOff, textYOff)
+                local tp, ip = GetPreviewTextAnchor(d)
+                btn._text:SetPoint(tp, btn, ip, textXOff, textYOff)
                 btn._text:SetTextColor(tc.r, tc.g, tc.b, 1)
                 btn._text:Show()
             else
@@ -548,7 +561,10 @@ initFrame:SetScript("OnEvent", function(self)
             local textXOff = d and d.textXOffset or 0
             local textYOff = d and d.textYOffset or -2
             local text = btn:CreateFontString(nil, "OVERLAY")
-            text:SetPoint("TOP", btn, "BOTTOM", textXOff, textYOff)
+            do
+                local tp, ip = GetPreviewTextAnchor(d)
+                text:SetPoint(tp, btn, ip, textXOff, textYOff)
+            end
             SetPVFont(text, fontPath, textSize)
             text:SetTextColor(tc.r, tc.g, tc.b, 1)
             text:SetText(iconData.label or "")
@@ -943,6 +959,14 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Text Size", min=6, max=30, step=1,
                       get=function() local d = DDB(); return d and d.textSize or 11 end,
                       set=function(v) local d = DDB(); if not d then return end; d.textSize = v; RefreshAll(); UpdatePreviewHeader() end },
+                    { type="dropdown", label="Anchor",
+                      values = {
+                          BOTTOM = "Below Icon", TOP = "Above Icon",
+                          CENTER = "On Icon", LEFT = "Left of Icon", RIGHT = "Right of Icon",
+                      },
+                      order = { "BOTTOM", "TOP", "CENTER", "LEFT", "RIGHT" },
+                      get=function() local d = DDB(); return d and d.textAnchor or "BOTTOM" end,
+                      set=function(v) local d = DDB(); if not d then return end; d.textAnchor = v; RefreshAll(); UpdatePreviewHeader() end },
                     { type="slider", label="X Offset", min=-50, max=50, step=1,
                       get=function() local d = DDB(); return d and d.textXOffset or 0 end,
                       set=function(v) local d = DDB(); if not d then return end; d.textXOffset = v; RefreshAll(); UpdatePreviewHeader() end },

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -26,6 +26,18 @@ local AURA_SCAN_LIMIT = 255  -- Midnight supports more than the legacy 40 buff l
 local DEFAULT_GLOW_COLOR = {r=1, g=0.776, b=0.376}
 local DEFAULT_TEXT_COLOR = {r=1, g=1, b=1}
 
+local TEXT_ANCHOR_POINTS = {
+    BOTTOM = { "TOP",    "BOTTOM" },
+    TOP    = { "BOTTOM", "TOP"    },
+    CENTER = { "CENTER", "CENTER" },
+    LEFT   = { "RIGHT",  "LEFT"   },
+    RIGHT  = { "LEFT",   "RIGHT"  },
+}
+local function GetTextAnchorPoints(p)
+    local m = TEXT_ANCHOR_POINTS[(p and p.textAnchor) or "BOTTOM"] or TEXT_ANCHOR_POINTS.BOTTOM
+    return m[1], m[2]
+end
+
 -------------------------------------------------------------------------------
 --  Profiler: zero cost when off, /eabrprof to toggle. debugprofilestop for
 --  per-label timing + C_AddOnProfiler for whole-addon avg/peak. Mirrors the
@@ -1532,6 +1544,7 @@ local defaults = {
             textFont = "Expressway",
             textXOffset = 0,
             textYOffset = -5,
+            textAnchor = "BOTTOM",
             iconSpacing = 14,
             opacity = 1.0,
             frameStrata = "MEDIUM",
@@ -1667,7 +1680,8 @@ local function ShowCombatIcon(iconIdx, spellID, texture, label)
         local yOff = p.textYOffset or -2
         SetABRFont(f._text, fontPath, textSize)
         f._text:ClearAllPoints()
-        f._text:SetPoint("TOP", f, "BOTTOM", xOff, yOff)
+        local tp, ip = GetTextAnchorPoints(p)
+        f._text:SetPoint(tp, f, ip, xOff, yOff)
         f._text:SetTextColor(tc.r, tc.g, tc.b, 1)
         f._text:SetText(label or "")
         f._text:Show()
@@ -1744,7 +1758,8 @@ local function ShowCursorIcon(iconIdx, spellID, texture, label)
         local yOff = p.textYOffset or -2
         SetABRFont(f._text, fontPath, textSize)
         f._text:ClearAllPoints()
-        f._text:SetPoint("TOP", f, "BOTTOM", xOff, yOff)
+        local tp, ip = GetTextAnchorPoints(p)
+        f._text:SetPoint(tp, f, ip, xOff, yOff)
         f._text:SetTextColor(tc.r, tc.g, tc.b, 1)
         f._text:SetText(label or "")
         f._text:Show()
@@ -2027,7 +2042,8 @@ local function ShowIcon(iconIdx, m)
         local yOff = p.textYOffset or -2
         SetABRFont(btn._text, fontPath, textSize)
         btn._text:ClearAllPoints()
-        btn._text:SetPoint("TOP", btn, "BOTTOM", xOff, yOff)
+        local tp, ip = GetTextAnchorPoints(p)
+        btn._text:SetPoint(tp, btn, ip, xOff, yOff)
         btn._text:SetTextColor(tc.r, tc.g, tc.b, 1)
         btn._text:Show()
     else
@@ -3227,7 +3243,8 @@ local function BeaconApplyText(f)
         local yOff = p.textYOffset or -2
         SetABRFont(f._text, fontPath, textSize)
         f._text:ClearAllPoints()
-        f._text:SetPoint("TOP", f, "BOTTOM", xOff, yOff)
+        local tp, ip = GetTextAnchorPoints(p)
+        f._text:SetPoint(tp, f, ip, xOff, yOff)
         f._text:SetTextColor(tc.r, tc.g, tc.b, 1)
         f._text:SetText(ShortLabel(f._spellID == _B.BOL and "Beacon of Light" or "Beacon of Faith"))
         f._text:Show()
@@ -3902,7 +3919,7 @@ mainFrame:RegisterEvent("PET_BAR_UPDATE")
 --  in a raid group and the player is a healer with < 80% mana.
 --  Out-of-combat only.
 -------------------------------------------------------------------------------
-do
+local SetupReadyCheckManaWarning = function()
     local warnFrame, warnFS, warnTimer, warnCurve
 
     -- Helpers hang on EABR, NOT block locals: this file's main chunk sits at
@@ -4080,4 +4097,5 @@ do
     _G._EABR_RCWarnHidePreview = HideWarning
     _G._EABR_RCWarnUpdateReg = UpdateReadyCheckRegistration
 end
+SetupReadyCheckManaWarning()
 


### PR DESCRIPTION
Adds an Anchor dropdown to the reminder text settings so the label can sit below, above, on, left of or right of the icon (offsets apply from the chosen side). Also moves the Ready Check Mana Warning section's locals into a function scope: the file main chunk was at Lua's 200-local register limit, and do-block locals still count against it. Includes locale entries.