### PR TITLE
fix(nameplates): pandemic glow no longer dimmed by the debuff duration swipe

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -1525,10 +1525,12 @@ local function StartPandemicGlow(slot, slotSize)
     if not pg then
         local wrapper = CreateFrame("Frame", nil, slot)
         wrapper:SetAllPoints()
-        -- Sit just above the border (slot+1) so the glow renders beneath the
-        -- cooldown countdown text (slot.cd at +2) and stack count (+3) instead
-        -- of covering them.
-        wrapper:SetFrameLevel(slot:GetFrameLevel() + 1)
+        -- Sit ABOVE the cooldown frame (slot.cd at +2) so the duration swipe
+        -- can't render on top of the pandemic border and dim it. Matches the
+        -- dispel glow (slot+5); the glow is an edge border, so it doesn't
+        -- meaningfully obscure the corner countdown / stack numbers. (At the old
+        -- slot+1 the swipe drew over the glow, making it hard to see.)
+        wrapper:SetFrameLevel(slot:GetFrameLevel() + 5)
         local flipTex = wrapper:CreateTexture(nil, "OVERLAY", nil, 7)
         flipTex:SetPoint("CENTER")
         local animGroup = flipTex:CreateAnimationGroup()


### PR DESCRIPTION
## Problem

With **pandemic glow on debuffs** enabled for nameplates, the pandemic border was rendered *under* the debuff's cooldown duration swipe, so the dark sweep drew on top of it and dimmed it — making the pandemic indicator hard to see.

## Root cause

The pandemic glow wrapper was created at `slot:GetFrameLevel() + 1`. That was deliberately chosen to keep it below the countdown/stack numbers, but the debuff cooldown frame (`slot.cd`, which draws the duration swipe) sits at `+2` — so the glow ended up **below the swipe**.

## Fix

Raise the pandemic glow wrapper to `slot:GetFrameLevel() + 5`, matching the sibling **dispel glow** (which already sits above the swipe). The glow is an edge border, so it doesn't obscure the countdown timer or stack count — those are at the corners with outlines, exactly as the dispel glow already coexists with them.

## Testing

Verified in-game: with pandemic glow enabled and a DoT ticking into the pandemic window on a dummy, the pandemic border is now clearly visible on top of the cooldown swipe, and the duration timer and stack count remain readable.

<img width="259" height="52" alt="pandemic1" src="https://github.com/user-attachments/assets/b5616841-8ccd-48e1-b37f-403268a2460f" />
<img width="763" height="245" alt="pandemic2" src="https://github.com/user-attachments/assets/32852046-8c7e-410a-b78c-ade897fcf3ad" />
<img width="1247" height="543" alt="pandemic3" src="https://github.com/user-attachments/assets/783c7d58-03b8-4d71-8967-9c2327f6e8ab" />

## Scope

One line (plus comment) in `EllesmereUINameplates/EllesmereUINameplates.lua`.
