### PR TITLE
fix(cdm): track cooldown for CD-Ready glow on trinkets/racials/potions

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -475,6 +475,32 @@ end
 --  ability is on cooldown. A cooldown ENDING has no reliable event, so this is a
 --  throttled poll -- but only while at least one preset actually uses it.
 -- ---------------------------------------------------------------------------
+-- Read an item's real (non-GCD) cooldown, container query first then C_Item,
+-- mirroring ProcessPresetCooldowns. Returns start,dur (dur nil / <=1.5 = ready).
+local function ReadItemCD(itemID)
+    local start, dur
+    if C_Container and C_Container.GetItemCooldown then start, dur = C_Container.GetItemCooldown(itemID) end
+    if not (start and dur and dur > 1.5) and C_Item and C_Item.GetItemCooldown then
+        start, dur = C_Item.GetItemCooldown(itemID)
+    end
+    return start, dur
+end
+
+-- itemID -> its preset's alternate item IDs. A preset (e.g. Light's Potential)
+-- covers several ranks of the same consumable; the player owns one alternate and
+-- the cooldown ticks on THAT id, not the primary. ProcessPresetCooldowns already
+-- walks these, so PresetOnCD must too or the "CD Ready" glow never turns off.
+local _presetAltMap
+local function PresetAltItemIDs(itemID)
+    if not _presetAltMap then
+        _presetAltMap = {}
+        for _, pr in ipairs(ns.CDM_ITEM_PRESETS or {}) do
+            if pr.itemID and pr.altItemIDs then _presetAltMap[pr.itemID] = pr.altItemIDs end
+        end
+    end
+    return _presetAltMap[itemID]
+end
+
 -- Unified "is this preset on a real (non-GCD) cooldown right now?" read.
 -- Trinkets/items read the ITEM cooldown (its on-use spell can have a shorter
 -- cooldown that would fire the ready edge early). Bail on nil / Secret Values.
@@ -499,9 +525,18 @@ PresetOnCD = function(key)
         if GetInventoryItemCooldown then start, dur, enable = GetInventoryItemCooldown("player", -key) end
     else
         local itemID = -key
-        if C_Container and C_Container.GetItemCooldown then start, dur = C_Container.GetItemCooldown(itemID) end
-        if (start == nil or dur == nil) and C_Item and C_Item.GetItemCooldown then
-            start, dur = C_Item.GetItemCooldown(itemID)
+        start, dur = ReadItemCD(itemID)
+        -- The primary id often reads ready because the player owns one of the
+        -- preset's alternates and the cooldown ticks on THAT id -- walk them,
+        -- matching ProcessPresetCooldowns, so the glow can turn off.
+        if not (start and dur and dur > 1.5) then
+            local alts = PresetAltItemIDs(itemID)
+            if alts then
+                for i = 1, #alts do
+                    start, dur = ReadItemCD(alts[i])
+                    if start and dur and dur > 1.5 then break end
+                end
+            end
         end
     end
     if start == nil or dur == nil then return false end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2411,6 +2411,24 @@ local function DecorateFrame(frame, barData)
                 if bk2:sub(1, 7) == "__ghost" then return end
                 -- FocusKick icon alpha is owned by SetFocusKickAlpha only.
                 if bk2 == ns.FOCUSKICK_BAR_KEY then return end
