### PR TITLE
feat(blizzskin): add Merchant item level toggle

### DIFF
--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -1161,6 +1161,29 @@ initFrame:SetScript("OnEvent", function(self)
         return y
     end
 
+    local function BuildMerchantContent(parent, y)
+        local W = EllesmereUI.Widgets
+        local _, h
+
+        _, h = WSCardSection(parent, "QUALITY OF LIFE", y);  y = y - h
+
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Item Level",
+              tooltip="Shows the item level on each weapon and armor piece a vendor is selling. Works with or without the reskin.",
+              getValue=function()
+                  return EllesmereUIDB and EllesmereUIDB.merchantShowItemLevel == true
+              end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.merchantShowItemLevel = v
+                  if EllesmereUI._Merchant_RefreshItemLevels then EllesmereUI._Merchant_RefreshItemLevels() end
+              end },
+            { type="label", text="" }
+        );  y = y - h
+
+        return y
+    end
+
     ---------------------------------------------------------------------------
     --  Blizzard Window Skins page: one expandable card per reskinned window.
     --  Card headers are custom chrome, but every sub-setting ROW is a standard
@@ -1510,6 +1533,7 @@ initFrame:SetScript("OnEvent", function(self)
                 if not EllesmereUIDB then EllesmereUIDB = {} end
                 EllesmereUIDB.reskinMerchant = v
             end,
+            buildContent = BuildMerchantContent,
         },
         {
             key   = "auctionhouse",

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -7610,6 +7610,83 @@ WSkin.RegisterWindow({
 })
 
 -------------------------------------------------------------------------------
+--  Merchant item-level overlay (QoL, independent of the Merchant reskin).
+--  Shows the item level on the top-left of each vendor tile for gear
+--  (weapons/armor) when EllesmereUIDB.merchantShowItemLevel is set. Buttons
+--  carry their merchant slot index as their ID (Blizzard's MerchantFrame_Update
+--  sets it), so we resolve the link straight from GetMerchantItemLink.
+-------------------------------------------------------------------------------
+local MERCHANT_ILVL_WEAPON = Enum.ItemClass.Weapon
+local MERCHANT_ILVL_ARMOR  = Enum.ItemClass.Armor
+
+local function UpdateMerchantItemLevels()
+    local f = _G.MerchantFrame
+    if not f then return end
+    local show = EllesmereUIDB and EllesmereUIDB.merchantShowItemLevel == true
+    local onSellTab = (f.selectedTab or 1) == 1
+    for i = 1, 12 do
+        local btn = _G["MerchantItem" .. i .. "ItemButton"]
+        if btn then
+            local fs = btn.EUIMerchantILvl
+            if not fs then
+                fs = btn:CreateFontString(nil, "OVERLAY", nil, 7)
+                fs:SetPoint("TOPLEFT", btn, "TOPLEFT", 1, -1)
+                local path = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath()) or "Fonts\\FRIZQT__.TTF"
+                local flag = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE"
+                fs:SetFont(path, 12, flag)
+                btn.EUIMerchantILvl = fs
+            end
+            fs:SetText("")
+            if show and onSellTab and f:IsVisible() then
+                local index = btn:GetID()
+                local link = index and index > 0 and GetMerchantItemLink(index)
+                if link then
+                    local _, _, _, _, _, classID = C_Item.GetItemInfoInstant(link)
+                    if classID == MERCHANT_ILVL_WEAPON or classID == MERCHANT_ILVL_ARMOR then
+                        local ilvl = C_Item.GetDetailedItemLevelInfo(link)
+                        if ilvl and ilvl > 0 then
+                            fs:SetText(ilvl)
+                            local quality = select(3, C_Item.GetItemInfo(link))
+                            local r, g, b = 1, 1, 1
+                            if EllesmereUI.GetItemLevelColor then
+                                local c = EllesmereUI.GetItemLevelColor(link, quality)
+                                if c then r, g, b = c.r or 1, c.g or 1, c.b or 1 end
+                            elseif quality then
+                                r, g, b = C_Item.GetItemQualityColor(quality)
+                            end
+                            fs:SetTextColor(r, g, b, 1)
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+EllesmereUI._Merchant_RefreshItemLevels = UpdateMerchantItemLevels
+
+local _merchantILvlHooked = false
+local function EnsureMerchantILvlHook()
+    if _merchantILvlHooked then return end
+    _merchantILvlHooked = true
+    if type(_G.MerchantFrame_Update) == "function" then
+        hooksecurefunc("MerchantFrame_Update", WSkin.Debounce(UpdateMerchantItemLevels))
+    end
+end
+
+local mILvlBoot = CreateFrame("Frame")
+mILvlBoot:RegisterEvent("PLAYER_LOGIN")
+mILvlBoot:RegisterEvent("MERCHANT_SHOW")
+mILvlBoot:RegisterEvent("GET_ITEM_INFO_RECEIVED")
+mILvlBoot:SetScript("OnEvent", function(_, event)
+    if event == "GET_ITEM_INFO_RECEIVED"
+       and not (_G.MerchantFrame and _G.MerchantFrame:IsVisible()) then
+        return
+    end
+    EnsureMerchantILvlHook()
+    UpdateMerchantItemLevels()
+end)
+
+-------------------------------------------------------------------------------
 --  Class / Profession Trainer (ClassTrainerFrame, Blizzard_TrainerUI)
 --  Portrait frame: flat chrome, squared skill-row icons, native availability
 --  text color kept (green/red/gray -- like item rarity, we never force white),

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -215,7 +215,6 @@ Font changed. A UI reload is needed to apply the new font.
 Food
 For Icons: Left click to edit group, Right click to custom size individual
 For player frame, this provides a simple, mini castbar below player frame. To edit the main player cast bar, %sclick here|r
-Frame Source
 From
 Full Preview
 GLOBAL
@@ -324,6 +323,7 @@ OneBag
 OneBank
 OneWarbank
 Opacity
+Override Active:
 PER-SPELL OPTIONS
 Page
 Paste your profile string here...


### PR DESCRIPTION
## Summary

- Adds a **Show Item Level** toggle under **Blizz UI Enhanced → Merchant** (new "Quality of Life" section on the Merchant card).
- When enabled, the item level is drawn on the top-left of each vendor tile for gear (weapons/armor only), colored via the shared `EllesmereUI.GetItemLevelColor` helper so it matches the Character/Inspect sheet coloring (custom override → upgrade-track hue → item rarity → white).
- Works with or without the Merchant reskin: the overlay hooks `MerchantFrame_Update` and refreshes on `MERCHANT_SHOW` / `GET_ITEM_INFO_RECEIVED`, and only shows on the sell tab (not buyback).

## Notes

- Uses the namespaced `C_Item.*` item APIs to avoid deprecation warnings.
- No new locale strings (option text is plain, consistent with the other toggles in this file), so `Locales/_keys.txt` is unchanged.

## Test plan

- [x] Enable **Blizz UI Enhanced → Merchant → Show Item Level**; open a vendor and confirm item levels appear on weapons/armor and are colored correctly.
- [x] Toggle the option while a vendor is open and confirm it updates live.
- [x] Page through the vendor and switch to Buyback; confirm the numbers only show on the sell tab.
- [x] Confirm it works both with the Merchant reskin on and off.
- [x] Disable the option and confirm the numbers disappear.
