### PR TITLE
fix(aurabuff): apply Show Consumes Below threshold to rogue poisons

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -2217,7 +2217,8 @@ local specialsActive = inInstance or co.showSpecialsNonInstanced
                         local isLethal = (poison.cat == "lethal")
                         if isLethal then knownL = knownL + 1 else knownNL = knownNL + 1 end
                         local aura = C_UnitAuras.GetPlayerAuraBySpellID(poison.castSpell)
-                        if aura then
+                        local active = aura and not IsUnderDuration(aura.duration, aura.expirationTime)
+                        if active then
                             if isLethal then activeL = activeL + 1 else activeNL = activeNL + 1 end
                         elseif co.enabled[poison.key] then
                             if isLethal and not missingL then missingL = poison


### PR DESCRIPTION
## Summary
- Rogue poison detection only checked if the aura existed, skipping the `IsUnderDuration` threshold that other consumables (Paladin Rites, flask, food) already use
- A rogue with a poison expiring within the configured "Show Consumes Below" threshold would not get a reminder to re-apply
- Now passes the aura's duration and expirationTime through `IsUnderDuration`, matching the pattern used by Paladin Rites

## Test plan
- [x] As rogue in M0 dungeon or raid, enable "Show Consumes Below" (e.g. 10 min for raid)
- [x] Apply a poison and wait until remaining duration is below the threshold
- [x] Verify the reminder fires to re-apply the poison
- [x] Verify reminder does not fire when poison has plenty of time remaining
- [x] Verify non-rogue consumables (flask, food) still work as before