### PR TITLE
Add combat indicator corner positions

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -3585,15 +3585,19 @@ initFrame:SetScript("OnEvent", function(self)
                     local ciSz = s.combatIndicatorSize or 22
                     local ciOx = s.combatIndicatorX or 0
                     local ciOy = s.combatIndicatorY or 0
-                    local ciPos = s.combatIndicatorPosition or "healthbar"
+                    local ciPos = s.combatIndicatorPosition or "topleft"
                     combatInd:SetSize(ciSz, ciSz)
                     combatInd:ClearAllPoints()
-                    local ciAnchor = pf
-                    if ciPos == "healthbar" then ciAnchor = health
-                    elseif ciPos == "textbar" and btbFrame then ciAnchor = btbFrame
-                    elseif ciPos == "portrait" and portraitFrame and sp then ciAnchor = portraitFrame
+                    if ciPos == "portrait" and portraitFrame and sp then
+                        combatInd:SetPoint("CENTER", portraitFrame, "CENTER", ciOx, ciOy)
+                    else
+                        local anchor =
+                            (ciPos == "topright"    and "TOPRIGHT")    or
+                            (ciPos == "bottomleft"  and "BOTTOMLEFT")  or
+                            (ciPos == "bottomright" and "BOTTOMRIGHT") or
+                            "TOPLEFT"
+                        combatInd:SetPoint(anchor, health, anchor, ciOx, ciOy)
                     end
-                    combatInd:SetPoint("CENTER", ciAnchor, "CENTER", ciOx, ciOy)
                     local _, classToken = UnitClass("player")
                     -- All custom combat icons (combat0..5) are shown as-is (no tint).
                     -- Standard/Class Theme are tinted by the colour mode below.
@@ -10998,8 +11002,8 @@ initFrame:SetScript("OnEvent", function(self)
             end)
 
             -- Cog popup for combat indicator settings
-            local combatPosValues = { ["portrait"]="Portrait", ["healthbar"]="Health Bar", ["textbar"]="Text Bar" }
-            local combatPosOrder = { "portrait", "healthbar", "textbar" }
+            local combatPosValues = { ["topleft"]="Top Left", ["topright"]="Top Right", ["bottomleft"]="Bottom Left", ["bottomright"]="Bottom Right", ["portrait"]="Portrait" }
+            local combatPosOrder = { "topleft", "topright", "bottomleft", "bottomright", "portrait" }
 
             local _, combatCogShowRaw = EllesmereUI.BuildCogPopup({
                 title = "Combat Indicator Settings",
@@ -11016,15 +11020,18 @@ initFrame:SetScript("OnEvent", function(self)
                       get=function() return SValSupported("combatIndicatorColor", "custom") == "classcolor" end,
                       set=function(v) SSetSupported("combatIndicatorColor", v and "classcolor" or "custom"); ReloadAndUpdate(); UpdatePreview() end },
                     { type="dropdown", label="Position", values=combatPosValues, order=combatPosOrder,
-                      get=function() return SValSupported("combatIndicatorPosition", "healthbar") end,
+                      get=function()
+                          local pos = SValSupported("combatIndicatorPosition", "topleft")
+                          return combatPosValues[pos] and pos or "topleft"
+                      end,
                       set=function(v) SSetSupported("combatIndicatorPosition", v); ReloadAndUpdate(); UpdatePreview() end },
                     { type="slider", label="Size", min=8, max=64, step=1,
                       get=function() return SValSupported("combatIndicatorSize", 22) end,
                       set=function(v) SSetSupported("combatIndicatorSize", v); ReloadAndUpdate(); UpdatePreview() end },
-                    { type="slider", label="X Offset", min=-100, max=100, step=1,
+                    { type="slider", label="X Offset", min=-200, max=200, step=1,
                       get=function() return SValSupported("combatIndicatorX", 0) end,
                       set=function(v) SSetSupported("combatIndicatorX", v); ReloadAndUpdate(); UpdatePreview() end },
-                    { type="slider", label="Y Offset", min=-100, max=100, step=1,
+                    { type="slider", label="Y Offset", min=-200, max=200, step=1,
                       get=function() return SValSupported("combatIndicatorY", 0) end,
                       set=function(v) SSetSupported("combatIndicatorY", v); ReloadAndUpdate(); UpdatePreview() end },
                 },

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -3593,6 +3593,7 @@ initFrame:SetScript("OnEvent", function(self)
                     else
                         local anchor =
                             (ciPos == "topright"    and "TOPRIGHT")    or
+                            (ciPos == "center"      and "CENTER")      or
                             (ciPos == "bottomleft"  and "BOTTOMLEFT")  or
                             (ciPos == "bottomright" and "BOTTOMRIGHT") or
                             "TOPLEFT"
@@ -11002,8 +11003,8 @@ initFrame:SetScript("OnEvent", function(self)
             end)
 
             -- Cog popup for combat indicator settings
-            local combatPosValues = { ["topleft"]="Top Left", ["topright"]="Top Right", ["bottomleft"]="Bottom Left", ["bottomright"]="Bottom Right", ["portrait"]="Portrait" }
-            local combatPosOrder = { "topleft", "topright", "bottomleft", "bottomright", "portrait" }
+            local combatPosValues = { ["topleft"]="Top Left", ["topright"]="Top Right", ["center"]="Center", ["bottomleft"]="Bottom Left", ["bottomright"]="Bottom Right", ["portrait"]="Portrait" }
+            local combatPosOrder = { "topleft", "topright", "center", "bottomleft", "bottomright", "portrait" }
 
             local _, combatCogShowRaw = EllesmereUI.BuildCogPopup({
                 title = "Combat Indicator Settings",

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -291,7 +291,7 @@ local defaults = {
             combatIndicatorStyle = "class",
             combatIndicatorColor = "custom",
             combatIndicatorCustomColor = { r = 1, g = 1, b = 1 },
-            combatIndicatorPosition = "healthbar",
+            combatIndicatorPosition = "topleft",
             combatIndicatorSize = 22,
             combatIndicatorX = 0,
             combatIndicatorY = 0,
@@ -328,7 +328,7 @@ local defaults = {
             combatIndicatorStyle = "none",
             combatIndicatorColor = "custom",
             combatIndicatorCustomColor = { r = 1, g = 1, b = 1 },
-            combatIndicatorPosition = "healthbar",
+            combatIndicatorPosition = "topleft",
             combatIndicatorSize = 22,
             combatIndicatorX = 0,
             combatIndicatorY = 0,
@@ -11349,21 +11349,21 @@ function InitializeFrames()
             local sz = ps.combatIndicatorSize or 22
             local ox = ps.combatIndicatorX or 0
             local oy = ps.combatIndicatorY or 0
-            local pos = ps.combatIndicatorPosition or "healthbar"
+            local pos = ps.combatIndicatorPosition or "topleft"
 
             combat:SetSize(sz, sz)
             combat:ClearAllPoints()
 
-            -- Determine anchor element
-            local anchor = pf
-            if pos == "healthbar" and pf.Health then
-                anchor = pf.Health
-            elseif pos == "textbar" and pf._btb then
-                anchor = pf._btb
-            elseif pos == "portrait" and pf.Portrait then
-                anchor = pf.Portrait
+            if pos == "portrait" and pf.Portrait then
+                combat:SetPoint("CENTER", pf.Portrait, "CENTER", ox, oy)
+            else
+                local anchor =
+                    (pos == "topright"    and "TOPRIGHT")    or
+                    (pos == "bottomleft"  and "BOTTOMLEFT")  or
+                    (pos == "bottomright" and "BOTTOMRIGHT") or
+                    "TOPLEFT"
+                combat:SetPoint(anchor, pf.Health or pf, anchor, ox, oy)
             end
-            combat:SetPoint("CENTER", anchor, "CENTER", ox, oy)
 
             -- Determine texture file (always use -custom / white base).
             -- Class theming resolves the FRAME's unit (player class on the

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -11359,6 +11359,7 @@ function InitializeFrames()
             else
                 local anchor =
                     (pos == "topright"    and "TOPRIGHT")    or
+                    (pos == "center"      and "CENTER")      or
                     (pos == "bottomleft"  and "BOTTOMLEFT")  or
                     (pos == "bottomright" and "BOTTOMRIGHT") or
                     "TOPLEFT"


### PR DESCRIPTION
Updates main unit-frame combat indicators to use the same corner-based position choices as leader icons. Keeps Portrait support and expands X/Y offset range to ±200.

<img width="431" height="282" alt="image" src="https://github.com/user-attachments/assets/4adf8c43-6e86-4af5-929e-62e4534e4ff0" />

Note: Previous Setting was just centered to either Healthbar / Text Bar (?) / Portrait depending what the user chose. I'm unsure how to migrate this to the new settings.