### PR TITLE
Fix: Boss frame class color

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -12158,12 +12158,27 @@ function InitializeFrames()
     -- this is a cheap no-op unless the user enabled a boss border.
     -- Defined on ns (not a local) to avoid the Lua 200-local cap.
     ns.UpdateBossTargetBorders = function()
+        local s = db.profile.boss
         for i = 1, 5 do
-            local f = frames["boss" .. i]
-            if f and f.unifiedBorder then
-                local isT = UnitIsUnit("boss" .. i, "target")
-                f._isTarget = (isT and not issecretvalue(isT)) and true or false
-                ns.ApplyBossBorderState(f)
+            local bUnit = "boss" .. i
+            local f = frames[bUnit]
+            if f then
+                if f.unifiedBorder then
+                    local isT = UnitIsUnit(bUnit, "target")
+                    f._isTarget = (isT and not issecretvalue(isT)) and true or false
+                    ns.ApplyBossBorderState(f)
+                end
+                if s then
+                    if f.LeftText and s.leftTextClassColor ~= nil then
+                        ApplyClassColor(f.LeftText, bUnit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
+                    end
+                    if f.RightText and s.rightTextClassColor ~= nil then
+                        ApplyClassColor(f.RightText, bUnit, s.rightTextClassColor, s.rightTextColorR, s.rightTextColorG, s.rightTextColorB)
+                    end
+                    if f.CenterText and s.centerTextClassColor ~= nil then
+                        ApplyClassColor(f.CenterText, bUnit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
+                    end
+                end
             end
         end
     end


### PR DESCRIPTION
## Fix: Boss frame text stays white despite "Class Colored"
 
### Problem
With `leftTextClassColor` (or right/center) enabled on boss frames, the
name text stays white permanently, regardless of the setting.
 
### Root Cause
`ApplyClassColor` for boss text is only ever called in two places:
1. once at frame build time in `StyleBossFrame` (`ApplyTextPositions`)
2. on changes made in the options panel
At frame build time (login/reload, outside an encounter), `bossN`
typically doesn't exist yet. `ns.ResolveUnitNameColor` checks
`UnitExists(unit)`; if that fails, it returns `nil` and `ApplyClassColor`
falls back to the white default color. That color is then **never
recomputed** once the boss actually appears — only the text *content*
runs through oUF's tag system and updates automatically, the *color*
does not.
 
The same pattern was already fixed once for ToT/focustarget
(`ReapplyFrameTextClassColors`); boss frames were missing the analogous
hook.
 
### Fix
`ns.UpdateBossTargetBorders` (already wired to `PLAYER_TARGET_CHANGED`,
`INSTANCE_ENCOUNTER_ENGAGE_UNIT`, `UNIT_TARGETABLE_CHANGED`,
`PLAYER_ENTERING_WORLD`) now also re-runs `ApplyClassColor` for
`LeftText`/`RightText`/`CenterText` on all `boss1`–`boss5`. No new
frame, no new event — just extends the existing update function.

Bug Report:
https://discord.com/channels/585577383847788554/1527028240915501208