### PR TITLE
Fix Simple Setup buff grid showing other players' auras

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -1760,6 +1760,8 @@ function ns.BM_UpdateSimpleGrid(button, unit, db, updateInfo)
     local seen = d._bmSimpleSeen
     if not seen then seen = {}; d._bmSimpleSeen = seen else wipe(seen) end
 
+    local ownOnly = bs.ownOnly ~= false
+
     local shown = 0
     local idx = 1
     while true do
@@ -1776,8 +1778,16 @@ function ns.BM_UpdateSimpleGrid(button, unit, db, updateInfo)
             if not issecretvalue(sid) then
                 local psid = PRIMARY_BY_ALT[sid] or sid
                 if simpleTrackedSpellIDs[psid] and not seen[psid] then
-                    matched = true
-                    seen[psid] = true
+                    -- Own Only: same PLAYER filter the custom path uses; secret
+                    -- auras below are always player-cast so they skip this check.
+                    local pass = true
+                    if ownOnly and C_UnitAuras_IsAuraFilteredOutByInstanceID then
+                        pass = not C_UnitAuras_IsAuraFilteredOutByInstanceID(unit, iid, "PLAYER|HELPFUL")
+                    end
+                    if pass then
+                        matched = true
+                        seen[psid] = true
+                    end
                 end
             else
                 local matchedSid = MatchSecretAuraSimple(unit, iid)
@@ -3895,7 +3905,10 @@ function ns.BM_BuildPage(pageName, parent, yOffset)
               disabled=BuffsOff, disabledTooltip="Show Buffs",
               getValue=function() return BVal("showStacks", true) end,
               setValue=function(v) BSet("showStacks", v) end },
-            { type="label", text="" });  sy = sy - hh
+            { type="toggle", text="Own Only", tooltip="Shows only the buffs you apply",
+              disabled=BuffsOff, disabledTooltip="Show Buffs",
+              getValue=function() return BVal("ownOnly", true) end,
+              setValue=function(v) BSet("ownOnly", v) end });  sy = sy - hh
         do
             local rgn = row5._leftRegion
             local swatch = EllesmereUI.BuildColorSwatch(rgn, row5:GetFrameLevel() + 3,

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -688,6 +688,7 @@ local defaults = {
         -- simple buff grid (all of the active spec's tracked buffs, in a grid).
         bmSimple = {
             showBuffs       = true,
+            ownOnly         = true,
             maxBuffs        = 8,
             iconsPerRow     = 4,
             position        = "topright",


### PR DESCRIPTION
## Bug report

- Connected to the Discord bug report: https://discord.com/channels/585577383847788554/1517525004495880294

## Summary

- In **Simple Setup** buff mode, the raid-frame grid matched auras only by spell ID against the spec whitelist and never checked the caster, so other players'' HoTs (e.g. a second resto druid'' Rejuvenation) rendered on your frames. This only reproduced in Simple mode because Custom mode already defaults to "Own Only".
- `BM_UpdateSimpleGrid` now applies the same `PLAYER|HELPFUL` filter the custom path uses for non-secret auras when Own Only is enabled. Secret auras are skipped since they are always player-cast by definition.
- Added an **Own Only** toggle to the Simple Setup options (previously an empty slot next to Show Stacks) and a matching `ownOnly = true` default in `bmSimple`, mirroring Custom mode.

## Test plan

- [ ] With two resto druids in a group, cast HoTs on each other; confirm only your own HoTs show in the Simple grid (Own Only on, the default)
- [ ] Toggle Own Only off; confirm other players'' matching buffs appear again
- [ ] Verify Custom buff display is unaffected
