### PR TITLE
fix: Sweeping Strikes bar wiped to 0 in combat / pinned at 0 in M+

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4535,45 +4535,23 @@ do
         end
     end
 
-    -- Aura probe for the drift check below, kept as a named function so the
-    -- pcall in the 0.1 s poll allocates nothing. Returns (absent, count):
-    -- absent=true only on a VERIFIED missing aura; count only when
-    -- applications is a readable positive number. Anything secret-shaped
-    -- returns neither (prediction stays in charge) or throws into the pcall.
-    local function ReadSweepAura()
-        local aura = C_UnitAuras.GetPlayerAuraBySpellID(SWEEP)
-        if not aura then return true end
-        local c = aura.applications
-        if c and not (issecretvalue and issecretvalue(c)) and c > 0 then
-            return false, c
-        end
-        return false
-    end
-
+    -- NO aura validation here, on purpose. v8.4.9 tried to correct
+    -- prediction drift against the real buff (first by name, then by
+    -- C_UnitAuras.GetPlayerAuraBySpellID), treating a missing aura as
+    -- "buff gone" and wiping the stacks. But on the live 12.x client the
+    -- player-aura read surface returns nothing for this buff even in the
+    -- open world -- verified in-game 2026-07-17: with Sweeping Strikes
+    -- visibly active, GetPlayerAuraBySpellID(260708) returned nil and a
+    -- full GetAuraDataByIndex("player", i, "HELPFUL") sweep enumerated
+    -- ZERO auras. Any validation built on that surface reads every live
+    -- buff as absent and zeroes the bar (the v8.4.9 bug: stacks wiped in
+    -- combat, pinned at 0 in M+). Until Blizzard exposes a readable
+    -- charge count, the cast-event prediction plus the duration timer IS
+    -- the tracker.
     function EllesmereUI.GetSweepingStrikes()
         if not sweepKnown then return 0, 0 end
         if expiresAt and GetTime() >= expiresAt then
             stacks, expiresAt = 0, nil
-        end
-        -- Validate prediction against the real aura to correct drift (the
-        -- reach probe is ~11 yd while the game sweeps within 8 yd of the
-        -- primary target). OPEN WORLD ONLY and fail-open: in instanced
-        -- content the 12.x aura surface is restricted -- the lookup can
-        -- return nil/secret (or throw) for a live buff -- and the v8.4.9
-        -- fail-closed version of this check wiped active stacks to 0 in
-        -- combat and pinned the bar at 0 for the whole run in M+. Only a
-        -- verified "buff gone" clears the prediction; an error or an
-        -- unreadable result changes nothing.
-        if stacks > 0 and not IsInInstance()
-           and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID then
-            local ok, absent, count = pcall(ReadSweepAura)
-            if ok then
-                if absent then
-                    stacks, expiresAt = 0, nil
-                elseif count then
-                    stacks = count
-                end
-            end
         end
         return stacks, MaxStacks()
     end

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4535,6 +4535,21 @@ do
         end
     end
 
+    -- Aura probe for the drift check below, kept as a named function so the
+    -- pcall in the 0.1 s poll allocates nothing. Returns (absent, count):
+    -- absent=true only on a VERIFIED missing aura; count only when
+    -- applications is a readable positive number. Anything secret-shaped
+    -- returns neither (prediction stays in charge) or throws into the pcall.
+    local function ReadSweepAura()
+        local aura = C_UnitAuras.GetPlayerAuraBySpellID(SWEEP)
+        if not aura then return true end
+        local c = aura.applications
+        if c and not (issecretvalue and issecretvalue(c)) and c > 0 then
+            return false, c
+        end
+        return false
+    end
+
     function EllesmereUI.GetSweepingStrikes()
         if not sweepKnown then return 0, 0 end
         if expiresAt and GetTime() >= expiresAt then
@@ -4542,18 +4557,20 @@ do
         end
         -- Validate prediction against the real aura to correct drift (the
         -- reach probe is ~11 yd while the game sweeps within 8 yd of the
-        -- primary target). Direct spellID lookup: zero-alloc on a 0.1 s
-        -- poll, and safe under 12.x restrictions -- aura PRESENCE stays
-        -- readable in keys (same contract the TBB bind-miss fallback relies
-        -- on), while a secret applications count simply leaves the
-        -- prediction in charge.
-        if stacks > 0 and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID then
-            local aura = C_UnitAuras.GetPlayerAuraBySpellID(SWEEP)
-            if not aura then
-                stacks, expiresAt = 0, nil
-            else
-                local count = aura.applications
-                if count and not (issecretvalue and issecretvalue(count)) and count > 0 then
+        -- primary target). OPEN WORLD ONLY and fail-open: in instanced
+        -- content the 12.x aura surface is restricted -- the lookup can
+        -- return nil/secret (or throw) for a live buff -- and the v8.4.9
+        -- fail-closed version of this check wiped active stacks to 0 in
+        -- combat and pinned the bar at 0 for the whole run in M+. Only a
+        -- verified "buff gone" clears the prediction; an error or an
+        -- unreadable result changes nothing.
+        if stacks > 0 and not IsInInstance()
+           and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID then
+            local ok, absent, count = pcall(ReadSweepAura)
+            if ok then
+                if absent then
+                    stacks, expiresAt = 0, nil
+                elseif count then
                     stacks = count
                 end
             end

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4527,7 +4527,9 @@ do
             -- If the game echoes the Fervor-of-Battle Slam as a real cast
             -- event, skip it -- the charge was already counted above. A
             -- player-pressed Slam can't land inside the 0.3 s window (GCD).
