### PR TITLE
fix(qol): stop auto-open double-using a locked container (stuck greyed items)

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -242,7 +242,13 @@ qolFrame:SetScript("OnEvent", function(self)
                                 if InCombatLockdown() or MerchantOpen() then wipe(_pendingOpens); return end
                                 local item = _pendingOpens[idx]
                                 local info = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                                if info and info.itemID then
+                                -- Never act on a slot mid-action (isLocked): re-using a
+                                -- container that's still resolving a previous open (a loot
+                                -- window or a slow server round-trip) leaves it stuck
+                                -- greyed/unopenable. For the same reason, a slot still
+                                -- locked at the post-open check is in-progress, not a real
+                                -- failure, so it isn't cached as failed -- a later pass retries.
+                                if info and info.itemID and not info.isLocked then
                                     if IsWarboundExcluded(item.bag, item.slot) then
                                         OpenNext(idx + 1)
                                         return
@@ -253,7 +259,7 @@ qolFrame:SetScript("OnEvent", function(self)
                                         C_Container.UseContainerItem(item.bag, item.slot)
                                         C_Timer.After(0.5, function()
                                             local after = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                                            if after and after.itemID == prevID and (after.stackCount or 1) >= prevCount then
+                                            if after and after.itemID == prevID and not after.isLocked and (after.stackCount or 1) >= prevCount then
                                                 _failedItems[prevID] = true
                                             end
                                             OpenNext(idx + 1)
@@ -346,7 +352,8 @@ qolFrame:SetScript("OnEvent", function(self)
                 if MerchantOpen() then return end
                 local item = toOpen[idx]
                 local info2 = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                if info2 and info2.itemID then
+                -- Skip locked (mid-action) slots -- see the scan pass above.
+                if info2 and info2.itemID and not info2.isLocked then
                     if IsWarboundExcluded(item.bag, item.slot) then
                         OpenNext(idx + 1)
                         return
@@ -357,7 +364,7 @@ qolFrame:SetScript("OnEvent", function(self)
                         C_Container.UseContainerItem(item.bag, item.slot)
                         C_Timer.After(0.5, function()
                             local after = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                            if after and after.itemID == prevID and (after.stackCount or 1) >= prevCount then
+                            if after and after.itemID == prevID and not after.isLocked and (after.stackCount or 1) >= prevCount then
                                 _failedItems[prevID] = true
                             end
                             OpenNext(idx + 1)


### PR DESCRIPTION
## Problem

Reported by @Hurricane (QoL, v8.4.7). With **Auto Open Containers** enabled, a container (reported for **Artisan's Consortium Payouts**) would sometimes fail to open and get stuck **greyed out and unopenable** in the bags. It stayed greyed even after turning the setting off, because the item itself was in a stuck client-side lock, not because auto-open kept retrying.

## Root cause

Opening a container fires `BAG_UPDATE_DELAYED`, which starts a fresh open pass that can overlap the previous one. Neither pass checked `isLocked`, so the second pass could call `C_Container.UseContainerItem` on the **same slot while the first open was still resolving** (a loot window, or a server round-trip longer than the 0.5s pass spacing). A double `UseContainerItem` on a still-locked container strands it in a client-side lock, greyed out and unopenable.

The ~0.5s open latency lining up with the 0.5s pass spacing is why it was intermittent.

Separately, the post-open "failed to open" check could fire while the container was still mid-open (locked), caching a slow container as permanently failed so it would no longer auto-open.

## Fix

Both open passes now:

1. **Skip slots reported as `isLocked`** before calling `UseContainerItem`. A locked slot is mid-action and is never safe to act on; it's retried on a later pass. This is the standard guard bag addons use.
2. **Don't cache a still-locked slot as "failed"** at the 0.5s recheck; a locked slot is in-progress, not a real failure.

The `isLocked` fields come from `C_Container.GetContainerItemInfo`; when absent (older API) the checks behave exactly as before, so there's no behavior change on clients without that field.

## Testing

This is a timing-dependent race, so it does not reproduce on demand and there's no clean live before/after. The change is a **pure defensive guard**: skipping a locked slot (rather than double-using it) is always-correct behavior and cannot regress the feature, a locked slot is simply retried a pass later instead of being stranded or wrongly blacklisted. It targets the only mechanism in this code that can leave a container stuck locked, matching the report.

## Scope

One file: `EllesmereUIQoL/EllesmereUIQoL.lua`.
