### PR TITLE
fix(spec-overrides): custom raid size settings now save to override groups

### DIFF
--- a/EllesmereUI_SpecOverrides.lua
+++ b/EllesmereUI_SpecOverrides.lua
@@ -296,8 +296,10 @@ end
 -- drop every capture in the subtree (users re-capture; honest beats
 -- silently applying one bar's override onto another).
 local CDM_BARS_PREFIX = "EllesmereUICooldownManager\31cdmBars\30bars\30"
+local RAID_SIZE_OV_PREFIX = "EllesmereUIRaidFrames\31raidSizeOverrides\30"
 local function NumAllowedFKey(fkey)
     return fkey:sub(1, #CDM_BARS_PREFIX) == CDM_BARS_PREFIX
+        or fkey:sub(1, #RAID_SIZE_OV_PREFIX) == RAID_SIZE_OV_PREFIX
 end
 
 function EllesmereUI.SpecOverrides_OnCDMBarsRestructured()


### PR DESCRIPTION
## Summary
- `raidSizeOverrides` uses numeric keys (10, 15, 25, 30) for tier sizes
- The auto-capture system's `NumAllowedFKey` gate only whitelisted CDM bar indices, rejecting all other numeric-keyed paths as unsafe
- Custom raid size settings (frame width/height, growth direction, X/Y offset) were silently dropped during capture and fell back to the Default group
- Added the `raidSizeOverrides` prefix to `NumAllowedFKey` so these paths are correctly captured

## Test plan
- [ ] Create a Healer override group in Spec Overrides
- [ ] Add custom raid sizes (e.g. 10 Man, 25 Man)
- [ ] Select the Healer override group and adjust frame width/height and position offsets
- [ ] Switch to Default group — verify the values revert to the default settings
- [ ] Switch back to Healer — verify the overridden values are restored
- [ ] Reload UI — verify the overrides persist