### PR TITLE
fix: macro name (and rank icon) left stale on action bars after moving/swapping

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2570,6 +2570,18 @@ function EAB_VTABLE.ForceButtonRefresh(btn, action)
         local display = C_ActionBar.GetActionDisplayCount(action)
         btn.Count:SetText(display or "")
     end
+    -- Macro / action text. The mixin's Update() maintains this normally, but
+    -- we suppress its per-button events, so a moved macro leaves its name
+    -- stuck on the old slot (and the new slot stays blank) until a hover runs
+    -- Blizzard's secure Update. Mirror that logic here: set the name only for
+    -- slots that use action text, clear it otherwise.
+    if btn.Name and C_ActionBar and C_ActionBar.UsesActionText then
+        if C_ActionBar.UsesActionText(action) then
+            btn.Name:SetText(C_ActionBar.GetActionText(action) or "")
+        else
+            btn.Name:SetText("")
+        end
+    end
     local cd = btn.cooldown
     if cd and C_ActionBar and C_ActionBar.GetActionCooldown then
         local cdInfo = C_ActionBar.GetActionCooldown(action)

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2577,7 +2577,8 @@ function EAB_VTABLE.ForceButtonRefresh(btn, action)
     -- slots that use action text, clear it otherwise.
     if btn.Name and C_ActionBar and C_ActionBar.UsesActionText then
         if C_ActionBar.UsesActionText(action) then
-            btn.Name:SetText(C_ActionBar.GetActionText(action) or "")
+            local nm = C_ActionBar.GetActionText and C_ActionBar.GetActionText(action)
+            btn.Name:SetText(nm or "")
         else
             btn.Name:SetText("")
         end

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -8871,7 +8871,8 @@ function EAB:OnInitialize()
         local _qPending = false
         local function QualityScan()
                 _qPending = false
-                local bars = EAB.db.profile.bars
+                local bars = EAB.db and EAB.db.profile and EAB.db.profile.bars
+                if not bars then return end
                 for _, info in ipairs(BAR_CONFIG) do
                     local btns = barButtons[info.key]
                     local s = bars[info.key]
@@ -8933,6 +8934,13 @@ function EAB:OnInitialize()
                 end
         end
         qf:RegisterEvent("ACTIONBAR_SLOT_CHANGED")
+        -- Loadout/spec swap changes slot CONTENTS but does not reliably fire
+        -- ACTIONBAR_SLOT_CHANGED for our EABButtons (same reason the spell
+        -- refresh sweep exists), so a rank icon from the old spec's item can
+        -- persist on a slot the new spec leaves empty or fills with a spell.
+        -- SPELLS_CHANGED covers that swap; the macro name is handled by the
+        -- ForceButtonRefresh sweep on the same event.
+        qf:RegisterEvent("SPELLS_CHANGED")
         qf:SetScript("OnEvent", function()
             if not _qPending then
                 _qPending = true


### PR DESCRIPTION
## Summary

Reported by @Zaughon (Action Bars, v8.4.9): with macro names enabled, moving a macro leaves its name stuck on the old slot until you hover it, and the new slot stays blank if you move the cursor away too fast. A tester also noted the same staleness class persists across talent loadout swaps for both macro names and rank (profession quality) icons. Both are addressed here.

## Root cause

Our action buttons (EABButtons) no longer receive Blizzard's per-button `ACTIONBAR_SLOT_CHANGED` natively, so the central dispatcher repaints them via `EAB_VTABLE.ForceButtonRefresh`. That function repainted the icon, count, and cooldown but never the `Name` fontstring, so the macro text only corrected itself when a hover ran Blizzard's secure `Update`. Separately, the rank-overlay refresh (`QualityScan`) only listened to `ACTIONBAR_SLOT_CHANGED`, which a loadout/spec swap does not reliably fire for our buttons, so a stale rank icon could linger after a swap.

## Fix

- Add the macro/action-text update to `ForceButtonRefresh`, mirroring Blizzard's own mixin: set the name from `C_ActionBar.GetActionText` when the slot `UsesActionText`, clear it otherwise. The changed slot (emptied source or filled destination) both match the dispatcher's slot test, and the spec-swap sweep runs `ForceButtonRefresh` on every button, so macro names update on move, swap, and loadout change without a hover.
- Register the rank/quality rescan (`QualityScan`) on `SPELLS_CHANGED` in addition to `ACTIONBAR_SLOT_CHANGED`, so an item's rank icon from one spec clears when the other spec leaves that slot empty or fills it with a spell. Its existing item/non-item gating only touches overlays that already exist (no lazy/tainted creation); added a nil-safe db guard since `SPELLS_CHANGED` can fire earlier than the first slot change.

Text content is orthogonal to the alpha-based "hide macro text" setting, so that toggle still fully hides names.

## Commits

- 3f3e6c82 - macro name text updates on slot change
- d842ce76 - clear stale rank icon on loadout/spec swap
- 0438bde1 - guard C_ActionBar.GetActionText existence (review hardening)

## Testing

Static: luac clean; high-recall code review (macro logic correct, taint/combat-safe like the adjacent Count:SetText, no conflict with hide-macro-text, rank rescan safe on SPELLS_CHANGED).

Did in-game pass: enable macro names; drag a macro between slots (old clears, new shows, incl. fast cursor flick); spell<->macro swap in place; then put a ranked consumable on one loadout's bar with that slot empty/spell on another and swap loadouts back and forth, confirm the rank diamond does not linger.