### PR TITLE
fix(cdm): update keybind display on druid/rogue form shifts

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -5182,7 +5182,7 @@ local function PlayPresetBuffLossSound(sd, sid, now)
 end
 
 local function UpdateCustomBuffBars()
-    -- if CooldownViewerSettings and CooldownViewerSettings:IsShown() then return end
+    if not ECME then return end
     local p = ECME.db and ECME.db.profile
     if not p or not p.cdmBars or not p.cdmBars.bars then return end
     local LayoutCDMBar = ns.LayoutCDMBar

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6589,8 +6589,9 @@ local function RebuildKeybindCache()
             if key then
                 local slot = def.startSlot + i - 1
                 if def.prefix == "ACTIONBUTTON" then
-                    local btn = _G["ActionButton" .. i]
-                    if btn and btn.action then slot = btn.action end
+                    local mbf = _G["EABBar_MainBar"]
+                    local pg = mbf and tonumber(mbf:GetAttribute("actionpage")) or 1
+                    slot = i + (pg - 1) * 12
                 end
                 local slotType, id = GetActionInfo(slot)
                 local spellID
@@ -6670,12 +6671,7 @@ local function ApplyCachedKeybinds()
     end
 end
 
--- Public entry point: rebuild cache then apply. Defers if in combat.
 local function UpdateCDMKeybinds()
-    if _inCombat then
-        _keybindRebuildPending = true
-        return
-    end
     _keybindRebuildPending = false
     RebuildKeybindCache()
     _keybindCacheReady = true
@@ -8273,10 +8269,6 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
         -- Flush deferred TBB rebuild that was queued during combat
         if event == "PLAYER_REGEN_ENABLED" and ns.IsTBBRebuildPending and ns.IsTBBRebuildPending() then
             if ns.BuildTrackedBuffBars then ns.BuildTrackedBuffBars() end
-        end
-        -- Flush deferred keybind rebuild that was blocked during combat
-        if event == "PLAYER_REGEN_ENABLED" and _keybindRebuildPending then
-            UpdateCDMKeybinds()
         end
         -- Flush deferred roster reanchor that was blocked during combat
         if event == "PLAYER_REGEN_ENABLED" and _rosterRebuildPending then


### PR DESCRIPTION
## Summary
- **btn.action taint fix**: `btn.action` is a secret attribute in Midnight that returns nil in insecure Lua. The CDM keybind cache was stuck on page-1 (caster) slots regardless of form. Now reads `actionpage` from the MainBar frame, matching the taint-safe pattern in `GetButtonActionSlot`.
- **Combat guard removal**: `UpdateCDMKeybinds` blocked rebuilds during combat, preventing keybind updates on form shift. All APIs used are read-only and safe in combat. The `PLAYER_REGEN_ENABLED` flush had a timing bug (`_inCombat` still true at flush time) and never ran — also removed.
- **ECME nil guard**: `UpdateCustomBuffBars` in CdmHooks crashed when called from the options page before CDM initialised.

Fixes reported issues:
- CDM keybinds not updating on druid shapeshift in combat
- CDM keybinds stuck showing caster bindings after form shift

## Test plan
- [x] Enable "Show Keybinds" on a CDM bar
- [x] As druid in caster form, verify keybinds show for caster spells (e.g. Wild Growth)
- [x] Shift to Cat Form — keybinds should update to cat spells (Shred, Rake)
- [x] Shift to Bear Form — keybinds should update to bear spells (Mangle, Thrash)
- [x] Repeat form shifts in combat — keybinds should update within ~0.5s
- [x] Open CDM options page before entering world — no ECME nil error
- [x] Check for ADDON_ACTION_BLOCKED or taint errors during extended play