### PR TITLE
Updating the fallback icon texture for ironbark

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -511,7 +511,7 @@ end
 
 -- Fallback icon textures for secret auras (icon field is also secret)
 local SECRET_SPELL_ICONS = {
-    [102342] = 136097,   -- Ironbark
+    [102342] = 572025,   -- Ironbark
     [33206]  = 135936,   -- Pain Suppression
     [10060]  = 135939,   -- Power Infusion
     [47788]  = 237542,   -- Guardian Spirit


### PR DESCRIPTION

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?
Updates the fallback spell icon that is shown when a user is specifically tracking the ironbark spell on their raid frames. 
Before: https://www.wowhead.com/icon=136097/spell-nature-stoneclawtotem 
After: https://www.wowhead.com/icon=572025/spell-druid-ironbark

## How was it tested?
Using EllesmereUI 8.5.2 I did the following steps to reproduce the issue before making the change and after making the change. Results shown in the screenshots section.
1) Make sure ironbark was specifically tracked rather than just the catch all external/defensive icon.
2) Get in combat with something
3) Cast ironbark on self

Without the change the icon for barkskin is displayed, afterwards it was ironbark as expected.

## Screenshots
Before:
<img width="155" height="87" alt="before" src="https://github.com/user-attachments/assets/1a850e01-00ab-4e98-a012-861a3d7e313a" />

After:
<img width="152" height="84" alt="after" src="https://github.com/user-attachments/assets/a6097f99-5252-44ed-ac60-8222e2974797" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- New settings default **OFF** (no behavior change without opt-in)
  - N/A. No new setting for bug fix.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built 
  - Zero change in cost
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
  - Zero change in cost
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
  - Only changes an icon id, no changes to other frames.
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
  - Tested on live and fixes the issue.
  - Tested on 12.1 PTR client and there's no load errors, but the reproduction steps no longer show the issue due to the aura API changes in 12.1