### PR TITLE
QoL: make the auto-repair message translatable + money format toggle

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -440,6 +440,15 @@ initFrame:SetScript("OnEvent", function(self)
                           if not EllesmereUIDB then EllesmereUIDB = {} end
                           EllesmereUIDB.autoRepairGuild = v
                       end },
+                    -- Off (default) = short text "12o 34a"; on = coin icons.
+                    { type="toggle", label="Coin Icons",
+                      get=function()
+                          return EllesmereUIDB and EllesmereUIDB.repairCoinIcons == true
+                      end,
+                      set=function(v)
+                          if not EllesmereUIDB then EllesmereUIDB = {} end
+                          EllesmereUIDB.repairCoinIcons = v
+                      end },
                 },
             })
 

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -600,6 +600,25 @@ qolFrame:SetScript("OnEvent", function(self)
     ---------------------------------------------------------------------------
     --  Auto Sell Junk + Auto Repair
     ---------------------------------------------------------------------------
+    -- Auto-repair cost string. Coin icons (opt-in via the Auto Repair cog) use
+    -- the game's own localized coin textures; the default short text builds
+    -- "12o 34a" from localized suffixes (EllesmereUI.L translates g/s -> o/a in
+    -- frFR; copper "c" falls through untranslated).
+    local function RepairCostString(cost)
+        if EllesmereUIDB and EllesmereUIDB.repairCoinIcons then
+            return C_CurrencyInfo.GetCoinTextureString(cost)
+        end
+        local g = floor(cost / 10000)
+        local s = floor((cost % 10000) / 100)
+        local c = cost % 100
+        local out = ""
+        if g > 0 then out = g .. EllesmereUI.L("g") end
+        if s > 0 then out = out .. (out ~= "" and " " or "") .. s .. EllesmereUI.L("s") end
+        if c > 0 then out = out .. (out ~= "" and " " or "") .. c .. EllesmereUI.L("c") end
+        if out == "" then out = "0" .. EllesmereUI.L("c") end
+        return out
+    end
+
     local merchantFrame = CreateFrame("Frame", "EUI_MerchantHandler", UIParent)
     merchantFrame:RegisterEvent("MERCHANT_SHOW")
     merchantFrame:SetScript("OnEvent", function()
@@ -624,7 +643,7 @@ qolFrame:SetScript("OnEvent", function(self)
 
                     -- Check if we can actually afford the repair
                     if not useGuild and GetMoney() < cost then
-                        EllesmereUI.Print("|cff0CD29DEllesmereUI:|r |cffff6060Not enough gold to repair.|r")
+                        EllesmereUI.Print("|cff0CD29DEllesmereUI:|r |cffff6060" .. EllesmereUI.L("Not enough gold to repair.") .. "|r")
                         return
                     end
 
@@ -641,10 +660,8 @@ qolFrame:SetScript("OnEvent", function(self)
                         end)
                     end
 
-                    local gold = floor(cost / 10000)
-                    local silver = floor((cost % 10000) / 100)
-                    local src = useGuild and " (guild bank)" or ""
-                    EllesmereUI.Print("|cff0CD29DEllesmereUI:|r Repaired all items for " .. gold .. "g " .. silver .. "s." .. src)
+                    local src = useGuild and EllesmereUI.L(" (guild bank)") or ""
+                    EllesmereUI.Print("|cff0CD29DEllesmereUI:|r " .. EllesmereUI.Lf("Repaired all items for %s", RepairCostString(cost)) .. src)
                 end
             end
         end


### PR DESCRIPTION
The auto-repair chat message and the 'not enough gold' warning were hardcoded English; they now route through EllesmereUI.Lf/.L so they localize. The repaired amount shows as coin-icon textures or short localized text (g/s/c suffixes), selectable via a new 'Coin Icons' toggle in the Auto Repair cog (text is the default).

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
