### PR TITLE
fix(actionbars): implement border pushed/highlight type

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -6531,6 +6531,57 @@ local PUSHED_TYPES = {
     [6] = "none",    -- No pushed effect
 }
 
+do
+local function _setupBorderEdges(btn, storeKey, driverTex)
+    local edges = btn[storeKey]
+    if not edges then
+        edges = {}
+        for j = 1, 4 do
+            local t = btn:CreateTexture(nil, "OVERLAY", nil, 2)
+            t:SetColorTexture(1, 1, 1, 1)
+            t:Hide()
+            edges[j] = t
+        end
+        btn[storeKey] = edges
+        if driverTex then
+            hooksecurefunc(driverTex, "Show", function()
+                if not edges._active then return end
+                for j = 1, 4 do edges[j]:Show() end
+            end)
+            hooksecurefunc(driverTex, "Hide", function()
+                for j = 1, 4 do edges[j]:Hide() end
+            end)
+        end
+    end
+    return edges
+end
+
+local function _applyBorderEdges(edges, btn, brdSize, cr, cg, cb)
+    edges._active = true
+    local anchor = btn.icon or btn.Icon or btn
+    local PP = EllesmereUI.PP
+    for j = 1, 4 do edges[j]:SetVertexColor(cr, cg, cb, 1) end
+    edges[1]:ClearAllPoints(); edges[1]:SetPoint("TOPLEFT", anchor); edges[1]:SetPoint("TOPRIGHT", anchor)
+    if PP then PP.Height(edges[1], brdSize) else edges[1]:SetHeight(brdSize) end
+    edges[2]:ClearAllPoints(); edges[2]:SetPoint("BOTTOMLEFT", anchor); edges[2]:SetPoint("BOTTOMRIGHT", anchor)
+    if PP then PP.Height(edges[2], brdSize) else edges[2]:SetHeight(brdSize) end
+    edges[3]:ClearAllPoints(); edges[3]:SetPoint("TOPLEFT", edges[1], "BOTTOMLEFT"); edges[3]:SetPoint("BOTTOMLEFT", edges[2], "TOPLEFT")
+    if PP then PP.Width(edges[3], brdSize) else edges[3]:SetWidth(brdSize) end
+    edges[4]:ClearAllPoints(); edges[4]:SetPoint("TOPRIGHT", edges[1], "BOTTOMRIGHT"); edges[4]:SetPoint("BOTTOMRIGHT", edges[2], "TOPRIGHT")
+    if PP then PP.Width(edges[4], brdSize) else edges[4]:SetWidth(brdSize) end
+end
+
+local function _hideBorderEdges(btn, storeKey)
+    local edges = btn[storeKey]
+    if not edges then return end
+    edges._active = false
+    for j = 1, 4 do edges[j]:Hide() end
+end
+ns._setupBorderEdges = _setupBorderEdges
+ns._applyBorderEdges = _applyBorderEdges
+ns._hideBorderEdges  = _hideBorderEdges
+end
+
 function EAB:ApplyPushedTextures()
     local p = self.db.profile
     local pType = p.pushedTextureType or 2
@@ -6551,27 +6602,28 @@ function EAB:ApplyPushedTextures()
                 local btn = buttons[i]
                 if btn and btn.PushedTexture then
                     if p.useBlizzardStyle then
-                        -- Restore Blizzard's default pushed atlas (UpdateButtonArt
-                        -- is nooped so the mixin never sets this itself).
-                        -- OVERLAY layer renders above the border frame.
                         btn.PushedTexture:SetAtlas("UI-HUD-ActionBar-IconFrame-Down", true)
                         btn.PushedTexture:SetDrawLayer("OVERLAY", 7)
                         btn.PushedTexture:ClearAllPoints()
                         btn.PushedTexture:SetAllPoints(btn)
                         btn.PushedTexture:SetVertexColor(1, 1, 1, 1)
                         btn.PushedTexture:SetAlpha(1)
+                        ns._hideBorderEdges(btn, "_pushedBorder")
                     elseif pType == 6 then
                         btn.PushedTexture:SetAlpha(0)
