### PR TITLE
fix(cdm): buff bar seconds timer rounds up to match Blizzard's aura timers

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 local _, ns = ...
 
+local ceil    = math.ceil
 local floor   = math.floor
 local format  = string.format
 local GetTime = GetTime
@@ -94,9 +95,14 @@ ns.TBB_TEXTURE_NAMES = TBB_TEXTURE_NAMES
 --  Shared Helpers
 -------------------------------------------------------------------------------
 local function FormatTime(remaining)
+    -- Whole SECONDS display uses ceil, matching Blizzard's aura timers: a buff
+    -- with 16.5s left reads "17", not "16". Flooring the seconds showed every
+    -- buff one second below Blizzard's frame (reported/verified for Aug Evoker
+    -- Ebon Might). Minutes/hours stay floor -- their round-up isn't verified
+    -- against Blizzard and buffs seldom sit that high. Sub-10s keeps tenths.
     if remaining >= 3600 then return format("%dh", floor(remaining / 3600)) end
     if remaining >= 60   then return format("%dm", floor(remaining / 60))   end
-    if remaining >= 10   then return format("%d",  floor(remaining))        end
+    if remaining >= 10   then return format("%d",  ceil(remaining))         end
     return format("%.1f", remaining)
 end
 


### PR DESCRIPTION
## Problem

On the CDM buff bar, a buff's countdown read **one second below Blizzard's own frame** — e.g. Aug Evoker Ebon Might showed `16` on the bar while Blizzard's BuffFrame showed `17`.

## Root cause

`FormatTime` floored the remaining whole seconds. Blizzard's aura timers round **up**, so flooring displayed every buff one second low in the ≥10s range.

Originally this looked like a "stale duplicate / refresh lag," but an instrumented in-game capture (on an Aug Evoker, across Ebon Might extensions) showed the bar's `remaining` matches the live aura's `expirationTime` exactly — only the *displayed integer* was floored. The two icons some users saw were also two distinct buffs (Ebon Might + its hero-talent buff), not a duplicate.

## Fix

Ceil the whole-second branch so a buff with 16.5s left reads `17`, matching Blizzard.

- **Minutes/hours are left as `floor`** on purpose: their round-up behavior wasn't verified against Blizzard, and buffs rarely sit in that range — so this ships only the verified change.
- Sub-10s still shows tenths (an existing CDM feature).

## Testing

Verified in-game on an Aug Evoker: the buff bar's whole-second number now matches Blizzard's BuffFrame at steady state.

Note: at the exact instant of a proc-driven Ebon Might extension there's a sub-half-second flicker where the bar trails Blizzard — that's Blizzard's aura data updating a beat behind its own BuffFrame (the bar faithfully reads the same aura API), and it isn't addressed here as it isn't cleanly fixable from an addon.

## Scope

One file: `EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua` (the shared `FormatTime` helper).
