### PR TITLE
[feature] Glow color swatches widget + default tint using true atlas textures

### DIFF
--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -895,65 +895,61 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline color swatch on Glow Type (right of row 3)
         do
             local rgn = row2._rightRegion
-            local swatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel()+5,
-                function()
-                    local d = DDB()
-                    local gc = d and d.glowColor or {r=1, g=0.776, b=0.376}
-                    return gc.r, gc.g, gc.b, 1
-                end,
-                function(r, g, b)
-                    local d = DDB(); if not d then return end
-                    d.glowColor = {r=r, g=g, b=b}
-                    d.glowColorMode = "custom"
-                    RefreshAll(); UpdatePreviewHeader()
-                end, false, 20)
-            swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -12, 0)
-            swatch:HookScript("OnEnter", function()
-                EllesmereUI.ShowWidgetTooltip(swatch, "Custom Color")
-            end)
-            swatch:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-
-            local defaultSwatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel()+5,
-                function() return 1.0, 0.788, 0.137, 1 end,
-                function() end, false, 20)
+            local isNone = function()
+                local d = DDB()
+                return not d or (d.glowType or 0) == 0
+            end
+            local swatch, defaultSwatch, classSwatch = EllesmereUI.BuildTrioColorSwatch(
+                rgn, rgn:GetFrameLevel()+5,
+                {
+                    getMode = function()
+                        local d = DDB()
+                        return (d and d.glowColorMode) or "default"
+                    end,
+                    setMode = function(m)
+                        local d = DDB(); if not d then return end
+                        d.glowColorMode = m
+                    end,
+                    getCustomRGB = function()
+                        local d = DDB()
+                        local gc = d and d.glowColor or {r=1.0, g=0.788, b=0.137}
+                        return gc.r, gc.g, gc.b
+                    end,
+                    setCustomRGB = function(r, g, b)
+                        local d = DDB(); if not d then return end
+                        d.glowColor = {r=r, g=g, b=b}
+                    end,
+                    hasClassColor = true,
+                    onChange = function() RefreshAll(); UpdatePreviewHeader(); EllesmereUI:RefreshPage() end,
+                    disabled = isNone,
+                    overrideSize = 20,
+                })
+            classSwatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -12, 0)
+            swatch:SetPoint("RIGHT", classSwatch, "LEFT", -8, 0)
             defaultSwatch:SetPoint("RIGHT", swatch, "LEFT", -8, 0)
             rgn._lastInline = defaultSwatch
-            defaultSwatch:SetScript("OnClick", function()
-                local d = DDB(); if not d then return end
-                d.glowColorMode = "default"
-                RefreshAll(); UpdatePreviewHeader()
-                EllesmereUI:RefreshPage()
-            end)
-            defaultSwatch:SetScript("OnEnter", function()
-                EllesmereUI.ShowWidgetTooltip(defaultSwatch, "Default (Untinted)")
-            end)
-            defaultSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
 
             -- Disabled overlay when glow type is None
-            local swatchBlock = CreateFrame("Frame", nil, swatch)
-            swatchBlock:SetAllPoints()
-            swatchBlock:SetFrameLevel(swatch:GetFrameLevel() + 10)
-            swatchBlock:EnableMouse(true)
-            swatchBlock:SetScript("OnEnter", function()
-                EllesmereUI.ShowWidgetTooltip(swatch, EllesmereUI.DisabledTooltip("This option requires a Glow Type other than None"))
-            end)
-            swatchBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-            local function UpdateSwatchDisabled()
-                local d = DDB()
-                local isNone = not d or (d.glowType or 0) == 0
-                local isCustom = d and _G._EABR_ResolveGlowTint and _G._EABR_ResolveGlowTint(d) ~= nil
-                if isNone then
-                    swatch:SetAlpha(0.3)
-                    defaultSwatch:SetAlpha(0.3)
-                    swatchBlock:Show()
-                else
-                    swatch:SetAlpha(isCustom and 1 or 0.3)
-                    defaultSwatch:SetAlpha(isCustom and 0.3 or 1)
-                    swatchBlock:Hide()
+            local function MakeSwatchBlock(target)
+                local block = CreateFrame("Frame", nil, target)
+                block:SetAllPoints()
+                block:SetFrameLevel(target:GetFrameLevel() + 10)
+                block:EnableMouse(true)
+                block:SetScript("OnEnter", function()
+                    EllesmereUI.ShowWidgetTooltip(target, EllesmereUI.DisabledTooltip("This option requires a Glow Type other than None"))
+                end)
+                block:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                return block
+            end
+            local swatchBlocks = { MakeSwatchBlock(swatch), MakeSwatchBlock(defaultSwatch), MakeSwatchBlock(classSwatch) }
+            local function UpdateSwatchBlock()
+                local none = isNone()
+                for _, block in ipairs(swatchBlocks) do
+                    if none then block:Show() else block:Hide() end
                 end
             end
-            UpdateSwatchDisabled()
-            EllesmereUI.RegisterWidgetRefresh(UpdateSwatchDisabled)
+            UpdateSwatchBlock()
+            EllesmereUI.RegisterWidgetRefresh(UpdateSwatchBlock)
         end
 
         -- Inline color swatch + cog on Show Text (left of row 2)

--- a/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIAuraBuffReminders/EUI_AuraBuffReminders_Options.lua
@@ -237,7 +237,13 @@ initFrame:SetScript("OnEvent", function(self)
         local sz = math.floor(ICON_SIZE * baseScale + 0.5)
         local spacing = d.iconSpacing or 8
         local glowType = d.glowType or 0
-        local gc = d.glowColor or {r=1, g=0.776, b=0.376}
+        local gr, gg, gb
+        if _G._EABR_ResolveGlowTint then
+            gr, gg, gb = _G._EABR_ResolveGlowTint(d)
+        else
+            local gc = d.glowColor or {r=1, g=0.776, b=0.376}
+            gr, gg, gb = gc.r, gc.g, gc.b
+        end
         local showText = d.showText
         local tc = d.textColor or {r=1, g=1, b=1}
         local opacity = d.opacity or 1.0
@@ -267,15 +273,17 @@ initFrame:SetScript("OnEvent", function(self)
             if glowType > 0 and GT then
                 local entry = GT[glowType]
                 if entry then
+                    local pr, pg, pb = gr, gg, gb
+                    if pr == nil then pr, pg, pb = 1.0, 0.788, 0.137 end
                     if entry.procedural and _G._EABR_StartPixelGlow then
-                        _G._EABR_StartPixelGlow(btn._glowWrapper, sz, gc.r, gc.g, gc.b)
+                        _G._EABR_StartPixelGlow(btn._glowWrapper, sz, pr, pg, pb)
                     elseif entry.buttonGlow and _G._EABR_StartButtonGlow then
-                        _G._EABR_StartButtonGlow(btn._glowWrapper, sz, gc.r, gc.g, gc.b, 1.36)
+                        _G._EABR_StartButtonGlow(btn._glowWrapper, sz, pr, pg, pb, 1.36)
                     elseif entry.autocast and _G._EABR_StartAutoCastShine then
-                        _G._EABR_StartAutoCastShine(btn._glowWrapper, sz, gc.r, gc.g, gc.b, 1.0)
+                        _G._EABR_StartAutoCastShine(btn._glowWrapper, sz, pr, pg, pb, 1.0)
                     elseif _G._EABR_StartFlipBookGlow then
                         -- FlipBook glow (GCD, Modern WoW, Classic WoW) use shared live function
-                        _G._EABR_StartFlipBookGlow(btn._glowWrapper, sz, entry, gc.r, gc.g, gc.b)
+                        _G._EABR_StartFlipBookGlow(btn._glowWrapper, sz, entry, gr, gg, gb)
                     end
                     btn._glowWrapper:Show()
                 end
@@ -896,10 +904,30 @@ initFrame:SetScript("OnEvent", function(self)
                 function(r, g, b)
                     local d = DDB(); if not d then return end
                     d.glowColor = {r=r, g=g, b=b}
+                    d.glowColorMode = "custom"
                     RefreshAll(); UpdatePreviewHeader()
                 end, false, 20)
             swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -12, 0)
-            rgn._lastInline = swatch
+            swatch:HookScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(swatch, "Custom Color")
+            end)
+            swatch:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+            local defaultSwatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel()+5,
+                function() return 1.0, 0.788, 0.137, 1 end,
+                function() end, false, 20)
+            defaultSwatch:SetPoint("RIGHT", swatch, "LEFT", -8, 0)
+            rgn._lastInline = defaultSwatch
+            defaultSwatch:SetScript("OnClick", function()
+                local d = DDB(); if not d then return end
+                d.glowColorMode = "default"
+                RefreshAll(); UpdatePreviewHeader()
+                EllesmereUI:RefreshPage()
+            end)
+            defaultSwatch:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(defaultSwatch, "Default (Untinted)")
+            end)
+            defaultSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
 
             -- Disabled overlay when glow type is None
             local swatchBlock = CreateFrame("Frame", nil, swatch)
