### PR TITLE
fix(cdm): normalize textured border thickness against Blizzard's per-icon scale

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2996,6 +2996,9 @@ do
         return DEFAULT_LSM_OFFSET
     end
 
+    -- Textured border edgeSize per size step (1-4).
+    local EDGE_MAP = { 12, 16, 24, 32 }
+
     --- Check if a border texture uses scaled offset (edgeSize/2 base).
     function EllesmereUI.BorderTextureUsesScaleOffset(key)
         if not key or key == "" or key == "solid" then return false end
@@ -3043,7 +3046,17 @@ do
     --- offsetOverride/offsetYOverride: optional user override (nil = use per-addon or global default).
     --- shiftX/shiftY: optional user override (nil = use per-addon default or 0).
     --- addonKey/sizeKey: optional per-addon registry lookup key pair for defaults.
-    function EllesmereUI.ApplyBorderStyle(borderFrame, size, r, g, b, a, textureKey, offsetOverride, offsetYOverride, shiftX, shiftY, addonKey, sizeKey)
+    --- normalizeScale: opt-in, textured borders only. Cancels the frame's scale
+    ---   chain below UIParent so the border matches an unscaled frame's. Pass it
+    ---   ONLY where that scale is an implementation detail the caller already
+    ---   cancels elsewhere -- CDM cancels Blizzard's per-icon scale for the
+    ---   icon's size (iS = 1/iconScale) but not for its border, which is the bug
+    ---   this exists for. Never pass it where the scale is the user's intent
+    ---   (nameplate target/cast scale, buff-bar position scale): those borders
+    ---   are meant to scale with the frame, and because ratio is sampled once at
+    ---   style time, a frame whose scale changes afterwards would bake in a
+    ---   transient value.
+    function EllesmereUI.ApplyBorderStyle(borderFrame, size, r, g, b, a, textureKey, offsetOverride, offsetYOverride, shiftX, shiftY, addonKey, sizeKey, normalizeScale)
         local PP = EllesmereUI.PP
         if not PP or not borderFrame then return end
         a = a or 1
@@ -3104,8 +3117,20 @@ do
                 _bdBorderData[borderFrame] = bdFrame
             end
             bdFrame:SetFrameLevel(borderFrame:GetFrameLevel())
-            local EDGE_MAP = { 12, 16, 24, 32 }
-            local edgeSize = EDGE_MAP[size] or 12
+            -- edgeSize is in local units, so SetBackdrop renders it at
+            -- edgeSize x effectiveScale: a scaled frame draws a proportionally
+            -- scaled border. That is correct by default, hence opt-in only.
+            -- uiES/es is exactly 1 / (scale chain below UIParent), so ratio is
+            -- 1 (and everything below a no-op) for an unscaled frame at any
+            -- resolution or UI scale. The 0.01 floor mirrors CDM's own
+            -- iconScale guard and keeps a degenerate scale from exploding it.
+            local ratio = 1
+            if normalizeScale then
+                local eok, es = pcall(bdFrame.GetEffectiveScale, bdFrame)
+                local uiES = UIParent and UIParent:GetEffectiveScale() or 1
+                if eok and es and es > 0.01 and uiES > 0 then ratio = uiES / es end
+            end
+            local edgeSize = (EDGE_MAP[size] or EDGE_MAP[1]) * ratio
             -- Resolve offset/shift defaults: per-addon registry first, then global fallback.
             local adjX, adjY, sx, sy
             if addonKey and sizeKey then
@@ -3120,6 +3145,10 @@ do
                 sx   = shiftX or 0
                 sy   = shiftY or 0
             end
+            -- Same factor as edgeSize, or a normalized edge would be positioned
+            -- by offsets still in the frame's scaled units.
+            adjX, adjY = adjX * ratio, adjY * ratio
+            sx, sy = sx * ratio, sy * ratio
             -- Custom textures (scaleOffset): base = edgeSize/2 so border tracks
             -- the edge at any size, plus a small fine-tune adjustment.
             -- Other textures: absolute offset (no edgeSize base).

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -1586,7 +1586,7 @@ local function DecorateFrame(frame, barData)
             brdR, brdG, brdB, barData.borderA or 1,
             textureKey, barData.borderTextureOffset, barData.borderTextureOffsetY,
             barData.borderTextureShiftX, barData.borderTextureShiftY,
-            "cdm", barData.borderThickness or "thin")
+            "cdm", barData.borderThickness or "thin", true)
         -- ApplyBorderStyle above always paints the bar's BASE color. If this
         -- spell's active-state tint is currently engaged (ns.ApplyActiveOverlays
         -- drives fd._activeBorderOn independently of DecorateFrame, via Blizzard's

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -4601,7 +4601,7 @@ ApplyShapeToCDMIcon = function(icon, shape, barData, ssb)
             if fd and fd.borderFrame then
                 fd.borderFrame:SetFrameLevel(barData.borderBehind and math.max(0, icon:GetFrameLevel() - 1) or (icon:GetFrameLevel() + 13))
             end