+                -- Preset frames (trinket / racial / potion / custom spell) own their
+                -- cd-state entirely through the Fake-Active engine, which reads the
+                -- ITEM/racial cooldown. C_Spell.GetSpellCooldown can't read a negative
+                -- item key, so this spell path always sees the item as ready and would
+                -- re-light the shared glowOverlay every desat tick while it's on
+                -- cooldown. Hand the frame off cleanly (clear any glow we owned).
+                if ns.PresetHasCdState and ns.PresetHasCdState(frame) then
+                    if fd._cdStateGlowOn then
+                        if fd.glowOverlay then ns.StopNativeGlow(fd.glowOverlay) end
+                        fd._cdStateGlowOn = false
+                        -- The Fake-Active path owns this overlay through its own
+                        -- flag; clear it too so its next tick re-asserts the glow we
+                        -- just stopped (otherwise it thinks the glow is still on and
+                        -- never re-starts it, leaving a ready preset dark).
+                        fd._presetCdGlowOn = false
+                    end
+                    return
+                end
                 local ss2 = ResolveSpellSettings(frame, sid2, ns.GetBarSpellData(bk2))
                 local cse = ss2 and ss2.cdStateEffect
                 -- Shift-Icons variants behave exactly like their base hidden
@@ -2523,9 +2541,22 @@ local function DecorateFrame(frame, barData)
                 local onCD = cseInfo and cseInfo.isActive and not cseInfo.isOnGCD
                 if cse == "pixelGlowReady" or cse == "buttonGlowReady" then
                     -- Plain CD Ready Glow: cooldown state only, decided right
-                    -- here -- no usability reads, no deferral, no events. The
-                    -- Resource Aware variants below carry those costs; these
-                    -- deliberately do not.
+                    -- here -- no usability reads, no deferral, no events for
+                    -- genuine Blizzard frames (Blizzard calls SetDesaturated on
+                    -- them at every cd transition, re-firing this hook).
+                    -- EUI's own custom frames (racials / trinkets / potions /
+                    -- custom spells) instead drive desaturation via
+                    -- SetDesaturation(float), which does NOT trigger this
+                    -- SetDesaturated hook -- so on those the glow would never
+                    -- re-evaluate and would stay lit through the whole cooldown.
+                    -- Register just those for the event-driven cooldown watch
+                    -- (its loop handles plain variants too); Blizzard frames keep
+                    -- the zero-event path.
+                    if (frame._isRacialFrame or frame._isTrinketFrame or frame._isPresetFrame
+                        or frame._isItemPresetFrame or frame._isCustomSpellFrame)
+                        and ns.CDGlowWatch then
+                        ns.CDGlowWatch(frame)
+                    end
                     -- Pool reassignment: glow state inherited from a previous
                     -- spell on this frame belongs to that spell -- reset now.
                     if fd._cdGlowBoundSid ~= sid2 then
@@ -3019,10 +3050,16 @@ do
             local sid2 = fc2 and fc2.spellID
             local bk2 = fc2 and fc2.barKey
             local keep = false
-            if fd and fd.glowOverlay and sid2 and bk2 then
+            -- Preset frames are owned by the Fake-Active engine (see the guard in
+            -- the SetDesaturated hook); never let the spell-cooldown path drive
+            -- their glow. keep=false below stops any leftover glow and unwatches.
+            if fd and fd.glowOverlay and sid2 and bk2
+               and not (ns.PresetHasCdState and ns.PresetHasCdState(frame)) then
                 local ss2 = RSP(frame, sid2, ns.GetBarSpellData(bk2))
                 local cse2 = ss2 and ss2.cdStateEffect
-                if cse2 == "pixelGlowReadyUsable" or cse2 == "buttonGlowReadyUsable" then
+                local plainGlow = cse2 == "pixelGlowReady" or cse2 == "buttonGlowReady"
+                local usableGlow = cse2 == "pixelGlowReadyUsable" or cse2 == "buttonGlowReadyUsable"
+                if plainGlow or usableGlow then
                     keep = true
                     -- Pool reassignment: glow state inherited from a previous
                     -- spell on this frame belongs to that spell -- reset now.
@@ -3039,30 +3076,31 @@ do
                     end
                     local ci = C_Spell.GetSpellCooldown(liveSid)
                     local onCD = ci and ci.isActive and not ci.isOnGCD
+                    local shouldGlow
                     if onCD then
                         -- On cooldown always stops the glow -- a safety net
                         -- independent of the SetDesaturated hook, in case that
