### PR TITLE
Add minimap rotation and facing cone options

### DIFF
--- a/EllesmereUIMinimap/EUI_Minimap_Options.lua
+++ b/EllesmereUIMinimap/EUI_Minimap_Options.lua
@@ -482,6 +482,29 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.RegisterWidgetRefresh(UpdateResetVis)
         end
 
+        -- Map orientation controls belong to Display, immediately before the
+        -- next section starts.
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Rotate Minimap with Player",
+              tooltip="Rotate the minimap texture so the direction your character is facing is always at the top. WoW's renderer does not support rotating a square map without exposing empty corners.",
+              disabled=function() local m = MinimapDB(); return m and (m.shape or "square") == "square" end,
+              disabledTooltip="Circle Shape",
+              getValue=function() local m = MinimapDB(); return m and m.rotateMinimap or false end,
+              setValue=function(v)
+                  local m = MinimapDB(); if not m then return end
+                  m.rotateMinimap = v
+                  RefreshMinimap()
+              end },
+            { type="toggle", text="Show Line of Sight Cone",
+              tooltip="Draw a blue cone on the minimap showing the direction your character is facing.",
+              getValue=function() local m = MinimapDB(); return m and m.showFacingCone or false end,
+              setValue=function(v)
+                  local m = MinimapDB(); if not m then return end
+                  m.showFacingCone = v
+                  RefreshMinimap()
+              end }
+        );  y = y - h
+
         y = y - 10
 
         -- MINIMAP & QOL BUTTONS section header
@@ -1741,26 +1764,6 @@ initFrame:SetScript("OnEvent", function(self)
             accentSwatch:SetAlpha(initAccent and 1 or 0.3)
             customSwatch:SetAlpha(initAccent and 0.3 or 1)
         end
-
-        -- Keep map-orientation controls together at the end of Display.
-        _, h = W:DualRow(parent, y,
-            { type="toggle", text="Rotate Minimap with Player",
-              tooltip="Rotate the minimap texture so the direction your character is facing is always at the top.",
-              getValue=function() local m = MinimapDB(); return m and m.rotateMinimap or false end,
-              setValue=function(v)
-                  local m = MinimapDB(); if not m then return end
-                  m.rotateMinimap = v
-                  RefreshMinimap()
-              end },
-            { type="toggle", text="Show Line of Sight Cone",
-              tooltip="Draw a cone on the minimap showing the direction your character is facing.",
-              getValue=function() local m = MinimapDB(); return m and m.showFacingCone or false end,
-              setValue=function(v)
-                  local m = MinimapDB(); if not m then return end
-                  m.showFacingCone = v
-                  RefreshMinimap()
-              end }
-        );  y = y - h
 
         return math.abs(y)
     end

--- a/EllesmereUIMinimap/EUI_Minimap_Options.lua
+++ b/EllesmereUIMinimap/EUI_Minimap_Options.lua
@@ -207,36 +207,6 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        -- Inline cog on Shape for the Rotate Minimap toggle. Off (default) keeps
-        -- the rotateMinimap CVar at 0; on sets it to 1 (enforced in ApplyMinimap).
-        do
-            local rgn = shapeRow._leftRegion
-            local _, cogShow = EllesmereUI.BuildCogPopup({
-                title = "Shape Settings",
-                rows = {
-                    { type = "toggle", label = "Rotate Minimap",
-                      get = function() local m = MinimapDB(); return m and m.rotateMinimap or false end,
-                      set = function(v)
-                          local m = MinimapDB(); if not m then return end
-                          m.rotateMinimap = v
-                          RefreshMinimap()
-                      end },
-                },
-            })
-            local cogBtn = CreateFrame("Button", nil, rgn)
-            cogBtn:SetSize(26, 26)
-            cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-            rgn._lastInline = cogBtn
-            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
-            cogBtn:SetAlpha(0.4)
-            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
-            cogTex:SetAllPoints()
-            cogTex:SetTexture(EllesmereUI.COGS_ICON)
-            cogBtn:SetScript("OnEnter", function(s) s:SetAlpha(0.7) end)
-            cogBtn:SetScript("OnLeave", function(s) s:SetAlpha(0.4) end)
-            cogBtn:SetScript("OnClick", function(s) cogShow(s) end)
-        end
-
         -- Border Style (+ offset cog) | Border Size (+ class/custom swatches)
         local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
         local borderRow
@@ -1771,6 +1741,26 @@ initFrame:SetScript("OnEvent", function(self)
             accentSwatch:SetAlpha(initAccent and 1 or 0.3)
             customSwatch:SetAlpha(initAccent and 0.3 or 1)
         end
+
+        -- Keep map-orientation controls together at the end of Display.
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Rotate Minimap with Player",
+              tooltip="Rotate the minimap texture so the direction your character is facing is always at the top.",
+              getValue=function() local m = MinimapDB(); return m and m.rotateMinimap or false end,
+              setValue=function(v)
+                  local m = MinimapDB(); if not m then return end
+                  m.rotateMinimap = v
+                  RefreshMinimap()
+              end },
+            { type="toggle", text="Show Line of Sight Cone",
+              tooltip="Draw a cone on the minimap showing the direction your character is facing.",
+              getValue=function() local m = MinimapDB(); return m and m.showFacingCone or false end,
+              setValue=function(v)
+                  local m = MinimapDB(); if not m then return end
+                  m.showFacingCone = v
+                  RefreshMinimap()
+              end }
+        );  y = y - h
 
         return math.abs(y)
     end

