### PR TITLE
fix(actionbars): refresh item rank icon when an item is swapped in place

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -8779,7 +8779,33 @@ function EAB:OnInitialize()
                 for _, info in ipairs(BAR_CONFIG) do
                     local btns = barButtons[info.key]
                     local s = bars[info.key]
-                    if btns and s and not s.showRankIcon then
+                    if btns and s and s.showRankIcon then
+                        -- Feature ON: Blizzard does NOT refresh the quality
+                        -- overlay when an item is swapped in place (rank 1 ->
+                        -- rank 2 potion in the same slot), so it keeps showing
+                        -- the previous item's rank until a hover forces the
+                        -- button's own update. Re-run that update here so the
+                        -- rank tracks the new item immediately.
+                        for _, btn in ipairs(btns) do
+                            -- Rank icons only apply to items, so only run the
+                            -- (item-info-querying) refresh on item slots -- an
+                            -- ACTIONBAR_SLOT_CHANGED storm from mouseover-macros
+                            -- re-resolving fires in combat, and this must not
+                            -- do a quality lookup on every spell button per
+                            -- frame. A non-item slot (spell swapped in, or the
+                            -- slot cleared) just gets any lingering rank hidden.
+                            local action = btn:GetAttribute("action") or 0
+                            if action > 0 and GetActionInfo
+                               and GetActionInfo(action) == "item" then
+                                if btn.UpdateProfessionQuality then
+                                    btn:UpdateProfessionQuality()
+                                end
+                            else
+                                local ov = btn.ProfessionQualityOverlayFrame
+                                if ov and ov:IsShown() then ov:SetShown(false) end
+                            end
+                        end
+                    elseif btns and s and not s.showRankIcon then
                         for _, btn in ipairs(btns) do
                             local ov = btn.ProfessionQualityOverlayFrame
                             if ov and ov:IsShown() then


### PR DESCRIPTION
## Problem

With **Show item rank** enabled, replacing an item in an action slot with a different rank **in the same slot** — e.g. a rank 1 Silvermoon Health Potion, then dropping a rank 2 from bags onto it — left the rank overlay showing the **old** rank. It only corrected itself after hovering the button a second time.

## Root cause

Blizzard doesn't re-run its `ProfessionQualityOverlayFrame` update on an in-place slot swap, so the overlay keeps the previous item's crafted-quality icon until a hover forces the button's own refresh. The addon's existing `ACTIONBAR_SLOT_CHANGED` scan only handled the feature-**off** case (hiding overlays) and did nothing to refresh the rank when the feature is on.

## Fix

On the same (coalesced, one-per-frame) `ACTIONBAR_SLOT_CHANGED` scan, re-run Blizzard's own `UpdateProfessionQuality()` for buttons on rank-enabled bars, so the rank tracks the new item immediately.

Gated to **item** slots: rank icons only apply to items, and `ACTIONBAR_SLOT_CHANGED` storms (mouseover-conditional macros re-resolving, which fire in combat) must not run a quality lookup on every spell button every frame. A non-item slot (a spell swapped in, or the slot cleared) simply gets any lingering rank overlay hidden.

## Testing

Verified in-game:
- Swapping a rank 1 potion for a rank 2 in the same slot now updates the rank **immediately** (no hover needed).
- Swapping to a non-ranked / non-item slot leaves **no stale** rank overlay.

## Scope

One file: `EllesmereUIActionBars/EllesmereUIActionBars.lua`.
