### PR TITLE
fix(blizzskin): re-layout tooltip after font changes on first show

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -160,7 +160,17 @@ end
         end
     end
 
-    local function _ttOnShow(self) _ttSkin(self); _ttFonts(self) end
+    local _ttRelaying = {}
+    local function _ttOnShow(self)
+        _ttSkin(self)
+        _ttFonts(self)
+        -- Re-show so the frame recalculates size with the new fonts.
+        if not _ttRelaying[self] then
+            _ttRelaying[self] = true
+            self:Show()
+            _ttRelaying[self] = nil
+        end
+    end
 
     local function _ttHook(tt)
         if not tt or tt:IsForbidden() or _ttSkinned[tt] then return end


### PR DESCRIPTION
## Summary
- Tooltip `OnShow` hook changes font face/size after the frame has already sized itself, causing mis-sized text on first show after `/reload`
- Subsequent shows worked because font strings retained the custom font from last time
- Adds a guarded `self:Show()` after font application to force the tooltip to recalculate its layout

## Test plan
- [ ] `/reload` and hover the game menu microbar button — tooltip text should be properly laid out on first hover
- [ ] Verify other tooltips (spells, items, units) also display correctly on first show
- [ ] Test with tooltip font scale at 1.0 and 1.25
- [ ] Confirm no flicker or infinite loop on rapid tooltip cycling