### PR TITLE
fix(databars): stale characters could never leave the gold history

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -315,37 +315,35 @@ local COIN_TEX = {
     "|TInterface\\MoneyFrame\\UI-SilverIcon:0:0:2:0|t",
     "|TInterface\\MoneyFrame\\UI-CopperIcon:0:0:2:0|t",
 }
-ns.COIN_TEX = COIN_TEX
-
 -- What trails the number for denomination i: a coin texture when Coin Icons is
--- on, otherwise the localized suffix letter, colored unless the caller asks for
--- plain. Every money formatter below goes through this, so the Coin Icons and
--- Show Silver and Copper options compose the same way in all of them --
--- GetCoinTextureString could not do that, it always emits all three coins.
+-- on, otherwise the localized suffix letter, colored on request. Every money
+-- renderer goes through this, so Coin Icons, Coin Colored and Show Silver and
+-- Copper compose the same way in all of them -- GetCoinTextureString could not
+-- do that, it always emits all three coins in one indivisible string.
 local function CoinMarker(i, coinIcons, coloured)
     if coinIcons then return COIN_TEX[i] end
-    if coloured == false then return DENOMINATIONS[i].symbol end
-    return DENOMINATIONS[i].color .. DENOMINATIONS[i].symbol .. "|r"
+    local d = DENOMINATIONS[i]
+    if coloured then return d.color .. d.symbol .. "|r" end
+    return d.symbol
 end
-ns.CoinMarker = CoinMarker
 
--- Money split per denomination, for Tip_AddColumns: one token per coin so the
--- amounts line up vertically down the tooltip. A single formatted string
--- cannot -- the game font is proportional, so "9o" and "1 234o" are different
--- widths and every column after the first drifts.
+-- Money split per denomination: one token per coin, so callers can lay them out
+-- in aligned columns (the tooltip) or on separate lines (a vertical bar). A
+-- single formatted string can do neither -- the game font is proportional, so
+-- "9o" and "1 234o" are different widths and everything after the first drifts.
 -- The buffer is reused; Tip_AddColumns copies it, so one buffer serves all rows.
 local _moneyTokens = {}
 
-function ns.MoneyTokens(amount, showSmall, coinIcons)
+function ns.MoneyTokens(amount, showSmall, coinIcons, coloured)
     amount = floor(abs(amount or 0))
     wipe(_moneyTokens)
     local gold = floor(amount / DENOMINATIONS[1].divisor)
     local gStr = BreakUpLargeNumbers and BreakUpLargeNumbers(gold) or tostring(gold)
-    _moneyTokens[1] = gStr .. CoinMarker(1, coinIcons)
+    _moneyTokens[1] = gStr .. CoinMarker(1, coinIcons, coloured)
     if showSmall ~= false then
         local silver = floor((amount % DENOMINATIONS[1].divisor) / DENOMINATIONS[2].divisor)
-        _moneyTokens[2] = silver .. CoinMarker(2, coinIcons)
-        _moneyTokens[3] = (amount % DENOMINATIONS[2].divisor) .. CoinMarker(3, coinIcons)
+        _moneyTokens[2] = silver .. CoinMarker(2, coinIcons, coloured)
+        _moneyTokens[3] = (amount % DENOMINATIONS[2].divisor) .. CoinMarker(3, coinIcons, coloured)
     end
     return _moneyTokens
 end
@@ -905,11 +903,12 @@ do
     -- they are the same thing to the player: an interactive tooltip row.
     -- The accent recolor only shows if the row's left text carries no embedded
     -- |c..|r codes; callers pass the normal color through the left-color args.
-    local function PlaceRowOverlay(b, i, d, innerW, ar, ag, ab)
+    local function PlaceRowOverlay(b, i, innerW)
+        local d, row = data[i], rows[i]
         b:ClearAllPoints()
         b:SetPoint("TOPLEFT", tip, "TOPLEFT", PAD, d._y)
         b:SetSize(max(1, innerW), max(1, d._h))
-        local row = rows[i]
+        local ar, ag, ab = ns.GetAccent()
         local lr, lg, lb = d.lr or 1, d.lg or 1, d.lb or 1
         b:SetScript("OnEnter", function() row.left:SetTextColor(ar, ag, ab, 1) end)
         b:SetScript("OnLeave", function() row.left:SetTextColor(lr, lg, lb, 1) end)
@@ -1243,7 +1242,6 @@ do
         HideActionButtons()
         interactive = false
         if not InCombatLockdown() then
-            local ar, ag, ab = ns.GetAccent()
             for i = 1, dataCount do
                 local d = data[i]
                 if d.action or d.actionToy or d.actionMacro then
@@ -1274,7 +1272,7 @@ do
                         b:SetAttribute("spell", nil)
                         b:SetAttribute("toy", nil)
                     end
-                    PlaceRowOverlay(b, i, d, innerW, ar, ag, ab)
+                    PlaceRowOverlay(b, i, innerW)
                 end
             end
         end
@@ -1283,15 +1281,13 @@ do
         -- the callbacks are unprotected -- and rebuilt from scratch each show
         -- so a reused tip never carries stale buttons.
         HideClickButtons()
-        local car, cag, cab
         for i = 1, dataCount do
             local d = data[i]
             if d.onClick then
                 interactive = true
-                if not car then car, cag, cab = ns.GetAccent() end
                 local b = AcquireClickButton()
                 local cb = d.onClick
