### PR TITLE
Character sheet: hide enchant tooltip on other frames

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -5217,8 +5217,10 @@ function EllesmereUI._refreshEnchantsVisibility()
         if slot and GetFFD(slot).enchantLabel then
             if showEnchants then
                 GetFFD(slot).enchantLabel:Show()
+                if GetFFD(slot).enchantHoverFrame then GetFFD(slot).enchantHoverFrame:Show() end
             else
                 GetFFD(slot).enchantLabel:Hide()
+                if GetFFD(slot).enchantHoverFrame then GetFFD(slot).enchantHoverFrame:Hide() end
             end
         end
     end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -921,6 +921,7 @@ local function SkinCharacterSheet()
                     slot:SetShown(isCharacterTab)
                     if GetFFD(slot).itemLevelLabel    then GetFFD(slot).itemLevelLabel:SetShown(isCharacterTab)    end
                     if GetFFD(slot).enchantLabel      then GetFFD(slot).enchantLabel:SetShown(isCharacterTab)      end
+                    if GetFFD(slot).enchantHoverFrame then GetFFD(slot).enchantHoverFrame:SetShown(isCharacterTab) end
                     if GetFFD(slot).upgradeTrackLabel then GetFFD(slot).upgradeTrackLabel:SetShown(isCharacterTab) end
                 end
             end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Hide enchant tooltip on other frames (reputation, currency...). Also hide the tooltip when enabling / disabling the option instantly instead of requiring a reload.

Bug report: https://discord.com/channels/585577383847788554/1523454113679937670

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
- 12.0.7, open character sheet, go to other frame, confirm tooltip is hidden, go back to character sheet, confirm tooltip is visible.
- Enable the show enchant option, confirm the tooltip is there, disable it, confirm the tooltip is hidden. Do a reload and the opposite (on to off).

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
This was the original issue:
<img width="592" height="235" alt="image" src="https://github.com/user-attachments/assets/fc15f0ea-01a5-451f-bfa8-66e612f86631" />

Now it does not appear.

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- N/A New settings default **OFF** (no behavior change without opt-in)
- N/A Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
