### PR TITLE
fix(blizzard-skin): avoid secret-boolean errors on Group Finder checkboxes

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
@@ -344,9 +344,9 @@ local function SkinCheckbox(cb)
     wash:Hide()
     local hovering = false
     local function updState()
-        local checked = cb:GetChecked() and true or false
-        tick:SetShown(checked)
-        wash:SetShown(hovering or checked)
+        local checked = cb:GetChecked() -- may be a secret boolean under LFG taint
+        if tick.SetAlphaFromBoolean then tick:SetAlphaFromBoolean(checked) else tick:SetShown(checked) end
+        if issecretvalue(checked) then wash:SetShown(hovering) else wash:SetShown(hovering or checked) end
     end
     cb:HookScript("OnEnter", function() hovering = true; updState() end)
     cb:HookScript("OnLeave", function() hovering = false; updState() end)
@@ -706,7 +706,10 @@ local function ResolveRailSelection(getBtn, captured, holder)
     if captured ~= nil then return captured end
     for i = 1, 4 do
         local b = getBtn(i)
-        if b and b.GetChecked and b:GetChecked() then return i end
+        if b and b.GetChecked then
+            local c = b:GetChecked()
+            if not issecretvalue(c) and c then return i end
+        end
     end
     local glowSel, glowCount = nil, 0
     for i = 1, 4 do
@@ -1235,11 +1238,13 @@ end
 
 local function SaveAppRoles(dialog)
     if not (RememberRolesOn() and dialog and EllesmereUIDB) then return end
-    local function chk(btn) return (btn and btn.CheckButton and btn.CheckButton:GetChecked()) and true or false end
+    local function chk(btn) return btn and btn.CheckButton and btn.CheckButton:GetChecked() end
+    local t, h, d = chk(dialog.TankButton), chk(dialog.HealerButton), chk(dialog.DamagerButton)
+    if issecretvalue(t) or issecretvalue(h) or issecretvalue(d) then return end -- can't persist secret role state
     EllesmereUIDB.lfgSavedRoles = {
-        tank    = chk(dialog.TankButton),
-        healer  = chk(dialog.HealerButton),
-        damager = chk(dialog.DamagerButton),
+        tank    = t and true or false,
+        healer  = h and true or false,
+        damager = d and true or false,
     }
 end
 

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
@@ -345,7 +345,7 @@ local function SkinCheckbox(cb)
     local hovering = false
     local function updState()
         local checked = cb:GetChecked() -- may be a secret boolean under LFG taint
-        if tick.SetAlphaFromBoolean then tick:SetAlphaFromBoolean(checked) else tick:SetShown(checked) end
+        if tick.SetAlphaFromBoolean then tick:SetAlphaFromBoolean(checked) elseif not issecretvalue(checked) then tick:SetShown(checked) end
         if issecretvalue(checked) then wash:SetShown(hovering) else wash:SetShown(hovering or checked) end
     end
     cb:HookScript("OnEnter", function() hovering = true; updState() end)

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -2469,7 +2469,7 @@ local function SkinGuildCheck(cb)
     local hovering = false
     local function updState()
         local checked = cb:GetChecked() -- may be a secret boolean under taint
-        if tick.SetAlphaFromBoolean then tick:SetAlphaFromBoolean(checked) else tick:SetShown(checked) end
+        if tick.SetAlphaFromBoolean then tick:SetAlphaFromBoolean(checked) elseif not issecretvalue(checked) then tick:SetShown(checked) end
         if issecretvalue(checked) then wash:SetShown(hovering) else wash:SetShown(hovering or checked) end
     end
     cb:HookScript("OnEnter", function() hovering = true; updState() end)

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -21,6 +21,7 @@ local Theme = WSkin.Theme
 local GetFFD = WSkin.GetFFD
 local FFD = WSkin.FFD
 local SolidTex = WSkin.SolidTex
+local issecretvalue = issecretvalue or function() return false end
 
 -------------------------------------------------------------------------------
 --  Collections (Mounts / Pets / Toys / Heirlooms / Appearances / Campsites)
@@ -2467,9 +2468,9 @@ local function SkinGuildCheck(cb)
     wash:Hide()
     local hovering = false
     local function updState()
-        local checked = cb:GetChecked() and true or false
-        tick:SetShown(checked)
-        wash:SetShown(hovering or checked)
+        local checked = cb:GetChecked() -- may be a secret boolean under taint
+        if tick.SetAlphaFromBoolean then tick:SetAlphaFromBoolean(checked) else tick:SetShown(checked) end
+        if issecretvalue(checked) then wash:SetShown(hovering) else wash:SetShown(hovering or checked) end
     end
     cb:HookScript("OnEnter", function() hovering = true; updState() end)
     cb:HookScript("OnLeave", function() hovering = false; updState() end)


### PR DESCRIPTION
## Summary
- Fixes Lua errors thrown by the Group Finder reskin under LFG taint (12.0 secret values). With `/euidev` on, creating/browsing a group raised `attempt to perform boolean test on a secret boolean value` and `bad argument #1 to 'SetShown'` from the custom checkbox skin.
- `CheckButton:GetChecked()` can now return a *secret boolean*; boolean tests on it and `SetShown(secret)` are disallowed on tainted paths.
- The custom checkmark is now driven with `Region:SetAlphaFromBoolean` (the sanctioned secret-safe API). Remaining checked-state reads (`ResolveRailSelection`, `SaveAppRoles`, and the hover wash) are guarded with `issecretvalue`, degrading gracefully instead of erroring.
- Same fix applied to the identical checkbox helper in `EllesmereUIBlizzardSkin_WindowPacks.lua`.

## Notes
- Behavior is unchanged outside restricted content. The only difference under LFG taint: the faint hover-wash won't light up purely from the checked state (still lights on hover); the green tick still reflects checked state correctly.
- No localized strings changed, so `Locales/_keys.txt` is untouched.

## Test plan
- [x] With `/euidev` on, open Group Finder and create a group — no `EllesmereUIBlizzardSkin_GroupFinder.lua` errors.
- [x] Browse Premade Groups and apply — no secret-boolean / SetShown errors.
- [x] Category-rail checkboxes and the sign-up role checkboxes render correctly (tick + hover) outside instances.
