### PR TITLE
Blizzard Skin: Add border options for tooltips, popups and game menu

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -11322,8 +11322,6 @@ initFrame:SetScript("OnEvent", function(self, event)
 
         -- Skin our custom buttons the same way as pooled Blizzard buttons
         if _reskinMenu then
-            local RS = EllesmereUI.RESKIN
-            local PP = EllesmereUI.PP
             for _, customBtn in ipairs({ btn, unlockBtn }) do
                 for j = 1, select("#", customBtn:GetRegions()) do
                     local r = select(j, customBtn:GetRegions())
@@ -11348,10 +11346,11 @@ initFrame:SetScript("OnEvent", function(self, event)
                 inset:SetFrameLevel(customBtn:GetFrameLevel())
                 local cBg = inset:CreateTexture(nil, "BACKGROUND", nil, -6)
                 cBg:SetAllPoints()
-                cBg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
-                if PP and PP.CreateBorder then
-                    PP.CreateBorder(inset, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-                end
+                local c=EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor or {r=.1,g=.1,b=.1,a=.8}
+                cBg:SetColorTexture(c.r,c.g,c.b,c.a == nil and .8 or c.a)
+                EllesmereUI._GetFFD(customBtn).gameMenuInset=inset
+                EllesmereUI._GetFFD(customBtn).gameMenuButtonBg=cBg
+                if EllesmereUI._applyBlizzardConfiguredBorder then EllesmereUI._applyBlizzardConfiguredBorder(inset,"popupMenuButton",1) end
                 local hl = customBtn:CreateTexture(nil, "HIGHLIGHT")
                 hl:SetAllPoints(inset)
                 hl:SetColorTexture(1, 1, 1, 0.1)
@@ -11360,6 +11359,7 @@ initFrame:SetScript("OnEvent", function(self, event)
                     local euiFont = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath() or nil
                     local _, size, flags = cfs:GetFont()
                     cfs:SetFont(euiFont or "Fonts\\FRIZQT__.TTF", (size or 14) - 2, flags or "")
+                    if EllesmereUI._getPopupMenuButtonTextColor then local r,g,b=EllesmereUI._getPopupMenuButtonTextColor(); cfs:SetTextColor(r,g,b,1) end
                 end
             end
         end
@@ -11378,8 +11378,10 @@ initFrame:SetScript("OnEvent", function(self, event)
                 if header then
                     local headerText = header.Text
                     if headerText and headerText.SetTextColor then
-                        local EG = ELLESMERE_GREEN
-                        headerText:SetTextColor(EG.r, EG.g, EG.b, 1)
+                        if EllesmereUI._getPopupMenuButtonTextColor then
+                            local r,g,b=EllesmereUI._getPopupMenuButtonTextColor()
+                            headerText:SetTextColor(r,g,b,1)
+                        end
                     end
                 end
             end
@@ -11391,9 +11393,6 @@ initFrame:SetScript("OnEvent", function(self, event)
             if not showEUI then btn:Hide() end
             if not showUnlock then unlockBtn:Hide() end
             if not showEUI and not showUnlock then return end
-
-            local eg = ELLESMERE_GREEN
-            local hex = string.format("|cff%02x%02x%02x", (eg.r or 0.05) * 255, (eg.g or 0.82) * 255, (eg.b or 0.62) * 255)
 
             -- Find the Shop button to anchor below (fall back to Options)
             local anchorBtn
@@ -11423,10 +11422,10 @@ initFrame:SetScript("OnEvent", function(self, event)
 
             if showEUI then
                 btn:Show()
-                btn:SetText(hex .. "Ellesmere|r|cffffffff" .. "UI|r")
+                btn:SetText("EllesmereUI")
                 if _reskinMenu then
                     local fs = btn:GetFontString()
-                    if fs then fs:SetFont(euiFont, btnFontSize, "") end
+                    if fs then fs:SetFont(euiFont, btnFontSize, ""); if EllesmereUI._getPopupMenuButtonTextColor then local r,g,b=EllesmereUI._getPopupMenuButtonTextColor(); fs:SetTextColor(r,g,b,1) end end
                 end
                 btn:ClearAllPoints()
                 btn:SetPoint("TOP", lastBtn, "BOTTOM", 0, -12)
@@ -11435,10 +11434,10 @@ initFrame:SetScript("OnEvent", function(self, event)
             end
             if showUnlock then
                 unlockBtn:Show()
-                unlockBtn:SetText(hex .. "EUI|r |cffffffffUnlock Mode|r")
+                unlockBtn:SetText("EUI Unlock Mode")
                 if _reskinMenu then
                     local fs2 = unlockBtn:GetFontString()
-                    if fs2 then fs2:SetFont(euiFont, btnFontSize, "") end
+                    if fs2 then fs2:SetFont(euiFont, btnFontSize, ""); if EllesmereUI._getPopupMenuButtonTextColor then local r,g,b=EllesmereUI._getPopupMenuButtonTextColor(); fs2:SetTextColor(r,g,b,1) end end
                 end
                 unlockBtn:ClearAllPoints()
                 unlockBtn:SetPoint("TOP", lastBtn, "BOTTOM", 0, showEUI and -4 or -12)

--- a/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIBlizzardSkin/EUI_BlizzardSkin_Options.lua
@@ -13,16 +13,60 @@ initFrame:SetScript("OnEvent", function(self)
     if not EllesmereUI or not EllesmereUI.RegisterModule then return end
 
     local function BuildTooltipsPage(pageName, parent, yOffset)
+        if not EllesmereUIDB then EllesmereUIDB = {} end
         local W = EllesmereUI.Widgets
         local y = yOffset
         local _, h
+        local BORDER_VALUES = { none="None", thin="Thin", normal="Normal", heavy="Heavy", strong="Strong" }
+        local BORDER_ORDER = { "none", "thin", "normal", "heavy", "strong" }
+
+        local function AttachBorderControls(row, prefix, disabledFn)
+            local PP = EllesmereUI.PanelPP
+            local left, right = row._leftRegion, row._rightRegion
+            local _, showOffset = EllesmereUI.BuildCogPopup({ title="Border Offset", rows={
+                { type="slider", label="Offset X", min=-10,max=10,step=1,
+                  get=function() local v=EllesmereUIDB[prefix.."BorderOffsetX"]; if v~=nil then return v end return EllesmereUI.GetBorderTextureDefaultOffset(EllesmereUIDB[prefix.."BorderTexture"] or "solid") end,
+                  set=function(v) EllesmereUIDB[prefix.."BorderOffsetX"]=v end },
+                { type="slider", label="Offset Y", min=-10,max=10,step=1,
+                  get=function() local v=EllesmereUIDB[prefix.."BorderOffsetY"]; if v~=nil then return v end return EllesmereUI.GetBorderTextureDefaultOffsetY(EllesmereUIDB[prefix.."BorderTexture"] or "solid") end,
+                  set=function(v) EllesmereUIDB[prefix.."BorderOffsetY"]=v end },
+            }})
+            local cog=CreateFrame("Button",nil,left); cog:SetSize(26,26); cog:SetPoint("RIGHT",left._control,"LEFT",-8,0); cog:SetAlpha(.4)
+            local ico=cog:CreateTexture(nil,"OVERLAY"); ico:SetAllPoints(); ico:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+            cog:SetScript("OnClick",function(self) showOffset(self) end); left._lastInline=cog
+
+            local function AddModeSwatch(anchor, mode, tip, getColor, custom)
+                local sw, refresh=EllesmereUI.BuildColorSwatch(right,right:GetFrameLevel()+5,getColor,
+                    function(r,g,b,a) EllesmereUIDB[prefix.."BorderColor"]={r=r,g=g,b=b}; EllesmereUIDB[prefix.."BorderOpacity"]=a; EllesmereUIDB[prefix.."BorderColorMode"]="custom" end,
+                    custom,20)
+                PP.Point(sw,"RIGHT",anchor,"LEFT",-8,0)
+                local orig=sw:GetScript("OnClick")
+                sw:SetScript("OnClick",function(self)
+                    if mode~="custom" or (EllesmereUIDB[prefix.."BorderColorMode"] or "custom")~="custom" then
+                        EllesmereUIDB[prefix.."BorderColorMode"]=mode; EllesmereUI:RefreshPage(); return
+                    end
+                    orig(self)
+                end)
+                sw:HookScript("OnEnter",function(self) EllesmereUI.ShowWidgetTooltip(self,tip) end)
+                sw:HookScript("OnLeave",function() EllesmereUI.HideWidgetTooltip() end)
+                EllesmereUI.RegisterWidgetRefresh(function()
+                    local off=disabledFn and disabledFn(); local active=(EllesmereUIDB[prefix.."BorderColorMode"] or "custom")==mode
+                    sw:SetAlpha(off and .15 or (active and 1 or .3)); sw:EnableMouse(not off); refresh()
+                end)
+                return sw
+            end
+            local accent=AddModeSwatch(right._control,"accent","Accent Color",function() local c=EllesmereUI.ELLESMERE_GREEN; return c.r,c.g,c.b,1 end,false)
+            local class=AddModeSwatch(accent,"class","Class Color",function() local _,k=UnitClass("player"); local c=RAID_CLASS_COLORS[k]; return c.r,c.g,c.b,1 end,false)
+            local custom=AddModeSwatch(class,"custom","Custom Color",function() local c=EllesmereUIDB[prefix.."BorderColor"] or {r=1,g=1,b=1}; return c.r,c.g,c.b,EllesmereUIDB[prefix.."BorderOpacity"] or EllesmereUI.RESKIN.BRD_ALPHA end,true)
+            right._lastInline=custom
+        end
 
         if EllesmereUI.ClearContentHeader then EllesmereUI:ClearContentHeader() end
         parent._showRowDivider = true
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
-        _, h = W:SectionHeader(parent, "BLIZZARD UI ELEMENTS", y);  y = y - h
+        _, h = W:SectionHeader(parent, "BLIZZARD POPUPS & GAME MENU", y);  y = y - h
 
         _, h = W:DualRow(parent, y,
             { type="toggle", text="Reskin Popups and Menus",
@@ -45,16 +89,31 @@ initFrame:SetScript("OnEvent", function(self)
                       })
                   end
               end },
-            { type="toggle", text="Accent Colored Elements",
-              tooltip="Recolors headers, arrows, and spell titles in Blizzard tooltips and context menus to match your UI Accent Color.",
-              getValue=function()
-                  return EllesmereUIDB and EllesmereUIDB.accentReskinElements or false
-              end,
-              setValue=function(v)
-                  if not EllesmereUIDB then EllesmereUIDB = {} end
-                  EllesmereUIDB.accentReskinElements = v
-              end }
+            { type="spacer", text="" }
         );  y = y - h
+
+        local function popupOff() return EllesmereUIDB.reskinPopupsMenus == false end
+        do
+            local texValues,texOrder=EllesmereUI.GetBorderTextureDropdown()
+            local outer
+            outer,h=W:DualRow(parent,y,
+                {type="dropdown",text="Border Style",disabled=popupOff,values=texValues,order=texOrder,getValue=function() return EllesmereUIDB.popupMenuBorderTexture or "solid" end,setValue=function(v) EllesmereUIDB.popupMenuBorderTexture=v; EllesmereUIDB.popupMenuBorderOffsetX=nil; EllesmereUIDB.popupMenuBorderOffsetY=nil end},
+                {type="dropdown",text="Border Size",disabled=popupOff,values=BORDER_VALUES,order=BORDER_ORDER,getValue=function() return EllesmereUIDB.popupMenuBorderThickness or "thin" end,setValue=function(v) EllesmereUIDB.popupMenuBorderThickness=v end}); y=y-h
+            AttachBorderControls(outer,"popupMenu",popupOff)
+            local buttons
+            buttons,h=W:DualRow(parent,y,
+                {type="dropdown",text="Button Border Style",disabled=popupOff,values=texValues,order=texOrder,getValue=function() return EllesmereUIDB.popupMenuButtonBorderTexture or "solid" end,setValue=function(v) EllesmereUIDB.popupMenuButtonBorderTexture=v; EllesmereUIDB.popupMenuButtonBorderOffsetX=nil; EllesmereUIDB.popupMenuButtonBorderOffsetY=nil end},
+                {type="dropdown",text="Button Border Size",disabled=popupOff,values=BORDER_VALUES,order=BORDER_ORDER,getValue=function() return EllesmereUIDB.popupMenuButtonBorderThickness or "thin" end,setValue=function(v) EllesmereUIDB.popupMenuButtonBorderThickness=v end}); y=y-h
+            AttachBorderControls(buttons,"popupMenuButton",popupOff)
+        end
+
+        _,h=W:DualRow(parent,y,
+            {type="colorpicker",text="Button Background",hasAlpha=true,disabled=popupOff,getValue=function() local c=EllesmereUIDB.popupMenuButtonBackgroundColor or {r=.1,g=.1,b=.1,a=.8}; return c.r,c.g,c.b,c.a end,setValue=function(r,g,b,a) EllesmereUIDB.popupMenuButtonBackgroundColor={r=r,g=g,b=b,a=a} end},
+            {type="multiSwatch",text="Element & Text Color",disabled=popupOff,swatches={
+                {tooltip="Accent Color",hasAlpha=false,getValue=function() local c=EllesmereUI.ELLESMERE_GREEN; return c.r,c.g,c.b end,setValue=function() end,onClick=function() EllesmereUIDB.popupMenuButtonTextColorMode="accent"; EllesmereUI:RefreshPage() end,refreshAlpha=function() return (EllesmereUIDB.popupMenuButtonTextColorMode or "accent")=="accent" and 1 or .3 end},
+                {tooltip="Custom Color",hasAlpha=false,getValue=function() local c=EllesmereUIDB.popupMenuButtonTextColor or {r=1,g=1,b=1}; return c.r,c.g,c.b end,setValue=function(r,g,b) EllesmereUIDB.popupMenuButtonTextColorMode="custom"; EllesmereUIDB.popupMenuButtonTextColor={r=r,g=g,b=b} end,onClick=function(self) if (EllesmereUIDB.popupMenuButtonTextColorMode or "accent")~="custom" then EllesmereUIDB.popupMenuButtonTextColorMode="custom"; EllesmereUI:RefreshPage(); return end self._eabOrigClick(self) end,refreshAlpha=function() return EllesmereUIDB.popupMenuButtonTextColorMode=="custom" and 1 or .3 end},
+                {tooltip="Class Color",hasAlpha=false,getValue=function() local _,k=UnitClass("player"); local c=RAID_CLASS_COLORS[k]; return c.r,c.g,c.b end,setValue=function() end,onClick=function() EllesmereUIDB.popupMenuButtonTextColorMode="class"; EllesmereUI:RefreshPage() end,refreshAlpha=function() return EllesmereUIDB.popupMenuButtonTextColorMode=="class" and 1 or .3 end},
+            }}); y=y-h
 
         local queueRow
         queueRow, h = W:DualRow(parent, y,
@@ -123,7 +182,7 @@ initFrame:SetScript("OnEvent", function(self)
                   if not EllesmereUIDB then EllesmereUIDB = {} end
                   EllesmereUIDB.showQueueTimer = v
               end },
-            { type="toggle", text="Reskin Pause Menu",
+            { type="toggle", text="Enable Blizzard Pause Menu",
               tooltip="Reskins the ESC / Game Menu with the EUI dark style, matching fonts, and accent-colored title.",
               getValue=function()
                   -- Independent, default on (not tied to any master reskin toggle).
@@ -517,22 +576,18 @@ initFrame:SetScript("OnEvent", function(self)
             UpdateShowModState()
         end
 
-        -- Border: size slider with an inline colour + opacity swatch. Part of the
-        -- tooltip reskin, so it grays with "Reskin Tooltip". Defaults to the
-        -- historical hardcoded look (white @ 18% alpha, 1px) -- unset = unchanged.
+        do
+            local texValues,texOrder=EllesmereUI.GetBorderTextureDropdown()
+            local tooltipBorder
+            tooltipBorder,h=W:DualRow(parent,y,
+                {type="dropdown",text="Border Style",disabled=ttReskinOff,values=texValues,order=texOrder,getValue=function() return EllesmereUIDB.tooltipBorderTexture or "solid" end,setValue=function(v) EllesmereUIDB.tooltipBorderTexture=v; EllesmereUIDB.tooltipBorderOffsetX=nil; EllesmereUIDB.tooltipBorderOffsetY=nil end},
+                {type="dropdown",text="Border Size",disabled=ttReskinOff,values=BORDER_VALUES,order=BORDER_ORDER,getValue=function() return EllesmereUIDB.tooltipBorderThickness or ({[0]="none",[1]="thin",[2]="normal",[3]="heavy",[4]="strong"})[EllesmereUIDB.tooltipBorderSize or 1] or "thin" end,setValue=function(v) EllesmereUIDB.tooltipBorderThickness=v end}); y=y-h
+            AttachBorderControls(tooltipBorder,"tooltip",ttReskinOff)
+        end
+
         local borderRow
         borderRow, h = W:DualRow(parent, y,
-            { type="slider", text="Border", min=0, max=4, step=1,
-              disabled=ttReskinOff, disabledTooltip="Reskin Tooltip",
-              getValue=function()
-                  local s = EllesmereUIDB and EllesmereUIDB.tooltipBorderSize
-                  if s == nil then return 1 end
-                  return s
-              end,
-              setValue=function(v)
-                  if not EllesmereUIDB then EllesmereUIDB = {} end
-                  EllesmereUIDB.tooltipBorderSize = v
-              end },
+            { type="spacer", text="" },
             -- Independent of the reskin, so it is NOT gated by "Reskin
             -- Tooltip" -- like Show Spell ID.
             { type="toggle", text="Show Max Stack for Items",
@@ -546,36 +601,6 @@ initFrame:SetScript("OnEvent", function(self)
                   EllesmereUI:RefreshPage()  -- update the Use Modifier cog disabled state
               end }
         );  y = y - h
-        -- Inline colour + opacity swatch on the Border slider (left region).
-        do
-            local PP = EllesmereUI.PanelPP
-            local rgn = borderRow._leftRegion
-            local swGet = function()
-                local c = EllesmereUIDB and EllesmereUIDB.tooltipBorderColor
-                local r = (c and c.r) or 1
-                local g = (c and c.g) or 1
-                local b = (c and c.b) or 1
-                local a = (EllesmereUIDB and EllesmereUIDB.tooltipBorderOpacity) or EllesmereUI.RESKIN.BRD_ALPHA
-                return r, g, b, a
-            end
-            local swSet = function(r, g, b, a)
-                if not EllesmereUIDB then EllesmereUIDB = {} end
-                EllesmereUIDB.tooltipBorderColor = { r = r, g = g, b = b }
-                if a ~= nil then EllesmereUIDB.tooltipBorderOpacity = a end
-            end
-            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5, swGet, swSet, true, 20)
-            PP.Point(swatch, "RIGHT", rgn._lastInline or rgn._control, "LEFT", -12, 0)
-            rgn._lastInline = swatch
-            EllesmereUI.RegisterWidgetRefresh(function()
-                local off = ttReskinOff()
-                swatch:SetAlpha(off and 0.15 or 1)
-                swatch:EnableMouse(not off)
-                updateSwatch()
-            end)
-            local off = ttReskinOff()
-            swatch:SetAlpha(off and 0.15 or 1)
-            swatch:EnableMouse(not off)
-        end
 
         -- "Use Modifier" cog on Show Max Stack for Items (right region): the Max
         -- Stack line only shows while the chosen modifier is held. Disabled
@@ -2463,6 +2488,14 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.tooltipShowMount = nil
                 EllesmereUIDB.reskinQueuePopup = nil
                 EllesmereUIDB.reskinGameMenu = nil
+                EllesmereUIDB.popupMenuButtonBackgroundColor=nil
+                EllesmereUIDB.popupMenuButtonTextColorMode=nil
+                EllesmereUIDB.popupMenuButtonTextColor=nil
+                for _,prefix in ipairs({"popupMenu","popupMenuButton","tooltip"}) do
+                    for _,suffix in ipairs({"BorderTexture","BorderThickness","BorderColor","BorderColorMode","BorderOpacity","BorderOffsetX","BorderOffsetY","BorderShiftX","BorderShiftY"}) do
+                        EllesmereUIDB[prefix..suffix]=nil
+                    end
+                end
                 EllesmereUIDB.reskinGreatVault = nil
                 EllesmereUIDB.reskinLFGMenu = nil
                 EllesmereUIDB.showQueueTimer = nil

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -119,6 +119,57 @@ end
         return not EllesmereUIDB or EllesmereUIDB.reskinPopupsMenus ~= false
     end
 
+    local function _applyConfiguredBorder(owner, prefix, legacySize)
+        if not owner or not EllesmereUI.ApplyBorderStyle then return end
+        local db = EllesmereUIDB or {}
+        local key = db[prefix .. "BorderThickness"]
+        local sizes = { none=0, thin=1, normal=2, heavy=3, strong=4 }
+        local size = key and (sizes[key] or 1) or (legacySize or 1)
+        key = key or ({ [0]="none", [1]="thin", [2]="normal", [3]="heavy", [4]="strong" })[size] or "thin"
+        local mode = db[prefix .. "BorderColorMode"] or "custom"
+        local color
+        if mode == "accent" then
+            color = EllesmereUI.ELLESMERE_GREEN or { r=.27, g=.86, b=.49 }
+        elseif mode == "class" then
+            local _, class = UnitClass("player")
+            color = class and RAID_CLASS_COLORS[class] or { r=1, g=1, b=1 }
+        else
+            color = db[prefix .. "BorderColor"] or { r=1, g=1, b=1 }
+        end
+        local alpha = db[prefix .. "BorderOpacity"]
+        if alpha == nil then alpha = (mode == "custom") and EllesmereUI.RESKIN.BRD_ALPHA or .5 end
+        local data = GetFFD(owner)
+        if not data.configBorder then
+            data.configBorder = CreateFrame("Frame", nil, owner, "BackdropTemplate")
+            data.configBorder:SetAllPoints(owner)
+            data.configBorder:SetFrameLevel(owner:GetFrameLevel() + 5)
+            data.configBorder:EnableMouse(false)
+            if not _PP then _PP = EllesmereUI.PP end
+            if _PP and _PP.HideBorder then _PP.HideBorder(owner) end
+        end
+        EllesmereUI.ApplyBorderStyle(data.configBorder, size, color.r, color.g, color.b, alpha,
+            db[prefix .. "BorderTexture"] or "solid", db[prefix .. "BorderOffsetX"],
+            db[prefix .. "BorderOffsetY"], db[prefix .. "BorderShiftX"], db[prefix .. "BorderShiftY"],
+            "blizzardSkin", key)
+    end
+    EllesmereUI._applyBlizzardConfiguredBorder = _applyConfiguredBorder
+
+    local function _getElementColor()
+        local db = EllesmereUIDB or {}
+        local mode = db.popupMenuButtonTextColorMode or "accent"
+        if mode == "custom" then
+            local c = db.popupMenuButtonTextColor or { r=1, g=1, b=1 }
+            return c.r, c.g, c.b
+        elseif mode == "class" then
+            local _, class = UnitClass("player")
+            local c = class and RAID_CLASS_COLORS[class]
+            if c then return c.r, c.g, c.b end
+        end
+        local c = EllesmereUI.ELLESMERE_GREEN or { r=.27, g=.86, b=.49 }
+        return c.r, c.g, c.b
+    end
+    EllesmereUI._getPopupMenuButtonTextColor = _getElementColor
+
     local function _ttSkin(tt, _, isEmbedded)
         if not tt or tt:IsForbidden() or not _enabled() then return end
         -- Embedded tooltips (e.g. EmbeddedItemTooltip, the reward-item block
@@ -132,10 +183,6 @@ end
         if not GetFFD(tt).bg then
             GetFFD(tt).bg = tt:CreateTexture(nil, "BACKGROUND", nil, -8)
             GetFFD(tt).bg:SetAllPoints()
-            if _PP and _PP.CreateBorder then
-                local bR, bG, bB, bA, bSize = EllesmereUI.GetTooltipBorder()
-                _PP.CreateBorder(tt, bR, bG, bB, bA, bSize, "OVERLAY", 7)
-            end
         end
         -- Unified, user-customizable background (shared with the EUI custom
         -- tooltips via EllesmereUI.GetTooltipBg). Re-applied each skin call so a
@@ -145,16 +192,8 @@ end
         -- Border size + colour are user-customizable (Blizz UI Enhanced >
         -- Blizzard Tooltip > Border). Re-applied each call like the bg so a
         -- change shows on the next tooltip; size 0 hides the border.
-        if _PP and _PP.GetBorders and _PP.GetBorders(tt) then
-            local bR, bG, bB, bA, bSize = EllesmereUI.GetTooltipBorder()
-            if bSize and bSize > 0 then
-                _PP.SetBorderSize(tt, bSize)
-                _PP.SetBorderColor(tt, bR, bG, bB, bA)
-                _PP.ShowBorder(tt)
-            else
-                _PP.HideBorder(tt)
-            end
-        end
+        local _, _, _, _, legacySize = EllesmereUI.GetTooltipBorder()
+        _applyConfiguredBorder(tt, "tooltip", legacySize)
     end
 
     local function _ttFonts(tt, startFrom)
@@ -197,7 +236,7 @@ end
     end
 
     local function _accentEnabled()
-        return EllesmereUIDB and EllesmereUIDB.accentReskinElements
+        return true
     end
 
     -- Unified inspect system: one NotifyInspect per GUID, one INSPECT_READY
@@ -607,8 +646,7 @@ end
             if tt ~= _GameTooltip or tt:IsForbidden() or not _accentEnabled() then return end
             if not _nameL1 then _nameL1 = _G.GameTooltipTextLeft1 end
             if _nameL1 then
-                local EG = EllesmereUI.ELLESMERE_GREEN
-                if EG then _nameL1:SetTextColor(EG.r, EG.g, EG.b) end
+                local r,g,b=_getElementColor(); _nameL1:SetTextColor(r,g,b)
             end
         end
         if TooltipDataProcessor and TooltipDataProcessor.AddTooltipPostCall and Enum and Enum.TooltipDataType then
@@ -640,13 +678,8 @@ end
                 region:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -1, 1)
             end
         end
-        if not _menuSkinned[frame] then
-            _menuSkinned[frame] = true
-            if _PP and _PP.CreateBorder then
-                local RS = EllesmereUI.RESKIN
-                _PP.CreateBorder(frame, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-            end
-        end
+        _menuSkinned[frame] = true
+        _applyConfiguredBorder(frame, "popupMenu", 1)
     end
 
     local function _menuOnOpen(manager, _, menuDescription)
@@ -711,6 +744,7 @@ end
             end
         end
         GetFFD(popup).bg:Show()
+        _applyConfiguredBorder(popup, "popupMenu", 1)
         -- Skin buttons (1-4 plus the optional extra action button)
         local popupBtns = {}
         for i = 1, 4 do
@@ -730,22 +764,10 @@ end
                         if r.SetAtlas then r:SetAtlas("") end
                     end
                 end
-                local RS = EllesmereUI.RESKIN
-                local EG = EllesmereUI.ELLESMERE_GREEN
-                local useAccent = _accentEnabled() and EG
                 local btnBg = btn:CreateTexture(nil, "BACKGROUND", nil, -6)
                 btnBg:SetAllPoints()
-                btnBg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
                 GetFFD(btnBg).owned = true
                 GetFFD(btn).bg = btnBg
-                if not _PP then _PP = EllesmereUI and EllesmereUI.PP end
-                if _PP and _PP.CreateBorder then
-                    if useAccent then
-                        _PP.CreateBorder(btn, EG.r, EG.g, EG.b, 0.5, 1, "OVERLAY", 7)
-                    else
-                        _PP.CreateBorder(btn, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-                    end
-                end
                 -- House hover: 10% white wash (HIGHLIGHT layer only renders
                 -- while the button is enabled and hovered).
                 local hov = btn:CreateTexture(nil, "HIGHLIGHT")
@@ -760,12 +782,8 @@ end
                     local enabled = (self.IsEnabled and self:IsEnabled()) and true or false
                     if fs then
                         if enabled then
-                            local EG2 = EllesmereUI.ELLESMERE_GREEN
-                            if _accentEnabled() and EG2 then
-                                fs:SetTextColor(EG2.r, EG2.g, EG2.b, 1)
-                            else
-                                fs:SetTextColor(1, 1, 1, 1)
-                            end
+                            local r, g, b = _getElementColor()
+                            fs:SetTextColor(r, g, b, 1)
                         else
                             fs:SetTextColor(0.4, 0.4, 0.4, 1)
                         end
@@ -778,6 +796,11 @@ end
                 btn:HookScript("OnEnable",  _euiRefreshEnabled)
                 btn:HookScript("OnDisable", _euiRefreshEnabled)
                 _euiRefreshEnabled(btn)
+            end
+            if btn then
+                local c = EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor or { r=.1,g=.1,b=.1,a=.8 }
+                if GetFFD(btn).bg then GetFFD(btn).bg:SetColorTexture(c.r, c.g, c.b, c.a == nil and .8 or c.a) end
+                _applyConfiguredBorder(btn, "popupMenuButton", 1)
             end
         end
 
@@ -822,15 +845,10 @@ end
             ebBg:SetColorTexture(0.05, 0.05, 0.05, 0.9)
             GetFFD(ebBg).owned = true
             -- Border matching the popup buttons (accent or white).
-            local RS2 = EllesmereUI.RESKIN
-            local EG3 = EllesmereUI.ELLESMERE_GREEN
+            local borderR, borderG, borderB = _getElementColor()
             if not _PP then _PP = EllesmereUI and EllesmereUI.PP end
             if _PP and _PP.CreateBorder then
-                if _accentEnabled() and EG3 then
-                    _PP.CreateBorder(eb, EG3.r, EG3.g, EG3.b, 0.5, 1, "OVERLAY", 7)
-                else
-                    _PP.CreateBorder(eb, 1, 1, 1, RS2.BRD_ALPHA, 1, "OVERLAY", 7)
-                end
+                _PP.CreateBorder(eb, borderR, borderG, borderB, 0.5, 1, "OVERLAY", 7)
             end
         end
     end
@@ -946,10 +964,8 @@ end
                 GetFFD(popup).bg:SetAllPoints()
                 GetFFD(popup).bg:SetColorTexture(RS.BG_R, RS.BG_G, RS.BG_B, RS.QT_ALPHA)
                 GetFFD(GetFFD(popup).bg).owned = true
-                if _PP and _PP.CreateBorder then
-                    _PP.CreateBorder(bgFrame, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-                end
             end
+            _applyConfiguredBorder(GetFFD(popup).bgFrame, "popupMenu", 1)
 
             -- Skin buttons (Enter Dungeon / Leave Queue).
             -- Re-strip textures every show (Blizzard re-applies art on each popup).
@@ -989,15 +1005,8 @@ end
                             local RS2 = EllesmereUI.RESKIN
                             local btnBg = btn:CreateTexture(nil, "BACKGROUND", nil, -6)
                             btnBg:SetAllPoints()
-                            btnBg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
                             GetFFD(btnBg).owned = true
-                            if _PP and _PP.CreateBorder then
-                                if useAccent then
-                                    _PP.CreateBorder(btn, EG.r, EG.g, EG.b, 0.5, 1, "OVERLAY", 7)
-                                else
-                                    _PP.CreateBorder(btn, 1, 1, 1, RS2.BRD_ALPHA, 1, "OVERLAY", 7)
-                                end
-                            end
+                            GetFFD(btn).bg = btnBg
                             -- House hover: 10% white wash (owned, so the
                             -- every-show re-strip above leaves it alone).
                             local hov = btn:CreateTexture(nil, "HIGHLIGHT")
@@ -1006,11 +1015,13 @@ end
                             GetFFD(hov).owned = true
                         end
                         -- Accent-color the button text (every show)
-                        local EG = EllesmereUI.ELLESMERE_GREEN
-                        local useAccent = _accentEnabled() and EG
+                        local c = EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor or { r=.1,g=.1,b=.1,a=.8 }
+                        if GetFFD(btn).bg then GetFFD(btn).bg:SetColorTexture(c.r,c.g,c.b,c.a == nil and .8 or c.a) end
+                        _applyConfiguredBorder(btn, "popupMenuButton", 1)
                         local fs = btn:GetFontString()
-                        if fs and useAccent then
-                            fs:SetTextColor(EG.r, EG.g, EG.b, 1)
+                        if fs then
+                            local r, g, b = _getElementColor()
+                            fs:SetTextColor(r, g, b, 1)
                         end
                     end
                 end
@@ -1235,8 +1246,7 @@ do
 
         -- Reskin buttons (Okay, Cancel, Defaults, UseCharacterBindings)
         local btnNames = { "OkayButton", "CancelButton", "DefaultsButton" }
-        local EG = EllesmereUI.ELLESMERE_GREEN
-        local useAccent = (EllesmereUIDB and EllesmereUIDB.accentReskinElements) and EG
+        local er,eg,eb=EllesmereUI._getPopupMenuButtonTextColor(); local EG={r=er,g=eg,b=eb}; local useAccent=EG
         for _, name in ipairs(btnNames) do
             local btn = qkb[name]
             if btn and not GetFFD(btn).skinned then
@@ -1350,7 +1360,7 @@ do
 
         -- Skin buttons
         local function _accentOn()
-            return EllesmereUIDB and EllesmereUIDB.accentReskinElements
+            return true
         end
         for _, btnName in ipairs({ "AcceptButton", "DeclineButton", "AcknowledgeButton" }) do
             local btn = dialog[btnName]
@@ -1375,7 +1385,7 @@ do
                             end)
                         end
                     end
-                    local EG = EllesmereUI.ELLESMERE_GREEN
+                    local er,eg,eb=EllesmereUI._getPopupMenuButtonTextColor(); local EG={r=er,g=eg,b=eb}
                     local useAccent = _accentOn() and EG
                     local btnBg = btn:CreateTexture(nil, "BACKGROUND", nil, -6)
                     btnBg:SetAllPoints()
@@ -1390,7 +1400,7 @@ do
                     end
                 end
                 -- Accent text (every show)
-                local EG = EllesmereUI.ELLESMERE_GREEN
+                local er,eg,eb=EllesmereUI._getPopupMenuButtonTextColor(); local EG={r=er,g=eg,b=eb}
                 local useAccent = _accentOn() and EG
                 local fs = btn:GetFontString()
                 if fs and useAccent then
@@ -1460,7 +1470,7 @@ do
         end
 
         local function _accentOn()
-            return EllesmereUIDB and EllesmereUIDB.accentReskinElements
+            return true
         end
         for _, btnName in ipairs({ "SignUpButton", "CancelButton" }) do
             local btn = dialog[btnName]
@@ -1483,7 +1493,7 @@ do
                         end)
                     end
                 end
-                local EG = EllesmereUI.ELLESMERE_GREEN
+                local er,eg,eb=EllesmereUI._getPopupMenuButtonTextColor(); local EG={r=er,g=eg,b=eb}
                 local useAccent = _accentOn() and EG
                 local btnBg = btn:CreateTexture(nil, "BACKGROUND", nil, -6)
                 btnBg:SetAllPoints()
@@ -1530,8 +1540,6 @@ do
         if EllesmereUIDB and EllesmereUIDB.reskinGameMenu == false then return end
 
         local RS = EllesmereUI.RESKIN
-        local PP = EllesmereUI.PP
-        local ELLESMERE_GREEN = EllesmereUI.ELLESMERE_GREEN or { r = 0.27, g = 0.86, b = 0.49 }
 
         -- Strip decorative textures
         for i = 1, select("#", GameMenuFrame:GetRegions()) do
@@ -1549,7 +1557,8 @@ do
             end
             local headerText = header.Text or (header.GetRegions and select(1, header:GetRegions()))
             if headerText and headerText.SetTextColor then
-                headerText:SetTextColor(ELLESMERE_GREEN.r, ELLESMERE_GREEN.g, ELLESMERE_GREEN.b, 1)
+                local r, g, b = EllesmereUI._getPopupMenuButtonTextColor()
+                headerText:SetTextColor(r, g, b, 1)
                 local euiFont = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("blizzardSkin") or "Fonts\\FRIZQT__.TTF"
                 local _, hSize = headerText:GetFont()
                 headerText:SetFont(euiFont, hSize or 16, "")
@@ -1561,9 +1570,29 @@ do
         local gmBg = GameMenuFrame:CreateTexture(nil, "BACKGROUND")
         gmBg:SetAllPoints()
         gmBg:SetColorTexture(RS.BG_R, RS.BG_G, RS.BG_B, RS.QT_ALPHA)
-        if PP and PP.CreateBorder then
-            PP.CreateBorder(GameMenuFrame, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
+        local function ApplyButtonStyle(btn)
+            local d = GetFFD(btn)
+            if not d.gameMenuInset then return end
+            local c = EllesmereUIDB and EllesmereUIDB.popupMenuButtonBackgroundColor or { r=.1,g=.1,b=.1,a=.8 }
+            d.gameMenuButtonBg:SetColorTexture(c.r, c.g, c.b, c.a == nil and .8 or c.a)
+            EllesmereUI._applyBlizzardConfiguredBorder(d.gameMenuInset, "popupMenuButton", 1)
+            local fs = btn:GetFontString()
+            if fs then
+                local r, g, b = EllesmereUI._getPopupMenuButtonTextColor()
+                fs:SetTextColor(r, g, b, 1)
+            end
         end
+        local function ApplyMenuStyle()
+            EllesmereUI._applyBlizzardConfiguredBorder(GameMenuFrame, "popupMenu", 1)
+            if GameMenuFrame.buttonPool then
+                for btn in GameMenuFrame.buttonPool:EnumerateActive() do ApplyButtonStyle(btn) end
+            end
+            local d = GetFFD(GameMenuFrame)
+            if d.euiBtn then ApplyButtonStyle(d.euiBtn) end
+            if d.unlockBtn then ApplyButtonStyle(d.unlockBtn) end
+        end
+        ApplyMenuStyle()
+        GameMenuFrame:HookScript("OnShow", ApplyMenuStyle)
         -- Skin pooled buttons via InitButtons hook
         hooksecurefunc(GameMenuFrame, "InitButtons", function(menu)
             if not menu.buttonPool then return end
@@ -1595,10 +1624,8 @@ do
                     inset:SetFrameLevel(menuBtn:GetFrameLevel())
                     local btnBg = inset:CreateTexture(nil, "BACKGROUND", nil, -6)
                     btnBg:SetAllPoints()
-                    btnBg:SetColorTexture(0.1, 0.1, 0.1, 0.8)
-                    if PP and PP.CreateBorder then
-                        PP.CreateBorder(inset, 1, 1, 1, RS.BRD_ALPHA, 1, "OVERLAY", 7)
-                    end
+                    GetFFD(menuBtn).gameMenuInset = inset
+                    GetFFD(menuBtn).gameMenuButtonBg = btnBg
                     local hl = menuBtn:CreateTexture(nil, "HIGHLIGHT")
                     hl:SetAllPoints(inset)
                     hl:SetColorTexture(1, 1, 1, 0.1)
@@ -1609,6 +1636,7 @@ do
                         fs:SetFont(euiFont or "Fonts\\FRIZQT__.TTF", (size or 14) - 2, flags or "")
                     end
                 end
+                ApplyButtonStyle(menuBtn)
             end
         end)
     end)


### PR DESCRIPTION
### What does this PR do?

Expands the Blizzard UI popup and menu styling options.

- Adds configurable borders for Blizzard tooltips, popups, context menus and the Game Menu.
- Uses a shared style for popups and the Blizzard Game Menu.
- Adds configurable popup and menu button styling:
  - Border style
  - Border size
  - Border color: Accent, Class, or Custom
  - Border offset
  - Background color and opacity
- Adds a shared Element & Text Color option with Accent and Custom modes.
- Applies the button style to:
  - Static popup buttons
- Blizzard Game Menu buttons

Keeps the default border appearance as Solid, Thin, and subtle white.

### How was it tested?

- Verified all changed Lua files with git diff --check.
- Checked fallback handling for existing profiles and removed settings.
- Its tested on live servers on version 12.0.7
- Need to test on PTR 12.1

### Screenshots
<img width="1338" height="980" alt="image" src="https://github.com/user-attachments/assets/a3910d7a-1236-4055-84fb-a727e6bf9283" />

Examples:

Popups:
<img width="644" height="341" alt="image" src="https://github.com/user-attachments/assets/20bcd87d-7eb0-4420-a11e-459b345af53a" />
<img width="687" height="309" alt="image" src="https://github.com/user-attachments/assets/e4084944-7db9-44e6-93a0-6ccfd0701c96" />

<img width="594" height="262" alt="image" src="https://github.com/user-attachments/assets/834e0a1e-fb31-44ff-8d05-35d573030588" />

Game Menu:
<img width="357" height="692" alt="image" src="https://github.com/user-attachments/assets/4fc7f223-2ed8-4985-b730-061f5746d8ef" />

<img width="393" height="715" alt="image" src="https://github.com/user-attachments/assets/c6936ead-20bc-48ff-aeff-a3f24e9792de" />

Rightclich-menus:

<img width="317" height="536" alt="image" src="https://github.com/user-attachments/assets/9f79f193-9a32-4f74-99b3-287469d6b5c7" />



### Checklist

- [x] New settings preserve the existing default appearance
- [x] Zero cost while disabled: no polling or per-frame update logic added
- [x] Cheap while enabled: styling is applied through existing show/init hooks
- [x] No polling, timers, or per-frame allocations added
- [x] Blizzard-owned frames use HookScript/hooksecurefunc; no new SetScript replacements
- [x] Tested in-game, works on live retail
- [x] Tested on the 12.1 PTR client