### PR TITLE
fix(bags): warbank aggregate views now stack across all tabs

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -1282,12 +1282,55 @@ local function ProcessTransfer(srcBag, srcSlot)
     end
     local bank = _G.EUI_BankFrame
     if not bank or not bank:IsVisible() then return true end -- bank closed, discard
-    local targetBag = bank:GetSelectedTabBagID()
-    if not targetBag then return true end -- no tab selected, discard
     local info = C_Container.GetContainerItemInfo(srcBag, srcSlot)
     if not info or not info.itemID then return true end
-    local targetSlot = FindTargetSlot(targetBag, info.itemID)
-    if not targetSlot then return true end -- no space, discard
+
+    local targetBag, targetSlot
+    -- Aggregate warband views: search ALL warband tabs for stacking, then empty
+    if _selectedView == -2 or _selectedView == -3 then
+        local maxStack = C_Item.GetItemMaxStackSizeByID(info.itemID) or 1
+        -- Pass 1: partial stack in any warband tab
+        if maxStack > 1 then
+            for _, tab in ipairs(_allTabs) do
+                if tab.isWarband then
+                    local numSlots = C_Container.GetContainerNumSlots(tab.bagID)
+                    for slot = 1, numSlots do
+                        if not IsSlotAllocated(tab.bagID, slot) then
+                            local si = C_Container.GetContainerItemInfo(tab.bagID, slot)
+                            if si and si.itemID == info.itemID and si.stackCount < maxStack then
+                                targetBag, targetSlot = tab.bagID, slot
+                                break
+                            end
+                        end
+                    end
+                    if targetSlot then break end
+                end
+            end
+        end
+        -- Pass 2: first empty slot in any warband tab
+        if not targetSlot then
+            for _, tab in ipairs(_allTabs) do
+                if tab.isWarband then
+                    local numSlots = C_Container.GetContainerNumSlots(tab.bagID)
+                    for slot = 1, numSlots do
+                        if not IsSlotAllocated(tab.bagID, slot) then
+                            if not C_Container.GetContainerItemInfo(tab.bagID, slot) then
+                                targetBag, targetSlot = tab.bagID, slot
+                                break
+                            end
+                        end
+                    end
+                    if targetSlot then break end
+                end
+            end
+        end
+    else
+        targetBag = bank:GetSelectedTabBagID()
+        if not targetBag then return true end
+        targetSlot = FindTargetSlot(targetBag, info.itemID)
+    end
+
+    if not targetBag or not targetSlot then return true end -- no space, discard
     AllocateSlot(targetBag, targetSlot)
     C_Container.PickupContainerItem(srcBag, srcSlot)
     C_Container.PickupContainerItem(targetBag, targetSlot)


### PR DESCRIPTION
## Summary
- In OneWarbank / All Warbank views, item transfers now scan all warband tabs for partial stacks before falling back to empty slots
- Previously `GetSelectedTabBagID` returned the first tab with any empty slot, so items deposited into a full tab 1 would skip to tab 2 even when tab 1 had stackable partial stacks of the same item

## Test plan
- [ ] Fill warbank tab 1 but leave some items with partial stacks
- [ ] Switch to OneWarbank or All Warbank view
- [ ] Right-click the same item from bags — verify it stacks in tab 1 instead of going to tab 2
- [ ] Verify items still go to the next tab when tab 1 is truly full (no partial stacks)
- [ ] Verify individual tab selection still works as before