### PR TITLE
fix(cdm): keep custom colours when applying Active State to a bar

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -8483,14 +8483,17 @@ initFrame:SetScript("OnEvent", function(self)
                             -- so Apply to Bar / All Specs here means "rejoin the bar" -- the
                             -- same as Include This Spell. Do that instead of re-applying the
                             -- value already on the bar (which would just toggle it off).
-                            -- For a scalar popup value (Threshold Seconds) the flyout item is
-                            -- a fixed identifier, not the bar's number, so "sits on the bar's
-                            -- value" is only true when the entered number actually matches
-                            -- this scope's value -- rejoin then (keeps the bar apply for other
-                            -- spells); otherwise fall through and push the new number, which
-                            -- rejoining would silently discard.
+                            -- Some items carry a payload the flyout val doesn't capture:
+                            -- a scalar popup value (Threshold Seconds), a custom colour
+                            -- ("custom" is a fixed identifier, the RGB lives in ss), and
+                            -- the + Border Color toggle (an on/off flag plus its RGBA).
+                            -- For those "sits on the bar's value" only holds when the
+                            -- payload actually matches this scope -- rejoin then (keeps
+                            -- the bar apply for other spells); otherwise fall through and
+                            -- push it, which rejoining would silently discard.
                             if AB.KeysBarApplied(keys) and AB.SpellHasOwn(keys)
-                               and (not ctx.scalarApply or (scopeActive and valuesMatch)) then
+                               and (not (ctx.scalarApply or ctx.payloadValue)
+                                    or (scopeActive and valuesMatch)) then
                                 AB.IncludeSpell(keys)
                                 if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end
                                 if ns.QueueReanchor then ns.QueueReanchor() end
@@ -8499,10 +8502,16 @@ initFrame:SetScript("OnEvent", function(self)
                                 return
                             end
                             -- Toggle OFF: clicking a scope that already holds this
-                            -- exact value un-applies it. Binary toggles un-apply on
-                            -- ANY active value (their valueOf flips each click, so
-                            -- an equality gesture doesn't exist for them).
-                            if scopeActive and (valuesMatch or ctx.isToggle) then
+                            -- exact value un-applies it. Binary toggles carry no value
+                            -- of their own, so any active scope is an un-apply gesture.
+                            -- The + Border Color toggle carries an RGBA payload, so
+                            -- equality IS meaningful: un-apply only when the colour
+                            -- matches, otherwise fall through and push the new one --
+                            -- un-applying there would discard it and snap back to the
+                            -- default. (Custom-colour value items aren't toggles, so
+                            -- isToggle already gates them here; only the rejoin branch
+                            -- above needed the payloadValue guard for them.)
+                            if scopeActive and (valuesMatch or (ctx.isToggle and not ctx.payloadValue)) then
                                 AB.RunBarUnapply(keys, allSpecs)
                                 if ctx.refresh then ctx.refresh() end
                                 if s._updateActive then s._updateActive() end
@@ -8842,6 +8851,23 @@ initFrame:SetScript("OnEvent", function(self)
                             -- Reachable from onItemCreated closures (color swatches),
                             -- which live outside this scope but capture `sub`.
                             sub._refreshSelection = RefreshFlyoutSelection
+                            -- True when apply keys contain an R/G/B triple, i.e. the item
+                            -- carries a per-spell colour the flyout val doesn't capture.
+                            -- Structural on purpose: keying off val == "custom" missed
+                            -- payload toggles that use a different discriminator (Threshold
+                            -- Color, + Border Color), silently reintroducing the reset bug.
+                            local function hasColourPayload(ks)
+                                if not ks then return false end
+                                local set = {}
+                                for _, k in ipairs(ks) do set[k] = true end
+                                for _, k in ipairs(ks) do
+                                    local base = k:match("^(.+)R$")
+                                    if base and set[base .. "G"] and set[base .. "B"] then
+                                        return true
+                                    end
+                                end
+                                return false
+                            end
                             for _, item in ipairs(items) do
                                 if item.divider then
                                     -- Thin separator line (e.g. between built-in sounds
@@ -8976,6 +9002,14 @@ initFrame:SetScript("OnEvent", function(self)
                                             write = applyWrite,
                                             scalarApply = item.scalarApply,
                                             isToggle = isChargeToggle or isActiveBorder or isFnToggle,
+                                            -- Item whose val is only a discriminator while
+                                            -- the real value carries a per-spell colour
+                                            -- payload (an R/G/B triple in applyKeys). For
+                                            -- those, equality must be judged by valuesMatch,
+                                            -- not the identifier, or the rejoin/toggle-off
+                                            -- shortcuts discard the colour (see the two
+                                            -- branches in the apply handler above).
+                                            payloadValue = hasColourPayload(applyKeys),
                                             -- Toggles: "Apply to Bar" ENABLES the feature
                                             -- on the bar (apply true). Disabling is the
                                             -- toggle-off press -- ctx.isToggle un-applies


### PR DESCRIPTION
## Problem

Picking a custom colour under **Active State** and clicking **Apply to Bar** or **Apply to Bar (All Specs)** discarded the colour and snapped the setting back to its default.

Reported by @Ascii on **CD Swipe Color**. The same defect also affects **+ Border Color** and **Threshold Color**.

## Cause

All three are the same shape. The flyout item's `val` is only a discriminator (`"custom"` for the swipe/glow colours, an on/off flag for `+ Border Color` and `Threshold Color`) while the real value is a per-spell **RGB(A) payload** that `applyWrite` reads from the store at apply time.

The Apply-to-Bar handler has two early-return branches that assume `val` fully identifies the value:

- **rejoin** (on an excluded/own spell the flyout "sits on the bar's value", so Apply means Include rather than re-apply): fired whenever the bar drove the keys and the spell had its own, *regardless of colour*, so it discarded the picked colour.
- **toggle-off**: the payload toggles set `isToggle`, and that shortcut un-applied on **any** active scope.

Once the bar had the keys applied (which repeated testing guarantees), every later click hit one of these and reverted to the bar default.

## Fix

This generalises the existing `scalarApply` idea from the Threshold Seconds fix. A new `payloadValue` flag marks any item whose `applyKeys` contain an **R/G/B triple**, and both branches then require `valuesMatch` for it: an unchanged colour still rejoins / toggles off, while a changed colour falls through and applies. `valuesMatch` already compares the full key set, colour included.

The signal is **structural, not the string `"custom"`**. An earlier cut of this fix keyed off `val == "custom"` and silently missed `+ Border Color` (an `activeBorder` toggle) and `Threshold Color` (an fn-toggle with `val = "color"`), both of which carry the same payload. The R/G/B-triple test covers every current colour row (the six `"custom"` pickers plus those two) and any future one, with no discriminator string to keep in sync.

`suppressStrip` is deliberately left alone: `itemIsBarApplied` keys off the discriminator (`applyKeys[1]`), so it already returns true when the bar is on the colour value and the strip is never wrongly hidden. The toggle-off branch is unchanged for binary toggles (no colour payload) and for non-toggle value items (`isToggle` already gates them there).

## Testing

Confirmed in game on all three rows: CD Swipe Color, + Border Color, and Threshold Color. Custom colour now survives both Apply to Bar and Apply to Bar (All Specs); applying the same colour twice still toggles off. No other Active State row changed behaviour.

## Note

`Threshold Color` and `+ Border Color` were found during review, not reported, so this fixes them pre-emptively rather than after separate tickets.