-            if spellID == 1464 and GetTime() < fobWindow then return end
+            -- 1269383: Master of Warfare replaces Slam with Heroic Strike,
+            -- so the echo carries that id instead.
+            if (spellID == 1464 or spellID == 1269383) and GetTime() < fobWindow then return end
             -- No sweep partner in range -> the game doesn't consume a charge
             if not EnemiesInReach(2) then return end
             stacks = max(0, stacks - SPENDERS[spellID])
@@ -4538,22 +4540,29 @@ do
     -- NO aura validation here, on purpose. v8.4.9 tried to correct
     -- prediction drift against the real buff (first by name, then by
     -- C_UnitAuras.GetPlayerAuraBySpellID), treating a missing aura as
-    -- "buff gone" and wiping the stacks. But on the live 12.x client the
-    -- player-aura read surface returns nothing for this buff even in the
-    -- open world -- verified in-game 2026-07-17: with Sweeping Strikes
-    -- visibly active, GetPlayerAuraBySpellID(260708) returned nil and a
-    -- full GetAuraDataByIndex("player", i, "HELPFUL") sweep enumerated
-    -- ZERO auras. Any validation built on that surface reads every live
-    -- buff as absent and zeroes the bar (the v8.4.9 bug: stacks wiped in
-    -- combat, pinned at 0 in M+). Until Blizzard exposes a readable
-    -- charge count, the cast-event prediction plus the duration timer IS
-    -- the tracker.
+    -- "buff gone" and wiping the stacks. But Sweeping Strikes (260708) is
+    -- NOT a whitelisted aura, and non-whitelisted player buffs are
+    -- invisible to the aura read surface -- verified in-game 2026-07-17:
+    -- with the buff visibly active, GetPlayerAuraBySpellID(260708)
+    -- returned nil and a GetAuraDataByIndex("player", i, "HELPFUL") sweep
+    -- enumerated zero auras. So any validation on this buff reads it as
+    -- absent and zeroes the bar (the v8.4.9 bug: stacks wiped in combat,
+    -- pinned at 0 in M+). Whitelisted buffs ARE readable -- see
+    -- GetMaelstromWeapon / GetSoulFragments below and the
+    -- NON_SECRET_SPELL_IDS catalogue + C_Secrets.ShouldSpellAuraBeSecret
+    -- probe in EllesmereUIAuraBuffReminders. If Blizzard ever whitelists
+    -- 260708, validation becomes possible again; until then the
+    -- cast-event prediction plus the duration timer IS the tracker.
     function EllesmereUI.GetSweepingStrikes()
         if not sweepKnown then return 0, 0 end
         if expiresAt and GetTime() >= expiresAt then
             stacks, expiresAt = 0, nil
         end
-        return stacks, MaxStacks()
+        -- Clamp: a mid-window respec out of Improved drops MaxStacks 18->12
+        -- while the predicted stacks upvalue keeps its old value.
+        local m = MaxStacks()
+        if stacks > m then stacks = m end
+        return stacks, m
     end
 end
 


### PR DESCRIPTION
## Summary

The Arms Warrior Sweeping Strikes charge bar (Resources & Cast Bars) broke in v8.4.9: stacks showed out of combat but vanished in combat, sat at 0 for entire M+ runs, and never resynced after combat. Worked in v8.4.8. Reported by @mac and Velds.

**Verified in-game: works out of combat, on dummies, and in dungeons with this branch.**

## Root cause

v8.4.9 added an aura-validation step to `GetSweepingStrikes` (first name-based in dca3ac21, reworked to `C_UnitAuras.GetPlayerAuraBySpellID(260708)` for release). The check was fail-closed: a lookup that returned no readable aura wiped the predicted stacks to 0 on every 0.1s poll.

Live in-game diagnosis (with the buff visibly active): `GetPlayerAuraBySpellID(260708)` returns **nil**, and a full `GetAuraDataByIndex("player", i, "HELPFUL")` sweep enumerates **zero auras**. Sweeping Strikes is not a whitelisted aura, and non-whitelisted player buffs are invisible to the aura read surface, so every variant of the validation read a live buff as absent and zeroed the bar. (Whitelisted buffs like Maelstrom Weapon / Soul Fragments remain readable; the readable set is catalogued in `NON_SECRET_SPELL_IDS` with the `C_Secrets.ShouldSpellAuraBeSecret` probe.)

## Fix

- Remove the aura validation entirely; the tracker returns to pure cast-event prediction plus the 30s duration timer (the exact v8.4.8 behavior). The drift the check was chasing (~11yd reach probe vs 8yd sweep) returns as a known minor inaccuracy; a wrong-by-one bar beats a permanently empty one. A comment documents the in-game finding and the unblock condition (Blizzard whitelisting 260708) so validation isn't re-added blindly.
- Review fixes: the Fervor of Battle echo guard now also matches Heroic Strike (1269383, replaces Slam under Master of Warfare) so an FoB proc can't double-decrement; and the getter clamps stacks to MaxStacks() so a mid-window respec out of Improved can't display 18 over a 12-pip bar.

## Commits

- c9b04f87 - first attempt (open-world-only fail-open validation); superseded once in-game dumps proved the aura surface returns nothing for this buff even in the open world
- f6ebc947 - drop aura validation entirely (pure prediction, v8.4.8 behavior)
- d6b04c99 - review fixes (comment accuracy, FoB/Heroic Strike echo guard, max clamp)

## Testing

In-game on an Arms Warrior: charges show and decrement correctly out of combat, at training dummies in combat, and in dungeons. Diagnosis dumps run live at a dummy confirmed the API behavior described above.