-            EllesmereUI.ApplyBorderStyle(bdrTarget, borderSz, brdR, brdG, brdB, brdA, texKey, barData.borderTextureOffset, barData.borderTextureOffsetY, barData.borderTextureShiftX, barData.borderTextureShiftY, "cdm", barData.borderThickness or "thin")
+            EllesmereUI.ApplyBorderStyle(bdrTarget, borderSz, brdR, brdG, brdB, brdA, texKey, barData.borderTextureOffset, barData.borderTextureOffsetY, barData.borderTextureShiftX, barData.borderTextureShiftY, "cdm", barData.borderThickness or "thin", true)
         end
 
         -- Restore icon texture -- fill the entire frame. The border renders
@@ -5281,7 +5281,7 @@ local function RefreshCDMIconAppearance(barKey)
         local bdrTgt = (fd and fd.borderFrame) or icon
         if fd and fd.borderFrame or EllesmereUI.PP.GetBorders(icon) then
             local textureKey = barData.borderTexture or "solid"
-            EllesmereUI.ApplyBorderStyle(bdrTgt, borderSize, barData.borderR or 0, barData.borderG or 0, barData.borderB or 0, barData.borderA or 1, textureKey, barData.borderTextureOffset, barData.borderTextureOffsetY, barData.borderTextureShiftX, barData.borderTextureShiftY, "cdm", barData.borderThickness or "thin")
+            EllesmereUI.ApplyBorderStyle(bdrTgt, borderSize, barData.borderR or 0, barData.borderG or 0, barData.borderB or 0, barData.borderA or 1, textureKey, barData.borderTextureOffset, barData.borderTextureOffsetY, barData.borderTextureShiftX, barData.borderTextureShiftY, "cdm", barData.borderThickness or "thin", true)
         end
         -- Update background
         if bg then


### PR DESCRIPTION
## Problem

Two reports, one cause.

**@Donny** (CDM, 8.4.1): "The borders on CDM Utility do not apply the same. On some spells the border is correct, on other spells the border is just totally different."

**@zac** (CDM, 8.4.7): "Border sizes for textures borders, are different between icons from the cdm/frames/custom icons etc... the borders on the cdm are also bigger than they used to be in the past."

## Cause

Blizzard assigns every CDM icon its own scale. CDM already cancels that for the icon's **size** so icons look uniform:

```lua
-- Compensate for Blizzard's per-icon scale so visual size matches.
local iconScale = icon:GetScale() or 1
local iS = 1 / iconScale
icon:SetSize(thisIconW * iS, thisIconH * iS)
```

The border never got that treatment. `edgeSize` is in the frame's local units, so `SetBackdrop` renders it at `edgeSize x effectiveScale`. Two spells in one Utility bar therefore drew identical icon sizes with different border thickness, which is exactly @Donny's report. @zac's cross-module version is the same defect at module granularity, and "bigger than they used to be" is CDM's effective scale rising rather than any border code changing. `EDGE_MAP` itself is not a regression (v7.7.5, 69be53ab).

Measured, a CDM icon at Blizzard scale 0.75 against its unscaled neighbours:

| | before | after | neighbours |
|---|---|---|---|
| 1440p auto | 9.00px | **12.00px** | 12.00px |
| 1080p + 0.5333 toggle | 6.75px | **9.00px** | 9.00px |

## Fix

`ApplyBorderStyle` gains an opt-in `normalizeScale` flag that cancels the frame's scale chain below UIParent (`uiES/es`). It's passed at the three CDM icon call sites only. **Every other caller is a no-op by construction**, not by argument.

Two deliberate choices, both of which I got wrong first and corrected after review:

**Opt-in, not engine-wide.** The engine can't distinguish an implementation detail from user intent. CDM's per-icon scale is Blizzard's and is already cancelled for size, so cancelling it for the border is right. A nameplate's target/cast scale and a buff bar's position scale are the *user's*, and those borders are meant to scale with the frame. There's also a timing trap: `ratio` is sampled once at style time, so it only holds where scale is stable afterwards. Nameplates fail that on both counts, since scale is animated by an easing `OnUpdate` driver (`EllesmereUINameplates.lua:7793`) and the border is lazily created from the **target** path (`:6748`). An engine-wide version baked a transient `1/1.3` into `edgeSize` and left that pooled plate permanently thin once it returned to rest, i.e. it reintroduced this very bug somewhere new.

**UIParent-relative, not absolute physical pixels.** Normalizing to physical pixels would match the solid path's convention, but it rebaselines every user whose UI scale isn't pixel-perfect: 4K, where `PixelBestSize()` clamps to the 0.4 floor (-11%), and anyone using the shipped "Set UI Scale to 0.5333" toggle (up to +34% at 1080p). Nobody reported textured-vs-solid disagreement; both reports are textured icons disagreeing with each other on one screen. With `uiES/es`, an unscaled frame gets `ratio = 1` and renders byte-identically at every resolution and UI scale, so there's no baseline shift and nothing to migrate. Textured staying UIParent-relative while solid is absolute-physical is the pre-existing status quo.

`es` is floored at 0.01, mirroring CDM's own `iconScale` guard, so a degenerate scale can't explode the ratio into a five-figure `edgeSize`.

## Testing

Confirmed in game by both reporters: CDM Utility borders now uniform across spells, and nothing else moved.

