### PR TITLE
fix(databars): gold suffixes were English on every localized client

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -91,9 +91,6 @@ local L = {
     OPEN_BAGS            = "Open Bags",
     OPEN_CURRENCIES      = "Open Currencies",
     RESET_SESSION        = "Reset Session",
-    GOLD_SUFFIX          = "g",
-    SILVER_SUFFIX        = "s",
-    COPPER_SUFFIX        = "c",
     TRAVEL_COOLDOWNS     = "Travel Cooldowns",
     HEARTHSTONE          = "Hearthstone",
     READY                = "Ready",
@@ -189,7 +186,7 @@ ns.BLOCK_DEFAULTS = {
     clock      = { localTime = true, twentyFour = true, showMail = true, showResting = true, fontSizeClock = nil, fontSizeInfo = nil },
     fps        = {},
     ms         = { useWorldLatency = false },
-    gold       = { showIcons = true, showBagSpace = false, showSmall = false },
+    gold       = { showIcons = true, showBagSpace = false, showSmall = false, coinIcons = false },
     durability = { showIcon = true },
     xprep      = { mode = "auto" },
     spec       = { showLoadout = true, useUppercase = false },
@@ -301,13 +298,23 @@ end
 --  Money / time formatting (pure)
 -------------------------------------------------------------------------------
 local DENOMINATIONS = {
-    { divisor = 10000, suffix = "GOLD_SUFFIX",   color = "|cffe2ac7a" },  -- E2AC7A (user-set; do not "restore" to ffd700)
-    { divisor = 100,   suffix = "SILVER_SUFFIX", color = "|cffc7c7cf" },
-    { divisor = 1,     suffix = "COPPER_SUFFIX", color = "|cffed8a3f" },  -- copper-orange
+    { divisor = 10000, symbol = GOLD_AMOUNT_SYMBOL,   color = "|cffe2ac7a" },  -- E2AC7A (user-set; do not "restore" to ffd700)
+    { divisor = 100,   symbol = SILVER_AMOUNT_SYMBOL, color = "|cffc7c7cf" },
+    { divisor = 1,     symbol = COPPER_AMOUNT_SYMBOL, color = "|cffed8a3f" },  -- copper-orange
 }
 
-function ns.FormatMoneyPlain(amount, showSmall)
+-- Opt-in per gold block: Blizzard's coin textures instead of the letters.
+-- GetCoinTextureString renders every denomination it needs in one indivisible
+-- string and has no colored/plain variants, so useColors and showSmall do not
+-- apply to it.
+local function CoinIconString(amount)
+    return C_CurrencyInfo.GetCoinTextureString(amount)
+end
+ns.CoinIconString = CoinIconString
+
+function ns.FormatMoneyPlain(amount, showSmall, coinIcons)
     amount = floor(abs(amount or 0))
+    if coinIcons then return CoinIconString(amount) end
     local parts, foundGold = {}, false
     for i, denom in ipairs(DENOMINATIONS) do
         local val = floor(amount / denom.divisor)
@@ -315,17 +322,18 @@ function ns.FormatMoneyPlain(amount, showSmall)
         if i == 1 and val > 0 then
             foundGold = true
             local display = BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
-            parts[#parts + 1] = display .. L[denom.suffix]
+            parts[#parts + 1] = display .. denom.symbol
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
-            parts[#parts + 1] = val .. L[denom.suffix]
+            parts[#parts + 1] = val .. denom.symbol
         end
     end
     if #parts > 0 then return tconcat(parts, " ") end
-    return "0" .. L["COPPER_SUFFIX"]
+    return "0" .. DENOMINATIONS[3].symbol
 end
 
-function ns.FormatMoney(amount, useColors, showSmall)
+function ns.FormatMoney(amount, useColors, showSmall, coinIcons)
     amount = floor(abs(amount or 0))
+    if coinIcons then return CoinIconString(amount) end
     local coloured = useColors ~= false
     local parts, foundGold = {}, false
     for i, denom in ipairs(DENOMINATIONS) do
@@ -336,17 +344,17 @@ function ns.FormatMoney(amount, useColors, showSmall)
             local display = BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
             local cOpen, cClose = "", ""
             if coloured then cOpen = denom.color; cClose = "|r" end
-            parts[#parts + 1] = display .. cOpen .. L[denom.suffix] .. cClose
+            parts[#parts + 1] = display .. cOpen .. denom.symbol .. cClose
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
             local cOpen, cClose = "", ""
             if coloured then cOpen = denom.color; cClose = "|r" end
-            parts[#parts + 1] = val .. cOpen .. L[denom.suffix] .. cClose
+            parts[#parts + 1] = val .. cOpen .. denom.symbol .. cClose
         end
     end
     if #parts == 0 then
         local cOpen, cClose = "", ""
         if coloured then cOpen = DENOMINATIONS[3].color; cClose = "|r" end
-        return "0" .. cOpen .. L["COPPER_SUFFIX"] .. cClose
+        return "0" .. cOpen .. DENOMINATIONS[3].symbol .. cClose
     end
     return tconcat(parts, " ")
 end

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -1207,25 +1207,36 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
     local _sideLineCount = 0
     -- coin: Coin Colored text mode -- suffix letters carry the denomination
     -- colors (same codes as ns.FormatMoney), numbers inherit the white base.
-    local function GetMoneySideLines(amount, showSmall, coin)
+    local function GetMoneySideLines(amount, showSmall, coin, coinIcons)
         amount = floor(abs(amount or 0))
+        -- Coin icons: GetCoinTextureString emits every denomination in one
+        -- string, so the vertical bar shows it as a single wrapped line
+        -- instead of one line per denomination. Coin Colored has nothing left
+        -- to tint -- the textures carry their own color.
+        if coinIcons then
+            _sideLinesBuf[1] = ns.CoinIconString(amount)
+            _sideLinesBuf[2] = nil
+            _sideLinesBuf[3] = nil
+            _sideLineCount = 1
+            return _sideLinesBuf, _sideLineCount
+        end
         local gold   = floor(amount / 10000)
         local silver = floor((amount % 10000) / 100)
         local copper = amount % 100
         local gStr
         if BreakUpLargeNumbers then gStr = BreakUpLargeNumbers(gold) else gStr = tostring(gold) end
         if coin then
-            _sideLinesBuf[1] = gStr .. "|cffe2ac7a" .. L["GOLD_SUFFIX"] .. "|r"
+            _sideLinesBuf[1] = gStr .. "|cffe2ac7a" .. GOLD_AMOUNT_SYMBOL .. "|r"
         else
-            _sideLinesBuf[1] = gStr .. L["GOLD_SUFFIX"]
+            _sideLinesBuf[1] = gStr .. GOLD_AMOUNT_SYMBOL
         end
         if showSmall ~= false then
             if coin then
-                _sideLinesBuf[2] = silver .. "|cffc7c7cf" .. L["SILVER_SUFFIX"] .. "|r"
-                _sideLinesBuf[3] = copper .. "|cffed8a3f" .. L["COPPER_SUFFIX"] .. "|r"
+                _sideLinesBuf[2] = silver .. "|cffc7c7cf" .. SILVER_AMOUNT_SYMBOL .. "|r"
+                _sideLinesBuf[3] = copper .. "|cffed8a3f" .. COPPER_AMOUNT_SYMBOL .. "|r"
             else
-                _sideLinesBuf[2] = silver .. L["SILVER_SUFFIX"]
-                _sideLinesBuf[3] = copper .. L["COPPER_SUFFIX"]
+                _sideLinesBuf[2] = silver .. SILVER_AMOUNT_SYMBOL
+                _sideLinesBuf[3] = copper .. COPPER_AMOUNT_SYMBOL
             end
             _sideLineCount = 3
         else
@@ -1263,11 +1274,12 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         ns.SetFont(bagText, fontSize, barCfg)
 
         local money = GetMoney()
+        local ci = dg.coinIcons == true
         if isSide then
             local slotW = VSlotW(inst)
             local innerW = max(30, slotW - 8)
             local lines, lineCount = GetMoneySideLines(money, dg.showSmall == true,
-                blockCfg.useCoinColor == true and not mouseOver)
+                blockCfg.useCoinColor == true and not mouseOver, ci)
             local startSize = min(fontSize, max(10, floor(CONTENT_BASE * 0.52 + 0.5)))
             local goldFontSize = startSize
             ns.SetFont(goldText, goldFontSize, barCfg)
@@ -1278,11 +1290,11 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             else r, g, b = BlockColorOf(blockCfg) end
             goldText:SetTextColor(r, g, b, 1)
         elseif mouseOver then
-            goldText:SetText(ns.FormatMoneyPlain(money, dg.showSmall == true))
+            goldText:SetText(ns.FormatMoneyPlain(money, dg.showSmall == true, ci))
             local r, g, b = ns.GetAccent()
             goldText:SetTextColor(r, g, b, 1)
         else
-            goldText:SetText(ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true))
+            goldText:SetText(ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci))
             if blockCfg.useCoinColor then
                 goldText:SetTextColor(1, 1, 1, 1)
             else
@@ -1351,8 +1363,8 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             -- Fit against BOTH money formats so font/icon size (and the frame
             -- width below) stay identical whether hovered or not; otherwise
             -- the element visibly resizes on mouseover.
-            local plainText = ns.FormatMoneyPlain(money, dg.showSmall == true)
-            local fancyText = ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true)
+            local plainText = ns.FormatMoneyPlain(money, dg.showSmall == true, ci)
+            local fancyText = ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci)
             local moneyText
             if mouseOver then moneyText = plainText else moneyText = fancyText end
             local bagTextValue = ""
@@ -1410,20 +1422,21 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         inst:Refresh()
         -- Tooltip money lines honor the block's Show Silver and Copper toggle.
         local sm = D().showSmall == true
+        local ci = D().coinIcons == true
         local ar, ag, ab = 1, 1, 1
         ns.Tip_Begin(goldButton)
         ns.Tip_AddLine(L["GOLD"], ar, ag, ab)
         ns.Tip_AddLine(" ")
         ns.Tip_AddLine(L["SESSION"], 0.8, 0.8, 0.8)
-        ns.Tip_AddDouble(L["EARNED"], ns.FormatMoney(goldLedger.profit, true, sm), 0.6, 0.6, 0.6, 0, 1, 0)
-        ns.Tip_AddDouble(L["SPENT"],  ns.FormatMoney(goldLedger.spent,  true, sm), 0.6, 0.6, 0.6, 1, 0.3, 0.3)
+        ns.Tip_AddDouble(L["EARNED"], ns.FormatMoney(goldLedger.profit, true, sm, ci), 0.6, 0.6, 0.6, 0, 1, 0)
+        ns.Tip_AddDouble(L["SPENT"],  ns.FormatMoney(goldLedger.spent,  true, sm, ci), 0.6, 0.6, 0.6, 1, 0.3, 0.3)
         local net = goldLedger.profit - goldLedger.spent
         if net ~= 0 then
             local label
             if net > 0 then label = L["PROFIT"] else label = L["DEFICIT"] end
             local nr, ngr = 1, 0.3
             if net > 0 then nr, ngr = 0, 1 end
-            ns.Tip_AddDouble(label, ns.FormatMoney(abs(net), true, sm), 0.6, 0.6, 0.6, nr, ngr, 0.3)
+            ns.Tip_AddDouble(label, ns.FormatMoney(abs(net), true, sm, ci), 0.6, 0.6, 0.6, nr, ngr, 0.3)
         end
         local store = GoldStore()
         local total, charList = 0, {}
@@ -1446,7 +1459,7 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
                 if char.name == UnitName("player") then
                     label = label .. " |TInterface\\COMMON\\Indicator-Green:14|t"
                 end
-                ns.Tip_AddDouble(label, ns.FormatMoney(char.currentMoney, true, sm), cr, cg, cb, 1, 1, 1)
+                ns.Tip_AddDouble(label, ns.FormatMoney(char.currentMoney, true, sm, ci), cr, cg, cb, 1, 1, 1)
             end
         end
         local bankType = 2
@@ -1455,15 +1468,15 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             local wbank = C_Bank.FetchDepositedMoney(bankType)
             if wbank and wbank > 0 then
                 ns.Tip_AddLine(" ")
-                ns.Tip_AddDouble(L["WARBANK"], ns.FormatMoney(wbank, true, sm), 0.6, 0.6, 0.6, 1, 1, 1)
+                ns.Tip_AddDouble(L["WARBANK"], ns.FormatMoney(wbank, true, sm, ci), 0.6, 0.6, 0.6, 1, 1, 1)
                 total = total + wbank
             end
         end
         ns.Tip_AddLine(" ")
-        ns.Tip_AddDouble(L["TOTAL"], ns.FormatMoney(total, true, sm), ar, ag, ab, 1, 1, 1)
+        ns.Tip_AddDouble(L["TOTAL"], ns.FormatMoney(total, true, sm, ci), ar, ag, ab, 1, 1, 1)
         if goldLedger.tokenPrice and goldLedger.tokenPrice > 0 then
             ns.Tip_AddLine(" ")
-            ns.Tip_AddDouble(L["WOW_TOKEN"], ns.FormatMoney(goldLedger.tokenPrice, true, sm), 0, 0.8, 1, 1, 1, 1)
+            ns.Tip_AddDouble(L["WOW_TOKEN"], ns.FormatMoney(goldLedger.tokenPrice, true, sm, ci), 0, 0.8, 1, 1, 1, 1)
         end
         ns.Tip_AddLine(" ")
         ns.Tip_AddDouble(L["LEFT_CLICK"],       L["OPEN_BAGS"],       1, 1, 1, ar, ag, ab)

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -2660,6 +2660,9 @@ initFrame:SetScript("OnEvent", function(self)
                 typeRows = {
                     MkToggle("Show Icon", "showIcons", "Shows the coin icon next to the amount."),
                     MkToggle("Show Bag Space", "showBagSpace", "Shows your free bag slots."),
+                    -- Off (default) = the letter suffixes; on = coin textures.
+                    -- Independent of Coin Colored, which tints those letters.
+                    MkToggle("Coin Icons", "coinIcons", "Uses Blizzard's coin textures instead of the letter suffixes."),
                 }
             elseif b.type == "xprep" then
                 typeRows = {


### PR DESCRIPTION
The Gold block printed "12g 34s 56c" regardless of client language -- "12o 34a 56c" in French, "12G 34S 56K" in German, and so on for all eleven.

The suffixes were read from the module's own `L` table, which is a static English table in EllesmereUIDataBars.lua. It is never routed through Locales/*.lua, so no translation could ever reach it -- not even the `L["g"] = "o"` / `L["s"] = "a"` entries frFR already carries for the QoL repair message. Three separate builders had the same bug: FormatMoney (bar text and every tooltip line), FormatMoneyPlain (bar text on hover), and the gold block's own GetMoneySideLines (vertical bars).

They now read the client's GlobalStrings -- GOLD_AMOUNT_SYMBOL and friends -- which are already localized and, locale for locale, hold exactly the values WonderBar's own suffix tables maintain by hand. No addon translation needed, all locales fixed at once, and the three now-unused L entries are gone.

Also adds a per-block "Coin Icons" toggle (default off), mirroring the one the QoL module already has for auto-repair messages: on, money renders with Blizzard's coin textures via GetCoinTextureString instead of the letters. On a vertical bar that string covers every denomination at once, so it shows as a single wrapped line rather than one line per coin.

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