--- a/EllesmereUIMinimap/EUI_Minimap_Options.lua
+++ b/EllesmereUIMinimap/EUI_Minimap_Options.lua
@@ -451,7 +451,14 @@ initFrame:SetScript("OnEvent", function(self)
                 RefreshMinimap()
                 EllesmereUI:RefreshPage()
               end },
-            { type="label", text="" }
+            { type="toggle", text="Show Line of Sight Cone",
+              tooltip="Draw a blue cone on the minimap showing the direction your character is facing.",
+              getValue=function() local m = MinimapDB(); return m and m.showFacingCone or false end,
+              setValue=function(v)
+                  local m = MinimapDB(); if not m then return end
+                  m.showFacingCone = v
+                  RefreshMinimap()
+              end }
         );  y = y - h
 
         -- "Reset" label next to the Free Move toggle (only visible when enabled)
@@ -495,14 +502,7 @@ initFrame:SetScript("OnEvent", function(self)
                   m.rotateMinimap = v
                   RefreshMinimap()
               end },
-            { type="toggle", text="Show Line of Sight Cone",
-              tooltip="Draw a blue cone on the minimap showing the direction your character is facing.",
-              getValue=function() local m = MinimapDB(); return m and m.showFacingCone or false end,
-              setValue=function(v)
-                  local m = MinimapDB(); if not m then return end
-                  m.showFacingCone = v
-                  RefreshMinimap()
-              end }
+            { type="label", text="" }
         );  y = y - h
 
         y = y - 10

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -4036,7 +4036,10 @@ local function ApplyMinimap()
 
     -- Rotate Minimap: enforce the CVar to match our setting. Default off keeps
     -- it at 0; turning it on sets 1. Runs out of combat (ApplyMinimap defers).
-    SetCVar("rotateMinimap", p.rotateMinimap and "1" or "0")
+    -- WoW's native rotating render has no overscan for a square mask, exposing
+    -- empty corners as it turns. Limit rotation to circular shapes.
+    local rotateMap = p.rotateMinimap and (p.shape == "circle" or p.shape == "textured_circle")
+    SetCVar("rotateMinimap", rotateMap and "1" or "0")
 
     local minimap = Minimap
     if not minimap then return end
