### PR TITLE
Character sheet: adjust quality, enchant. missing and gem borders frame level setting

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -4200,7 +4200,7 @@ local function SkinCharacterSheet()
             -- 2px pixel-perfect border, recolored per-gem in UpdateSocketIcons.
             PP_GEM.CreateBorder(gemFrame, 1, 1, 1, 1, 2, "OVERLAY", 1)
             local gemBdr = PP_GEM.GetBorders(gemFrame)
-            if gemBdr then gemBdr:SetFrameLevel(gemFrame:GetFrameLevel() + 1) end
+            if gemBdr then gemBdr:SetFrameLevel(gemFrame:GetFrameLevel()) end
 
             GetFFD(slot).charSocketsFrames[i] = gemFrame
             GetFFD(slot).charSocketsIcons[i]  = icon

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -2796,7 +2796,7 @@ local function SkinCharacterSheet()
 
         -- Add border directly on the slot with item color (2px thickness)
         if EllesmereUI and EllesmereUI.PanelPP then
-            EllesmereUI.PanelPP.CreateBorder(slot, borderR, borderG, borderB, 1, 2, "OVERLAY", 7)
+            EllesmereUI.PanelPP.CreateBorder(slot, borderR, borderG, borderB, 1, 2, "OVERLAY", 1)
             local bdrFrame = EllesmereUI.PanelPP.GetBorders(slot)
             if bdrFrame then bdrFrame:SetFrameLevel(slot:GetFrameLevel()) end
         end
@@ -4125,7 +4125,7 @@ local function SkinCharacterSheet()
                 overlay:SetAllPoints(slot)
                 overlay:SetFrameLevel(slot:GetFrameLevel())
                 if EllesmereUI and EllesmereUI.PanelPP then
-                    EllesmereUI.PanelPP.CreateBorder(overlay, 0.898, 0.286, 0.286, 1, 2, "OVERLAY", 7)  -- #e54949
+                    EllesmereUI.PanelPP.CreateBorder(overlay, 0.898, 0.286, 0.286, 1, 2, "OVERLAY", 1)  -- #e54949
                     local enchBdr = EllesmereUI.PanelPP.GetBorders(overlay)
                     if enchBdr then enchBdr:SetFrameLevel(slot:GetFrameLevel()) end
                 end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

The quality, enchant. missing and gem borders wereshowing above the `ItemContextOverlay` which was a little bit weird visually.

Bug report: https://discord.com/channels/585577383847788554/1527384164976824511

## How was it tested?

12.0.7 only.
After first login and after a /reload:
- Open the character sheet, then open catalyst
- Open the catalyst, then open the catalyst
- Open and close the character sheet will the catalyst is open
- While having the catalyst open, walk away far enough for the catalyst to auto close

## Screenshots

Before / After
<img width="50" height="373" alt="image" src="https://github.com/user-attachments/assets/a413cb3b-4051-4c4e-8373-76e4b48f6d08" /> <img width="53" height="377" alt="image" src="https://github.com/user-attachments/assets/fe82a0f1-dde7-459d-bf5b-993b86338589" />

</body></html><!--EndFragment-->
</body>
</html>

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- N/A New settings default **OFF** (no behavior change without opt-in)
- N/A Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
