### PR TITLE
Resource: disable expand power bar if no resource when height matched

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -7315,6 +7315,8 @@ initFrame:SetScript("OnEvent", function(self)
               disabled = function()
                   local p = DB(); if not p then return false end
                   if not p.primary.enabled then return true end
+                  -- Disabled when height matched
+                  if EllesmereUI.GetHeightMatchTarget and EllesmereUI.GetHeightMatchTarget("ERB_Power") then return true end
                   -- Shift blocks expand when the dropdown is set to Up/Down. This is
                   -- independent of "Show Class Resource" -- toggling the resource bar
                   -- must NOT change this control's disabled state.
@@ -7324,6 +7326,9 @@ initFrame:SetScript("OnEvent", function(self)
               disabledTooltip = function()
                   local p = DB()
                   if p and not p.primary.enabled then return "Power Bar" end
+	              if EllesmereUI.GetHeightMatchTarget and EllesmereUI.GetHeightMatchTarget("ERB_Power") then
+                      return "This option can't be used while you have the Power Bar Height Matched in the Unlock Mode."
+                  end
                   return "This option can't be used while Shift Elements if No Resource is enabled."
               end,
               getValue = function()


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Disable expand power bar if no resource when height matched. The value is already forced to false when the power bar is height matched so this just confused users.

Bug report: https://discord.com/channels/585577383847788554/1527391805912645704

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
12.0.7.
Went in unlock mode, height matched the power bar another frame. Then went in resource options and confirmed that "expand power bar if no resource" was disabled with the correct disabled tooltip. Without closing EUI, went to unlock mode and removed the height matched, option was not disabled anymore. Tested also with a /reload between each step.

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
<img width="469" height="77" alt="image" src="https://github.com/user-attachments/assets/95cea00f-f233-45d4-9e3c-7b52cfef14dc" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- N/A New settings default **OFF** (no behavior change without opt-in)
- N/A Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- N/A Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- N/A No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