@@ -4047,7 +4050,10 @@ local function ApplyMinimap()
         EBS._rotateMinimapHooked = true
         hooksecurefunc(MinimapCluster, "SetRotateMinimap", function()
             local mp = EBS.db and EBS.db.profile and EBS.db.profile.minimap
-            if mp then SetCVar("rotateMinimap", mp.rotateMinimap and "1" or "0") end
+            if mp then
+                local rotate = mp.rotateMinimap and (mp.shape == "circle" or mp.shape == "textured_circle")
+                SetCVar("rotateMinimap", rotate and "1" or "0")
+            end
         end)
     end
 
@@ -4059,11 +4065,18 @@ local function ApplyMinimap()
         cone:SetAllPoints(minimap)
         cone:SetFrameLevel(minimap:GetFrameLevel() + 2)
         cone:EnableMouse(false)
+        cone.fillLines = {}
+        for i = 1, 41 do
+            local line = cone:CreateLine(nil, "ARTWORK")
+            line:SetThickness(3)
+            line:SetColorTexture(0.15, 0.55, 1, 0.12)
+            cone.fillLines[i] = line
+        end
         cone.lines = {}
         for i = 1, 12 do
             local line = cone:CreateLine(nil, "OVERLAY")
             line:SetThickness(i <= 2 and 1.5 or 1)
