### PR TITLE
fix(cdm): restore CDM bars after PvP instance transitions

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -5634,6 +5634,8 @@ local function ProcessReanchorQueue(self)
     reanchorDirty = false
     _lastReanchorTime = now
     CollectAndReanchor()
+    -- Reapply visibility: newly collected icons may be at alpha 0.
+    if ns.CDMApplyVisibility then ns.CDMApplyVisibility() end
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8397,27 +8397,27 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
     end
     if event == "PLAYER_ENTERING_WORLD" then
         _inCombat = InCombatLockdown and InCombatLockdown() or false
-        -- Arena exit backstop: leaving an arena reverts PvP talents and
-        -- spell overrides, and Blizzard re-evaluates the viewer's tracked
-        -- cooldown set. If PLAYER_PVP_TALENT_UPDATE did not fire across the
-        -- zone-out, nothing re-claims the new pool frames and the
-        -- unclaimed-frame cleanup blanks them (arena-exit empty-CDM bug).
-        -- Schedule the same debounced rebuild a talent change gets; the
-        -- token debounce collapses this with the event-driven trigger when
-        -- both fire, so at most one rebuild runs.
+        -- PvP instance transition backstop: entering or leaving a PvP
+        -- instance rebuilds viewer pools (PvP talents activate/deactivate).
+        -- Rebuild + reanchor so the new pool frames are claimed.
         local _, instType = IsInInstance()
-        if ns._cdmWasInArena and instType ~= "arena" then
+        local wasPvP = ns._cdmWasInPvP
+        local isPvP = (instType == "arena" or instType == "pvp")
+        if wasPvP and not isPvP then
             ScheduleTalentRebuild()
         end
-        ns._cdmWasInArena = (instType == "arena") or nil
+        ns._cdmWasInPvP = isPvP or nil
+        if isPvP and not wasPvP then
+            if ns.QueueReanchor then ns.QueueReanchor() end
+        end
         -- Install rotation helper hook after CDM frames have been built
         C_Timer.After(1, function()
             InstallRotationHook()
         end)
-        -- Safety: re-apply visibility after rebuild settles. Blizzard may
-        -- hide/re-show CDM viewers during loading screens (PvP scoreboard,
-        -- barbershop) and the timing race can leave viewer alpha at 0.
+        -- Safety: re-apply visibility after loading screen settles.
+        -- Two passes to catch both fast and late viewer pool rebuilds.
         C_Timer.After(1.5, _CDMApplyVisibility)
+        C_Timer.After(3, _CDMApplyVisibility)
     end
     if event == "SPELLS_CHANGED" then
         CheckSpecChange()


### PR DESCRIPTION
## Summary
- CDM bars (Blizzard-tracked cooldowns) vanished after entering/exiting PvP instances (arenas, BGs). Custom EUI-added icons were unaffected because they don't inherit Blizzard viewer alpha.
- **Root cause**: `CollectAndReanchor` repopulates `cdmBarIcons` with freshly-acquired Blizzard pool frames, but never called `_CDMApplyVisibility` afterward — icons stayed at alpha 0 from the unclaimed-frame sweep
- **Secondary cause**: The PvP exit backstop (`_cdmWasInArena`) only covered arena exits, missing battlegrounds entirely. Entering PvP instances also didn't trigger a reanchor.
- Call `CDMApplyVisibility` after every `CollectAndReanchor` so newly collected icons get visibility restored immediately
- Extend the PvP backstop to all PvP instance types (`arena` + `pvp`)
- Queue a reanchor on PvP instance entry (viewer pools rebuilt for PvP talents)
- Add a second deferred visibility pass at 3s as an extra safety net for late viewer rebuilds

## Test plan
- [ ] Enter a battleground — CDM bars should remain visible throughout
- [ ] Exit a battleground (including while in combat) — CDM bars should restore after loading screen
- [ ] Enter/exit an arena — CDM bars should remain visible
- [ ] Verify custom EUI-added icons are unaffected by the change
- [ ] Verify trinket frame continues working across PvP transitions
- [ ] Verify no performance regression during normal gameplay (reanchor throttle unchanged at 0.2s)