### PR TITLE
fix(cdm): trinket cooldown disappears when visiting crafting vendor

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2815,11 +2815,13 @@ local function UpdateTrinketFrame(slotID)
     local _, spellID = C_Item.GetItemSpell(itemID)
     f._trinketSpellID = spellID
     local isRealOnUse = false
+    local scanConclusive = false
     if spellID and spellID > 0 then
         local locale = GetLocale()
         if locale == "enUS" or locale == "enGB" then
             local tipData = C_TooltipInfo and C_TooltipInfo.GetItemByID(itemID)
             if tipData and tipData.lines then
+                scanConclusive = true
                 for _, tipLine in ipairs(tipData.lines) do
                     local lt = tipLine.leftText
                     if lt and lt:find("Cooldown%)") then
@@ -2843,9 +2845,14 @@ local function UpdateTrinketFrame(slotID)
             end
         else
             isRealOnUse = true
+            scanConclusive = true
         end
+    else
+        scanConclusive = (spellID == nil or spellID == 0)
     end
-    f._trinketIsOnUse = isRealOnUse
+    if scanConclusive then
+        f._trinketIsOnUse = isRealOnUse
+    end
 end
 ns.UpdateTrinketFrame = UpdateTrinketFrame
 


### PR DESCRIPTION
## Summary
- `UpdateTrinketFrame` determines on-use status by scanning tooltip lines for cooldown text via `C_TooltipInfo.GetItemByID`
- When tooltip data is temporarily unavailable (e.g. during crafting order vendor interaction), the scan found no lines and reset `_trinketIsOnUse` to false, causing the trinket icon to hide
- Now preserves the previous on-use state when the tooltip scan is inconclusive (no tooltip data returned)

## Test plan
- [ ] Equip an on-use trinket and add it to a CDM bar
- [ ] Use the trinket so it shows a cooldown
- [ ] Click the crafting order vendor — verify the trinket cooldown icon stays visible
- [ ] Close the vendor — verify the icon is still there
- [ ] Swap trinkets — verify the icon updates correctly