### PR TITLE
Nameplates: support localized "Interrupted" text via EllesmereUI.L

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -8150,10 +8150,7 @@ function NameplateFrame:ShowInterrupted(interrupterGUID)
     local fc = (p and p.interruptedFlashColor) or defaults.interruptedFlashColor
     self.cast:GetStatusBarTexture():SetVertexColor(fc.r, fc.g, fc.b)
 
-    -- Resolve the interrupter's name + class from the GUID, exactly as PR #398
-    -- does. Class-color is applied via an embedded hex code when the class
-    -- resolves; if it doesn't (e.g. a secret GUID), the `if interrupterClass`
-    -- check simply skips coloring and the name shows uncolored.
+    -- Resolve the interrupter's name + class from the GUID.
     local interrupterName
     local interrupterClass
     if interrupterGUID then
@@ -8177,11 +8174,11 @@ function NameplateFrame:ShowInterrupted(interrupterGUID)
     -- FontString; the cast-target / timer slots are cleared during the flash.
     local castW = self.cast:GetWidth()
     if castW and castW > 0 then
-        -- Interrupter name uses near-full bar width to fit "Interrupted (Name)";
-        -- the plain "Interrupted" flash falls back to the configured name width %.
         local cnWPct = (p and p.castNameWidthPct) or defaults.castNameWidthPct
         self.castName:SetWidth(interrupterName and math.max(castW - 8, 20) or castW * cnWPct / 100)
     end
+
+    local interruptedText = (EllesmereUI and EllesmereUI.L and EllesmereUI.L("Interrupted")) or "Interrupted"
     if interrupterName then
         local sourceText = interrupterName
         if useClassColor and interrupterClass and C_ClassColor then
@@ -8194,10 +8191,11 @@ function NameplateFrame:ShowInterrupted(interrupterGUID)
                 if hex then sourceText = "|c" .. hex .. interrupterName .. "|r" end
             end
         end
-        self.castName:SetText("Interrupted (" .. sourceText .. ")")
+        self.castName:SetText(interruptedText .. " (" .. sourceText .. ")")
     else
-        self.castName:SetText("Interrupted")
+        self.castName:SetText(interruptedText)
     end
+
     self.castTarget:SetText("")
     self.castTarget:Hide()
     self.castTimer:Hide()


### PR DESCRIPTION
Use EllesmereUI.L("Interrupted") to retrieve the translated interrupt text, falling back to "Interrupted" if EllesmereUI.L is unavailable.

Concatenate the translated text with the interrupter’s name (preserving existing color support) to produce "Interrupted (Name)" (or just "Interrupted") in the target language.

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<When an enemy's spell cast is interrupted, the “Interrupted” text on the nameplate’s cast bar now appears in your client’s language (e.g. "已打断" in Simplified Chinese) instead of always being English. The interrupter’s name remains colored by class, and the fallback to English works when no translation is available.>

## How was it tested?

<Simplified Chinese client (with EllesmereUI_zhCN and zhCN.lua containing L["Interrupted"] = "已打断"):
Interrupted an enemy → cast bar displayed "已打断" (no interrupter name) or "已打断 (玩家名)" (with interrupter) – correct translation.
Interrupter name with class color → hex formatting preserved.
With localization engine present but missing the key → fell back to "Interrupted" – no>

## Screenshots

<img width="368" height="190" alt="6b4e6eb3a1df00e45967a6c5e2050004" src="https://github.com/user-attachments/assets/f3d4c634-3436-4610-8cca-667ae965436a" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
