### PR TITLE
fix(cdm): individually configure buffs that share a spellID (Diabolist)

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -7525,7 +7525,17 @@ initFrame:SetScript("OnEvent", function(self)
         -- (see RefreshCDMIconAppearance), so writer and reader agree. Custom/injected
         -- buffs have their own positive id as _previewSpellID, which works too.
         local function ResolveBuffSettingsKey(af)
-            return af and af._previewSpellID
+            local sid = af and af._previewSpellID
+            if not sid then return nil end
+            -- Same-spellID collision (Diabolist Demonic Art vs Diabolic Ritual):
+            -- when two viewer slots share this displayed id, key THIS slot by its
+            -- own cooldownID so each is configured independently. Non-collided
+            -- buffs keep the stable spellID key (survives talent swaps).
+            local cdID = af and (af._previewCdID or af.cooldownID)
+            if type(cdID) == "number" and ns.IsCollidedBuffSid and ns.IsCollidedBuffSid(sid) then
+                return "c" .. cdID
+            end
+            return sid
         end
 
         local allSpells = {}
@@ -7800,6 +7810,12 @@ initFrame:SetScript("OnEvent", function(self)
                     local function EnsureSS()
                         if store and not store[spellID] then
                             store[spellID] = ss
+                            -- Flip the runtime hot-path gate the moment a
+                            -- cooldownID-scoped buff entry is first persisted.
+                            if type(spellID) == "string" and string.byte(spellID, 1) == 99
+                               and ns.MarkBuffFamHasCdKey then
+                                ns.MarkBuffFamHasCdKey()
+                            end
                         end
                         return ss
                     end

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -7532,8 +7532,15 @@ initFrame:SetScript("OnEvent", function(self)
             -- own cooldownID so each is configured independently. Non-collided
             -- buffs keep the stable spellID key (survives talent swaps).
             local cdID = af and (af._previewCdID or af.cooldownID)
-            if type(cdID) == "number" and ns.IsCollidedBuffSid and ns.IsCollidedBuffSid(sid) then
-                return "c" .. cdID
+            if type(cdID) == "number" then
+                local ckey = "c" .. cdID
+                -- Read-your-writes: once a per-cooldownID entry exists, keep
+                -- editing it even if the collision later ends (re-talent), so the
+                -- menu never splits from what the runtime resolver reads (which
+                -- prefers an existing c-entry whenever one is present).
+                local bstore = ns.GetSpellSettingsStore and ns.GetSpellSettingsStore("buffs")
+                if bstore and bstore[ckey] then return ckey end
+                if ns.IsCollidedBuffSid and ns.IsCollidedBuffSid(sid) then return ckey end
             end
             return sid
         end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -338,6 +338,23 @@ local function ResolveSpellSettings(frame, sid2, sd2, barKey)
 
     local ChainSettings = ns.ChainSettings
 
+    -- Per-cooldownID buff override: two buff-viewer slots can share one
+    -- canonical spellID (Diabolist Demonic Art vs Diabolic Ritual) but be
+    -- configured independently under a "c"..cooldownID key. Gated so the hot
+    -- path is untouched for every store WITHOUT such a key (BuffFamHasCdKey is
+    -- a cheap store-identity-cached bool), and scoped to buff-viewer frames so
+    -- no cooldown/utility icon ever pays the string build.
+    if frame then
+        local fdC = ns._hookFrameData and ns._hookFrameData[frame]
+        if fdC and fdC._isBuffViewerFrame then
+            local cdID = frame.cooldownID
+            if type(cdID) == "number" and ns.BuffFamHasCdKey and ns.BuffFamHasCdKey() then
+                local cd = settings["c" .. cdID]
+                if cd then ChainSettings(cd, tier); return cd end
+            end
+        end
+    end
+
     -- Fast path: direct hit on the primary id (the common, non-override case).
     -- Returns before building the identity set / addId closure below, so the hot
     -- SetSwipeColor path stays allocation-free for spells without an override.

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -346,9 +346,14 @@ local function ResolveSpellSettings(frame, sid2, sd2, barKey)
     -- no cooldown/utility icon ever pays the string build.
     if frame then
         local fdC = ns._hookFrameData and ns._hookFrameData[frame]
-        if fdC and fdC._isBuffViewerFrame then
+        -- Buff-viewer frames AND their inactive-buff placeholders (Always Show /
+        -- Keep in Same Place) both carry the viewer cooldownID and must resolve
+        -- the same per-slot entry, else a collided slot's styling would revert
+        -- whenever the placeholder shows. type(cdID) == "number" still excludes
+        -- preset placeholders, which nil the cooldownID.
+        if (fdC and fdC._isBuffViewerFrame) or frame._isPlaceholderFrame then
             local cdID = frame.cooldownID
-            if type(cdID) == "number" and ns.BuffFamHasCdKey and ns.BuffFamHasCdKey() then
+            if type(cdID) == "number" and ns.BuffFamHasCdKey and ns.BuffFamHasCdKey(settings) then
                 local cd = settings["c" .. cdID]
                 if cd then ChainSettings(cd, tier); return cd end
             end

--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -1077,6 +1077,63 @@ function ns.CollectDefaultBuffTrackEntries()
     return out
 end
 
+-------------------------------------------------------------------------------
+--  Same-spellID buff disambiguation (Diabolist Demonic Art vs Diabolic Ritual)
+--
+--  Blizzard can report the SAME canonical spellID on two DIFFERENT buff-viewer
+--  slots (cooldownIDs). Per-icon buff settings are keyed by spellID, so those
+--  two collide onto one entry. We let a COLLIDED slot key its settings by
+--  "c"..cooldownID instead, giving each its own entry. Only collided slots do
+--  this: keying every buff by cooldownID would regress non-collided buffs,
+--  whose settings must survive talent swaps (cooldownID drifts; spellID does
+--  not). Collided slots trade that away -- their per-slot settings are
+--  session-stable but may not follow a talent-loadout swap, which is
+--  unavoidable when the two share every identity except the drifting id.
+-------------------------------------------------------------------------------
+
+--- Set of canonical spellIDs that map to 2+ distinct buff-viewer cooldownIDs.
+--- Cold path (settings popup); recomputed per call from the live viewer pool.
+function ns.CollidedBuffSids()
+    local counts, out = {}, {}
+    local entries = ns.EnumerateCDMViewerSpells and ns.EnumerateCDMViewerSpells(true) or {}
+    for _, e in ipairs(entries) do
+        if e.sid and type(e.cdID) == "number" then
+            counts[e.sid] = (counts[e.sid] or 0) + 1
+        end
+    end
+    for sid, n in pairs(counts) do if n > 1 then out[sid] = true end end
+    return out
+end
+
+function ns.IsCollidedBuffSid(sid)
+    if type(sid) ~= "number" or sid <= 0 then return false end
+    return ns.CollidedBuffSids()[sid] == true
+end
+
+-- Runtime hot-path gate: true only when the current spec's buffs store holds at
+-- least one "c"..cooldownID key. Cached by store-table identity, so a spec or
+-- profile swap (which hands back a different store table) recomputes for free
+-- without any explicit invalidation hook.
+local _cdKeyGate
+function ns.BuffFamHasCdKey()
+    local store = ns.GetSpellSettingsStore and ns.GetSpellSettingsStore("buffs")
+    if not store then return false end
+    if _cdKeyGate and _cdKeyGate.store == store then return _cdKeyGate.has end
+    local hit = false
+    for k in pairs(store) do
+        if type(k) == "string" and string.byte(k, 1) == 99 then hit = true; break end  -- 'c'
+    end
+    _cdKeyGate = { store = store, has = hit }
+    return hit
+end
+
+--- Called when a "c"..cooldownID buff entry is first persisted, so the hot-path
+--- gate flips on without waiting for the store-identity cache to expire.
+function ns.MarkBuffFamHasCdKey()
+    local store = ns.GetSpellSettingsStore and ns.GetSpellSettingsStore("buffs")
+    _cdKeyGate = { store = store, has = true }
+end
+
 --- Reorder present keys to match Blizzard viewer order while absent keys (talent
 --- gaps, untalented catalog entries) keep their stored slots.
 local function SyncPresentBuffOrderToBlizzard(order, present, entries)

--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -1115,8 +1115,10 @@ end
 -- profile swap (which hands back a different store table) recomputes for free
 -- without any explicit invalidation hook.
 local _cdKeyGate
-function ns.BuffFamHasCdKey()
-    local store = ns.GetSpellSettingsStore and ns.GetSpellSettingsStore("buffs")
+function ns.BuffFamHasCdKey(store)
+    -- The runtime resolver already holds the buffs store; accept it to skip a
+    -- second spec/profile lookup per buff-frame resolve.
+    store = store or (ns.GetSpellSettingsStore and ns.GetSpellSettingsStore("buffs"))
     if not store then return false end
     if _cdKeyGate and _cdKeyGate.store == store then return _cdKeyGate.has end
     local hit = false

--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -247,8 +247,20 @@ local function EnumerateCDMViewerSpells(includeBuffViewer)
             for frame in viewer.itemFramePool:EnumerateActive() do
                 if frame:IsShown() or frame.cooldownInfo then
                     local sid = GetCanonicalSpellIDForFrame(frame)
-                    if _IsUsableSID(sid) and not seen[sid] then
-                        seen[sid] = true
+                    -- Dedup identity. In the BUFF viewer each slot is a distinct
+                    -- cooldownID, and Blizzard can report the SAME canonical
+                    -- spellID for two DIFFERENT cooldownIDs (Diabolist: the
+                    -- Demonic Art slot reports Diabolic Ritual's id) -- deduping
+                    -- by sid there wrongly merges the two into one, so the user
+                    -- can't see or style them individually. Key on cooldownID so
+                    -- both survive. CD/util viewers keep sid-dedup to collapse a
+                    -- spell that shows up in two viewers. Non-colliding specs are
+                    -- unaffected: there a unique sid implies a unique cooldownID.
+                    local cd = frame.cooldownID
+                    local dkey = (includeBuffViewer and type(cd) == "number")
+                        and ("c" .. cd) or sid
+                    if _IsUsableSID(sid) and dkey ~= nil and not seen[dkey] then
+                        seen[dkey] = true
                         entries[#entries + 1] = {
                             sid          = sid,
                             cdID         = frame.cooldownID,
@@ -1014,17 +1026,19 @@ function ns.CollectDefaultBuffTrackEntries()
     local seen = {}
     local entries = ns.EnumerateCDMViewerSpells and ns.EnumerateCDMViewerSpells(true) or {}
     for _, e in ipairs(entries) do
-        if e.sid and not diverted[e.sid] and not seen[e.sid] then
-            seen[e.sid] = true
-            local key = BuffDisplayStableKey(e.sid, e.cdID)
-            if key then
-                out[#out + 1] = {
-                    key         = key,
-                    sid         = e.sid,
-                    cdID        = e.cdID,
-                    layoutIndex = e.layoutIndex or 0,
-                }
-            end
+        -- Dedup on the stable (cooldownID-derived) key, not e.sid: two viewer
+        -- slots can share a canonical spellID but are distinct cooldownIDs
+        -- (Diabolist Demonic Art vs Diabolic Ritual). Keying on sid here would
+        -- re-merge what EnumerateCDMViewerSpells now keeps separate.
+        local key = BuffDisplayStableKey(e.sid, e.cdID)
+        if e.sid and not diverted[e.sid] and key and not seen[key] then
+            seen[key] = true
+            out[#out + 1] = {
+                key         = key,
+                sid         = e.sid,
+                cdID        = e.cdID,
+                layoutIndex = e.layoutIndex or 0,
+            }
         end
     end
 


### PR DESCRIPTION
## Summary

Reported by @Nawte (Cooldown Manager, v8.4.9): on a Demo/Destro **Diabolist** Warlock, Demonic Art and Diabolic Ritual are two separate tracked buffs, but Blizzard reports the **same name/icon/spellID** on both cooldown-viewer slots (the Demonic Art slot returns Diabolic Ritual's spellID). Both render at runtime, but EUI collapsed them: they couldn't be seen, ordered, or configured individually in the options.

**Verified in-game on a Diabolist:** both buffs now appear as separate orderable slots, per-icon settings apply independently to each, and each keeps its own styling when its buff drops (placeholder path).

## Root cause

Each viewer slot is a distinct `cooldownID`, but `GetCanonicalSpellIDForFrame` resolves both frames to the same spellID. EUI deduped the buff enumeration by spellID, dropping the second slot, and per-icon settings were keyed by that shared spellID, so configuring one changed both.

## Fix

1. **Enumeration** (`EllesmereUICdmSpellPicker.lua`): the buff-viewer path now dedups by `cooldownID` instead of spellID (`EnumerateCDMViewerSpells`, `CollectDefaultBuffTrackEntries`), so two slots colliding on spellID but distinct by cooldownID both survive. CD/utility viewers keep spellID-dedup (a spell shown in two viewers is one logical cooldown). **Non-colliding specs are byte-identical** (a unique spellID there implies a unique cooldownID).

2. **Per-icon settings** (`EUI_CooldownManager_Options.lua`, `EllesmereUICdmHooks.lua`): a **collided** buff slot keys its per-icon settings by `"c"..cooldownID` instead of the shared spellID, so each viewer slot gets its own entry. Only collided slots opt in, keying every buff by cooldownID would regress non-collided buffs, whose settings must survive talent swaps (cooldownID drifts, spellID does not). The runtime resolver's hot path is gated behind a cheap store-identity-cached flag, so any spec with no such key pays nothing. Inactive-buff placeholders resolve the same per-slot entry, and an existing per-cooldownID entry keeps being edited even if the collision later ends (read-your-writes).

## Scope / known limitations

- The **Button Glow** page already handled these two icons per-slot in 8.4.9 (it keys off the runtime bar icons by cooldownID); this branch's contribution is the per-icon **settings** independence plus seeing/ordering both slots.
- A collided slot's per-icon settings are session-stable but may not follow a **talent-loadout swap**, the two buffs share every persistable identity except the drifting cooldownID, so there is no stable per-slot key to migrate against. Documented, not fixable given Blizzard's data.
- Per-cooldownID buff entries are spec-local and are cleared by an Apply-to-Bar (both consistent with viewer-slot scoping).

## Testing

In-game on a Diabolist Warlock: both buffs show as separate orderable icons; distinct per-icon settings (glow-on-active, size, etc.) applied to each render independently at runtime; styling holds when a buff drops and its placeholder shows. `luac` clean.

<img width="412" height="230" alt="Screenshot 2026-07-17 195922" src="https://github.com/user-attachments/assets/73d512c9-8f62-4524-91b8-1c0f361ab038" />
