### PR TITLE
M+ and achv alignment bug

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -3321,19 +3321,81 @@ local function Skin_Guild()
         local cdStock = capturePts(cd2)
         local boxWide = boxStock and widePts(boxStock, 23, 20)
         local cdWide = cdStock and widePts(cdStock, 23, 23)
+        -- EXPERIMENT: also widen `ml` (MemberList) itself at the source,
+        -- since Blizzard's own row-sizing below (SetWidth(GetMemberList()
+        -- :GetWidth())) reads ml's width directly. RefreshLayout only ever
+        -- gives `ml` a single positional anchor (not a LEFT+RIGHT pair like
+        -- box2/cd2), so it's resized with a plain SetWidth rather than the
+        -- capturePts/widePts anchor-nudge technique above. This is additive,
+        -- not a replacement for the per-row SetWidth override below: if
+        -- Blizzard's own layout starts producing correctly-sized rows from
+        -- this alone, the per-row override becomes a harmless no-op; if not,
+        -- it still runs and keeps rows correct either way.
+        local mlStockWidth = ml:GetWidth()
+        local mlWideWidth = mlStockWidth + 23 + 20
+        -- Every roster row is sized by Blizzard to MemberList's own width
+        -- (CommunitiesMemberListEntryMixin:SetExpanded -> SetWidth(GetMemberList()
+        -- :GetWidth())), a frame this pass never touches -- only its ScrollBox
+        -- and ColumnDisplay children get widened above. Left alone, rows stay
+        -- stock width while the header grows, so each row's GuildInfo text
+        -- (RIGHT-anchored to the row, -4) sits in a box that ends well short of
+        -- the widened header -- the Achievement Points / M+ Rating value renders
+        -- under the Note column instead of the far-right stat column. Re-stamp
+        -- every live row to the ScrollBox's actual current width so it always
+        -- matches. GuildInfo is also LEFT-justified in that box by default, so
+        -- widening it alone never moves the visible text -- center it and nudge
+        -- it left while the roster is showing, and put both back to Blizzard's
+        -- stock LEFT/20/-4 layout when it's not, since MemberList/ScrollBox is
+        -- shared with the Chat tab's narrower names column and a row must not
+        -- stay stranded in the roster's styling after the swap.
+        local GUILD_INFO_NUDGE = 20
+        local function ApplyRowLayout(row)
+            if not row then return end
+            if row.SetWidth then row:SetWidth(box2:GetWidth()) end
+            local gi = row.GuildInfo
+            if gi and row.Note and gi.SetJustifyH and gi.ClearAllPoints then
+                gi:ClearAllPoints()
+                if cd2:IsShown() then
+                    gi:SetJustifyH("CENTER")
+                    gi:SetPoint("LEFT", row.Note, "RIGHT", 20 - GUILD_INFO_NUDGE, 0)
+                    gi:SetPoint("RIGHT", row, "RIGHT", -4 - GUILD_INFO_NUDGE, 0)
+                else
+                    gi:SetJustifyH("LEFT")
+                    gi:SetPoint("LEFT", row.Note, "RIGHT", 20, 0)
+                    gi:SetPoint("RIGHT", row, "RIGHT", -4, 0)
+                end
+            end
+        end
+        -- Same uninitialized-ScrollBox guard used for the AH summary/rail rows
+        -- elsewhere in this file: ForEachFrame errors inside Blizzard's code
+        -- if the view doesn't exist yet (e.g. this pass runs at ADDON_LOADED,
+        -- before the roster has ever been shown).
+        local function SyncRowWidths()
+            if box2.ForEachFrame and box2.GetView and box2:GetView() then
+                pcall(box2.ForEachFrame, box2, ApplyRowLayout)
+            end
+        end
+        hooksecurefunc(box2, "Update", WSkin.Debounce(SyncRowWidths))
         cd2:HookScript("OnShow", function()
             applyPts(box2, boxWide)
             applyPts(cd2, cdWide)
+            ml:SetWidth(mlWideWidth)
+            SyncRowWidths()
         end)
         cd2:HookScript("OnHide", function()
             applyPts(box2, boxStock)
+            ml:SetWidth(mlStockWidth)
+            SyncRowWidths()
         end)
         if cd2:IsShown() then
             applyPts(box2, boxWide)
             applyPts(cd2, cdWide)
+            ml:SetWidth(mlWideWidth)
         else
             applyPts(box2, boxStock)
+            ml:SetWidth(mlStockWidth)
         end
+        SyncRowWidths()
     end
 
     -- Chat view's names-column scrollbar sits 5px right (one-shot, every

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -215,7 +215,6 @@ Font changed. A UI reload is needed to apply the new font.
 Food
 For Icons: Left click to edit group, Right click to custom size individual
 For player frame, this provides a simple, mini castbar below player frame. To edit the main player cast bar, %sclick here|r
-Frame Source
 From
 Full Preview
 GLOBAL
@@ -324,6 +323,7 @@ OneBag
 OneBank
 OneWarbank
 Opacity
+Override Active:
 PER-SPELL OPTIONS
 Page
 Paste your profile string here...


### PR DESCRIPTION
## Summary

Fixes the Guild & Communities roster: the Achievement Points / M+ Rating value for each member was rendering under the **Note** column instead of under its own header on the far right.

Root cause: the roster's header row (`ColumnDisplay`) and scroll area (`ScrollBox`) get widened, but Blizzard sizes each row from `MemberList`'s own width, which was never touched — so rows stayed stock-width while the header grew. On top of that, the value text field is left-justified inside its box, so simply widening the row never moved the visible number; it stayed pinned next to Note regardless.

Fix widens `MemberList` at the source (same technique already used for its `ColumnDisplay`/`ScrollBox` children) and keeps a per-row fallback that centers and nudges the value while the roster is showing. Both the row width and the value's justify/anchor now revert to Blizzard's stock layout when the roster isn't showing, since `MemberList`/`ScrollBox` is shared with the Chat tab's narrower names column and nothing should stay stranded in the roster's styling after switching away from it.

## How was it tested?

In-game on live retail: opened Guild & Communities → Roster, confirmed Achievement Points values render flush under their header instead of under Note; switched the roster stat dropdown to M+ Rating and confirmed the same; switched to the Chat tab and back to Roster to confirm no stranded styling or layout regression. Iterated on exact pixel alignment (justify + nudge) against screenshots until it read cleanly under the header.

## Screenshots

Before: Achievement Points / M+ Rating values rendered under the Note column.
After: values render under the Achievement Points / M+ Rating header, matching Target/Focus-style alignment.

<img width="465" height="158" alt="m+tab" src="https://github.com/user-attachments/assets/2a592412-0d3d-4552-b089-327ac9f78c5e" />
<img width="1284" height="637" alt="pointsfixed" src="https://github.com/user-attachments/assets/d2f50349-635a-4ac6-99f3-d63d2e575a54" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) — N/A, pure bug fix, no new setting
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built — N/A, always-on layout correction while the roster frame exists, same as the code it's patching
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) — debounced `hooksecurefunc(Update, ...)`, no ticker/polling
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
