### PR TITLE
CDM: Add more anchors to stack

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -4956,7 +4956,7 @@ initFrame:SetScript("OnEvent", function(self)
                           return bd and bd.chargeHashLineWidth or 2
                       end,
                       set = function(v)
-                          local bd = SelectedTBB(); if not bd then return end
+                  local bd = SelectedTBB(); if not bd then return end
                           bd.chargeHashLineWidth = v
                           RefreshTBB()
                       end },
@@ -5002,11 +5002,11 @@ initFrame:SetScript("OnEvent", function(self)
                     or bd.chargeHashLines ~= true
                 cogBtn:SetAlpha(disabled and 0.15 or 0.4)
                 if disabled then cogBlock:Show() else cogBlock:Hide() end
-            end
+                      end
             cogBtn:HookScript("OnShow", UpdateChargeHashCog)
             EllesmereUI.RegisterWidgetRefresh(UpdateChargeHashCog)
             UpdateChargeHashCog()
-        end
+                  end
 
         do
             local rgn = chargeHashRow._rightRegion
@@ -10044,8 +10044,8 @@ initFrame:SetScript("OnEvent", function(self)
                                       get=function() return ss.stackCountR or (cdmBd and cdmBd.stackCountR) or 1, ss.stackCountG or (cdmBd and cdmBd.stackCountG) or 1, ss.stackCountB or (cdmBd and cdmBd.stackCountB) or 1 end,
                                       set=function(r, g, b) EnsureSS(); ss.stackCountR = r; ss.stackCountG = g; ss.stackCountB = b; if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end if row._updateLabel then row._updateLabel() end end },
                                     { type="dropdown", label="Position",
-                                      values={ bottomright="Bottom Right", bottomleft="Bottom Left", topright="Top Right", topleft="Top Left", center="Center" },
-                                      order={ "bottomright", "bottomleft", "topright", "topleft", "center" },
+                                      values={ bottomright="Bottom Right", bottom="Bottom", bottomleft="Bottom Left", left="Left", topleft="Top Left", top="Top", topright="Top Right", right="Right", center="Center" },
+                                      order={ "bottomright", "bottom", "bottomleft", "left", "topleft", "top", "topright", "right", "center" },
                                       get=function() return ss.stackCountPosition or (cdmBd and cdmBd.stackCountPosition) or "bottomright" end,
                                       set=function(v) EnsureSS(); ss.stackCountPosition = v; if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end if row._updateLabel then row._updateLabel() end end },
                                     { type="slider", label="X Offset", min=-150, max=150, step=1,
@@ -14436,9 +14436,13 @@ initFrame:SetScript("OnEvent", function(self)
                         local scY = bd.stackCountY or 0
                         local scPoint = bd.stackCountPosition or "bottomright"
                         if scPoint == "bottomleft" then scPoint = "BOTTOMLEFT"; scY = scY + 2
+                        elseif scPoint == "bottom" then scPoint = "BOTTOM"; scY = scY + 2
                         elseif scPoint == "topright" then scPoint = "TOPRIGHT"
+                        elseif scPoint == "top" then scPoint = "top"
                         elseif scPoint == "topleft" then scPoint = "TOPLEFT"
                         elseif scPoint == "center" then scPoint = "CENTER"
+                        elseif scPoint == "left" then scPoint = "LEFT"
+                        elseif scPoint == "right" then scPoint = "RIGHT"
                         else scPoint = "BOTTOMRIGHT"; scY = scY + 2 end
                         EllesmereUI.ApplyIconTextFont(slot._stackText, scFont, scSize, "cdm")
                         slot._stackText:SetTextColor(scR, scG, scB)
@@ -17451,8 +17455,8 @@ initFrame:SetScript("OnEvent", function(self)
                           ns.RefreshCDMIconAppearance(BD().key); ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreview(); EllesmereUI:RefreshPage()
                       end },
                     { type="dropdown", label="Position",
-                      values={ bottomright="Bottom Right", bottomleft="Bottom Left", topright="Top Right", topleft="Top Left", center="Center" },
-                      order={ "bottomright", "bottomleft", "topright", "topleft", "center" },
+                      values={ bottomright="Bottom Right", bottom="Bottom", bottomleft="Bottom Left", left="Left", topleft="Top Left", top="Top", topright="Top Right", right="Right", center="Center" },
+                      order={ "bottomright", "bottom", "bottomleft", "left", "topleft", "top", "topright", "right", "center" },
                       get=function() return BD().stackCountPosition or "bottomright" end,
                       set=function(v)
                           BD().stackCountPosition = v

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -4956,7 +4956,7 @@ initFrame:SetScript("OnEvent", function(self)
                           return bd and bd.chargeHashLineWidth or 2
                       end,
                       set = function(v)
-                  local bd = SelectedTBB(); if not bd then return end
+                          local bd = SelectedTBB(); if not bd then return end
                           bd.chargeHashLineWidth = v
                           RefreshTBB()
                       end },
@@ -5002,11 +5002,11 @@ initFrame:SetScript("OnEvent", function(self)
                     or bd.chargeHashLines ~= true
                 cogBtn:SetAlpha(disabled and 0.15 or 0.4)
                 if disabled then cogBlock:Show() else cogBlock:Hide() end
-                      end
+            end
             cogBtn:HookScript("OnShow", UpdateChargeHashCog)
             EllesmereUI.RegisterWidgetRefresh(UpdateChargeHashCog)
             UpdateChargeHashCog()
-                  end
+        end
 
         do
             local rgn = chargeHashRow._rightRegion

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -5021,9 +5021,13 @@ function ns.StyleCustomChargeText(icon, barKey)
     local scY = (barData.stackCountY or 0) / iconScale
     local scPoint = barData.stackCountPosition or "bottomright"
     if scPoint == "bottomleft" then scPoint = "BOTTOMLEFT"; scY = scY + 2
+    elseif scPoint == "bottom" then scPoint = "BOTTOM"; scY = scY + 2
     elseif scPoint == "topright" then scPoint = "TOPRIGHT"
+    elseif scPoint == "top" then scPoint = "TOP"
     elseif scPoint == "topleft" then scPoint = "TOPLEFT"
     elseif scPoint == "center" then scPoint = "CENTER"
+    elseif scPoint == "left" then scPoint = "LEFT"
+    elseif scPoint == "right" then scPoint = "RIGHT"
     else scPoint = "BOTTOMRIGHT"; scY = scY + 2 end
     SetBlizzCDMFont(fs, GetCDMFont(), scSize,
         barData.stackCountR or 1, barData.stackCountG or 1, barData.stackCountB or 1)
@@ -5304,9 +5308,13 @@ local function RefreshCDMIconAppearance(barKey)
         -- top and center positions sit flush with no baseline nudge.
         local scPoint = (ssb and ssb.stackCountPosition) or barData.stackCountPosition or "bottomright"
         if scPoint == "bottomleft" then scPoint = "BOTTOMLEFT"; scY = scY + 2
+        elseif scPoint == "bottom" then scPoint = "BOTTOM"; scY = scY + 2
         elseif scPoint == "topright" then scPoint = "TOPRIGHT"
+        elseif scPoint == "top" then scPoint = "TOP"
         elseif scPoint == "topleft" then scPoint = "TOPLEFT"
         elseif scPoint == "center" then scPoint = "CENTER"
+        elseif scPoint == "left" then scPoint = "LEFT"
+        elseif scPoint == "right" then scPoint = "RIGHT"
         else scPoint = "BOTTOMRIGHT"; scY = scY + 2 end
         local showItemCount = barData.showItemCount ~= false
         if ssb and ssb.showItemCount ~= nil then showItemCount = ssb.showItemCount end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Add TOP, BOTTOM, LEFT and RIGHT anchor to stack anchor in the CDM. Also revisit the ordering of the anchor to be clockwise starting from bottom right (the default).

Feature request: https://discord.com/channels/585577383847788554/1528049855149113394

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
12.0.7, changing value both for one spell / buff in particular and for the whole bar

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

<img width="256" height="285" alt="image" src="https://github.com/user-attachments/assets/d71f5f94-9e83-472d-a7d0-8cf67f6f0b71" />

<img width="439" height="474" alt="image" src="https://github.com/user-attachments/assets/6ce17127-211d-4906-a072-4b0160ccce89" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
