### PR TITLE
Pixel-unit spacing sliders: 1 = 1 physical pixel at any UI scale

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2076,7 +2076,12 @@ do
         local m = PP.mult
         if m == 1 then return x end
         local pixels = x / m
-        pixels = x > 0 and math.floor(pixels) or math.ceil(pixels)
+        -- Epsilon-guarded truncation: values saved by pixel-unit sliders sit
+        -- exactly ON a grid boundary (px * mult), and float dust from the
+        -- multiply/divide round trip can land them a hair below it -- without
+        -- the guard the floor drops a whole pixel. 0.001 px is far below any
+        -- legitimate mid-interval distance, so ordinary values are unaffected.
+        pixels = x > 0 and math.floor(pixels + 0.001) or math.ceil(pixels - 0.001)
         return pixels * m
     end
 
@@ -11700,7 +11705,7 @@ initFrame:SetScript("OnEvent", function(self, event)
                     _, h = W:SectionHeader(parent, "LAYOUT", y);                                          y = y - h
                     _, h = W:Slider(parent, "Button Spacing", y, 0, 12, 1,
                         function() return dS[k].spacing end,
-                        function(v) dS[k].spacing = v end);                                              y = y - h
+                        function(v) dS[k].spacing = v end, nil, true);                                   y = y - h
                     _, h = W:Slider(parent, "Global Scale", y, 50, 200, 5,
                         function() return dS[k].scale end,
                         function(v) dS[k].scale = v end);                                                y = y - h

--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -2041,7 +2041,7 @@ initFrame:SetScript("OnEvent", function(self)
                       SUpdatePreviewAndResize()
                       EllesmereUI:RefreshPage()
                   end },
