### PR TITLE
Bug/resource bar text value

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1118,7 +1118,7 @@ local DEFAULTS = {
             bgR         = 1, bgG = 1, bgB = 1, bgA = 0.1,
             showText    = true,
             showTextOnlyIfNoPower = false,  -- only show the resource text while the power bar is hidden (see IsPowerBarHidden)
-            showPercent = true,
+            showPercent = false,  -- secondary "Show %": OFF = value (default), ON = percent (Maelstrom/Insanity/Focus/Astral Power bars)
             showMaxStacks = true,
             textSize    = 11,
             textR       = 1, textG = 1, textB = 1,
@@ -4717,45 +4717,39 @@ local function UpdateSecondaryResource()
             end
             -- Count text
             if sp.showText and secondaryFrame._countText then
+                local ct = secondaryFrame._countText
                 local percentSuffix = (sp.showPercent == false) and "" or "%"
-                if not tainted then
-                    if powerType == "BREWMASTER_STAGGER" then
-                        -- Show stagger as percentage of max health
+                -- The power-based bar resources :"Show %" as a
+                -- value<->percent switch: ON = percent (secret-safe via the
+                -- ScaleTo100 declassifier; capped 0-100 by nature), OFF = the raw
+                -- value. Value is the default (showPercent defaults false for
+                -- the secondary). Both modes use SetFormattedText, which renders a
+                -- secret value's digits engine-side, so they work in instanced
+                -- combat with no Lua compare/concat on the secret.
+                local pType = (powerType == "MAELSTROM_BAR") and PT.MAELSTROM
+                           or (powerType == "INSANITY_BAR") and PT.INSANITY
+                           or (powerType == "FOCUS_BAR") and PT.FOCUS
+                           or (powerType == "LUNAR_POWER_BAR") and PT.LUNAR_POWER
+                           or nil
+                if powerType == "BREWMASTER_STAGGER" then
+                    -- Stagger always shows a percentage of max health
+                    -- The "%" sign is the only thing "Show %" toggles here
+                    if not tainted then
                         local pct = maxC > 0 and (cur / maxC * 100) or 0
-                        secondaryFrame._countText:SetText(format("%d", pct) .. percentSuffix)
-                    elseif powerType == "IGNOREPAIN_BAR" then
-                        -- Text is driven per-frame by IP.UpdateText (viewer
-                        -- capture preferred, fill-width fallback). No-op here.
-                    elseif sp.showMaxStacks == false then
-                        -- Devourer with Show Max Stacks off: current count only.
-                        secondaryFrame._countText:SetFormattedText("%s", cur)
+                        ct:SetText(format("%d", pct) .. percentSuffix)
                     else
-                        -- Current / max. SetFormattedText renders the (possibly
-                        -- secret) current and keeps the clean max -- no Lua concat
-                        -- of a secret value (see the note at the primary bar).
-                        secondaryFrame._countText:SetFormattedText("%s / %s", cur, maxC)
+                        local cp = secondaryBar._staggerPctCache
+                        if cp then ct:SetText(format("%d", cp) .. percentSuffix) else ct:SetText("") end
                     end
+                elseif powerType == "IGNOREPAIN_BAR" then
+                    -- Text is driven per-frame by IP.UpdateText. No-op here.
+                elseif pType and sp.showPercent and UnitPowerPercent then
+                    -- Percent
+                    local pct = UnitPowerPercent("player", pType, true, CurveConstants and CurveConstants.ScaleTo100) or 0
+                    ct:SetFormattedText("%d%%", pct)
                 else
-                    -- Secret value path: percent through the ScaleTo100 curve
-                    -- (bare UnitPowerPercent returns a 0-1 fraction).
-                    local pType = (powerType == "MAELSTROM_BAR") and PT.MAELSTROM
-                               or (powerType == "INSANITY_BAR") and PT.INSANITY
-                               or (powerType == "FOCUS_BAR") and PT.FOCUS
-                               or (powerType == "LUNAR_POWER_BAR") and PT.LUNAR_POWER
-                               or nil
-                    if pType and UnitPowerPercent then
-                        local pct = UnitPowerPercent("player", pType, true, CurveConstants and CurveConstants.ScaleTo100) or 0
-                        -- SetFormattedText formats engine-side, so a SECRET
-                        -- percent still renders; Lua format()/concat on a
-                        -- secret would error instead.
-                        secondaryFrame._countText:SetFormattedText("%d%s", pct, percentSuffix)
-                    elseif powerType == "IGNOREPAIN_BAR" then
-                        -- Text is driven per-frame by IP.UpdateText. No-op here.
-                    elseif sp.showMaxStacks == false then
-                        secondaryFrame._countText:SetFormattedText("%s", cur)
-                    else
-                        secondaryFrame._countText:SetFormattedText("%s / %s", cur, maxC)
-                    end
+                    -- Value
+                    ct:SetFormattedText("%s", cur)
                 end
             end
         end


### PR DESCRIPTION
## What does this PR do?

Fix resource bar showing percentage incorrectly
Add a toggle between value and percentage

## How was it tested?

In follow dungeon with /euidev: Both live and PTR, on shaman, toggle between both modes. Sanity check brew stagger bar on live.

## Screenshots
<img width="261" height="111" alt="image" src="https://github.com/user-attachments/assets/73c7974b-b1a7-4e53-acf9-43a4afb59b79" />
<img width="336" height="291" alt="image" src="https://github.com/user-attachments/assets/f2ed7bc1-e1d1-4e8a-bb23-2c40ea6ff7bc" />
<img width="340" height="252" alt="image" src="https://github.com/user-attachments/assets/b6bffae3-6d41-4cc0-ac0e-3f4d7e2766c1" />

## Checklist

- [ x] New settings default **OFF** (no behavior change without opt-in)
- [ x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
