### PR TITLE
fix(qol): stop patron-order/loot-window containers from stranding greyed

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -164,6 +164,19 @@ qolFrame:SetScript("OnEvent", function(self)
         local _openableCache = {}  -- itemID -> true/false
         local _failedItems = {}   -- itemID -> true (items that failed to open, skip forever)
         local _cacheBuilt = false
+        -- Self-tracked in-flight opens, keyed by bag/slot. Set synchronously in
+        -- the same tick as UseContainerItem (Lua is single-threaded, so no other
+        -- open pass can slip between the use and this write) and cleared at the
+        -- 0.5s recheck. This -- not Blizzard's isLocked flag, which isn't set
+        -- until a server round-trip completes -- is what stops two overlapping
+        -- passes from double-using the same slot and stranding it greyed.
+        local _openInProgress = {}
+        -- Many payout containers (e.g. Artisan's Consortium Payouts) open a loot
+        -- window and linger in the bag until looted. Opening another container --
+        -- or re-opening the lingering one -- while that window is up strands it.
+        -- Gate all opens on this and resume on LOOT_CLOSED.
+        local _lootOpen = false
+        local function SlotKey(bag, slot) return bag * 1000 + slot end
         local function IsEnabled()
             return EllesmereUIDB and EllesmereUIDB.autoOpenContainers == true
         end
@@ -240,15 +253,20 @@ qolFrame:SetScript("OnEvent", function(self)
                                 if idx > #_pendingOpens then wipe(_pendingOpens); return end
                                 if not IsEnabled() then wipe(_pendingOpens); return end
                                 if InCombatLockdown() or MerchantOpen() then wipe(_pendingOpens); return end
+                                -- A loot window is up: stop here rather than opening
+                                -- over it. LOOT_CLOSED re-runs ScanAndOpen, which
+                                -- picks up whatever is left in the bags.
+                                if _lootOpen then return end
                                 local item = _pendingOpens[idx]
+                                local key = SlotKey(item.bag, item.slot)
                                 local info = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                                -- Never act on a slot mid-action (isLocked): re-using a
-                                -- container that's still resolving a previous open (a loot
-                                -- window or a slow server round-trip) leaves it stuck
-                                -- greyed/unopenable. For the same reason, a slot still
+                                -- Never act on a slot mid-action: our own _openInProgress
+                                -- flag (set synchronously below) or Blizzard's isLocked.
+                                -- Re-using a container that's still resolving a previous
+                                -- open leaves it stuck greyed/unopenable. A slot still
                                 -- locked at the post-open check is in-progress, not a real
                                 -- failure, so it isn't cached as failed -- a later pass retries.
-                                if info and info.itemID and not info.isLocked then
+                                if info and info.itemID and not info.isLocked and not _openInProgress[key] then
                                     if IsWarboundExcluded(item.bag, item.slot) then
                                         OpenNext(idx + 1)
                                         return
@@ -256,10 +274,12 @@ qolFrame:SetScript("OnEvent", function(self)
                                     if _openableCache[info.itemID] and not _failedItems[info.itemID] then
                                         local prevID = info.itemID
                                         local prevCount = info.stackCount or 1
+                                        _openInProgress[key] = true
                                         C_Container.UseContainerItem(item.bag, item.slot)
                                         C_Timer.After(0.5, function()
+                                            _openInProgress[key] = nil
                                             local after = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                                            if after and after.itemID == prevID and not after.isLocked and (after.stackCount or 1) >= prevCount then
+                                            if after and after.itemID == prevID and not after.isLocked and not _lootOpen and (after.stackCount or 1) >= prevCount then
                                                 _failedItems[prevID] = true
                                             end
                                             OpenNext(idx + 1)
@@ -301,6 +321,10 @@ qolFrame:SetScript("OnEvent", function(self)
                 -- suppressed), so without this the just-bought containers would
                 -- never open after leaving the vendor.
                 containerFrame:RegisterEvent("MERCHANT_CLOSED")
+                -- Track loot windows so payout containers (which open one and
+                -- linger in the bag) aren't opened over / re-opened while looting.
+                containerFrame:RegisterEvent("LOOT_OPENED")
+                containerFrame:RegisterEvent("LOOT_CLOSED")
                 if not _cacheBuilt then
                     _scanBag = BACKPACK_CONTAINER
                     _scanSlot = 1
@@ -310,6 +334,9 @@ qolFrame:SetScript("OnEvent", function(self)
             else
                 containerFrame:UnregisterEvent("BAG_UPDATE_DELAYED")
                 containerFrame:UnregisterEvent("MERCHANT_CLOSED")
+                containerFrame:UnregisterEvent("LOOT_OPENED")
+                containerFrame:UnregisterEvent("LOOT_CLOSED")
+                _lootOpen = false
                 scanFrame:Hide()
             end
         end
@@ -350,10 +377,13 @@ qolFrame:SetScript("OnEvent", function(self)
                 if not IsEnabled() then return end
                 if InCombatLockdown() then return end
                 if MerchantOpen() then return end
+                -- Loot window up: stop; LOOT_CLOSED restarts this pass.
+                if _lootOpen then return end
                 local item = toOpen[idx]
+                local key = SlotKey(item.bag, item.slot)
                 local info2 = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                -- Skip locked (mid-action) slots -- see the scan pass above.
-                if info2 and info2.itemID and not info2.isLocked then
+                -- Skip mid-action slots (our in-flight flag or isLocked) -- see the scan pass above.
+                if info2 and info2.itemID and not info2.isLocked and not _openInProgress[key] then
                     if IsWarboundExcluded(item.bag, item.slot) then
                         OpenNext(idx + 1)
                         return
@@ -361,10 +391,12 @@ qolFrame:SetScript("OnEvent", function(self)
                     if _openableCache[info2.itemID] and not _failedItems[info2.itemID] then
                         local prevID = info2.itemID
                         local prevCount = info2.stackCount or 1
+                        _openInProgress[key] = true
                         C_Container.UseContainerItem(item.bag, item.slot)
                         C_Timer.After(0.5, function()
+                            _openInProgress[key] = nil
                             local after = C_Container.GetContainerItemInfo(item.bag, item.slot)
-                            if after and after.itemID == prevID and not after.isLocked and (after.stackCount or 1) >= prevCount then
+                            if after and after.itemID == prevID and not after.isLocked and not _lootOpen and (after.stackCount or 1) >= prevCount then
                                 _failedItems[prevID] = true
                             end
                             OpenNext(idx + 1)
@@ -378,6 +410,17 @@ qolFrame:SetScript("OnEvent", function(self)
         end
 
         containerFrame:SetScript("OnEvent", function(_, event)
+            if event == "LOOT_OPENED" then
+                _lootOpen = true
+                return
+            end
+            if event == "LOOT_CLOSED" then
+                _lootOpen = false
+                -- Resume opens that were deferred while the window was up. Delay
+                -- so the looted container has left the bag before we re-scan.
+                C_Timer.After(0.5, function() ScanAndOpen(false) end)
+                return
+            end
             -- MERCHANT_CLOSED: the interaction is over but the frame may not
             -- have hidden yet -- skip the entry gate (see ScanAndOpen note)
             -- instead of settling on a timer.


### PR DESCRIPTION
## Summary

Follow-up to #766. The `isLocked` guard from that PR did **not** stop Auto Open Containers from stranding **loot-window payout containers** (crafting patron orders / Artisan's Consortium Payouts) greyed and unopenable. An in-game tester confirmed the greyed-out state still occurred after #766, then confirmed this change fixes it (4 containers opened cleanly, none stuck).

## Why #766 was insufficient

`isLocked` is not set at the moment a second open pass re-reads the slot, so two double-use paths survived it:

1. **Overlapping passes within the server round-trip** - every `BAG_UPDATE_DELAYED` spawns a fresh `ScanAndOpen`, so a second pass can read the slot after `UseContainerItem` but before `isLocked`/`LOOT_OPENED` land, and use it again.
2. **Lingering payout item** - the container stays in the bag with its loot window open; a later `BAG_UPDATE_DELAYED` re-opens it over that window.

Double-use on a container mid-open strands it in a client-side lock (greyed, unopenable, persists even after disabling the setting).

## Fix (independent of Blizzard's lock timing)

- **`_openInProgress`** - a self-tracked per-slot flag set in the **same synchronous tick** as `UseContainerItem` and cleared at the 0.5s recheck. Lua is single-threaded, so no concurrent pass can slip between the use and the flag, making same-slot double-use impossible regardless of when `isLocked` is set.
- **Loot-window gate** - track `LOOT_OPENED`/`LOOT_CLOSED` and never open a second container, or re-open a lingering one, while a loot window is up; resume on `LOOT_CLOSED`. The two guards hand off cleanly (in-flight covers the round trip, the loot gate covers the window's full duration).
- Don't blacklist a container whose loot window is still open at the 0.5s recheck (added `not _lootOpen` to the failed-marking condition).

The `isLocked` checks are kept as an additional layer.

## Testing

Verified in-game: 4 patron-order containers all auto-opened cleanly with none stranded greyed. (Pre-existing stuck items clear on relog; the fix prevents new ones from sticking.)