-                { type="slider", text="Button Spacing", min=-10, max=20, step=1,
+                { type="slider", pixel=true, text="Button Spacing", min=-10, max=20, step=1,
                   getValue=function() return SVal("buttonPadding", 2) end,
                   setValue=function(v)
                       SSet("buttonPadding", v, function(k) EAB:ApplyPaddingForBar(k) end)

--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -1010,7 +1010,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 4: Icon Spacing (+ directions cog) | Attach Important Buffs to Cursor
         local row3
         row3, h = W:DualRow(parent, y,
-            { type="slider", text="Icon Spacing", min=0, max=50, step=1,
+            { type="slider", pixel=true, text="Icon Spacing", min=0, max=50, step=1,
               getValue=function() local d = DDB(); return d and d.iconSpacing or 8 end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.iconSpacing = v

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -2263,12 +2263,12 @@ initFrame:SetScript("OnEvent", function(self)
             { type = "slider", text = "Width", min = 80, max = 600, step = 1,
               getValue = function() return EDR_Cfg("width") end,
               setValue = function(v) EDR_Set("width", v); EDR_Rebuild() end },
-            { type = "slider", text = "Element Spacing", min = 0, max = 12, step = 1,
+            { type = "slider", pixel = true, text = "Element Spacing", min = 0, max = 12, step = 1,
               getValue = function() return EDR_Cfg("gap") end,
               setValue = function(v) EDR_Set("gap", v); EDR_Rebuild() end }
         ); y = y - h
         _, h = W:DualRow(parent, y,
-            { type = "slider", text = "Stack Spacing", min = 0, max = 10, step = 1,
+            { type = "slider", pixel = true, text = "Stack Spacing", min = 0, max = 10, step = 1,
               getValue = function() return EDR_Cfg("stackSpacing") end,
               setValue = function(v) EDR_Set("stackSpacing", v); EDR_Rebuild() end },
             { type = "toggle", text = "Show Icon Cooldown Text",

--- a/EllesmereUIChat/EUI_Chat_Options.lua
+++ b/EllesmereUIChat/EUI_Chat_Options.lua
@@ -451,7 +451,7 @@ initFrame:SetScript("OnEvent", function(self)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Icon Settings",
                 rows = {
-                    { type="slider", label="Icon Spacing",
+                    { type="slider", pixel=true, label="Icon Spacing",
                       min = 0, max = 30, step = 1,
                       get=function() return Cfg("sidebarIconSpacing") or 10 end,
                       set=function(v)

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -4245,7 +4245,7 @@ initFrame:SetScript("OnEvent", function(self)
                       ns.BuildTrackedBuffBars()
                       EllesmereUI:RefreshPage()
                   end },
-                { type = "slider", text = "Bar Spacing", min = -2, max = 20, step = 1,
+                { type = "slider", pixel = true, text = "Bar Spacing", min = -2, max = 20, step = 1,
                   getValue = function() return ns.TBBGroupSpacing(gid) end,
                   setValue = function(v)
                       ns.TBBSetGroupSpacing(gid, v)
@@ -16273,7 +16273,7 @@ initFrame:SetScript("OnEvent", function(self)
                       BD().buffGlowType = v; ns.BuildAllCDMBars(); Refresh()
                       C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
                   end },
-                { type="slider", text="Icon Spacing",
+                { type="slider", pixel=true, text="Icon Spacing",
                   min=-10, max=20, step=1,
                   getValue=function() return BD().spacing or 2 end,
                   setValue=function(v)
@@ -16729,7 +16729,7 @@ initFrame:SetScript("OnEvent", function(self)
                   bd._matchStrideH = nil
                   ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
               end },
-            { type="slider", text="Icon Spacing",
+            { type="slider", pixel=true, text="Icon Spacing",
               min=-10, max=20, step=1,
               getValue=function() return BD().spacing or 2 end,
               setValue=function(v)

--- a/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
@@ -598,7 +598,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Bar Spacing | Icon Style
         local iconRow, h = W:DualRow(parent, y,
-            { type="slider", text="Spacing", min = -1, max = 10, step = 1,
+            { type="slider", pixel=true, text="Spacing", min = -1, max = 10, step = 1,
             getValue = function() return Cfg("barSpacing") or 2 end,
             setValue = function(v) Set("barSpacing", v); Refresh() end },
             { type="dropdown", text="Icon Style",
@@ -1451,7 +1451,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Row 4: Icon Spacing | Opacity
         _, h = W:DualRow(parent, y,
-            { type = "slider", text = "Icon Spacing",
+            { type = "slider", pixel = true, text = "Icon Spacing",
               min = 0, max = 10, step = 1,
               disabled = iconOff, disabledTooltip = "Icon History",
               getValue = function() return SHDB().iconSpacing or 1 end,

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -2307,7 +2307,7 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       setValue = function(v) b.align = v; Apply() end },
                     MkToggle("Hide Blizzard Micro Menu", "disableBlizzardMicroMenu", "Hides Blizzard's own micro menu while any bar has this on."),
-                    { type = "slider", text = "Menu Spacing", min = 0, max = 16, step = 1,
+                    { type = "slider", pixel = true, text = "Menu Spacing", min = 0, max = 16, step = 1,
                       tooltip = "Gap between the main menu button and the icon row.",
                       getValue = function()
                           local v = s.mainMenuSpacing
@@ -2315,7 +2315,7 @@ initFrame:SetScript("OnEvent", function(self)
                           return v
                       end,
                       setValue = function(v) s.mainMenuSpacing = v; Apply() end },
-                    { type = "slider", text = "Icon Spacing", min = 0, max = 16, step = 1,
+                    { type = "slider", pixel = true, text = "Icon Spacing", min = 0, max = 16, step = 1,
                       tooltip = "Gap between the micro menu icons.",
                       getValue = function()
                           local v = s.iconSpacing

--- a/EllesmereUIMinimap/EUI_Minimap_Options.lua
+++ b/EllesmereUIMinimap/EUI_Minimap_Options.lua
@@ -763,7 +763,7 @@ initFrame:SetScript("OnEvent", function(self)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Button Row Settings",
                 rows = {
-                    { type = "slider", label = "Icon Spacing", min = -20, max = 40, step = 1,
+                    { type = "slider", pixel = true, label = "Icon Spacing", min = -20, max = 40, step = 1,
                       get = function() local m = MinimapDB(); return m and m.btnRowSpacing or 0 end,
                       set = function(v)
                           local m = MinimapDB(); if not m then return end
@@ -1037,7 +1037,7 @@ initFrame:SetScript("OnEvent", function(self)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Element Row Spacing",
                 rows = {
-                    { type = "slider", label = "Icon Spacing", min = -20, max = 40, step = 1,
+                    { type = "slider", pixel = true, label = "Icon Spacing", min = -20, max = 40, step = 1,
                       get = function() local m = MinimapDB(); return m and m.elementRowSpacing or 0 end,
                       set = function(v)
                           local m = MinimapDB(); if not m then return end

--- a/EllesmereUIMythicTimer/EUI_MythicTimer_Options.lua
+++ b/EllesmereUIMythicTimer/EUI_MythicTimer_Options.lua
@@ -451,7 +451,7 @@ initFrame:SetScript("OnEvent", function(self)
               disabledTooltip="Show Dungeon Name", requireState="disabled",
               get=function() return Cfg("showKeyLevelOnTimer") == true end,
               set=function(v) Set("showKeyLevelOnTimer", v); Refresh() end },
-            { type="slider", label="Spacing", min=0, max=40, step=1,
+            { type="slider", pixel=true, label="Spacing", min=0, max=40, step=1,
               disabled=function() return Cfg("showKeyLevelOnTimer") ~= true end,
               disabledTooltip="Show Key Level on Timer",
               get=function() return Cfg("keyLevelTimerSpacing") or 8 end,
@@ -485,17 +485,17 @@ initFrame:SetScript("OnEvent", function(self)
         }, function() return Cfg("enabled") == false or Cfg("showAffixes") == false end)
         -- Title/Affix Spacing cog on Position (now the right-side widget)
         _AttachPopupButton(row._rightRegion, EllesmereUI.RESIZE_ICON, "Title/Affix Spacing", {
-            { type="slider", label="Death Gap", min=-10, max=30, step=1,
+            { type="slider", pixel=true, label="Death Gap", min=-10, max=30, step=1,
               disabled=function() return (Cfg("titleAffixPosition") or "ABOVE_TIMER") == "BELOW_TIMER" end,
               disabledTooltip="Above Timer",
               get=function() return Cfg("titleAffixDeathGap") or 11 end,
               set=function(v) Set("titleAffixDeathGap", v); Refresh() end },
-            { type="slider", label="Timer Gap", min=-10, max=30, step=1,
+            { type="slider", pixel=true, label="Timer Gap", min=-10, max=30, step=1,
               disabled=function() return (Cfg("titleAffixPosition") or "ABOVE_TIMER") ~= "BELOW_TIMER" end,
               disabledTooltip="Below Timer",
               get=function() return Cfg("titleAffixTimerGap") or Cfg("titleAffixSandwichGap") or 6 end,
               set=function(v) Set("titleAffixTimerGap", v); Refresh() end },
-            { type="slider", label="Bar Gap", min=-10, max=30, step=1,
+            { type="slider", pixel=true, label="Bar Gap", min=-10, max=30, step=1,
               disabled=function() return (Cfg("titleAffixPosition") or "ABOVE_TIMER") ~= "BELOW_TIMER" end,
               disabledTooltip="Below Timer",
               get=function() return Cfg("titleAffixBarGap") or Cfg("titleAffixSandwichGap") or 6 end,
@@ -791,7 +791,7 @@ initFrame:SetScript("OnEvent", function(self)
               disabledTooltip="Ticks",
               get=function() return Cfg("tickAlpha") or 1 end,
               set=function(v) Set("tickAlpha", v); Refresh() end },
-            { type="slider", label="Gap Size", min=0, max=12, step=1,
+            { type="slider", pixel=true, label="Gap Size", min=0, max=12, step=1,
               disabled=function() return (Cfg("timerBarStyle") or "TICKS") ~= "SEGMENTS" end,
               disabledTooltip="Gaps",
               get=function() return Cfg("timerBarSegmentGap") or 2 end,
@@ -915,7 +915,7 @@ initFrame:SetScript("OnEvent", function(self)
         y = y - h
 
         row, h = W:DualRow(parent, y,
-            { type="slider", text="Objective Spacing",
+            { type="slider", pixel=true, text="Objective Spacing",
               disabled=function() return Cfg("enabled") == false or Cfg("showObjectives") == false end,
               disabledTooltip="Show Boss Objectives",
               min=0, max=12, step=1, isPercent=false,

--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -7103,7 +7103,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 3: Bar Spacing + Background Color (with alpha)
         local classResourceRow3
         classResourceRow3, h = W:DualRow(parent, y,
-            { type="slider", text="Bar Spacing", min=0, max=10, step=1,
+            { type="slider", pixel=true, text="Bar Spacing", min=0, max=10, step=1,
               disabled=classPowerDisabled,
               disabledTooltip="Show Class Resource",
               getValue=function() return DBVal("classPowerGap") or defaults.classPowerGap end,

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -3854,7 +3854,7 @@ function ns.BM_BuildPage(pageName, parent, yOffset)
         -- Row 3: Spacing | Border Size (+ swatch)
         local row3
         row3, hh = W:DualRow(optsFrame, sy,
-            { type="slider", text="Spacing", min=-1, max=10, step=1,
+            { type="slider", pixel=true, text="Spacing", min=-1, max=10, step=1,
               disabled=BuffsOff, disabledTooltip="Show Buffs",
               getValue=function() return BVal("spacing", 1) end,
               setValue=function(v) BSet("spacing", v) end },
@@ -5616,7 +5616,7 @@ function ns.BM_BuildPage(pageName, parent, yOffset)
                 { type="slider", text="Size", min=4, max=40, step=1,
                   getValue=function() return ind.size or 12 end,
                   setValue=function(v) ind.size = v; ReloadAndUpdate() end },
-                { type="slider", text="Spacing", min=-1, max=10, step=1,
+                { type="slider", pixel=true, text="Spacing", min=-1, max=10, step=1,
                   getValue=function() return ind.spacing or 1 end,
                   setValue=function(v) ind.spacing = v; ReloadAndUpdate() end })
 

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -4710,10 +4710,10 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Row 2: Frame Spacing | Group Spacing
         _, h = W:DualRow(parent, y,
-            { type="slider", text="Frame Spacing", min=-1, max=15, step=1,
+            { type="slider", pixel=true, text="Frame Spacing", min=-1, max=15, step=1,
               getValue=function() return SVal("cellSpacing", 2) end,
               setValue=function(v) SSet("cellSpacing", v) end },
-            { type="slider", text="Group Spacing", min=-1, max=15, step=1,
+            { type="slider", pixel=true, text="Group Spacing", min=-1, max=15, step=1,
               getValue=function() return SVal("groupSpacing", 8) end,
               setValue=function(v) SSet("groupSpacing", v) end });  y = y - h
 
@@ -5375,7 +5375,7 @@ initFrame:SetScript("OnEvent", function(self)
               values={ __placeholder = "All" }, order={ "__placeholder" },
               getValue=function() return "__placeholder" end,
               setValue=function() end },
-            { type="slider", text="Frame Spacing", min=-1, max=15, step=1,
+            { type="slider", pixel=true, text="Frame Spacing", min=-1, max=15, step=1,
               getValue=function() return SVal("partyCellSpacing", db.profile.cellSpacing or 2) end,
               setValue=function(v) PSSet("partyCellSpacing", v) end });  y = y - h
         -- Overlay the checkbox dropdown onto the LEFT region (Auto Resize Icons
@@ -5841,7 +5841,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 3: Spacing | Border Size (+ swatch)
         local defBdrRow
         defBdrRow, h = W:DualRow(parent, y,
-            { type="slider", text="Spacing", min=-1, max=10, step=1,
+            { type="slider", pixel=true, text="Spacing", min=-1, max=10, step=1,
               disabled=DefDisabled, disabledTooltip="Show Defensives & Externals",
               getValue=function() return SVal("defSpacing", 1) end,
               setValue=function(v) SSet("defSpacing", v) end },
@@ -6056,7 +6056,7 @@ initFrame:SetScript("OnEvent", function(self)
             { type="slider", text="Icon Size", min=10, max=40, step=1,
               getValue=function() return SVal("paSize", 20) end,
               setValue=function(v) SSet("paSize", v) end },
-            { type="slider", text="Spacing", min=-1, max=10, step=1,
+            { type="slider", pixel=true, text="Spacing", min=-1, max=10, step=1,
               getValue=function() return SVal("paSpacing", 0) end,
               setValue=function(v) SSet("paSpacing", v) end });  y = y - h
 
@@ -6316,7 +6316,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 2: Spacing | Show Stacks (+ swatch + cog)
         local dbStacksRow
         dbStacksRow, h = W:DualRow(parent, y,
-            { type="slider", text="Spacing", min=-1, max=10, step=1,
+            { type="slider", pixel=true, text="Spacing", min=-1, max=10, step=1,
               disabled=function() return SVal("debuffFilter", "all") == "none" end,
               disabledTooltip="Show Debuffs",
               getValue=function() return SVal("debuffSpacing", 1) end,

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -4803,7 +4803,7 @@ initFrame:SetScript("OnEvent", function(self)
         do
             local classGapRow
             classGapRow, h = W:DualRow(parent, y,
-                { type = "slider", text = "Bar Spacing", min = 0, max = 20, step = 1,
+                { type = "slider", pixel = true, text = "Bar Spacing", min = 0, max = 20, step = 1,
                   disabled = classOff,
                   disabledTooltip = "Class Resource",
                   getValue = function() local c = cfg(); return c and c.pipSpacing or 3 end,
@@ -8976,7 +8976,7 @@ initFrame:SetScript("OnEvent", function(self)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Icon Settings",
                 rows = {
-                    { type = "slider", label = "Spacing", min = 0, max = 20, step = 1,
+                    { type = "slider", pixel = true, label = "Spacing", min = 0, max = 20, step = 1,
                       get = function() local p = DB(); return p and (p.totemBar.spacing or 2) end,
                       set = function(v)
                           local p = DB(); if not p then return end

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -9669,7 +9669,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 3: Bar Spacing + Background Color (with alpha)
         local sharedClassResRow3
         sharedClassResRow3, h = W:DualRow(parent, y,
-            { type="slider", text="Bar Spacing", min=0, max=10, step=1,
+            { type="slider", pixel=true, text="Bar Spacing", min=0, max=10, step=1,
               disabled=function() return SValSupported("classPowerStyle", "none") ~= "modern" end,
               disabledTooltip="Class Resource must be set to Modern", rawTooltip=true,
               getValue=function() return SValSupported("classPowerSpacing", 2) end,
@@ -9899,10 +9899,10 @@ initFrame:SetScript("OnEvent", function(self)
                       get=function() return SValSupported("buffOffsetY", 0) end,
                       set=function(v) SSetSupported("buffOffsetY", v) end },
                     -- Physical-pixel-perfect gaps between buff icons (X = columns, Y = rows).
-                    { type="slider", label="Spacing X", min=-1, max=10, step=1,
+                    { type="slider", pixel=true, label="Spacing X", min=-1, max=10, step=1,
                       get=function() return SValSupported("buffSpacingX", 1) end,
                       set=function(v) SSetSupported("buffSpacingX", v) end },
-                    { type="slider", label="Spacing Y", min=-1, max=10, step=1,
+                    { type="slider", pixel=true, label="Spacing Y", min=-1, max=10, step=1,
                       get=function() return SValSupported("buffSpacingY", 1) end,
                       set=function(v) SSetSupported("buffSpacingY", v) end },
                 },
@@ -10026,10 +10026,10 @@ initFrame:SetScript("OnEvent", function(self)
                       get=function() return SValSupported("debuffOffsetY", 0) end,
                       set=function(v) SSetSupported("debuffOffsetY", v) end },
                     -- Physical-pixel-perfect gaps between debuff icons (X = columns, Y = rows).
-                    { type="slider", label="Spacing X", min=-1, max=10, step=1,
+                    { type="slider", pixel=true, label="Spacing X", min=-1, max=10, step=1,
                       get=function() return SValSupported("debuffSpacingX", 1) end,
                       set=function(v) SSetSupported("debuffSpacingX", v) end },
-                    { type="slider", label="Spacing Y", min=-1, max=10, step=1,
+                    { type="slider", pixel=true, label="Spacing Y", min=-1, max=10, step=1,
                       get=function() return SValSupported("debuffSpacingY", 1) end,
                       set=function(v) SSetSupported("debuffSpacingY", v) end },
                 },
@@ -10411,7 +10411,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Row 3: Spacing | Show Countdown Text
         _, h = W:DualRow(parent, y,
-            { type="slider", text="Spacing", min=-1, max=10, step=1,
+            { type="slider", pixel=true, text="Spacing", min=-1, max=10, step=1,
               getValue=function() return PrivGet("paSpacing", 0) end,
               setValue=function(v) PrivSet("paSpacing", v) end },
             { type="toggle", text="Show Countdown Text",
@@ -13053,7 +13053,7 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="dropdown", text="Stack Direction", values={ up="Up", down="Down" }, order={ "up", "down" },
                       getValue=function() return db.profile.boss.bossStackDirection or "down" end,
                       setValue=function(v) db.profile.boss.bossStackDirection = v; ReloadAndUpdate() end },
-                    { type="slider", text="Vertical Spacing", min=-200, max=200, step=1,
+                    { type="slider", pixel=true, text="Vertical Spacing", min=-200, max=200, step=1,
                       getValue=function() return db.profile.bossSpacing or 80 end,
                       setValue=function(v) db.profile.bossSpacing = v; ReloadAndUpdate() end })
                 total = total + ch
@@ -13170,7 +13170,7 @@ initFrame:SetScript("OnEvent", function(self)
                           get=function() local _, y = ns.GetBossSimpleBuffOffset(db.profile.boss); return y end,
                           set=function(v) db.profile.boss.simpleBuffOffsetY = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                         -- Physical-pixel-perfect gap between the simple buff icons.
-                        { type="slider", label="Spacing", min=-1, max=10, step=1,
+                        { type="slider", pixel=true, label="Spacing", min=-1, max=10, step=1,
                           get=function() return db.profile.boss.simpleBuffSpacing or 1 end,
                           set=function(v) db.profile.boss.simpleBuffSpacing = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                     },
@@ -13304,7 +13304,7 @@ initFrame:SetScript("OnEvent", function(self)
                           get=function() local _, y = ns.GetBossSimpleDebuffOffset(db.profile.boss); return y end,
                           set=function(v) db.profile.boss.simpleDebuffOffsetY = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                         -- Physical-pixel-perfect gap between the simple debuff icons.
-                        { type="slider", label="Spacing", min=-1, max=10, step=1,
+                        { type="slider", pixel=true, label="Spacing", min=-1, max=10, step=1,
                           get=function() return db.profile.boss.simpleDebuffSpacing or 1 end,
                           set=function(v) db.profile.boss.simpleDebuffSpacing = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                     },
@@ -13476,7 +13476,7 @@ initFrame:SetScript("OnEvent", function(self)
                       get=function() return db.profile.boss.buffOffsetY or 0 end,
                       set=function(v) db.profile.boss.buffOffsetY = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                     -- Physical-pixel-perfect gap between the boss buff icons.
-                    { type="slider", label="Spacing", min=-1, max=10, step=1,
+                    { type="slider", pixel=true, label="Spacing", min=-1, max=10, step=1,
                       get=function() return db.profile.boss.buffSpacing or 1 end,
                       set=function(v) db.profile.boss.buffSpacing = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                 } })
@@ -13501,7 +13501,7 @@ initFrame:SetScript("OnEvent", function(self)
                       get=function() return db.profile.boss.debuffOffsetY or 0 end,
                       set=function(v) db.profile.boss.debuffOffsetY = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                     -- Physical-pixel-perfect gap between the boss debuff icons.
-                    { type="slider", label="Spacing", min=-1, max=10, step=1,
+                    { type="slider", pixel=true, label="Spacing", min=-1, max=10, step=1,
                       get=function() return db.profile.boss.debuffSpacing or 1 end,
                       set=function(v) db.profile.boss.debuffSpacing = v; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end },
                 } })

--- a/EllesmereUI_Widgets.lua
+++ b/EllesmereUI_Widgets.lua
@@ -1605,6 +1605,47 @@ local function BuildSliderCore(parent, trackW, trackH, thumbSz, inputW, inputH, 
 end
 
 -------------------------------------------------------------------------------
+--  Pixel-unit sliders  (cfg.pixel = true)
+--
+--  The saved value stays in WoW coordinate units (profile format unchanged);
+--  the slider displays and edits whole physical screen pixels, so "1" is one
+--  on-screen pixel at any resolution/UI scale. min/max are declared in
+--  coordinate units and converted at build time, keeping the physical range
+--  identical to the pre-pixel slider. At a pixel-perfect UI scale
+--  (PP.mult == 1) every conversion is the identity and nothing changes.
+--  Supports both accessor conventions: getValue/setValue (row configs) and
+--  get/set (cog popup rows). Returns the cfg untouched when the flag is off,
+--  so callers can pass every slider cfg through unconditionally.
+-------------------------------------------------------------------------------
+local function PixelizeSliderCfg(cfg)
+    -- Conversions run against the GAME screen grid (EllesmereUI.PP), not this
+    -- file's panel-scale PP (PanelPP) -- the saved values live in UIParent
+    -- coordinate units.
+    local gamePP = EllesmereUI.PP
+    if not (cfg and cfg.pixel and gamePP) then return cfg end
+    local px = {}
+    for k, v in pairs(cfg) do px[k] = v end
+    px.min, px.max, px.step = gamePP.ToPixels(cfg.min or 0), gamePP.ToPixels(cfg.max or 0), 1
+    local get, set = cfg.getValue or cfg.get, cfg.setValue or cfg.set
+    local pxGet = get and function()
+        local v = get()
+        return v and gamePP.ToPixels(v)
+    end
+    local pxSet = set and function(v) return set(gamePP.FromPixels(v)) end
+    if cfg.getValue then px.getValue = pxGet end
+    if cfg.get then px.get = pxGet end
+    if cfg.setValue then px.setValue = pxSet end
+    if cfg.set then px.set = pxSet end
+    return px
+end
+
+-- Localized label with the pixel-unit suffix. The suffix is appended after
+-- localization so the L() lookup key stays the untouched English string.
+local function PixelLabel(text)
+    return EllesmereUI.L(text or "") .. " (px)"
+end
+
+-------------------------------------------------------------------------------
 --  Shared Tooltip  (single frame, lazily created, reused by all widgets)
 -------------------------------------------------------------------------------
 local tooltipFrame
@@ -2296,7 +2337,7 @@ function WidgetFactory:Toggle(parent, text, yOffset, getValue, setValue, tooltip
 end
 
 -- Slider with teal fill bar
-function WidgetFactory:Slider(parent, text, yOffset, minVal, maxVal, step, getValue, setValue, tooltip)
+function WidgetFactory:Slider(parent, text, yOffset, minVal, maxVal, step, getValue, setValue, tooltip, pixel)
     local ROW_H = 50
     local frame = CreateFrame("Frame", nil, parent)
     PP.Size(frame, parent:GetWidth() - CONTENT_PAD * 2, ROW_H)
@@ -2305,8 +2346,9 @@ function WidgetFactory:Slider(parent, text, yOffset, minVal, maxVal, step, getVa
     TagOptionRow(frame, parent, text, tooltip)
     local label = MakeFont(frame, 14, nil, TEXT_WHITE_R, TEXT_WHITE_G, TEXT_WHITE_B)
     PP.Point(label, "LEFT", frame, "LEFT", 20, 0)
-    label:SetText(EllesmereUI.L(text))
-    local trackFrame, valBox = BuildSliderCore(frame, 320, 4, 14, 40, 26, 13, SL.INPUT_A, minVal, maxVal, step, getValue, setValue)
+    label:SetText(pixel and PixelLabel(text) or EllesmereUI.L(text))
+    local scfg = PixelizeSliderCfg({ pixel = pixel, min = minVal, max = maxVal, step = step, getValue = getValue, setValue = setValue })
+    local trackFrame, valBox = BuildSliderCore(frame, 320, 4, 14, 40, 26, 13, SL.INPUT_A, scfg.min, scfg.max, scfg.step, scfg.getValue, scfg.setValue)
     PP.Point(valBox, "RIGHT", frame, "RIGHT", -20, 0)
     PP.Point(trackFrame, "RIGHT", valBox, "LEFT", -16, 0)
     AttachLabelHover(frame, label, (ClampRowLabel(label, trackFrame, "LEFT", 12, text, tooltip)))
@@ -3435,8 +3477,10 @@ function WidgetFactory:DualRow(parent, yOffset, leftCfg, rightCfg)
 
         if t == "slider" then
             local defaultTrackW = isRussian and 120 or 160
+            local scfg = PixelizeSliderCfg(cfg)
+            if scfg ~= cfg then label:SetText(PixelLabel(cfg.text)) end
             local trackFrame, valBox, _, slThumb = BuildSliderCore(region, cfg.trackWidth or defaultTrackW, 4, 14, 40, 26, 13, SL.INPUT_A,
-                cfg.min, cfg.max, cfg.step, cfg.getValue, cfg.setValue, true, cfg.snapPoints)
+                scfg.min, scfg.max, scfg.step, scfg.getValue, scfg.setValue, true, cfg.snapPoints)
             PP.Point(valBox, "RIGHT", region, "RIGHT", -SIDE_PAD, 0)
             PP.Point(trackFrame, "RIGHT", valBox, "LEFT", -12, 0)
             controlFrame = nil  -- slider handles its own disabled state; don't let generic handler disable mouse
@@ -3857,8 +3901,10 @@ function WidgetFactory:TripleRow(parent, yOffset, leftCfg, midCfg, rightCfg, spl
 
         if t == "slider" then
             local defaultTrackW = isRussian and 100 or 130
+            local scfg = PixelizeSliderCfg(cfg)
+            if scfg ~= cfg then label:SetText(PixelLabel(cfg.text)) end
             local trackFrame, valBox, _, slThumb = BuildSliderCore(region, cfg.trackWidth or defaultTrackW, 4, 14, 40, 26, 13, SL.INPUT_A,
-                cfg.min, cfg.max, cfg.step, cfg.getValue, cfg.setValue, true, cfg.snapPoints)
+                scfg.min, scfg.max, scfg.step, scfg.getValue, scfg.setValue, true, cfg.snapPoints)
             PP.Point(valBox, "RIGHT", region, "RIGHT", -SIDE_PAD, 0)
             PP.Point(trackFrame, "RIGHT", valBox, "LEFT", -12, 0)
             RegisterWidgetRefresh(function()
@@ -4539,7 +4585,7 @@ local function BuildCogPopup(opts)
         local maxDDLblW = 0
         for _, row in ipairs(opts.rows) do
             if row.type == "slider" or row.type == "input" then
-                tmpFS:SetText(EllesmereUI.L(row.label))
+                tmpFS:SetText(row.pixel and PixelLabel(row.label) or EllesmereUI.L(row.label))
                 local w = tmpFS:GetStringWidth()
                 if w > maxLblW then maxLblW = w end
             elseif row.type == "dropdown" or row.type == "segmented" then
@@ -4625,12 +4671,13 @@ local function BuildCogPopup(opts)
             if i > 1 then curY = curY - GAP end
 
             if row.type == "slider" then
+                local srow = PixelizeSliderCfg(row)
                 local lbl = MakeFont(pf, 11, nil, 1, 1, 1); lbl:SetAlpha(0.6)
-                lbl:SetText(EllesmereUI.L(row.label))
+                lbl:SetText(srow ~= row and PixelLabel(row.label) or EllesmereUI.L(row.label))
                 lbl:SetPoint("LEFT", pf, "TOPLEFT", SIDE_PAD, curY - ROW_H / 2 - 1)
 
                 local track, valBox, updateVisual = BuildSliderCore(pf, SLIDER_W, 4, 12, INPUT_W, ROW_H, 11, POPUP_INPUT_A,
-                    row.min, row.max, row.step, row.get, row.set, true)
+                    srow.min, srow.max, srow.step, srow.get, srow.set, true)
                 track:SetPoint("LEFT", pf, "TOPLEFT", SLIDER_LEFT, curY - ROW_H / 2)
                 valBox:ClearAllPoints()
                 valBox:SetPoint("RIGHT", pf, "TOPRIGHT", -SIDE_PAD, curY - ROW_H / 2)
@@ -4655,7 +4702,7 @@ local function BuildCogPopup(opts)
                     sliderDis:SetScript("OnLeave", function() if EllesmereUI.HideWidgetTooltip then EllesmereUI.HideWidgetTooltip() end end)
                 end
 
-                rowWidgets[#rowWidgets + 1] = { type = "slider", updateVisual = updateVisual, get = row.get, disOverlay = sliderDis, disCheck = row.disabled }
+                rowWidgets[#rowWidgets + 1] = { type = "slider", updateVisual = updateVisual, get = srow.get, disOverlay = sliderDis, disCheck = row.disabled }
                 curY = curY - ROW_H
 
             elseif row.type == "toggle" then


### PR DESCRIPTION
## What does this PR do?

At non-pixel-perfect UI scales the spacing sliders cannot express a true 1-pixel gap. Example: 4K (2160p) at uiScale 0.71, where `PP.mult ~= 0.5008`, so the smallest slider step of 1 coordinate unit renders as 2 physical pixels -- there is no value that produces a 1px gap.

This PR makes every inter-element spacing slider display and edit **whole physical screen pixels** while keeping the saved value in WoW coordinate units:

- **Profile format unchanged, no migration.** Reads convert coord -> px via `PP.ToPixels`, writes convert px -> coord via `PP.FromPixels`, only at the GUI boundary. Existing profiles render exactly as before; the slider simply shows the true pixel count (a stored `1` at 4K/0.71 now displays as `2` px).
- **One mechanism, flag per slider.** A single `PixelizeSliderCfg` helper in `EllesmereUI_Widgets.lua`, applied in the four slider build paths (DualRow, TripleRow, cog popup, positional `W:Slider`). Each spacing slider opts in with a `pixel = true` flag (43 sliders across ActionBars, ABR, BlizzardSkin, CDM, DamageMeters, DataBars micro menu, Minimap, MythicTimer, Nameplates, RaidFrames, ResourceBars, UnitFrames, Chat sidebar cog, and the internal Button Spacing slider). Labels get an ASCII " (px)" suffix appended after the `L()` lookup so locale keys are untouched.
- **min/max converted at build time**, so each slider's physical range matches its previous coordinate range. At a pixel-perfect scale (`PP.mult == 1`) every conversion is the identity and nothing changes for those users.
- **`PP.Scale` gains an epsilon guard** (same idiom as `SnapForES`): pixel-slider writes sit exactly on a grid boundary (`px * mult`) and float dust from the multiply/divide round trip can land a hair below it, silently costing a whole pixel. Measured: 21-25 of 400 grid values were dropped at 4K/0.53 and 1080p/1.0 with the old unguarded floor. Mid-interval values are unaffected.

Deliberately excluded: Nameplates "Stacked Nameplate Spacing" (a percent scale, not a coordinate gap) and DataBars Left/Right/Top/Bottom content gaps (reserved-space widths, not inter-element spacing).

**On criterion 2 (opt-in):** this is a display-unit change, not a rendering change -- stored values and everything on screen stay identical for existing users; only the number and label shown in the options panel change (plus finer granularity where mult < 1). If you would rather gate the px display behind a General toggle, happy to add that -- the flag architecture makes it a small diff.

## How was it tested?

- Verified in game on live retail at 4K/0.71: CDM Icon Spacing set to 1 renders exactly 1 physical pixel; existing profile values unchanged visually.
- Round-trip harness under Lua 5.1 (same math the client uses): GUI px -> stored coord -> redisplayed px -> `PP.Scale`-rendered px is exact for every value in -400..400 px across eight resolution/scale combos (4K at 0.71 / 0.53 / perfect, 1440p at 0.5333 / perfect, 1080p at 0.71 / 1.0, 1600p at 0.65).
- `luac -p` clean on all 16 touched files; added lines are ASCII-only.
- Not yet run on the 12.1 PTR client, but the change is pure Lua arithmetic in the options layer -- no API surface that diverges under `IS_121`.

## Screenshots
- Before:
<img width="1700" height="690" alt="image" src="https://github.com/user-attachments/assets/accb05c9-6308-4e8e-ae3a-8d73e6047a43" />

- After:
<img width="836" height="140" alt="{4854C09C-8553-41FE-9F2E-6E3AB8A4FD0F}" src="https://github.com/user-attachments/assets/322fba1f-98e3-4c19-83ac-0453dec14385" />

## Checklist

- [ ] New settings default **OFF** (no behavior change without opt-in) -- N/A: no new setting; saved values and on-screen rendering are unchanged, only the options-panel unit display changes (see note above; can be gated if preferred)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- conversions run only while an options slider is built or dragged; zero gameplay-time cost
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- touches only EllesmereUI's own widget layer
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client -- tested on live retail (4K, multiple scales); PTR not yet verified
