### PR TITLE
fix(cdm): lower tracked buff bar strata from HIGH to MEDIUM

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -1797,12 +1797,10 @@ ns.RefreshBuffBarGating  = function() end
 -------------------------------------------------------------------------------
 local function CreateTrackedBuffBarFrame(parent, idx)
     local wrapFrame = CreateFrame("Frame", "ECME_TBBWrap" .. idx, parent)
-    -- HIGH strata so the whole bar (fill, border, glow, text) renders above
-    -- the buff-icon displays (MEDIUM) -- including their borders and cooldown
-    -- swipes -- when the two elements overlap. Internal ordering stays
-    -- level-based within the wrap (strips +6 < pandemic glow +7 < text +8).
-    wrapFrame:SetFrameStrata("HIGH")
-    wrapFrame:SetFrameLevel(10)
+    -- Level above the buff-icon displays (MEDIUM 5..27) so the bar renders
+    -- on top when they overlap, without elevating strata past MEDIUM.
+    wrapFrame:SetFrameStrata("MEDIUM")
+    wrapFrame:SetFrameLevel(100)
 
     local bar = CreateFrame("StatusBar", "ECME_TBB" .. idx, wrapFrame)
     if bar.EnableMouseClicks then bar:EnableMouseClicks(false) end


### PR DESCRIPTION
## Summary
- v8.4.3 elevated tracked buff bar wrapper from `MEDIUM` to `HIGH` strata to render above buff-icon borders/swipes
- `HIGH` strata renders above the dragonriding HUD and resource/power text
- Changed to `MEDIUM` strata with frame level 100, which clears the icon display stack (levels 5–27) without overlapping unrelated UI

## Test plan
- [ ] Verify tracked buff bars still render above buff-icon borders when overlapping
- [ ] Dragonriding with a tracked bar active — bar should not cover the HUD
- [ ] Confirm bar does not clip over resource/power text