### PR TITLE
fix(unitframes) player and target frames leader icon not showing assistant

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -3,6 +3,7 @@ local addonName, ns = ...
 local math_floor, math_ceil, math_max, math_min, math_abs =
     math.floor, math.ceil, math.max, math.min, math.abs
 local string_format = string.format
+local issecretvalue = issecretvalue
 
 local oUF = ns.oUF or oUF
 local PP = EllesmereUI.PP
@@ -11357,7 +11358,6 @@ function InitializeFrames()
     -- Must run after target frame is spawned (right above) so the texture can
     -- be parented to it.
     do
-        local LEADER_ATLAS = "plunderstorm-glues-icon-leader"
         local _leaderUnits = {}
 
         local function _leaderRefresh(uf)
@@ -11366,8 +11366,13 @@ function InitializeFrames()
             local tex = uf._leaderIndicator
             if s.leaderIndicatorEnabled == false then tex:Hide(); return end
             local unit = uf.unit
-            if unit and UnitExists(unit) and UnitIsGroupLeader(unit) then
-                tex:SetAtlas(LEADER_ATLAS)
+            local isLeader = UnitIsGroupLeader(unit)
+            local isAssist = UnitIsGroupAssistant(unit)
+            if isLeader and not issecretvalue(isLeader) then
+                tex:SetTexture("Interface\\GroupFrame\\UI-Group-LeaderIcon")
+                tex:Show()
+            elseif isAssist and not issecretvalue(isAssist) then
+                tex:SetTexture("Interface\\GroupFrame\\UI-Group-AssistantIcon")
                 tex:Show()
             else
                 tex:Hide()


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Fixes the leader/assistant icon on player and target unit frames. Previously only the leader icon was shown via atlas. Now both leader and assistant icons display correctly using their respective Interface\GroupFrame textures.

## How was it tested?

On retail-live client. No PTR testing, but it should not broke

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ N/A] New settings default **OFF** (no behavior change without opt-in)
- [ N/A] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ N/A] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ X] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ X] Tested in-game, works on live retail; no load errors on the 12.1 PTR client