@@ -913,11 +941,14 @@ initFrame:SetScript("OnEvent", function(self)
             local function UpdateSwatchDisabled()
                 local d = DDB()
                 local isNone = not d or (d.glowType or 0) == 0
+                local isCustom = d and _G._EABR_ResolveGlowTint and _G._EABR_ResolveGlowTint(d) ~= nil
                 if isNone then
                     swatch:SetAlpha(0.3)
+                    defaultSwatch:SetAlpha(0.3)
                     swatchBlock:Show()
                 else
-                    swatch:SetAlpha(1)
+                    swatch:SetAlpha(isCustom and 1 or 0.3)
+                    defaultSwatch:SetAlpha(isCustom and 0.3 or 1)
                     swatchBlock:Hide()
                 end
             end

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -29,10 +29,8 @@ local DEFAULT_TEXT_COLOR = {r=1, g=1, b=1}
 local function ResolveGlowTint(p)
     if not p then return nil end
     if p.glowColorMode == "class" then
-        local _, ct = UnitClass("player")
-        local cc = ct and RAID_CLASS_COLORS[ct]
-        if cc then return cc.r, cc.g, cc.b end
-        return nil
+        local cc = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
+        return cc.r, cc.g, cc.b
     end
     if p.glowColorMode ~= "custom" then return nil end
     local c = p.glowColor

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -27,13 +27,17 @@ local DEFAULT_GLOW_COLOR = {r=1, g=0.776, b=0.376}
 local DEFAULT_TEXT_COLOR = {r=1, g=1, b=1}
 
 local function ResolveGlowTint(p)
-    local c = p and p.glowColor or DEFAULT_GLOW_COLOR
-    local mode = p and p.glowColorMode
-    local isStock = c.r == DEFAULT_GLOW_COLOR.r and c.g == DEFAULT_GLOW_COLOR.g and c.b == DEFAULT_GLOW_COLOR.b
-    if mode == "custom" or (mode == nil and not isStock) then
-        return c.r or 1, c.g or 0.776, c.b or 0.376
+    if not p then return nil end
+    if p.glowColorMode == "class" then
+        local _, ct = UnitClass("player")
+        local cc = ct and RAID_CLASS_COLORS[ct]
+        if cc then return cc.r, cc.g, cc.b end
+        return nil
     end
-    return nil
+    if p.glowColorMode ~= "custom" then return nil end
+    local c = p.glowColor
+    if not c then return nil end
+    return c.r or 1, c.g or 0.776, c.b or 0.376
 end
 
 local TEXT_ANCHOR_POINTS = {
@@ -1544,7 +1548,6 @@ local defaults = {
         display = {
             remindersEnabled = true,
             glowType = 0,
-            glowColor = {r=1, g=0.776, b=0.376},
             scale = 1.0,
             xOffset = 0,
             yOffset = 200,
@@ -3428,6 +3431,17 @@ end
 -------------------------------------------------------------------------------
 function EABR:OnInitialize()
     db = EllesmereUI.Lite.NewDB("EllesmereUIAuraBuffRemindersDB", defaults, true)
+
+    -- Live migration: glowColorMode replaced glowColor always being set
+    local d = db.profile.display
+    if d and not d.glowColorMode then
+        local c = d.glowColor
+        if c and not (c.r == 1 and c.g == 0.776 and c.b == 0.376) then
+            d.glowColorMode = "custom"
+        else
+            d.glowColorMode = "default"
+        end
+    end
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -26,6 +26,16 @@ local AURA_SCAN_LIMIT = 255  -- Midnight supports more than the legacy 40 buff l
 local DEFAULT_GLOW_COLOR = {r=1, g=0.776, b=0.376}
 local DEFAULT_TEXT_COLOR = {r=1, g=1, b=1}
 
+local function ResolveGlowTint(p)
+    local c = p and p.glowColor or DEFAULT_GLOW_COLOR
+    local mode = p and p.glowColorMode
+    local isStock = c.r == DEFAULT_GLOW_COLOR.r and c.g == DEFAULT_GLOW_COLOR.g and c.b == DEFAULT_GLOW_COLOR.b
+    if mode == "custom" or (mode == nil and not isStock) then
+        return c.r or 1, c.g or 0.776, c.b or 0.376
+    end
+    return nil
+end
+
 local TEXT_ANCHOR_POINTS = {
     BOTTOM = { "TOP",    "BOTTOM" },
     TOP    = { "BOTTOM", "TOP"    },
@@ -1809,6 +1819,9 @@ end
 local function ApplyGlow(btn, glowType, cr, cg, cb, overrideSz)
     if glowType == 0 then return end
     local entry = GLOW_TYPES[glowType]; if not entry then return end
+    if cr == nil and (entry.procedural or entry.buttonGlow or entry.autocast) then
+        cr, cg, cb = 1.0, 0.788, 0.137
+    end
     if not btn._eabrGlowWrapper then
         local w = CreateFrame("Frame", nil, btn); w:SetAllPoints(btn); w:SetFrameLevel(btn:GetFrameLevel()+4)
         btn._eabrGlowWrapper = w
@@ -2029,11 +2042,11 @@ local function ShowIcon(iconIdx, m)
     ApplySetup(btn, m)
     local p = db.profile.display
     local glowType = p.glowType or 0
-    local gc = p.glowColor or DEFAULT_GLOW_COLOR
+    local gr, gg, gb = ResolveGlowTint(p)
     local baseScale = p.scale or 1.0
     local sz = floor(ICON_SIZE * baseScale + 0.5)
     RemoveGlow(btn)
-    ApplyGlow(btn, glowType, gc.r, gc.g, gc.b, sz)
+    ApplyGlow(btn, glowType, gr, gg, gb, sz)
     if p.showText then
         local tc = p.textColor or DEFAULT_TEXT_COLOR
         local fontPath = ResolveFontPath(p.textFont)
@@ -2819,10 +2832,10 @@ local function Refresh()
                         if f then
                             RemoveGlow(f)
                             local p = db.profile.display
-                            local gc = p.glowColor or DEFAULT_GLOW_COLOR
+                            local gr, gg, gb = ResolveGlowTint(p)
                             local baseScale = p.scale or 1.0
                             local sz = floor(ICON_SIZE * baseScale + 0.5)
-                            ApplyGlow(f, p.glowType or 0, gc.r, gc.g, gc.b, sz)
+                            ApplyGlow(f, p.glowType or 0, gr, gg, gb, sz)
                         end
                     end
                 end
@@ -2860,10 +2873,10 @@ local function Refresh()
                     if f then
                         RemoveGlow(f)
                         local p = db.profile.display
-                        local gc = p.glowColor or DEFAULT_GLOW_COLOR
+                        local gr, gg, gb = ResolveGlowTint(p)
                         local baseScale = p.scale or 1.0
                         local sz = floor(ICON_SIZE * baseScale + 0.5)
-                        ApplyGlow(f, p.glowType or 0, gc.r, gc.g, gc.b, sz)
+                        ApplyGlow(f, p.glowType or 0, gr, gg, gb, sz)
                     end
                 else
                     iconIdx = iconIdx + 1
@@ -3220,10 +3233,10 @@ local function BeaconApplyGlow(f, show)
         local p = db and db.profile.display
         local glowType = p and p.glowType or 0
         if glowType > 0 then
-            local gc = p and p.glowColor or DEFAULT_GLOW_COLOR
+            local gr, gg, gb = ResolveGlowTint(p)
             local baseScale = p and p.scale or 1.0
             local sz = floor(ICON_SIZE * baseScale + 0.5)
-            ApplyGlow(f, glowType, gc.r, gc.g, gc.b, sz)
+            ApplyGlow(f, glowType, gr, gg, gb, sz)
         end
         _B.glowState[f._spellID] = true
     else
@@ -3437,6 +3450,7 @@ function EABR:OnEnable()
     _G._EABR_StartAutoCastShine = StartAutoCastShine
     _G._EABR_StartFlipBookGlow = StartFlipBookGlow
     _G._EABR_StopAllGlows = StopAllGlows
+    _G._EABR_ResolveGlowTint = ResolveGlowTint
     _G._EABR_RegisterUnlock = RegisterUnlockElements
     _G._EABR_ApplyUnlockPos = ApplyUnlockPos
     _G._EABR_RAID_BUFFS = RAID_BUFFS

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -282,13 +282,19 @@ initFrame:SetScript("OnEvent", function(self)
     -- (best-effort, name-based so styles never shift across surfaces). Callers
     -- build a payload with EllesmereUI.PandemicPayloadFrom* and pass it.
 
-    -- Create a pandemic glow preview icon in a DualRow right-half
-    local function BuildPandemicPreview(row, isOffFn, getDataFn)
+    -- Create a pandemic glow preview icon in a DualRow half. anchorRgn defaults
+    -- to the row's right half (row._rightRegion) for TBB's layout; CDM anchors
+    -- it inline in the left half instead
+    local function BuildPandemicPreview(row, isOffFn, getDataFn, anchorRgn)
         local SIDE_PAD = 20
         local iconSize = 36
         local iconFrame = CreateFrame("Frame", nil, row)
         PP.Size(iconFrame, iconSize, iconSize)
-        PP.Point(iconFrame, "RIGHT", row, "RIGHT", -SIDE_PAD, 0)
+        if anchorRgn then
+            PP.Point(iconFrame, "RIGHT", anchorRgn._control, "LEFT", -8, 0)
+        else
+            PP.Point(iconFrame, "RIGHT", row, "RIGHT", -SIDE_PAD, 0)
+        end
 
         local iconTex = iconFrame:CreateTexture(nil, "ARTWORK")
         iconTex:SetAllPoints()
@@ -323,7 +329,14 @@ initFrame:SetScript("OnEvent", function(self)
             local bd = getDataFn()
             if not bd then return end
             local style = bd.pandemicGlowStyle or 1
-            local c = bd.pandemicGlowColor
+            local c
+            if bd.pandemicGlowMode == "class" then
+                local _, ct = UnitClass("player")
+                local cc = ct and RAID_CLASS_COLORS[ct]
+                if cc then c = cc end
+            elseif bd.pandemicGlowMode == "custom" then
+                c = bd.pandemicGlowColor
+            end
             local glowOpts = (style == 1) and {
                 N = bd.pandemicGlowLines or 8,
                 th = bd.pandemicGlowThickness or 2,
@@ -334,11 +347,11 @@ initFrame:SetScript("OnEvent", function(self)
                     b = (bd.pandemicGlowBackgroundColor and bd.pandemicGlowBackgroundColor.b) or 0,
                 } or nil,
             } or nil
-            ns.StartNativeGlow(glowOvr, style, c and (c.r or 1), c and (c.g or 1), c and (c.b or 0), glowOpts)
+            ns.StartNativeGlow(glowOvr, style, c and c.r, c and c.g, c and c.b, glowOpts)
         end
         RefreshPreview()
 
-        local previewLabel = ({ row._rightRegion:GetRegions() })[1]
+        local previewLabel = not anchorRgn and ({ row._rightRegion:GetRegions() })[1]
         EllesmereUI.RegisterWidgetRefresh(function()
             local off = isOffFn()
             iconFrame:SetAlpha(off and 0.3 or 1)
@@ -349,6 +362,7 @@ initFrame:SetScript("OnEvent", function(self)
         end)
 
         row._refreshPreview = RefreshPreview
+        return iconFrame
     end
 
     -- Create a pixel glow cog popup for pandemic settings
@@ -771,8 +785,6 @@ initFrame:SetScript("OnEvent", function(self)
                     local newEntry = {
                         spellID = sp.spellID,
                         glowStyle = 1,
-                        glowColor = { r = 1, g = 0.82, b = 0.1 },
-                        classColor = false,
                         mode = "ACTIVE",
                         onlyInCombat = false,
                     }
@@ -1568,17 +1580,17 @@ initFrame:SetScript("OnEvent", function(self)
                         if not ov then return end
                         local style = BarHasCustomShape(curBar) and 2 or (entry.glowStyle or 1)
                         local cr, cg, cb
-                        if entry.classColor then
+                        if entry.colorMode == "class" then
                             local _, ct = UnitClass("player")
                             if ct then local cc = RAID_CLASS_COLORS[ct]; if cc then cr, cg, cb = cc.r, cc.g, cc.b end end
-                        elseif entry.glowColor then
+                        elseif entry.colorMode == "custom" and entry.glowColor then
                             cr, cg, cb = entry.glowColor.r, entry.glowColor.g, entry.glowColor.b
                         end
                         ns.StopNativeGlow(ov)
                         ns.StartNativeGlow(ov, style, cr, cg, cb)
                     end
 
-                    -- Row 2: Glow Type (with eyeball) | Class Colored Glow (with swatch)
+                    -- Row 2: Glow Type (with eyeball) | Glow Color Swatch Selectors
                     local glowRow
                     glowRow, h = W:DualRow(parent, y,
                         { type = "dropdown", text = "Glow Type",
@@ -1595,15 +1607,7 @@ initFrame:SetScript("OnEvent", function(self)
                               RefreshPreviewGlow()
                           end,
                         },
-                        { type = "toggle", text = "Class Colored Glow",
-                          getValue = function() return entry.classColor end,
-                          setValue = function(v)
-                              entry.classColor = v
-                              Refresh()
-                              RefreshPreviewGlow()
-                              EllesmereUI:RefreshPage()
-                          end,
-                        }
+                        { type = "label", text = "Glow Color" }
                     );  y = y - h
 
                     -- Eyeball preview toggle (on left region of glow type row)
@@ -1642,10 +1646,10 @@ initFrame:SetScript("OnEvent", function(self)
                                 else
                                     local style = BarHasCustomShape(curBar) and 2 or (entry.glowStyle or 1)
                                     local cr, cg, cb
-                                    if entry.classColor then
+                                    if entry.colorMode == "class" then
                                         local _, ct = UnitClass("player")
                                         if ct then local cc = RAID_CLASS_COLORS[ct]; if cc then cr, cg, cb = cc.r, cc.g, cc.b end end
-                                    elseif entry.glowColor then
+                                    elseif entry.colorMode == "custom" and entry.glowColor then
                                         cr, cg, cb = entry.glowColor.r, entry.glowColor.g, entry.glowColor.b
                                     end
                                     ns.StartNativeGlow(ov, style, cr, cg, cb)
@@ -1663,48 +1667,26 @@ initFrame:SetScript("OnEvent", function(self)
                     -- Inline color swatch for glow color (on right region of row 2)
                     do
                         local rightRgn = glowRow._rightRegion
-                        if rightRgn and rightRgn._control and EllesmereUI.BuildColorSwatch then
-                            local toggle = rightRgn._control
-                            local glowSwatch, updateGlowSwatch = EllesmereUI.BuildColorSwatch(
+                        if rightRgn and EllesmereUI.BuildTrioColorSwatch then
+                            local glowSwatch, defaultSwatch, classSwatch = EllesmereUI.BuildTrioColorSwatch(
                                 rightRgn, glowRow:GetFrameLevel() + 3,
-                                function()
-                                    if entry.classColor then
-                                        local _, ct = UnitClass("player")
-                                        if ct then local cc = RAID_CLASS_COLORS[ct]; if cc then return cc.r, cc.g, cc.b end end
-                                    end
-                                    local c = entry.glowColor or { r = 1, g = 0.82, b = 0.1 }
-                                    return c.r, c.g, c.b
-                                end,
-                                function(r, g, b)
-                                    entry.glowColor = { r = r, g = g, b = b }
-                                    entry.classColor = false
-                                    Refresh()
-                                    RefreshPreviewGlow()
-                                    EllesmereUI:RefreshPage()
-                                end,
-                                false, 20)
-                            PP.Point(glowSwatch, "RIGHT", toggle, "LEFT", -8, 0)
-
-                            local defaultSwatch = EllesmereUI.BuildColorSwatch(
-                                rightRgn, glowRow:GetFrameLevel() + 3,
-                                function() return 1.0, 0.788, 0.137 end,
-                                function() end,
-                                false, 20)
+                                {
+                                    getMode = function() return entry.colorMode or "default" end,
+                                    setMode = function(m) entry.colorMode = m end,
+                                    getCustomRGB = function()
+                                        local c = entry.glowColor or { r = 1.0, g = 0.788, b = 0.137 }
+                                        return c.r, c.g, c.b
+                                    end,
+                                    setCustomRGB = function(r, g, b)
+                                        entry.glowColor = { r = r, g = g, b = b }
+                                    end,
+                                    hasClassColor = true,
+                                    onChange = function() Refresh(); RefreshPreviewGlow(); EllesmereUI:RefreshPage() end,
+                                    overrideSize = 20,
+                                })
+                            PP.Point(classSwatch, "RIGHT", rightRgn, "RIGHT", -20, 0)
+                            PP.Point(glowSwatch, "RIGHT", classSwatch, "LEFT", -8, 0)
                             PP.Point(defaultSwatch, "RIGHT", glowSwatch, "LEFT", -8, 0)
-                            defaultSwatch:SetScript("OnClick", function()
-                                entry.glowColor = nil
-                                entry.classColor = false
-                                Refresh()
-                                RefreshPreviewGlow()
-                                EllesmereUI:RefreshPage()
-                            end)
-                            defaultSwatch:SetScript("OnEnter", function()
-                                EllesmereUI.ShowWidgetTooltip(defaultSwatch, "Default (Untinted)")
-                            end)
-                            defaultSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-                            local isDefault = not entry.classColor and not entry.glowColor
-                            defaultSwatch:SetAlpha(isDefault and 1 or 0.3)
-                            glowSwatch:SetAlpha(isDefault and 0.3 or 1)
                         end
                     end
 
@@ -17458,89 +17440,37 @@ initFrame:SetScript("OnEvent", function(self)
                 local leftRgn = buffGlowRow._leftRegion
                 local ctrl = leftRgn._control
 
-                local classSwatch, updateClassSwatch = EllesmereUI.BuildColorSwatch(
+                local noGlow = function()
+                    local gt = BD().buffGlowType or 0
+                    return gt == 0 or IsCustomShape()
+                end
+                local glowSwatch, defaultSwatch, classSwatch = EllesmereUI.BuildTrioColorSwatch(
                     leftRgn, buffGlowRow:GetFrameLevel() + 3,
-                    function()
-                        local _, classFile = UnitClass("player")
-                        local cc = classFile and RAID_CLASS_COLORS and RAID_CLASS_COLORS[classFile]
-                        if cc then return cc.r, cc.g, cc.b end
-                        return 1, 0.82, 0
-                    end,
-                    function() end,
-                    false, 20)
+                    {
+                        getMode = function() return BD().buffGlowMode or "default" end,
+                        setMode = function(m) BD().buffGlowMode = m; ns.BuildAllCDMBars() end,
+                        getCustomRGB = function() return BD().buffGlowR or 1.0, BD().buffGlowG or 0.788, BD().buffGlowB or 0.137 end,
+                        setCustomRGB = function(r, g, b)
+                            BD().buffGlowR = r; BD().buffGlowG = g; BD().buffGlowB = b
+                        end,
+                        hasClassColor = true,
+                        onChange = function() Refresh(); EllesmereUI:RefreshPage() end,
+                        disabled = noGlow,
+                        overrideSize = 20,
+                    })
                 PP.Point(classSwatch, "RIGHT", ctrl, "LEFT", -8, 0)
-                classSwatch:SetScript("OnClick", function()
-                    BD().buffGlowClassColor = true; ns.BuildAllCDMBars()
-                    Refresh(); EllesmereUI:RefreshPage()
-                end)
-                classSwatch:SetScript("OnEnter", function()
-                    EllesmereUI.ShowWidgetTooltip(classSwatch, "Class Colored")
-                end)
-                classSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-
-                local glowSwatch, updateGlowSwatch = EllesmereUI.BuildColorSwatch(
-                    leftRgn, buffGlowRow:GetFrameLevel() + 3,
-                    function() return BD().buffGlowR or 1.0, BD().buffGlowG or 0.776, BD().buffGlowB or 0.376 end,
-                    function(r, g, b)
-                        BD().buffGlowR = r; BD().buffGlowG = g; BD().buffGlowB = b
-                        ns.BuildAllCDMBars(); Refresh()
-                    end,
-                    false, 20)
                 PP.Point(glowSwatch, "RIGHT", classSwatch, "LEFT", -8, 0)
-                glowSwatch:SetScript("OnEnter", function()
-                    EllesmereUI.ShowWidgetTooltip(glowSwatch, "Custom Colored")
-                end)
-                glowSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                PP.Point(defaultSwatch, "RIGHT", glowSwatch, "LEFT", -8, 0)
 
-                -- Click the dimmed custom swatch to switch back from class/default color (no block overlay)
+                -- No glow selected (or custom shape): allow swapping boxes but do not open the color picker
                 local origGlowClick = glowSwatch:GetScript("OnClick")
                 glowSwatch:SetScript("OnClick", function(self, ...)
-                    if BD().buffGlowClassColor or BD().buffGlowR == nil then
-                        BD().buffGlowClassColor = false
-                        if BD().buffGlowR == nil then
-                            BD().buffGlowR = 1.0; BD().buffGlowG = 0.776; BD().buffGlowB = 0.376
-                        end
-                        ns.BuildAllCDMBars()
-                        Refresh(); EllesmereUI:RefreshPage()
-                        return
-                    end
-                    -- No glow selected (or custom shape): allow swapping boxes but do not open the color picker
-                    if (BD().buffGlowType or 0) == 0 or IsCustomShape() then return end
+                    if noGlow() then return end
                     if origGlowClick then origGlowClick(self, ...) end
                 end)
 
-                local defaultSwatch, updateDefaultSwatch = EllesmereUI.BuildColorSwatch(
-                    leftRgn, buffGlowRow:GetFrameLevel() + 3,
-                    function() return 1.0, 0.788, 0.137 end,
-                    function() end,
-                    false, 20)
-                PP.Point(defaultSwatch, "RIGHT", glowSwatch, "LEFT", -8, 0)
-                defaultSwatch:SetScript("OnClick", function()
-                    BD().buffGlowClassColor = false
-                    BD().buffGlowR = nil; BD().buffGlowG = nil; BD().buffGlowB = nil
-                    ns.BuildAllCDMBars()
-                    Refresh(); EllesmereUI:RefreshPage()
-                end)
-                defaultSwatch:SetScript("OnEnter", function()
-                    EllesmereUI.ShowWidgetTooltip(defaultSwatch, "Default (Untinted)")
-                end)
-                defaultSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-
                 -- Anchor for the inline pixel-glow cog (placed left of the swatches).
                 leftRgn._lastInline = defaultSwatch
-
-                local function UpdateBuffGlowState()
-                    local gt = BD().buffGlowType or 0
-                    local noGlow = gt == 0 or IsCustomShape()
-                    local isClassColored = BD().buffGlowClassColor
-                    local isCustom = not isClassColored and BD().buffGlowR ~= nil
-                    local isDefault = not isClassColored and not isCustom
-                    glowSwatch:SetAlpha((isCustom and not noGlow) and 1 or 0.3)
-                    classSwatch:SetAlpha((isClassColored and not noGlow) and 1 or 0.3)
-                    defaultSwatch:SetAlpha((isDefault and not noGlow) and 1 or 0.3)
-                end
-                EllesmereUI.RegisterWidgetRefresh(function() updateGlowSwatch(); updateClassSwatch(); updateDefaultSwatch(); UpdateBuffGlowState() end)
-                UpdateBuffGlowState()
             end
 
             -- (Pixel Glow Thickness / Lines / Speed moved to a dedicated row at the
@@ -18713,60 +18643,54 @@ initFrame:SetScript("OnEvent", function(self)
                       C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
                   end,
                   tooltip="Show a glow on icons when the remaining duration is in the pandemic window (last 30%)" },
-                { type="label", text="Pandemic Glow Preview" });  y = y - h
+                { type="label", text="Pandemic Glow Color" });  y = y - h
 
-            BuildPandemicPreview(panGlowRow, pandemicOff, BD)
-
-            do
-                local leftRgn = panGlowRow._leftRegion
-                local ctrl = leftRgn and leftRgn._control
-                if ctrl and EllesmereUI.BuildColorSwatch then
-                    local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
-                        leftRgn, panGlowRow:GetFrameLevel() + 3,
-                        function()
-                            local c = BD().pandemicGlowColor
-                            if c then return c.r or 1, c.g or 1, c.b or 0 end
-                            return BD().pandemicR or 1, BD().pandemicG or 1, BD().pandemicB or 0
-                        end,
-                        function(r, g, b)
-                            BD().pandemicGlowColor = { r = r, g = g, b = b }
-                            ns.BuildAllCDMBars(); Refresh()
-                            if panGlowRow._refreshPreview then panGlowRow._refreshPreview() end
-                        end, nil, 20)
-                    PP.Point(swatch, "RIGHT", ctrl, "LEFT", -12, 0)
-
-                    local defaultSwatch = EllesmereUI.BuildColorSwatch(
-                        leftRgn, panGlowRow:GetFrameLevel() + 3,
-                        function() return 1.0, 0.788, 0.137 end,
-                        function() end, nil, 20)
-                    PP.Point(defaultSwatch, "RIGHT", swatch, "LEFT", -8, 0)
-                    defaultSwatch:SetScript("OnClick", function()
-                        BD().pandemicGlowColor = nil
-                        ns.BuildAllCDMBars(); Refresh()
-                        if panGlowRow._refreshPreview then panGlowRow._refreshPreview() end
-                        EllesmereUI:RefreshPage()
-                    end)
-                    defaultSwatch:SetScript("OnEnter", function()
-                        EllesmereUI.ShowWidgetTooltip(defaultSwatch, "Default (Untinted)")
-                    end)
-                    defaultSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-
-                    leftRgn._lastInline = defaultSwatch
-                    local function UpdatePanSwatches()
-                        local off = pandemicOff()
-                        local isCustom = BD().pandemicGlowColor ~= nil
-                        swatch:SetAlpha(off and 0.15 or (isCustom and 1 or 0.3)); swatch:EnableMouse(not off)
-                        defaultSwatch:SetAlpha(off and 0.15 or (isCustom and 0.3 or 1)); defaultSwatch:EnableMouse(not off)
-                    end
-                    EllesmereUI.RegisterWidgetRefresh(function()
-                        UpdatePanSwatches()
-                        if updateSwatch then updateSwatch() end
-                    end)
-                    UpdatePanSwatches()
-                end
-            end
+            local leftRgn = panGlowRow._leftRegion
+            local previewIcon = BuildPandemicPreview(panGlowRow, pandemicOff, BD, leftRgn)
+            leftRgn._lastInline = previewIcon
 
             BuildPandemicCogButton(panGlowRow, antsOff, BD, function() ns.BuildAllCDMBars() end)
+
+            do
+                local rightRgn = panGlowRow._rightRegion
+                if rightRgn and EllesmereUI.BuildTrioColorSwatch then
+                    local swatch, defaultSwatch, classSwatch = EllesmereUI.BuildTrioColorSwatch(
+                        rightRgn, panGlowRow:GetFrameLevel() + 3,
+                        {
+                            getMode = function() return BD().pandemicGlowMode or "default" end,
+                            setMode = function(m)
+                                BD().pandemicGlowMode = m
+                                ns.BuildAllCDMBars(); Refresh()
+                                if panGlowRow._refreshPreview then panGlowRow._refreshPreview() end
+                            end,
+                            getCustomRGB = function()
+                                local c = BD().pandemicGlowColor
+                                return (c and c.r) or 1, (c and c.g) or 1, (c and c.b) or 0
+                            end,
+                            setCustomRGB = function(r, g, b)
+                                BD().pandemicGlowColor = { r = r, g = g, b = b }
+                                ns.BuildAllCDMBars(); Refresh()
+                                if panGlowRow._refreshPreview then panGlowRow._refreshPreview() end
+                            end,
+                            hasClassColor = true,
+                            onChange = function() EllesmereUI:RefreshPage() end,
+                            disabled = pandemicOff,
+                            disabledAlpha = 0.15,
+                        })
+                    PP.Point(classSwatch, "RIGHT", rightRgn, "RIGHT", -20, 0)
+                    PP.Point(swatch, "RIGHT", classSwatch, "LEFT", -8, 0)
+                    PP.Point(defaultSwatch, "RIGHT", swatch, "LEFT", -8, 0)
+
+                    local function UpdatePanSwatchMouse()
+                        local off = pandemicOff()
+                        swatch:EnableMouse(not off)
+                        defaultSwatch:EnableMouse(not off)
+                        classSwatch:EnableMouse(not off)
+                    end
+                    EllesmereUI.RegisterWidgetRefresh(UpdatePanSwatchMouse)
+                    UpdatePanSwatchMouse()
+                end
+            end
 
             if EllesmereUI.BuildSyncIcon and EllesmereUI.ApplyPandemicGlowToAll then
                 EllesmereUI.BuildSyncIcon({

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -331,9 +331,7 @@ initFrame:SetScript("OnEvent", function(self)
             local style = bd.pandemicGlowStyle or 1
             local c
             if bd.pandemicGlowMode == "class" then
-                local _, ct = UnitClass("player")
-                local cc = ct and RAID_CLASS_COLORS[ct]
-                if cc then c = cc end
+                c = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
             elseif bd.pandemicGlowMode == "custom" then
                 c = bd.pandemicGlowColor
             end
@@ -1581,8 +1579,8 @@ initFrame:SetScript("OnEvent", function(self)
                         local style = BarHasCustomShape(curBar) and 2 or (entry.glowStyle or 1)
                         local cr, cg, cb
                         if entry.colorMode == "class" then
-                            local _, ct = UnitClass("player")
-                            if ct then local cc = RAID_CLASS_COLORS[ct]; if cc then cr, cg, cb = cc.r, cc.g, cc.b end end
+                            local cc = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
+                            cr, cg, cb = cc.r, cc.g, cc.b
                         elseif entry.colorMode == "custom" and entry.glowColor then
                             cr, cg, cb = entry.glowColor.r, entry.glowColor.g, entry.glowColor.b
                         end
@@ -1647,8 +1645,8 @@ initFrame:SetScript("OnEvent", function(self)
                                     local style = BarHasCustomShape(curBar) and 2 or (entry.glowStyle or 1)
                                     local cr, cg, cb
                                     if entry.colorMode == "class" then
-                                        local _, ct = UnitClass("player")
-                                        if ct then local cc = RAID_CLASS_COLORS[ct]; if cc then cr, cg, cb = cc.r, cc.g, cc.b end end
+                                        local cc = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
+                                        cr, cg, cb = cc.r, cc.g, cc.b
                                     elseif entry.colorMode == "custom" and entry.glowColor then
                                         cr, cg, cb = entry.glowColor.r, entry.glowColor.g, entry.glowColor.b
                                     end

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -323,7 +323,7 @@ initFrame:SetScript("OnEvent", function(self)
             local bd = getDataFn()
             if not bd then return end
             local style = bd.pandemicGlowStyle or 1
-            local c = bd.pandemicGlowColor or { r = 1, g = 1, b = 0 }
+            local c = bd.pandemicGlowColor
             local glowOpts = (style == 1) and {
                 N = bd.pandemicGlowLines or 8,
                 th = bd.pandemicGlowThickness or 2,
@@ -334,7 +334,7 @@ initFrame:SetScript("OnEvent", function(self)
                     b = (bd.pandemicGlowBackgroundColor and bd.pandemicGlowBackgroundColor.b) or 0,
                 } or nil,
             } or nil
-            ns.StartNativeGlow(glowOvr, style, c.r or 1, c.g or 1, c.b or 0, glowOpts)
+            ns.StartNativeGlow(glowOvr, style, c and (c.r or 1), c and (c.g or 1), c and (c.b or 0), glowOpts)
         end
         RefreshPreview()
 
@@ -1567,7 +1567,7 @@ initFrame:SetScript("OnEvent", function(self)
                         local ov = _bgPreviewGlowOverlays[pvKey]
                         if not ov then return end
                         local style = BarHasCustomShape(curBar) and 2 or (entry.glowStyle or 1)
-                        local cr, cg, cb = 1, 0.82, 0.1
+                        local cr, cg, cb
                         if entry.classColor then
                             local _, ct = UnitClass("player")
                             if ct then local cc = RAID_CLASS_COLORS[ct]; if cc then cr, cg, cb = cc.r, cc.g, cc.b end end
@@ -1641,7 +1641,7 @@ initFrame:SetScript("OnEvent", function(self)
                                     if previewBtn._accentBrd then previewBtn._accentBrd:Show() end
                                 else
                                     local style = BarHasCustomShape(curBar) and 2 or (entry.glowStyle or 1)
-                                    local cr, cg, cb = 1, 0.82, 0.1
+                                    local cr, cg, cb
                                     if entry.classColor then
                                         local _, ct = UnitClass("player")
                                         if ct then local cc = RAID_CLASS_COLORS[ct]; if cc then cr, cg, cb = cc.r, cc.g, cc.b end end
@@ -1684,6 +1684,27 @@ initFrame:SetScript("OnEvent", function(self)
                                 end,
                                 false, 20)
                             PP.Point(glowSwatch, "RIGHT", toggle, "LEFT", -8, 0)
+
+                            local defaultSwatch = EllesmereUI.BuildColorSwatch(
+                                rightRgn, glowRow:GetFrameLevel() + 3,
+                                function() return 1.0, 0.788, 0.137 end,
+                                function() end,
+                                false, 20)
+                            PP.Point(defaultSwatch, "RIGHT", glowSwatch, "LEFT", -8, 0)
+                            defaultSwatch:SetScript("OnClick", function()
+                                entry.glowColor = nil
+                                entry.classColor = false
+                                Refresh()
+                                RefreshPreviewGlow()
+                                EllesmereUI:RefreshPage()
+                            end)
+                            defaultSwatch:SetScript("OnEnter", function()
+                                EllesmereUI.ShowWidgetTooltip(defaultSwatch, "Default (Untinted)")
+                            end)
+                            defaultSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                            local isDefault = not entry.classColor and not entry.glowColor
+                            defaultSwatch:SetAlpha(isDefault and 1 or 0.3)
+                            glowSwatch:SetAlpha(isDefault and 0.3 or 1)
                         end
                     end
 
@@ -17471,11 +17492,15 @@ initFrame:SetScript("OnEvent", function(self)
                 end)
                 glowSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
 
-                -- Click the dimmed custom swatch to switch back from class color (no block overlay)
+                -- Click the dimmed custom swatch to switch back from class/default color (no block overlay)
                 local origGlowClick = glowSwatch:GetScript("OnClick")
                 glowSwatch:SetScript("OnClick", function(self, ...)
-                    if BD().buffGlowClassColor then
-                        BD().buffGlowClassColor = false; ns.BuildAllCDMBars()
+                    if BD().buffGlowClassColor or BD().buffGlowR == nil then
+                        BD().buffGlowClassColor = false
+                        if BD().buffGlowR == nil then
+                            BD().buffGlowR = 1.0; BD().buffGlowG = 0.776; BD().buffGlowB = 0.376
+                        end
+                        ns.BuildAllCDMBars()
                         Refresh(); EllesmereUI:RefreshPage()
                         return
                     end
@@ -17484,17 +17509,37 @@ initFrame:SetScript("OnEvent", function(self)
                     if origGlowClick then origGlowClick(self, ...) end
                 end)
 
+                local defaultSwatch, updateDefaultSwatch = EllesmereUI.BuildColorSwatch(
+                    leftRgn, buffGlowRow:GetFrameLevel() + 3,
+                    function() return 1.0, 0.788, 0.137 end,
+                    function() end,
+                    false, 20)
+                PP.Point(defaultSwatch, "RIGHT", glowSwatch, "LEFT", -8, 0)
+                defaultSwatch:SetScript("OnClick", function()
+                    BD().buffGlowClassColor = false
+                    BD().buffGlowR = nil; BD().buffGlowG = nil; BD().buffGlowB = nil
+                    ns.BuildAllCDMBars()
+                    Refresh(); EllesmereUI:RefreshPage()
+                end)
+                defaultSwatch:SetScript("OnEnter", function()
+                    EllesmereUI.ShowWidgetTooltip(defaultSwatch, "Default (Untinted)")
+                end)
+                defaultSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
                 -- Anchor for the inline pixel-glow cog (placed left of the swatches).
-                leftRgn._lastInline = glowSwatch
+                leftRgn._lastInline = defaultSwatch
 
                 local function UpdateBuffGlowState()
                     local gt = BD().buffGlowType or 0
                     local noGlow = gt == 0 or IsCustomShape()
                     local isClassColored = BD().buffGlowClassColor
-                    glowSwatch:SetAlpha((isClassColored or noGlow) and 0.3 or 1)
+                    local isCustom = not isClassColored and BD().buffGlowR ~= nil
+                    local isDefault = not isClassColored and not isCustom
+                    glowSwatch:SetAlpha((isCustom and not noGlow) and 1 or 0.3)
                     classSwatch:SetAlpha((isClassColored and not noGlow) and 1 or 0.3)
+                    defaultSwatch:SetAlpha((isDefault and not noGlow) and 1 or 0.3)
                 end
-                EllesmereUI.RegisterWidgetRefresh(function() updateGlowSwatch(); updateClassSwatch(); UpdateBuffGlowState() end)
+                EllesmereUI.RegisterWidgetRefresh(function() updateGlowSwatch(); updateClassSwatch(); updateDefaultSwatch(); UpdateBuffGlowState() end)
                 UpdateBuffGlowState()
             end
 
@@ -18689,14 +18734,35 @@ initFrame:SetScript("OnEvent", function(self)
                             if panGlowRow._refreshPreview then panGlowRow._refreshPreview() end
                         end, nil, 20)
                     PP.Point(swatch, "RIGHT", ctrl, "LEFT", -12, 0)
-                    leftRgn._lastInline = swatch
-                    EllesmereUI.RegisterWidgetRefresh(function()
+
+                    local defaultSwatch = EllesmereUI.BuildColorSwatch(
+                        leftRgn, panGlowRow:GetFrameLevel() + 3,
+                        function() return 1.0, 0.788, 0.137 end,
+                        function() end, nil, 20)
+                    PP.Point(defaultSwatch, "RIGHT", swatch, "LEFT", -8, 0)
+                    defaultSwatch:SetScript("OnClick", function()
+                        BD().pandemicGlowColor = nil
+                        ns.BuildAllCDMBars(); Refresh()
+                        if panGlowRow._refreshPreview then panGlowRow._refreshPreview() end
+                        EllesmereUI:RefreshPage()
+                    end)
+                    defaultSwatch:SetScript("OnEnter", function()
+                        EllesmereUI.ShowWidgetTooltip(defaultSwatch, "Default (Untinted)")
+                    end)
+                    defaultSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+                    leftRgn._lastInline = defaultSwatch
+                    local function UpdatePanSwatches()
                         local off = pandemicOff()
-                        swatch:SetAlpha(off and 0.15 or 1); swatch:EnableMouse(not off)
+                        local isCustom = BD().pandemicGlowColor ~= nil
+                        swatch:SetAlpha(off and 0.15 or (isCustom and 1 or 0.3)); swatch:EnableMouse(not off)
+                        defaultSwatch:SetAlpha(off and 0.15 or (isCustom and 0.3 or 1)); defaultSwatch:EnableMouse(not off)
+                    end
+                    EllesmereUI.RegisterWidgetRefresh(function()
+                        UpdatePanSwatches()
                         if updateSwatch then updateSwatch() end
                     end)
-                    swatch:SetAlpha(pandemicOff() and 0.15 or 1)
-                    swatch:EnableMouse(not pandemicOff())
+                    UpdatePanSwatches()
                 end
             end
 

--- a/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
@@ -270,7 +270,7 @@ local function UpdateOverlayVisuals()
                     if shapeName and shapeName ~= "square" and shapeName ~= "csquare" and shapeName ~= "none" then
                         style = 2
                     end
-                    local cr, cg, cb = 1, 0.82, 0.1
+                    local cr, cg, cb
                     if entry.classColor then
                         local _, ct = UnitClass("player")
                         if ct then

--- a/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
@@ -289,11 +289,8 @@ local function UpdateOverlayVisuals()
                     end
                     local cr, cg, cb
                     if entry.colorMode == "class" then
-                        local _, ct = UnitClass("player")
-                        if ct then
-                            local cc = RAID_CLASS_COLORS[ct]
-                            if cc then cr, cg, cb = cc.r, cc.g, cc.b end
-                        end
+                        local cc = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
+                        cr, cg, cb = cc.r, cc.g, cc.b
                     elseif entry.colorMode == "custom" and entry.glowColor then
                         cr = entry.glowColor.r or 1
                         cg = entry.glowColor.g or 0.788

--- a/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
@@ -76,6 +76,23 @@ function ns.GetBarGlows()
             assignments = {},
         }
     end
+    -- Live migration: colorMode replaced classColor + "glowColor set" nil check
+    if not prof.barGlows._colorModeMigrated then
+        prof.barGlows._colorModeMigrated = true
+        for _, buffList in pairs(prof.barGlows.assignments) do
+            for _, entry in ipairs(buffList) do
+                if not entry.colorMode then
+                    if entry.classColor then
+                        entry.colorMode = "class"
+                    elseif entry.glowColor then
+                        entry.colorMode = "custom"
+                    else
+                        entry.colorMode = "default"
+                    end
+                end
+            end
+        end
+    end
     return prof.barGlows
 end
 
@@ -271,16 +288,16 @@ local function UpdateOverlayVisuals()
                         style = 2
                     end
                     local cr, cg, cb
-                    if entry.classColor then
+                    if entry.colorMode == "class" then
                         local _, ct = UnitClass("player")
                         if ct then
                             local cc = RAID_CLASS_COLORS[ct]
                             if cc then cr, cg, cb = cc.r, cc.g, cc.b end
                         end
-                    elseif entry.glowColor then
+                    elseif entry.colorMode == "custom" and entry.glowColor then
                         cr = entry.glowColor.r or 1
-                        cg = entry.glowColor.g or 0.82
-                        cb = entry.glowColor.b or 0.1
+                        cg = entry.glowColor.g or 0.788
+                        cb = entry.glowColor.b or 0.137
                     end
                     StartNativeGlow(overlay, style, cr, cg, cb)
                 else

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -3301,9 +3301,7 @@ local function UpdatePandemic(bar, cfg)
         end
         local c
         if cfg.pandemicGlowMode == "class" then
-            local _, ct = UnitClass("player")
-            local cc = ct and RAID_CLASS_COLORS[ct]
-            if cc then c = cc end
+            c = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
         elseif cfg.pandemicGlowMode == "custom" then
             c = cfg.pandemicGlowColor
         end

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -294,7 +294,6 @@ local TBB_DEFAULT_BAR = {
     stackBasedBar = false,
     pandemicGlow = true,
     pandemicGlowStyle = -1,
-    pandemicGlowColor = { r = 1, g = 1, b = 0 },
     pandemicGlowLines = 8,
     pandemicGlowThickness = 2,
     pandemicGlowSpeed = 4,
@@ -347,6 +346,20 @@ function ns.GetTrackedBuffBars()
             end
         end
         tbb._iconTotalMigrated = true
+    end
+    -- Live migration: pandemicGlowMode replaced pandemicGlowColor always being set
+    if not tbb._pandemicModeMigrated then
+        for _, b in ipairs(tbb.bars or {}) do
+            if not b.pandemicGlowMode then
+                local c = b.pandemicGlowColor
+                if c and not (c.r == 1 and c.g == 1 and c.b == 0) then
+                    b.pandemicGlowMode = "custom"
+                else
+                    b.pandemicGlowMode = "default"
+                end
+            end
+        end
+        tbb._pandemicModeMigrated = true
     end
     return tbb
 end
@@ -3286,7 +3299,14 @@ local function UpdatePandemic(bar, cfg)
            and bar._pandemicGlowTarget ~= glowTarget then
             StopGlow(bar._pandemicGlowTarget)
         end
-        local c = cfg.pandemicGlowColor or { r = 1, g = 1, b = 0 }
+        local c
+        if cfg.pandemicGlowMode == "class" then
+            local _, ct = UnitClass("player")
+            local cc = ct and RAID_CLASS_COLORS[ct]
+            if cc then c = cc end
+        elseif cfg.pandemicGlowMode == "custom" then
+            c = cfg.pandemicGlowColor
+        end
         local glowOpts = (style == 1) and {
             N      = cfg.pandemicGlowLines or 8,
             th     = cfg.pandemicGlowThickness or 2,
@@ -3297,7 +3317,7 @@ local function UpdatePandemic(bar, cfg)
                 b = (cfg.pandemicGlowBackgroundColor and cfg.pandemicGlowBackgroundColor.b) or 0,
             } or nil,
         } or nil
-        StartGlow(glowTarget, style, c.r or 1, c.g or 1, c.b or 0, glowOpts)
+        StartGlow(glowTarget, style, c and c.r, c and c.g, c and c.b, glowOpts)
         bar._pandemicGlowActive   = true
         bar._pandemicGlowStyleIdx = style
         bar._pandemicGlowTarget   = glowTarget

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -6474,9 +6474,9 @@ function ns.SetupViewerHooks()
                                             classColor = false
                                             cr, cg, cb = fd._bgR or cr, fd._bgG or cg, fd._bgB or cb
                                         end
-                                        if classColor and _cachedClassToken then
-                                            local cc = RAID_CLASS_COLORS[_cachedClassToken]
-                                            if cc then cr, cg, cb = cc.r, cc.g, cc.b end
+                                        if classColor then
+                                            local cc = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
+                                            cr, cg, cb = cc.r, cc.g, cc.b
                                         end
                                         fd.buffGlowOverlay:SetAlpha(1)
                                         ns.StartNativeGlow(fd.buffGlowOverlay, effGlowType, cr, cg, cb, {
@@ -6518,8 +6518,7 @@ function ns.SetupViewerHooks()
                                         if not fd.pandemicGlowActive then
                                             local c
                                             if bd.pandemicGlowMode == "class" then
-                                                local cc = _cachedClassToken and RAID_CLASS_COLORS[_cachedClassToken]
-                                                if cc then c = cc end
+                                                c = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
                                             elseif bd.pandemicGlowMode == "custom" then
                                                 c = bd.pandemicGlowColor
                                             end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -6463,8 +6463,11 @@ function ns.SetupViewerHooks()
                                     -- each pass, matching the primary glowOverlay (+16).
                                     fd.buffGlowOverlay:SetFrameLevel(frame:GetFrameLevel() + 16)
                                     if not fd.buffGlowActive then
-                                        local cr, cg, cb = bd.buffGlowR, bd.buffGlowG, bd.buffGlowB
-                                        local classColor = bd.buffGlowClassColor
+                                        local cr, cg, cb
+                                        if bd.buffGlowMode == "custom" then
+                                            cr, cg, cb = bd.buffGlowR, bd.buffGlowG, bd.buffGlowB
+                                        end
+                                        local classColor = bd.buffGlowMode == "class"
                                         if fd._bgColor == "class" then
                                             classColor = true
                                         elseif fd._bgColor == "custom" then
@@ -6513,7 +6516,13 @@ function ns.SetupViewerHooks()
                                         -- level higher so pandemic sits above buff glow.
                                         fd.pandemicOverlay:SetFrameLevel(frame:GetFrameLevel() + 17)
                                         if not fd.pandemicGlowActive then
-                                            local c = bd.pandemicGlowColor
+                                            local c
+                                            if bd.pandemicGlowMode == "class" then
+                                                local cc = _cachedClassToken and RAID_CLASS_COLORS[_cachedClassToken]
+                                                if cc then c = cc end
+                                            elseif bd.pandemicGlowMode == "custom" then
+                                                c = bd.pandemicGlowColor
+                                            end
                                             local style = bd.pandemicGlowStyle or 1
                                             local glowOpts = (style == 1) and {
                                                 N      = bd.pandemicGlowLines or 8,
@@ -6526,7 +6535,7 @@ function ns.SetupViewerHooks()
                                                 } or nil,
                                             } or nil
                                             fd.pandemicOverlay:SetAlpha(1)
-                                            ns.StartNativeGlow(fd.pandemicOverlay, style, c and (c.r or 1), c and (c.g or 1), c and (c.b or 0), glowOpts)
+                                            ns.StartNativeGlow(fd.pandemicOverlay, style, c and c.r, c and c.g, c and c.b, glowOpts)
                                             fd.pandemicGlowActive = true
                                         end
                                     elseif fd.pandemicGlowActive and fd.pandemicOverlay then

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -505,10 +505,9 @@ function ns.ApplyActiveOverlays(frame, fd, ss, isActive, bd)
                         local cc = RAID_CLASS_COLORS[ct]
                         if cc then gr, gg, gb = cc.r, cc.g, cc.b end
                     end
+                elseif ss.activeGlowR ~= nil then
+                    gr, gg, gb = ss.activeGlowR, ss.activeGlowG or 0.85, ss.activeGlowB or 0
                 end
-                gr = gr or (ss.activeGlowR or 1)
-                gg = gg or (ss.activeGlowG or 0.85)
-                gb = gb or (ss.activeGlowB or 0)
             end
             -- (Re)start on first activation OR when the style/colour changed, so a
             -- live colour edit takes effect. A steady active window with unchanged
@@ -1062,7 +1061,6 @@ local function ApplyMaxStacksGlow(frame, fd, ss2, atMax)
             if mo then
                 if frame then mo:SetFrameLevel(frame:GetFrameLevel() + 16) end
                 local gr, gg, gb = ns.ResolveGlowColor(ss2)
-                gr = gr or 1; gg = gg or 0.85; gb = gb or 0
                 ns.StartNativeGlow(mo, ss2.maxStacksGlow, gr, gg, gb)
                 fd._maxStacksGlowOn = true
             end
@@ -6465,7 +6463,7 @@ function ns.SetupViewerHooks()
                                     -- each pass, matching the primary glowOverlay (+16).
                                     fd.buffGlowOverlay:SetFrameLevel(frame:GetFrameLevel() + 16)
                                     if not fd.buffGlowActive then
-                                        local cr, cg, cb = bd.buffGlowR or 1.0, bd.buffGlowG or 0.776, bd.buffGlowB or 0.376
+                                        local cr, cg, cb = bd.buffGlowR, bd.buffGlowG, bd.buffGlowB
                                         local classColor = bd.buffGlowClassColor
                                         if fd._bgColor == "class" then
                                             classColor = true
@@ -6515,7 +6513,7 @@ function ns.SetupViewerHooks()
                                         -- level higher so pandemic sits above buff glow.
                                         fd.pandemicOverlay:SetFrameLevel(frame:GetFrameLevel() + 17)
                                         if not fd.pandemicGlowActive then
-                                            local c = bd.pandemicGlowColor or { r = 1, g = 1, b = 0 }
+                                            local c = bd.pandemicGlowColor
                                             local style = bd.pandemicGlowStyle or 1
                                             local glowOpts = (style == 1) and {
                                                 N      = bd.pandemicGlowLines or 8,
@@ -6528,7 +6526,7 @@ function ns.SetupViewerHooks()
                                                 } or nil,
                                             } or nil
                                             fd.pandemicOverlay:SetAlpha(1)
-                                            ns.StartNativeGlow(fd.pandemicOverlay, style, c.r or 1, c.g or 1, c.b or 0, glowOpts)
+                                            ns.StartNativeGlow(fd.pandemicOverlay, style, c and (c.r or 1), c and (c.g or 1), c and (c.b or 0), glowOpts)
                                             fd.pandemicGlowActive = true
                                         end
                                     elseif fd.pandemicGlowActive and fd.pandemicOverlay then

--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -1880,7 +1880,6 @@ function ns.AddCDMBar(barType, name, numRows)
         outOfRangeOverlay = false,
         pandemicGlow = true,
         pandemicGlowStyle = -1,
-        pandemicGlowColor = { r = 1, g = 1, b = 0 },
         pandemicGlowLines = 8,
         pandemicGlowThickness = 2,
         pandemicGlowSpeed = 4,

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -2229,6 +2229,8 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
     local pW, pH = parent:GetWidth(), parent:GetHeight()
     if pW < 5 then pW = 36 end
     if pH < 5 then pH = 36 end
+    local noColor = (cr == nil)
+    if noColor then cr, cg, cb = 1.0, 0.788, 0.137 end
     cr = cr or 1; cg = cg or 1; cb = cb or 1
 
     if entry.shapeGlow then
@@ -2283,6 +2285,7 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
     elseif entry.autocast then
         _G_Glows.StartAutoCastShine(overlay, pW, cr, cg, cb, 1.0, pH)
     else
+        if noColor then cr, cg, cb = nil, nil, nil end
         _G_Glows.StartFlipBookGlow(overlay, pW, entry, cr, cg, cb, pH)
     end
 
@@ -2518,9 +2521,6 @@ local function StopProcGlow(icon)
     if fd then fd.procGlowActive = false end
 end
 
--- Proc glow color: hardcoded gold (#ffc923)
-local PROC_GLOW_COLOR = { 1.0, 0.788, 0.137 }
-
 -- Install hooks on ActionButtonSpellAlertManager (called once during init)
 local _procGlowHooksInstalled = false
 local function InstallProcGlowHooks()
@@ -2542,8 +2542,7 @@ local function InstallProcGlowHooks()
         -- No defer needed -- icon mapping is current from the last reanchor.
         local ourIcon = FindOurIconForBlizzChild(barKey, cdmChild)
         if not ourIcon then return end
-        local cr, cg, cb = PROC_GLOW_COLOR[1], PROC_GLOW_COLOR[2], PROC_GLOW_COLOR[3]
-        ShowProcGlow(ourIcon, cr, cg, cb)
+        ShowProcGlow(ourIcon)
         -- Force icon texture re-evaluation so override textures apply immediately
         FC(ourIcon).lastTex = nil
     end)
@@ -5464,7 +5463,7 @@ local function RefreshCDMIconAppearance(barKey)
             -- Stop then restart with per-spell settings
             StopNativeGlow(glowOv)
             if ifd then ifd.procGlowActive = false end
-            ShowProcGlow(icon, PROC_GLOW_COLOR[1], PROC_GLOW_COLOR[2], PROC_GLOW_COLOR[3])
+            ShowProcGlow(icon)
         elseif hadActiveGlow then
             -- Don't touch: active glow is managed by the SetSwipeColor hook.
             -- Stopping it here causes a visible blink.

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6992,6 +6992,25 @@ BuildAllCDMBars = function()
     ns._cdmAnyOverflowCfg = nil
     for i, barData in ipairs(p.cdmBars.bars) do
         barDataByKey[barData.key] = barData
+        -- Live migration: buffGlowMode replaced buffGlowClassColor + "buffGlowR set" nil checks
+        if not barData.buffGlowMode then
+            if barData.buffGlowClassColor then
+                barData.buffGlowMode = "class"
+            elseif barData.buffGlowR ~= nil then
+                barData.buffGlowMode = "custom"
+            else
+                barData.buffGlowMode = "default"
+            end
+        end
+        -- Live migration: pandemicGlowMode replaced pandemicGlowColor always being set
+        if not barData.pandemicGlowMode then
+            local c = barData.pandemicGlowColor
+            if c and not (c.r == 1 and c.g == 1 and c.b == 0) then
+                barData.pandemicGlowMode = "custom"
+            else
+                barData.pandemicGlowMode = "default"
+            end
+        end
         -- Max Icons overflow: cheap session gate. Validity of the target is
         -- checked at reanchor time (Phase 3b); this only answers "is it
         -- worth looking" so the feature is two nil-checks when unused.

--- a/EllesmereUI_Glows.lua
+++ b/EllesmereUI_Glows.lua
@@ -631,8 +631,14 @@ local function StartFlipBookGlow(wrapper, szOrW, entry, cr, cg, cb, szH)
     elseif entry.texture then
         d.tex:SetTexture(entry.texture)
     end
-    d.tex:SetDesaturated(true)
-    d.tex:SetVertexColor(cr, cg, cb)
+    if cr then
+        d.tex:SetDesaturated(true)
+        d.tex:SetVertexColor(cr, cg, cb)
+    else
+        -- no color requested - just show atlas untinted
+        d.tex:SetDesaturated(false)
+        d.tex:SetVertexColor(1, 1, 1)
+    end
     d.tex:Show()
     d.anim:SetFlipBookRows(entry.rows or 6)
     d.anim:SetFlipBookColumns(entry.columns or 5)

--- a/EllesmereUI_Widgets.lua
+++ b/EllesmereUI_Widgets.lua
@@ -2973,6 +2973,8 @@ local function BuildColorPickerPopup()
     local _confirmed = false
     MakeStyledButton(okBtn, "OK", 10, RB_COLOURS, function()
         RecordRecentColor(HSVtoRGB(currentH, currentS, currentV))
+        -- fire callback when "ok" is clicked, even if no color was changed as to confirm selection
+        FireCallbacks()
         _confirmed = true; popup:Hide()
     end)
 
@@ -3268,6 +3270,91 @@ local function BuildColorSwatch(parentFrame, baseLevel, getValue, setValue, hasA
     end
 
     return swatch, UpdateSwatch
+end
+
+-- default/custom/class color swatch widget
+-- callers track a mode string ("default"/"custom"/"class")
+-- opts:
+--   getMode()           -> "default" | "custom" | "class"
+--   setMode(mode)       -> store the new mode
+--   getCustomRGB()      -> r, g, b of the custom color
+--   setCustomRGB(r,g,b) -> store the picked color
+--   onChange()          -> optional, called after any swatch click
+--   disabled()          -> optional, true to disable all swatches
+--   disabledAlpha       -> optional alpha while disabled (default 0.3)
+--   hasAlpha, overrideSize -> forwarded to BuildColorSwatch
+-- Returns customSwatch, defaultSwatch, classSwatch, Update.
+local DEFAULT_UNTINTED_R, DEFAULT_UNTINTED_G, DEFAULT_UNTINTED_B = 1.0, 0.788, 0.137
+local function BuildTrioColorSwatch(parentFrame, baseLevel, opts)
+    local customSwatch, updateCustom = BuildColorSwatch(parentFrame, baseLevel,
+        function()
+            local r, g, b = opts.getCustomRGB()
+            return r, g, b, 1
+        end,
+        function(r, g, b)
+            opts.setCustomRGB(r, g, b)
+            opts.setMode("custom")
+            if opts.onChange then opts.onChange() end
+        end,
+        opts.hasAlpha, opts.overrideSize)
+    customSwatch:HookScript("OnEnter", function()
+        ShowWidgetTooltip(customSwatch, "Custom Color")
+    end)
+    customSwatch:HookScript("OnLeave", function() HideWidgetTooltip() end)
+
+    local defaultSwatch = BuildColorSwatch(parentFrame, baseLevel,
+        function() return DEFAULT_UNTINTED_R, DEFAULT_UNTINTED_G, DEFAULT_UNTINTED_B, 1 end,
+        function() end,
+        opts.hasAlpha, opts.overrideSize)
+    defaultSwatch:SetScript("OnClick", function()
+        opts.setMode("default")
+        if opts.onChange then opts.onChange() end
+    end)
+    defaultSwatch:SetScript("OnEnter", function()
+        ShowWidgetTooltip(defaultSwatch, "Default")
+    end)
+    defaultSwatch:SetScript("OnLeave", function() HideWidgetTooltip() end)
+
+    local classSwatch
+    if opts.hasClassColor then
+        classSwatch = BuildColorSwatch(parentFrame, baseLevel,
+            function()
+                local _, classFile = UnitClass("player")
+                local cc = classFile and RAID_CLASS_COLORS and RAID_CLASS_COLORS[classFile]
+                if cc then return cc.r, cc.g, cc.b, 1 end
+                return 1, 0.82, 0, 1
+            end,
+            function() end,
+            opts.hasAlpha, opts.overrideSize)
+        classSwatch:SetScript("OnClick", function()
+            opts.setMode("class")
+            if opts.onChange then opts.onChange() end
+        end)
+        classSwatch:SetScript("OnEnter", function()
+            ShowWidgetTooltip(classSwatch, "Class Colored")
+        end)
+        classSwatch:SetScript("OnLeave", function() HideWidgetTooltip() end)
+    end
+
+    local function Update()
+        local disabled = opts.disabled and opts.disabled()
+        local mode = opts.getMode()
+        if disabled then
+            local a = opts.disabledAlpha or 0.3
+            customSwatch:SetAlpha(a)
+            defaultSwatch:SetAlpha(a)
+            if classSwatch then classSwatch:SetAlpha(a) end
+        else
+            customSwatch:SetAlpha(mode == "custom" and 1 or 0.3)
+            defaultSwatch:SetAlpha(mode == "default" and 1 or 0.3)
+            if classSwatch then classSwatch:SetAlpha(mode == "class" and 1 or 0.3) end
+        end
+        updateCustom()
+    end
+    Update()
+    RegisterWidgetRefresh(Update)
+
+    return customSwatch, defaultSwatch, classSwatch, Update
 end
 
 -- Color Picker  (swatch that opens Blizzard's ColorPickerFrame)
@@ -6818,6 +6905,7 @@ end
 EllesmereUI.BuildSliderCore     = BuildSliderCore
 EllesmereUI.BuildDropdownControl = BuildDropdownControl
 EllesmereUI.BuildColorSwatch    = BuildColorSwatch
+EllesmereUI.BuildTrioColorSwatch = BuildTrioColorSwatch
 EllesmereUI.BuildToggleControl   = BuildToggleControl
 EllesmereUI.BuildInlineToggle    = BuildInlineToggle
 EllesmereUI.BuildCheckboxControl = BuildCheckboxControl

--- a/EllesmereUI_Widgets.lua
+++ b/EllesmereUI_Widgets.lua
@@ -3319,10 +3319,8 @@ local function BuildTrioColorSwatch(parentFrame, baseLevel, opts)
     if opts.hasClassColor then
         classSwatch = BuildColorSwatch(parentFrame, baseLevel,
             function()
-                local _, classFile = UnitClass("player")
-                local cc = classFile and RAID_CLASS_COLORS and RAID_CLASS_COLORS[classFile]
-                if cc then return cc.r, cc.g, cc.b, 1 end
-                return 1, 0.82, 0, 1
+                local cc = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
+                return cc.r, cc.g, cc.b, 1
             end,
             function() end,
             opts.hasAlpha, opts.overrideSize)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

Glow options now define a 3 swatch choice: "default", "custom", "class color". Custom and class color continue their standard approach, while adding the brand new "default" mode: atlas/texture glows from FlipBook apply no coloration, keeping their standard true-gold color as opposed to applying the color mask of a "fake" gold coloration that was default for (most) glows.

Since this adds a new 3 swatch choice, this also adds class color options to AuraBuff Reminders and Pandemic Glows in the cooldown manager, as opposed to only custom coloration.

Note: some places have been unchanged, as the scope was ever-increasing with these changes that were initially created to just use the default non-tinted proc glow for cooldown manager. These places include action bars -> bar animations -> custom proc glow, and cooldown manager -> tracking bars pandemic glows.  (that both should likely follow suit with the pandemic glow display in cooldown manager). Quick search through the code also has some of that in Nameplates, but as I don't have nameplates enabled, it's skipped under this PR.

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

Tested in 12.0.7.68453.
Used all versions of glows (AuraBuff Reminders, Cooldown Manager's CDM Bars Pandemic Glow & right click button's glow effect color, Bar Glows, etc) to verify their states utilize the appropriate color mode ("default", "custom", "class color") in previews and out on their respective UI elements

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

Default new:
<img width="83" height="77" alt="image" src="https://github.com/user-attachments/assets/07a5289c-f03e-4e17-a157-819d8415427b" />
<img width="69" height="60" alt="image" src="https://github.com/user-attachments/assets/6e29e6e3-b0f4-4891-9011-26f15e58304f" />

Default old:
<img width="69" height="76" alt="image" src="https://github.com/user-attachments/assets/4d38f002-3f3a-406d-b0ae-b1d2a7a55936" />
<img width="70" height="57" alt="image" src="https://github.com/user-attachments/assets/9011550f-27ae-4645-a92a-9fb41f23f3ef" />


### Cooldown Manager -> CDM Bars -> Extras
Before:
<img width="932" height="64" alt="image" src="https://github.com/user-attachments/assets/dbcb0eae-f7da-4088-93b7-b4203eb7d656" />

After:
Note, I just have a custom color of #ffffff set here, the default is unchanged from the base EUI.
<img width="937" height="62" alt="image" src="https://github.com/user-attachments/assets/744c4db7-725d-4830-a7ed-19d8ec315084" />

### Cooldown Manager -> CDM Bars -> (Buffs dropdown) -> Icon Display
Before:
<img width="482" height="60" alt="image" src="https://github.com/user-attachments/assets/91243541-0166-42a8-a48d-6312d6433e44" />

After:
<img width="477" height="68" alt="image" src="https://github.com/user-attachments/assets/3d7a09fd-6e0e-4de5-9ebb-33af29641abc" />


### Cooldown Manager -> Bar Glows
Before:
<img width="951" height="74" alt="image" src="https://github.com/user-attachments/assets/63e05a7c-6d54-4415-846c-986a8bedb2fa" />

After:
<img width="944" height="141" alt="image" src="https://github.com/user-attachments/assets/540fd072-3c1c-4a0a-b1b5-f320ebcad913" />

###  AuraBuff Reminders -> Auras, Buffs & Consumables
Before:
<img width="483" height="70" alt="image" src="https://github.com/user-attachments/assets/65927baa-c34d-4dc5-9057-6ee07f80dd8d" />

After:
<img width="474" height="93" alt="image" src="https://github.com/user-attachments/assets/a546d55c-d58a-42ab-ab69-a6a30fe9ef7e" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client

The first setting I've kept unchecked, simply because this technically does change default behavior - where the old "default" was a fake-gold coloration and now the default mode actually does set it to its default coloration via the atlas/texture component of the custom glows. For glow types outside of FlipBook types, they will continue to use the default coloration of #FFC923, except for Pandemic Glow, that had a default of #FFFF00.
