### PR TITLE
feat(databars): opt-in character stats tooltip on the micro menu

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -166,7 +166,7 @@ ns.BLOCK_DEFAULTS = {
     profession = {},
     profession2 = {},
     travel     = { randomizeHs = true },
-    micromenu  = { disableBlizzardMicroMenu = false, hideSocialText = false, mainMenuSpacing = 4, iconSpacing = 2,
+    micromenu  = { disableBlizzardMicroMenu = false, hideSocialText = false, charStatsTooltip = false, mainMenuSpacing = 4, iconSpacing = 2,
                    menu = true, guild = true, social = true, char = true, spell = true, ach = true, quest = true, lfg = true,
                    pvp = true, housing = true, journal = true, pet = true, shop = true, help = true },
     currency   = { currencyId = nil, showIcon = true },

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -3062,6 +3062,59 @@ function ns.RefreshMicroMenuHider()
     end)
 end
 
+-- Character stats tooltip (opt-in via the micromenu block's charStatsTooltip
+-- setting). Fixed set: equipped item level, primary stat, and the four
+-- secondary percentages with their raw combat rating in parentheses. The
+-- versatility read is wrapped in pcall -- GetVersatilityBonus /
+-- GetCombatRatingBonus can hand back a Midnight "secret value" under
+-- addon-tainted execution, and any arithmetic on it errors, so the line is
+-- dropped rather than crashing the whole tooltip.
+local CS_DIM = "|cffaaaaaa"
+
+local function MMPrimaryStat()
+    local specIndex = GetSpecialization and GetSpecialization()
+    if not specIndex or specIndex <= 0 then return nil end
+    local _, _, _, _, _, statID = GetSpecializationInfo(specIndex)
+    if statID == LE_UNIT_STAT_STRENGTH  then return SPELL_STAT1_NAME or "Strength",  1 end
+    if statID == LE_UNIT_STAT_AGILITY   then return SPELL_STAT2_NAME or "Agility",   2 end
+    if statID == LE_UNIT_STAT_INTELLECT then return SPELL_STAT4_NAME or "Intellect", 4 end
+    return nil
+end
+
+local function MMAddCharStats()
+    local ar, ag, ab = ns.GetAccent()
+    local function pctRating(label, pct, rating)
+        ns.Tip_AddDouble(label,
+            format("%.2f%%", pct or 0) .. " " .. CS_DIM .. "(" .. floor((rating or 0) + 0.5) .. ")|r",
+            ar, ag, ab, 1, 1, 1)
+    end
+
+    ns.Tip_AddLine(" ")
+
+    local _, eq = GetAverageItemLevel()
+    ns.Tip_AddDouble(STAT_AVERAGE_ITEM_LEVEL or "Item Level", format("%.1f", eq or 0), ar, ag, ab, 1, 1, 1)
+
+    local pLabel, pIdx = MMPrimaryStat()
+    if pLabel and pIdx then
+        local _, eff = UnitStat("player", pIdx)
+        ns.Tip_AddDouble(pLabel, format("%.0f", eff or 0), ar, ag, ab, 1, 1, 1)
+    end
+
+    pctRating(STAT_CRITICAL_STRIKE or "Critical Strike", GetCritChance(),    GetCombatRating(CR_CRIT_MELEE))
+    pctRating(STAT_HASTE or "Haste",                     GetHaste(),         GetCombatRating(CR_HASTE_MELEE))
+    pctRating(STAT_MASTERY or "Mastery",                 GetMasteryEffect(), GetCombatRating(CR_MASTERY))
+
+    -- Versatility: secret-value-safe (see block comment above).
+    local ok, dmg, rating = pcall(function()
+        local d = (GetCombatRatingBonus(CR_VERSATILITY_DAMAGE_DONE) or 0)
+                + (GetVersatilityBonus(CR_VERSATILITY_DAMAGE_DONE)  or 0)
+        return d, GetCombatRating(CR_VERSATILITY_DAMAGE_DONE) or 0
+    end)
+    if ok then
+        pctRating(STAT_VERSATILITY or "Versatility", dmg, rating)
+    end
+end
+
 ns.BlockFactories.micromenu = function(blockCfg, slot, content, barCtx)
     local inst = { cfg = blockCfg, slot = slot, content = content, ctx = barCtx }
     inst.key = InstKey(barCtx, blockCfg)
@@ -3150,6 +3203,10 @@ ns.BlockFactories.micromenu = function(blockCfg, slot, content, barCtx)
             end
             ns.Tip_AddDouble('|cFFFFFFFF' .. L["COMPANION_LEVEL"] .. '|r',
                 '|cFF' .. hexAccent .. companionLvl .. '|r', 1, 1, 1, r, g, b)
+        end
+
+        if name == 'char' and D().charStatsTooltip then
+            MMAddCharStats()
         end
 
         ns.Tip_Show()

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -2314,6 +2314,7 @@ initFrame:SetScript("OnEvent", function(self)
                           return v
                       end,
                       setValue = function(v) s.iconSpacing = v; Apply() end },
+                    MkToggle("Character Stats Tooltip", "charStatsTooltip", "Shows item level and secondary stats in the Character button's tooltip."),
                     -- Individual button toggles live in the "Menu Elements"
                     -- checklist dropdown appended after the shared row loop.
                 }


### PR DESCRIPTION
Hovering the micro menu's Character button can now show a stats readout in its tooltip: item level, primary stat, and the Crit / Haste / Mastery / Versatility percentages with their raw combat rating. Off by default -- a new "Character Stats Tooltip" toggle in the micro menu block options turns it on.

- charStatsTooltip default (false) in BLOCK_DEFAULTS.micromenu
- MMAddCharStats / MMPrimaryStat helpers + a `char` branch in ShowButtonTooltip; stat labels use Blizzard globals (auto-localized)
- Versatility read wrapped in pcall: GetVersatilityBonus / GetCombatRatingBonus can return a Midnight "secret value" under tainted execution, so the line is dropped rather than crashing the tooltip

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
