### PR TITLE
fix(visibility): druid flight form now triggers dragonriding hide

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8347,17 +8347,21 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
         return
     end
     if event == "UPDATE_SHAPESHIFT_FORM" then
-        -- Bail fast if no bar actually uses visHideMounted: druids shift
-        -- constantly in combat (Bear/Cat) and we don't want to re-run the
-        -- visibility pipeline for nothing.
+        -- Bail fast if no bar uses mount/dragonriding visibility: druids
+        -- shift constantly in combat (Bear/Cat) and we don't want to
+        -- re-run the visibility pipeline for nothing.
         local p = ECME.db and ECME.db.profile
         local bars = p and p.cdmBars and p.cdmBars.bars
         if not bars then return end
-        local anyMountedOpt = false
+        local anyRelevant = false
         for _, bd in ipairs(bars) do
-            if bd.visHideMounted then anyMountedOpt = true; break end
+            if bd.visHideMounted then anyRelevant = true; break end
+            local bv = bd.barVisibility
+            if bv == "show_dragonriding" or bv == "show_not_dragonriding" then anyRelevant = true; break end
+            local vm = bd.visibilityModes
+            if vm and (vm.show_dragonriding or vm.show_not_dragonriding) then anyRelevant = true; break end
         end
-        if not anyMountedOpt then return end
+        if not anyRelevant then return end
         -- Defer one frame: the Travel Form aura is applied slightly after
         -- UPDATE_SHAPESHIFT_FORM fires, so IsPlayerMountedLike's aura check
         -- would miss it on the immediate pass.

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -255,13 +255,11 @@ local VIS_COMBINABLE_KEYS = { mouseover = true }
 for _, k in ipairs(VIS_REPRESENTATIVE_ORDER) do VIS_COMBINABLE_KEYS[k] = true end
 EUI.VIS_COMBINABLE_KEYS = VIS_COMBINABLE_KEYS
 
--- Airborne skyriding predicate shared by CheckVisibilityMode's dragonriding
--- branches and the multi-select engine. Approximates the secure driver's
--- [advflyable,flying]; the additional IsMounted() requirement is a
--- deliberate, documented drift (Druid Flight Form matches the secure driver
--- but not this predicate).
+-- Skyriding predicate shared by CheckVisibilityMode's dragonriding branches
+-- and the multi-select engine. Returns true when mounted (or in a druid
+-- mount-like form) with skyriding capability, even before takeoff.
 function EUI.IsAirborneSkyriding()
-    if not (IsMounted and IsMounted() and IsFlying and IsFlying()) then return false end
+    if not (EUI.IsPlayerMountedLike and EUI.IsPlayerMountedLike()) then return false end
     if C_PlayerInfo and C_PlayerInfo.GetGlidingInfo then
         local _, canGlide = C_PlayerInfo.GetGlidingInfo()
         return canGlide == true


### PR DESCRIPTION
## Summary
- `IsAirborneSkyriding()` used `IsMounted()` which returns false for druid flight form — switched to `IsPlayerMountedLike()` which covers druid mount-like shapeshift forms (Travel Form, Flight Form, Aquatic Form)
- Removed the `IsFlying()` requirement so bars hide as soon as the skyriding mount/form is active, not only after takeoff (addresses the "bars should hide when dragonriding bar pops up" feedback)
- Updated CDM's `UPDATE_SHAPESHIFT_FORM` handler to also re-evaluate visibility when any bar uses dragonriding visibility modes, not just `visHideMounted`

## Test plan
- [ ] Set a CDM or resource bar to "When Not Dragonriding" visibility
- [ ] As a druid, shift into flight form — verify bars hide
- [ ] Land and shift out — verify bars reappear
- [ ] Mount a regular skyriding mount — verify bars hide before takeoff (when dragonriding bar appears)
- [ ] Non-druid: mount a skyriding mount — verify bars hide
- [ ] Verify bars still show correctly in combat druid forms (Cat/Bear/Moonkin)