### PR TITLE
fix(cooldownmanager): Suppress GCD breaks cooldown swipe for override spells (Rushing Wind Kick)

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -481,7 +481,16 @@ end
 PresetOnCD = function(key)
     local now = GetTime()
     if key > 0 then
-        local ci = C_Spell and C_Spell.GetSpellCooldown and C_Spell.GetSpellCooldown(key)
+        -- A transform's real CD ticks on the override ID (e.g. Rushing Wind
+        -- Kick over Rising Sun Kick); the base-ID query reads not-on-CD
+        -- through that whole CD.
+        local effKey = key
+        if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
+            local ov = C_SpellBook.FindSpellOverrideByID(key)
+            if ov and ov > 0 and ov ~= key then effKey = ov end
+        end
+        local ci = C_Spell and C_Spell.GetSpellCooldown
+            and (C_Spell.GetSpellCooldown(effKey) or C_Spell.GetSpellCooldown(key))
         return (ci and ci.isActive and not ci.isOnGCD) or false
     end
 

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -1787,18 +1787,23 @@ local function DecorateFrame(frame, barData)
                     -- suppressed. Both fields are clean (maxCharges int, isActive bool;
                     -- the secret currentCharges is never read). Override ID resolved for
                     -- transform spells, mirroring the re-arm paths below.
+                    local effID2 = sid2
+                    if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
+                        local ovr = C_SpellBook.FindSpellOverrideByID(sid2)
+                        if ovr and ovr > 0 and ovr ~= sid2 then effID2 = ovr end
+                    end
                     local chargeRecharging = false
                     if C_Spell.GetSpellCharges then
-                        local effIDc = sid2
-                        if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
-                            local ovr = C_SpellBook.FindSpellOverrideByID(sid2)
-                            if ovr and ovr > 0 and ovr ~= sid2 then effIDc = ovr end
-                        end
-                        local ci = C_Spell.GetSpellCharges(effIDc) or C_Spell.GetSpellCharges(sid2)
+                        local ci = C_Spell.GetSpellCharges(effID2) or C_Spell.GetSpellCharges(sid2)
                         chargeRecharging = (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true) or false
                     end
                     if not chargeRecharging then
-                        local cdInfo = C_Spell.GetSpellCooldown(sid2)
+                        -- The GCD read must use the override too: a transform's real
+                        -- CD ticks on the override ID (e.g. Rushing Wind Kick over
+                        -- Rising Sun Kick), and the base-ID query reads isOnGCD=true
+                        -- through that whole CD, leaving the swipe suppressed for
+                        -- its full duration.
+                        local cdInfo = C_Spell.GetSpellCooldown(effID2) or C_Spell.GetSpellCooldown(sid2)
                         if cdInfo and cdInfo.isOnGCD then
                             cd:SetSwipeColor(0, 0, 0, 0)
                             _gcdSuppressed = true

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -215,7 +215,6 @@ Font changed. A UI reload is needed to apply the new font.
 Food
 For Icons: Left click to edit group, Right click to custom size individual
 For player frame, this provides a simple, mini castbar below player frame. To edit the main player cast bar, %sclick here|r
-Frame Source
 From
 Full Preview
 GLOBAL
@@ -324,6 +323,7 @@ OneBag
 OneBank
 OneWarbank
 Opacity
+Override Active:
 PER-SPELL OPTIONS
 Page
 Paste your profile string here...


### PR DESCRIPTION
## Bug

**Reported by:** @Crackles (Cooldown Manager, v8.4.1)

With GCD suppression enabled on a CDM bar, the non-GCD cooldown swipe for Rushing Wind Kick either never appeared or appeared seconds late. Untalented Rising Sun Kick worked fine.

## Root cause

Rushing Wind Kick is a spellbook **override** of Rising Sun Kick: the CDM icon keeps the base spell ID, but the real cooldown ticks on the override ID. The per-bar Suppress GCD check (inside the `SetSwipeColor` hook in `EllesmereUICdmHooks.lua`) queried `C_Spell.GetSpellCooldown` with the **base** ID, which reports `isOnGCD = true` through the override's entire real cooldown. The hook re-fires on every swipe repaint, so it kept painting the swipe alpha-0 for the full CD. Untalented RSK works because base and live ID are the same.

Every other cooldown read in this block already resolved the override (the charge-recharge guard, the sibling hide-active block, the desat correction, the CD-ready sound paths); this was the one remaining raw base-ID read.

## Fix

- `EllesmereUICdmHooks.lua`: hoist the override resolution (`C_SpellBook.FindSpellOverrideByID`) that the charge guard was already doing privately, and point the GCD query at the resolved ID, with the same base-ID fallback the charge read carries for transient nil returns.
- `EllesmereUICdmFakeActive.lua` (`PresetOnCD`): fix the identical misread found during review. Hide-on-CD / glow-when-ready presets judged an override transform as permanently off-cooldown for its whole real CD. Same guarded resolution + fallback pattern.

## Review notes

Multi-angle review confirmed the non-transform path is byte-identical, pure-GCD suppression still works for talented users (the GCD is global, so the override read still reports `isOnGCD=true` for GCDs pushed by other abilities), and the swipe now agrees with the desaturation logic (which already used the override). Two lower-priority follow-ups were identified and deliberately left out: the preset custom-spell block has the same latent misread if a user adds a transform's base ID manually, and the resolve-override snippet is inlined ~14 times in the hooks file in two divergent variants and could be extracted into a shared helper.

## Testing

Verified in-game on Mistweaver: with Suppress GCD enabled, RWK's cooldown swipe now appears immediately on cast; pure GCDs pushed by other abilities remain suppressed; untalented RSK unchanged.