+                        ns._hideBorderEdges(btn, "_pushedBorder")
+                    elseif pType == 5 then
+                        btn.PushedTexture:SetAlpha(0)
+                        local edges = ns._setupBorderEdges(btn, "_pushedBorder", btn.PushedTexture)
+                        ns._applyBorderEdges(edges, btn, brdSize, cr, cg, cb)
                     else
                         btn.PushedTexture:SetAlpha(1)
+                        ns._hideBorderEdges(btn, "_pushedBorder")
                         if pType <= 3 then
                             SetSquareTexture(btn.PushedTexture, HIGHLIGHT_TEXTURES[pType] or HIGHLIGHT_TEXTURES[2])
                             btn.PushedTexture:SetVertexColor(cr, cg, cb, 1)
                         elseif pType == 4 then
                             btn.PushedTexture:SetColorTexture(cr, cg, cb, 0.35)
-                        elseif pType == 5 then
-                            SetSquareTexture(btn.PushedTexture, HIGHLIGHT_TEXTURES[1])
-                            btn.PushedTexture:SetVertexColor(cr, cg, cb, 1)
                         end
                     end
                 end
@@ -6677,6 +6729,7 @@ function EAB:ApplyHighlightTextures()
     local hType = p.highlightTextureType or 2
     local useCC = p.highlightUseClassColor
     local customC = p.highlightCustomColor or { r=0.973, g=0.839, b=0.604, a=1 }
+    local brdSize = p.highlightBorderSize or 4
 
     local cr, cg, cb = customC.r, customC.g, customC.b
     if useCC then
@@ -6695,16 +6748,30 @@ function EAB:ApplyHighlightTextures()
                 if btn and btn.HighlightTexture then
                     if hType == 6 then
                         btn.HighlightTexture:SetAlpha(0)
+                        ns._hideBorderEdges(btn, "_highlightBorder")
+                    elseif hType == 5 then
+                        btn.HighlightTexture:SetAlpha(0)
+                        local edges = ns._setupBorderEdges(btn, "_highlightBorder")
+                        ns._applyBorderEdges(edges, btn, brdSize, cr, cg, cb)
+                        if not btn._hlBorderHooked then
+                            btn._hlBorderHooked = true
+                            btn:HookScript("OnEnter", function(self)
+                                local be = self._highlightBorder
+                                if be and be._active then for j = 1, 4 do be[j]:Show() end end
+                            end)
+                            btn:HookScript("OnLeave", function(self)
+                                local be = self._highlightBorder
+                                if be then for j = 1, 4 do be[j]:Hide() end end
+                            end)
+                        end
                     else
                         btn.HighlightTexture:SetAlpha(1)
+                        ns._hideBorderEdges(btn, "_highlightBorder")
                         if hType <= 3 then
                             SetSquareTexture(btn.HighlightTexture, HIGHLIGHT_TEXTURES[hType] or HIGHLIGHT_TEXTURES[1])
                             btn.HighlightTexture:SetVertexColor(cr, cg, cb, 1)
                         elseif hType == 4 then
                             btn.HighlightTexture:SetColorTexture(cr, cg, cb, 0.35)
-                        elseif hType == 5 then
-                            SetSquareTexture(btn.HighlightTexture, HIGHLIGHT_TEXTURES[1])
-                            btn.HighlightTexture:SetVertexColor(cr, cg, cb, 1)
                         end
                     end
                 end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -6146,7 +6146,7 @@ do
     end
 
     -- Style tex to match the bars' pushed look. Returns false when pushed is set
-    -- to "None" (so the CDM press mirrors that), true otherwise.
+    -- to "None" (so the CDM press mirrors that), "border" for border mode, true otherwise.
     local function StylePush(tex)
         local p = GetABProfile()
         if p then
@@ -6164,14 +6164,15 @@ do
                 return true
             elseif pType == 6 then
                 tex:SetAlpha(0); return false
+            elseif pType == 5 then
+                tex:SetAlpha(0)
+                return "border", cr, cg, cb, p.pushedBorderSize or 4
             end
             tex:SetAlpha(1)
             if pType <= 3 then
                 tex:SetAtlas(nil); tex:SetTexture(AB_HIGHLIGHT[pType] or AB_HIGHLIGHT[2]); tex:SetVertexColor(cr, cg, cb, 1)
             elseif pType == 4 then
                 tex:SetColorTexture(cr, cg, cb, 0.35)
