### PR TITLE
Fix/databar currency empty state

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -101,6 +101,7 @@ local L = {
     DELVE_JOURNEY        = "Delver's Journey",
     COMPANION_LEVEL      = "Companion Level",
     SELECT_CURRENCY      = "Select a currency",
+    OPEN_SETTINGS        = "Open Settings",
     WHISPER              = "Whisper",
     WHISPER_BNET         = "Whisper BNet",
     INVITE               = "Invite",

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -43,6 +43,15 @@
 --   ns.UpdateAllBarVisibility()
 --   ns.MakePreviewBackdrop(host, themeCfg)
 --   ns.BLOCK_TYPES / ns.BLOCK_DEFAULTS / ns.EDB_VIS_CAPS / ns.EDGE_PAD
+--
+--  The one call that runs the other way -- options file -> runtime, so a block
+--  whose empty state invites a click can send the player to the control that
+--  fills it in. Defined from the options file's PLAYER_LOGIN handler, hence
+--  the nil guard at its call site:
+--
+--   ns.OpenBlockSettings(barId, blockId, settingKey)
+--       deep-links to the "block:<blockId>:<settingKey>" click target the
+--       options page registers for that row (see _edbClickTargets).
 
 local ADDON_NAME, ns = ...
 

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -3827,7 +3827,17 @@ ns.BlockFactories.currency = function(blockCfg, slot, content, barCtx)
     -- Manual tooltip composition (the owned tooltip has no SetCurrencyByID).
     local function ShowCurrencyTooltip()
         local s = D()
-        if not s.currencyId then return end
+        local ar, ag, ab = ns.GetAccent()
+        -- Unconfigured: the placeholder is the whole block, so the tooltip
+        -- has to say where the currency is actually picked.
+        if not s.currencyId then
+            ns.Tip_Begin(button)
+            ns.Tip_AddLine(L["SELECT_CURRENCY"], 1, 1, 1)
+            ns.Tip_AddLine(" ")
+            ns.Tip_AddDouble(L["LEFT_CLICK"], L["OPEN_SETTINGS"], 1, 1, 1, ar, ag, ab)
+            ns.Tip_Show()
+            return
+        end
         local info = nil
         if C_CurrencyInfo and C_CurrencyInfo.GetCurrencyInfo then
             info = C_CurrencyInfo.GetCurrencyInfo(s.currencyId)
@@ -3854,6 +3864,8 @@ ns.BlockFactories.currency = function(blockCfg, slot, content, barCtx)
         else
             ns.Tip_AddDouble(L["TOTAL"], qty, 0.6, 0.6, 0.6, 1, 1, 1)
         end
+        ns.Tip_AddLine(" ")
+        ns.Tip_AddDouble(L["LEFT_CLICK"], L["OPEN_CURRENCIES"], 1, 1, 1, ar, ag, ab)
         ns.Tip_Show()
     end
 
@@ -3869,6 +3881,14 @@ ns.BlockFactories.currency = function(blockCfg, slot, content, barCtx)
     end)
     button:SetScript("OnClick", function(_, mb)
         if mb == "LeftButton" then
+            -- No currency picked yet: the Blizzard panel cannot assign one,
+            -- so send the player to the picker instead of dead-ending there.
+            if not D().currencyId then
+                if ns.OpenBlockSettings then
+                    ns.OpenBlockSettings(barCtx.id, blockCfg.id, "currency")
+                end
+                return
+            end
             if C_CurrencyInfo and C_CurrencyInfo.OpenCurrencyPanel then
                 C_CurrencyInfo.OpenCurrencyPanel()
             elseif ToggleCharacter then

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -2354,7 +2354,14 @@ initFrame:SetScript("OnEvent", function(self)
             for k = 1, #typeRows, 2 do
                 local rightCfg = typeRows[k + 1]
                 if not rightCfg then rightCfg = { type = "label", text = "" } end
-                _, h = W:DualRow(parent, y, typeRows[k], rightCfg);  y = y - h
+                row, h = W:DualRow(parent, y, typeRows[k], rightCfg);  y = y - h
+                -- Deep-link target for an unconfigured currency block: clicking
+                -- its "Select a currency" placeholder on the live bar lands on
+                -- the picker itself, not just the section (ns.OpenBlockSettings).
+                if b.type == "currency" and k == 1 then
+                    parent._edbClickTargets["block:" .. blockId .. ":currency"] =
+                        { section = secHdr, target = row, slotSide = "left" }
+                end
             end
 
             if b.type == "micromenu" then
@@ -2469,6 +2476,29 @@ initFrame:SetScript("OnEvent", function(self)
         W:Spacer(parent, y, 20);  y = y - 20
 
         return math.abs(y)
+    end
+
+    ---------------------------------------------------------------------------
+    --  Deep link from a live block to its own settings row. A block whose
+    --  empty state invites a click (the currency picker's placeholder) calls
+    --  this so the invitation leads to the control that fulfills it; the
+    --  preview strip navigates through _edbNavigateFn directly.
+    ---------------------------------------------------------------------------
+    function ns.OpenBlockSettings(barId, blockId, settingKey)
+        if not EllesmereUI.NavigateToElementSettings then return end
+        local key = "block:" .. blockId
+        if settingKey then key = key .. ":" .. settingKey end
+        EllesmereUI:NavigateToElementSettings("EllesmereUIDataBars", PAGE_DATABARS, nil,
+            function()
+                local p = Profile()
+                if p then p.selectedBarId = barId end
+            end)
+        -- The click-target map belongs to the page build the call above kicks
+        -- off; resolve the scroll target once it has repopulated (same settle
+        -- delay NavigateToElementSettings uses for its own section lookup).
+        C_Timer.After(0.05, function()
+            if _edbNavigateFn then _edbNavigateFn(key) end
+        end)
     end
 
     ---------------------------------------------------------------------------

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -1478,12 +1478,10 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         local function GlowTargetOf(m)
-            if m.slotSide then
-                local region
-                if m.slotSide == "left" then region = m.target._leftRegion else region = m.target._rightRegion end
-                if region then return region end
-            end
-            return m.target
+            if not m.slotSide then return m.target end
+            local region
+            if m.slotSide == "left" then region = m.target._leftRegion else region = m.target._rightRegion end
+            return region or m.target
         end
 
         local function NavigateToSetting(key)
@@ -1500,10 +1498,16 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         -- A held glow belongs to the SETTING, not to the navigation that first
-        -- showed it. Every page rebuild -- reordering a block, switching bars,
-        -- reopening the panel -- destroys the row it was parented to, which
+        -- showed it. A page rebuild -- reordering a block, switching bars,
+        -- adding or removing one -- destroys the row it was parented to, which
         -- released the pulse for good even though the setting was still empty.
         -- Re-attach it to the freshly built row.
+        --
+        -- Scope: rebuilds only. Reopening the panel takes SelectPage's warm
+        -- path (EllesmereUI.lua), which re-shows the cached wrapper without
+        -- running the page builder, so nothing calls this -- the pulse stays
+        -- dead until the next rebuild. Covering that means driving this from
+        -- onPageCacheRestore too, the way _edbStripRelayout is.
         local function RearmHeldGlow()
             if not _edbHeldGlowKey then return end
             local targets = parent._edbClickTargets

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -1448,18 +1448,16 @@ initFrame:SetScript("OnEvent", function(self)
             _navGlowFrame:SetAlpha(1)
             _navGlowFrame:Show()
             local elapsed = 0
-            local holding = holdWhile ~= nil
             _navGlowFrame:SetScript("OnUpdate", function(glowSelf, dt)
                 elapsed = elapsed + dt
-                if holding then
+                if holdWhile then
                     if targetFrame:IsVisible() and holdWhile() then
                         glowSelf:SetAlpha(0.35 + 0.65 * math.abs(math.sin(elapsed * 3)))
                         return
                     end
-                    -- Released: restart the clock so the normal fade plays out
-                    -- from full alpha instead of expiring on its first frame.
-                    holding = false
-                    elapsed = 0
+                    -- Released: drop the predicate and restart the clock so the
+                    -- fade plays from full alpha instead of expiring at once.
+                    holdWhile, elapsed = nil, 0
                 end
                 if elapsed >= 0.75 then
                     glowSelf:Hide()
@@ -2375,6 +2373,8 @@ initFrame:SetScript("OnEvent", function(self)
                 -- Deep-link target for an unconfigured currency block: clicking
                 -- its "Select a currency" placeholder on the live bar lands on
                 -- the picker itself, not just the section (ns.OpenBlockSettings).
+                -- k == 1 IS the Currency dropdown: it heads the currency
+                -- typeRows built above. Prepend a row there and retarget here.
                 if b.type == "currency" and k == 1 then
                     parent._edbClickTargets["block:" .. blockId .. ":currency"] =
                         { section = secHdr, target = row, slotSide = "left",
@@ -2504,9 +2504,7 @@ initFrame:SetScript("OnEvent", function(self)
     --  preview strip navigates through _edbNavigateFn directly.
     ---------------------------------------------------------------------------
     function ns.OpenBlockSettings(barId, blockId, settingKey)
-        if not EllesmereUI.NavigateToElementSettings then return end
-        local key = "block:" .. blockId
-        if settingKey then key = key .. ":" .. settingKey end
+        local key = "block:" .. blockId .. ":" .. settingKey
         EllesmereUI:NavigateToElementSettings("EllesmereUIDataBars", PAGE_DATABARS, nil,
             function()
                 local p = Profile()

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -45,6 +45,9 @@ initFrame:SetScript("OnEvent", function(self)
     local _edbPreviewHost        -- the preview strip frame (live theme feedback)
     local _edbHeldGlowKey        -- click-target key whose glow pulses until the
                                  -- setting is filled in; outlives page builds
+    local _edbHeldGlowY          -- its section offset when last shown: sections
+                                 -- follow bar order, so a change means the row
+                                 -- moved and the view has to follow it
     local _cardsExpanded = false -- template card strip open/closed
     local _dividerDragging = false
 
@@ -1492,7 +1495,7 @@ initFrame:SetScript("OnEvent", function(self)
             if not headerY then return end
             EllesmereUI.SmoothScrollTo(math.max(0, math.abs(headerY) - 40))
             local glowTarget = GlowTargetOf(m)
-            if m.holdWhile then _edbHeldGlowKey = key end
+            if m.holdWhile then _edbHeldGlowKey, _edbHeldGlowY = key, headerY end
             C_Timer.After(0.15, function() PlaySettingGlow(glowTarget, m.holdWhile) end)
         end
 
@@ -1500,17 +1503,25 @@ initFrame:SetScript("OnEvent", function(self)
         -- showed it. Every page rebuild -- reordering a block, switching bars,
         -- reopening the panel -- destroys the row it was parented to, which
         -- released the pulse for good even though the setting was still empty.
-        -- Re-attach it to the freshly built row, without scrolling: the player
-        -- did not ask to go anywhere, they just moved something.
+        -- Re-attach it to the freshly built row.
         local function RearmHeldGlow()
             if not _edbHeldGlowKey then return end
             local targets = parent._edbClickTargets
             local m = targets and targets[_edbHeldGlowKey]
             -- Absent from this build (another bar is selected): keep the key so
             -- coming back re-arms. Only a satisfied predicate retires it.
-            if not (m and m.target and m.holdWhile) then return end
+            if not (m and m.section and m.target and m.holdWhile) then return end
             if not m.holdWhile() then
                 _edbHeldGlowKey = nil
+                return
+            end
+            -- Sections are laid out in bar order, so reordering blocks moves
+            -- this row: re-glowing in place would pulse off-screen. Follow it
+            -- only when it actually moved -- yanking the view on an unrelated
+            -- rebuild (a Fill toggle, a theme change) would be worse.
+            local _, _, _, _, headerY = m.section:GetPoint(1)
+            if headerY ~= _edbHeldGlowY then
+                NavigateToSetting(_edbHeldGlowKey)
                 return
             end
             PlaySettingGlow(GlowTargetOf(m), m.holdWhile)

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -1418,7 +1418,13 @@ initFrame:SetScript("OnEvent", function(self)
         --  cached/restored header never fires a stale closure.
         -------------------------------------------------------------------
         local _navGlowFrame
-        local function PlaySettingGlow(targetFrame)
+        -- holdWhile (optional): keeps the glow pulsing for as long as it
+        -- returns true, instead of the one-shot fade. Used when the glow is
+        -- pointing at a setting the player still has to fill in -- a 0.75s
+        -- flash is gone before they have finished reading the page. The pulse
+        -- also releases when the target stops being visible (page rebuilt,
+        -- options closed), so the shared frame can never strand its OnUpdate.
+        local function PlaySettingGlow(targetFrame, holdWhile)
             if not targetFrame then return end
             if not _navGlowFrame then
                 _navGlowFrame = CreateFrame("Frame")
@@ -1442,8 +1448,19 @@ initFrame:SetScript("OnEvent", function(self)
             _navGlowFrame:SetAlpha(1)
             _navGlowFrame:Show()
             local elapsed = 0
+            local holding = holdWhile ~= nil
             _navGlowFrame:SetScript("OnUpdate", function(glowSelf, dt)
                 elapsed = elapsed + dt
+                if holding then
+                    if targetFrame:IsVisible() and holdWhile() then
+                        glowSelf:SetAlpha(0.35 + 0.65 * math.abs(math.sin(elapsed * 3)))
+                        return
+                    end
+                    -- Released: restart the clock so the normal fade plays out
+                    -- from full alpha instead of expiring on its first frame.
+                    holding = false
+                    elapsed = 0
+                end
                 if elapsed >= 0.75 then
                     glowSelf:Hide()
                     glowSelf:SetScript("OnUpdate", nil)
@@ -1467,7 +1484,7 @@ initFrame:SetScript("OnEvent", function(self)
                 if m.slotSide == "left" then region = m.target._leftRegion else region = m.target._rightRegion end
                 if region then glowTarget = region end
             end
-            C_Timer.After(0.15, function() PlaySettingGlow(glowTarget) end)
+            C_Timer.After(0.15, function() PlaySettingGlow(glowTarget, m.holdWhile) end)
         end
         -- Never retarget the live header's click handler from a hidden
         -- global-search pre-build: its targets belong to an off-screen
@@ -2360,7 +2377,9 @@ initFrame:SetScript("OnEvent", function(self)
                 -- the picker itself, not just the section (ns.OpenBlockSettings).
                 if b.type == "currency" and k == 1 then
                     parent._edbClickTargets["block:" .. blockId .. ":currency"] =
-                        { section = secHdr, target = row, slotSide = "left" }
+                        { section = secHdr, target = row, slotSide = "left",
+                          -- Pulse until the player actually picks one.
+                          holdWhile = function() return s.currencyId == nil end }
                 end
             end
 

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -43,6 +43,8 @@ initFrame:SetScript("OnEvent", function(self)
                                  -- bar highlight (the watcher must not clear it)
     local _edbStripRelayout      -- set per header build: re-solves + repositions the preview
     local _edbPreviewHost        -- the preview strip frame (live theme feedback)
+    local _edbHeldGlowKey        -- click-target key whose glow pulses until the
+                                 -- setting is filled in; outlives page builds
     local _cardsExpanded = false -- template card strip open/closed
     local _dividerDragging = false
 
@@ -1472,6 +1474,15 @@ initFrame:SetScript("OnEvent", function(self)
             end)
         end
 
+        local function GlowTargetOf(m)
+            if m.slotSide then
+                local region
+                if m.slotSide == "left" then region = m.target._leftRegion else region = m.target._rightRegion end
+                if region then return region end
+            end
+            return m.target
+        end
+
         local function NavigateToSetting(key)
             local targets = parent._edbClickTargets
             if not targets then return end
@@ -1480,14 +1491,31 @@ initFrame:SetScript("OnEvent", function(self)
             local _, _, _, _, headerY = m.section:GetPoint(1)
             if not headerY then return end
             EllesmereUI.SmoothScrollTo(math.max(0, math.abs(headerY) - 40))
-            local glowTarget = m.target
-            if m.slotSide then
-                local region
-                if m.slotSide == "left" then region = m.target._leftRegion else region = m.target._rightRegion end
-                if region then glowTarget = region end
-            end
+            local glowTarget = GlowTargetOf(m)
+            if m.holdWhile then _edbHeldGlowKey = key end
             C_Timer.After(0.15, function() PlaySettingGlow(glowTarget, m.holdWhile) end)
         end
+
+        -- A held glow belongs to the SETTING, not to the navigation that first
+        -- showed it. Every page rebuild -- reordering a block, switching bars,
+        -- reopening the panel -- destroys the row it was parented to, which
+        -- released the pulse for good even though the setting was still empty.
+        -- Re-attach it to the freshly built row, without scrolling: the player
+        -- did not ask to go anywhere, they just moved something.
+        local function RearmHeldGlow()
+            if not _edbHeldGlowKey then return end
+            local targets = parent._edbClickTargets
+            local m = targets and targets[_edbHeldGlowKey]
+            -- Absent from this build (another bar is selected): keep the key so
+            -- coming back re-arms. Only a satisfied predicate retires it.
+            if not (m and m.target and m.holdWhile) then return end
+            if not m.holdWhile() then
+                _edbHeldGlowKey = nil
+                return
+            end
+            PlaySettingGlow(GlowTargetOf(m), m.holdWhile)
+        end
+
         -- Never retarget the live header's click handler from a hidden
         -- global-search pre-build: its targets belong to an off-screen
         -- wrapper. (SetContentHeader itself is stubbed out during pre-builds
@@ -2497,6 +2525,14 @@ initFrame:SetScript("OnEvent", function(self)
         -- Adding blocks lives in the preview strip's "+" tile only -- no
         -- body section.
         W:Spacer(parent, y, 20);  y = y - 20
+
+        -- Every click target of this build is registered by now. Same settle
+        -- delay the navigation paths use, and the same pre-build guard: a
+        -- hidden search pre-build would steal the shared glow frame for rows
+        -- nobody can see.
+        if not EllesmereUI._prebuilding then
+            C_Timer.After(0.05, RearmHeldGlow)
+        end
 
         return math.abs(y)
     end

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -1347,6 +1347,10 @@ initFrame:SetScript("OnEvent", function(self)
                     HardRefresh()
                     if nb then
                         local navKey = "block:" .. nb.id
+                        -- A currency block lands unusable until one is picked,
+                        -- so aim at the picker itself: that target pulses until
+                        -- it is filled in, instead of the one-shot section glow.
+                        if typeKey == "currency" then navKey = navKey .. ":currency" end
                         C_Timer.After(0.05, function()
                             if _edbNavigateFn then _edbNavigateFn(navKey) end
                         end)


### PR DESCRIPTION
## The bug

Adding a Currency block to a bar produces a block that says **"Select a currency"** and cannot be configured from anywhere the player is likely to look.

The placeholder invites a click. The click was wired to `C_CurrencyInfo.OpenCurrencyPanel()` — Blizzard's currency panel, which has no way to assign a currency to a DataBar block. Clicking a currency there does nothing to the block. The currency is only selectable from a dropdown in the DataBars options, and nothing on screen said so: the unconfigured block had no tooltip at all.

So the block shipped with an empty state that leads nowhere. A player either already knows where the dropdown is, or gives up.

## The fix

Left click now branches on the block's state:

- **no currency selected** → opens the options deep-linked to that block's Currency dropdown: the right bar pre-selected, scrolled into view, and the row marked
- **currency selected** → opens the currency panel, exactly as before

The marker pulses until a currency is actually chosen, instead of the one-shot 0.75s flash the deep-link machinery normally uses — long enough to say "here", too short to survive the time it takes to read the page. It survives page rebuilds, and follows the row when reordering blocks relocates it (options sections are laid out in bar order). It clears the moment `settings.currencyId` is set.

The same marker now also fires when the block is **added** from the preview strip's "+" tile, which is the moment the intent is freshest. That path already navigated; it just aimed at the sizing row instead of the choice.

Tooltips got the other half of the gap: the unconfigured block had none, and the configured one never mentioned what a click does (the Gold block already did this — Currency didn't).

## Implementation notes

The deep link reuses what the preview strip already relies on — `EllesmereUI:NavigateToElementSettings` plus the per-build `_edbClickTargets` map — so the new plumbing is small:

- `ns.OpenBlockSettings(barId, blockId, settingKey)` — the one call that runs options → runtime, documented as such in the API header of `EllesmereUIDataBars.lua`, since that header otherwise states the traffic is one-way
- one extra click target for the picker row, keyed `block:<id>:currency` (a namespace extension of the existing `block:<id>`)
- an optional `holdWhile` predicate on `PlaySettingGlow`; every existing caller passes nothing and keeps the one-shot fade

**Blizzard's currency panel is not touched.** Hooking its rows to capture the clicked currency was the other possible route and was rejected: `EllesmereUIBlizzardSkin_WindowPacks.lua` already documents that touching those rows taints the warband currency transfer and gets the protected `RequestCurrencyFromAccountCharacter` forbidden, which is why the skin module leaves them 100% stock.

## Known scope limit

The pulse re-arms on page **rebuilds**. Reopening the options panel takes `SelectPage`'s warm path, which re-shows the cached wrapper without running the page builder, so the pulse stays dead until the next rebuild. Noted in the code with the seam that would close it (`onPageCacheRestore`, the way `_edbStripRelayout` is driven). Left out deliberately to keep the diff to the reported problem.

## Notes for translators

Adds one source string: `Open Settings`. It reaches `EllesmereUI.L` through the DataBars `ns.L` table, so it is invisible to `.tools/extract-locale-keys.sh` and `Locales/_keys.txt` is unchanged (verified — the script is a no-op on this branch).

## Testing

In-game, on a live bar:

- add a Currency block → the picker is marked immediately, and keeps pulsing
- click the placeholder on the bar → lands on the picker, marked
- reorder the block on the bar before choosing → the view follows it to its new position and it keeps pulsing
- toggle an unrelated setting on another block → the view does **not** jump
- choose a currency, then reorder → nothing pulses any more
- tooltips in both states

`luac -p` clean on all three files.


<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
