### PR TITLE
Fix macro keybind resolution

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6696,15 +6696,56 @@ local function RebuildKeybindCache()
                     end
                     slot = i + (pg - 1) * 12
                 end
-                local slotType, id = GetActionInfo(slot)
+                local slotType, id, subType = GetActionInfo(slot)
                 local spellID
                 local fromMacro = false
                 if slotType == "spell" then
                     spellID = id
-                elseif slotType == "macro" and id then
-                    local macroSpell = GetMacroSpell(id)
-                    spellID = macroSpell or (id > 0 and id) or nil
+                elseif slotType == "macro" then
                     fromMacro = true
+                    if subType == "spell" then
+                        -- "Smart" single-spell macro: Blizzard already
+                        -- resolved it, and `id` here IS the spellID, not a
+                        -- macro index -- passing it to GetMacroSpell would
+                        -- look up the wrong thing.
+                        spellID = id
+                    else
+                        -- Everything else (single-item, mount/companion,
+                        -- multi-line/conditional...): `id` from GetActionInfo
+                        -- is NOT a reliable identifier here. Resolve the real
+                        -- macro index via its name instead (same workaround
+                        -- EllesmereUICdmHooks.lua's SlotSpellID already uses).
+                        local macroName = GetActionText(slot)
+                        local macroIndex = macroName and GetMacroIndexByName(macroName)
+                        if macroIndex and macroIndex > 0 then
+                            spellID = GetMacroSpell(macroIndex)
+                            if not spellID then
+                                -- Not a spell-shaped macro: pull the first
+                                -- /use target out of the macro body and
+                                -- resolve it as an item instead.
+                                local body = GetMacroBody and GetMacroBody(macroIndex)
+                                local target = body and body:match("/use!?%s+([^\r\n]+)")
+                                if target then
+                                    target = target:gsub("^%[.-%]%s*", ""):match("^%s*(.-)%s*$")
+                                    -- "item:NNNN" is macro-only shorthand for
+                                    -- targeting an itemID directly. It is NOT
+                                    -- a valid GetItemInfoInstant input (that
+                                    -- wants a bare itemID, item name, or a
+                                    -- full item link) -- pull the numeric ID
+                                    -- out ourselves instead of handing the
+                                    -- literal "item:NNNN" string to it.
+                                    local itemID = target:match("^item:(%d+)")
+                                    itemID = itemID and tonumber(itemID)
+                                    if not itemID and not tonumber(target) then
+                                        itemID = C_Item and C_Item.GetItemInfoInstant and C_Item.GetItemInfoInstant(target)
+                                    end
+                                    if itemID then
+                                        _SetKeybind(-itemID, FormatKeybindKey(key), true)
+                                    end
+                                end
+                            end
+                        end
+                    end
                 elseif slotType == "item" and id then
                     -- Store under negated itemID (-id) to match the FC
                     -- convention for item presets/trinkets.


### PR DESCRIPTION
## What does this PR do?

Fixes CDM icons showing no keybind, or the wrong item's keybind, for spells/items bound via a macro on an action bar key.

`GetActionInfo`'s second return value is not a reliable macro index except for Blizzard's auto-resolved "smart" single-spell macros. For every other macro shape (item, mount, multi-line/conditional), it was previously being trusted anyway and could collide with an unrelated macro's index, showing the wrong keybind entirely. This now resolves the macro's real index via its name (`GetActionText` → `GetMacroIndexByName`) before reading the spell/item off it, matching a workaround already used elsewhere in the addon (`EllesmereUICdmHooks.lua`'s `SlotSpellID`). Also fixes `/use item:NNNN` macro shorthand being silently dropped, since that syntax isn't a valid `GetItemInfoInstant` input.

## How was it tested?

Tested in-game on live retail against a real macro (multi-line, `/use item:NNNN` + name-based fallback lines) bound to an action bar key. Before: CDM icon showed no keybind / the wrong key. After: correct keybind shown.

## Screenshots

N/A — keybind text only, no visual/layout change.

## Checklist

- [x] New settings default **OFF** — N/A, no new setting added, this is a bugfix to existing always-on behavior
- [x] Zero cost while disabled — N/A, no opt-in toggle
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) — runs inside the existing debounced `RebuildKeybindCache` pass, no new events/timers added
- [x] No writes onto Blizzard-owned frames — change is read-only Blizzard API calls only (`GetActionInfo`, `GetActionText`, `GetMacroIndexByName`, `GetMacroSpell`, `GetMacroBody`), touches no frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client — confirmed on live retail; **not tested on the 12.1 PTR client**