### PR TITLE
fix(unitframes): keep detached power bar text above its border

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -3998,9 +3998,24 @@ function ns.UpdatePowerBorder(power, settings)
         settings.powerBorderAlpha or 1, settings.powerBorderStyle or "solid",
         settings.powerBorderOffsetX, settings.powerBorderOffsetY,
         settings.powerBorderShiftX, settings.powerBorderShiftY, "unitframes", size)
-    border:SetFrameLevel(settings.powerBorderBehind
-        and math.max(0, power:GetFrameLevel() - 1) or (power:GetFrameLevel() + 5))
-    if isDet and size > 0 then border:Show() else border:Hide() end
+    local borderLevel = settings.powerBorderBehind
+        and math.max(0, power:GetFrameLevel() - 1) or (power:GetFrameLevel() + 5)
+    border:SetFrameLevel(borderLevel)
+    local showBorder = isDet and size > 0
+    if showBorder then border:Show() else border:Hide() end
+
+    -- Power text overlay must clear the border: it shares the bar's strata and can
+    -- sit above the overlay's default level, so match strata and lift past it.
+    local ovr = power._ppTextOvr
+    if ovr then
+        ovr:SetFrameStrata(power:GetFrameStrata())
+        if showBorder then
+            ovr:SetFrameLevel(borderLevel + 5)
+        else
+            local pf = power:GetParent()
+            ovr:SetFrameLevel((pf and pf:GetFrameLevel() or power:GetFrameLevel()) + 15)
+        end
+    end
 end
 
 local function CreatePowerBar(frame, unit, settings)

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -215,7 +215,6 @@ Font changed. A UI reload is needed to apply the new font.
 Food
 For Icons: Left click to edit group, Right click to custom size individual
 For player frame, this provides a simple, mini castbar below player frame. To edit the main player cast bar, %sclick here|r
-Frame Source
 From
 Full Preview
 GLOBAL
@@ -324,6 +323,7 @@ OneBag
 OneBank
 OneWarbank
 Opacity
+Override Active:
 PER-SPELL OPTIONS
 Page
 Paste your profile string here...


### PR DESCRIPTION
## Bug report

- Connected to the Discord bug report: https://discord.com/channels/585577383847788554/1526322453176123506

## Summary

- Fixes the detached power bar border drawing over the power percent text (reported for Unit Frames: set a power bar to Detached Bottom/Top with Border Size >= 1 and the text renders behind the border).
- Root cause: the border is parented to the power bar at a frame level above the text overlay, and it shares the bar's strata, so the "Custom Bar Stratas" dropdown moved the bar and border together and never lifted the text out from behind them.
- Fix lives in the shared `ns.UpdatePowerBorder`, so it applies to every unit frame with a detached power bar (player, target, focus, etc.), works with or without Custom Bar Stratas, and restores default ordering when the border is hidden or the bar is re-attached. The `powerBorderBehind` case still keeps the border under the bar.

## Notes

- Includes a `chore: regenerate locale keys` commit. `Locales/_keys.txt` on `main` was already stale (missing `Override Active:`, and `Frame Source` is no longer a literal `L()` key); regenerating was required for the Locale keys CI check. This is unrelated to the fix itself.

## Test plan

- [x] Target with power bar set to Detached Bottom, Border Size >= 1: power % text renders in front of the border.
- [x] Same for Detached Top and for the player/focus frames.
- [x] Toggle Custom Bar Stratas on/off and change the Detached Power Bar strata: text stays in front of the border.
- [x] Enable "border behind" behavior: border still sits under the bar, text in front.
- [x] Switch the power bar back to Below/Above: no regression in text/border ordering.