-                        -- hook doesn't fire for a given transition.
-                        if fd._cdStateGlowOn then
-                            ns.StopNativeGlow(fd.glowOverlay)
-                            fd._cdStateGlowOn = false
-                        end
+                        -- hook doesn't fire for a given transition (it never does
+                        -- for EUI custom frames -- they use SetDesaturation).
+                        shouldGlow = false
+                    elseif usableGlow then
+                        -- Resource Aware: also require castability (resources,
+                        -- form, lockout). nil = no data yet -> not usable.
+                        shouldGlow = (C_Spell.IsSpellUsable and C_Spell.IsSpellUsable(liveSid)) == true
                     else
-                        -- IsSpellUsable is the complete castability signal
-                        -- (resources, form, lockout). nil = no data yet ->
-                        -- treat as not usable; a later event re-evaluates.
-                        local isUsable = C_Spell.IsSpellUsable and C_Spell.IsSpellUsable(liveSid)
-                        if isUsable == true then
-                            if not fd._cdStateGlowOn then
-                                local style = cse2 == "pixelGlowReadyUsable" and 1 or 3
-                                local gr, gg, gb = ns.ResolveGlowColor(ss2)
-                                ns.StartNativeGlow(fd.glowOverlay, style, gr or 1, gg or 1, gb or 1)
-                                fd._cdStateGlowOn = true
-                            end
-                        elseif fd._cdStateGlowOn then
-                            ns.StopNativeGlow(fd.glowOverlay)
-                            fd._cdStateGlowOn = false
+                        -- Plain: cooldown state only.
+                        shouldGlow = true
+                    end
+                    if shouldGlow then
+                        if not fd._cdStateGlowOn then
+                            local style = (cse2 == "pixelGlowReady" or cse2 == "pixelGlowReadyUsable") and 1 or 3
+                            local gr, gg, gb = ns.ResolveGlowColor(ss2)
+                            ns.StartNativeGlow(fd.glowOverlay, style, gr or 1, gg or 1, gb or 1)
+                            fd._cdStateGlowOn = true
                         end
+                    elseif fd._cdStateGlowOn then
+                        ns.StopNativeGlow(fd.glowOverlay)
+                        fd._cdStateGlowOn = false
                     end
                 end
             end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -5436,9 +5436,18 @@ local function RefreshCDMIconAppearance(barKey)
                             ifd._cdStateGlowOn = true
                         end
                     end
-                    -- Event-driven re-evaluation for Resource Aware glows only
-                    -- (inert unless watched).
-                    if glowUsable and ns.CDGlowWatch then ns.CDGlowWatch(icon) end
+                    -- Event-driven re-evaluation: Resource Aware glows always,
+                    -- plus plain glows on EUI custom frames (their SetDesaturation
+                    -- never fires the SetDesaturated hook that would re-evaluate
+                    -- them). Fake-Active-owned frames (PresetHasCdState) excluded.
+                    local watchGlow = glowUsable
+                    if not watchGlow
+                        and (icon._isRacialFrame or icon._isTrinketFrame or icon._isPresetFrame
+                             or icon._isItemPresetFrame or icon._isCustomSpellFrame)
+                        and not (ns.PresetHasCdState and ns.PresetHasCdState(icon)) then
+                        watchGlow = true
+                    end
+                    if watchGlow and ns.CDGlowWatch then ns.CDGlowWatch(icon) end
                 end
             end
         elseif glowOv then
@@ -5520,8 +5529,21 @@ local function RefreshCDMIconAppearance(barKey)
                             end
                         end
                     end
