### PR TITLE
fix(questtracker): quest item hotkey not finding quest items

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_QoL.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_QoL.lua
@@ -128,22 +128,25 @@ end
 local function ScanForQuestItem()
     if not C_QuestLog then return nil end
     local num = C_QuestLog.GetNumQuestLogEntries() or 0
+    local fallback = nil
     for i = 1, num do
         local info = C_QuestLog.GetInfo(i)
         if info and not info.isHeader and info.questID then
-            local qID = info.questID
-            local wt = C_QuestLog.GetQuestWatchType and C_QuestLog.GetQuestWatchType(qID)
-            if wt ~= nil then
-                local logIdx = C_QuestLog.GetLogIndexForQuestID and C_QuestLog.GetLogIndexForQuestID(qID) or i
-                local link, itemTex = GetQuestLogSpecialItemInfo(logIdx)
-                if link then
-                    local name = link:match("%[(.-)%]")
-                    if name then return name end
+            local logIdx = C_QuestLog.GetLogIndexForQuestID
+                and C_QuestLog.GetLogIndexForQuestID(info.questID) or i
+            local link = GetQuestLogSpecialItemInfo(logIdx)
+            if link then
+                local name = link:match("%[(.-)%]")
+                if name then
+                    local wt = C_QuestLog.GetQuestWatchType
+                        and C_QuestLog.GetQuestWatchType(info.questID)
+                    if wt ~= nil then return name end
+                    fallback = fallback or name
                 end
             end
         end
     end
-    return nil
+    return fallback
 end
 
 local function InstallQuestItemHotkey()


### PR DESCRIPTION
## Summary
- `ScanForQuestItem` only considered watched quests (`GetQuestWatchType ~= nil`), so quest items from untracked quests were never found
- The secure button's `item` attribute stayed nil, no override binding was created, and the hotkey did nothing
- Now scans all quests for items, prioritising watched quests but falling back to any quest with a usable item

## Test plan
- [ ] Set a quest item hotkey in Quest Tracker settings
- [ ] Have a quest with a usable item (AH pickup, crafting, world quest item, etc.)
- [ ] Press the hotkey — should use the quest item
- [ ] Track a different quest with an item — hotkey should prefer the tracked quest's item
- [ ] Verify hotkey still works after `/reload`