### PR TITLE
BlizzardUI Skin: Border and button options for popups and menus

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -11322,8 +11322,6 @@ initFrame:SetScript("OnEvent", function(self, event)
 
         -- Skin our custom buttons the same way as pooled Blizzard buttons
         if _reskinMenu then
-            local RS = EllesmereUI.RESKIN
-            local PP = EllesmereUI.PP
             for _, customBtn in ipairs({ btn, unlockBtn }) do
                 for j = 1, select("#", customBtn:GetRegions()) do
                     local r = select(j, customBtn:GetRegions())
@@ -11348,9 +11346,14 @@ initFrame:SetScript("OnEvent", function(self, event)
                 inset:SetFrameLevel(customBtn:GetFrameLevel())
                 local cBg = inset:CreateTexture(nil, "BACKGROUND", nil, -6)
                 cBg:SetAllPoints()
-                cBg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
-                if PP and PP.CreateBorder then
-                    PP.CreateBorder(inset, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
+                local buttonColor = EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor
+                    or { r=0.1, g=0.1, b=0.1, a=0.8 }
+                cBg:SetColorTexture(buttonColor.r or 0.1, buttonColor.g or 0.1,
+                    buttonColor.b or 0.1, buttonColor.a == nil and 0.8 or buttonColor.a)
+                EllesmereUI._GetFFD(customBtn).gameMenuInset = inset
+                EllesmereUI._GetFFD(customBtn).gameMenuButtonBg = cBg
+                if EllesmereUI._applyBlizzardConfiguredBorder then
+                    EllesmereUI._applyBlizzardConfiguredBorder(inset, "popupMenuButton", 1)
                 end
                 local hl = customBtn:CreateTexture(nil, "HIGHLIGHT")
                 hl:SetAllPoints(inset)
@@ -11360,6 +11363,10 @@ initFrame:SetScript("OnEvent", function(self, event)
                     local euiFont = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath() or nil
                     local _, size, flags = cfs:GetFont()
                     cfs:SetFont(euiFont or "Fonts\\FRIZQT__.TTF", (size or 14) - 2, flags or "")
+                    if EllesmereUI._getPopupMenuButtonTextColor then
+                        local r, g, b = EllesmereUI._getPopupMenuButtonTextColor()
+                        cfs:SetTextColor(r, g, b, 1)
+                    end
                 end
             end
         end
@@ -11378,8 +11385,10 @@ initFrame:SetScript("OnEvent", function(self, event)
                 if header then
                     local headerText = header.Text
                     if headerText and headerText.SetTextColor then
-                        local EG = ELLESMERE_GREEN
-                        headerText:SetTextColor(EG.r, EG.g, EG.b, 1)
+                        if EllesmereUI._getPopupMenuButtonTextColor then
+                            local r, g, b = EllesmereUI._getPopupMenuButtonTextColor()
+                            headerText:SetTextColor(r, g, b, 1)
+                        end
                     end
                 end
             end

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -11401,9 +11401,6 @@ initFrame:SetScript("OnEvent", function(self, event)
             if not showUnlock then unlockBtn:Hide() end
             if not showEUI and not showUnlock then return end
 
-            local eg = ELLESMERE_GREEN
-            local hex = string.format("|cff%02x%02x%02x", (eg.r or 0.05) * 255, (eg.g or 0.82) * 255, (eg.b or 0.62) * 255)
-
             -- Find the Shop button to anchor below (fall back to Options)
             local anchorBtn
             for menuBtn in GameMenuFrame.buttonPool:EnumerateActive() do
@@ -11432,10 +11429,16 @@ initFrame:SetScript("OnEvent", function(self, event)
 
             if showEUI then
                 btn:Show()
-                btn:SetText(hex .. "Ellesmere|r|cffffffff" .. "UI|r")
+                btn:SetText("EllesmereUI")
                 if _reskinMenu then
                     local fs = btn:GetFontString()
-                    if fs then fs:SetFont(euiFont, btnFontSize, "") end
+                    if fs then
+                        fs:SetFont(euiFont, btnFontSize, "")
+                        if EllesmereUI._getPopupMenuButtonTextColor then
+                            local r, g, b = EllesmereUI._getPopupMenuButtonTextColor()
+                            fs:SetTextColor(r, g, b, 1)
+                        end
+                    end
                 end
                 btn:ClearAllPoints()
                 btn:SetPoint("TOP", lastBtn, "BOTTOM", 0, -12)
@@ -11444,10 +11447,16 @@ initFrame:SetScript("OnEvent", function(self, event)
             end
             if showUnlock then
                 unlockBtn:Show()
-                unlockBtn:SetText(hex .. "EUI|r |cffffffffUnlock Mode|r")
+                unlockBtn:SetText("EUI Unlock Mode")
                 if _reskinMenu then
                     local fs2 = unlockBtn:GetFontString()
-                    if fs2 then fs2:SetFont(euiFont, btnFontSize, "") end
+                    if fs2 then
+                        fs2:SetFont(euiFont, btnFontSize, "")
+                        if EllesmereUI._getPopupMenuButtonTextColor then
+                            local r, g, b = EllesmereUI._getPopupMenuButtonTextColor()
+                            fs2:SetTextColor(r, g, b, 1)
+                        end
+                    end
                 end
                 unlockBtn:ClearAllPoints()
                 unlockBtn:SetPoint("TOP", lastBtn, "BOTTOM", 0, showEUI and -4 or -12)

--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -693,8 +693,25 @@ initFrame:SetScript("OnEvent", function(self)
             local gridH = gridRows * scaledBtnH + (gridRows - 1) * scaledPad
             local gridStartX = Snap(math.max(0, (self:GetWidth() - gridW) / 2))
 
-            -- Resize preview frame to fit all rows
-            local frameH = Snap(gridH + 20)  -- 10px padding top + bottom
+            -- Reserve room for a background that grows above/below the icon
+            -- grid. The ScrollFrame clips outside its scroll child, so without
+            -- this inset an upward-growing background loses its top border.
+            local bgTopInset, bgBottomInset = 0, 0
+            if settings.bgEnabled then
+                local rawBgPadding = settings.bgPadding
+                local bgSpacing = Snap((rawBgPadding ~= nil and rawBgPadding or (settings.bgPadY or 0)) * totalScale)
+                local bgMultiplierY = math.max(1, math.min(4, math.floor((settings.bgMultiplierY or 1) + 0.5)))
+                local bgIconPadding = Snap((settings.buttonPadding or 0) * totalScale)
+                local bgGrowY = (bgMultiplierY - 1) * (gridH + bgIconPadding)
+                if (settings.bgExpandDirectionY or "up") == "down" then
+                    bgBottomInset = bgSpacing + bgGrowY
+                else
+                    bgTopInset = bgSpacing + bgGrowY
+                end
+            end
+
+            -- Resize preview frame to fit all rows and background overflow.
+            local frameH = Snap(gridH + 20 + bgTopInset + bgBottomInset)
             self:SetHeight(frameH)
 
             -- Resize wrapper to min(content, max) and toggle scrollbar
@@ -703,7 +720,7 @@ initFrame:SetScript("OnEvent", function(self)
             if parentH > maxH then
                 -- Add bottom padding so the last icon row is fully visible
                 -- when scrolled to the bottom
-                local paddedH = Snap(gridH + 20 + scaledBtnH)
+                local paddedH = Snap(gridH + 20 + bgTopInset + bgBottomInset + scaledBtnH)
                 self:SetHeight(paddedH)
                 self._wrapper:SetHeight(maxH)
             else
@@ -715,10 +732,11 @@ initFrame:SetScript("OnEvent", function(self)
 
             -- Store grid bounds for background anchoring
             self._gridStartX = gridStartX
+            self._gridStartY = -Snap(10) - bgTopInset
             self._gridW      = gridW
             self._gridH      = gridH
 
-            local startY = -Snap(10)  -- top padding
+            local startY = self._gridStartY
             -- Match live layout: rows grow upward for "up" OR "center" (live
             -- lumps center with up for the icon grid; horizontal bars only ever
             -- store left/right/center, so a plain == "up" check never fired).
@@ -1077,7 +1095,7 @@ initFrame:SetScript("OnEvent", function(self)
                 local gx = self._gridStartX or 0
                 local gw = self._gridW or 0
                 local gh = self._gridH or 0
-                local gy = -Snap(10)  -- top padding (matches startY)
+                local gy = self._gridStartY or -Snap(10)
                 previewBG:ClearAllPoints()
                 local left, right = gx - extraX, gx + gw + extraX
                 local top, bottom = gy + extraY, gy - gh - extraY

--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -563,6 +563,8 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Preview background texture (behind all buttons)
         local previewBG = pf:CreateTexture(nil, "BACKGROUND", nil, -1)
+        local previewBGBorder = CreateFrame("Frame", nil, pf, "BackdropTemplate")
+        previewBGBorder:EnableMouse(false)
         previewBG:Hide()
 
         -- Store barFrame ref and base size for Update
@@ -1067,8 +1069,9 @@ initFrame:SetScript("OnEvent", function(self)
             if settings.bgEnabled then
                 local bgC = settings.bgColor or { r = 0, g = 0, b = 0, a = 0.5 }
                 previewBG:SetColorTexture(bgC.r, bgC.g, bgC.b, bgC.a)
-                local extraX = Snap((settings.bgPadX or 0) * totalScale)
-                local extraY = Snap((settings.bgPadY or 0) * totalScale)
+                local rawPadding = settings.bgPadding
+                local extraX = Snap((rawPadding ~= nil and rawPadding or (settings.bgPadX or 0)) * totalScale)
+                local extraY = Snap((rawPadding ~= nil and rawPadding or (settings.bgPadY or 0)) * totalScale)
                 -- Anchor to the full grid bounds (not individual buttons) so multi-row
                 -- backgrounds cover the entire grid even when the last row is shorter.
                 local gx = self._gridStartX or 0
@@ -1076,11 +1079,40 @@ initFrame:SetScript("OnEvent", function(self)
                 local gh = self._gridH or 0
                 local gy = -Snap(10)  -- top padding (matches startY)
                 previewBG:ClearAllPoints()
-                previewBG:SetPoint("TOPLEFT",     self, "TOPLEFT", gx - extraX,       gy + extraY)
-                previewBG:SetPoint("BOTTOMRIGHT", self, "TOPLEFT", gx + gw + extraX,  gy - gh - extraY)
+                local left, right = gx - extraX, gx + gw + extraX
+                local top, bottom = gy + extraY, gy - gh - extraY
+                local multiplierX = math.max(1, math.min(4, math.floor((settings.bgMultiplierX or 1) + 0.5)))
+                local multiplierY = math.max(1, math.min(4, math.floor((settings.bgMultiplierY or 1) + 0.5)))
+                local directionX = settings.bgExpandDirectionX or "right"
+                local directionY = settings.bgExpandDirectionY or "up"
+                local iconPadding = Snap((settings.buttonPadding or 0) * totalScale)
+                local growX = (multiplierX - 1) * (gw + iconPadding)
+                local growY = (multiplierY - 1) * (gh + iconPadding)
+                if directionX == "left" then left = left - growX else right = right + growX end
+                if directionY == "down" then bottom = bottom - growY else top = top + growY end
+                previewBG:SetPoint("TOPLEFT", self, "TOPLEFT", left, top)
+                previewBG:SetPoint("BOTTOMRIGHT", self, "TOPLEFT", right, bottom)
                 previewBG:Show()
+                previewBGBorder:ClearAllPoints()
+                previewBGBorder:SetAllPoints(previewBG)
+                if EllesmereUI.ApplyBorderStyle then
+                    local bc = settings.bgBorderColor or { r = 0, g = 0, b = 0, a = 1 }
+                    local thicknessKey = settings.bgBorderThickness or "none"
+                    local thickness = ns.BORDER_THICKNESS and ns.BORDER_THICKNESS[thicknessKey]
+                    local borderSize = thickness and thickness.regular or 0
+                    EllesmereUI.ApplyBorderStyle(previewBGBorder, borderSize,
+                        bc.r, bc.g, bc.b, bc.a or 1, settings.bgBorderTexture or "solid",
+                        settings.bgBorderOffsetX, settings.bgBorderOffsetY,
+                        settings.bgBorderShiftX, settings.bgBorderShiftY,
+                        "actionbars", thicknessKey)
+                end
             else
                 previewBG:Hide()
+                if EllesmereUI.ApplyBorderStyle then
+                    EllesmereUI.ApplyBorderStyle(previewBGBorder, 0, 0, 0, 0, settings.bgBorderTexture or "solid")
+                else
+                    previewBGBorder:Hide()
+                end
             end
 
             -- Apply bar opacity to the preview
@@ -2277,7 +2309,7 @@ initFrame:SetScript("OnEvent", function(self)
                 MakeCogBtn(rightRgn, growCogShow)
             end
 
-            -- Row 3: Vertical Orientation | Bar Background
+            -- Row 3: Vertical Orientation
             do
                 local orientRow
                 orientRow, h = W:DualRow(parent, y,
@@ -2297,13 +2329,7 @@ initFrame:SetScript("OnEvent", function(self)
                           EllesmereUI:RefreshPage()
                       end,
                       tooltip="Toggle between horizontal and vertical bar layout." },
-                    { type="toggle", text="Bar Background",
-                      getValue=function() return SGet("bgEnabled") end,
-                      setValue=function(v)
-                          SSet("bgEnabled", v, function(k) EAB:ApplyBackgroundForBar(k) end)
-                          SUpdatePreview()
-                          EllesmereUI:RefreshPage()
-                      end });  y = y - h
+                    { type="label", text="" });  y = y - h
                 -- Sync icon: Orientation (left)
                 do
                     local rgn = orientRow._leftRegion
@@ -2344,6 +2370,10 @@ initFrame:SetScript("OnEvent", function(self)
                     })
                 end
 
+                -- Legacy background controls used to live in Layout. Keep the
+                -- implementation block disabled so only the dedicated section
+                -- below owns these settings.
+                if false then
                 -- Sync icon: Bar Background (right region)
                 do
                     local rgn = orientRow._rightRegion
@@ -2354,13 +2384,19 @@ initFrame:SetScript("OnEvent", function(self)
                             local s = SB()
                             local en = s.bgEnabled
                             local c = s.bgColor
+                            local bc = s.bgBorderColor
                             local px = s.bgPadX or 0
                             local py = s.bgPadY or 0
                             for _, key in ipairs(GROUP_BAR_ORDER) do
-                                EAB.db.profile.bars[key].bgEnabled = en
-                                if c then EAB.db.profile.bars[key].bgColor = { r=c.r, g=c.g, b=c.b, a=c.a } end
-                                EAB.db.profile.bars[key].bgPadX = px
-                                EAB.db.profile.bars[key].bgPadY = py
+                                local bs = EAB.db.profile.bars[key]
+                                bs.bgEnabled = en
+                                if c then bs.bgColor = { r=c.r, g=c.g, b=c.b, a=c.a } end
+                                bs.bgPadX = px
+                                bs.bgPadY = py
+                                bs.bgBorderThickness = s.bgBorderThickness
+                                bs.bgBorderTexture = s.bgBorderTexture
+                                bs.bgBorderSize = s.bgBorderSize
+                                if bc then bs.bgBorderColor = { r=bc.r, g=bc.g, b=bc.b, a=bc.a } end
                                 EAB:ApplyBackgroundForBar(key)
                             end
                             EllesmereUI:RefreshPage()
@@ -2375,6 +2411,9 @@ initFrame:SetScript("OnEvent", function(self)
                                 if (bs.bgEnabled or false) ~= en then return false end
                                 if (bs.bgPadX or 0) ~= px then return false end
                                 if (bs.bgPadY or 0) ~= py then return false end
+                                if (bs.bgBorderThickness or "none") ~= (s.bgBorderThickness or "none") then return false end
+                                if (bs.bgBorderTexture or "solid") ~= (s.bgBorderTexture or "solid") then return false end
+                                if (bs.bgBorderSize or 1) ~= (s.bgBorderSize or 1) then return false end
                             end
                             return true
                         end,
@@ -2387,13 +2426,19 @@ initFrame:SetScript("OnEvent", function(self)
                                 local s = SB()
                                 local en = s.bgEnabled
                                 local c = s.bgColor
+                                local bc = s.bgBorderColor
                                 local px = s.bgPadX or 0
                                 local py = s.bgPadY or 0
                                 for _, key in ipairs(checkedKeys) do
-                                    EAB.db.profile.bars[key].bgEnabled = en
-                                    if c then EAB.db.profile.bars[key].bgColor = { r=c.r, g=c.g, b=c.b, a=c.a } end
-                                    EAB.db.profile.bars[key].bgPadX = px
-                                    EAB.db.profile.bars[key].bgPadY = py
+                                    local bs = EAB.db.profile.bars[key]
+                                    bs.bgEnabled = en
+                                    if c then bs.bgColor = { r=c.r, g=c.g, b=c.b, a=c.a } end
+                                    bs.bgPadX = px
+                                    bs.bgPadY = py
+                                    bs.bgBorderThickness = s.bgBorderThickness
+                                    bs.bgBorderTexture = s.bgBorderTexture
+                                    bs.bgBorderSize = s.bgBorderSize
+                                    if bc then bs.bgBorderColor = { r=bc.r, g=bc.g, b=bc.b, a=bc.a } end
                                     EAB:ApplyBackgroundForBar(key)
                                 end
                                 EllesmereUI:RefreshPage()
@@ -2475,39 +2520,393 @@ initFrame:SetScript("OnEvent", function(self)
                         bgCogBtn:SetAlpha(BgDisabled() and 0.15 or 0.4)
                     end)
                 end
+                end
             end
 
-            -- Row 4: Icon Order | (empty)
-            -- Supersedes the old Reverse Icon Order toggle. "default" and
-            -- "reversed" map exactly onto the legacy boolean (kept in sync
-            -- so older readers of the flag stay correct); the corner values
-            -- place button 1 in that corner of the bar's grid.
-            local iconOrderValues = {
-                default     = "Default",
-                reversed    = "Reversed",
-                TOPLEFT     = "Top Left",
-                TOPRIGHT    = "Top Right",
-                BOTTOMLEFT  = "Bottom Left",
-                BOTTOMRIGHT = "Bottom Right",
-            }
-            local iconOrderOrder = { "default", "reversed", "TOPLEFT", "TOPRIGHT", "BOTTOMLEFT", "BOTTOMRIGHT" }
-            _, h = W:DualRow(parent, y,
-                { type="dropdown", text="Icon Order",
-                  tooltip="Order of the buttons on this bar; corner options place the first button in that corner.",
-                  values=iconOrderValues, order=iconOrderOrder,
+            -- Built later, directly below ICON EFFECTS. Keeping the builder
+            -- near the other layout helpers avoids duplicating its callbacks.
+            local function BuildBarBackgroundSection()
+            -------------------------------------------------------------------
+            --  BAR BACKGROUND
+            -------------------------------------------------------------------
+            _, h = W:SectionHeader(parent, "BAR BACKGROUND", y);  y = y - h
+
+            local bgOptionsRow
+            bgOptionsRow, h = W:DualRow(parent, y,
+                { type="toggle", text="Enable",
+                  getValue=function() return SVal("bgEnabled", false) end,
+                  setValue=function(v)
+                      SSet("bgEnabled", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                      SUpdatePreview()
+                  end },
+                { type="slider", text="Spacing", min=0, max=20, step=1,
+                  disabled=BgDisabled,
+                  disabledTooltip="Bar Background",
                   getValue=function()
-                      local v = SVal("iconOrder", nil)
-                      if v == nil then
-                          v = SVal("reverseIconOrder", false) and "reversed" or "default"
-                      end
-                      return v
+                      local v = SGet("bgPadding")
+                      if v ~= nil then return v end
+                      return math.max(SVal("bgPadX", 0), SVal("bgPadY", 0))
                   end,
                   setValue=function(v)
-                      SDB().reverseIconOrder = (v == "reversed")
-                      SSet("iconOrder", v, function(k) EAB:ApplyIconRowOverrides(k) end)
-                      SUpdatePreviewAndResize()
+                      SB().bgPadX, SB().bgPadY = nil, nil
+                      SSet("bgPadding", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                      SUpdatePreview()
+                  end });  y = y - h
+
+            -- Background color swatch.
+            do
+                local left = bgOptionsRow._leftRegion
+                local swatch, refresh = EllesmereUI.BuildColorSwatch(left, left:GetFrameLevel() + 5,
+                    function()
+                        local c = SGet("bgColor") or { r=0, g=0, b=0, a=0.5 }
+                        return c.r, c.g, c.b, c.a
+                    end,
+                    function(r, g, b, a)
+                        SSetColor("bgColor", r, g, b, a, function(k) EAB:ApplyBackgroundForBar(k) end)
+                        SUpdatePreview()
+                    end, true, 20)
+                PP.Point(swatch, "RIGHT", left._control, "LEFT", -12, 0)
+                left._lastInline = swatch
+                EllesmereUI.RegisterWidgetRefresh(refresh)
+
+            end
+
+            do
+                local region = bgOptionsRow._leftRegion
+                EllesmereUI.BuildSyncIcon({
+                    region=region,
+                    tooltip="Apply Bar Background Enable to all Bars",
+                    onClick=function()
+                        local enabled = SVal("bgEnabled", false)
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            EAB.db.profile.bars[key].bgEnabled = enabled
+                            EAB:ApplyBackgroundForBar(key)
+                        end
+                        EllesmereUI:RefreshPage()
+                    end,
+                    isSynced=function()
+                        local enabled = SVal("bgEnabled", false)
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            if (EAB.db.profile.bars[key].bgEnabled or false) ~= enabled then return false end
+                        end
+                        return true
+                    end,
+                    flashTargets=function() return { region } end,
+                    multiApply={
+                        elementKeys=GROUP_BAR_ORDER,
+                        elementLabels=SHORT_LABELS,
+                        getCurrentKey=function() return SelectedKey() end,
+                        onApply=function(checkedKeys)
+                            local enabled = SVal("bgEnabled", false)
+                            for _, key in ipairs(checkedKeys) do
+                                EAB.db.profile.bars[key].bgEnabled = enabled
+                                EAB:ApplyBackgroundForBar(key)
+                            end
+                            EllesmereUI:RefreshPage()
+                        end,
+                    },
+                })
+            end
+
+            do
+                local region = bgOptionsRow._rightRegion
+                local function CurrentSpacing(settings)
+                    if settings.bgPadding ~= nil then return settings.bgPadding end
+                    return math.max(settings.bgPadX or 0, settings.bgPadY or 0)
+                end
+                local function ApplySpacingTo(key)
+                    local target = EAB.db.profile.bars[key]
+                    target.bgPadding = CurrentSpacing(SB())
+                    target.bgPadX = nil
+                    target.bgPadY = nil
+                    EAB:ApplyBackgroundForBar(key)
+                end
+                EllesmereUI.BuildSyncIcon({
+                    region=region,
+                    tooltip="Apply Bar Background Spacing to all Bars",
+                    onClick=function()
+                        for _, key in ipairs(GROUP_BAR_ORDER) do ApplySpacingTo(key) end
+                        EllesmereUI:RefreshPage()
+                    end,
+                    isSynced=function()
+                        local spacing = CurrentSpacing(SB())
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            if CurrentSpacing(EAB.db.profile.bars[key]) ~= spacing then return false end
+                        end
+                        return true
+                    end,
+                    flashTargets=function() return { region } end,
+                    multiApply={
+                        elementKeys=GROUP_BAR_ORDER,
+                        elementLabels=SHORT_LABELS,
+                        getCurrentKey=function() return SelectedKey() end,
+                        onApply=function(checkedKeys)
+                            for _, key in ipairs(checkedKeys) do ApplySpacingTo(key) end
+                            EllesmereUI:RefreshPage()
+                        end,
+                    },
+                })
+            end
+
+            do
+                local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
+                local bgBorderRow
+                bgBorderRow, h = W:DualRow(parent, y,
+                    { type="dropdown", text="Border Style",
+                      disabled=BgDisabled,
+                      disabledTooltip="Bar Background Border",
+                      values=texValues, order=texOrder,
+                      getValue=function() return SVal("bgBorderTexture", "solid") end,
+                      setValue=function(v)
+                          SSet("bgBorderTexture", v, function(k)
+                              local settings = EAB.db.profile.bars[k]
+                              settings.bgBorderOffsetX = nil
+                              settings.bgBorderOffsetY = nil
+                              settings.bgBorderShiftX = nil
+                              settings.bgBorderShiftY = nil
+                              EAB:ApplyBackgroundForBar(k)
+                          end)
+                          SUpdatePreview()
+                      end },
+                    { type="dropdown", text="Border Size",
+                      disabled=BgDisabled,
+                      disabledTooltip="Bar Background Border",
+                      values=ns.BORDER_THICKNESS_LABELS, order=ns.BORDER_THICKNESS_ORDER,
+                      getValue=function() return SVal("bgBorderThickness", "none") end,
+                      setValue=function(v)
+                          SSet("bgBorderThickness", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                          SUpdatePreview()
+                      end });  y = y - h
+
+                do
+                    local region = bgBorderRow._rightRegion
+                    local borderSwatch, refreshBorder = EllesmereUI.BuildColorSwatch(region, region:GetFrameLevel() + 5,
+                        function()
+                            local c = SGet("bgBorderColor") or { r=0, g=0, b=0, a=1 }
+                            return c.r, c.g, c.b, c.a
+                        end,
+                        function(r, g, b, a)
+                            SSetColor("bgBorderColor", r, g, b, a, function(k) EAB:ApplyBackgroundForBar(k) end)
+                            SUpdatePreview()
+                    end, true, 20)
+                    PP.Point(borderSwatch, "RIGHT", region._control, "LEFT", -12, 0)
+                    region._lastInline = borderSwatch
+                    EllesmereUI.RegisterWidgetRefresh(function()
+                        local disabled = BgDisabled() or SVal("bgBorderThickness", "none") == "none"
+                        borderSwatch:SetAlpha(disabled and 0.15 or 1)
+                        refreshBorder()
+                    end)
+                end
+
+                do
+                    local region = bgBorderRow._rightRegion
+                    local function ApplySizeTo(key)
+                        local source = SB()
+                        local target = EAB.db.profile.bars[key]
+                        target.bgBorderThickness = source.bgBorderThickness
+                        local color = source.bgBorderColor
+                        if color then
+                            target.bgBorderColor = { r=color.r, g=color.g, b=color.b, a=color.a }
+                        end
+                        EAB:ApplyBackgroundForBar(key)
+                    end
+                    EllesmereUI.BuildSyncIcon({
+                        region=region,
+                        tooltip="Apply Background Border Size and Color to all Bars",
+                        onClick=function()
+                            for _, key in ipairs(GROUP_BAR_ORDER) do ApplySizeTo(key) end
+                            EllesmereUI:RefreshPage()
+                        end,
+                        isSynced=function()
+                            local thickness = SVal("bgBorderThickness", "none")
+                            local color = SGet("bgBorderColor") or { r=0, g=0, b=0, a=1 }
+                            for _, key in ipairs(GROUP_BAR_ORDER) do
+                                local target = EAB.db.profile.bars[key]
+                                if (target.bgBorderThickness or "none") ~= thickness then return false end
+                                local targetColor = target.bgBorderColor or { r=0, g=0, b=0, a=1 }
+                                if targetColor.r ~= color.r or targetColor.g ~= color.g
+                                    or targetColor.b ~= color.b or targetColor.a ~= color.a then return false end
+                            end
+                            return true
+                        end,
+                        flashTargets=function() return { region } end,
+                        multiApply={
+                            elementKeys=GROUP_BAR_ORDER,
+                            elementLabels=SHORT_LABELS,
+                            getCurrentKey=function() return SelectedKey() end,
+                            onApply=function(checkedKeys)
+                                for _, key in ipairs(checkedKeys) do ApplySizeTo(key) end
+                                EllesmereUI:RefreshPage()
+                            end,
+                        },
+                    })
+                end
+
+                do
+                    local region = bgBorderRow._leftRegion
+                    local _, showOffsetPopup = EllesmereUI.BuildCogPopup({
+                        title="Border Offset",
+                        captureRegion=region,
+                        rows={
+                            { type="slider", label="Offset X", min=-10, max=10, step=1,
+                              get=function()
+                                  local value = SGet("bgBorderOffsetX")
+                                  if value ~= nil then return value end
+                                  local texture = SVal("bgBorderTexture", "solid")
+                                  local thickness = SVal("bgBorderThickness", "thin")
+                                  local defaultX = EllesmereUI.GetBorderDefaults("actionbars", texture, thickness)
+                                  return defaultX
+                              end,
+                              set=function(v)
+                                  SSet("bgBorderOffsetX", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                                  SUpdatePreview()
+                              end },
+                            { type="slider", label="Offset Y", min=-10, max=10, step=1,
+                              get=function()
+                                  local value = SGet("bgBorderOffsetY")
+                                  if value ~= nil then return value end
+                                  local texture = SVal("bgBorderTexture", "solid")
+                                  local thickness = SVal("bgBorderThickness", "thin")
+                                  local _, defaultY = EllesmereUI.GetBorderDefaults("actionbars", texture, thickness)
+                                  return defaultY
+                              end,
+                              set=function(v)
+                                  SSet("bgBorderOffsetY", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                                  SUpdatePreview()
+                              end },
+                            { type="slider", label="Shift X", min=-10, max=10, step=1,
+                              get=function()
+                                  local value = SGet("bgBorderShiftX")
+                                  if value ~= nil then return value end
+                                  local texture = SVal("bgBorderTexture", "solid")
+                                  local thickness = SVal("bgBorderThickness", "thin")
+                                  local _, _, defaultX = EllesmereUI.GetBorderDefaults("actionbars", texture, thickness)
+                                  return defaultX
+                              end,
+                              set=function(v)
+                                  SSet("bgBorderShiftX", v == 0 and nil or v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                                  SUpdatePreview()
+                              end },
+                            { type="slider", label="Shift Y", min=-10, max=10, step=1,
+                              get=function()
+                                  local value = SGet("bgBorderShiftY")
+                                  if value ~= nil then return value end
+                                  local texture = SVal("bgBorderTexture", "solid")
+                                  local thickness = SVal("bgBorderThickness", "thin")
+                                  local _, _, _, defaultY = EllesmereUI.GetBorderDefaults("actionbars", texture, thickness)
+                                  return defaultY
+                              end,
+                              set=function(v)
+                                  SSet("bgBorderShiftY", v == 0 and nil or v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                                  SUpdatePreview()
+                              end },
+                        },
+                    })
+                    local offsetButton = MakeCogBtn(region, showOffsetPopup, nil, EllesmereUI.DIRECTIONS_ICON)
+                    local function UpdateOffsetButton()
+                        local hidden = BgDisabled()
+                        offsetButton:SetShown(not hidden)
+                    end
+                    EllesmereUI.RegisterWidgetRefresh(UpdateOffsetButton)
+                    UpdateOffsetButton()
+                end
+
+                do
+                    local region = bgBorderRow._leftRegion
+                    local function ApplyStyleTo(key)
+                        local source = SB()
+                        local target = EAB.db.profile.bars[key]
+                        target.bgBorderTexture = source.bgBorderTexture
+                        target.bgBorderOffsetX = source.bgBorderOffsetX
+                        target.bgBorderOffsetY = source.bgBorderOffsetY
+                        target.bgBorderShiftX = source.bgBorderShiftX
+                        target.bgBorderShiftY = source.bgBorderShiftY
+                        EAB:ApplyBackgroundForBar(key)
+                    end
+                    EllesmereUI.BuildSyncIcon({
+                        region=region,
+                        tooltip="Apply Background Border Style to all Bars",
+                        onClick=function()
+                            for _, key in ipairs(GROUP_BAR_ORDER) do ApplyStyleTo(key) end
+                            EllesmereUI:RefreshPage()
+                        end,
+                        isSynced=function()
+                            local source = SB()
+                            for _, key in ipairs(GROUP_BAR_ORDER) do
+                                local target = EAB.db.profile.bars[key]
+                                if (target.bgBorderTexture or "solid") ~= (source.bgBorderTexture or "solid") then return false end
+                                if target.bgBorderOffsetX ~= source.bgBorderOffsetX then return false end
+                                if target.bgBorderOffsetY ~= source.bgBorderOffsetY then return false end
+                                if target.bgBorderShiftX ~= source.bgBorderShiftX then return false end
+                                if target.bgBorderShiftY ~= source.bgBorderShiftY then return false end
+                            end
+                            return true
+                        end,
+                        flashTargets=function() return { region } end,
+                        multiApply={
+                            elementKeys=GROUP_BAR_ORDER,
+                            elementLabels=SHORT_LABELS,
+                            getCurrentKey=function() return SelectedKey() end,
+                            onApply=function(checkedKeys)
+                                for _, key in ipairs(checkedKeys) do ApplyStyleTo(key) end
+                                EllesmereUI:RefreshPage()
+                            end,
+                        },
+                    })
+                end
+            end
+
+            local bgMultiplierRow
+            bgMultiplierRow, h = W:DualRow(parent, y,
+                { type="slider", text="Multiplier X", min=1, max=4, step=1,
+                  disabled=BgDisabled,
+                  disabledTooltip="Bar Background",
+                  getValue=function() return SVal("bgMultiplierX", 1) end,
+                  setValue=function(v)
+                      SSet("bgMultiplierX", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                      SUpdatePreview()
                   end },
-                { type="label", text="" });  y = y - h
+                { type="slider", text="Multiplier Y", min=1, max=4, step=1,
+                  disabled=BgDisabled,
+                  disabledTooltip="Bar Background",
+                  getValue=function() return SVal("bgMultiplierY", 1) end,
+                  setValue=function(v)
+                      SSet("bgMultiplierY", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                      SUpdatePreview()
+                  end });  y = y - h
+
+            do
+                local region = bgMultiplierRow._leftRegion
+                local _, showDirectionX = EllesmereUI.BuildCogPopup({
+                    title="Multiplier X Settings",
+                    captureRegion=region,
+                    rows={{ type="dropdown", label="Growth Direction",
+                        values={ left="Left", right="Right" }, order={ "left", "right" },
+                        get=function() return SVal("bgExpandDirectionX", "right") end,
+                        set=function(v)
+                            SSet("bgExpandDirectionX", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                            SUpdatePreview()
+                        end }},
+                })
+                MakeCogBtn(region, showDirectionX, nil, EllesmereUI.DIRECTIONS_ICON)
+            end
+
+            do
+                local region = bgMultiplierRow._rightRegion
+                local _, showDirectionY = EllesmereUI.BuildCogPopup({
+                    title="Multiplier Y Settings",
+                    captureRegion=region,
+                    rows={{ type="dropdown", label="Growth Direction",
+                        values={ up="Up", down="Down" }, order={ "up", "down" },
+                        get=function() return SVal("bgExpandDirectionY", "up") end,
+                        set=function(v)
+                            SSet("bgExpandDirectionY", v, function(k) EAB:ApplyBackgroundForBar(k) end)
+                            SUpdatePreview()
+                        end }},
+                })
+                MakeCogBtn(region, showDirectionY, nil, EllesmereUI.DIRECTIONS_ICON)
+            end
+            end
 
             -------------------------------------------------------------------
             --  ICON APPEARANCE
@@ -3493,6 +3892,8 @@ initFrame:SetScript("OnEvent", function(self)
                 swatch:SetAlpha(off0 and 0.3 or 1)
                 block:SetShown(off0)
             end
+
+            BuildBarBackgroundSection()
 
             -------------------------------------------------------------------
             --  PAGING (MainBar + Bars 2-8 only, not Stance/Pet/Micro/Bag)

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -438,6 +438,14 @@ for _, info in ipairs(BAR_CONFIG) do
         paging = {},
         bgEnabled = false,
         bgColor = { r = 0, g = 0, b = 0, a = 0.5 },
+        bgBorderColor = { r = 0, g = 0, b = 0, a = 1 },
+        bgBorderTexture = "solid",
+        bgBorderSize = 1,
+        bgBorderThickness = "none",
+        bgMultiplierX = 1,
+        bgMultiplierY = 1,
+        bgExpandDirectionX = "right",
+        bgExpandDirectionY = "up",
         outOfRangeColoring = false,
         outOfRangeColor = { r = 0.8, g = 0.1, b = 0.1 },
         buttonShape = "none",
@@ -5072,9 +5080,9 @@ function EAB:ApplyCooldownSwipeColor()
 end
 
 -------------------------------------------------------------------------------
---  Background Texture
+--  Bar Background
 -------------------------------------------------------------------------------
-local barBackgrounds = {}  -- [barKey] = texture
+local barBackgrounds = {}  -- [barKey] = { fill = Texture, border = Frame }
 
 function EAB:ApplyBackgroundForBar(barKey)
     local s = self.db.profile.bars[barKey]
@@ -5083,24 +5091,67 @@ function EAB:ApplyBackgroundForBar(barKey)
     if not frame then return end
 
     if not s.bgEnabled then
-        if barBackgrounds[barKey] then barBackgrounds[barKey]:Hide() end
+        local background = barBackgrounds[barKey]
+        if background then
+            background.fill:Hide()
+            if EllesmereUI and EllesmereUI.ApplyBorderStyle then
+                EllesmereUI.ApplyBorderStyle(background.border, 0, 0, 0, 0, s.bgBorderTexture or "solid")
+            else
+                background.border:Hide()
+            end
+        end
         return
     end
 
-    local bg = barBackgrounds[barKey]
-    if not bg then
-        bg = frame:CreateTexture(nil, "BACKGROUND", nil, -1)
-        barBackgrounds[barKey] = bg
+    local background = barBackgrounds[barKey]
+    if not background then
+        local fill = frame:CreateTexture(nil, "BACKGROUND", nil, -1)
+        local border = CreateFrame("Frame", nil, frame, "BackdropTemplate")
+        border:EnableMouse(false)
+        border:SetFrameLevel(math.max(0, frame:GetFrameLevel()))
+        background = { fill = fill, border = border }
+        barBackgrounds[barKey] = background
     end
 
     local c = s.bgColor or { r=0, g=0, b=0, a=0.5 }
-    bg:SetColorTexture(c.r, c.g, c.b, c.a)
-    local padX = s.bgPadX or 0
-    local padY = s.bgPadY or 0
-    bg:ClearAllPoints()
-    bg:SetPoint("TOPLEFT", frame, "TOPLEFT", -padX, padY)
-    bg:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", padX, -padY)
-    bg:Show()
+    background.fill:SetColorTexture(c.r, c.g, c.b, c.a)
+    -- bgPadX/bgPadY are retained as fallbacks for profiles made before the
+    -- unified spacing control was introduced.
+    local padding = s.bgPadding
+    local padX = padding ~= nil and padding or (s.bgPadX or 0)
+    local padY = padding ~= nil and padding or (s.bgPadY or 0)
+    local multiplierX = math.max(1, math.min(4, math.floor((s.bgMultiplierX or 1) + 0.5)))
+    local multiplierY = math.max(1, math.min(4, math.floor((s.bgMultiplierY or 1) + 0.5)))
+    local directionX = s.bgExpandDirectionX or "right"
+    local directionY = s.bgExpandDirectionY or "up"
+    local iconPadding = s.buttonPadding or 0
+    local growX = (multiplierX - 1) * ((frame:GetWidth() or 0) + iconPadding)
+    local growY = (multiplierY - 1) * ((frame:GetHeight() or 0) + iconPadding)
+    local left, right, top, bottom = -padX, padX, padY, -padY
+    if directionX == "left" then left = left - growX else right = right + growX end
+    if directionY == "down" then bottom = bottom - growY else top = top + growY end
+    background.fill:ClearAllPoints()
+    background.fill:SetPoint("TOPLEFT", frame, "TOPLEFT", left, top)
+    background.fill:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", right, bottom)
+    background.fill:Show()
+
+    local border = background.border
+    border:ClearAllPoints()
+    border:SetPoint("TOPLEFT", frame, "TOPLEFT", left, top)
+    border:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", right, bottom)
+    if EllesmereUI and EllesmereUI.ApplyBorderStyle then
+        local bc = s.bgBorderColor or { r=0, g=0, b=0, a=1 }
+        local thicknessKey = s.bgBorderThickness or "none"
+        local thickness = ns.BORDER_THICKNESS and ns.BORDER_THICKNESS[thicknessKey]
+        local borderSize = thickness and thickness.regular or 0
+        EllesmereUI.ApplyBorderStyle(border, borderSize,
+            bc.r, bc.g, bc.b, bc.a or 1, s.bgBorderTexture or "solid",
+            s.bgBorderOffsetX, s.bgBorderOffsetY,
+            s.bgBorderShiftX, s.bgBorderShiftY,
+            "actionbars", thicknessKey)
+    else
+        border:Hide()
+    end
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -248,6 +248,20 @@ initFrame:SetScript("OnEvent", function(self)
                     refreshAlpha=function()
                         return EllesmereUIDB and EllesmereUIDB.popupMenuButtonTextColorMode == "custom" and 1 or 0.3
                     end },
+                  { tooltip="Class Color", hasAlpha=false,
+                    getValue=function()
+                        local _, class = UnitClass("player")
+                        local c = class and RAID_CLASS_COLORS[class]
+                        return (c and c.r) or 1, (c and c.g) or 1, (c and c.b) or 1
+                    end,
+                    setValue=function() end,
+                    onClick=function()
+                        EllesmereUIDB.popupMenuButtonTextColorMode = "class"
+                        EllesmereUI:RefreshPage()
+                    end,
+                    refreshAlpha=function()
+                        return EllesmereUIDB and EllesmereUIDB.popupMenuButtonTextColorMode == "class" and 1 or 0.3
+                    end },
               } }
         ); y = y - h
 

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -13,9 +13,76 @@ initFrame:SetScript("OnEvent", function(self)
     if not EllesmereUI or not EllesmereUI.RegisterModule then return end
 
     local function BuildTooltipsPage(pageName, parent, yOffset)
+        if not EllesmereUIDB then EllesmereUIDB = {} end
         local W = EllesmereUI.Widgets
         local y = yOffset
         local _, h
+        local BORDER_VALUES = { none="None", thin="Thin", normal="Normal", heavy="Heavy", strong="Strong" }
+        local BORDER_ORDER = { "none", "thin", "normal", "heavy", "strong" }
+
+        local function AttachBorderControls(row, prefix, disabledFn)
+            local PP = EllesmereUI.PanelPP
+            local left = row._leftRegion
+            local _, showOffset = EllesmereUI.BuildCogPopup({
+                title="Border Offset",
+                rows={
+                    { type="slider", label="Offset X", min=-10, max=10, step=1,
+                      get=function()
+                          local value = EllesmereUIDB and EllesmereUIDB[prefix .. "BorderOffsetX"]
+                          if value ~= nil then return value end
+                          return EllesmereUI.GetBorderTextureDefaultOffset((EllesmereUIDB and EllesmereUIDB[prefix .. "BorderTexture"]) or "solid")
+                      end,
+                      set=function(v) EllesmereUIDB[prefix .. "BorderOffsetX"] = v end },
+                    { type="slider", label="Offset Y", min=-10, max=10, step=1,
+                      get=function()
+                          local value = EllesmereUIDB and EllesmereUIDB[prefix .. "BorderOffsetY"]
+                          if value ~= nil then return value end
+                          return EllesmereUI.GetBorderTextureDefaultOffsetY((EllesmereUIDB and EllesmereUIDB[prefix .. "BorderTexture"]) or "solid")
+                      end,
+                      set=function(v) EllesmereUIDB[prefix .. "BorderOffsetY"] = v end },
+                    { type="slider", label="Shift X", min=-10, max=10, step=1,
+                      get=function() return (EllesmereUIDB and EllesmereUIDB[prefix .. "BorderShiftX"]) or 0 end,
+                      set=function(v) EllesmereUIDB[prefix .. "BorderShiftX"] = v == 0 and nil or v end },
+                    { type="slider", label="Shift Y", min=-10, max=10, step=1,
+                      get=function() return (EllesmereUIDB and EllesmereUIDB[prefix .. "BorderShiftY"]) or 0 end,
+                      set=function(v) EllesmereUIDB[prefix .. "BorderShiftY"] = v == 0 and nil or v end },
+                },
+            })
+            local offsetBtn = CreateFrame("Button", nil, left)
+            offsetBtn:SetSize(26, 26)
+            offsetBtn:SetPoint("RIGHT", left._control, "LEFT", -8, 0)
+            offsetBtn:SetFrameLevel(left:GetFrameLevel() + 5)
+            offsetBtn:SetAlpha(0.4)
+            local icon = offsetBtn:CreateTexture(nil, "OVERLAY")
+            icon:SetAllPoints(); icon:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+            offsetBtn:SetScript("OnClick", function(self) showOffset(self) end)
+            offsetBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            offsetBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            left._lastInline = offsetBtn
+
+            local right = row._rightRegion
+            local swatch, refresh = EllesmereUI.BuildColorSwatch(right, right:GetFrameLevel() + 5,
+                function()
+                    local color = EllesmereUIDB and EllesmereUIDB[prefix .. "BorderColor"]
+                    local alpha = (EllesmereUIDB and EllesmereUIDB[prefix .. "BorderOpacity"])
+                    if alpha == nil then alpha = EllesmereUI.RESKIN.BRD_ALPHA end
+                    return (color and color.r) or 1, (color and color.g) or 1, (color and color.b) or 1, alpha
+                end,
+                function(r, g, b, a)
+                    EllesmereUIDB[prefix .. "BorderColor"] = { r=r, g=g, b=b }
+                    EllesmereUIDB[prefix .. "BorderOpacity"] = a
+                end, true, 20)
+            PP.Point(swatch, "RIGHT", right._control, "LEFT", -12, 0)
+            right._lastInline = swatch
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = disabledFn and disabledFn()
+                offsetBtn:SetAlpha(off and 0.15 or 0.4)
+                offsetBtn:EnableMouse(not off)
+                swatch:SetAlpha(off and 0.15 or 1)
+                swatch:EnableMouse(not off)
+                refresh()
+            end)
+        end
 
         if EllesmereUI.ClearContentHeader then EllesmereUI:ClearContentHeader() end
         parent._showRowDivider = true
@@ -55,6 +122,28 @@ initFrame:SetScript("OnEvent", function(self)
                   EllesmereUIDB.accentReskinElements = v
               end }
         );  y = y - h
+
+        local function popupReskinOff()
+            return EllesmereUIDB and EllesmereUIDB.reskinPopupsMenus == false
+        end
+        do
+            local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
+            local popupBorderRow
+            popupBorderRow, h = W:DualRow(parent, y,
+                { type="dropdown", text="Border Style", disabled=popupReskinOff,
+                  disabledTooltip="Reskin Popups and Menus", values=texValues, order=texOrder,
+                  getValue=function() return (EllesmereUIDB and EllesmereUIDB.popupMenuBorderTexture) or "solid" end,
+                  setValue=function(v)
+                      EllesmereUIDB.popupMenuBorderTexture = v
+                      EllesmereUIDB.popupMenuBorderOffsetX = nil; EllesmereUIDB.popupMenuBorderOffsetY = nil
+                      EllesmereUIDB.popupMenuBorderShiftX = nil; EllesmereUIDB.popupMenuBorderShiftY = nil
+                  end },
+                { type="dropdown", text="Border Size", disabled=popupReskinOff,
+                  disabledTooltip="Reskin Popups and Menus", values=BORDER_VALUES, order=BORDER_ORDER,
+                  getValue=function() return (EllesmereUIDB and EllesmereUIDB.popupMenuBorderThickness) or "thin" end,
+                  setValue=function(v) EllesmereUIDB.popupMenuBorderThickness = v end }); y = y - h
+            AttachBorderControls(popupBorderRow, "popupMenu", popupReskinOff)
+        end
 
         local queueRow
         queueRow, h = W:DualRow(parent, y,
@@ -517,24 +606,34 @@ initFrame:SetScript("OnEvent", function(self)
             UpdateShowModState()
         end
 
-        -- Border: size slider with an inline colour + opacity swatch. Part of the
-        -- tooltip reskin, so it grays with "Reskin Tooltip". Defaults to the
-        -- historical hardcoded look (white @ 18% alpha, 1px) -- unset = unchanged.
+        -- Configurable tooltip border style, thickness, offsets and colour.
+        do
+            local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
+            local tooltipBorderRow
+            tooltipBorderRow, h = W:DualRow(parent, y,
+                { type="dropdown", text="Border Style", disabled=ttReskinOff,
+                  disabledTooltip="Reskin Tooltip", values=texValues, order=texOrder,
+                  getValue=function() return (EllesmereUIDB and EllesmereUIDB.tooltipBorderTexture) or "solid" end,
+                  setValue=function(v)
+                      EllesmereUIDB.tooltipBorderTexture = v
+                      EllesmereUIDB.tooltipBorderOffsetX = nil; EllesmereUIDB.tooltipBorderOffsetY = nil
+                      EllesmereUIDB.tooltipBorderShiftX = nil; EllesmereUIDB.tooltipBorderShiftY = nil
+                  end },
+                { type="dropdown", text="Border Size", disabled=ttReskinOff,
+                  disabledTooltip="Reskin Tooltip", values=BORDER_VALUES, order=BORDER_ORDER,
+                  getValue=function()
+                      if EllesmereUIDB and EllesmereUIDB.tooltipBorderThickness then
+                          return EllesmereUIDB.tooltipBorderThickness
+                      end
+                      local legacy = EllesmereUIDB and EllesmereUIDB.tooltipBorderSize
+                      return ({ [0]="none", [1]="thin", [2]="normal", [3]="heavy", [4]="strong" })[legacy or 1] or "thin"
+                  end,
+                  setValue=function(v) EllesmereUIDB.tooltipBorderThickness = v end }); y = y - h
+            AttachBorderControls(tooltipBorderRow, "tooltip", ttReskinOff)
+        end
+
         local borderRow
         borderRow, h = W:DualRow(parent, y,
-            { type="slider", text="Border", min=0, max=4, step=1,
-              disabled=ttReskinOff, disabledTooltip="Reskin Tooltip",
-              getValue=function()
-                  local s = EllesmereUIDB and EllesmereUIDB.tooltipBorderSize
-                  if s == nil then return 1 end
-                  return s
-              end,
-              setValue=function(v)
-                  if not EllesmereUIDB then EllesmereUIDB = {} end
-                  EllesmereUIDB.tooltipBorderSize = v
-              end },
-            -- Independent of the reskin, so it is NOT gated by "Reskin
-            -- Tooltip" -- like Show Spell ID.
             { type="toggle", text="Show Max Stack for Items",
               tooltip="Appends an item's max stack count on tooltip.",
               getValue=function()
@@ -544,44 +643,15 @@ initFrame:SetScript("OnEvent", function(self)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.showItemMaxStacks = v
                   EllesmereUI:RefreshPage()  -- update the Use Modifier cog disabled state
-              end }
+              end },
+            { type="label", text="" }
         );  y = y - h
-        -- Inline colour + opacity swatch on the Border slider (left region).
-        do
-            local PP = EllesmereUI.PanelPP
-            local rgn = borderRow._leftRegion
-            local swGet = function()
-                local c = EllesmereUIDB and EllesmereUIDB.tooltipBorderColor
-                local r = (c and c.r) or 1
-                local g = (c and c.g) or 1
-                local b = (c and c.b) or 1
-                local a = (EllesmereUIDB and EllesmereUIDB.tooltipBorderOpacity) or EllesmereUI.RESKIN.BRD_ALPHA
-                return r, g, b, a
-            end
-            local swSet = function(r, g, b, a)
-                if not EllesmereUIDB then EllesmereUIDB = {} end
-                EllesmereUIDB.tooltipBorderColor = { r = r, g = g, b = b }
-                if a ~= nil then EllesmereUIDB.tooltipBorderOpacity = a end
-            end
-            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5, swGet, swSet, true, 20)
-            PP.Point(swatch, "RIGHT", rgn._lastInline or rgn._control, "LEFT", -12, 0)
-            rgn._lastInline = swatch
-            EllesmereUI.RegisterWidgetRefresh(function()
-                local off = ttReskinOff()
-                swatch:SetAlpha(off and 0.15 or 1)
-                swatch:EnableMouse(not off)
-                updateSwatch()
-            end)
-            local off = ttReskinOff()
-            swatch:SetAlpha(off and 0.15 or 1)
-            swatch:EnableMouse(not off)
-        end
 
         -- "Use Modifier" cog on Show Max Stack for Items (right region): the Max
         -- Stack line only shows while the chosen modifier is held. Disabled
         -- (blocked + dimmed) when the toggle is off, mirroring the Spell ID cog.
         do
-            local rightRgn = borderRow._rightRegion
+            local rightRgn = borderRow._leftRegion
             local function iStacksOff()
                 return not (EllesmereUIDB and EllesmereUIDB.showItemMaxStacks)
             end

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -61,7 +61,37 @@ initFrame:SetScript("OnEvent", function(self)
             left._lastInline = offsetBtn
 
             local right = row._rightRegion
-            local swatch, refresh = EllesmereUI.BuildColorSwatch(right, right:GetFrameLevel() + 5,
+            local accentSwatch, refreshAccent = EllesmereUI.BuildColorSwatch(right, right:GetFrameLevel() + 5,
+                function()
+                    local color = EllesmereUI.ELLESMERE_GREEN or { r=0.27, g=0.86, b=0.49 }
+                    return color.r, color.g, color.b, 1
+                end,
+                function() end, false, 20)
+            PP.Point(accentSwatch, "RIGHT", right._control, "LEFT", -12, 0)
+            accentSwatch:SetScript("OnClick", function()
+                EllesmereUIDB[prefix .. "BorderColorMode"] = "accent"
+                EllesmereUI:RefreshPage()
+            end)
+            accentSwatch:HookScript("OnEnter", function(self) EllesmereUI.ShowWidgetTooltip(self, "Accent Color") end)
+            accentSwatch:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+            local classSwatch, refreshClass = EllesmereUI.BuildColorSwatch(right, right:GetFrameLevel() + 5,
+                function()
+                    local _, class = UnitClass("player")
+                    local color = class and RAID_CLASS_COLORS[class]
+                    return (color and color.r) or 1, (color and color.g) or 1,
+                        (color and color.b) or 1, 1
+                end,
+                function() end, false, 20)
+            PP.Point(classSwatch, "RIGHT", accentSwatch, "LEFT", -8, 0)
+            classSwatch:SetScript("OnClick", function()
+                EllesmereUIDB[prefix .. "BorderColorMode"] = "class"
+                EllesmereUI:RefreshPage()
+            end)
+            classSwatch:HookScript("OnEnter", function(self) EllesmereUI.ShowWidgetTooltip(self, "Class Color") end)
+            classSwatch:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+            local customSwatch, refreshCustom = EllesmereUI.BuildColorSwatch(right, right:GetFrameLevel() + 5,
                 function()
                     local color = EllesmereUIDB and EllesmereUIDB[prefix .. "BorderColor"]
                     local alpha = (EllesmereUIDB and EllesmereUIDB[prefix .. "BorderOpacity"])
@@ -72,15 +102,33 @@ initFrame:SetScript("OnEvent", function(self)
                     EllesmereUIDB[prefix .. "BorderColor"] = { r=r, g=g, b=b }
                     EllesmereUIDB[prefix .. "BorderOpacity"] = a
                 end, true, 20)
-            PP.Point(swatch, "RIGHT", right._control, "LEFT", -12, 0)
-            right._lastInline = swatch
+            PP.Point(customSwatch, "RIGHT", classSwatch, "LEFT", -8, 0)
+            customSwatch._eabOrigClick = customSwatch:GetScript("OnClick")
+            customSwatch:SetScript("OnClick", function(self)
+                if (EllesmereUIDB[prefix .. "BorderColorMode"] or "custom") ~= "custom" then
+                    EllesmereUIDB[prefix .. "BorderColorMode"] = "custom"
+                    EllesmereUI:RefreshPage()
+                    return
+                end
+                self._eabOrigClick(self)
+            end)
+            customSwatch:HookScript("OnEnter", function(self) EllesmereUI.ShowWidgetTooltip(self, "Custom Color") end)
+            customSwatch:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            right._lastInline = customSwatch
             EllesmereUI.RegisterWidgetRefresh(function()
                 local off = disabledFn and disabledFn()
+                local mode = (EllesmereUIDB and EllesmereUIDB[prefix .. "BorderColorMode"]) or "custom"
                 offsetBtn:SetAlpha(off and 0.15 or 0.4)
                 offsetBtn:EnableMouse(not off)
-                swatch:SetAlpha(off and 0.15 or 1)
-                swatch:EnableMouse(not off)
-                refresh()
+                accentSwatch:SetAlpha(off and 0.15 or (mode == "accent" and 1 or 0.3))
+                accentSwatch:EnableMouse(not off)
+                classSwatch:SetAlpha(off and 0.15 or (mode == "class" and 1 or 0.3))
+                classSwatch:EnableMouse(not off)
+                customSwatch:SetAlpha(off and 0.15 or (mode == "custom" and 1 or 0.3))
+                customSwatch:EnableMouse(not off)
+                refreshAccent()
+                refreshClass()
+                refreshCustom()
             end)
         end
 
@@ -89,7 +137,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
-        _, h = W:SectionHeader(parent, "BLIZZARD UI ELEMENTS", y);  y = y - h
+        _, h = W:SectionHeader(parent, "BLIZZARD POPUPS & GAME MENU", y);  y = y - h
 
         _, h = W:DualRow(parent, y,
             { type="toggle", text="Reskin Popups and Menus",
@@ -112,15 +160,7 @@ initFrame:SetScript("OnEvent", function(self)
                       })
                   end
               end },
-            { type="toggle", text="Accent Colored Elements",
-              tooltip="Recolors headers, arrows, and spell titles in Blizzard tooltips and context menus to match your UI Accent Color.",
-              getValue=function()
-                  return EllesmereUIDB and EllesmereUIDB.accentReskinElements or false
-              end,
-              setValue=function(v)
-                  if not EllesmereUIDB then EllesmereUIDB = {} end
-                  EllesmereUIDB.accentReskinElements = v
-              end }
+            { type="spacer", text="" }
         );  y = y - h
 
         local function popupReskinOff()
@@ -143,7 +183,73 @@ initFrame:SetScript("OnEvent", function(self)
                   getValue=function() return (EllesmereUIDB and EllesmereUIDB.popupMenuBorderThickness) or "thin" end,
                   setValue=function(v) EllesmereUIDB.popupMenuBorderThickness = v end }); y = y - h
             AttachBorderControls(popupBorderRow, "popupMenu", popupReskinOff)
+
+            local buttonBorderRow
+            buttonBorderRow, h = W:DualRow(parent, y,
+                { type="dropdown", text="Button Border Style", disabled=popupReskinOff,
+                  disabledTooltip="Reskin Popups and Menus", values=texValues, order=texOrder,
+                  getValue=function() return (EllesmereUIDB and EllesmereUIDB.popupMenuButtonBorderTexture) or "solid" end,
+                  setValue=function(v)
+                      EllesmereUIDB.popupMenuButtonBorderTexture = v
+                      EllesmereUIDB.popupMenuButtonBorderOffsetX = nil; EllesmereUIDB.popupMenuButtonBorderOffsetY = nil
+                      EllesmereUIDB.popupMenuButtonBorderShiftX = nil; EllesmereUIDB.popupMenuButtonBorderShiftY = nil
+                  end },
+                { type="dropdown", text="Button Border Size", disabled=popupReskinOff,
+                  disabledTooltip="Reskin Popups and Menus", values=BORDER_VALUES, order=BORDER_ORDER,
+                  getValue=function() return (EllesmereUIDB and EllesmereUIDB.popupMenuButtonBorderThickness) or "thin" end,
+                  setValue=function(v) EllesmereUIDB.popupMenuButtonBorderThickness = v end }); y = y - h
+            AttachBorderControls(buttonBorderRow, "popupMenuButton", popupReskinOff)
         end
+
+        _, h = W:DualRow(parent, y,
+            { type="colorpicker", text="Button Background", hasAlpha=true,
+              disabled=popupReskinOff, disabledTooltip="Reskin Popups and Menus",
+              getValue=function()
+                  local c = EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor
+                  return (c and c.r) or 0.1, (c and c.g) or 0.1,
+                      (c and c.b) or 0.1, (c and c.a) or 0.8
+              end,
+              setValue=function(r, g, b, a)
+                  EllesmereUIDB.popupMenuButtonBackgroundColor = { r=r, g=g, b=b, a=a }
+              end },
+            { type="multiSwatch", text="Element & Text Color", disabled=popupReskinOff,
+              disabledTooltip="Reskin Popups and Menus",
+              swatches={
+                  { tooltip="Accent Color", hasAlpha=false,
+                    getValue=function()
+                        local c = EllesmereUI.ELLESMERE_GREEN or { r=0.27, g=0.86, b=0.49 }
+                        return c.r, c.g, c.b
+                    end,
+                    setValue=function() end,
+                    onClick=function()
+                        EllesmereUIDB.popupMenuButtonTextColorMode = "accent"
+                        EllesmereUI:RefreshPage()
+                    end,
+                    refreshAlpha=function()
+                        return ((EllesmereUIDB and EllesmereUIDB.popupMenuButtonTextColorMode) or "accent") == "accent" and 1 or 0.3
+                    end },
+                  { tooltip="Custom Color", hasAlpha=false,
+                    getValue=function()
+                        local c = EllesmereUIDB and EllesmereUIDB.popupMenuButtonTextColor
+                        return (c and c.r) or 1, (c and c.g) or 1, (c and c.b) or 1
+                    end,
+                    setValue=function(r, g, b)
+                        EllesmereUIDB.popupMenuButtonTextColorMode = "custom"
+                        EllesmereUIDB.popupMenuButtonTextColor = { r=r, g=g, b=b }
+                    end,
+                    onClick=function(self)
+                        if (EllesmereUIDB.popupMenuButtonTextColorMode or "accent") ~= "custom" then
+                            EllesmereUIDB.popupMenuButtonTextColorMode = "custom"
+                            EllesmereUI:RefreshPage()
+                            return
+                        end
+                        if self._eabOrigClick then self._eabOrigClick(self) end
+                    end,
+                    refreshAlpha=function()
+                        return EllesmereUIDB and EllesmereUIDB.popupMenuButtonTextColorMode == "custom" and 1 or 0.3
+                    end },
+              } }
+        ); y = y - h
 
         local queueRow
         queueRow, h = W:DualRow(parent, y,
@@ -212,7 +318,7 @@ initFrame:SetScript("OnEvent", function(self)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.showQueueTimer = v
               end },
-            { type="toggle", text="Reskin Pause Menu",
+            { type="toggle", text="Enable Blizzard Pause Menu",
               tooltip="Reskins the ESC / Game Menu with the EUI dark style, matching fonts, and accent-colored title.",
               getValue=function()
                   -- Independent, default on (not tied to any master reskin toggle).
@@ -2533,6 +2639,23 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.tooltipShowMount = nil
                 EllesmereUIDB.reskinQueuePopup = nil
                 EllesmereUIDB.reskinGameMenu = nil
+                EllesmereUIDB.popupMenuButtonBackgroundColor = nil
+                EllesmereUIDB.popupMenuButtonTextColorMode = nil
+                EllesmereUIDB.popupMenuButtonTextColor = nil
+                -- Remove the superseded separate Game Menu values as well so
+                -- profiles cleanly fall back to the shared popup style.
+                EllesmereUIDB.gameMenuButtonBackgroundColor = nil
+                for _, prefix in ipairs({ "popupMenu", "popupMenuButton", "tooltip", "gameMenu", "gameMenuButton" }) do
+                    EllesmereUIDB[prefix .. "BorderTexture"] = nil
+                    EllesmereUIDB[prefix .. "BorderThickness"] = nil
+                    EllesmereUIDB[prefix .. "BorderColor"] = nil
+                    EllesmereUIDB[prefix .. "BorderColorMode"] = nil
+                    EllesmereUIDB[prefix .. "BorderOpacity"] = nil
+                    EllesmereUIDB[prefix .. "BorderOffsetX"] = nil
+                    EllesmereUIDB[prefix .. "BorderOffsetY"] = nil
+                    EllesmereUIDB[prefix .. "BorderShiftX"] = nil
+                    EllesmereUIDB[prefix .. "BorderShiftY"] = nil
+                end
                 EllesmereUIDB.reskinGreatVault = nil
                 EllesmereUIDB.reskinLFGMenu = nil
                 EllesmereUIDB.showQueueTimer = nil

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -131,9 +131,23 @@ end
             size = legacySize ~= nil and legacySize or 1
             key = ({ [0]="none", [1]="thin", [2]="normal", [3]="heavy", [4]="strong" })[size] or "thin"
         end
-        local color = db[prefix .. "BorderColor"] or { r=1, g=1, b=1 }
+        local color
+        if db[prefix .. "BorderColorMode"] == "accent" then
+            color = EllesmereUI.ELLESMERE_GREEN or { r=0.27, g=0.86, b=0.49 }
+        elseif db[prefix .. "BorderColorMode"] == "class" then
+            local _, class = UnitClass("player")
+            color = class and RAID_CLASS_COLORS[class] or { r=1, g=1, b=1 }
+        else
+            -- Default: a subtle white border. Custom mode starts from this
+            -- value until the player explicitly chooses another color.
+            color = db[prefix .. "BorderColor"] or { r=1, g=1, b=1 }
+        end
         local alpha = db[prefix .. "BorderOpacity"]
-        if alpha == nil then alpha = EllesmereUI.RESKIN.BRD_ALPHA end
+        if alpha == nil then
+            alpha = (db[prefix .. "BorderColorMode"] == "accent"
+                or db[prefix .. "BorderColorMode"] == "class")
+                and 0.5 or EllesmereUI.RESKIN.BRD_ALPHA
+        end
         local data = GetFFD(owner)
         if not data.configBorder then
             data.configBorder = CreateFrame("Frame", nil, owner, "BackdropTemplate")
@@ -148,6 +162,23 @@ end
             db[prefix .. "BorderOffsetX"], db[prefix .. "BorderOffsetY"],
             db[prefix .. "BorderShiftX"], db[prefix .. "BorderShiftY"])
     end
+
+    -- Shared with independently skinned Blizzard popup-style frames such as
+    -- the ESC / Game Menu. Keeping the resolver here makes all of them use the
+    -- exact same Border Style, Size, Color and Offset settings.
+    EllesmereUI._applyBlizzardConfiguredBorder = _applyConfiguredBorder
+
+    local function _getPopupMenuButtonTextColor()
+        local db = EllesmereUIDB or {}
+        local mode = db.popupMenuButtonTextColorMode or "accent"
+        if mode == "custom" then
+            local color = db.popupMenuButtonTextColor or { r=1, g=1, b=1 }
+            return color.r or 1, color.g or 1, color.b or 1
+        end
+        local accent = EllesmereUI.ELLESMERE_GREEN or { r=0.27, g=0.86, b=0.49 }
+        return accent.r, accent.g, accent.b
+    end
+    EllesmereUI._getPopupMenuButtonTextColor = _getPopupMenuButtonTextColor
 
     local function _ttSkin(tt, _, isEmbedded)
         if not tt or tt:IsForbidden() or not _enabled() then return end
@@ -212,10 +243,6 @@ end
         if not tt or tt:IsForbidden() or _ttSkinned[tt] then return end
         _ttSkinned[tt] = true
         tt:HookScript("OnShow", _ttOnShow)
-    end
-
-    local function _accentEnabled()
-        return EllesmereUIDB and EllesmereUIDB.accentReskinElements
     end
 
     -- Unified inspect system: one NotifyInspect per GUID, one INSPECT_READY
@@ -607,7 +634,7 @@ end
     -- Tooltip DATA additions: class-colored names, player-title control, M+ score,
     -- item level (via _ttUnitColor) and accent spell/macro titles. Each has its own
     -- toggle (tooltipPlayerTitles / tooltipMythicScore / tooltipItemLevel /
-    -- accentReskinElements), but the whole set is gated by the "Reskin Tooltip"
+    -- shared Element & Text Color), but the whole set is gated by "Reskin Tooltip"
     -- master (customTooltips) -- the PLAYER_LOGIN handler only calls this when
     -- _enabled() -- so disabling the reskin grays out AND stops every tooltip
     -- option together. Idempotent so the live re-apply path can never double-register.
@@ -622,11 +649,11 @@ end
         _GameTooltip:HookScript("OnHide", function() _tipShownGUID = nil end)
         -- Accent-color the title line for spells/macros (not items or units)
         local function _ttAccentTitle(tt)
-            if tt ~= _GameTooltip or tt:IsForbidden() or not _accentEnabled() then return end
+            if tt ~= _GameTooltip or tt:IsForbidden() then return end
             if not _nameL1 then _nameL1 = _G.GameTooltipTextLeft1 end
             if _nameL1 then
-                local EG = EllesmereUI.ELLESMERE_GREEN
-                if EG then _nameL1:SetTextColor(EG.r, EG.g, EG.b) end
+                local r, g, b = _getPopupMenuButtonTextColor()
+                _nameL1:SetTextColor(r, g, b)
             end
         end
         if TooltipDataProcessor and TooltipDataProcessor.AddTooltipPostCall and Enum and Enum.TooltipDataType then
@@ -741,22 +768,10 @@ end
                         if r.SetAtlas then r:SetAtlas("") end
                     end
                 end
-                local RS = EllesmereUI.RESKIN
-                local EG = EllesmereUI.ELLESMERE_GREEN
-                local useAccent = _accentEnabled() and EG
                 local btnBg = btn:CreateTexture(nil, "BACKGROUND", nil, -6)
                 btnBg:SetAllPoints()
-                btnBg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
                 GetFFD(btnBg).owned = true
                 GetFFD(btn).bg = btnBg
-                if not _PP then _PP = EllesmereUI and EllesmereUI.PP end
-                if _PP and _PP.CreateBorder then
-                    if useAccent then
-                        _PP.CreateBorder(btn, EG.r, EG.g, EG.b, 0.5, 1, "OVERLAY", 7)
-                    else
-                        _PP.CreateBorder(btn, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-                    end
-                end
                 -- House hover: 10% white wash (HIGHLIGHT layer only renders
                 -- while the button is enabled and hovered).
                 local hov = btn:CreateTexture(nil, "HIGHLIGHT")
@@ -771,12 +786,8 @@ end
                     local enabled = (self.IsEnabled and self:IsEnabled()) and true or false
                     if fs then
                         if enabled then
-                            local EG2 = EllesmereUI.ELLESMERE_GREEN
-                            if _accentEnabled() and EG2 then
-                                fs:SetTextColor(EG2.r, EG2.g, EG2.b, 1)
-                            else
-                                fs:SetTextColor(1, 1, 1, 1)
-                            end
+                            local r, g, b = _getPopupMenuButtonTextColor()
+                            fs:SetTextColor(r, g, b, 1)
                         else
                             fs:SetTextColor(0.4, 0.4, 0.4, 1)
                         end
@@ -790,6 +801,13 @@ end
                 btn:HookScript("OnDisable", _euiRefreshEnabled)
                 _euiRefreshEnabled(btn)
             end
+            local buttonColor = EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor
+                or { r=0.1, g=0.1, b=0.1, a=0.8 }
+            if GetFFD(btn).bg then
+                GetFFD(btn).bg:SetColorTexture(buttonColor.r or 0.1, buttonColor.g or 0.1,
+                    buttonColor.b or 0.1, buttonColor.a == nil and 0.8 or buttonColor.a)
+            end
+            _applyConfiguredBorder(btn, "popupMenuButton", 1)
         end
 
         -- Hook UpdateRecapButton once per popup so our per-button enabled
@@ -833,15 +851,10 @@ end
             ebBg:SetColorTexture(0.05, 0.05, 0.05, 0.9)
             GetFFD(ebBg).owned = true
             -- Border matching the popup buttons (accent or white).
-            local RS2 = EllesmereUI.RESKIN
-            local EG3 = EllesmereUI.ELLESMERE_GREEN
+            local borderR, borderG, borderB = _getPopupMenuButtonTextColor()
             if not _PP then _PP = EllesmereUI and EllesmereUI.PP end
             if _PP and _PP.CreateBorder then
-                if _accentEnabled() and EG3 then
-                    _PP.CreateBorder(eb, EG3.r, EG3.g, EG3.b, 0.5, 1, "OVERLAY", 7)
-                else
-                    _PP.CreateBorder(eb, 1, 1, 1, RS2.BRD_ALPHA, 1, "OVERLAY", 7)
-                end
+                _PP.CreateBorder(eb, borderR, borderG, borderB, 0.5, 1, "OVERLAY", 7)
             end
         end
     end
@@ -947,7 +960,6 @@ end
             -- lets the user drag LFGDungeonReadyDialog independently.
             if not GetFFD(popup).bg then
                 local RS = EllesmereUI.RESKIN
-                if not _PP then _PP = EllesmereUI and EllesmereUI.PP end
                 local anchor = dialog or popup
                 local bgFrame = CreateFrame("Frame", nil, anchor)
                 bgFrame:SetAllPoints(anchor)
@@ -957,10 +969,8 @@ end
                 GetFFD(popup).bg:SetAllPoints()
                 GetFFD(popup).bg:SetColorTexture(RS.BG_R, RS.BG_G, RS.BG_B, RS.QT_ALPHA)
                 GetFFD(GetFFD(popup).bg).owned = true
-                if _PP and _PP.CreateBorder then
-                    _PP.CreateBorder(bgFrame, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-                end
             end
+            _applyConfiguredBorder(GetFFD(popup).bgFrame, "popupMenu", 1)
 
             -- Skin buttons (Enter Dungeon / Leave Queue).
             -- Re-strip textures every show (Blizzard re-applies art on each popup).
@@ -995,20 +1005,10 @@ end
                                     end)
                                 end
                             end
-                            local EG = EllesmereUI.ELLESMERE_GREEN
-                            local useAccent = _accentEnabled() and EG
-                            local RS2 = EllesmereUI.RESKIN
                             local btnBg = btn:CreateTexture(nil, "BACKGROUND", nil, -6)
                             btnBg:SetAllPoints()
-                            btnBg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
                             GetFFD(btnBg).owned = true
-                            if _PP and _PP.CreateBorder then
-                                if useAccent then
-                                    _PP.CreateBorder(btn, EG.r, EG.g, EG.b, 0.5, 1, "OVERLAY", 7)
-                                else
-                                    _PP.CreateBorder(btn, 1, 1, 1, RS2.BRD_ALPHA, 1, "OVERLAY", 7)
-                                end
-                            end
+                            GetFFD(btn).bg = btnBg
                             -- House hover: 10% white wash (owned, so the
                             -- every-show re-strip above leaves it alone).
                             local hov = btn:CreateTexture(nil, "HIGHLIGHT")
@@ -1016,12 +1016,18 @@ end
                             hov:SetAllPoints()
                             GetFFD(hov).owned = true
                         end
-                        -- Accent-color the button text (every show)
-                        local EG = EllesmereUI.ELLESMERE_GREEN
-                        local useAccent = _accentEnabled() and EG
+                        -- Apply the shared popup/game-menu button style every show.
+                        local buttonColor = EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor
+                            or { r=0.1, g=0.1, b=0.1, a=0.8 }
+                        if GetFFD(btn).bg then
+                            GetFFD(btn).bg:SetColorTexture(buttonColor.r or 0.1, buttonColor.g or 0.1,
+                                buttonColor.b or 0.1, buttonColor.a == nil and 0.8 or buttonColor.a)
+                        end
+                        _applyConfiguredBorder(btn, "popupMenuButton", 1)
                         local fs = btn:GetFontString()
-                        if fs and useAccent then
-                            fs:SetTextColor(EG.r, EG.g, EG.b, 1)
+                        if fs then
+                            local r, g, b = _getPopupMenuButtonTextColor()
+                            fs:SetTextColor(r, g, b, 1)
                         end
                     end
                 end
@@ -1246,8 +1252,9 @@ do
 
         -- Reskin buttons (Okay, Cancel, Defaults, UseCharacterBindings)
         local btnNames = { "OkayButton", "CancelButton", "DefaultsButton" }
-        local EG = EllesmereUI.ELLESMERE_GREEN
-        local useAccent = (EllesmereUIDB and EllesmereUIDB.accentReskinElements) and EG
+        local er, eg, eb = EllesmereUI._getPopupMenuButtonTextColor()
+        local EG = { r=er, g=eg, b=eb }
+        local useAccent = EG
         for _, name in ipairs(btnNames) do
             local btn = qkb[name]
             if btn and not GetFFD(btn).skinned then
@@ -1361,7 +1368,7 @@ do
 
         -- Skin buttons
         local function _accentOn()
-            return EllesmereUIDB and EllesmereUIDB.accentReskinElements
+            return true
         end
         for _, btnName in ipairs({ "AcceptButton", "DeclineButton", "AcknowledgeButton" }) do
             local btn = dialog[btnName]
@@ -1386,7 +1393,8 @@ do
                             end)
                         end
                     end
-                    local EG = EllesmereUI.ELLESMERE_GREEN
+                    local er, eg, eb = EllesmereUI._getPopupMenuButtonTextColor()
+                    local EG = { r=er, g=eg, b=eb }
                     local useAccent = _accentOn() and EG
                     local btnBg = btn:CreateTexture(nil, "BACKGROUND", nil, -6)
                     btnBg:SetAllPoints()
@@ -1401,7 +1409,8 @@ do
                     end
                 end
                 -- Accent text (every show)
-                local EG = EllesmereUI.ELLESMERE_GREEN
+                local er, eg, eb = EllesmereUI._getPopupMenuButtonTextColor()
+                local EG = { r=er, g=eg, b=eb }
                 local useAccent = _accentOn() and EG
                 local fs = btn:GetFontString()
                 if fs and useAccent then
@@ -1471,7 +1480,7 @@ do
         end
 
         local function _accentOn()
-            return EllesmereUIDB and EllesmereUIDB.accentReskinElements
+            return true
         end
         for _, btnName in ipairs({ "SignUpButton", "CancelButton" }) do
             local btn = dialog[btnName]
@@ -1494,7 +1503,8 @@ do
                         end)
                     end
                 end
-                local EG = EllesmereUI.ELLESMERE_GREEN
+                local er, eg, eb = EllesmereUI._getPopupMenuButtonTextColor()
+                local EG = { r=er, g=eg, b=eb }
                 local useAccent = _accentOn() and EG
                 local btnBg = btn:CreateTexture(nil, "BACKGROUND", nil, -6)
                 btnBg:SetAllPoints()
@@ -1541,8 +1551,6 @@ do
         if EllesmereUIDB and EllesmereUIDB.reskinGameMenu == false then return end
 
         local RS = EllesmereUI.RESKIN
-        local PP = EllesmereUI.PP
-        local ELLESMERE_GREEN = EllesmereUI.ELLESMERE_GREEN or { r = 0.27, g = 0.86, b = 0.49 }
 
         -- Strip decorative textures
         for i = 1, select("#", GameMenuFrame:GetRegions()) do
@@ -1560,7 +1568,8 @@ do
             end
             local headerText = header.Text or (header.GetRegions and select(1, header:GetRegions()))
             if headerText and headerText.SetTextColor then
-                headerText:SetTextColor(ELLESMERE_GREEN.r, ELLESMERE_GREEN.g, ELLESMERE_GREEN.b, 1)
+                local r, g, b = EllesmereUI._getPopupMenuButtonTextColor()
+                headerText:SetTextColor(r, g, b, 1)
                 local euiFont = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("blizzardSkin") or "Fonts\\FRIZQT__.TTF"
                 local _, hSize = headerText:GetFont()
                 headerText:SetFont(euiFont, hSize or 16, "")
@@ -1568,13 +1577,48 @@ do
             header:ClearAllPoints()
             header:SetPoint("TOP", GameMenuFrame, "TOP", 0, -10)
         end
-        -- Dark bg + border
+        -- Dark bg + independently configured Game Menu border.
         local gmBg = GameMenuFrame:CreateTexture(nil, "BACKGROUND")
         gmBg:SetAllPoints()
         gmBg:SetColorTexture(RS.BG_R, RS.BG_G, RS.BG_B, RS.QT_ALPHA)
-        if PP and PP.CreateBorder then
-            PP.CreateBorder(GameMenuFrame, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
+        local function ApplyGameMenuButtonStyle(menuBtn)
+            local data = GetFFD(menuBtn)
+            local inset = data.gameMenuInset
+            if not inset then return end
+            local color = EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor
+                or { r=0.1, g=0.1, b=0.1, a=0.8 }
+            if data.gameMenuButtonBg then
+                data.gameMenuButtonBg:SetColorTexture(color.r or 0.1, color.g or 0.1,
+                    color.b or 0.1, color.a == nil and 0.8 or color.a)
+            end
+            if EllesmereUI._applyBlizzardConfiguredBorder then
+                EllesmereUI._applyBlizzardConfiguredBorder(inset, "popupMenuButton", 1)
+            end
+            local fs = menuBtn:GetFontString()
+            if fs then
+                if menuBtn.IsEnabled and not menuBtn:IsEnabled() then
+                    fs:SetTextColor(0.4, 0.4, 0.4, 1)
+                elseif EllesmereUI._getPopupMenuButtonTextColor then
+                    local r, g, b = EllesmereUI._getPopupMenuButtonTextColor()
+                    fs:SetTextColor(r, g, b, 1)
+                end
+            end
         end
+        local function ApplyGameMenuBorder()
+            if EllesmereUI._applyBlizzardConfiguredBorder then
+                EllesmereUI._applyBlizzardConfiguredBorder(GameMenuFrame, "popupMenu", 1)
+            end
+            if GameMenuFrame.buttonPool then
+                for menuBtn in GameMenuFrame.buttonPool:EnumerateActive() do
+                    ApplyGameMenuButtonStyle(menuBtn)
+                end
+            end
+            local frameData = GetFFD(GameMenuFrame)
+            if frameData.euiBtn then ApplyGameMenuButtonStyle(frameData.euiBtn) end
+            if frameData.unlockBtn then ApplyGameMenuButtonStyle(frameData.unlockBtn) end
+        end
+        ApplyGameMenuBorder()
+        GameMenuFrame:HookScript("OnShow", ApplyGameMenuBorder)
         -- Skin pooled buttons via InitButtons hook
         hooksecurefunc(GameMenuFrame, "InitButtons", function(menu)
             if not menu.buttonPool then return end
@@ -1606,10 +1650,8 @@ do
                     inset:SetFrameLevel(menuBtn:GetFrameLevel())
                     local btnBg = inset:CreateTexture(nil, "BACKGROUND", nil, -6)
                     btnBg:SetAllPoints()
-                    btnBg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
-                    if PP and PP.CreateBorder then
-                        PP.CreateBorder(inset, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-                    end
+                    GetFFD(menuBtn).gameMenuInset = inset
+                    GetFFD(menuBtn).gameMenuButtonBg = btnBg
                     local hl = menuBtn:CreateTexture(nil, "HIGHLIGHT")
                     hl:SetAllPoints(inset)
                     hl:SetColorTexture(1, 1, 1, 0.1)
@@ -1619,7 +1661,10 @@ do
                         local _, size, flags = fs:GetFont()
                         fs:SetFont(euiFont or "Fonts\\FRIZQT__.TTF", (size or 14) - 2, flags or "")
                     end
+                    menuBtn:HookScript("OnEnable", ApplyGameMenuButtonStyle)
+                    menuBtn:HookScript("OnDisable", ApplyGameMenuButtonStyle)
                 end
+                ApplyGameMenuButtonStyle(menuBtn)
             end
         end)
     end)

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -119,6 +119,36 @@ end
         return not EllesmereUIDB or EllesmereUIDB.reskinPopupsMenus ~= false
     end
 
+    local function _applyConfiguredBorder(owner, prefix, legacySize)
+        if not owner or not EllesmereUI or not EllesmereUI.ApplyBorderStyle then return end
+        local db = EllesmereUIDB or {}
+        local key = db[prefix .. "BorderThickness"]
+        local sizeMap = { none=0, thin=1, normal=2, heavy=3, strong=4 }
+        local size
+        if key then
+            size = sizeMap[key] or 1
+        else
+            size = legacySize ~= nil and legacySize or 1
+            key = ({ [0]="none", [1]="thin", [2]="normal", [3]="heavy", [4]="strong" })[size] or "thin"
+        end
+        local color = db[prefix .. "BorderColor"] or { r=1, g=1, b=1 }
+        local alpha = db[prefix .. "BorderOpacity"]
+        if alpha == nil then alpha = EllesmereUI.RESKIN.BRD_ALPHA end
+        local data = GetFFD(owner)
+        if not data.configBorder then
+            data.configBorder = CreateFrame("Frame", nil, owner, "BackdropTemplate")
+            data.configBorder:SetAllPoints(owner)
+            data.configBorder:SetFrameLevel(owner:GetFrameLevel() + 5)
+            data.configBorder:EnableMouse(false)
+            if _PP and _PP.HideBorder then _PP.HideBorder(owner) end
+        end
+        EllesmereUI.ApplyBorderStyle(data.configBorder, size,
+            color.r or 1, color.g or 1, color.b or 1, alpha,
+            db[prefix .. "BorderTexture"] or "solid",
+            db[prefix .. "BorderOffsetX"], db[prefix .. "BorderOffsetY"],
+            db[prefix .. "BorderShiftX"], db[prefix .. "BorderShiftY"])
+    end
+
     local function _ttSkin(tt, _, isEmbedded)
         if not tt or tt:IsForbidden() or not _enabled() then return end
         -- Embedded tooltips (e.g. EmbeddedItemTooltip, the reward-item block
@@ -132,10 +162,6 @@ end
         if not GetFFD(tt).bg then
             GetFFD(tt).bg = tt:CreateTexture(nil, "BACKGROUND", nil, -8)
             GetFFD(tt).bg:SetAllPoints()
-            if _PP and _PP.CreateBorder then
-                local bR, bG, bB, bA, bSize = EllesmereUI.GetTooltipBorder()
-                _PP.CreateBorder(tt, bR, bG, bB, bA, bSize, "OVERLAY", 7)
-            end
         end
         -- Unified, user-customizable background (shared with the EUI custom
         -- tooltips via EllesmereUI.GetTooltipBg). Re-applied each skin call so a
@@ -145,16 +171,8 @@ end
         -- Border size + colour are user-customizable (Blizz UI Enhanced >
         -- Blizzard Tooltip > Border). Re-applied each call like the bg so a
         -- change shows on the next tooltip; size 0 hides the border.
-        if _PP and _PP.GetBorders and _PP.GetBorders(tt) then
-            local bR, bG, bB, bA, bSize = EllesmereUI.GetTooltipBorder()
-            if bSize and bSize > 0 then
-                _PP.SetBorderSize(tt, bSize)
-                _PP.SetBorderColor(tt, bR, bG, bB, bA)
-                _PP.ShowBorder(tt)
-            else
-                _PP.HideBorder(tt)
-            end
-        end
+        local _, _, _, _, legacySize = EllesmereUI.GetTooltipBorder()
+        _applyConfiguredBorder(tt, "tooltip", legacySize)
     end
 
     local function _ttFonts(tt, startFrom)
@@ -640,13 +658,8 @@ end
                 region:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -1, 1)
             end
         end
-        if not _menuSkinned[frame] then
-            _menuSkinned[frame] = true
-            if _PP and _PP.CreateBorder then
-                local RS = EllesmereUI.RESKIN
-                _PP.CreateBorder(frame, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-            end
-        end
+        if not _menuSkinned[frame] then _menuSkinned[frame] = true end
+        _applyConfiguredBorder(frame, "popupMenu", 1)
     end
 
     local function _menuOnOpen(manager, _, menuDescription)
@@ -705,12 +718,10 @@ end
             GetFFD(popup).bg:SetAllPoints()
             GetFFD(popup).bg:SetColorTexture(RS.BG_R, RS.BG_G, RS.BG_B, RS.QT_ALPHA)
             GetFFD(GetFFD(popup).bg).owned = true
-            if not _PP then _PP = EllesmereUI and EllesmereUI.PP end
-            if _PP and _PP.CreateBorder then
-                _PP.CreateBorder(popup, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-            end
         end
         GetFFD(popup).bg:Show()
+        if not _PP then _PP = EllesmereUI and EllesmereUI.PP end
+        _applyConfiguredBorder(popup, "popupMenu", 1)
         -- Skin buttons (1-4 plus the optional extra action button)
         local popupBtns = {}
         for i = 1, 4 do

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -175,6 +175,11 @@ end
             local color = db.popupMenuButtonTextColor or { r=1, g=1, b=1 }
             return color.r or 1, color.g or 1, color.b or 1
         end
+        if mode == "class" then
+            local _, class = UnitClass("player")
+            local color = class and _RAID_CC[class]
+            if color then return color.r, color.g, color.b end
+        end
         local accent = EllesmereUI.ELLESMERE_GREEN or { r=0.27, g=0.86, b=0.49 }
         return accent.r, accent.g, accent.b
     end


### PR DESCRIPTION
### What does this PR do?

Expands the Blizzard UI popup and menu styling options.

- Adds configurable borders for Blizzard tooltips, popups, context menus and the Game Menu.
- Uses a shared style for popups and the Blizzard Game Menu.
- Adds configurable popup and menu button styling:
  - Border style
  - Border size
  - Border color: Accent, Class, or Custom
  - Border offset
  - Background color and opacity
- Adds a shared Element & Text Color option with Accent and Custom modes.
- Applies the button style to:
  - Static popup buttons
- Blizzard Game Menu buttons

Keeps the default border appearance as Solid, Thin, and subtle white.

### How was it tested?

- Verified all changed Lua files with git diff --check.
- Checked fallback handling for existing profiles and removed settings.
- Its tested on live servers on version 12.0.7
- Need to test on PTR 12.1

### Screenshots
<img width="1323" height="975" alt="image" src="https://github.com/user-attachments/assets/4f2ec1ad-ed6e-4827-9d95-954df8aab538" />

Examples:

Popups:
<img width="644" height="341" alt="image" src="https://github.com/user-attachments/assets/20bcd87d-7eb0-4420-a11e-459b345af53a" />
<img width="687" height="309" alt="image" src="https://github.com/user-attachments/assets/e4084944-7db9-44e6-93a0-6ccfd0701c96" />

<img width="594" height="262" alt="image" src="https://github.com/user-attachments/assets/834e0a1e-fb31-44ff-8d05-35d573030588" />

Game Menu:
<img width="357" height="692" alt="image" src="https://github.com/user-attachments/assets/4fc7f223-2ed8-4985-b730-061f5746d8ef" />

<img width="393" height="715" alt="image" src="https://github.com/user-attachments/assets/c6936ead-20bc-48ff-aeff-a3f24e9792de" />

Rightclich-menus:

<img width="317" height="536" alt="image" src="https://github.com/user-attachments/assets/9f79f193-9a32-4f74-99b3-287469d6b5c7" />



### Checklist

- [x] New settings preserve the existing default appearance
- [x] Zero cost while disabled: no polling or per-frame update logic added
- [x] Cheap while enabled: styling is applied through existing show/init hooks
- [x] No polling, timers, or per-frame allocations added
- [x] Blizzard-owned frames use HookScript/hooksecurefunc; no new SetScript replacements
- [x] Tested in-game, works on live retail
- [ ] Tested on the 12.1 PTR client