### PR TITLE
fix(cdm): rotation helper glow for override spells

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7959,9 +7959,16 @@ local function UpdateRotationHighlights()
             for _, icon in ipairs(icons) do
                 local ifc = _ecmeFC[icon]
                 local sid = ifc and ifc.spellID
-                if sid and sid == suggestedSpell and icon:IsShown() then
-                    _rotShow(icon)
-                    newSet[icon] = true
+                if sid and icon:IsShown() then
+                    local match = (sid == suggestedSpell)
+                    if not match and C_SpellBook and C_SpellBook.FindSpellOverrideByID then
+                        local ovr = C_SpellBook.FindSpellOverrideByID(sid)
+                        match = ovr and ovr == suggestedSpell
+                    end
+                    if match then
+                        _rotShow(icon)
+                        newSet[icon] = true
+                    end
                 end
             end
         end


### PR DESCRIPTION
## Summary
- Rotation helper glow (`C_AssistedCombat.GetNextCastSpell`) returns the override spellID (e.g. Raze), but CDM icons store the base spellID (e.g. Maul). The direct comparison fails silently, so override spells never glow in CDM.
- Falls back to `C_SpellBook.FindSpellOverrideByID` when the direct match misses, correctly matching override spells like Guardian Druid's Raze.

## Test plan
- [x] Guardian Druid: enable rotation helper, add Raze to CDM, build rage — Raze should glow in both action bar and CDM
- [x] Verify non-override spells (e.g. Moonfire) still glow correctly
- [x] Verify no performance impact (override check only runs on miss)