-            elseif pType == 5 then
-                tex:SetAtlas(nil); tex:SetTexture(AB_HIGHLIGHT[1]); tex:SetVertexColor(cr, cg, cb, 1)
             end
             return true
         end
@@ -6181,6 +6182,19 @@ do
         tex:SetTexCoord(DEPRESS_INSET, 1 - DEPRESS_INSET, DEPRESS_INSET, 1 - DEPRESS_INSET)
         tex:SetVertexColor(1, 1, 1, 1); tex:SetAlpha(1)
         return true
+    end
+
+    local function EnsureBorderEdges(ov)
+        if ov._borderEdges then return ov._borderEdges end
+        local edges = {}
+        for j = 1, 4 do
+            local t = ov:CreateTexture(nil, "OVERLAY", nil, 2)
+            t:SetColorTexture(1, 1, 1, 1)
+            t:Hide()
+            edges[j] = t
+        end
+        ov._borderEdges = edges
+        return edges
     end
 
     local function ShowPush(icon)
@@ -6194,11 +6208,24 @@ do
             ov._tex = tex
             _pushOverlay[icon] = ov
         end
-        if not StylePush(ov._tex) then ov:Hide(); return nil end
+        local result, cr, cg, cb, bsz = StylePush(ov._tex)
+        if not result then ov:Hide(); return nil end
         local region = icon.Icon or icon
         ov:ClearAllPoints()
         ov:SetPoint("TOPLEFT", region, "TOPLEFT", 0, 0)
         ov:SetPoint("BOTTOMRIGHT", region, "BOTTOMRIGHT", 0, 0)
+        if result == "border" then
+            ov._tex:Hide()
+            local edges = EnsureBorderEdges(ov)
+            for j = 1, 4 do edges[j]:SetVertexColor(cr, cg, cb, 1) end
+            edges[1]:ClearAllPoints(); edges[1]:SetPoint("TOPLEFT", ov); edges[1]:SetPoint("TOPRIGHT", ov); edges[1]:SetHeight(bsz); edges[1]:Show()
+            edges[2]:ClearAllPoints(); edges[2]:SetPoint("BOTTOMLEFT", ov); edges[2]:SetPoint("BOTTOMRIGHT", ov); edges[2]:SetHeight(bsz); edges[2]:Show()
+            edges[3]:ClearAllPoints(); edges[3]:SetPoint("TOPLEFT", edges[1], "BOTTOMLEFT"); edges[3]:SetPoint("BOTTOMLEFT", edges[2], "TOPLEFT"); edges[3]:SetWidth(bsz); edges[3]:Show()
+            edges[4]:ClearAllPoints(); edges[4]:SetPoint("TOPRIGHT", edges[1], "BOTTOMRIGHT"); edges[4]:SetPoint("BOTTOMRIGHT", edges[2], "TOPRIGHT"); edges[4]:SetWidth(bsz); edges[4]:Show()
+        else
+            ov._tex:Show()
+            if ov._borderEdges then for j = 1, 4 do ov._borderEdges[j]:Hide() end end
+        end
         ov:Show()
         return ov
     end


### PR DESCRIPTION
## Summary
- "Border" option for Pushed Type and Highlight Type was rendering as a Light overlay instead of an actual border
- Creates 4 edge textures per button, driven by the native texture Show/Hide state (pushed) or OnEnter/OnLeave hooks (highlight)
- Gated by an `_active` flag so switching to another type cleanly disables the border
- Also fixes CDM Mirror Key Presses to render border mode correctly

## Test plan
- [x] Set Pushed Type to "Border" → press keybind → colored border appears on action bar button
- [x] Switch Pushed Type to "Medium" → border no longer appears
- [x] Set Highlight Type to "Border" → hover action bar button → colored border appears
- [x] Adjust border size via cog → size updates correctly
- [x] CDM Mirror Key Presses with Border pushed type shows border on CDM icons