-                    if (cse == "pixelGlowReadyUsable" or cse == "buttonGlowReadyUsable")
-                       and glowOv and ns.CDGlowWatch then
+                    -- Resource Aware glows always watch cooldown events. Plain
+                    -- glows normally re-evaluate through the SetDesaturated hook,
+                    -- but EUI's custom frames (racial / trinket / potion / custom)
+                    -- drive desaturation via SetDesaturation(float), which never
+                    -- fires that hook -- without a watch their glow stays lit for
+                    -- the whole cooldown. Frames owned by the Fake-Active preset
+                    -- path (PresetHasCdState) are excluded; that engine glows them.
+                    local watchGlow = cse == "pixelGlowReadyUsable" or cse == "buttonGlowReadyUsable"
+                    if not watchGlow and (cse == "pixelGlowReady" or cse == "buttonGlowReady")
+                        and (icon._isRacialFrame or icon._isTrinketFrame or icon._isPresetFrame
+                             or icon._isItemPresetFrame or icon._isCustomSpellFrame)
+                        and not (ns.PresetHasCdState and ns.PresetHasCdState(icon)) then
+                        watchGlow = true
+                    end
+                    if watchGlow and glowOv and ns.CDGlowWatch then
                         ns.CDGlowWatch(icon)
                     end
                 end


### PR DESCRIPTION
## Problem

Reported by @Dahkeus (v8.4.7). The per-spell **Pixel Glow (CD Ready)** / **Button Glow (CD Ready)** effect stays lit through the entire cooldown when applied to a **trinket, racial, or potion** preset, instead of turning off while the ability is on cooldown and returning when it becomes ready. It works correctly for normal spells.

## Root cause

Two independent causes, one per preset type:

### 1. Item presets (potions / healthstones)

`PresetOnCD` queried only the preset's primary itemID. For these consumables the item-cooldown API (`C_Container.GetItemCooldown` / `C_Item.GetItemCooldown`) returns a valid `start` but **no duration** on the primary id. The real cooldown ticks on whichever `altItemID` the player actually owns (a `C_Item` read on the owned alt does return the duration). `ProcessPresetCooldowns` already walks the alternates, which is why its swipe was correct while the glow was not.

On top of that, the spell-cooldown path (the `SetDesaturated` hook) also drove the **shared** glow overlay on these preset frames. It reads the cooldown via `C_Spell.GetSpellCooldown`, which cannot resolve a negative item key, so it always saw the item as ready and re-lit the glow every desat tick.

### 2. Racials / custom frames on a native Cooldown viewer bar

EUI's own custom frames drive desaturation via `SetDesaturation(float)`, which never fires the `SetDesaturated(boolean)` hook that the plain glow relied on to re-evaluate. So the glow started when the ability was ready and was never cleared on the cooldown transition. (`GetSpellCooldown` reads the racial's cooldown fine, `active=true`; the problem was purely the missing re-evaluation trigger.)

## Fix

- **Item presets:** `PresetOnCD` now walks the preset's `altItemIDs` (mirroring `ProcessPresetCooldowns`) so the on-cooldown read succeeds.
- **Ownership guard:** `PresetHasCdState(frame)` now hands preset frames off to the Fake-Active engine in both the `SetDesaturated` hook and the glow-watch loop, clearing both glow flags so the preset path re-asserts the correct state. (Clearing only the spell-path flag left the preset path thinking its glow was still on, leaving a ready preset dark.)
- **Custom-frame plain glow:** registered for the existing `SPELL_UPDATE_COOLDOWN` watch (whose loop now handles the plain variants too), so their glow re-evaluates on cooldown changes. Genuine Blizzard frames keep the zero-event `SetDesaturated` path, so normal spells are unchanged.

## Testing

Verified in-game across multiple characters:
- Light's Potential potion: glows when ready, clears for the full cooldown, returns when ready.
- Will to Survive racial (on the Cooldown viewer bar): correct in all three states.
- Normal spells: unchanged.

## Scope

Three files, all in the Cooldown Manager module:
- `EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua`
- `EllesmereUICooldownManager/EllesmereUICdmHooks.lua`
- `EllesmereUICooldownManager/EllesmereUICooldownManager.lua`
