### PR TITLE
Change on/off addon icon based on addon status

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -7173,7 +7173,8 @@ local function CreateMainFrame()
                 end
             end)
             pwrBtn:SetScript("OnLeave", function(self)
-                self._tex:SetVertexColor(1, 1, 1, 1)
+                local enabled = IsAddonLoaded(self._folder)
+                self._tex:SetVertexColor(1, 1, 1, enabled and 1 or 0.5)
                 if EllesmereUI.HideWidgetTooltip then EllesmereUI.HideWidgetTooltip() end
             end)
             pwrBtn:SetScript("OnClick", function(self)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

The alpha of the power button was always set to 1 no matter what, even if the previous alpha was 0.5 (addon disabled state) on hover leave.

## How was it tested?

Hover the icon, if it was previously greyed-out (alpha 0.5), it should stay that way after the mouse leave the icon. Same for already enabled icon should stay to 1.

## Screenshots

Before:
<img width="266" height="29" alt="image" src="https://github.com/user-attachments/assets/27e631fb-1689-4a9b-8ddc-3d0616c61b94" />

After :
<img width="273" height="26" alt="image" src="https://github.com/user-attachments/assets/6be931d7-b129-4959-bd77-fe685569472b" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
