### PR TITLE
fix(resourcebars): prevent cast bar jump on off-GCD during casts/channels

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -6288,7 +6288,9 @@ OnCastStart = function()
     castBarFrame._spellName = name
     castBarFrame._totalDurSuffix = " / " .. format("%.1f", (endTimeMS - startTimeMS) / 1000)
     castBarFrame._nameText:SetText(name)
-    castBarFrame._bar:SetValue(0)
+    local castDur = endTimeMS - startTimeMS
+    local initProgress = (castDur > 0) and ((GetTime() - startTimeMS / 1000) / (castDur / 1000)) or 0
+    castBarFrame._bar:SetValue(min(max(initProgress, 0), 1))
 
     -- Hide empower pips
     if castBarFrame._pips then
@@ -6343,7 +6345,9 @@ OnChannelStart = function()
     castBarFrame._spellName = name
     castBarFrame._totalDurSuffix = " / " .. format("%.1f", (endTimeMS - startTimeMS) / 1000)
     castBarFrame._nameText:SetText(name)
-    castBarFrame._bar:SetValue(1)
+    local chanDur = endTimeMS - startTimeMS
+    local initProgress = (chanDur > 0) and ((endTimeMS / 1000 - GetTime()) / (chanDur / 1000)) or 1
+    castBarFrame._bar:SetValue(min(max(initProgress, 0), 1))
 
     -- Hide empower pips
     if castBarFrame._pips then
@@ -6501,7 +6505,9 @@ OnEmpowerStart = function()
     castBarFrame._totalDurSuffix = " / " .. format("%.1f", (endTimeMS - startTimeMS) / 1000)
     HideLatencyOverlay()
     castBarFrame._nameText:SetText(name)
-    castBarFrame._bar:SetValue(0)
+    local empDur = endTimeMS - startTimeMS
+    local empProgress = (empDur > 0) and ((GetTime() - startTimeMS / 1000) / (empDur / 1000)) or 0
+    castBarFrame._bar:SetValue(min(max(empProgress, 0), 1))
     HideChannelTicks()
 
     -- Icon


### PR DESCRIPTION
## Summary
- Pressing off-GCD abilities (e.g. Hover) during channeled spells (Disintegrate, Drain Soul) or normal casts causes the cast bar to visually jump
- WoW fires CHANNEL_STOP + CHANNEL_START as a seamless channel restart when off-GCD spells are used mid-channel
- `OnChannelStart` was hardcoding `SetValue(1)` and `OnCastStart`/`OnEmpowerStart` were hardcoding `SetValue(0)`, causing the bar to snap to full/empty before the next OnUpdate frame corrected it
- Fix: compute the correct initial progress from the API-reported start/end times so the bar stays at the right position during restarts

## Test plan
- [ ] Channel Disintegrate (Evoker) and press Hover mid-channel — bar should not jump
- [ ] Channel Drain Soul (Warlock) and press an off-GCD mid-channel — bar should not jump
- [ ] Cast a normal spell and press Hover (Aug Evoker) — bar should not jump
- [ ] Start a fresh cast/channel from idle — bar should still start at the correct position (0% for casts, 100% for channels)
- [ ] Empower spells (Fire Breath etc.) should still fill correctly from the start