### PR TITLE
fix(bags): allow renaming the Miscellaneous category

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags_Categories.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Categories.lua
@@ -463,7 +463,6 @@ end
 function CategoryManager:RenameCategory(index, newName)
     local cats = self:GetCategories()
     if not cats[index] then return false end
-    if cats[index].isCatchAll then return false end
     if not newName or newName == "" then return false end
     local oldGroup = cats[index].groupName
     local shouldRegenerate = oldGroup and not self:IsGroupNameCustom(oldGroup)


### PR DESCRIPTION
## Summary
- `RenameCategory` blocked catch-all categories (`isCatchAll`) from being renamed
- The `isCatchAll` flag is only used for item classification and ordering — the display name is purely cosmetic
- Removed the guard so Miscellaneous can be renamed like any other category

## Test plan
- [ ] Right-click the Miscellaneous category header in OneBag
- [ ] Click Rename, enter a new name
- [ ] Verify the category is renamed
- [ ] Verify unclassified items still land in the renamed category
- [ ] Verify the rename persists across `/reload`