### PR TITLE
Fix the fallback anchor to class resource when using Shift if no resource option

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -2306,6 +2306,14 @@ do
         local gsx, gsy = EllesmereUI._FallbackGrowShift(childKey, side, cW, cH)
         cx = cx + gsx
         cy = cy + gsy
+        -- Temporary per-target visual shift (e.g. "Shift Elements if No
+        -- Resource/Power"), mirrors the main path's block at ~3278-3283.
+        -- fb.target is the live target actually being used here (not
+        -- targetKey, which is the inactive primary target).
+        if not isUnlocked and EllesmereUI._GetAnchorTargetShiftDir then
+            local dir, extraY = EllesmereUI._GetAnchorTargetShiftDir(fb.target, childKey)
+            if dir ~= 0 then cy = cy + dir * ((tT - tB) + (extraY or 0)) end
+        end
         -- Child-local scale space + pixel snap + idempotent guard, mirroring
         -- the standard CENTER path in ApplyAnchorPosition.
         local acRatio = uiS / cS
@@ -3511,7 +3519,15 @@ PropagateAnchorChain = function(parentKey, visited, changedAxis)
         PropagateAnchorChain(aliasKey, visited, changedAxis)
     end
     for childKey, info in pairs(anchorDB) do
-        if info.target == parentKey then
+        local primaryMatch = (info.target == parentKey)
+        -- A child reached only via its fallback link (e.g. a buff bar/icon
+        -- whose primary target is a TBB bar, fallback-anchored to Class
+        -- Resource/Power) must also re-cascade when ITS fallback target
+        -- moves/shifts -- otherwise it goes stale until the next full
+        -- ReapplyAllUnlockAnchors pass (login/settle/etc).
+        local fallbackMatch = (not primaryMatch) and info.fallback
+            and info.fallback.target == parentKey
+        if primaryMatch or fallbackMatch then
             -- Axis isolation: skip children on the unaffected axis. A resize
             -- leaves a perpendicular-anchored child unaffected ONLY when the
             -- target's center is invariant on the changed axis. That holds for
@@ -3525,8 +3541,12 @@ PropagateAnchorChain = function(parentKey, visited, changedAxis)
             -- content-sized bar (corner-follow needs the same-tick cascade); and
             -- a plain AB grow child of a still-dominated CDM/chain-driven parent.
             -- Every other child keeps the original gate.
+            -- fallbackMatch skips this entirely: info.side describes the
+            -- PRIMARY anchor's geometry, meaningless for the fallback
+            -- relationship's own side/offset math, and this child is only
+            -- reached here because ITS fallback target moved.
             local dominated = false
-            if changedAxis == "width" then
+            if primaryMatch and changedAxis == "width" then
                 dominated = (info.side == "TOP" or info.side == "BOTTOM")
                 if dominated then
                     if parentKey:sub(1, 4) == "CDM_"
@@ -3544,7 +3564,7 @@ PropagateAnchorChain = function(parentKey, visited, changedAxis)
                         dominated = false
                     end
                 end
-            elseif changedAxis == "height" then
+            elseif primaryMatch and changedAxis == "height" then
                 dominated = (info.side == "LEFT" or info.side == "RIGHT")
                 if dominated then
                     if parentKey:sub(1, 4) == "CDM_"


### PR DESCRIPTION

## What does this PR do?

Fixes an anchor bug: buff bars/icons (Cooldown Manager) positioned through their **fallback anchor** to the Class Resource bar or the Power Bar did not respect the **"Shift Elements if No Resource/No Power"** option.

Specifically, when an element (buff icon or bar) is primarily anchored to another tracked buff bar (TBB) with a fallback to Class Resource/Power, and that fallback is active (the primary TBB is absent), the element was placed at its target's **un-shifted** position, even when the rest of the stack (Cooldowns, Cast Bar, etc.) was correctly shifted — leaving it visibly detached from the rest of the bars.

Two fixes in `EUI_UnlockMode.lua`:
- `_TryFallbackAnchor` now applies the same shift as the normal anchor path (`_GetAnchorTargetShiftDir`), based on the actual fallback target.
- `PropagateAnchorChain` now also revisits children that are linked only through their fallback anchor (not just their primary anchor), so repositioning happens immediately when the resource/power state changes live (spec swap, toggle), without needing a `/reload`.

## How was it tested?

- Paladin (has a class resource): buff icon anchored to a buff bar with a fallback to Class Resource, "Shift if No Resource" = Down. Toggle the class resource off/on live (no reload) and confirm the icon follows immediately.
- Mistweaver Monk (no class resource): confirm the icon lands on top of the Power Bar.
- Regression: a direct (non-fallback) anchor to Class Resource/Power still behaves as before.

## Screenshots

### Anchors
<img width="351" height="175" alt="image" src="https://github.com/user-attachments/assets/1fe2de4e-1e6a-4f0b-8d2e-ce9362aaf6dd" />

### Before fix
<img width="318" height="141" alt="image" src="https://github.com/user-attachments/assets/47b96e8d-cfeb-496c-9744-11f747630ca9" />

### Afterfix
<img width="352" height="163" alt="image" src="https://github.com/user-attachments/assets/8182daea-8ae5-4bab-9905-6118f21c5937" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) — N/A, this is not a new setting but a bug fix to existing behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built — only adds a branch inside an already-conditional path (fallback active) and one extra check inside an existing cascade loop; no new events/hooks/frames
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) — reuses the existing shift-dir provider and cascade mechanism; no `OnUpdate`/timer added
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames — N/A, only touches EllesmereUI's own internal anchor engine
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client — **not yet tested in-game**, pending validation
