### PR TITLE
Fix: Quest tracker top padding

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -822,28 +822,27 @@ local function ProcessBlockChildren(frame, depth)
 
 end
 
--- Weak-keyed so pooled/recycled poiButtons don't leak or get double-hooked.
-local _hookedPOIButtons = setmetatable({}, { __mode = "k" })
+-- Suppress a POI button permanently. Hooks Show + SetAlpha so Blizzard
+-- can never make it visible again. The _euiSuppressed flag is on the
+-- frame object itself, so it persists even if the button is pooled.
+local _poiHiddenParent = CreateFrame("Frame")
+_poiHiddenParent:Hide()
 
 local function SuppressPOI(block)
+    -- "Show Quest Icons" on: leave Blizzard's native POI button visible and
+    -- skip installing the keep-hidden hook entirely. Reload-gated, so this is
+    -- read fresh per block; no live un-suppression needed.
     if EQT.Cfg("showQuestIcons") then return end
     local pb = block and block.poiButton
-    if not pb then return end
-    if pb:IsShown() then pb:Hide() end
+    if not pb or EllesmereUI._GetFFD(pb).suppressed then return end
+    EllesmereUI._GetFFD(pb).suppressed = true
+    pb:SetParent(_poiHiddenParent)
     pb:EnableMouse(false)
-
-    -- Re-hide synchronously whenever Blizzard shows this button again (e.g.
-    -- on SUPER_TRACKING_CHANGED from clicking a quest) so there's no visible
-    -- flash before the next SkinBlock/suppression pass. Hide() only, never
-    -- SetParent -- that's the taint-safe version of this pattern (see
-    -- InstallShowHook's otf Show-hook above, which does the same thing).
-    if not _hookedPOIButtons[pb] then
-        _hookedPOIButtons[pb] = true
-        hooksecurefunc(pb, "Show", function(self)
-            if EQT.Cfg("showQuestIcons") then return end
-            self:Hide()
-        end)
-    end
+    hooksecurefunc(pb, "SetParent", function(self, parent)
+        if parent ~= _poiHiddenParent then
+            self:SetParent(_poiHiddenParent)
+        end
+    end)
 end
 
 local function SkinBlock(block)
@@ -980,6 +979,34 @@ local function SkinExistingBlocks(tracker)
 end
 
 -------------------------------------------------------------------------------
+-- Blizzard anchors whichever module currently sits in the top slot with a
+-- fixed TOP/TOP offset relative to ObjectiveTrackerFrame. Verified via /dump
+-- across QuestObjectiveTracker and ProfessionsRecipeTracker: always -38,
+-- independent of module type and independent of Header's height (ruled out
+-- separately). We tighten this gap after each layout pass.
+-------------------------------------------------------------------------------
+local TOP_ANCHOR_OFFSET = -6  -- ASSUMPTION: Startwert, per Auge nachjustieren
+-- Shared with EllesmereUIQuestTracker_Visibility.lua (BG/top-divider offset)
+-- so both files derive the top gap from a single source instead of two
+-- independent magic numbers drifting apart.
+EQT.TOP_ANCHOR_OFFSET = TOP_ANCHOR_OFFSET
+
+local function TightenTopAnchor(tracker)
+    if not tracker or not tracker.GetPoint or not tracker.SetPoint then return end
+    if InCombatLockdown and InCombatLockdown() then return end
+    -- Nicht während Blizzards Collapse/Expand-Slide-Animation eingreifen,
+    -- sonst kollidiert unser SetPoint mit ObjectiveTrackerSlidingMixin.
+    if tracker.IsSliding and tracker:IsSliding() then return end
+
+    local point, relativeTo, relativePoint, xOfs, yOfs = tracker:GetPoint(1)
+    if point == "TOP" and relativePoint == "TOP" and relativeTo == _G.ObjectiveTrackerFrame then
+        if yOfs and math.abs(yOfs - TOP_ANCHOR_OFFSET) > 0.01 then
+            tracker:SetPoint("TOP", relativeTo, "TOP", xOfs or 0, TOP_ANCHOR_OFFSET)
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
 -- Hook a single sub-tracker.
 -------------------------------------------------------------------------------
 local function HookTracker(tracker)
