### PR TITLE
fix: restore Assisted Highlight on action bars and CDM (broken since 8.4.6)

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7534,6 +7534,180 @@ do
     end
 end
 
+-------------------------------------------------------------------------------
+--  Assisted Combat Highlight (self-painted)
+--  Our action buttons are EABButton frames permanently removed from
+--  ActionBarButtonEventsFrame.frames (the taint fix), so Blizzard's
+--  AssistedCombatManager never builds them into its highlight-candidate list
+--  (it walks .frames once at activation). The result: the shine appeared only
+--  on a button after a mouseover (native OnActionChanged re-adds that one
+--  button to the candidate map) and never survived a reload or a mid-session
+--  CVar toggle. We paint our own shine, driven by the same AssistedCombatManager
+--  events the CDM module uses, so it is immune to that candidate-list timing.
+--  Blizzard may still show its own frame on a hovered button (candidate re-add);
+--  we defer to it there to avoid stacking two identical shines.
+-------------------------------------------------------------------------------
+do
+    local _assistGlowed = {}   -- btn -> true while showing our shine
+    local _assistInCombat = false
+    local _assistHookInstalled = false
+
+    local function AssistCVarOn()
+        return GetCVarBool and GetCVarBool("assistedCombatHighlight")
+    end
+
+    local function AssistCreate(btn)
+        local ok, hf = pcall(CreateFrame, "Frame", nil, btn, "ActionBarButtonAssistedCombatHighlightTemplate")
+        if not ok or not hf then return nil end
+        hf:SetPoint("CENTER")
+        -- Freeze on a single flipbook frame until we actually animate (in combat).
+        if hf.Flipbook and hf.Flipbook.Anim then
+            hf.Flipbook.Anim:Play()
+            hf.Flipbook.Anim:Stop()
+        end
+        hf:Hide()
+        return hf
+    end
+
+    local function AssistHide(btn)
+        local hf = EFD(btn).assistHL
+        if not hf then return end
+        if hf.Flipbook and hf.Flipbook.Anim then hf.Flipbook.Anim:Stop() end
+        hf:Hide()
+    end
+
+    local function AssistShow(btn)
+        local fd = EFD(btn)
+        local hf = fd.assistHL
+        if not hf then
+            hf = AssistCreate(btn)
+            if not hf then return end
+            fd.assistHL = hf
+        end
+        local w = btn:GetWidth() or 45
+        hf:SetScale(w / 45)
+        hf:Show()
+        if hf.Flipbook and hf.Flipbook.Anim then
+            if _assistInCombat then hf.Flipbook.Anim:Play() else hf.Flipbook.Anim:Stop() end
+        end
+    end
+
+    -- The (spell) id a button currently represents, mirroring Blizzard's
+    -- AssistedCombatManager:GetActionButtonSpellForAssistedHighlight.
+    local function ButtonSpell(btn)
+        local action = btn.action
+        if action == nil and btn.GetAttribute then action = btn:GetAttribute("action") end
+        if action == nil then return nil end
+        local atype, id, subType = GetActionInfo(action)
+        if atype == "spell" and subType ~= "assistedcombat" then
+            return id
+        elseif atype == "macro" and subType == "spell" then
+            return id
+        end
+        return nil
+    end
+
+    local function UpdateAssistHighlights()
+        if not AssistCVarOn() then
+            for btn in pairs(_assistGlowed) do
+                AssistHide(btn)
+                _assistGlowed[btn] = nil
+            end
+            return
+        end
+        local suggested = C_AssistedCombat and C_AssistedCombat.GetNextCastSpell
+            and C_AssistedCombat.GetNextCastSpell()
+        local newSet = {}
+        if suggested then
+            -- Match base ids in both directions (button or suggestion may hold
+            -- either the base or an override), same as the CDM side. sid > 0
+            -- guards item/macro pseudo-ids out of GetBaseSpell.
+            local GetBaseSpell = C_Spell and C_Spell.GetBaseSpell
+            local suggestedBase = (GetBaseSpell and GetBaseSpell(suggested)) or suggested
+            for _, info in ipairs(BAR_CONFIG) do
+                if not info.isStance and not info.isPetBar then
+                    local buttons = barButtons[info.key]
+                    if buttons then
+                        for i = 1, #buttons do
+                            local btn = buttons[i]
+                            if btn and btn:IsShown() then
+                                local sid = ButtonSpell(btn)
+                                if sid then
+                                    local match = (sid == suggested) or (sid == suggestedBase)
+                                    if not match and GetBaseSpell and sid > 0 then
+                                        match = GetBaseSpell(sid) == suggestedBase
+                                    end
+                                    if match then
+                                        local bf = btn.AssistedCombatHighlightFrame
+                                        if bf and bf:IsShown() then
+                                            AssistHide(btn)  -- Blizzard's covers it
+                                        else
+                                            AssistShow(btn)
+                                        end
+                                        newSet[btn] = true
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+        for btn in pairs(_assistGlowed) do
+            if not newSet[btn] then AssistHide(btn) end
+        end
+        _assistGlowed = newSet
+    end
+    ns.UpdateAssistHighlights = UpdateAssistHighlights
+
+    local function SyncAssistCombat()
+        _assistInCombat = (InCombatLockdown() or UnitAffectingCombat("player")) and true or false
+        for btn in pairs(_assistGlowed) do
+            local hf = EFD(btn).assistHL
+            if hf and hf:IsShown() and hf.Flipbook and hf.Flipbook.Anim then
+                if _assistInCombat then
+                    if not hf.Flipbook.Anim:IsPlaying() then hf.Flipbook.Anim:Play() end
+                else
+                    if hf.Flipbook.Anim:IsPlaying() then hf.Flipbook.Anim:Stop() end
+                end
+            end
+        end
+    end
+
+    local function InstallAssistHook()
+        if _assistHookInstalled then return end
+        _assistHookInstalled = true
+        SyncAssistCombat()
+        if EventRegistry and EventRegistry.RegisterCallback then
+            EventRegistry:RegisterCallback("AssistedCombatManager.OnAssistedHighlightSpellChange", function()
+                UpdateAssistHighlights()
+            end, "EAB_AssistHighlight")
+            -- Fires when the assistedCombatHighlight CVar is toggled at runtime.
+            EventRegistry:RegisterCallback("AssistedCombatManager.OnSetUseAssistedHighlight", function()
+                UpdateAssistHighlights()
+            end, "EAB_AssistHighlight_CVar")
+        end
+        if AssistedCombatManager and AssistedCombatManager.UpdateAllAssistedHighlightFramesForSpell then
+            hooksecurefunc(AssistedCombatManager, "UpdateAllAssistedHighlightFramesForSpell", function()
+                UpdateAssistHighlights()
+            end)
+        end
+        local cf = CreateFrame("Frame")
+        cf:RegisterEvent("PLAYER_REGEN_ENABLED")
+        cf:RegisterEvent("PLAYER_REGEN_DISABLED")
+        cf:RegisterEvent("PLAYER_ENTERING_WORLD")
+        cf:SetScript("OnEvent", function(_, event)
+            if event == "PLAYER_ENTERING_WORLD" then
+                UpdateAssistHighlights()
+            else
+                SyncAssistCombat()
+            end
+        end)
+        UpdateAssistHighlights()
+    end
+    InstallAssistHook()
+end
+
 function EAB:RefreshProcGlows()
     for _, info in ipairs(BAR_CONFIG) do
         local buttons = barButtons[info.key]

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2731,6 +2731,12 @@ do
         -- per-button overhead. With 60 populated buttons, the mixin path
         -- caused visible frame drops on high-frequency events.
         dispatcher:SetScript("OnEvent", function(_, event, arg1)
+            -- Assisted shine follows slot contents; coalesced (storm-safe),
+            -- and belt-and-braces vs. the OnActionChanged callback -- an
+            -- in-combat Update() abort dies before Blizzard's TriggerEvent.
+            if event == "ACTIONBAR_SLOT_CHANGED" and ns.QueueAssistRescan then
+                ns.QueueAssistRescan()
+            end
             for _, info in ipairs(BAR_CONFIG) do
                 if not info.isStance and not info.isPetBar then
                     local btns = barButtons[info.key]
@@ -7560,6 +7566,9 @@ do
         local ok, hf = pcall(CreateFrame, "Frame", nil, btn, "ActionBarButtonAssistedCombatHighlightTemplate")
         if not ok or not hf then return nil end
         hf:SetPoint("CENTER")
+        -- Above the cooldown swipe, border frame, glowOverlay (+6) and proc
+        -- alerts -- same margin the CDM twin uses.
+        hf:SetFrameLevel(btn:GetFrameLevel() + 15)
         -- Freeze on a single flipbook frame until we actually animate (in combat).
         if hf.Flipbook and hf.Flipbook.Anim then
             hf.Flipbook.Anim:Play()
@@ -7586,6 +7595,8 @@ do
         end
         local w = btn:GetWidth() or 45
         hf:SetScale(w / 45)
+        -- Re-assert: bar layout can change the button's frame level after create.
+        hf:SetFrameLevel(btn:GetFrameLevel() + 15)
         hf:Show()
         if hf.Flipbook and hf.Flipbook.Anim then
             if _assistInCombat then hf.Flipbook.Anim:Play() else hf.Flipbook.Anim:Stop() end
@@ -7594,9 +7605,12 @@ do
 
     -- The (spell) id a button currently represents, mirroring Blizzard's
     -- AssistedCombatManager:GetActionButtonSpellForAssistedHighlight.
+    -- Attribute first: the secure paging writes the "action" attribute and it
+    -- is the authoritative slot (see ForceCooldownPaint's note); btn.action is
+    -- a derived mirror.
     local function ButtonSpell(btn)
-        local action = btn.action
-        if action == nil and btn.GetAttribute then action = btn:GetAttribute("action") end
+        local action = btn.GetAttribute and btn:GetAttribute("action")
+        if action == nil then action = btn.action end
         if action == nil then return nil end
         local atype, id, subType = GetActionInfo(action)
         if atype == "spell" and subType ~= "assistedcombat" then
@@ -7660,6 +7674,21 @@ do
     end
     ns.UpdateAssistHighlights = UpdateAssistHighlights
 
+    -- Coalesced re-run: OnActionChanged fires per button on page swaps and
+    -- SLOT_CHANGED storms dozens of times per second (mouseover-conditional
+    -- macros re-resolving); one pending flag collapses a burst into a single
+    -- next-frame pass.
+    local _assistRescanPending = false
+    local function QueueAssistRescan()
+        if _assistRescanPending then return end
+        _assistRescanPending = true
+        C_Timer.After(0, function()
+            _assistRescanPending = false
+            UpdateAssistHighlights()
+        end)
+    end
+    ns.QueueAssistRescan = QueueAssistRescan
+
     local function SyncAssistCombat()
         _assistInCombat = (InCombatLockdown() or UnitAffectingCombat("player")) and true or false
         for btn in pairs(_assistGlowed) do
@@ -7679,18 +7708,22 @@ do
         _assistHookInstalled = true
         SyncAssistCombat()
         if EventRegistry and EventRegistry.RegisterCallback then
+            -- No hooksecurefunc on UpdateAllAssistedHighlightFramesForSpell:
+            -- the manager calls it then fires this event right after, so a
+            -- hook would run the full walk twice per suggestion change.
             EventRegistry:RegisterCallback("AssistedCombatManager.OnAssistedHighlightSpellChange", function()
-                UpdateAssistHighlights()
+                QueueAssistRescan()
             end, "EAB_AssistHighlight")
             -- Fires when the assistedCombatHighlight CVar is toggled at runtime.
             EventRegistry:RegisterCallback("AssistedCombatManager.OnSetUseAssistedHighlight", function()
-                UpdateAssistHighlights()
+                QueueAssistRescan()
             end, "EAB_AssistHighlight_CVar")
-        end
-        if AssistedCombatManager and AssistedCombatManager.UpdateAllAssistedHighlightFramesForSpell then
-            hooksecurefunc(AssistedCombatManager, "UpdateAllAssistedHighlightFramesForSpell", function()
-                UpdateAssistHighlights()
-            end)
+            -- Page swaps / drags / hover re-candidacy: the suggestion may not
+            -- change, but which button holds it (or whether Blizzard shows its
+            -- own frame on a hovered button) does. Same signal Blizzard uses.
+            EventRegistry:RegisterCallback("ActionButton.OnActionChanged", function()
+                QueueAssistRescan()
+            end, "EAB_AssistHighlight_Action")
         end
         local cf = CreateFrame("Frame")
         cf:RegisterEvent("PLAYER_REGEN_ENABLED")
@@ -7698,6 +7731,7 @@ do
         cf:RegisterEvent("PLAYER_ENTERING_WORLD")
         cf:SetScript("OnEvent", function(_, event)
             if event == "PLAYER_ENTERING_WORLD" then
+                SyncAssistCombat()
                 UpdateAssistHighlights()
             else
                 SyncAssistCombat()

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -779,54 +779,11 @@ do
     -- slot, so our own dispatch can't paint their cooldown; only Blizzard's
     -- native update, driven by this broadcaster, can).
     local _vehNeed, _extraNeed, _broadcasterActive = false, false, false
-    -- Our buttons' entries in ActionBarButtonEventsFrame.frames are stripped
-    -- only WHILE the broadcaster dispatches, and restored (same keys, never
-    -- tremove) when it goes quiet. The taint problem the strip solves -- the
-    -- dispatch loop reading our tainted entry and running the button's whole
-    -- mixin OnEvent tainted (see the note at button setup) -- only exists
-    -- while the broadcaster has events registered. Outside that window the
-    -- entries must stay: AssistedCombatManager builds its assisted-highlight
-    -- candidate list by walking .frames once at activation, so a permanent
-    -- strip left our buttons unable to show the assisted shine after a
-    -- reload (only a native OnEnter re-added the hovered button).
-    -- _abefOwned is filled at button setup; the stash remembers what we
-    -- removed so deactivation restores exactly that.
-    ns._abefOwned = {}
-    local _abefStripped = {}
-    local function StripOwnedFrames()
-        local frames = ActionBarButtonEventsFrame
-            and type(ActionBarButtonEventsFrame.frames) == "table"
-            and ActionBarButtonEventsFrame.frames
-        if not frames then return end
-        local owned = ns._abefOwned
-        for k, f in pairs(frames) do
-            if owned[f] then
-                _abefStripped[k] = f
-                frames[k] = nil
-            end
-        end
-    end
-    -- For buttons set up while the broadcaster is already live (bar enabled
-    -- mid-vehicle): strip immediately, stash for the eventual restore.
-    ns._abefStripIfActive = function(btn)
-        if not _broadcasterActive then return end
-        local frames = ActionBarButtonEventsFrame
-            and type(ActionBarButtonEventsFrame.frames) == "table"
-            and ActionBarButtonEventsFrame.frames
-        if not frames then return end
-        for k, f in pairs(frames) do
-            if f == btn then
-                _abefStripped[k] = f
-                frames[k] = nil
-            end
-        end
-    end
     local function ApplyBroadcaster()
         local want = _vehNeed or _extraNeed
         if want == _broadcasterActive then return end
         _broadcasterActive = want
         if want then
-            StripOwnedFrames()
             if ActionBarButtonEventsFrame then
                 for _, ev in ipairs(_abefEvents) do
                     ActionBarButtonEventsFrame:RegisterEvent(ev)
@@ -840,15 +797,6 @@ do
         else
             if ActionBarButtonEventsFrame then ActionBarButtonEventsFrame:UnregisterAllEvents() end
             if ActionBarActionEventsFrame then ActionBarActionEventsFrame:UnregisterAllEvents() end
-            local frames = ActionBarButtonEventsFrame
-                and type(ActionBarButtonEventsFrame.frames) == "table"
-                and ActionBarButtonEventsFrame.frames
-            if frames then
-                for k, f in pairs(_abefStripped) do
-                    if frames[k] == nil then frames[k] = f end
-                end
-            end
-            wipe(_abefStripped)
         end
     end
     -- Recompute both needs from ground truth -- the actual visibility of the
@@ -1752,16 +1700,16 @@ local function GetOrCreateButton(slot, parent, info, index, skipProtected)
         -- resolves the method at fire time -- a replacement function of ours
         -- is a tainted value and would taint EVERY per-button event dispatch
         -- (per-button cooldown updates only work because they start secure).
-        -- Instead the entry is removed from the broadcaster's list -- but only
-        -- WHILE the broadcaster is live (see ApplyBroadcaster): a permanent
-        -- removal here broke the assisted-combat shine, because
-        -- AssistedCombatManager builds its highlight-candidate list by walking
-        -- this table. Here we just mark the button as ours; ApplyBroadcaster
-        -- strips/restores around the vehicle/extra-button windows (nil-out in
-        -- place, never tremove -- shifting would rewrite later Blizzard-owned
-        -- entries as tainted values).
-        if ns._abefOwned then ns._abefOwned[btn] = true end
-        if ns._abefStripIfActive then ns._abefStripIfActive(btn) end
+        -- Instead, remove our entry from the broadcaster's list: nil it out
+        -- in place (never tremove -- shifting would rewrite later
+        -- Blizzard-owned entries as tainted values). The button loses
+        -- nothing: every event it needs is self-registered
+        -- (BUTTON_EVENT_LISTS) or handled by the central dispatcher.
+        if ActionBarButtonEventsFrame and type(ActionBarButtonEventsFrame.frames) == "table" then
+            for k, f in pairs(ActionBarButtonEventsFrame.frames) do
+                if f == btn then ActionBarButtonEventsFrame.frames[k] = nil end
+            end
+        end
         -- Desaturate-on-cooldown / on-CD alpha: re-evaluate the icon's visual
         -- state the moment the main cooldown display completes. The
         -- SetDesaturation/SetAlpha writes are static between events, so

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -779,11 +779,54 @@ do
     -- slot, so our own dispatch can't paint their cooldown; only Blizzard's
     -- native update, driven by this broadcaster, can).
     local _vehNeed, _extraNeed, _broadcasterActive = false, false, false
+    -- Our buttons' entries in ActionBarButtonEventsFrame.frames are stripped
+    -- only WHILE the broadcaster dispatches, and restored (same keys, never
+    -- tremove) when it goes quiet. The taint problem the strip solves -- the
+    -- dispatch loop reading our tainted entry and running the button's whole
+    -- mixin OnEvent tainted (see the note at button setup) -- only exists
+    -- while the broadcaster has events registered. Outside that window the
+    -- entries must stay: AssistedCombatManager builds its assisted-highlight
+    -- candidate list by walking .frames once at activation, so a permanent
+    -- strip left our buttons unable to show the assisted shine after a
+    -- reload (only a native OnEnter re-added the hovered button).
+    -- _abefOwned is filled at button setup; the stash remembers what we
+    -- removed so deactivation restores exactly that.
+    ns._abefOwned = {}
+    local _abefStripped = {}
+    local function StripOwnedFrames()
+        local frames = ActionBarButtonEventsFrame
+            and type(ActionBarButtonEventsFrame.frames) == "table"
+            and ActionBarButtonEventsFrame.frames
+        if not frames then return end
+        local owned = ns._abefOwned
+        for k, f in pairs(frames) do
+            if owned[f] then
+                _abefStripped[k] = f
+                frames[k] = nil
+            end
+        end
+    end
+    -- For buttons set up while the broadcaster is already live (bar enabled
+    -- mid-vehicle): strip immediately, stash for the eventual restore.
+    ns._abefStripIfActive = function(btn)
+        if not _broadcasterActive then return end
+        local frames = ActionBarButtonEventsFrame
+            and type(ActionBarButtonEventsFrame.frames) == "table"
+            and ActionBarButtonEventsFrame.frames
+        if not frames then return end
+        for k, f in pairs(frames) do
+            if f == btn then
+                _abefStripped[k] = f
+                frames[k] = nil
+            end
+        end
+    end
     local function ApplyBroadcaster()
         local want = _vehNeed or _extraNeed
         if want == _broadcasterActive then return end
         _broadcasterActive = want
         if want then
+            StripOwnedFrames()
             if ActionBarButtonEventsFrame then
                 for _, ev in ipairs(_abefEvents) do
                     ActionBarButtonEventsFrame:RegisterEvent(ev)
@@ -797,6 +840,15 @@ do
         else
             if ActionBarButtonEventsFrame then ActionBarButtonEventsFrame:UnregisterAllEvents() end
             if ActionBarActionEventsFrame then ActionBarActionEventsFrame:UnregisterAllEvents() end
+            local frames = ActionBarButtonEventsFrame
+                and type(ActionBarButtonEventsFrame.frames) == "table"
+                and ActionBarButtonEventsFrame.frames
+            if frames then
+                for k, f in pairs(_abefStripped) do
+                    if frames[k] == nil then frames[k] = f end
+                end
+            end
+            wipe(_abefStripped)
         end
     end
     -- Recompute both needs from ground truth -- the actual visibility of the
@@ -1700,16 +1752,16 @@ local function GetOrCreateButton(slot, parent, info, index, skipProtected)
         -- resolves the method at fire time -- a replacement function of ours
         -- is a tainted value and would taint EVERY per-button event dispatch
         -- (per-button cooldown updates only work because they start secure).
-        -- Instead, remove our entry from the broadcaster's list: nil it out
-        -- in place (never tremove -- shifting would rewrite later
-        -- Blizzard-owned entries as tainted values). The button loses
-        -- nothing: every event it needs is self-registered
-        -- (BUTTON_EVENT_LISTS) or handled by the central dispatcher.
-        if ActionBarButtonEventsFrame and type(ActionBarButtonEventsFrame.frames) == "table" then
-            for k, f in pairs(ActionBarButtonEventsFrame.frames) do
-                if f == btn then ActionBarButtonEventsFrame.frames[k] = nil end
-            end
-        end
+        -- Instead the entry is removed from the broadcaster's list -- but only
+        -- WHILE the broadcaster is live (see ApplyBroadcaster): a permanent
+        -- removal here broke the assisted-combat shine, because
+        -- AssistedCombatManager builds its highlight-candidate list by walking
+        -- this table. Here we just mark the button as ours; ApplyBroadcaster
+        -- strips/restores around the vehicle/extra-button windows (nil-out in
+        -- place, never tremove -- shifting would rewrite later Blizzard-owned
+        -- entries as tainted values).
+        if ns._abefOwned then ns._abefOwned[btn] = true end
+        if ns._abefStripIfActive then ns._abefStripIfActive(btn) end
         -- Desaturate-on-cooldown / on-CD alpha: re-evaluate the icon's visual
         -- state the moment the main cooldown display completes. The
         -- SetDesaturation/SetAlpha writes are static between events, so

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8131,21 +8131,31 @@ local function UpdateRotationHighlights()
 
     local newSet = {}
     if suggestedSpell then
-        -- Icons store BASE spell ids while GetNextCastSpell returns the
-        -- OVERRIDE (e.g. Maul stored, Raze suggested). Resolve the
-        -- suggestion's base ONCE per pass instead of querying an override
-        -- per icon -- this runs every assisted-highlight change in combat.
-        local suggestedBase = C_Spell and C_Spell.GetBaseSpell
-            and C_Spell.GetBaseSpell(suggestedSpell)
-        if suggestedBase == suggestedSpell then suggestedBase = nil end
+        -- A CDM icon and GetNextCastSpell can each hold EITHER the base or an
+        -- override spell id (e.g. Maul <-> Raze), and which side is which
+        -- varies by spec. The old code only resolved the suggestion's base and
+        -- compared it to the stored id, so it matched "icon=base, suggested=
+        -- override" but missed the reverse ("icon=override, suggested=base"),
+        -- leaving those icons un-highlighted. Compare on base ids in BOTH
+        -- directions. This is strictly a superset of the old exact-id match, so
+        -- anything that highlighted before still does.
+        local GetBaseSpell = C_Spell and C_Spell.GetBaseSpell
+        local suggestedBase = (GetBaseSpell and GetBaseSpell(suggestedSpell)) or suggestedSpell
         for _, icons in pairs(cdmBarIcons) do
             for _, icon in ipairs(icons) do
                 local ifc = _ecmeFC[icon]
                 local sid = ifc and ifc.spellID
-                if sid and (sid == suggestedSpell or (suggestedBase and sid == suggestedBase))
-                   and icon:IsShown() then
-                    _rotShow(icon)
-                    newSet[icon] = true
+                if sid and icon:IsShown() then
+                    -- Direct/base match first (cheap); only resolve the icon's
+                    -- own base if those miss, to keep the common path light.
+                    local match = (sid == suggestedSpell) or (sid == suggestedBase)
+                    if not match and GetBaseSpell then
+                        match = GetBaseSpell(sid) == suggestedBase
+                    end
+                    if match then
+                        _rotShow(icon)
+                        newSet[icon] = true
+                    end
                 end
             end
         end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8148,8 +8148,10 @@ local function UpdateRotationHighlights()
                 if sid and icon:IsShown() then
                     -- Direct/base match first (cheap); only resolve the icon's
                     -- own base if those miss, to keep the common path light.
+                    -- sid > 0: item/trinket icons store -itemID / -13 / -14,
+                    -- which must not be fed to GetBaseSpell.
                     local match = (sid == suggestedSpell) or (sid == suggestedBase)
-                    if not match and GetBaseSpell then
+                    if not match and GetBaseSpell and sid > 0 then
                         match = GetBaseSpell(sid) == suggestedBase
                     end
                     if match then


### PR DESCRIPTION
## Summary

Blizzard's **Assisted Highlight** (one-button-assist shine) stopped working on action bars in v8.4.6+ (worked in 8.4.5). Testers reported: no shine after login/reload; it only appeared on a button after mousing over it, and vanished again after every `/reload`. A later repro narrowed it further: toggling Assisted Highlight ON mid-session lit CDM icons but not the action bar.

**Verified in-game by testers: action bar shine now works on login, reload, and mid-session toggle.**

## Root cause

v8.4.6 started permanently removing EUI's action buttons (`EABButton` frames) from `ActionBarButtonEventsFrame.frames` at setup - a legitimate taint fix for the broadcaster dispatch loop. But Blizzard's `AssistedCombatManager` builds its highlight-candidate list by walking exactly that table, once, at activation (`BuildAssistedHighlightCandidateActionButtonsList` via `ForEachFrame`). Stripped buttons are never candidates, so they never shine. Mouseover "fixed" one button per session because native `OnEnter` fires `ActionButton.OnActionChanged`, which re-adds that single button to the candidate map.

Re-adding our buttons to `.frames` around broadcaster windows was tried first (commits `70c4df7c`/`58aa589d`, since reverted): it fixed reload but not the mid-session CVar toggle, because Blizzard builds candidates **before** firing `OnSetUseAssistedHighlight`, so no addon callback can reliably inject buttons into that build.

## Fix

**Action bars now paint their own shine** (same proven pattern as the CDM rotation-helper integration):

- Gated on the `assistedCombatHighlight` CVar; suggested spell from `C_AssistedCombat.GetNextCastSpell()`.
- Per-button match via the secure `action` attribute (authoritative slot) -> `GetActionInfo`, comparing base spell ids in both directions (handles base-vs-override in either position, e.g. Maul/Raze).
- Shine is a frame from Blizzard's own `ActionBarButtonAssistedCombatHighlightTemplate`, parented to the button at frame level +15 (above cooldown swipe/proc alerts), stored in EUI's external frame-data table (no tainted writes on the secure button). Flipbook animates only in combat, matching Blizzard.
- Driven by `AssistedCombatManager.OnAssistedHighlightSpellChange` / `OnSetUseAssistedHighlight` / `ActionButton.OnActionChanged` EventRegistry callbacks plus `PLAYER_ENTERING_WORLD` and the central dispatcher's `ACTIONBAR_SLOT_CHANGED` branch - all coalesced into one next-frame pass (storm-safe against mouseover-conditional macro re-resolution).
- When Blizzard shows its own frame on a hovered button, ours defers to it (no double shine).
- The permanent `.frames` strip (the 8.4.6 taint fix) stays exactly as it was.

**CDM side** (two small hardening commits):
- Rotation-helper match now compares base ids in both directions (previously only the suggestion's base was resolved, so an icon storing the override spell while the suggestion returned the base never lit). Strict superset of the old match.
- Guard item/trinket pseudo-ids (`-itemID`, `-13`, `-14`) out of `C_Spell.GetBaseSpell`.

## Commits

- `aa270ef6` fix(cdm): match rotation-helper glow when icon holds the override spell
- `70c4df7c` / `58aa589d` - `.frames` juggling approach, tried and reverted (see root cause)
- `f87ce2b9` fix(cdm): don't feed item/trinket pseudo-ids to GetBaseSpell
- `d069410d` fix(actionbars): self-paint assisted-combat highlight
- `35b433cd` fix(actionbars): apply review findings (frame level, coalesced re-run on action changes, drop redundant hook, attribute-first accessor)

## Testing

In-game tester confirmation on the final build: shine appears on action bars without mouseover after login and after `/reload`, and appears immediately when Assisted Highlight is toggled ON mid-session (the case that previously required a reload). CDM icons highlight as before. Hovering the suggested button shows a single shine.
