### PR TITLE
fix(actionbars): keybinds fire correct action in druid/rogue form bars

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7515,6 +7515,12 @@ local function UpdateKeybinds()
             -- ElvUI/Bartender do for every button via LibActionButton.
             local bs = EAB and EAB.db and EAB.db.profile and EAB.db.profile.bars[info.key]
             local barHasCustomPaging = (bs and bs.paging and next(bs.paging) ~= nil) and true or false
+            if not barHasCustomPaging and info.key == "MainBar" then
+                local _, cls = UnitClass("player")
+                if cls == "DRUID" or cls == "ROGUE" then
+                    barHasCustomPaging = true
+                end
+            end
             for i, btn in ipairs(btns) do
                 if btn then
                     local cmd = prefix .. i


### PR DESCRIPTION
## Summary
- **Keybind/visual mismatch in forms**: MainBar keybinds used `SetOverrideBinding` to native commands (`ACTIONBUTTON1` etc.) which the engine resolves via `GetActionBarPage()`. Druid/Rogue form paging uses the state driver (`[bonusbar:N]` conditions), not `GetActionBarPage()`, so paging the bar while in a form caused keybinds to fire a different slot than displayed. Now treats class bonusbar paging the same as custom paging, routing through `SetOverrideBindingClick` so keybinds always fire what the button shows.
- **Page number display**: Reads `state-page` from the bar frame instead of `GetActionBarPage()` so the page number matches the visual in forms.

Fixes reported issue:
- Druid forms — action bar shows form abilities but keybinds fire the wrong bar page when paged via shift+scroll

## Test plan
- [x] As druid, enter Cat Form and press Next Action Bar Page repeatedly
- [x] Verify keybind 1 always fires the displayed spell (e.g. Shred stays Shred)
- [x] In caster form, page through bars 1-6 normally — no regression
- [x] Enable paging arrows — page number should show 7 (cat), 9 (bear), 10 (moonkin)
- [x] Test empower spells (if available) — hold-to-cast should still work
- [x] Check for ADDON_ACTION_BLOCKED or taint errors