### PR TITLE
Dragon riding widght bug

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -1729,6 +1729,47 @@ local function ApplyAllWidthHeightMatches()
     ApplyMatchesInDependencyOrder(MatchH.GetHeightMatchDB(), MatchH.ApplyHeightMatch)
 end
 
+-- Re-sync every active width/height match when the global UI Scale changes.
+-- ApplyWidthMatch/ApplyHeightMatch convert the target's size into the
+-- source's coordinate space via GetEffectiveScale() ratio -- correct at the
+-- moment they run, but nothing previously re-ran that conversion after a UI
+-- Scale change, so a source/target pair whose frames don't scale identically
+-- (e.g. a custom element parented to UIParent matched against a Blizzard
+-- Edit Mode frame with its own independent scale) is left using the OLD
+-- scale ratio until something UNRELATED happens to trigger a re-match. This
+-- produced reports of "extra spacing" on Dragon Riding's Width Match to
+-- Cooldowns that only went away when changing something else forced a
+-- re-application. A short delay lets every frame's GetEffectiveScale()
+-- finish propagating through the hierarchy before recomputing.
+-- Debounced to a quiet period rather than a fixed delay from the first
+-- event: a live-preview UI Scale slider can fire this event many times per
+-- second while being dragged, and re-running the match pass on every single
+-- firing (each one capturing a different, still-transient scale) was itself
+-- causing a non-converging feedback loop -- the re-applied width feeding
+-- into the next SetSize, which re-fires the resize-propagation chain, which
+-- re-applies again with a slightly different value, repeating indefinitely.
+-- Cancelling and rescheduling on every event means the pass only actually
+-- runs once scale changes stop arriving for a moment.
+-- Shares its debounce timer (on EllesmereUI.PP) with the other UI-Scale
+-- trigger in EllesmereUI.lua's PP.SetUIScale, rather than keeping an
+-- independent local timer: whether UIParent:SetScale() also raises this
+-- event is not something we could verify statically, so if it does, this
+-- listener cancels/replaces PP.SetUIScale's own pending timer (or vice
+-- versa) instead of both firing a full match pass back to back.
+do
+    local f = CreateFrame("Frame")
+    f:RegisterEvent("UI_SCALE_CHANGED")
+    f:SetScript("OnEvent", function()
+        local PPu = EllesmereUI and EllesmereUI.PP
+        if not PPu then return end
+        if PPu._scaleMatchDebounce then PPu._scaleMatchDebounce:Cancel() end
+        PPu._scaleMatchDebounce = C_Timer.NewTimer(0.3, function()
+            PPu._scaleMatchDebounce = nil
+            ApplyAllWidthHeightMatches()
+        end)
+    end)
+end
+
 -------------------------------------------------------------------------------
 --  OnSizeChanged hook for registered element frames
 --  Automatically fires NotifyElementResized when a frame changes size,

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -1867,6 +1867,21 @@ do
             if _G._ERB_Apply then _G._ERB_Apply() end
             if _G._EAB_Apply then _G._EAB_Apply() end
             if _G._ECME_Apply then _G._ECME_Apply() end
+            -- Re-sync width/height matches (e.g. Dragon Riding's Width Match
+            -- to Cooldowns) against the new pixel grid. This is EllesmereUI's
+            -- own scale setter -- it calls UIParent:SetScale() directly, which
+            -- does NOT fire Blizzard's UI_SCALE_CHANGED (that's tied to the
+            -- CVar system), so a listener on that event never catches this
+            -- path. Debounced the same way: the Options slider can call this
+            -- repeatedly while being dragged, and re-matching on every single
+            -- call was itself causing a non-converging feedback loop.
+            if EllesmereUI.ApplyAllWidthHeightMatches then
+                if PP._scaleMatchDebounce then PP._scaleMatchDebounce:Cancel() end
+                PP._scaleMatchDebounce = C_Timer.NewTimer(0.3, function()
+                    PP._scaleMatchDebounce = nil
+                    EllesmereUI.ApplyAllWidthHeightMatches()
+                end)
+            end
         end
     end
 

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
@@ -413,12 +413,29 @@ end
 --  Build / Rebuild / Redraw
 -------------------------------------------------------------------------------
 local function LayoutPips(frame, pipCount, width, height, spacing)
