### PR TITLE
fix(options): clamp config panel to screen

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -6321,8 +6321,7 @@ local function CreateMainFrame()
     clickArea:EnableMouse(true)
     clickArea:SetMovable(true)
     clickArea:RegisterForDrag("LeftButton")
-    -- No SetClampedToScreen -- the whole window (bg + content) moves as one
-    -- and can be dragged freely off any edge.
+    mainFrame:SetClampedToScreen(true)
     clickArea:SetScript("OnDragStart", function() mainFrame:StartMoving() end)
     clickArea:SetScript("OnDragStop",  function() mainFrame:StopMovingOrSizing() end)
 


### PR DESCRIPTION
## Summary
- Config panel could be dragged off-screen with no recovery other than relogging
- Adds `SetClampedToScreen(true)` on the main frame

## Test plan
- [ ] Drag the config panel toward all screen edges — should stop at the boundary
- [ ] Multi-monitor setup — panel stays within the game window