### PR TITLE
[Feature] CDM Tracking Bar Charges

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -2019,8 +2019,10 @@ initFrame:SetScript("OnEvent", function(self)
                 local sb = wrap._bar
                 if sb then sb:SetFrameLevel(base + 1) end
                 if wrap._gradClip and sb then wrap._gradClip:SetFrameLevel(sb:GetFrameLevel() + 1) end
+                if wrap._chargeHashFillClip and sb then wrap._chargeHashFillClip:SetFrameLevel(sb:GetFrameLevel() + 1) end
                 if wrap._threshOverlay and sb then wrap._threshOverlay:SetFrameLevel(sb:GetFrameLevel() + 2) end
                 if wrap._sparkOverlay and sb then wrap._sparkOverlay:SetFrameLevel(sb:GetFrameLevel() + 2) end
+                if wrap._chargeHashOverlay and sb then wrap._chargeHashOverlay:SetFrameLevel(sb:GetFrameLevel() + 4) end
                 if wrap._barBorder then wrap._barBorder:SetFrameLevel(base + 5) end
                 if wrap._pandemicGlowOverlay then wrap._pandemicGlowOverlay:SetFrameLevel(base + 7) end
                 if wrap._textOverlay and sb then wrap._textOverlay:SetFrameLevel(sb:GetFrameLevel() + 7) end
@@ -2976,6 +2978,12 @@ initFrame:SetScript("OnEvent", function(self)
             local t = ns.GetTrackedBuffBars()
             if _tbbSelectedBar < 1 or _tbbSelectedBar > #t.bars then return nil end
             return t.bars[_tbbSelectedBar]
+        end
+
+        local function SelectedTBBSupportsChargeHash()
+            local bd = SelectedTBB()
+            return bd and ns.GetTBBMaxCharges
+                and ns.GetTBBMaxCharges(bd) ~= nil
         end
 
         -- Validate the group selection against the live group list (groups
@@ -4867,22 +4875,133 @@ initFrame:SetScript("OnEvent", function(self)
             })
         end
 
-        -- Smooth Bars: PROFILE-wide checkbox dropdown (all bars, all specs
-        -- -- deliberately NOT per bar or per spec). Buffs = buff mirrors +
-        -- self-timed presets; Cooldowns = cooldown-tracking bars. Read by
-        -- the tick each pass, so changes apply instantly with no rebuild.
+        -- Charge Hash Lines | Smooth Bars. The number and orientation of hash
+        -- separators are resolved automatically from the tracked spell's max
+        -- charges. Smooth Bars remains profile-wide rather than per bar/spec.
         local SMOOTH_ITEMS = {
             { key = "buffs",     label = "Buffs" },
             { key = "cooldowns", label = "Cooldowns" },
         }
         local SMOOTH_DEFAULT = { buffs = true, cooldowns = false }
-        local smoothRow
-        smoothRow, h = W:DualRow(parent, y,
+        local chargeHashRow
+        chargeHashRow, h = W:DualRow(parent, y,
+            { type = "toggle", text = "Charge Hash Lines",
+              tooltip = "Divides a cooldown-tracking bar into one recovery section per ability charge. The timer shows the next charge's cooldown.",
+              disabled = function()
+                  local bd = SelectedTBB()
+                  return not bd or bd.trackType ~= "cooldown"
+                      or not SelectedTBBSupportsChargeHash()
+              end,
+              disabledTooltip = function()
+                  local bd = SelectedTBB()
+                  if not bd or bd.trackType ~= "cooldown" then
+                      return "This option requires a cooldown-tracking bar"
+                  end
+                  return "This option is only available for abilities with multiple charges"
+              end,
+              getValue = function()
+                  local bd = SelectedTBB()
+                  return bd and bd.chargeHashLines == true
+                      and SelectedTBBSupportsChargeHash()
+              end,
+              setValue = function(v)
+                  local bd = SelectedTBB(); if not bd then return end
+                  if v and not SelectedTBBSupportsChargeHash() then return end
+                  bd.chargeHashLines = v and true or nil
+                  RefreshTBB(); EllesmereUI:RefreshPage()
+              end },
             { type = "dropdown", text = "Smooth Bars",
               tooltip = "Eases bar movement instead of snapping. Affects all Tracking Bars of that type, in every spec of this profile.",
               values = { __placeholder = "..." }, order = { "__placeholder" },
               getValue = function() return "__placeholder" end,
-              setValue = function() end },
+              setValue = function() end });  y = y - h
+        do
+            local rgn = chargeHashRow._leftRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Charge Hash Line Settings",
+                rows = {
+                    { type = "slider", label = "Line Width", min = 1, max = 10, step = 1,
+                      get = function()
+                          local bd = SelectedTBB()
+                          return bd and bd.chargeHashLineWidth or 2
+                      end,
+                      set = function(v)
+                          local bd = SelectedTBB(); if not bd then return end
+                          bd.chargeHashLineWidth = v
+                          RefreshTBB()
+                      end },
+                    { type = "colorpicker", label = "Line Color", hasAlpha = true,
+                      get = function()
+                          local bd = SelectedTBB()
+                          if not bd then return 0, 0, 0, 1 end
+                          local a = bd.chargeHashLineA
+                          if a == nil then a = 1 end
+                          return bd.chargeHashLineR or 0, bd.chargeHashLineG or 0,
+                              bd.chargeHashLineB or 0, a
+                      end,
+                      set = function(r, g, b, a)
+                          local bd = SelectedTBB(); if not bd then return end
+                          bd.chargeHashLineR, bd.chargeHashLineG = r, g
+                          bd.chargeHashLineB, bd.chargeHashLineA = b, a
+                          RefreshTBB()
+                      end },
+                },
+            })
+            local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.COGS_ICON)
+            local cogBlock = CreateFrame("Frame", nil, cogBtn)
+            cogBlock:SetAllPoints()
+            cogBlock:SetFrameLevel(cogBtn:GetFrameLevel() + 10)
+            cogBlock:EnableMouse(true)
+            cogBlock:SetScript("OnEnter", function()
+                local bd = SelectedTBB()
+                local tip
+                if not bd or bd.trackType ~= "cooldown" then
+                    tip = "This option requires a cooldown-tracking bar"
+                elseif not SelectedTBBSupportsChargeHash() then
+                    tip = "This option is only available for abilities with multiple charges"
+                else
+                    tip = "Enable Charge Hash Lines first"
+                end
+                EllesmereUI.ShowWidgetTooltip(cogBtn, tip)
+            end)
+            cogBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            local function UpdateChargeHashCog()
+                local bd = SelectedTBB()
+                local disabled = not bd or bd.trackType ~= "cooldown"
+                    or not SelectedTBBSupportsChargeHash()
+                    or bd.chargeHashLines ~= true
+                cogBtn:SetAlpha(disabled and 0.15 or 0.4)
+                if disabled then cogBlock:Show() else cogBlock:Hide() end
+            end
+            cogBtn:HookScript("OnShow", UpdateChargeHashCog)
+            EllesmereUI.RegisterWidgetRefresh(UpdateChargeHashCog)
+            UpdateChargeHashCog()
+        end
+
+        do
+            local rgn = chargeHashRow._rightRegion
+            if rgn._control then rgn._control:Hide() end
+            local cbDD, cbDDRefresh = EllesmereUI.BuildVisOptsCBDropdown(
+                rgn, 210, rgn:GetFrameLevel() + 2,
+                SMOOTH_ITEMS,
+                function(k)
+                    local s = ns.GetTBBSmoothSettings and ns.GetTBBSmoothSettings()
+                    if not s or s[k] == nil then return SMOOTH_DEFAULT[k] end
+                    return s[k] == true
+                end,
+                function(k, v)
+                    local s = ns.GetTBBSmoothSettings and ns.GetTBBSmoothSettings()
+                    if s then s[k] = v and true or false end
+                end)
+            PP.Point(cbDD, "RIGHT", rgn, "RIGHT", -20, 0)
+            rgn._control = cbDD
+            rgn._lastInline = nil
+            EllesmereUI.RegisterWidgetRefresh(cbDDRefresh)
+        end
+
+        -- Bar Strata
+        local barStrataRow
+        barStrataRow, h = W:DualRow(parent, y,
             { type = "dropdown", text = "Bar Strata",
               tooltip = "Screen layer the bar renders on; changing a grouped bar changes its whole group.",
               values = { BACKGROUND = "Background", LOW = "Low", MEDIUM = "Medium",
@@ -4903,27 +5022,8 @@ initFrame:SetScript("OnEvent", function(self)
                       end
                   end
                   RefreshTBB()
-              end });  y = y - h
-        do
-            local rgn = smoothRow._leftRegion
-            if rgn._control then rgn._control:Hide() end
-            local cbDD, cbDDRefresh = EllesmereUI.BuildVisOptsCBDropdown(
-                rgn, 210, rgn:GetFrameLevel() + 2,
-                SMOOTH_ITEMS,
-                function(k)
-                    local s = ns.GetTBBSmoothSettings and ns.GetTBBSmoothSettings()
-                    if not s or s[k] == nil then return SMOOTH_DEFAULT[k] end
-                    return s[k] == true
-                end,
-                function(k, v)
-                    local s = ns.GetTBBSmoothSettings and ns.GetTBBSmoothSettings()
-                    if s then s[k] = v and true or false end
-                end)
-            PP.Point(cbDD, "RIGHT", rgn, "RIGHT", -20, 0)
-            rgn._control = cbDD
-            rgn._lastInline = nil
-            EllesmereUI.RegisterWidgetRefresh(cbDDRefresh)
-        end
+              end },
+            { type = "label", text = "" });  y = y - h
 
         -------------------------------------------------------------------
         --  DISPLAY

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -252,6 +252,10 @@ local TBB_DEFAULT_BAR = {
     width     = 270,
     verticalOrientation = false,
     reverseFill = false,
+    chargeHashLines = false,
+    chargeHashLineWidth = 2,
+    chargeHashLineR = 0, chargeHashLineG = 0,
+    chargeHashLineB = 0, chargeHashLineA = 1,
     texture   = "none",
     fillR = _classR, fillG = _classG, fillB = _classB, fillA = 1,
     bgR = 0, bgG = 0, bgB = 0, bgA = 0.4,
@@ -1429,7 +1433,10 @@ end
 --  numbers (those are spell-specific, matching AddTrackedBuffBar's reset set).
 -------------------------------------------------------------------------------
 local TBB_STYLE_KEYS = {
-    "height", "width", "verticalOrientation", "reverseFill", "texture", "strata",
+    "height", "width", "verticalOrientation", "reverseFill",
+    "chargeHashLines", "chargeHashLineWidth",
+    "chargeHashLineR", "chargeHashLineG", "chargeHashLineB", "chargeHashLineA",
+    "texture", "strata",
     "fillColorMode", "fillR", "fillG", "fillB", "fillA",
     "bgR", "bgG", "bgB", "bgA",
     "gradientEnabled", "gradientR", "gradientG", "gradientB", "gradientA", "gradientDir",
@@ -1925,7 +1932,8 @@ local function EnsureTBBThresholdOverlay(bar)
 end
 
 local function SetupTBBThresholdOverlay(bar, cfg)
-    if not cfg.stackThresholdEnabled then
+    if not cfg.stackThresholdEnabled
+       or (cfg.trackType == "cooldown" and cfg.chargeHashLines == true) then
         if bar._threshOverlay then bar._threshOverlay:Hide() end
         return
     end
@@ -1955,6 +1963,34 @@ end
 -------------------------------------------------------------------------------
 --  Tick Marks
 -------------------------------------------------------------------------------
+-- Cooldown state must follow the spell the user saved, not the transient
+-- override returned for an icon while a proc is active. The base fallback only
+-- handles a saved talent override that is no longer learned.
+local function StableCooldownSpellID(cfg)
+    local sid = cfg and cfg.spellID
+    if type(sid) ~= "number" or sid <= 0 then return nil end
+    local base = cfg.baseSpellID
+    if type(base) == "number" and base > 0 and IsPlayerSpell
+       and not IsPlayerSpell(sid) and IsPlayerSpell(base) then
+        return base
+    end
+    return sid
+end
+
+local function GetTBBMaxCharges(cfg)
+    if not cfg or cfg.trackType ~= "cooldown" then return nil end
+    local sid = StableCooldownSpellID(cfg)
+    local ch = sid and C_Spell and C_Spell.GetSpellCharges
+        and C_Spell.GetSpellCharges(sid)
+    local maxCharges = ch and ch.maxCharges
+    if issecretvalue and issecretvalue(maxCharges) then return nil end
+    if type(maxCharges) == "number" and maxCharges > 1 then
+        return math.floor(maxCharges + 0.5)
+    end
+    return nil
+end
+ns.GetTBBMaxCharges = GetTBBMaxCharges
+
 local function ParseTickValues(str)
     if not str or str == "" then return nil end
     local vals = {}
@@ -1971,7 +2007,8 @@ local function ApplyTBBTickMarks(sb, cfg, tickCache, isVert, tickParent)
     if tickCache then
         for i = 1, #tickCache do tickCache[i]:Hide() end
     end
-    if not cfg.stackThresholdEnabled or not cfg.stackThresholdMaxEnabled
+    if (cfg.trackType == "cooldown" and cfg.chargeHashLines == true)
+       or not cfg.stackThresholdEnabled or not cfg.stackThresholdMaxEnabled
        or not vals or maxStacks < 1 or not tickCache then return end
 
     local PP = EllesmereUI and EllesmereUI.PP
@@ -2017,6 +2054,165 @@ local function ApplyTBBTickMarks(sb, cfg, tickCache, isVert, tickParent)
 end
 ns.ApplyTBBTickMarks = ApplyTBBTickMarks
 
+-- Charge separators are fixed geometry over the full StatusBar. A spell with
+-- N charges receives N-1 separators. Equal divisions do not move when Reverse
+-- Fill changes the recovery origin; vertical bars simply rotate the marks.
+local function ApplyTBBChargeHashLines(bar, cfg, maxCharges)
+    if not bar or not cfg then return end
+    local sb = bar._bar
+    if not sb then return end
+
+    local ticks = bar._chargeHashTicks
+    if cfg.chargeHashLines ~= true or cfg.trackType ~= "cooldown"
+       or type(maxCharges) ~= "number" or maxCharges <= 1 then
+        if ticks then
+            for i = 1, #ticks do ticks[i]:Hide() end
+        end
+        bar._chargeHashLineCacheValid = nil
+        if bar._chargeHashOverlay then bar._chargeHashOverlay:Hide() end
+        return
+    end
+
+    local barW, barH = sb:GetWidth(), sb:GetHeight()
+    if not barW or not barH or barW <= 0 or barH <= 0 then
+        if ticks then
+            for i = 1, #ticks do ticks[i]:Hide() end
+        end
+        if bar._chargeHashOverlay then bar._chargeHashOverlay:Hide() end
+        bar._chargeHashLineCacheValid = nil
+        return
+    end
+
+    local width = tonumber(cfg.chargeHashLineWidth) or 2
+    width = math.max(1, math.min(10, math.floor(width + 0.5)))
+    local lineR = cfg.chargeHashLineR or 0
+    local lineG = cfg.chargeHashLineG or 0
+    local lineB = cfg.chargeHashLineB or 0
+    local lineA = cfg.chargeHashLineA
+    if lineA == nil then lineA = 1 end
+    local isVert = cfg.verticalOrientation and true or false
+    local effectiveScale = sb:GetEffectiveScale() or 1
+    -- This function also runs from the shared timer tick. Keep the cache scalar:
+    -- synthesized table/string keys would generate garbage even on a cache hit.
+    if bar._chargeHashLineCacheValid
+       and bar._chargeHashLineMaxCharges == maxCharges
+       and bar._chargeHashLineWidth == width
+       and bar._chargeHashLineVertical == isVert
+       and bar._chargeHashLineBarW == barW
+       and bar._chargeHashLineBarH == barH
+       and bar._chargeHashLineScale == effectiveScale
+       and bar._chargeHashLineR == lineR
+       and bar._chargeHashLineG == lineG
+       and bar._chargeHashLineB == lineB
+       and bar._chargeHashLineA == lineA
+       and bar._chargeHashOverlay and bar._chargeHashOverlay:IsShown() then
+        return
+    end
+
+    if ticks then
+        for i = 1, #ticks do ticks[i]:Hide() end
+    end
+
+    if not bar._chargeHashOverlay then
+        local overlay = CreateFrame("Frame", nil, sb)
+        overlay:SetAllPoints(sb)
+        overlay:SetFrameLevel(sb:GetFrameLevel() + 4)
+        bar._chargeHashOverlay = overlay
+    end
+    bar._chargeHashOverlay:Show()
+    if not ticks then
+        ticks = {}
+        bar._chargeHashTicks = ticks
+    end
+
+    while #ticks < maxCharges - 1 do
+        local tick = bar._chargeHashOverlay:CreateTexture(nil, "OVERLAY", nil, 7)
+        tick:SetSnapToPixelGrid(false)
+        tick:SetTexelSnappingBias(0)
+        ticks[#ticks + 1] = tick
+    end
+
+    local PP = EllesmereUI and EllesmereUI.PP
+    local lineWidth = PP and PP.Scale(width) or width
+    for i = 1, maxCharges - 1 do
+        local tick = ticks[i]
+        local frac = i / maxCharges
+        tick:SetColorTexture(lineR, lineG, lineB, lineA)
+        tick:ClearAllPoints()
+        if isVert then
+            local offset = PP and PP.Scale(barH * frac) or (barH * frac)
+            tick:SetSize(barW, lineWidth)
+            tick:SetPoint("CENTER", sb, "BOTTOM", 0, offset)
+        else
+            local offset = PP and PP.Scale(barW * frac) or (barW * frac)
+            tick:SetSize(lineWidth, barH)
+            tick:SetPoint("CENTER", sb, "LEFT", offset, 0)
+        end
+        tick:Show()
+    end
+    for i = maxCharges, #ticks do ticks[i]:Hide() end
+    bar._chargeHashLineCacheValid = true
+    bar._chargeHashLineMaxCharges = maxCharges
+    bar._chargeHashLineWidth = width
+    bar._chargeHashLineVertical = isVert
+    bar._chargeHashLineBarW = barW
+    bar._chargeHashLineBarH = barH
+    bar._chargeHashLineScale = effectiveScale
+    bar._chargeHashLineR = lineR
+    bar._chargeHashLineG = lineG
+    bar._chargeHashLineB = lineB
+    bar._chargeHashLineA = lineA
+end
+
+local function AnchorTBBSparkState(bar, anchor, isVert, reverse, flushToEdge)
+    local sb, spark = bar and bar._bar, bar and bar._spark
+    if not sb or not spark or not anchor then return end
+    isVert = isVert and true or false
+    reverse = reverse and true or false
+    flushToEdge = flushToEdge and true or false
+    local barW, barH = sb:GetWidth(), sb:GetHeight()
+    if bar._sparkAnchorTarget == anchor
+       and bar._sparkAnchorVertical == isVert
+       and bar._sparkAnchorReverse == reverse
+       and bar._sparkAnchorFlush == flushToEdge
+       and bar._sparkAnchorBarW == barW
+       and bar._sparkAnchorBarH == barH then
+        return
+    end
+    if isVert then
+        spark:SetSize(barW, 8)
+        spark:SetTexCoord(0, 1, 1, 1, 0, 0, 1, 0)
+    else
+        spark:SetSize(8, barH)
+        spark:SetTexCoord(0, 0, 0, 1, 1, 0, 1, 1)
+    end
+    spark:ClearAllPoints()
+    if isVert then
+        spark:SetPoint("CENTER", anchor, reverse and "BOTTOM" or "TOP", 0, 0)
+    else
+        spark:SetPoint("CENTER", anchor,
+            reverse and "LEFT" or "RIGHT",
+            flushToEdge and 0 or (reverse and 1 or -1), 0)
+    end
+    bar._sparkAnchorTarget = anchor
+    bar._sparkAnchorVertical = isVert
+    bar._sparkAnchorReverse = reverse
+    bar._sparkAnchorFlush = flushToEdge
+    bar._sparkAnchorBarW = barW
+    bar._sparkAnchorBarH = barH
+end
+
+local function AnchorTBBSpark(bar, cfg, anchor, flushToEdge)
+    if not cfg then return end
+    AnchorTBBSparkState(bar, anchor, cfg.verticalOrientation,
+        cfg.reverseFill, flushToEdge)
+end
+
+-- Defined with the charge renderer below; ApplySettings calls it whenever a
+-- pooled bar frame is restyled so stale composite geometry cannot leak into a
+-- different bar after deletion, reordering, or a tracking-type change.
+local _restoreTBBNormalFill
+
 -------------------------------------------------------------------------------
 --  Apply Visual Settings
 -------------------------------------------------------------------------------
@@ -2024,6 +2220,7 @@ local function ApplyTrackedBuffBarSettings(bar, cfg)
     if not bar or not cfg then return end
     local sb = bar._bar
     if not sb then return end
+    if _restoreTBBNormalFill then _restoreTBBNormalFill(bar, cfg) end
 
     -- User-selectable strata for the whole bar (the options setter keeps
     -- grouped bars uniform). A parent strata change COLLAPSES child frame
@@ -2038,8 +2235,10 @@ local function ApplyTrackedBuffBarSettings(bar, cfg)
         local base = bar:GetFrameLevel()
         sb:SetFrameLevel(base + 1)
         if bar._gradClip then bar._gradClip:SetFrameLevel(sb:GetFrameLevel() + 1) end
+        if bar._chargeHashFillClip then bar._chargeHashFillClip:SetFrameLevel(sb:GetFrameLevel() + 1) end
         if bar._threshOverlay then bar._threshOverlay:SetFrameLevel(sb:GetFrameLevel() + 2) end
         if bar._sparkOverlay then bar._sparkOverlay:SetFrameLevel(sb:GetFrameLevel() + 2) end
+        if bar._chargeHashOverlay then bar._chargeHashOverlay:SetFrameLevel(sb:GetFrameLevel() + 4) end
         if bar._barBorder then bar._barBorder:SetFrameLevel(base + 5) end
         if bar._pandemicGlowOverlay then bar._pandemicGlowOverlay:SetFrameLevel(base + 7) end
         if bar._textOverlay then bar._textOverlay:SetFrameLevel(sb:GetFrameLevel() + 7) end
@@ -2103,13 +2302,15 @@ local function ApplyTrackedBuffBarSettings(bar, cfg)
         sb:SetStatusBarTexture(texPath)
         bar._lastTexPath = texPath
     end
+    local fillTex = sb:GetStatusBarTexture()
+    bar._cachedOurFillTex = fillTex
 
     -- Fill color
     local fR = cfg.fillR or _classR
     local fG = cfg.fillG or _classG
     local fB = cfg.fillB or _classB
     local fA = cfg.fillA or 1
-    sb:GetStatusBarTexture():SetVertexColor(fR, fG, fB, fA)
+    fillTex:SetVertexColor(fR, fG, fB, fA)
     bar._baseFillR, bar._baseFillG, bar._baseFillB, bar._baseFillA = fR, fG, fB, fA
 
     -- Background
@@ -2118,7 +2319,6 @@ local function ApplyTrackedBuffBarSettings(bar, cfg)
     end
 
     -- Gradient
-    local fillTex = sb:GetStatusBarTexture()
     if cfg.gradientEnabled then
         local dir = cfg.gradientDir or "HORIZONTAL"
         fillTex:SetVertexColor(1, 1, 1, 0)
@@ -2201,22 +2401,7 @@ local function ApplyTrackedBuffBarSettings(bar, cfg)
     bar._lastReverse = cfg.reverseFill and true or false
     if cfg.showSpark then
         local sparkAnchor = (bar._gradientActive and bar._gradClip) or fillTex
-        if isVert then
-            bar._spark:SetSize(w, 8)
-            bar._spark:SetTexCoord(0, 1, 1, 1, 0, 0, 1, 0)
-        else
-            bar._spark:SetSize(8, h)
-            bar._spark:SetTexCoord(0, 0, 0, 1, 1, 0, 1, 1)
-        end
-        bar._spark:ClearAllPoints()
-        if isVert then
-            bar._spark:SetPoint("CENTER", sparkAnchor, cfg.reverseFill and "BOTTOM" or "TOP", 0, 0)
-        else
-            -- 1px inward so the spark sits over the fill edge, not past it.
-            bar._spark:SetPoint("CENTER", sparkAnchor,
-                cfg.reverseFill and "LEFT" or "RIGHT",
-                cfg.reverseFill and 1 or -1, 0)
-        end
+        AnchorTBBSpark(bar, cfg, sparkAnchor)
         bar._spark:Show()
     else
         bar._spark:Hide()
@@ -2336,6 +2521,7 @@ local function ApplyTrackedBuffBarSettings(bar, cfg)
         bar._tickOverlay = to
     end
     ApplyTBBTickMarks(sb, cfg, bar._threshTicks, isVert, bar._tickOverlay)
+    ApplyTBBChargeHashLines(bar, cfg, GetTBBMaxCharges(cfg))
     bar._ticksDirty = true
 end
 
@@ -3424,6 +3610,283 @@ local function _tbbCleanNum(v)
 end
 
 -------------------------------------------------------------------------------
+--  Charge hash fill
+--
+--  currentCharges is secret in combat, so addon Lua cannot calculate
+--      (currentCharges + next-recharge progress) / maxCharges.
+--  Instead, two invisible native StatusBars provide the geometry: one accepts
+--  Blizzard's charge count directly, and one animates exactly one charge-wide
+--  segment from the duration object. A single full-size texture is clipped to
+--  their combined edge, so the player still sees one continuous bar and the
+--  existing texture, gradient, spark, orientation, and reverse-fill settings.
+-------------------------------------------------------------------------------
+local function _ensureTBBChargeHashFill(bar)
+    if bar._chargeHashCountBar then return end
+    local sb = bar._bar
+    if not sb then return end
+
+    local countBar = CreateFrame("StatusBar", nil, sb)
+    countBar:SetAllPoints(sb)
+    countBar:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
+    local countTexture = countBar:GetStatusBarTexture()
+    countTexture:SetSnapToPixelGrid(false)
+    countTexture:SetTexelSnappingBias(0)
+    countBar:SetAlpha(0)
+    countBar:EnableMouse(false)
+    bar._chargeHashCountBar = countBar
+    bar._chargeHashCountTexture = countTexture
+
+    local progressBar = CreateFrame("StatusBar", nil, sb)
+    progressBar:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
+    local progressTexture = progressBar:GetStatusBarTexture()
+    progressTexture:SetSnapToPixelGrid(false)
+    progressTexture:SetTexelSnappingBias(0)
+    progressBar:SetAlpha(0)
+    progressBar:EnableMouse(false)
+    bar._chargeHashProgressBar = progressBar
+    bar._chargeHashProgressTexture = progressTexture
+
+    local clip = CreateFrame("Frame", nil, sb)
+    clip:SetClipsChildren(true)
+    clip:SetFrameLevel(sb:GetFrameLevel() + 1)
+    clip:Hide()
+    bar._chargeHashFillClip = clip
+
+    local fill = clip:CreateTexture(nil, "ARTWORK", nil, 1)
+    fill:SetPoint("TOPLEFT", sb, "TOPLEFT", 0, 0)
+    fill:SetPoint("BOTTOMRIGHT", sb, "BOTTOMRIGHT", 0, 0)
+    fill:SetSnapToPixelGrid(false)
+    fill:SetTexelSnappingBias(0)
+    bar._chargeHashFillTexture = fill
+end
+
+local function _styleTBBChargeHashFill(bar, cfg)
+    local fill = bar._chargeHashFillTexture
+    if not fill then return end
+    local texPath = bar._lastTexPath or "Interface\\Buttons\\WHITE8x8"
+    local fR, fG = bar._baseFillR or _classR, bar._baseFillG or _classG
+    local fB, fA = bar._baseFillB or _classB, bar._baseFillA or 1
+    local gradientEnabled = cfg.gradientEnabled and true or false
+    local gradientDir = cfg.gradientDir or "HORIZONTAL"
+    local gR, gG = cfg.gradientR or 0.20, cfg.gradientG or 0.20
+    local gB, gA = cfg.gradientB or 0.80, cfg.gradientA or 1
+    -- Scalar style signature: unchanged active bars take this branch without
+    -- allocating a temporary table/key string every tick.
+    if bar._chargeHashFillStyleValid
+       and bar._chargeHashFillStyleTexPath == texPath
+       and bar._chargeHashFillStyleGradient == gradientEnabled
+       and bar._chargeHashFillStyleDirection == gradientDir
+       and bar._chargeHashFillStyleR == fR
+       and bar._chargeHashFillStyleG == fG
+       and bar._chargeHashFillStyleB == fB
+       and bar._chargeHashFillStyleA == fA
+       and bar._chargeHashFillStyleGradientR == gR
+       and bar._chargeHashFillStyleGradientG == gG
+       and bar._chargeHashFillStyleGradientB == gB
+       and bar._chargeHashFillStyleGradientA == gA then
+        return
+    end
+
+    fill:SetTexture(texPath)
+    fill:ClearAllPoints()
+    if gradientEnabled then
+        -- Gradients stay mapped across the full bar and are revealed by the
+        -- moving clip, matching the stock gradient path.
+        fill:SetPoint("TOPLEFT", bar._bar, "TOPLEFT", 0, 0)
+        fill:SetPoint("BOTTOMRIGHT", bar._bar, "BOTTOMRIGHT", 0, 0)
+        fill:SetVertexColor(1, 1, 1, 1)
+        local c1 = bar._chargeHashGradientColor1
+        local c2 = bar._chargeHashGradientColor2
+        if not c1 then
+            c1 = CreateColor(fR, fG, fB, fA)
+            c2 = CreateColor(gR, gG, gB, gA)
+            bar._chargeHashGradientColor1 = c1
+            bar._chargeHashGradientColor2 = c2
+        else
+            c1.r, c1.g, c1.b, c1.a = fR, fG, fB, fA
+            c2.r, c2.g, c2.b, c2.a = gR, gG, gB, gA
+        end
+        fill:SetGradient(gradientDir, c1, c2)
+    else
+        -- Plain/patterned StatusBar textures stretch with the visible fill.
+        fill:SetAllPoints(bar._chargeHashFillClip)
+        fill:SetVertexColor(fR, fG, fB, fA)
+    end
+    bar._chargeHashFillStyleValid = true
+    bar._chargeHashFillStyleTexPath = texPath
+    bar._chargeHashFillStyleGradient = gradientEnabled
+    bar._chargeHashFillStyleDirection = gradientDir
+    bar._chargeHashFillStyleR = fR
+    bar._chargeHashFillStyleG = fG
+    bar._chargeHashFillStyleB = fB
+    bar._chargeHashFillStyleA = fA
+    bar._chargeHashFillStyleGradientR = gR
+    bar._chargeHashFillStyleGradientG = gG
+    bar._chargeHashFillStyleGradientB = gB
+    bar._chargeHashFillStyleGradientA = gA
+end
+
+_restoreTBBNormalFill = function(bar, cfg)
+    if not bar._chargeHashFillActive then return end
+    if bar._chargeHashFillClip then bar._chargeHashFillClip:Hide() end
+    if bar._chargeHashCountBar then bar._chargeHashCountBar:Hide() end
+    if bar._chargeHashProgressBar then bar._chargeHashProgressBar:Hide() end
+
+    local sb = bar._bar
+    local fillTex = bar._cachedOurFillTex
+    if not fillTex and sb then
+        fillTex = sb:GetStatusBarTexture()
+        bar._cachedOurFillTex = fillTex
+    end
+    if fillTex then fillTex:SetAlpha(1) end
+    if bar._gradientActive and bar._gradClip then bar._gradClip:Show() end
+    if cfg.showSpark and fillTex then
+        AnchorTBBSpark(bar, cfg, (bar._gradientActive and bar._gradClip) or fillTex)
+    end
+
+    bar._chargeHashFillActive = nil
+    bar._chargeHashDuration = nil
+    -- The stock bar timer is not re-armed while its texture is hidden. If hash
+    -- mode is disabled mid-recharge, force the original path to refresh it.
+    bar._cdNeedSet = true
+end
+
+local function _updateTBBChargeHashFill(bar, cfg, maxCharges, currentCharges,
+        durObj, remaining, duration, wasShown)
+    if cfg.chargeHashLines ~= true or type(maxCharges) ~= "number"
+       or maxCharges <= 1 then
+        return false
+    end
+    local secretCount = issecretvalue and issecretvalue(currentCharges)
+    if not secretCount and type(currentCharges) ~= "number" then return false end
+    if not durObj and not (_tbbCleanNum(remaining) and _tbbCleanNum(duration)
+       and duration > 0) then
+        return false
+    end
+
+    _ensureTBBChargeHashFill(bar)
+    local sb = bar._bar
+    local countBar = bar._chargeHashCountBar
+    local progressBar = bar._chargeHashProgressBar
+    local countTexture = bar._chargeHashCountTexture
+    local progressTexture = bar._chargeHashProgressTexture
+    local clip = bar._chargeHashFillClip
+    if not sb or not countBar or not progressBar or not countTexture
+       or not progressTexture or not clip then return false end
+
+    local isVert = cfg.verticalOrientation and true or false
+    local reverse = cfg.reverseFill and true or false
+    local orientation = isVert and "VERTICAL" or "HORIZONTAL"
+    local barW, barH = sb:GetWidth(), sb:GetHeight()
+    -- Direct scalar comparisons preserve every geometry invalidator while
+    -- keeping the steady-state update allocation-free.
+    if not bar._chargeHashFillGeometryValid
+       or bar._chargeHashFillMaxCharges ~= maxCharges
+       or bar._chargeHashFillVertical ~= isVert
+       or bar._chargeHashFillReverse ~= reverse
+       or bar._chargeHashFillBarW ~= barW
+       or bar._chargeHashFillBarH ~= barH then
+        countBar:SetOrientation(orientation)
+        countBar:SetReverseFill(reverse)
+        countBar:SetMinMaxValues(0, maxCharges)
+
+        progressBar:ClearAllPoints()
+        progressBar:SetOrientation(orientation)
+        progressBar:SetReverseFill(reverse)
+        progressBar:SetMinMaxValues(0, 1)
+        if isVert then
+            progressBar:SetHeight(barH / maxCharges)
+            if reverse then
+                progressBar:SetPoint("TOPLEFT", countTexture, "BOTTOMLEFT", 0, 0)
+                progressBar:SetPoint("TOPRIGHT", countTexture, "BOTTOMRIGHT", 0, 0)
+            else
+                progressBar:SetPoint("BOTTOMLEFT", countTexture, "TOPLEFT", 0, 0)
+                progressBar:SetPoint("BOTTOMRIGHT", countTexture, "TOPRIGHT", 0, 0)
+            end
+        else
+            progressBar:SetWidth(barW / maxCharges)
+            if reverse then
+                progressBar:SetPoint("TOPRIGHT", countTexture, "TOPLEFT", 0, 0)
+                progressBar:SetPoint("BOTTOMRIGHT", countTexture, "BOTTOMLEFT", 0, 0)
+            else
+                progressBar:SetPoint("TOPLEFT", countTexture, "TOPRIGHT", 0, 0)
+                progressBar:SetPoint("BOTTOMLEFT", countTexture, "BOTTOMRIGHT", 0, 0)
+            end
+        end
+
+        clip:ClearAllPoints()
+        if isVert then
+            if reverse then
+                clip:SetPoint("TOPRIGHT", sb, "TOPRIGHT", 0, 0)
+                clip:SetPoint("BOTTOMLEFT", progressTexture, "BOTTOMLEFT", 0, 0)
+            else
+                clip:SetPoint("BOTTOMLEFT", sb, "BOTTOMLEFT", 0, 0)
+                clip:SetPoint("TOPRIGHT", progressTexture, "TOPRIGHT", 0, 0)
+            end
+        else
+            if reverse then
+                clip:SetPoint("TOPLEFT", progressTexture, "TOPLEFT", 0, 0)
+                clip:SetPoint("BOTTOMRIGHT", sb, "BOTTOMRIGHT", 0, 0)
+            else
+                clip:SetPoint("TOPLEFT", sb, "TOPLEFT", 0, 0)
+                clip:SetPoint("BOTTOMRIGHT", progressTexture, "BOTTOMRIGHT", 0, 0)
+            end
+        end
+        bar._chargeHashFillGeometryValid = true
+        bar._chargeHashFillMaxCharges = maxCharges
+        bar._chargeHashFillVertical = isVert
+        bar._chargeHashFillReverse = reverse
+        bar._chargeHashFillBarW = barW
+        bar._chargeHashFillBarH = barH
+    end
+
+    -- SetValue is a supported secret sink: never inspect or calculate with the
+    -- live count in Lua.
+    countBar:SetValue(currentCharges)
+
+    if durObj and progressBar.SetTimerDuration and Enum
+       and Enum.StatusBarTimerDirection then
+        if bar._cdNeedSet or bar._chargeHashDuration ~= durObj or not wasShown then
+            local interp = Enum.StatusBarInterpolation
+                and Enum.StatusBarInterpolation.Immediate
+            progressBar:SetTimerDuration(durObj, interp,
+                Enum.StatusBarTimerDirection.ElapsedTime)
+            bar._chargeHashDuration = durObj
+        end
+    else
+        -- Compatibility fallback for clients that expose only clean timing.
+        progressBar:SetValue(1 - (remaining / duration))
+        bar._chargeHashDuration = nil
+    end
+
+    _styleTBBChargeHashFill(bar, cfg)
+    local activating = not bar._chargeHashFillActive
+    if activating then
+        countBar:Show()
+        progressBar:Show()
+        local fillTex = bar._cachedOurFillTex
+        if not fillTex then
+            fillTex = sb:GetStatusBarTexture()
+            bar._cachedOurFillTex = fillTex
+        end
+        if fillTex then fillTex:SetAlpha(0) end
+        if bar._gradClip then bar._gradClip:Hide() end
+        clip:Show()
+    end
+    if cfg.showSpark and bar._spark then
+        -- Anchor to the actual native progress texture, not the intermediate
+        -- clip frame. Its moving edge is also the exact visible fill boundary;
+        -- avoiding the frame's pixel rounding keeps the spark physically joined
+        -- to that edge in both normal and reverse fill.
+        AnchorTBBSpark(bar, cfg, progressTexture, true)
+        if not bar._spark:IsShown() then bar._spark:Show() end
+    end
+    bar._chargeHashFillActive = true
+    bar._cdNeedSet = nil
+    return true
+end
+
+-------------------------------------------------------------------------------
 --  Cooldown-bar cast mirror. In combat the cooldown APIs keep isActive
 --  readable but turn startTime/duration SECRET, which used to drop every
 --  on-cooldown bar into the shown-full fail-open for the whole fight. So
@@ -3535,7 +3998,7 @@ function ns.UpdateCooldownCastListener()
     if tbb and tbb.bars then
         for _, cfg in ipairs(tbb.bars) do
             if cfg.enabled ~= false and cfg.trackType == "cooldown" then
-                local canon = EffectiveIconSpellID(cfg)
+                local canon = StableCooldownSpellID(cfg)
                 if canon then
                     any = true
                     -- Every form the cast event could fire with maps to the
@@ -3587,11 +4050,11 @@ SlashCmdList.TBBCD = function()
     for i, cfg in ipairs(tbb.bars) do
         if cfg.enabled ~= false and cfg.trackType == "cooldown" then
             found = true
-            local sid = EffectiveIconSpellID(cfg)
+            local sid = StableCooldownSpellID(cfg)
             local name = sid and C_Spell.GetSpellName and C_Spell.GetSpellName(sid)
             print("  bar " .. i .. " " .. tostring(name)
                 .. " saved=" .. tostring(cfg.spellID)
-                .. " effective=" .. tostring(sid)
+                .. " state=" .. tostring(sid)
                 .. " watched=" .. tostring(sid ~= nil and _cdWatch[sid] ~= nil))
             if sid then
                 print("    durCache=" .. tostring(_cdDurCache[sid])
@@ -3639,11 +4102,12 @@ SlashCmdList.TBBCD = function()
 end
 
 -------------------------------------------------------------------------------
---  Cooldown-tracking bar (cfg.trackType == "cooldown"): fill drains with the
---  spell's remaining cooldown, timer text = remaining, stacks text = current
---  charges. Ready (off cooldown / GCD-only / at max charges / spell unknown)
---  counts as INACTIVE for hideWhenInactive; a shown-but-ready bar renders
---  full with no timer.
+--  Cooldown-tracking bar (cfg.trackType == "cooldown"): the stock fill drains
+--  with the spell's remaining cooldown. Charge Hash Lines instead fill through
+--  one section per recovered charge while the timer remains the NEXT charge's
+--  remaining cooldown. Stacks text = current charges. Ready (off cooldown /
+--  GCD-only / at max charges / spell unknown) counts as INACTIVE for
+--  hideWhenInactive; a shown-but-ready bar renders full with no timer.
 --
 --  FILL SOURCE ORDER:
 --  1. Engine duration handle (C_Spell.GetSpellCooldownDuration /
@@ -3660,7 +4124,7 @@ end
 --     errors.
 -------------------------------------------------------------------------------
 local function _UpdateCooldownBar(bar, cfg)
-    local sid = EffectiveIconSpellID(cfg)  -- override/base-resolved saved id
+    local sid = StableCooldownSpellID(cfg)
 
     -- remaining/duration: CLEAN numbers only (nil = ready or secret).
     -- wantHandle: which engine duration handle drives the fill ("charge" /
@@ -3671,10 +4135,12 @@ local function _UpdateCooldownBar(bar, cfg)
     -- flag so no secret is ever branched on.
     local remaining, duration, unreadable, wantHandle, timingSecret
     local charges, chargesDisplay, hasCharges
+    local maxCharges, chargeCountValue
     if sid then
         local ch = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(sid)
         local maxCh = ch and ch.maxCharges
         if _tbbCleanNum(maxCh) and maxCh > 1 then
+            maxCharges = math.floor(maxCh + 0.5)
             -- Charge spell: bar tracks the next charge's recharge. The
             -- recharge-active flag is the same CLEAN combat signal the Max
             -- Stacks Glow uses: false only at max charges, and it stays
@@ -3687,6 +4153,7 @@ local function _UpdateCooldownBar(bar, cfg)
                 -- touching the secret currentCharges field.
                 charges = maxCh
                 chargesDisplay = maxCh
+                chargeCountValue = maxCh
                 hasCharges = true
             else
                 -- Recharging (below max).
@@ -3696,6 +4163,7 @@ local function _UpdateCooldownBar(bar, cfg)
                     charges = cur
                 end
                 chargesDisplay = cur
+                chargeCountValue = cur
                 hasCharges = true
                 local st, du = ch.cooldownStartTime, ch.cooldownDuration
                 if _tbbCleanNum(st) and _tbbCleanNum(du) and du > 0 then
@@ -3827,12 +4295,19 @@ local function _UpdateCooldownBar(bar, cfg)
 
     local onCooldown = (remaining ~= nil) or (durObj ~= nil) or unreadable
 
+    local hashChargeMode = cfg.chargeHashLines == true
+        and type(maxCharges) == "number" and maxCharges > 1
+    if bar._bar then
+        ApplyTBBChargeHashLines(bar, cfg, maxCharges)
+    end
+
     -- No pandemic concept for cooldowns; clear any stale glow from a
     -- re-purposed bar frame.
     if bar._pandemicGlowActive then ClearPandemic(bar) end
 
     if not onCooldown and cfg.hideWhenInactive ~= false then
         -- Ready = inactive: hide, matching the buff inactive branch.
+        _restoreTBBNormalFill(bar, cfg)
         bar._stackCount = 0
         if bar._stacksText then bar._stacksText:Hide() end
         bar._nameSet = nil
@@ -3845,7 +4320,14 @@ local function _UpdateCooldownBar(bar, cfg)
     local sb = bar._bar
     if sb then
         local timerDir = Enum and Enum.StatusBarTimerDirection
-        if durObj and sb.SetTimerDuration and timerDir then
+        local hashFillActive = hashChargeMode and _updateTBBChargeHashFill(
+            bar, cfg, maxCharges, chargeCountValue,
+            durObj, remaining, duration, wasShown)
+        if hashFillActive then
+            -- The composite's invisible native bars own the recovery geometry;
+            -- the visible clipped texture and spark were updated above.
+        elseif durObj and sb.SetTimerDuration and timerDir then
+            _restoreTBBNormalFill(bar, cfg)
             -- Engine-driven drain: the duration handle tracks CDR and
             -- resets live, no numbers ever read. The bar timer is re-set
             -- only when a fresh handle was fetched (event/revalidate) or
@@ -3870,6 +4352,7 @@ local function _UpdateCooldownBar(bar, cfg)
             end
             if cfg.showSpark and bar._spark then bar._spark:Show() end
         elseif remaining then
+            _restoreTBBNormalFill(bar, cfg)
             sb:SetMinMaxValues(0, duration)
             -- Smooth fill is baseline (see UpdateLustBar note).
             local smooth = _smoothCooldowns and wasShown and Enum
@@ -3882,6 +4365,7 @@ local function _UpdateCooldownBar(bar, cfg)
             end
             if cfg.showSpark and bar._spark then bar._spark:Show() end
         else
+            _restoreTBBNormalFill(bar, cfg)
             -- Ready (kept on screen) or unreadable fail-open: full bar.
             -- Plain SetValue also cancels any running bar timer.
             sb:SetMinMaxValues(0, 1)
@@ -3892,11 +4376,13 @@ local function _UpdateCooldownBar(bar, cfg)
 
     -- Timer: remaining cooldown; hidden when ready/unreadable. Clean
     -- numbers get the pretty format; a secret remaining from the duration
-    -- handle goes through SetFormattedText (accepts secrets) as whole
-    -- seconds -- no clean compare exists to pick m:ss.
+    -- handle goes through SetFormattedText (accepts secrets). Hash mode keeps
+    -- tenths visible; stock mode retains its whole-second secret display.
     if bar._timerText then
         if remaining and cfg.showTimer then
-            if remaining < 10 then
+            if hashChargeMode then
+                bar._timerText:SetFormattedText("%.1f", remaining)
+            elseif remaining < 10 then
                 bar._timerText:SetText(string.format("%.1f", remaining))
             else
                 bar._timerText:SetText(FormatTime(remaining))
@@ -3905,7 +4391,7 @@ local function _UpdateCooldownBar(bar, cfg)
         elseif cfg.showTimer and durObj and durObj.GetRemainingDuration then
             local rem = durObj:GetRemainingDuration()
             if (issecretvalue and issecretvalue(rem)) or type(rem) == "number" then
-                bar._timerText:SetFormattedText("%.0f", rem)
+                bar._timerText:SetFormattedText(hashChargeMode and "%.1f" or "%.0f", rem)
                 bar._timerText:Show()
             else
                 bar._timerText:Hide()
@@ -4364,20 +4850,22 @@ function ns.UpdateTrackedBuffBarTimers()
         end
     end
 
-    -- Spark re-anchor: use cached texture ref to avoid GetStatusBarTexture() alloc.
-    -- SetPoint on an already-anchored spark to the same anchor is a no-op internally.
+    -- Normal-fill spark maintenance. Hash-fill sparks are anchored directly by
+    -- their renderer; both paths use AnchorTBBSparkState's scalar signature so
+    -- unchanged anchors do no native layout work and allocate nothing.
     for _, bar in ipairs(tbbFrames) do
         if bar and bar._spark and bar._spark:IsShown() and bar._bar then
-            local anchor = (bar._gradientActive and bar._gradClip) or bar._cachedOurFillTex
-            if not anchor then
-                anchor = bar._bar:GetStatusBarTexture()
-                bar._cachedOurFillTex = anchor
-            end
-            if anchor then
-                bar._spark:SetPoint("CENTER", anchor,
-                    bar._lastVertical and (bar._lastReverse and "BOTTOM" or "TOP")
-                        or (bar._lastReverse and "LEFT" or "RIGHT"),
-                    bar._lastVertical and 0 or (bar._lastReverse and 1 or -1), 0)
+            if not bar._chargeHashFillActive then
+                local anchor = (bar._gradientActive and bar._gradClip)
+                    or bar._cachedOurFillTex
+                if not anchor then
+                    anchor = bar._bar:GetStatusBarTexture()
+                    bar._cachedOurFillTex = anchor
+                end
+                if anchor then
+                    AnchorTBBSparkState(bar, anchor, bar._lastVertical,
+                        bar._lastReverse, false)
+                end
             end
         end
     end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

This PR adds a setting for charge-based ability bars in CDM to show a hashline separation and cooldown per-charge, ability to customize size of hashline and color/opacity using gear icon.

## How was it tested?

8.4.7 & 8.4.9, Dev mode enabled through follower dungeons and multiple different classes/abilities.

## Screenshots


https://github.com/user-attachments/assets/9351e1ee-7b74-4d56-aecd-fe51328427f2



## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [✓ ] New settings default **OFF** (no behavior change without opt-in)
- [ ✓] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [✓ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [✓ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [✓ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client