-            line:SetColorTexture(1, 1, 1, i <= 2 and 0.65 or 0.45)
+            line:SetColorTexture(0.25, 0.7, 1, i <= 2 and 0.8 or 0.65)
             cone.lines[i] = line
         end
         cone:SetScript("OnUpdate", function(self, elapsed)
@@ -4077,7 +4090,8 @@ local function ApplyMinimap()
             if not facing then self:SetAlpha(0); return end
             self:SetAlpha(1)
 
-            local angle = mp.rotateMinimap and 0 or facing
+            local rotates = mp.rotateMinimap and (mp.shape == "circle" or mp.shape == "textured_circle")
+            local angle = rotates and 0 or facing
             local radius = min(self:GetWidth(), self:GetHeight()) * 0.42
             local halfAngle = math.rad(32)
             local cx, cy = 0, 0
@@ -4087,6 +4101,16 @@ local function ApplyMinimap()
 
             local leftX, leftY = Point(angle - halfAngle)
             local rightX, rightY = Point(angle + halfAngle)
+
+            -- Closely-spaced translucent rays create the filled blue sector.
+            for i = 1, 41 do
+                local a = angle - halfAngle + (i - 1) * (halfAngle * 2 / 40)
+                local x, y = Point(a)
+                local line = self.fillLines[i]
+                line:SetStartPoint("CENTER", self, cx, cy)
+                line:SetEndPoint("CENTER", self, x, y)
+            end
+
             self.lines[1]:SetStartPoint("CENTER", self, cx, cy)
             self.lines[1]:SetEndPoint("CENTER", self, leftX, leftY)
             self.lines[2]:SetStartPoint("CENTER", self, cx, cy)

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -4092,7 +4092,7 @@ local function ApplyMinimap()
 
             local rotates = mp.rotateMinimap and (mp.shape == "circle" or mp.shape == "textured_circle")
             local angle = rotates and 0 or facing
-            local radius = min(self:GetWidth(), self:GetHeight()) * 0.21
+            local radius = min(self:GetWidth(), self:GetHeight()) * 0.315
             local halfAngle = math.rad(32)
             local cx, cy = 0, 0
             local function Point(a)

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -4092,7 +4092,7 @@ local function ApplyMinimap()
 
             local rotates = mp.rotateMinimap and (mp.shape == "circle" or mp.shape == "textured_circle")
             local angle = rotates and 0 or facing
-            local radius = min(self:GetWidth(), self:GetHeight()) * 0.42
+            local radius = min(self:GetWidth(), self:GetHeight()) * 0.21
             local halfAngle = math.rad(32)
             local cx, cy = 0, 0
             local function Point(a)

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -69,6 +69,7 @@ local defaults = {
             enabled       = true,
             shape         = "square",
             rotateMinimap = false,
+            showFacingCone = false,
             borderSize    = 1,
             showCoords    = false,
             coordPrecision = 0,
@@ -4039,6 +4040,72 @@ local function ApplyMinimap()
 
     local minimap = Minimap
     if not minimap then return end
+
+    -- Blizzard can re-apply its own rotate-minimap preference during layout
+    -- changes. Keep our explicit setting authoritative, as SexyMap does.
+    if MinimapCluster and not EBS._rotateMinimapHooked then
+        EBS._rotateMinimapHooked = true
+        hooksecurefunc(MinimapCluster, "SetRotateMinimap", function()
+            local mp = EBS.db and EBS.db.profile and EBS.db.profile.minimap
+            if mp then SetCVar("rotateMinimap", mp.rotateMinimap and "1" or "0") end
+        end)
+    end
+
+    -- Player-facing line-of-sight cone. Lines avoid an additional texture
+    -- asset and remain crisp at every minimap size. With a rotating map the
+    -- player always faces up; on a north-up map the cone follows facing.
+    if not minimap._euiFacingCone then
+        local cone = CreateFrame("Frame", nil, minimap)
+        cone:SetAllPoints(minimap)
+        cone:SetFrameLevel(minimap:GetFrameLevel() + 2)
+        cone:EnableMouse(false)
+        cone.lines = {}
+        for i = 1, 12 do
+            local line = cone:CreateLine(nil, "OVERLAY")
+            line:SetThickness(i <= 2 and 1.5 or 1)
+            line:SetColorTexture(1, 1, 1, i <= 2 and 0.65 or 0.45)
+            cone.lines[i] = line
+        end
+        cone:SetScript("OnUpdate", function(self, elapsed)
+            self.elapsed = (self.elapsed or 0) + elapsed
+            if self.elapsed < 0.03 then return end
+            self.elapsed = 0
+
+            local mp = EBS.db and EBS.db.profile and EBS.db.profile.minimap
+            if not mp or not mp.showFacingCone then return end
+            local facing = GetPlayerFacing()
+            if not facing then self:SetAlpha(0); return end
+            self:SetAlpha(1)
+
+            local angle = mp.rotateMinimap and 0 or facing
+            local radius = min(self:GetWidth(), self:GetHeight()) * 0.42
+            local halfAngle = math.rad(32)
+            local cx, cy = 0, 0
+            local function Point(a)
+                return cx + math.sin(a) * radius, cy + math.cos(a) * radius
+            end
+
+            local leftX, leftY = Point(angle - halfAngle)
+            local rightX, rightY = Point(angle + halfAngle)
+            self.lines[1]:SetStartPoint("CENTER", self, cx, cy)
+            self.lines[1]:SetEndPoint("CENTER", self, leftX, leftY)
+            self.lines[2]:SetStartPoint("CENTER", self, cx, cy)
+            self.lines[2]:SetEndPoint("CENTER", self, rightX, rightY)
+
+            -- Ten short segments form the curved outer edge of the cone.
+            for i = 1, 10 do
+                local a1 = angle - halfAngle + (i - 1) * (halfAngle * 2 / 10)
+                local a2 = angle - halfAngle + i * (halfAngle * 2 / 10)
+                local x1, y1 = Point(a1)
+                local x2, y2 = Point(a2)
+                local line = self.lines[i + 2]
+                line:SetStartPoint("CENTER", self, x1, y1)
+                line:SetEndPoint("CENTER", self, x2, y2)
+            end
+        end)
+        minimap._euiFacingCone = cone
+    end
+    minimap._euiFacingCone:SetShown(p.showFacingCone)
 
     if not p.enabled then
         -- If we never touched the minimap this session, do absolutely nothing.


### PR DESCRIPTION
## Summary

- add a toggle that rotates circular minimap textures with the player
- add an independent blue facing cone for circular and square minimaps
- place both controls at the end of the Minimap Display section

## Why

These options make the player's facing direction easier to read at a glance. Rotation uses WoW's native minimap behavior for circular maps, while the facing cone also supports square maps without exposing the native rotating renderer's empty corners.

## Demo
https://github.com/user-attachments/assets/f2abecfe-65b4-4a25-9396-eaeaa6a8e810
