### PR TITLE
fix(blizzardskin): Dragon Riding stays visible after exiting Unlock Mode

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -10231,6 +10231,11 @@ local function DoClose()
         _G.EllesmereUIQuestTracker.UpdateVisibility()
     end
 
+    -- Re-check Dragon Riding's real visibility (it force-shows while unlocked
+    -- so it can be edited off-mount; without this it stays stuck visible
+    -- after exiting Unlock Mode if the player dismounted while unlocked).
+    if _G._EDR_UpdateVisibility then pcall(_G._EDR_UpdateVisibility) end
+
     if not unlockFrame then return end
 
     unlockFrame:SetScript("OnUpdate", nil)
@@ -11572,6 +11577,12 @@ local function SuspendForCombat()
     isUnlocked = false
     EllesmereUI._unlockActive = false
     EllesmereUI._unlockModeActive = false
+
+    -- Re-check Dragon Riding's real visibility (it force-shows while
+    -- _unlockActive is true so it can be edited off-mount; must run AFTER
+    -- _unlockActive is cleared above, or UpdateVisibility() still hits that
+    -- force-show branch and this call is a no-op).
+    if _G._EDR_UpdateVisibility then pcall(_G._EDR_UpdateVisibility) end
 
     if unlockFrame then
         unlockFrame:SetScript("OnUpdate", nil)

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
@@ -198,6 +198,16 @@ function UpdateVisibility()
     end
 end
 
+-- Re-check real visibility when Unlock Mode exits. UpdateVisibility()
+-- force-shows the HUD while EllesmereUI._unlockActive is true (so it can be
+-- edited even off-mount), but nothing previously re-ran it on exit, so
+-- dismounting during Unlock Mode left it stuck visible until an unrelated
+-- mount/dismount happened to call UpdateVisibility() again. Called from
+-- EUI_UnlockMode.lua's exit path, matching the Quest Tracker's same pattern.
+_G._EDR_UpdateVisibility = function()
+    UpdateVisibility()
+end
+
 -------------------------------------------------------------------------------
 --  OnUpdate
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Fix: Dragon Riding HUD stays visible after exiting Unlock Mode

**Bug report:** Reported by @Toludin (Unlock Mode, v8.3.2) and confirmed reproducible. If you're Dragonriding, turn on Unlock Mode, dismount, then exit Unlock Mode, the Dragon Riding HUD stays visible until you mount and dismount again.

### Root cause
`UpdateVisibility()` force-shows the Dragon Riding HUD while `EllesmereUI._unlockActive` is true, so it can be edited even off-mount, which is correct behavior while Unlock Mode is open. But nothing re-ran `UpdateVisibility()` when Unlock Mode exited, so if the player dismounted while unlocked, the HUD stayed stuck in its forced-visible state until an unrelated mount/dismount cycle happened to trigger a fresh visibility check.

### Fix
Exposed `UpdateVisibility()` globally as `_G._EDR_UpdateVisibility` (matching this file's existing `_EDR_Rebuild` naming convention) and called it from both of `EUI_UnlockMode.lua`'s exit paths: the normal close (`DoClose`) and the combat-forced suspend (`SuspendForCombat`), right alongside the existing Quest Tracker notification that already does the same thing on exit.

### Code review
A review of the fix caught a real bug in the first pass: the `SuspendForCombat` call ran *before* `_unlockActive` was actually cleared, seven lines earlier than where the flag flips to false, making the fix a no-op in that specific path (dismounting during a combat-forced suspend would still leave the HUD stuck). Fixed the ordering to match the working `DoClose` path.

The review also surfaced that Damage Meters has the identical bug class (force-shows during Unlock Mode, never re-checks on exit), unfixed. That's a separate, pre-existing issue in a different module and wasn't part of this report, so it was left alone rather than expand scope, flagging here in case it's worth a follow-up bug report. Will fix this one next.

### Testing
- Mounted a Dragonriding mount, entered Unlock Mode, dismounted, exited Unlock Mode. The HUD now hides immediately instead of staying visible.