### PR TITLE
fix(bags): prevent click-through during rapid right-click transfers

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -5047,7 +5047,6 @@ function EUI_Bags:RefreshInventory()
     -- 5. Render grid into scroll child
     local _t0GridSetup = ProfBegin("GridSetup")
     for _, btn in pairs(itemSlots) do
-        btn:GetParent():Hide()
         if btn.ProfessionQualityOverlay then btn.ProfessionQualityOverlay:SetAlpha(0) end
         if btn.IconOverlay then btn.IconOverlay:SetAlpha(0); btn.IconOverlay:Hide() end
         if btn.IconOverlay2 then btn.IconOverlay2:SetAlpha(0); btn.IconOverlay2:Hide() end
@@ -6068,6 +6067,12 @@ function EUI_Bags:RefreshInventory()
             local gridRows = math.ceil(totalItems / columns)
             curY = curY - (gridRows * (SLOT_SIZE + SPACING))
         end
+    end
+
+    -- Hide slots that were not rendered this pass
+    for i = slotIdx + 1, #itemSlots do
+        local btn = itemSlots[i]
+        if btn then btn:GetParent():Hide() end
     end
 
     -- Set scroll child height to content height


### PR DESCRIPTION
## Summary
- Defers hiding unused item slots until after the render pass instead of hiding all slots at the start of `RefreshInventory()`
- Eliminates the brief window where all slots are hidden during the debounced refresh (0.1s `C_Timer.After`), which caused right-clicks to fall through to action bars during rapid item transfers

## Test plan
- [ ] Open bags near a bank/warbank
- [ ] Rapidly right-click items to transfer them
- [ ] Verify clicks no longer miss or fall through to action bars beneath the bag window
- [ ] Switch between category tabs and OneBag view to confirm slots render correctly
- [ ] Verify no ghost/stale slots remain visible after switching tabs