### PR TITLE
fix(cdm): stop saved icon order snapping back to Blizzard order on reload

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -6331,10 +6331,6 @@ initFrame:SetScript("OnEvent", function(self)
                           and ns.cdmBarIcons and ns.cdmBarIcons[barKeyE]
         if liveIcons then
             if not sd.assignedSpells then sd.assignedSpells = {} end
-            local seen = {}
-            for _, existing in ipairs(sd.assignedSpells) do
-                seen[existing] = true
-            end
             local removed = sd.removedSpells
             -- Never materialize a spell that's currently HIDDEN (in the ghost bar)
             -- onto a visible bar -- that recreates a both-state and the spell would
@@ -6378,7 +6374,14 @@ initFrame:SetScript("OnEvent", function(self)
             -- position instead of being appended at the very end (which piled
             -- talent-swap spells after the trinket/racial slots and never survived
             -- a /reload cleanly).
-            local insertAfterSid = nil
+            -- Variant-aware presence + POSITION cursor (mirrors the reseed pass in
+            -- EllesmereUICooldownManager.lua): the old exact-match seen set missed a
+            -- stored entry when the live icon resolved to a different variant form,
+            -- re-inserting a duplicate at Blizzard's position -- and the normalize
+            -- pass above then deduped keeping that copy, deleting the user's saved
+            -- slot (the Raptor Strike / Kill Command order swap, 8.4.9). The
+            -- by-value cursor lookup failed identically and dumped inserts at 1.
+            local insertPos = nil
             for _, icon in ipairs(liveIcons) do
                 -- Resolve the live icon's DISPLAYED spell the same way the picker
                 -- does (canonical = GetSpellID-first, with the active-frame cache),
@@ -6407,30 +6410,23 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 if _sid and _sid ~= 0 then
                     if _sid > 0 then _sid = NormalizeToBase(_sid) end
-                    if seen[_sid] then
-                        -- Already has a slot (Blizzard spell OR a custom trinket/item
-                        -- marker): advance the cursor so the next NEW spell lands after
-                        -- it, matching the on-screen order across custom entries too.
-                        insertAfterSid = _sid
+                    -- FindVar handles negatives by exact scan internally; variant
+                    -- matching is a superset of exact for positives.
+                    local at = FindVar and FindVar(sd.assignedSpells, _sid)
+                    if at then
+                        -- Already has a slot (any variant form, or a custom trinket/
+                        -- item marker): advance the cursor so the next NEW spell
+                        -- lands after it, matching the on-screen order.
+                        insertPos = at
                     elseif _sid > 0
                        and not (removed and removed[_sid])
                        and not (ghostList and FindVar and FindVar(ghostList, _sid))
                        and not (claimedElsewhere and ns.ResolveVariantValue and ns.ResolveVariantValue(claimedElsewhere, _sid)) then
-                        local pos
-                        if insertAfterSid then
-                            for i = 1, #sd.assignedSpells do
-                                if sd.assignedSpells[i] == insertAfterSid then pos = i; break end
-                            end
-                        end
-                        if pos then
-                            table.insert(sd.assignedSpells, pos + 1, _sid)
-                        else
-                            -- No anchored predecessor yet: this new spell is the
-                            -- left-most live icon, so it belongs at the front.
-                            table.insert(sd.assignedSpells, 1, _sid)
-                        end
-                        seen[_sid] = true
-                        insertAfterSid = _sid
+                        -- No anchored predecessor yet: this new spell is the
+                        -- left-most live icon, so it belongs at the front.
+                        local pos = insertPos and (insertPos + 1) or 1
+                        table.insert(sd.assignedSpells, pos, _sid)
+                        insertPos = pos
                     end
                 end
             end

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -6398,6 +6398,22 @@ initFrame:SetScript("OnEvent", function(self)
                 -- for the same spell (the buff frame's id resolves positive).
                 local _fdLI = ns._hookFrameData and ns._hookFrameData[icon]
                 if icon._isPlaceholderFrame or (_fdLI and _fdLI._isBuffViewerFrame) then
+                    -- Advance the cursor over the hosted buff's MARKER entry so
+                    -- a spell inserted after it on a mixed bar lands after the
+                    -- buff, not squeezed back beside the previous CD spell
+                    -- (mirrors the reseed pass).
+                    if type(_sid) == "number" and _sid > 0
+                       and ns.HostedBuffMarkerToSpell
+                       and not (ns.CdmFrameOverflowBar and ns.CdmFrameOverflowBar(icon)) then
+                        for i = 1, #sd.assignedSpells do
+                            local dec = ns.HostedBuffMarkerToSpell(sd.assignedSpells[i])
+                            if dec and (dec == _sid
+                                or (ns.IsVariantOf and ns.IsVariantOf(dec, _sid))) then
+                                if not insertPos or i > insertPos then insertPos = i end
+                                break
+                            end
+                        end
+                    end
                     _sid = nil
                 end
                 -- Skip overflow-diverted icons outright: they render on this

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7328,16 +7328,24 @@ function ns.ReseedAssignedSpellsFromLiveIcons(cdUtilOnly)
             local icons = ns.cdmBarIcons and ns.cdmBarIcons[barData.key]
             if sd and icons then
                 if not sd.assignedSpells then sd.assignedSpells = {} end
-                local seen = {}
-                for _, existing in ipairs(sd.assignedSpells) do
-                    seen[existing] = true
-                end
                 -- Insert each missing spell right after its left neighbour in the
                 -- live icon order (which CollectAndReanchor has already placed in
                 -- Blizzard-layout order), instead of appending at the end. This keeps
                 -- the seeded list matching what the player sees so re-talenting a
                 -- cooldown restores it to its Blizzard-CDM slot rather than the tail.
-                local insertAfterSid = nil
+                --
+                -- Presence is VARIANT-AWARE and the cursor is a POSITION, not an id.
+                -- The old exact-match seen set missed a stored entry when the live
+                -- icon reported a different variant form (fc.spellID can be the
+                -- talent override, e.g. Mongoose Bite 259387, while the stored slot
+                -- holds the base Raptor Strike 186270 the options normalize pass
+                -- wrote). Every reload then re-inserted the live form at Blizzard's
+                -- position, the order map ranked the frame by that copy, and the
+                -- next options normalize deduped in favor of it -- permanently
+                -- snapping the user's saved order back to Blizzard order (the
+                -- Raptor Strike / Kill Command swap, 8.4.9). The by-value cursor
+                -- lookup failed the same way and dumped inserts at slot 1.
+                local insertPos = nil
                 for _, icon in ipairs(icons) do
                     local fc = ns._ecmeFC and ns._ecmeFC[icon]
                     local sid = fc and fc.spellID
@@ -7356,11 +7364,15 @@ function ns.ReseedAssignedSpellsFromLiveIcons(cdUtilOnly)
                         sid = nil
                     end
                     if type(sid) == "number" and sid ~= 0 then
-                        if seen[sid] then
-                            -- Already has a slot (Blizzard spell OR a custom trinket/
-                            -- item marker): advance the cursor so the next NEW spell
-                            -- lands after it, matching the on-screen order.
-                            insertAfterSid = sid
+                        -- FindVar handles negatives by exact scan internally, and
+                        -- variant matching is a strict superset of exact equality
+                        -- for stored positives -- no exact fallback needed.
+                        local at = FindVar and FindVar(sd.assignedSpells, sid)
+                        if at then
+                            -- Already has a slot (any variant form, or a custom
+                            -- trinket/item marker): advance the cursor so the next
+                            -- NEW spell lands after it, matching on-screen order.
+                            insertPos = at
                         elseif sid > 0 then
                             -- Never materialize a hidden (ghosted) spell, or a spell a
                             -- DIFFERENT bar already owns (variant-aware).
@@ -7368,19 +7380,18 @@ function ns.ReseedAssignedSpellsFromLiveIcons(cdUtilOnly)
                                           and ns.ResolveVariantValue(ownerOf, sid)
                             local ghosted = ghostList and FindVar and FindVar(ghostList, sid)
                             if not ghosted and not (owner and owner ~= barData.key) then
-                                local pos
-                                if insertAfterSid then
-                                    for i = 1, #sd.assignedSpells do
-                                        if sd.assignedSpells[i] == insertAfterSid then pos = i; break end
-                                    end
+                                -- Store the BASE form, matching what the options
+                                -- normalize pass writes -- otherwise this pass
+                                -- persists the talent-override form and the two
+                                -- writers diverge (exports could ship either).
+                                local nsid = sid
+                                if C_Spell and C_Spell.GetBaseSpell then
+                                    local b = C_Spell.GetBaseSpell(sid)
+                                    if b and b > 0 then nsid = b end
                                 end
-                                if pos then
-                                    table.insert(sd.assignedSpells, pos + 1, sid)
-                                else
-                                    table.insert(sd.assignedSpells, 1, sid)
-                                end
-                                seen[sid] = true
-                                insertAfterSid = sid
+                                local pos = insertPos and (insertPos + 1) or 1
+                                table.insert(sd.assignedSpells, pos, nsid)
+                                insertPos = pos
                             end
                         end
                     end
@@ -8903,6 +8914,49 @@ SlashCmdList.EUIORDER = function()
             end
             P("   rendered(" .. (icons and #icons or 0) .. "): "
                 .. (next(rparts) and table.concat(rparts, "  ") or (DIM .. "(none)" .. OFF)))
+            -- Per-icon identity probes: every id the OrderKeyFor chain can match
+            -- against the spellOrder map, so a wrong sortOrder can be traced to
+            -- the exact colliding/missing probe.
+            if icons then
+                local fso = C_SpellBook and C_SpellBook.FindSpellOverrideByID
+                for i = 1, #icons do
+                    local frame = icons[i]
+                    local fc = ns._ecmeFC and ns._ecmeFC[frame]
+                    local sid = fc and fc.spellID
+                    local ovr = (fso and type(sid) == "number" and sid > 0) and fso(sid) or nil
+                    local gbase = (C_Spell and C_Spell.GetBaseSpell and type(sid) == "number" and sid > 0)
+                        and C_Spell.GetBaseSpell(sid) or nil
+                    local canon = ns.GetCanonicalSpellIDForFrame and ns.GetCanonicalSpellIDForFrame(frame) or nil
+                    local linked = ""
+                    if fc and fc.linkedSpellIDs then
+                        local lp = {}
+                        for _, lid in ipairs(fc.linkedSpellIDs) do lp[#lp + 1] = tostring(lid) end
+                        linked = table.concat(lp, "/")
+                    end
+                    P(string.format("   probe %d) sid=%s base=%s fOvr=%s gBase=%s canon=%s rsv=%s linked=[%s] cdID=%s LI=%s so=%s",
+                        i, tostring(sid), tostring(fc and fc.baseSpellID), tostring(ovr),
+                        tostring(gbase), tostring(canon), tostring(fc and fc.resolvedSid), linked,
+                        tostring(frame.cooldownID), tostring(frame.layoutIndex),
+                        tostring(fc and fc.sortOrder)))
+                end
+            end
+            -- The bar's cached spellOrder map (id -> assignedSpells idx). Two ids
+            -- landing on the same idx, or a rendered sid absent here, IS the bug.
+            local container = cdmBarFrames[bd.key]
+            local om = container and container._cachedSpellOrder
+            if om and next(om) then
+                local entries = {}
+                for id, idx in pairs(om) do entries[#entries + 1] = { id = id, idx = idx } end
+                table.sort(entries, function(a, b)
+                    if a.idx ~= b.idx then return a.idx < b.idx end
+                    return a.id < b.id
+                end)
+                local mp = {}
+                for _, e in ipairs(entries) do mp[#mp + 1] = e.idx .. "<-" .. NM(e.id) end
+                P("   orderMap: " .. DIM .. table.concat(mp, "  ") .. OFF)
+            else
+                P("   orderMap: " .. DIM .. "(empty/stale)" .. OFF)
+            end
         end
     end
 end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7352,9 +7352,28 @@ function ns.ReseedAssignedSpellsFromLiveIcons(cdUtilOnly)
                     -- Skip hosted-buff frames and their placeholders: their bar
                     -- membership is the hosted MARKER entry, and their positive
                     -- spellID would materialize the same spell's COOLDOWN form.
+                    -- But DO advance the cursor over their marker: on a mixed
+                    -- bar (spells + hosted buffs) a spell re-inserted after a
+                    -- buff must land after the buff's marker, not squeezed back
+                    -- next to the previous CD spell (reported: Shift snapping
+                    -- to right after Voidray, jumping its three buffs).
                     local fdRS = ns._hookFrameData and ns._hookFrameData[icon]
                     if (fc and fc.isHostedBuff) or icon._isPlaceholderFrame
                        or (fdRS and fdRS._isBuffViewerFrame) then
+                        local hSid = fc and fc.spellID
+                        if type(hSid) == "number" and hSid > 0
+                           and ns.HostedBuffMarkerToSpell
+                           and not (fc and fc._overflowLayoutBar) then
+                            for i = 1, #sd.assignedSpells do
+                                local dec = ns.HostedBuffMarkerToSpell(sd.assignedSpells[i])
+                                if dec and (dec == hSid
+                                    or (ns.IsVariantOf and ns.IsVariantOf(dec, hSid))) then
+                                    -- Forward-only: never drag the cursor backward.
+                                    if not insertPos or i > insertPos then insertPos = i end
+                                    break
+                                end
+                            end
+                        end
                         sid = nil
                     end
                     -- Skip overflow-diverted icons: they render on this bar


### PR DESCRIPTION
## Problem

Reported by @woaw (8.4.9, Survival Hunter): Raptor Strike and Kill Command swap places in the CDM after every `/reload`, regardless of how often they're reordered in EUI.

## Root cause (confirmed with a live event dump)

Blizzard's spell data links **SV Kill Command (259489) to Steady Shot (56641) as its base spell** -- a different ability. The options normalize pass therefore stores Kill Command's slot as `56641` (a live `/euiorder` dump literally shows "56641:Steady Shot" on a Survival cooldowns bar).

The login reseed pass compared live icons against stored ids with an **exact-match** seen set. Live `259489` never matched stored `56641`, so every reload re-inserted Kill Command at its **Blizzard layout position** -- in front of Raptor Strike for layouts where Blizzard places it leftmost. The next options-panel open then deduped in favor of that copy, permanently deleting the user's saved slot. Re-dragging could never stick. A second latent bug rode along: the insert cursor was looked up **by value**, which fails the same way on a variant mismatch and dumps inserts at slot 1.

## Fix

In both materializer passes (the automatic login reseed in `ReseedAssignedSpellsFromLiveIcons` and the options append in `EnsureAssignedSpells`):

- **Presence is variant-aware** via `ns.FindVariantIndexInList`, so any stored variant form (base or override) counts as already-slotted. FindVariantIndexInList handles negative trinket/item markers by exact scan internally, so no separate fallback is needed.
- **The insertion cursor is a position index**, immune to id-form mismatches.
- **The reseed now stores the base form**, matching the options normalize pass, so the two writers can no longer persist divergent forms of the same spell (previously exports shipped whichever form the last-run pass wrote).

All guards (ghost, other-bar owner, hosted-buff/overflow/placeholder skips, claimed-elsewhere) are unchanged, and behavior for non-variant spells is identical.

Also extends the permanent `/euiorder` diagnostic with per-icon identity probes (sid/base/override/canonical/linked/layoutIndex/sortOrder) and a dump of the bar's cached order map -- this instrumentation is what pinned the root cause from a single paste.

## Review

High-effort multi-angle review before submitting: a removed-behavior audit traced every invariant of the old code as re-established (including out-of-order live-icon sequences and negative-marker handling), and dead fallback loops flagged by the review were removed. Known pre-existing latents deliberately left out of scope (candidates for follow-ups): the `NormalizeToBase` writer itself has no round-trip guard for cross-spell base links, and a few manual-add/preset-overlap guards elsewhere still use exact id matching.

## Testing

Verified in-game on a Survival Hunter: with the fix loaded, stored order and rendered order agree (`/euiorder` shows the bridged order map ranking Kill Command at its stored Steady-Shot slot), reordering Raptor Strike / Kill Command persists across `/reload` in both directions, and non-variant spells reorder exactly as before. Users bitten by the old bug need one final re-drag (their saved order was already destroyed); it sticks from then on.
