### PR TITLE
fix(raidframes): connect aura containers to Friendly Boss Frames

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -6494,6 +6494,11 @@ FB.EnsureBuilt = function()
             FB.Update(self)
             FB.ApplyRange(self)
             FB.UpdateRangeTicker()
+            if ns.RFC_OnUnitAssigned then
+                local d = GetFFD(self)
+                local unit = FB.UnitOf(self)
+                if d and unit then ns.RFC_OnUnitAssigned(self, d, unit) end
+            end
         end)
         b:HookScript("OnHide", function(self)
             FB.visCount = math.max(0, (FB.visCount or 0) - 1)
@@ -6517,6 +6522,11 @@ FB.EnsureBuilt = function()
             if name == "unit" and self:IsVisible() then
                 FB.Update(self)
                 FB.ApplyRange(self)
+                if ns.RFC_OnUnitAssigned then
+                    local d = GetFFD(self)
+                    local unit = FB.UnitOf(self)
+                    if d and unit then ns.RFC_OnUnitAssigned(self, d, unit) end
+                end
             end
         end)
 
@@ -6542,6 +6552,11 @@ FB.EnsureBuilt = function()
         FB.trackers[i] = t
 
         FB.buttons[i] = b
+
+        if ns.RFC_SetupButton then
+            local d = GetFFD(b)
+            ns.RFC_SetupButton(b, b._health, d)
+        end
     end
 
     -- Slot controller: collapses friendly bosses into the FIRST slots. Button


### PR DESCRIPTION
## Summary
- FB buttons skipped `RFC_SetupButton`, so they never got aura container shells — no debuffs, defensives, or buff manager indicators displayed
- `OnShow` and `OnAttributeChanged` hooks lacked `RFC_OnUnitAssigned` calls, so containers were never bound to the boss unit
- Adds `RFC_SetupButton` at FB button creation and `RFC_OnUnitAssigned` in both hooks

## Test plan
- [ ] Enter a raid encounter with friendly boss units (e.g. Council fights, Aberrus NPCs)
- [ ] Verify buff manager indicators appear on Friendly Boss Frames
- [ ] Verify debuff and defensive overlays display correctly on FB frames
- [ ] Confirm no taint or errors on boss spawn/despawn mid-combat