### PR TITLE
fix(blizzardskin): apply skin font to mail body text

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -4932,9 +4932,7 @@ local function SkinMailRow(row)
     if row.Button then SkinMailItemButton(row.Button) end
 end
 
--- Letter body is a SimpleHTML with per-element colors and fonts; force
--- readable white in the skin font so stationery-specific faces (AH, crafting)
--- don't look out of place on the dark background.
+-- Letter body: force readable white + skin font on the SimpleHTML elements.
 local function WhitenMailText()
     local html = _G.OpenMailBodyText
     if html and html.SetTextColor then

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -4932,17 +4932,27 @@ local function SkinMailRow(row)
     if row.Button then SkinMailItemButton(row.Button) end
 end
 
--- Letter body is a SimpleHTML with per-element colors; force readable white.
+-- Letter body is a SimpleHTML with per-element colors and fonts; force
+-- readable white in the skin font so stationery-specific faces (AH, crafting)
+-- don't look out of place on the dark background.
 local function WhitenMailText()
     local html = _G.OpenMailBodyText
     if html and html.SetTextColor then
+        local fp = Theme.fontPath
+        local ff = Theme.fontFlag or ""
         for _, el in ipairs({ "P", "H1", "H2", "H3" }) do
             pcall(html.SetTextColor, html, el, 1, 1, 1)
+            if fp and html.GetFont then
+                local ok, _, sz = pcall(html.GetFont, html, el)
+                if ok and sz and not issecretvalue(sz) then
+                    pcall(html.SetFont, html, el, fp, sz, ff)
+                end
+            end
         end
     end
-    if _G.OpenMailSubject then WSkin.White(_G.OpenMailSubject) end
+    if _G.OpenMailSubject then WSkin.Font(_G.OpenMailSubject); WSkin.White(_G.OpenMailSubject) end
     local sender = _G.OpenMailSender
-    if sender and sender.Name then WSkin.White(sender.Name) end
+    if sender and sender.Name then WSkin.Font(sender.Name); WSkin.White(sender.Name) end
 end
 
 local function Skin_OpenMail()


### PR DESCRIPTION
## Summary
- Mail body text (`OpenMailBodyText` SimpleHTML) only had its color set to white but kept the stationery-specific font
- AH and crafting mails use ornate stationery fonts that are hard to read on the dark skin background
- Apply `Theme.fontPath` to P/H1/H2/H3 elements of the mail body, preserving existing font sizes
- Also apply `WSkin.Font` to subject and sender labels in the open mail view

## Test plan
- [ ] Open an AH mail — body text should use the skin font, readable on dark background
- [ ] Open a crafting order mail — same
- [ ] Open a regular player mail — should also look correct
- [ ] Verify inbox row sender/subject fonts are unchanged