+    -- Distribute in whole PHYSICAL-pixel units (PP.mult), not whole
+    -- UI-coordinate units. 1 UI-unit only equals 1 physical pixel at the
+    -- "pixel perfect" scale -- at any other UI Scale, flooring to whole
+    -- UI-units left a fractional remainder unassigned, so the last pip fell
+    -- short of the frame's actual right edge (the "extra spacing between
+    -- charges and Whirling Surge" report, reproducible at UI scales where
+    -- that leftover doesn't round away to ~0).
+    local PPdr = EllesmereUI and EllesmereUI.PP
+    local px = (PPdr and PPdr.mult and PPdr.mult > 0) and PPdr.mult or 1
     local widthAvail = max(0, width - (pipCount - 1) * spacing)
-    local pipW = floor(widthAvail / pipCount)
-    local rem  = widthAvail - pipW * pipCount
+    -- If the whole row doesn't span even one physical pixel (a very small
+    -- bar at a low UI Scale, where px itself is large), snapping to whole
+    -- physical-pixel units would floor every pip to 0 width -- pips
+    -- vanishing entirely is worse than the sub-pixel gap this fix targets.
+    -- Fall back to plain UI-unit distribution (pre-fix behavior) in that
+    -- degenerate case so pips stay visible, just not perfectly pixel-snapped.
+    if widthAvail < px then px = 1 end
+    local totalUnits = floor(widthAvail / px + 1e-6)
+    local unitsPer = floor(totalUnits / pipCount)
+    local remUnits = totalUnits - unitsPer * pipCount
     local x = 0
     for i = 1, pipCount do
-        local thisW = pipW + (i <= rem and 1 or 0)
+        local thisW = (unitsPer + (i <= remUnits and 1 or 0)) * px
         local pip = frame.pips[i]
         pip:ClearAllPoints()
         pip:SetPoint("TOPLEFT", frame, "TOPLEFT", x, 0)


### PR DESCRIPTION
## Fix: Dragon Riding "extra spacing between charges and Whirling Surge" with Width Match

**Bug report:** Reported by @Keitaan (Blizz UI Enhanced, v7.2.7) with Dragon Riding's Width Match set to Cooldowns, certain CDM icon sizes/counts (e.g. 6 icons at size 36) produce extra spacing between the skyriding charge pips and the Whirling Surge icon. Adding more abilities or changing icon size made it go away.

### Root cause
`LayoutPips()` distributed the skyriding-charge and second-wind pip rows using `math.floor()` on whole UI-coordinate units which only equals 1 physical pixel at a specific "pixel perfect" UI scale. At any other UI Scale, flooring to whole UI-units left a fractional remainder unassigned, so the last pip in each row fell short of the frame's actual right edge. This is exactly why it looked inconsistent: whether the leftover happens to round away to ~0 depends on the specific scale value in use, and anything that re-triggered a layout pass (changing CDM icon count/size) coincidentally "fixed" it by re-running the same lossy math with slightly different inputs.

Diagnosed live with the reporter across several rounds: traced every `Rebuild()`/`setWidth()`/`setHeight()` call to rule out a scale-matching/timing issue, then a geometry dump caught the actual smoking gun — a persistent ~0.84px delta between the last pip's right edge and the pip row's own frame edge, confirming the pixel-rounding theory.

### Fix
- `LayoutPips()` now distributes pip widths in whole **physical**-pixel units (via `EllesmereUI.PP.mult`) instead of whole UI-coordinate units, so the row fills correctly to within a sub-pixel amount at any UI Scale.
- Falls back to the old whole-UI-unit distribution when a pip row is smaller than one physical pixel total, so pips can't floor to zero width and disappear at extreme low UI scales (caught in code review before shipping).

### Related fix found along the way
While chasing this, discovered that Width/Height Match relationships go stale after a UI Scale change `ApplyWidthMatch`/`ApplyHeightMatch`'s scale-conversion ratio was never recomputed once the scale actually changed, only re-syncing when something unrelated (like a CDM rebuild) happened to re-trigger it. Added re-sync triggers on both Blizzard's native `UI_SCALE_CHANGED` event and EllesmereUI's own UI Scale setter (which changes scale directly and doesn't reliably fire that event), sharing one debounce timer so the two triggers can't cause a redundant double-pass.

### Testing
- Reproduced and confirmed fixed live at UI Scale 0.62 with Width Match to Cooldowns and a 6×36 CDM setup  pip row now fills flush to the Whirling Surge icon with no gap.
- Code-reviewed (8-angle parallel review): caught and fixed a real regression in the fix itself (pips could floor to zero width at extreme low UI scales) and hardened the two UI-Scale re-sync triggers to share a debounce instead of independently double-firing.

<img width="333" height="142" alt="nogap" src="https://github.com/user-attachments/assets/870ffdac-09e4-4fd0-957f-699c234891f6" />