-                PlaceRowOverlay(b, i, d, innerW, car, cag, cab)
+                PlaceRowOverlay(b, i, innerW)
                 b:SetScript("OnClick", function(_, mouseButton) cb(mouseButton) end)
             end
         end

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -65,6 +65,7 @@ local L = {
     SHIFT_MIDDLE_CLICK   = "|cffFFFFFFShift + Middle Click:|r",
     SHIFT_LEFT_CLICK     = "|cffFFFFFFShift + Left Click:|r",
     CTRL_RIGHT_CLICK     = "|cffFFFFFFCtrl + Right Click:|r",
+    CTRL_ALT_LEFT_CLICK  = "|cffFFFFFFCtrl + Alt + Left Click:|r",
     YOU_HAVE_MAIL        = "You've Got Mail!",
     SERVER_TIME          = "Server time",
     SAVED_INSTANCES      = "Saved Raid(s)",
@@ -91,6 +92,7 @@ local L = {
     OPEN_BAGS            = "Open Bags",
     OPEN_CURRENCIES      = "Open Currencies",
     RESET_SESSION        = "Reset Session",
+    REMOVE_CHARACTER     = "Remove Character",
     TRAVEL_COOLDOWNS     = "Travel Cooldowns",
     HEARTHSTONE          = "Hearthstone",
     READY                = "Ready",
@@ -311,6 +313,33 @@ local function CoinIconString(amount)
     return C_CurrencyInfo.GetCoinTextureString(amount)
 end
 ns.CoinIconString = CoinIconString
+
+-- Money split per denomination, for Tip_AddColumns: one token per coin so the
+-- suffixes line up vertically down the tooltip. A single formatted string
+-- cannot -- the game font is proportional, so "9o" and "1 234o" are different
+-- widths and every column after the first drifts.
+-- Coin icons render every denomination in one indivisible string, so that mode
+-- yields a single token (still one aligned column, just not three).
+-- The buffer is reused; Tip_AddColumns copies it, so one buffer serves all rows.
+local _moneyTokens = {}
+function ns.MoneyTokens(amount, showSmall, coinIcons)
+    amount = floor(abs(amount or 0))
+    wipe(_moneyTokens)
+    if coinIcons then
+        _moneyTokens[1] = CoinIconString(amount)
+        return _moneyTokens
+    end
+    local gold = floor(amount / DENOMINATIONS[1].divisor)
+    local gStr = BreakUpLargeNumbers and BreakUpLargeNumbers(gold) or tostring(gold)
+    _moneyTokens[1] = gStr .. DENOMINATIONS[1].color .. DENOMINATIONS[1].symbol .. "|r"
+    if showSmall ~= false then
+        local silver = floor((amount % DENOMINATIONS[1].divisor) / DENOMINATIONS[2].divisor)
+        _moneyTokens[2] = silver .. DENOMINATIONS[2].color .. DENOMINATIONS[2].symbol .. "|r"
+        _moneyTokens[3] = (amount % DENOMINATIONS[2].divisor)
+            .. DENOMINATIONS[3].color .. DENOMINATIONS[3].symbol .. "|r"
+    end
+    return _moneyTokens
+end
 
 function ns.FormatMoneyPlain(amount, showSmall, coinIcons)
     amount = floor(abs(amount or 0))
@@ -1042,6 +1071,16 @@ do
     -- combat.
     function ns.Tip_AddClickable(left, right, onClick, lr, lg, lb, rr, rg, rb)
         if ns.Tip_AddDouble(left, right, lr, lg, lb, rr, rg, rb) and onClick then
+            data[dataCount].onClick = onClick
+        end
+    end
+
+    -- Tip_AddColumns + Tip_AddClickable: sub-column alignment AND a click
+    -- overlay. The two were mutually exclusive only because each add-function
+    -- clears the other's field; the overlay is placed over the row's rectangle
+    -- and never cared how the row was laid out.
+    function ns.Tip_AddClickableColumns(left, tokens, onClick, lr, lg, lb)
+        if ns.Tip_AddColumns(left, tokens, lr, lg, lb) and onClick then
             data[dataCount].onClick = onClick
         end
     end

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -887,6 +887,12 @@ do
             b:SetFrameLevel(tip:GetFrameLevel() + 5)
             b:EnableMouse(true)
             b:RegisterForClicks("AnyUp")
+            -- Same full-row white hover wash the secure action rows carry
+            -- (house style: rows 0.10). These rows only ever recolored their
+            -- left text, so "exactly like the M+ teleport rows" was half true.
+            local hl = b:CreateTexture(nil, "HIGHLIGHT")
+            hl:SetAllPoints()
+            hl:SetColorTexture(1, 1, 1, 0.10)
             clickPool[activeClicks] = b
         end
         return b

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -91,9 +91,6 @@ local L = {
     OPEN_BAGS            = "Open Bags",
     OPEN_CURRENCIES      = "Open Currencies",
     RESET_SESSION        = "Reset Session",
-    GOLD_SUFFIX          = "g",
-    SILVER_SUFFIX        = "s",
-    COPPER_SUFFIX        = "c",
     TRAVEL_COOLDOWNS     = "Travel Cooldowns",
     HEARTHSTONE          = "Hearthstone",
     READY                = "Ready",
@@ -189,7 +186,7 @@ ns.BLOCK_DEFAULTS = {
     clock      = { localTime = true, twentyFour = true, showMail = true, showResting = true, fontSizeClock = nil, fontSizeInfo = nil },
     fps        = {},
     ms         = { useWorldLatency = false },
-    gold       = { showIcons = true, showBagSpace = false, showSmall = false },
+    gold       = { showIcons = true, showBagSpace = false, showSmall = false, coinIcons = false },
     durability = { showIcon = true },
     xprep      = { mode = "auto" },
     spec       = { showLoadout = true, useUppercase = false },
@@ -301,13 +298,23 @@ end
 --  Money / time formatting (pure)
 -------------------------------------------------------------------------------
 local DENOMINATIONS = {
-    { divisor = 10000, suffix = "GOLD_SUFFIX",   color = "|cffe2ac7a" },  -- E2AC7A (user-set; do not "restore" to ffd700)
-    { divisor = 100,   suffix = "SILVER_SUFFIX", color = "|cffc7c7cf" },
-    { divisor = 1,     suffix = "COPPER_SUFFIX", color = "|cffed8a3f" },  -- copper-orange
+    { divisor = 10000, symbol = GOLD_AMOUNT_SYMBOL,   color = "|cffe2ac7a" },  -- E2AC7A (user-set; do not "restore" to ffd700)
+    { divisor = 100,   symbol = SILVER_AMOUNT_SYMBOL, color = "|cffc7c7cf" },
+    { divisor = 1,     symbol = COPPER_AMOUNT_SYMBOL, color = "|cffed8a3f" },  -- copper-orange
 }
 
-function ns.FormatMoneyPlain(amount, showSmall)
+-- Opt-in per gold block: Blizzard's coin textures instead of the letters.
+-- GetCoinTextureString renders every denomination it needs in one indivisible
+-- string and has no colored/plain variants, so useColors and showSmall do not
+-- apply to it.
+local function CoinIconString(amount)
+    return C_CurrencyInfo.GetCoinTextureString(amount)
+end
+ns.CoinIconString = CoinIconString
+
+function ns.FormatMoneyPlain(amount, showSmall, coinIcons)
     amount = floor(abs(amount or 0))
+    if coinIcons then return CoinIconString(amount) end
     local parts, foundGold = {}, false
     for i, denom in ipairs(DENOMINATIONS) do
         local val = floor(amount / denom.divisor)
@@ -315,17 +322,18 @@ function ns.FormatMoneyPlain(amount, showSmall)
         if i == 1 and val > 0 then
             foundGold = true
             local display = BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
-            parts[#parts + 1] = display .. L[denom.suffix]
+            parts[#parts + 1] = display .. denom.symbol
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
-            parts[#parts + 1] = val .. L[denom.suffix]
+            parts[#parts + 1] = val .. denom.symbol
         end
     end
     if #parts > 0 then return tconcat(parts, " ") end
-    return "0" .. L["COPPER_SUFFIX"]
+    return "0" .. DENOMINATIONS[3].symbol
 end
 
-function ns.FormatMoney(amount, useColors, showSmall)
+function ns.FormatMoney(amount, useColors, showSmall, coinIcons)
     amount = floor(abs(amount or 0))
+    if coinIcons then return CoinIconString(amount) end
     local coloured = useColors ~= false
     local parts, foundGold = {}, false
     for i, denom in ipairs(DENOMINATIONS) do
@@ -336,17 +344,17 @@ function ns.FormatMoney(amount, useColors, showSmall)
             local display = BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
             local cOpen, cClose = "", ""
             if coloured then cOpen = denom.color; cClose = "|r" end
-            parts[#parts + 1] = display .. cOpen .. L[denom.suffix] .. cClose
+            parts[#parts + 1] = display .. cOpen .. denom.symbol .. cClose
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
             local cOpen, cClose = "", ""
             if coloured then cOpen = denom.color; cClose = "|r" end
-            parts[#parts + 1] = val .. cOpen .. L[denom.suffix] .. cClose
+            parts[#parts + 1] = val .. cOpen .. denom.symbol .. cClose
         end
     end
     if #parts == 0 then
         local cOpen, cClose = "", ""
         if coloured then cOpen = DENOMINATIONS[3].color; cClose = "|r" end
-        return "0" .. cOpen .. L["COPPER_SUFFIX"] .. cClose
+        return "0" .. cOpen .. DENOMINATIONS[3].symbol .. cClose
     end
     return tconcat(parts, " ")
 end

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -305,45 +305,53 @@ local DENOMINATIONS = {
     { divisor = 1,     symbol = COPPER_AMOUNT_SYMBOL, color = "|cffed8a3f" },  -- copper-orange
 }
 
--- Opt-in per gold block: Blizzard's coin textures instead of the letters.
--- GetCoinTextureString renders every denomination it needs in one indivisible
--- string and has no colored/plain variants, so useColors and showSmall do not
--- apply to it.
-local function CoinIconString(amount)
-    return C_CurrencyInfo.GetCoinTextureString(amount)
+-- Coin textures, one per denomination, same paths the bag module already uses.
+-- ":0:0:2:0" is Blizzard's own sizing in GetCoinTextureString: 0 height means
+-- inherit the font, so the icons follow the bar's and the tooltip's text size.
+-- Split per coin on purpose -- GetCoinTextureString returns all three welded
+-- into one string, which cannot be laid out in aligned columns.
+local COIN_TEX = {
+    "|TInterface\\MoneyFrame\\UI-GoldIcon:0:0:2:0|t",
+    "|TInterface\\MoneyFrame\\UI-SilverIcon:0:0:2:0|t",
+    "|TInterface\\MoneyFrame\\UI-CopperIcon:0:0:2:0|t",
+}
+ns.COIN_TEX = COIN_TEX
+
+-- What trails the number for denomination i: a coin texture when Coin Icons is
+-- on, otherwise the localized suffix letter, colored unless the caller asks for
+-- plain. Every money formatter below goes through this, so the Coin Icons and
+-- Show Silver and Copper options compose the same way in all of them --
+-- GetCoinTextureString could not do that, it always emits all three coins.
+local function CoinMarker(i, coinIcons, coloured)
+    if coinIcons then return COIN_TEX[i] end
+    if coloured == false then return DENOMINATIONS[i].symbol end
+    return DENOMINATIONS[i].color .. DENOMINATIONS[i].symbol .. "|r"
 end
-ns.CoinIconString = CoinIconString
+ns.CoinMarker = CoinMarker
 
 -- Money split per denomination, for Tip_AddColumns: one token per coin so the
--- suffixes line up vertically down the tooltip. A single formatted string
+-- amounts line up vertically down the tooltip. A single formatted string
 -- cannot -- the game font is proportional, so "9o" and "1 234o" are different
 -- widths and every column after the first drifts.
--- Coin icons render every denomination in one indivisible string, so that mode
--- yields a single token (still one aligned column, just not three).
 -- The buffer is reused; Tip_AddColumns copies it, so one buffer serves all rows.
 local _moneyTokens = {}
+
 function ns.MoneyTokens(amount, showSmall, coinIcons)
     amount = floor(abs(amount or 0))
     wipe(_moneyTokens)
-    if coinIcons then
-        _moneyTokens[1] = CoinIconString(amount)
-        return _moneyTokens
-    end
     local gold = floor(amount / DENOMINATIONS[1].divisor)
     local gStr = BreakUpLargeNumbers and BreakUpLargeNumbers(gold) or tostring(gold)
-    _moneyTokens[1] = gStr .. DENOMINATIONS[1].color .. DENOMINATIONS[1].symbol .. "|r"
+    _moneyTokens[1] = gStr .. CoinMarker(1, coinIcons)
     if showSmall ~= false then
         local silver = floor((amount % DENOMINATIONS[1].divisor) / DENOMINATIONS[2].divisor)
-        _moneyTokens[2] = silver .. DENOMINATIONS[2].color .. DENOMINATIONS[2].symbol .. "|r"
-        _moneyTokens[3] = (amount % DENOMINATIONS[2].divisor)
-            .. DENOMINATIONS[3].color .. DENOMINATIONS[3].symbol .. "|r"
+        _moneyTokens[2] = silver .. CoinMarker(2, coinIcons)
+        _moneyTokens[3] = (amount % DENOMINATIONS[2].divisor) .. CoinMarker(3, coinIcons)
     end
     return _moneyTokens
 end
 
 function ns.FormatMoneyPlain(amount, showSmall, coinIcons)
     amount = floor(abs(amount or 0))
-    if coinIcons then return CoinIconString(amount) end
     local parts, foundGold = {}, false
     for i, denom in ipairs(DENOMINATIONS) do
         local val = floor(amount / denom.divisor)
@@ -351,18 +359,17 @@ function ns.FormatMoneyPlain(amount, showSmall, coinIcons)
         if i == 1 and val > 0 then
             foundGold = true
             local display = BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
-            parts[#parts + 1] = display .. denom.symbol
+            parts[#parts + 1] = display .. CoinMarker(i, coinIcons, false)
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
-            parts[#parts + 1] = val .. denom.symbol
+            parts[#parts + 1] = val .. CoinMarker(i, coinIcons, false)
         end
     end
     if #parts > 0 then return tconcat(parts, " ") end
-    return "0" .. DENOMINATIONS[3].symbol
+    return "0" .. CoinMarker(3, coinIcons, false)
 end
 
 function ns.FormatMoney(amount, useColors, showSmall, coinIcons)
     amount = floor(abs(amount or 0))
-    if coinIcons then return CoinIconString(amount) end
     local coloured = useColors ~= false
     local parts, foundGold = {}, false
     for i, denom in ipairs(DENOMINATIONS) do
@@ -371,19 +378,13 @@ function ns.FormatMoney(amount, useColors, showSmall, coinIcons)
         if i == 1 and val > 0 then
             foundGold = true
             local display = BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
-            local cOpen, cClose = "", ""
-            if coloured then cOpen = denom.color; cClose = "|r" end
-            parts[#parts + 1] = display .. cOpen .. denom.symbol .. cClose
+            parts[#parts + 1] = display .. CoinMarker(i, coinIcons, coloured)
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
-            local cOpen, cClose = "", ""
-            if coloured then cOpen = denom.color; cClose = "|r" end
-            parts[#parts + 1] = val .. cOpen .. denom.symbol .. cClose
+            parts[#parts + 1] = val .. CoinMarker(i, coinIcons, coloured)
         end
     end
     if #parts == 0 then
-        local cOpen, cClose = "", ""
-        if coloured then cOpen = DENOMINATIONS[3].color; cClose = "|r" end
-        return "0" .. cOpen .. DENOMINATIONS[3].symbol .. cClose
+        return "0" .. CoinMarker(3, coinIcons, coloured)
     end
     return tconcat(parts, " ")
 end

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -832,6 +832,16 @@ do
     -- Grow-only pool; buttons are configured fresh on every Tip_Show. Creation
     -- and reconfiguration only ever run out of combat (the overlay build is
     -- combat-skipped), so the secure attribute writes are always legal.
+    -- House style for an interactive tooltip row: a white 0.10 wash across the
+    -- whole row on hover, HIGHLIGHT layer, no scripts involved. Both overlay
+    -- pools go through this -- when only one of them had it, the two kinds of
+    -- clickable row silently looked different for as long as they existed.
+    local function AddRowHighlight(b)
+        local hl = b:CreateTexture(nil, "HIGHLIGHT")
+        hl:SetAllPoints()
+        hl:SetColorTexture(1, 1, 1, 0.10)
+    end
+
     local function AcquireActionButton()
         activeActions = activeActions + 1
         local b = actionPool[activeActions]
@@ -845,11 +855,7 @@ do
             -- started -- same rule as the travel block's hearth button.
             b:RegisterForClicks("AnyUp")
             b:SetAttribute("useOnKeyDown", false)
-            -- Full-row white hover wash (house style: rows 0.10). HIGHLIGHT
-            -- layer shows on hover automatically -- no scripts involved.
-            local hl = b:CreateTexture(nil, "HIGHLIGHT")
-            hl:SetAllPoints()
-            hl:SetColorTexture(1, 1, 1, 0.10)
+            AddRowHighlight(b)
             -- Default type; the overlay build swaps type/payload per row
             -- (spell rows and toy rows share this pool).
             b:SetAttribute("type", "spell")
@@ -887,15 +893,26 @@ do
             b:SetFrameLevel(tip:GetFrameLevel() + 5)
             b:EnableMouse(true)
             b:RegisterForClicks("AnyUp")
-            -- Same full-row white hover wash the secure action rows carry
-            -- (house style: rows 0.10). These rows only ever recolored their
-            -- left text, so "exactly like the M+ teleport rows" was half true.
-            local hl = b:CreateTexture(nil, "HIGHLIGHT")
-            hl:SetAllPoints()
-            hl:SetColorTexture(1, 1, 1, 0.10)
+            AddRowHighlight(b)
             clickPool[activeClicks] = b
         end
         return b
+    end
+
+    -- Lay an overlay button over row i and wire its hover affordance. Shared by
+    -- both kinds -- secure action rows and insecure clickable ones -- because
+    -- they are the same thing to the player: an interactive tooltip row.
+    -- The accent recolor only shows if the row's left text carries no embedded
+    -- |c..|r codes; callers pass the normal color through the left-color args.
+    local function PlaceRowOverlay(b, i, d, innerW, ar, ag, ab)
+        b:ClearAllPoints()
+        b:SetPoint("TOPLEFT", tip, "TOPLEFT", PAD, d._y)
+        b:SetSize(max(1, innerW), max(1, d._h))
+        local row = rows[i]
+        local lr, lg, lb = d.lr or 1, d.lg or 1, d.lb or 1
+        b:SetScript("OnEnter", function() row.left:SetTextColor(ar, ag, ab, 1) end)
+        b:SetScript("OnLeave", function() row.left:SetTextColor(lr, lg, lb, 1) end)
+        b:Show()
     end
 
     local function StopKeepAlive()
@@ -1256,14 +1273,7 @@ do
                         b:SetAttribute("spell", nil)
                         b:SetAttribute("toy", nil)
                     end
-                    b:ClearAllPoints()
-                    b:SetPoint("TOPLEFT", tip, "TOPLEFT", PAD, d._y)
-                    b:SetSize(max(1, innerW), max(1, d._h))
-                    local row = rows[i]
-                    local lr, lg, lb = d.lr or 1, d.lg or 1, d.lb or 1
-                    b:SetScript("OnEnter", function() row.left:SetTextColor(ar, ag, ab, 1) end)
-                    b:SetScript("OnLeave", function() row.left:SetTextColor(lr, lg, lb, 1) end)
-                    b:Show()
+                    PlaceRowOverlay(b, i, d, innerW, ar, ag, ab)
                 end
             end
         end
@@ -1279,20 +1289,9 @@ do
                 interactive = true
                 if not car then car, cag, cab = ns.GetAccent() end
                 local b = AcquireClickButton()
-                b:ClearAllPoints()
-                b:SetPoint("TOPLEFT", tip, "TOPLEFT", PAD, d._y)
-                b:SetSize(max(1, innerW), max(1, d._h))
-                -- Hover affordance: recolor the row's left text to the accent,
-                -- exactly like the M+ teleport rows. For this to show, the row
-                -- text must NOT embed its own |c..|r codes -- callers pass the
-                -- normal color through the left-color args instead.
-                local row = rows[i]
-                local lr, lg, lb = d.lr or 1, d.lg or 1, d.lb or 1
                 local cb = d.onClick
-                b:SetScript("OnEnter", function() row.left:SetTextColor(car, cag, cab, 1) end)
-                b:SetScript("OnLeave", function() row.left:SetTextColor(lr, lg, lb, 1) end)
+                PlaceRowOverlay(b, i, d, innerW, car, cag, cab)
                 b:SetScript("OnClick", function(_, mouseButton) cb(mouseButton) end)
-                b:Show()
             end
         end
 

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -1440,26 +1440,42 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         end
         local store = GoldStore()
         local total, charList = 0, {}
-        for _, cdata in pairs(store) do
+        -- The store key ("Name-Realm") rides along: it is what a delete needs,
+        -- and the entry itself does not carry it.
+        for key, cdata in pairs(store) do
             if cdata and cdata.currentMoney then
-                tinsert(charList, cdata)
+                tinsert(charList, { key = key, data = cdata })
                 total = total + cdata.currentMoney
             end
         end
-        tsort(charList, function(a, b) return (a.currentMoney or 0) > (b.currentMoney or 0) end)
+        tsort(charList, function(a, b) return (a.data.currentMoney or 0) > (b.data.currentMoney or 0) end)
         if #charList > 0 then
+            local selfKey = GoldCharKey()
             ns.Tip_AddLine(" ")
             ns.Tip_AddLine(GetRealmName() or "?", 0.5, 0.78, 1)
-            for _, char in ipairs(charList) do
+            for _, entry in ipairs(charList) do
+                local char = entry.data
                 local cr, cg, cb = 1, 1, 1
                 if char.class and RAID_CLASS_COLORS and RAID_CLASS_COLORS[char.class] then
                     local cc = RAID_CLASS_COLORS[char.class]; cr, cg, cb = cc.r, cc.g, cc.b
                 end
                 local label = char.name or "?"
-                if char.name == UnitName("player") then
+                local tokens = ns.MoneyTokens(char.currentMoney, sm, ci)
+                if entry.key == selfKey then
+                    -- The live character re-saves itself on every money event,
+                    -- so deleting it would only bring it straight back.
                     label = label .. " |TInterface\\COMMON\\Indicator-Green:14|t"
+                    ns.Tip_AddColumns(label, tokens, cr, cg, cb)
+                else
+                    local delKey = entry.key
+                    ns.Tip_AddClickableColumns(label, tokens, function(mouseButton)
+                        if mouseButton ~= "LeftButton" then return end
+                        if not (IsControlKeyDown() and IsAltKeyDown()) then return end
+                        GoldStore()[delKey] = nil
+                        ns.Tip_Hide(goldButton)
+                        for gi in pairs(goldInstances) do gi:QueueRefresh() end
+                    end, cr, cg, cb)
                 end
-                ns.Tip_AddDouble(label, ns.FormatMoney(char.currentMoney, true, sm, ci), cr, cg, cb, 1, 1, 1)
             end
         end
         local bankType = 2
@@ -1482,11 +1498,16 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         ns.Tip_AddDouble(L["LEFT_CLICK"],       L["OPEN_BAGS"],       1, 1, 1, ar, ag, ab)
         ns.Tip_AddDouble(L["RIGHT_CLICK"],      L["OPEN_CURRENCIES"], 1, 1, 1, ar, ag, ab)
         ns.Tip_AddDouble(L["CTRL_RIGHT_CLICK"], L["RESET_SESSION"],   1, 1, 1, ar, ag, ab)
+        if #charList > 1 then
+            ns.Tip_AddDouble(L["CTRL_ALT_LEFT_CLICK"], L["REMOVE_CHARACTER"], 1, 1, 1, ar, ag, ab)
+        end
         ns.Tip_Show()
     end)
     goldButton:SetScript("OnLeave", function()
         mouseOver = false
-        ns.Tip_Hide(goldButton)
+        -- The character rows are clickable, so the tooltip has to survive the
+        -- cursor leaving the block to be reachable at all.
+        ns.Tip_HideUnlessInteractive(goldButton)
         inst:Refresh()
     end)
     goldButton:SetScript("OnClick", function(_, button)

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -1126,6 +1126,13 @@ local function GoldStore()
     return profile.characters
 end
 
+-- Drop a character the player no longer has (renamed, deleted, transferred).
+-- Sits next to the writer so both mutations of the store are in one place.
+local function GoldForgetCharacter(key)
+    GoldStore()[key] = nil
+    for gi in pairs(goldInstances) do gi:QueueRefresh() end
+end
+
 local function GoldSaveCurrentMoney(money)
     local store = GoldStore()
     local _, class = UnitClass("player")
@@ -1203,46 +1210,6 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
     local function D() return blockCfg.settings or {} end
     local function BC() return barCtx.cfg end
 
-    local _sideLinesBuf = { "", "", "" }
-    local _sideLineCount = 0
-    -- coin: Coin Colored text mode -- suffix letters carry the denomination
-    -- colors (same codes as ns.FormatMoney), numbers inherit the white base.
-    local function GetMoneySideLines(amount, showSmall, coin, coinIcons)
-        amount = floor(abs(amount or 0))
-        local gold   = floor(amount / 10000)
-        local silver = floor((amount % 10000) / 100)
-        local copper = amount % 100
-        local gStr
-        if BreakUpLargeNumbers then gStr = BreakUpLargeNumbers(gold) else gStr = tostring(gold) end
-        -- Coin icons carry their own color, so Coin Colored has nothing left to
-        -- tint and the two options compose instead of fighting.
-        if coinIcons then
-            _sideLinesBuf[1] = gStr .. ns.COIN_TEX[1]
-        elseif coin then
-            _sideLinesBuf[1] = gStr .. "|cffe2ac7a" .. GOLD_AMOUNT_SYMBOL .. "|r"
-        else
-            _sideLinesBuf[1] = gStr .. GOLD_AMOUNT_SYMBOL
-        end
-        if showSmall ~= false then
-            if coinIcons then
-                _sideLinesBuf[2] = silver .. ns.COIN_TEX[2]
-                _sideLinesBuf[3] = copper .. ns.COIN_TEX[3]
-            elseif coin then
-                _sideLinesBuf[2] = silver .. "|cffc7c7cf" .. SILVER_AMOUNT_SYMBOL .. "|r"
-                _sideLinesBuf[3] = copper .. "|cffed8a3f" .. COPPER_AMOUNT_SYMBOL .. "|r"
-            else
-                _sideLinesBuf[2] = silver .. SILVER_AMOUNT_SYMBOL
-                _sideLinesBuf[3] = copper .. COPPER_AMOUNT_SYMBOL
-            end
-            _sideLineCount = 3
-        else
-            _sideLinesBuf[2] = nil
-            _sideLinesBuf[3] = nil
-            _sideLineCount = 1
-        end
-        return _sideLinesBuf, _sideLineCount
-    end
-
     local goldButton = CreateFrame("Button", nil, content)
     goldButton:SetSize(120, 20); goldButton:SetPoint("CENTER")
     goldButton:EnableMouse(true); goldButton:RegisterForClicks("AnyUp")
@@ -1274,12 +1241,15 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         if isSide then
             local slotW = VSlotW(inst)
             local innerW = max(30, slotW - 8)
-            local lines, lineCount = GetMoneySideLines(money, dg.showSmall == true,
-                blockCfg.useCoinColor == true and not mouseOver, ci)
+            -- One token per coin, one coin per line. Coin Colored tints the
+            -- suffix letters (nothing to tint once Coin Icons is on, so the two
+            -- compose); hovering drops it so the accent wash reads.
+            local lines = ns.MoneyTokens(money, dg.showSmall == true, ci,
+                blockCfg.useCoinColor == true and not mouseOver)
             local startSize = min(fontSize, max(10, floor(CONTENT_BASE * 0.52 + 0.5)))
             local goldFontSize = startSize
             ns.SetFont(goldText, goldFontSize, barCfg)
-            goldText:SetText(tconcat(lines, "\n", 1, lineCount))
+            goldText:SetText(tconcat(lines, "\n"))
             local r, g, b
             if mouseOver then r, g, b = ns.GetAccent()
             elseif blockCfg.useCoinColor then r, g, b = 1, 1, 1
@@ -1435,41 +1405,41 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             ns.Tip_AddDouble(label, ns.FormatMoney(abs(net), true, sm, ci), 0.6, 0.6, 0.6, nr, ngr, 0.3)
         end
         local store = GoldStore()
+        -- The list holds store KEYS ("Name-Realm"): a delete needs the key, and
+        -- the entry itself does not carry one.
         local total, charList = 0, {}
-        -- The store key ("Name-Realm") rides along: it is what a delete needs,
-        -- and the entry itself does not carry it.
         for key, cdata in pairs(store) do
             if cdata and cdata.currentMoney then
-                tinsert(charList, { key = key, data = cdata })
+                tinsert(charList, key)
                 total = total + cdata.currentMoney
             end
         end
-        tsort(charList, function(a, b) return (a.data.currentMoney or 0) > (b.data.currentMoney or 0) end)
+        tsort(charList, function(a, b)
+            return (store[a].currentMoney or 0) > (store[b].currentMoney or 0)
+        end)
         if #charList > 0 then
             local selfKey = GoldCharKey()
             ns.Tip_AddLine(" ")
             ns.Tip_AddLine(GetRealmName() or "?", 0.5, 0.78, 1)
-            for _, entry in ipairs(charList) do
-                local char = entry.data
+            for _, key in ipairs(charList) do
+                local char = store[key]
                 local cr, cg, cb = 1, 1, 1
                 if char.class and RAID_CLASS_COLORS and RAID_CLASS_COLORS[char.class] then
                     local cc = RAID_CLASS_COLORS[char.class]; cr, cg, cb = cc.r, cc.g, cc.b
                 end
                 local label = char.name or "?"
-                local tokens = ns.MoneyTokens(char.currentMoney, sm, ci)
-                if entry.key == selfKey then
+                local tokens = ns.MoneyTokens(char.currentMoney, sm, ci, true)
+                if key == selfKey then
                     -- The live character re-saves itself on every money event,
                     -- so deleting it would only bring it straight back.
                     label = label .. " |TInterface\\COMMON\\Indicator-Green:14|t"
                     ns.Tip_AddColumns(label, tokens, cr, cg, cb)
                 else
-                    local delKey = entry.key
                     ns.Tip_AddClickableColumns(label, tokens, function(mouseButton)
                         if mouseButton ~= "LeftButton" then return end
                         if not (IsControlKeyDown() and IsAltKeyDown()) then return end
-                        GoldStore()[delKey] = nil
+                        GoldForgetCharacter(key)
                         ns.Tip_Hide(goldButton)
-                        for gi in pairs(goldInstances) do gi:QueueRefresh() end
                     end, cr, cg, cb)
                 end
             end

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -1207,25 +1207,36 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
     local _sideLineCount = 0
     -- coin: Coin Colored text mode -- suffix letters carry the denomination
     -- colors (same codes as ns.FormatMoney), numbers inherit the white base.
-    local function GetMoneySideLines(amount, showSmall, coin)
+    local function GetMoneySideLines(amount, showSmall, coin, coinIcons)
         amount = floor(abs(amount or 0))
+        -- Coin icons: GetCoinTextureString emits every denomination in one
+        -- string, so the vertical bar shows it as a single wrapped line
+        -- instead of one line per denomination. Coin Colored has nothing left
+        -- to tint -- the textures carry their own color.
+        if coinIcons then
+            _sideLinesBuf[1] = ns.CoinIconString(amount)
+            _sideLinesBuf[2] = nil
+            _sideLinesBuf[3] = nil
+            _sideLineCount = 1
+            return _sideLinesBuf, _sideLineCount
+        end
         local gold   = floor(amount / 10000)
         local silver = floor((amount % 10000) / 100)
         local copper = amount % 100
         local gStr
         if BreakUpLargeNumbers then gStr = BreakUpLargeNumbers(gold) else gStr = tostring(gold) end
         if coin then
-            _sideLinesBuf[1] = gStr .. "|cffe2ac7a" .. L["GOLD_SUFFIX"] .. "|r"
+            _sideLinesBuf[1] = gStr .. "|cffe2ac7a" .. GOLD_AMOUNT_SYMBOL .. "|r"
         else
-            _sideLinesBuf[1] = gStr .. L["GOLD_SUFFIX"]
+            _sideLinesBuf[1] = gStr .. GOLD_AMOUNT_SYMBOL
         end
         if showSmall ~= false then
             if coin then
-                _sideLinesBuf[2] = silver .. "|cffc7c7cf" .. L["SILVER_SUFFIX"] .. "|r"
-                _sideLinesBuf[3] = copper .. "|cffed8a3f" .. L["COPPER_SUFFIX"] .. "|r"
+                _sideLinesBuf[2] = silver .. "|cffc7c7cf" .. SILVER_AMOUNT_SYMBOL .. "|r"
+                _sideLinesBuf[3] = copper .. "|cffed8a3f" .. COPPER_AMOUNT_SYMBOL .. "|r"
             else
-                _sideLinesBuf[2] = silver .. L["SILVER_SUFFIX"]
-                _sideLinesBuf[3] = copper .. L["COPPER_SUFFIX"]
+                _sideLinesBuf[2] = silver .. SILVER_AMOUNT_SYMBOL
+                _sideLinesBuf[3] = copper .. COPPER_AMOUNT_SYMBOL
             end
             _sideLineCount = 3
         else
@@ -1263,11 +1274,12 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         ns.SetFont(bagText, fontSize, barCfg)
 
         local money = GetMoney()
+        local ci = dg.coinIcons == true
         if isSide then
             local slotW = VSlotW(inst)
             local innerW = max(30, slotW - 8)
             local lines, lineCount = GetMoneySideLines(money, dg.showSmall == true,
-                blockCfg.useCoinColor == true and not mouseOver)
+                blockCfg.useCoinColor == true and not mouseOver, ci)
             local startSize = min(fontSize, max(10, floor(CONTENT_BASE * 0.52 + 0.5)))
             local goldFontSize = startSize
             ns.SetFont(goldText, goldFontSize, barCfg)
@@ -1278,11 +1290,11 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             else r, g, b = BlockColorOf(blockCfg) end
             goldText:SetTextColor(r, g, b, 1)
         elseif mouseOver then
-            goldText:SetText(ns.FormatMoneyPlain(money, dg.showSmall == true))
+            goldText:SetText(ns.FormatMoneyPlain(money, dg.showSmall == true, ci))
             local r, g, b = ns.GetAccent()
             goldText:SetTextColor(r, g, b, 1)
         else
-            goldText:SetText(ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true))
+            goldText:SetText(ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci))
             if blockCfg.useCoinColor then
                 goldText:SetTextColor(1, 1, 1, 1)
             else
@@ -1351,8 +1363,8 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             -- Fit against BOTH money formats so font/icon size (and the frame
             -- width below) stay identical whether hovered or not; otherwise
             -- the element visibly resizes on mouseover.
-            local plainText = ns.FormatMoneyPlain(money, dg.showSmall == true)
-            local fancyText = ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true)
+            local plainText = ns.FormatMoneyPlain(money, dg.showSmall == true, ci)
+            local fancyText = ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci)
             local moneyText
             if mouseOver then moneyText = plainText else moneyText = fancyText end
             local bagTextValue = ""
@@ -1410,20 +1422,21 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         inst:Refresh()
         -- Tooltip money lines honor the block's Show Silver and Copper toggle.
         local sm = D().showSmall == true
+        local ci = D().coinIcons == true
         local ar, ag, ab = 1, 1, 1
         ns.Tip_Begin(goldButton)
         ns.Tip_AddLine(L["GOLD"], ar, ag, ab)
         ns.Tip_AddLine(" ")
         ns.Tip_AddLine(L["SESSION"], 0.8, 0.8, 0.8)
-        ns.Tip_AddDouble(L["EARNED"], ns.FormatMoney(goldLedger.profit, true, sm), 0.6, 0.6, 0.6, 0, 1, 0)
-        ns.Tip_AddDouble(L["SPENT"],  ns.FormatMoney(goldLedger.spent,  true, sm), 0.6, 0.6, 0.6, 1, 0.3, 0.3)
+        ns.Tip_AddDouble(L["EARNED"], ns.FormatMoney(goldLedger.profit, true, sm, ci), 0.6, 0.6, 0.6, 0, 1, 0)
+        ns.Tip_AddDouble(L["SPENT"],  ns.FormatMoney(goldLedger.spent,  true, sm, ci), 0.6, 0.6, 0.6, 1, 0.3, 0.3)
         local net = goldLedger.profit - goldLedger.spent
         if net ~= 0 then
             local label
             if net > 0 then label = L["PROFIT"] else label = L["DEFICIT"] end
             local nr, ngr = 1, 0.3
             if net > 0 then nr, ngr = 0, 1 end
-            ns.Tip_AddDouble(label, ns.FormatMoney(abs(net), true, sm), 0.6, 0.6, 0.6, nr, ngr, 0.3)
+            ns.Tip_AddDouble(label, ns.FormatMoney(abs(net), true, sm, ci), 0.6, 0.6, 0.6, nr, ngr, 0.3)
         end
         local store = GoldStore()
         local total, charList = 0, {}
@@ -1446,7 +1459,7 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
                 if char.name == UnitName("player") then
                     label = label .. " |TInterface\\COMMON\\Indicator-Green:14|t"
                 end
-                ns.Tip_AddDouble(label, ns.FormatMoney(char.currentMoney, true, sm), cr, cg, cb, 1, 1, 1)
+                ns.Tip_AddDouble(label, ns.FormatMoney(char.currentMoney, true, sm, ci), cr, cg, cb, 1, 1, 1)
             end
         end
         local bankType = 2
@@ -1455,15 +1468,15 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             local wbank = C_Bank.FetchDepositedMoney(bankType)
             if wbank and wbank > 0 then
                 ns.Tip_AddLine(" ")
-                ns.Tip_AddDouble(L["WARBANK"], ns.FormatMoney(wbank, true, sm), 0.6, 0.6, 0.6, 1, 1, 1)
+                ns.Tip_AddDouble(L["WARBANK"], ns.FormatMoney(wbank, true, sm, ci), 0.6, 0.6, 0.6, 1, 1, 1)
                 total = total + wbank
             end
         end
         ns.Tip_AddLine(" ")
-        ns.Tip_AddDouble(L["TOTAL"], ns.FormatMoney(total, true, sm), ar, ag, ab, 1, 1, 1)
+        ns.Tip_AddDouble(L["TOTAL"], ns.FormatMoney(total, true, sm, ci), ar, ag, ab, 1, 1, 1)
         if goldLedger.tokenPrice and goldLedger.tokenPrice > 0 then
             ns.Tip_AddLine(" ")
-            ns.Tip_AddDouble(L["WOW_TOKEN"], ns.FormatMoney(goldLedger.tokenPrice, true, sm), 0, 0.8, 1, 1, 1, 1)
+            ns.Tip_AddDouble(L["WOW_TOKEN"], ns.FormatMoney(goldLedger.tokenPrice, true, sm, ci), 0, 0.8, 1, 1, 1, 1)
         end
         ns.Tip_AddLine(" ")
         ns.Tip_AddDouble(L["LEFT_CLICK"],       L["OPEN_BAGS"],       1, 1, 1, ar, ag, ab)

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -1209,29 +1209,25 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
     -- colors (same codes as ns.FormatMoney), numbers inherit the white base.
     local function GetMoneySideLines(amount, showSmall, coin, coinIcons)
         amount = floor(abs(amount or 0))
-        -- Coin icons: GetCoinTextureString emits every denomination in one
-        -- string, so the vertical bar shows it as a single wrapped line
-        -- instead of one line per denomination. Coin Colored has nothing left
-        -- to tint -- the textures carry their own color.
-        if coinIcons then
-            _sideLinesBuf[1] = ns.CoinIconString(amount)
-            _sideLinesBuf[2] = nil
-            _sideLinesBuf[3] = nil
-            _sideLineCount = 1
-            return _sideLinesBuf, _sideLineCount
-        end
         local gold   = floor(amount / 10000)
         local silver = floor((amount % 10000) / 100)
         local copper = amount % 100
         local gStr
         if BreakUpLargeNumbers then gStr = BreakUpLargeNumbers(gold) else gStr = tostring(gold) end
-        if coin then
+        -- Coin icons carry their own color, so Coin Colored has nothing left to
+        -- tint and the two options compose instead of fighting.
+        if coinIcons then
+            _sideLinesBuf[1] = gStr .. ns.COIN_TEX[1]
+        elseif coin then
             _sideLinesBuf[1] = gStr .. "|cffe2ac7a" .. GOLD_AMOUNT_SYMBOL .. "|r"
         else
             _sideLinesBuf[1] = gStr .. GOLD_AMOUNT_SYMBOL
         end
         if showSmall ~= false then
-            if coin then
+            if coinIcons then
+                _sideLinesBuf[2] = silver .. ns.COIN_TEX[2]
+                _sideLinesBuf[3] = copper .. ns.COIN_TEX[3]
+            elseif coin then
                 _sideLinesBuf[2] = silver .. "|cffc7c7cf" .. SILVER_AMOUNT_SYMBOL .. "|r"
                 _sideLinesBuf[3] = copper .. "|cffed8a3f" .. COPPER_AMOUNT_SYMBOL .. "|r"
             else

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Options.lua
@@ -2660,6 +2660,9 @@ initFrame:SetScript("OnEvent", function(self)
                 typeRows = {
                     MkToggle("Show Icon", "showIcons", "Shows the coin icon next to the amount."),
                     MkToggle("Show Bag Space", "showBagSpace", "Shows your free bag slots."),
+                    -- Off (default) = the letter suffixes; on = coin textures.
+                    -- Independent of Coin Colored, which tints those letters.
+                    MkToggle("Coin Icons", "coinIcons", "Uses Blizzard's coin textures instead of the letter suffixes."),
                 }
             elseif b.type == "xprep" then
                 typeRows = {


### PR DESCRIPTION
> Stacked on #874 (`fix/databars-gold-coin-locale`). Until that merges, the diff below includes its commit; GitHub drops it automatically once the base lands.

## The problem

The gold tooltip lists every character on the account with their last known balance. Nothing ever removes an entry. Rename a character, delete one, transfer it — the old name stays in the list forever, with a balance that will never update again, and the only way out is wiping the saved variables.

The amounts were also hard to read down the list: each row printed one string, and the game font is proportional, so `9o` and `1 234o` are different widths and the suffixes never lined up.

## The fix

**Ctrl + Alt + Left Click** on a character row removes that entry. The gesture is deliberately awkward: it is unconfirmed and unrecoverable, and the modifier pair is the guard. The hint line appears only when there is something to delete.

The live character is not clickable — it re-saves itself on every money event, so deleting it would only bring it straight back — and keeps its green indicator. Identifying it by store key rather than by name also stops an alt on a connected realm being mistaken for you.

The amounts now go through `Tip_AddColumns`, which measures each column across all rows, so the suffixes line up down the list in both text and coin-icon modes.

## Shared tooltip layer

Making the rows clickable exposed two things in the shared layer:

**The two kinds of interactive row did not look alike.** The secure action rows (Mythic+ teleports, hearthstone) carry a white 0.10 `HIGHLIGHT` wash across the whole row; the insecure clickable rows (social, guild) only ever recolored their left text — while the code's own comment claimed the two behaved alike. The missing half is the one that reads as *this line is the target*. `AcquireClickButton` now creates the same highlight its secure sibling does, which also completes what the social and guild rows were meant to get when they were added.

**Two copies of "what an interactive row is."** The hover wash lived in the two pool factories and the geometry plus accent recolor was eight lines duplicated verbatim in `Tip_Show`. Two copies of an invariant is exactly how the look drifted in the first place. `AddRowHighlight` and `PlaceRowOverlay` now hold it once, so a third kind of interactive row inherits it instead of reinventing it.

`Tip_AddClickableColumns` decorates `Tip_AddColumns` the way `Tip_AddClickable` already decorates `Tip_AddDouble`. The two were mutually exclusive only because each add-function cleared the other's field; the click overlay is placed over the row's rectangle and never cared how the row was laid out.

## Notes for translators

Two new source strings: `Remove Character` and `Ctrl + Alt + Left Click:`. Both reach `EllesmereUI.L` through the module's `ns.L` table, so `Locales/_keys.txt` is unchanged (verified).

## Testing

- add a character's worth of gold on an alt, then remove that alt's entry from the tooltip
- confirm a plain click on a row does nothing, and that the current character has no delete
- the money columns line up, in text mode and with Coin Icons on
- the whole row washes on hover, and the name returns to its class color on leave
- **the shared change reaches other blocks**: the social, guild and travel tooltips should behave identically

`luac -p` clean on all three files.

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
