### PR TITLE
fix(actionbars): restore MicroBar and BagBar after pet battles

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -5907,8 +5907,8 @@ function EAB:ApplyExtraBarVisibility()
             -- state is "hide" during pet battle, "show" otherwise
             local shouldHide = (state == "hide")
             for _, info in ipairs(EXTRA_BARS) do
-                if info.noManagedVisibility or info.blizzOwnedVisibility then
-                    -- skip: Blizzard handles pet battle visibility for these
+                if info.noManagedVisibility then
+                    -- skip
                 else
                 local key = info.key
                 local s = EAB.db and EAB.db.profile.bars[key]


### PR DESCRIPTION
## Summary
- `blizzOwnedVisibility` bars (MicroBar, BagBar) were skipped entirely in the pet battle state driver handler, trusting Blizzard to restore them after pet battles end
- Blizzard does not restore them reliably, leaving MicroBar hidden until `/reload`
- Removed `blizzOwnedVisibility` from the skip condition so these bars use the existing `SetManagedBlizzOwnedSuppressed` save/restore logic, which properly tracks pre-pet-battle visibility state

## Test plan
- [ ] Enter a pet battle with MicroBar visible
- [ ] Complete or forfeit the pet battle
- [ ] Verify MicroBar reappears without needing `/reload`
- [ ] Verify BagBar also reappears correctly
- [ ] Verify MicroBar still hides during the pet battle itself
- [ ] If MicroBar was hidden via user settings before pet battle, verify it stays hidden after