### PR TITLE
fix(resourcebars): validate Sweeping Strikes charges against actual aura

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4240,6 +4240,7 @@ do
     -- never register the watcher: the flags stay false and both entry
     -- points early-out on a plain upvalue read.
     local sweepKnown, improvedKnown, broadKnown, fervorKnown = false, false, false, false
+    local sweepName -- cached spell name for aura lookups (resolved outside M+)
     do
         local _, cls = UnitClass("player")
         if cls == "WARRIOR" then
@@ -4249,6 +4250,10 @@ do
                 improvedKnown = (sb and sb.IsSpellKnown(IMPROVED)) or false
                 broadKnown    = (sb and sb.IsSpellKnown(BROAD)) or false
                 fervorKnown   = (sb and sb.IsSpellKnown(FERVOR)) or false
+                if not sweepName then
+                    local n = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(SWEEP)
+                    if n and not (issecretvalue and issecretvalue(n)) then sweepName = n end
+                end
             end
             local watcher = CreateFrame("Frame")
             watcher:RegisterEvent("PLAYER_LOGIN")
@@ -4384,6 +4389,15 @@ do
         if not sweepKnown then return 0, 0 end
         if expiresAt and GetTime() >= expiresAt then
             stacks, expiresAt = 0, nil
+        end
+        -- Validate prediction against the actual aura to correct drift.
+        if stacks > 0 and sweepName and AuraUtil and AuraUtil.FindAuraByName then
+            local name, _, count = AuraUtil.FindAuraByName(sweepName, "player", "HELPFUL")
+            if not name then
+                stacks, expiresAt = 0, nil
+            elseif count and not (issecretvalue and issecretvalue(count)) then
+                stacks = count
+            end
         end
         return stacks, MaxStacks()
     end


### PR DESCRIPTION
## Summary
- Sweeping Strikes charge tracker is purely prediction-based, drifting because `EnemiesInReach` checks player-to-enemy distance (~11 yd interact) while the game sweeps within 8 yd of the **primary target**
- Adds aura validation in `GetSweepingStrikes`: resets to 0 when the buff is gone, syncs to real charge count when readable (outside M+)
- Caches spell name at talent refresh (outside M+ where names aren't secret)

## Test plan
- [ ] Arms Warrior with Sweeping Strikes — verify pips match actual charges during cleave
- [ ] Test with Broad Strokes (Colossus Smash activating SS) — no extra phantom pips
- [ ] Test in M+ (Sporefall / similar) — bar resets to 0 when buff expires or is fully consumed
- [ ] Test with Improved Sweeping Strikes (18 charges) — correct max displayed