### PR TITLE
feat(charsheet): add character and inspect sheet scale slider

### DIFF
--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -907,6 +907,18 @@ initFrame:SetScript("OnEvent", function(self)
             { type="label", text="" }
         );  y = y - h
 
+        _, h = W:DualRow(parent, y,
+            { type="slider", text="Scale", min=0.5, max=1.5, step=0.05,
+              tooltip="Scales the entire character and inspect sheet. Applies out of combat; changes made in combat take effect when combat ends.",
+              getValue=function() return (EllesmereUIDB and EllesmereUIDB.charSheetScale) or 1.0 end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.charSheetScale = v
+                  if EllesmereUI._refreshCharSheetScale then EllesmereUI._refreshCharSheetScale() end
+              end },
+            { type="spacer" }
+        );  y = y - h
+
         _, h = W:Spacer(parent, y, 10);  y = y - h
 
         ---------------------------------------------------------------------------

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -4912,6 +4912,9 @@ if EllesmereUI then
             -- Heavy skin (model, slots, stats, tabs) defers to first OnShow.
             CharacterFrame:HookScript("OnShow", ApplyThemedCharacterSheet)
 
+            EllesmereUI._refreshCharSheetScale()
+            CharacterFrame:HookScript("OnShow", EllesmereUI._refreshCharSheetScale)
+
             -- Function to detect and set active equipment set
             local function UpdateActiveEquipmentSet()
                 local setIDs = C_EquipmentSet.GetEquipmentSetIDs()
@@ -5138,6 +5141,27 @@ function EllesmereUI._refreshCharSheetIconZoom()
             slot.icon:SetTexCoord(z, 1 - z, z, 1 - z)
         end
     end
+end
+
+-- Apply the user scale to the character (and inspect) sheet. SetScale on these
+-- managed UIPanels taints the panel-position manager if it runs while the
+-- position manager executes, so defer to PLAYER_REGEN_ENABLED when in combat.
+local _charSheetScaleWaiter
+function EllesmereUI._refreshCharSheetScale()
+    local s = (EllesmereUIDB and EllesmereUIDB.charSheetScale) or 1.0
+    if InCombatLockdown() then
+        if not _charSheetScaleWaiter then
+            _charSheetScaleWaiter = CreateFrame("Frame")
+            _charSheetScaleWaiter:SetScript("OnEvent", function(self)
+                self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+                EllesmereUI._refreshCharSheetScale()
+            end)
+        end
+        _charSheetScaleWaiter:RegisterEvent("PLAYER_REGEN_ENABLED")
+        return
+    end
+    if CharacterFrame and CharacterFrame:GetScale() ~= s then CharacterFrame:SetScale(s) end
+    if InspectFrame and InspectFrame:GetScale() ~= s then InspectFrame:SetScale(s) end
 end
 
 -- Function to refresh upgrade track visibility when toggle changes

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
@@ -1053,6 +1053,7 @@ if EllesmereUI then
         InspectFrame:HookScript("OnShow", function()
             skinned = false
             ApplyThemedInspectSheet()
+            if EllesmereUI._refreshCharSheetScale then EllesmereUI._refreshCharSheetScale() end
             C_Timer.After(0.1, function()
                 if not InspectFrame or not InspectFrame:IsShown() then return end
                 if EllesmereUI._refreshInspectItemLevelVisibility then

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -215,7 +215,6 @@ Font changed. A UI reload is needed to apply the new font.
 Food
 For Icons: Left click to edit group, Right click to custom size individual
 For player frame, this provides a simple, mini castbar below player frame. To edit the main player cast bar, %sclick here|r
-Frame Source
 From
 Full Preview
 GLOBAL
@@ -324,6 +323,7 @@ OneBag
 OneBank
 OneWarbank
 Opacity
+Override Active:
 PER-SPELL OPTIONS
 Page
 Paste your profile string here...


### PR DESCRIPTION
## Summary

- Adds a **Scale** slider to the Character Sheet options (Blizz UI Enhanced → Character Sheet) that scales the entire character and inspect sheet (0.5–1.5).
- Implemented via `EllesmereUI._refreshCharSheetScale`, applied on `CharacterFrame`/`InspectFrame` show. Scale changes made in combat are deferred to `PLAYER_REGEN_ENABLED` to avoid tainting the UIPanel position manager.

## Notes

- The Scale slider label/tooltip are plain strings (consistent with the other options), so the feature adds no new locale keys. The `Locales/_keys.txt` update in this PR is a regeneration that corrects pre-existing upstream staleness (an `Override Active:` key that was missing and a stale `Frame Source` entry).

## Test plan

- [x] Set **Character Sheet → Scale** to various values out of combat; confirm the character sheet resizes.
- [x] Open an inspect frame and confirm it uses the same scale.
- [x] Change the slider while in combat; confirm no taint errors and that the new scale applies once combat ends.
- [x] Reset to 1.0 and confirm default sizing.