@@ -1039,6 +1066,7 @@ local function HookTracker(tracker)
                 if ShouldSkipSkin() then return end
             
                 if tracker.Header then EnsureAccentDivider(tracker.Header) end
+                TightenTopAnchor(tracker)
                 if EQT.QueueResize then EQT.QueueResize() end
                 if tracker.usedBlocks then
                     for _, byTemplate in pairs(tracker.usedBlocks) do
@@ -1131,7 +1159,11 @@ function EQT.InitSkin()
         end
         if otf.Header and otf.Header ~= headerMenu then
             otf.Header:Hide()
-            otf.Header:HookScript("OnShow", function(self) self:Hide() end)
+            if otf.Header.SetHeight then otf.Header:SetHeight(0.001) end
+            otf.Header:HookScript("OnShow", function(self)
+                self:Hide()
+                if self.SetHeight then self:SetHeight(0.001) end
+            end)
         end
         -- Strip the parchment / nine-slice background behind the whole tracker.
         if otf.NineSlice then otf.NineSlice:Hide() end

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -1007,6 +1007,47 @@ local function TightenTopAnchor(tracker)
 end
 
 -------------------------------------------------------------------------------
+-- Short-lived per-frame anchor poller. Diagnostic logging (see chat history /
+-- PR notes) showed two things: (1) the TOP/TOP anchor is NOT set yet at the
+-- moment tracker:Update() returns -- GetPoint(1) returns nil/nil right then,
+-- so a synchronous TightenTopAnchor call in the Update hook is a permanent
+-- no-op for this anchor; the real -38 value only exists on the next frame.
+-- (2) Blizzard can fire several independent native Update() passes within
+-- ~0.2s of a single quest interaction (observed: 4 in ~208ms), each
+-- resetting the anchor to -38 again. A single next-frame correction per
+-- burst chased each reset individually and never caught up during the
+-- burst -- visible as the tracker repeatedly dropping back to -38 for that
+-- whole window.
+--
+-- This frame is OUR OWN (never Blizzard's -- respects "never SetScript on
+-- tracker frames"). Its OnUpdate runs every frame for a short window after
+-- any native Update(), re-tightening the anchor before that frame renders
+-- instead of one frame late. TightenTopAnchor() itself is unchanged and
+-- still cheap (GetPoint + early-return unless off by >0.01), so polling it
+-- every frame for a bounded window is negligible cost.
+-------------------------------------------------------------------------------
+local _anchorPoller = CreateFrame("Frame")
+local _pollUntil = 0
+local _pollTrackers = nil  -- set by EQT.InitSkin() once EachTracker exists
+_anchorPoller:Hide()
+_anchorPoller:SetScript("OnUpdate", function()
+    if GetTime() > _pollUntil then
+        _anchorPoller:Hide()
+        return
+    end
+    if _pollTrackers then _pollTrackers() end
+end)
+
+-- Extends (or starts) the poll window. Called from the Update hook below on
+-- every native Update() so any burst of resets stays covered until it goes
+-- quiet for POLL_WINDOW seconds.
+local POLL_WINDOW = 0.4
+local function StartAnchorPoll()
+    _pollUntil = GetTime() + POLL_WINDOW
+    if not _anchorPoller:IsShown() then _anchorPoller:Show() end
+end
+
+-------------------------------------------------------------------------------
 -- Hook a single sub-tracker.
 -------------------------------------------------------------------------------
 local function HookTracker(tracker)
@@ -1059,7 +1100,15 @@ local function HookTracker(tracker)
     local _updateDirty = false
     if tracker.Update then
         hooksecurefunc(tracker, "Update", function()
-            if ShouldSkipSkin() or _updateDirty then return end
+            if ShouldSkipSkin() then return end
+            -- The synchronous TightenTopAnchor call that used to live here
+            -- was removed: diagnostic logging proved it always ran before
+            -- Blizzard assigns the anchor (GetPoint(1) still nil at that
+            -- point), so it never corrected anything. StartAnchorPoll()
+            -- keeps the per-frame poller alive instead, which is the thing
+            -- that actually catches the reset once Blizzard sets it.
+            StartAnchorPoll()
+            if _updateDirty then return end
             _updateDirty = true
             C_Timer.After(0, function()
                 _updateDirty = false
@@ -1078,6 +1127,23 @@ local function HookTracker(tracker)
                     end
                 end
             end)
+        end)
+    end
+
+    -- ObjectiveTrackerSlidingMixin (SUPER_TRACKING_CHANGED can trigger a
+    -- reorder slide, not just collapse/expand) calls tracker:OnEndSlide()
+    -- from EndSlide() right after clearing slideInfo -- i.e. exactly when
+    -- IsSliding() flips back to false. TightenTopAnchor bails out entirely
+    -- while IsSliding() is true (see comment there), so without this hook
+    -- the anchor sits at Blizzard's untightened -38 for the ~0.2-0.3s slide
+    -- duration and only snaps to TOP_ANCHOR_OFFSET on the next Update() call,
+    -- which is what showed up as the whole tracker shifting down briefly on
+    -- quest click. Verified against Blizzard_ObjectiveTrackerShared.lua:
+    -- EndSlide() -> self.slideInfo = nil -> self:OnEndSlide(...).
+    if tracker.OnEndSlide then
+        hooksecurefunc(tracker, "OnEndSlide", function(self)
+            if ShouldSkipSkin() then return end
+            TightenTopAnchor(self)
         end)
     end
 
@@ -1168,6 +1234,15 @@ function EQT.InitSkin()
         -- Strip the parchment / nine-slice background behind the whole tracker.
         if otf.NineSlice then otf.NineSlice:Hide() end
         StripTextures(otf)
+    end
+
+    -- Wire the anchor poller's tracker walk now that EachTracker exists.
+    -- Skips shared-widget-pool trackers, same as the rest of this module.
+    _pollTrackers = function()
+        EachTracker(function(t)
+            if SharesWidgetPool(t) then return end
+            TightenTopAnchor(t)
+        end)
     end
 
     EachTracker(HookTracker)

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
@@ -26,6 +26,14 @@ local _bgFrame
 
 local function GetTracker() return _G.ObjectiveTrackerFrame end
 
+-- Shared with EllesmereUIQuestTracker_Skin.lua's TightenTopAnchor: the BG
+-- and top accent divider must start at the same Y offset the content's top
+-- module is anchored to, otherwise the divider renders inside/below the
+-- first block instead of above it. Fallback matches Skin.lua's default.
+local function TopGapOffset()
+    return EQT.TOP_ANCHOR_OFFSET or -6
+end
+
 -------------------------------------------------------------------------------
 -- Top-level collapse / expand via SetParent. No child recursion.
 -------------------------------------------------------------------------------
@@ -197,23 +205,26 @@ local function EnsureBG()
     _bgFrame = CreateFrame("Frame", "EllesmereUIQTBackground", UIParent)
     _bgFrame:SetFrameStrata(otf:GetFrameStrata() or "MEDIUM")
     _bgFrame:SetFrameLevel(math.max(0, otf:GetFrameLevel() - 1))
-    -- Cut 30px off the top so the background doesn't bleed behind the
-    -- master header area. Bottom edge extends 6px past the last block.
-    _bgFrame:SetPoint("TOPLEFT", otf, "TOPLEFT", -6, -30)
+    -- Start the background at the same Y offset the top module is anchored
+    -- to (see TightenTopAnchor in Skin.lua), so it doesn't bleed above the
+    -- content or leave a gap below it. Bottom edge extends past the last
+    -- block (re-anchored dynamically below).
+    local topOfs = TopGapOffset()
+    _bgFrame:SetPoint("TOPLEFT", otf, "TOPLEFT", -6, topOfs)
     -- Bottom is re-anchored dynamically in ResizeBGToContent(); this is
-    -- only the fallback extent when no content has loaded yet.
-    _bgFrame:SetPoint("BOTTOMRIGHT", otf, "TOPRIGHT", 11, -60)
+    -- only the fallback extent when no content has loaded yet (30px tall).
+    _bgFrame:SetPoint("BOTTOMRIGHT", otf, "TOPRIGHT", 11, topOfs - 30)
     local tex = _bgFrame:CreateTexture(nil, "BACKGROUND")
     tex:SetAllPoints()
     _bgFrame._tex = tex
 
     -- 1px physical-pixel-perfect accent divider at the very top of the BG
-    -- (i.e. at the -30px cutoff line). Full width of the tracker, anchored
+    -- (i.e. at the topOfs cutoff line). Full width of the tracker, anchored
     -- directly to it so the line matches tracker width regardless of BG
     -- padding. Same snap pattern as PP.CreateBorder.
     local divider = _bgFrame:CreateTexture(nil, "OVERLAY")
-    divider:SetPoint("TOPLEFT",  otf, "TOPLEFT",  -6, -30)
-    divider:SetPoint("TOPRIGHT", otf, "TOPRIGHT",  11, -30)
+    divider:SetPoint("TOPLEFT",  otf, "TOPLEFT",  -6, topOfs)
+    divider:SetPoint("TOPRIGHT", otf, "TOPRIGHT",  11, topOfs)
     _bgFrame._divider = divider
     return _bgFrame
 end
@@ -357,20 +368,21 @@ local function ResizeBGToContent()
     end
     bg._hideCheck = nil
     if not bg:IsShown() then bg:Show() end
+    local topOfs = TopGapOffset()
     local otfTop = otf:GetTop()
     local lowestBottom = lowest:GetBottom()
     if otfTop and lowestBottom then
-        local h = otfTop - 30 - lowestBottom + 15
+        local h = otfTop + topOfs - lowestBottom + 15
         if h < 1 then h = 1 end
         bg:ClearAllPoints()
-        bg:SetPoint("TOPLEFT",  otf, "TOPLEFT",  -6, -30)
-        bg:SetPoint("TOPRIGHT", otf, "TOPRIGHT", 11, -30)
+        bg:SetPoint("TOPLEFT",  otf, "TOPLEFT",  -6, topOfs)
+        bg:SetPoint("TOPRIGHT", otf, "TOPRIGHT", 11, topOfs)
         bg:SetHeight(h)
         bg._lastHeight = h
     elseif bg._lastHeight then
         bg:ClearAllPoints()
-        bg:SetPoint("TOPLEFT",  otf, "TOPLEFT",  -6, -30)
-        bg:SetPoint("TOPRIGHT", otf, "TOPRIGHT", 11, -30)
+        bg:SetPoint("TOPLEFT",  otf, "TOPLEFT",  -6, topOfs)
+        bg:SetPoint("TOPRIGHT", otf, "TOPRIGHT", 11, topOfs)
         bg:SetHeight(bg._lastHeight)
     end
     bg._lastLowest = lowest


### PR DESCRIPTION
## Fix: Excessive top padding in ObjectiveTrackerFrame (Quest Tracker)

Bug report: https://discord.com/channels/585577383847788554/1497471942775541911

### Problem

With the master `Header`/`HeaderMenu` hidden, the tracker's top-most module (Quests, Professions, Achievements, etc. — whichever happens to be on top) still rendered with a large gap above its first line. Visible clearly in Blizzard's Edit Mode selection box around `ObjectiveTrackerFrame`.

### Root cause

Two independent issues stacked on top of each other:

1. **`otf.Header` never actually shrank.** In `EQT.InitSkin()`, the `SetHeight(0.001)` call was only applied to `otf.HeaderMenu` — the `otf.Header` block (a separate frame, guarded by `otf.Header ~= headerMenu`) was only `:Hide()`-den, never resized. `Hide()` alone doesn't remove a frame from anchor calculations, so this didn't contribute to the actual gap, but it was a real gap in the intended fix and is corrected as a drive-by (harmless, verified via `/dump`: `Header:GetHeight()` now reports `~0.001` instead of `32`).
2. **The real cause:** Blizzard anchors whichever module currently sits in the top slot with a fixed `TOP`/`TOP` offset relative to `ObjectiveTrackerFrame`, independent of `Header`'s height. Verified via `/dump <Tracker>:GetPoint(1)` across `QuestObjectiveTracker` and `ProfessionsRecipeTracker`: both anchor at `TOP, ObjectiveTrackerFrame, TOP, 0, -38` — a constant Blizzard applies at layout time, not something derived from `Header`'s size.

### Fix

**`EllesmereUIQuestTracker_Skin.lua`**
- `otf.Header` now also gets `SetHeight(0.001)` (both at init and re-applied in its `OnShow` hook, mirroring `headerMenu`'s treatment) — closes the gap in the original fix, harmless even though it wasn't the actual cause.
- New `TightenTopAnchor(tracker)`, called from the existing deferred `tracker.Update` hook: detects when a module's point-1 anchor is `TOP/ObjectiveTrackerFrame/TOP` and re-anchors it to a tighter `TOP_ANCHOR_OFFSET` (currently `-6`, tune to taste) instead of Blizzard's `-38`. Guarded by `InCombatLockdown()` and skips while `tracker:IsSliding()` to avoid fighting Blizzard's collapse/expand slide animation. Not called for `ScenarioObjectiveTracker` / `UIWidgetObjectiveTracker` (early-return via `SharesWidgetPool`, same as the rest of the block-skinning code).
- `TOP_ANCHOR_OFFSET` is exposed as `EQT.TOP_ANCHOR_OFFSET` — single source of truth shared with the visibility module (see below).

**`EllesmereUIQuestTracker_Visibility.lua`**
- The background frame and the "Show Top Line" accent divider were hardcoded to a `-30` / `-60` offset that matched the *old* `-38` content anchor (an intentional 8px buffer above the content). After tightening the content anchor to `-6`, that hardcoded offset left the divider rendering ~24px below the new content start — inside/below the first line instead of above it.
- New `TopGapOffset()` helper reads `EQT.TOP_ANCHOR_OFFSET` (fallback `-6`) instead of the stale hardcoded `-30`. Used in `EnsureBG()`'s initial anchors, `ApplyTopDivider()`'s line, and `ResizeBGToContent()`'s height math and dynamic re-anchors — so the BG/divider top always tracks wherever `TightenTopAnchor` places the content, without a second magic number to keep in sync manually.

### Taint / combat-lockdown risk assessment

Assessed as **low risk**, not zero:

- `TightenTopAnchor` only touches the module container frame itself via `SetPoint` — never a child (no quest-item `SecureActionButton`s, no LFG queue elements touched).
- Never runs on `ScenarioObjectiveTracker` / `UIWidgetObjectiveTracker` (the two trackers with a known, previously-hit taint history via the shared tooltip/AreaPOI widget pool).
- Guarded by `InCombatLockdown()`.
- `SetPoint` is a much lower-risk API surface than `SetScale`, `SetAttribute`, or reading Secret Value fields.

Residual unknown: whether `ObjectiveTrackerContainerMixin`'s internal layout re-reads a module's anchor later inside a protected code path (e.g. when positioning a quest-item button relative to it). Could not verify against Blizzard's source. No taint observed in manual testing so far; recommend a few days of normal play covering AreaPOI tooltip hover, M+ completion reward toast, quest-item right-click menus, and LFG queue interaction before considering this fully confirmed.

### Testing

- [x] `luac5.1 -p` clean on both files
- [x] Manual `/dump` verification of `Header:GetHeight()` before/after
- [x] Manual `/dump` verification of top-module anchor across `QuestObjectiveTracker` and `ProfessionsRecipeTracker` (both `-38` before fix)
- [x] Visual confirmation: top gap closed, "Show Top Line" divider correctly repositioned above content
- [x] Extended play-test for taint (see risk assessment above)

## Update: click flicker fix
 
**Bug:** Tracker briefly shifted down (~0.2s) when clicking a quest.
 
**Root cause (confirmed via debug logging):** Blizzard fires several native `tracker:Update()` passes (~4 within ~200ms) after a quest interaction, resetting the TOP anchor to `-38` each time. Our correction only ran once per burst, one frame late, so it never caught up during the burst. Also confirmed the anchor isn't even set yet at the moment `Update()` returns — a synchronous fix-in-hook was a no-op.
 
**Fix:**
- Removed the useless synchronous `TightenTopAnchor` call in the `Update` hook.
- Added a short-lived per-frame poller (own frame, not Blizzard's) that re-tightens the anchor every frame for 0.4s after any native `Update()`, closing the gap for the whole burst instead of once.
- Added an `OnEndSlide` hook (fires when `ObjectiveTrackerSlidingMixin` finishes a slide) so the anchor also corrects immediately after collapse/expand animations, not just on the next `Update()`.
**Risk:** Same API surface as before (`GetPoint`/`SetPoint` on the module frame only), same `InCombatLockdown()` guard. Poller only runs in short bursts after activity, not continuously — negligible perf cost.
 
Verified: no flicker on quest click after fix (manual testing).
