### PR TITLE
Unitframes and Blizzard Auraframe: Add border options to player-, target-, bossunitframe and blizzard auras

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -3013,16 +3013,15 @@ do
         return false
     end
 
-    --- Border color + Show Behind to apply when the user picks a border style.
-    --- Shadow -> black + behind on; everything else -> behind off (Shadow is the
-    --- only style that renders behind). Solid/Shadow default to black, other
-    --- textured styles default to white. Returns (colorTable, behindBool).
+    --- Border color + layer defaults to apply when a border style is selected.
+    --- Shadow is the only style rendered behind both its icon and Unit Frame.
+    --- Returns (colorTable, behindBool, behindUnitFrameBool).
     function EllesmereUI.GetBorderStyleSelectDefaults(textureKey)
-        if textureKey == "shadow" then return { r = 0, g = 0, b = 0 }, true end
+        if textureKey == "shadow" then return { r = 0, g = 0, b = 0 }, true, true end
         if not textureKey or textureKey == "" or textureKey == "solid" then
-            return { r = 0, g = 0, b = 0 }, false
+            return { r = 0, g = 0, b = 0 }, false, false
         end
-        return { r = 1, g = 1, b = 1 }, false
+        return { r = 1, g = 1, b = 1 }, false, false
     end
 
     --- Resolve a border texture key to a file path.
@@ -3176,6 +3175,69 @@ do
             bdFrame:Show()
             borderFrame:Show()
         end
+    end
+
+    -- BackdropTemplate performs arithmetic on its owner's width/height and is
+    -- therefore unusable for frames anchored to secret aura geometry. This
+    -- variant renders textured borders as the same eight edge-file slices,
+    -- while retaining the normal PP path for Solid. `state` is any caller-owned
+    -- table used to cache the eight textures (FFD, AuraKit button data, etc.).
+    local SECRET_BORDER_UV = {
+        topLeft     = { 0.5078125, 0.0625, 0.5078125, 0.9375, 0.6171875, 0.0625, 0.6171875, 0.9375 },
+        topRight    = { 0.6328125, 0.0625, 0.6328125, 0.9375, 0.7421875, 0.0625, 0.7421875, 0.9375 },
+        bottomLeft  = { 0.7578125, 0.0625, 0.7578125, 0.9375, 0.8671875, 0.0625, 0.8671875, 0.9375 },
+        bottomRight = { 0.8828125, 0.0625, 0.8828125, 0.9375, 0.9921875, 0.0625, 0.9921875, 0.9375 },
+        top         = { 0.2578125, 0.9375, 0.3671875, 0.9375, 0.2578125, 0.0625, 0.3671875, 0.0625 },
+        bottom      = { 0.3828125, 0.9375, 0.4921875, 0.9375, 0.3828125, 0.0625, 0.4921875, 0.0625 },
+        left        = { 0.0078125, 0.0625, 0.0078125, 0.9375, 0.1171875, 0.0625, 0.1171875, 0.9375 },
+        right       = { 0.1328125, 0.0625, 0.1328125, 0.9375, 0.2421875, 0.0625, 0.2421875, 0.9375 },
+    }
+
+    function EllesmereUI.ApplySecretSafeBorderStyle(borderFrame, state, size, r, g, b, a,
+        textureKey, offsetX, offsetY, shiftX, shiftY, addonKey, sizeKey)
+        if not borderFrame or not state then return end
+        size, textureKey = size or 0, textureKey or "solid"
+        local edges = state._secretBorderEdges
+        local function HideEdges()
+            if edges then for _, tex in pairs(edges) do tex:Hide() end end
+        end
+        if textureKey == "" or textureKey == "solid" or size <= 0 then
+            HideEdges()
+            EllesmereUI.ApplyBorderStyle(borderFrame, size, r, g, b, a, "solid")
+            return
+        end
+        local path = EllesmereUI.ResolveBorderTexture(textureKey)
+        if not path then HideEdges(); EllesmereUI.ApplyBorderStyle(borderFrame, 0, 0, 0, 0, 0, "solid"); return end
+        -- Also hides any BackdropTemplate child left by an older live version.
+        EllesmereUI.ApplyBorderStyle(borderFrame, 0, 0, 0, 0, 0, "solid")
+        borderFrame:Show()
+        if not edges then
+            edges = {}
+            for key, uv in pairs(SECRET_BORDER_UV) do
+                local tex = borderFrame:CreateTexture(nil, "OVERLAY", nil, 7)
+                tex:SetTexCoord(unpack(uv)); edges[key] = tex
+            end
+            state._secretBorderEdges = edges
+        end
+        local edgeSize = EDGE_MAP[size] or EDGE_MAP[1]
+        local ox, oy, sx, sy = EllesmereUI.GetBorderDefaults(addonKey, textureKey, sizeKey)
+        ox = offsetX ~= nil and offsetX or ox; oy = offsetY ~= nil and offsetY or oy
+        sx = shiftX ~= nil and shiftX or sx; sy = shiftY ~= nil and shiftY or sy
+        if EllesmereUI.BorderTextureUsesScaleOffset(textureKey) then
+            ox, oy = edgeSize / 2 + ox, edgeSize / 2 + oy
+        end
+        for _, tex in pairs(edges) do
+            tex:SetTexture(path, true, true); tex:SetVertexColor(r, g, b, a or 1)
+            tex:ClearAllPoints(); tex:Show()
+        end
+        edges.topLeft:SetSize(edgeSize, edgeSize); edges.topLeft:SetPoint("TOPLEFT", borderFrame, "TOPLEFT", -ox + sx, oy + sy)
+        edges.topRight:SetSize(edgeSize, edgeSize); edges.topRight:SetPoint("TOPRIGHT", borderFrame, "TOPRIGHT", ox + sx, oy + sy)
+        edges.bottomLeft:SetSize(edgeSize, edgeSize); edges.bottomLeft:SetPoint("BOTTOMLEFT", borderFrame, "BOTTOMLEFT", -ox + sx, -oy + sy)
+        edges.bottomRight:SetSize(edgeSize, edgeSize); edges.bottomRight:SetPoint("BOTTOMRIGHT", borderFrame, "BOTTOMRIGHT", ox + sx, -oy + sy)
+        edges.top:SetHeight(edgeSize); edges.top:SetPoint("TOPLEFT", edges.topLeft, "TOPRIGHT"); edges.top:SetPoint("TOPRIGHT", edges.topRight, "TOPLEFT")
+        edges.bottom:SetHeight(edgeSize); edges.bottom:SetPoint("BOTTOMLEFT", edges.bottomLeft, "BOTTOMRIGHT"); edges.bottom:SetPoint("BOTTOMRIGHT", edges.bottomRight, "BOTTOMLEFT")
+        edges.left:SetWidth(edgeSize); edges.left:SetPoint("TOPLEFT", edges.topLeft, "BOTTOMLEFT"); edges.left:SetPoint("BOTTOMLEFT", edges.bottomLeft, "TOPLEFT")
+        edges.right:SetWidth(edgeSize); edges.right:SetPoint("TOPRIGHT", edges.topRight, "BOTTOMRIGHT"); edges.right:SetPoint("BOTTOMRIGHT", edges.bottomRight, "TOPRIGHT")
     end
 
     --- Set border color on whichever system is currently active (PP or backdrop).

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
@@ -319,13 +319,18 @@ end
 
 -- Fingerprint of a BUILT style table (BuildStyle is a pure function of the
 -- settings, so hashing its scalar output covers every input, including the
--- boss-simple sizing and scale). Constant fields (border, cooldown flags,
--- cancelButtons) are omitted.
+-- boss-simple sizing and scale). Constant cooldown/cancel fields are omitted;
+-- every user-configurable border scalar must participate so layer-only edits
+-- schedule an immediate AuraKit restyle.
 local function StyleTableFP(st, font)
     local tc = st.texCoord
+    local b = st.border
     return FP(font, st.width, st.height, tc[1], tc[2], tc[3], tc[4],
         st.hideDurationText, st.cdTextSize, CK(st.cdTextColor), st.cdOffX, st.cdOffY,
-        st.stackSize, CK(st.stackColor), st.stackPos, st.stackOffX, st.stackOffY)
+        st.stackSize, CK(st.stackColor), st.stackPos, st.stackOffX, st.stackOffY,
+        b and b.texture, b and b.size, b and b[1], b and b[2], b and b[3], b and b[4],
+        b and b.offsetX, b and b.offsetY, b and b.shiftX, b and b.shiftY,
+        b and b.behind, b and b.behindUnitFrame, b and b.unitFrameLevel)
 end
 
 -- Effective engine group key: own-only variants are SEPARATE groups
@@ -392,7 +397,7 @@ local function ElementSize(unit, base, s)
     return size, h, cropped
 end
 
-local function BuildStyle(unit, base, s)
+local function BuildStyle(unit, base, s, unitFrame)
     local isBuff = (base == "HELPFUL")
     local size, h, cropped = ElementSize(unit, base, s)
     local p = Pick(isBuff, "buff", "debuff")
@@ -411,7 +416,18 @@ local function BuildStyle(unit, base, s)
         width = size,
         height = h,
         texCoord = CropCoords(cropped, size, h, Pick(isBuff, s.buffIconZoom, s.debuffIconZoom)),
-        border = { 0, 0, 0, 1 },
+        border = {
+            s.auraBorderR or 0, s.auraBorderG or 0, s.auraBorderB or 0, s.auraBorderA or 1,
+            size = s.auraBorderSize or 1,
+            texture = s.auraBorderTexture or "solid",
+            offsetX = s.auraBorderTextureOffset,
+            offsetY = s.auraBorderTextureOffsetY,
+            shiftX = s.auraBorderTextureShiftX,
+            shiftY = s.auraBorderTextureShiftY,
+            behind = s.auraBorderBehind,
+            behindUnitFrame = s.auraBorderBehindUnitFrame,
+            unitFrameLevel = unitFrame and unitFrame:GetFrameLevel() or 1,
+        },
         cooldownReverse = true,
         cooldownDrawEdge = false,
         noDefaultFonts = true,
@@ -858,7 +874,7 @@ function ns.UF_ReloadAuraContainers(frame, unit)
 
         -- Restyle only when the built style actually differs; the deferred
         -- time-sliced restyler spreads the button decoration work out.
-        local style = BuildStyle(unit, base, s)
+        local style = BuildStyle(unit, base, s, entry.frame)
         local styleV = StyleTableFP(style, font)
         if st.style ~= styleV then
             st.style = styleV
@@ -1036,7 +1052,7 @@ local function BuildUnitContainers(frame, unit)
     local font = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames")) or ""
     for _, base in ipairs({ "HELPFUL", "HARMFUL" }) do
         local key = StyleKey(unit, base)
-        local style = BuildStyle(unit, base, s)
+        local style = BuildStyle(unit, base, s, frame)
         AK.styles[key] = style
         ufFP[key] = { style = StyleTableFP(style, font) }
     end

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -14186,6 +14186,7 @@ initFrame:SetScript("OnEvent", function(self)
                         EllesmereUI.RegisterWidgetRefresh(upd)
                     end
                 end
+                AddBossAuraBorderSettings()
                 -- Boss Debuff Filter in slot 1. The right slot is the
                 -- 12.1-only Boss Buff Filter; on 12.0 it stays the blank
                 -- label it is today (boss buffs are never filtered there).
@@ -14363,9 +14364,8 @@ initFrame:SetScript("OnEvent", function(self)
                     UpdateDebuffCogDisabled()
                     EllesmereUI.RegisterWidgetRefresh(UpdateDebuffCogDisabled)
                 end
-            end
 
-            AddBossAuraBorderSettings()
+            end
 
             -- Buff/Debuff text colors now live as inline swatches on the Buff Text
             -- Size / Debuff Text Size sliders above (Duration + Stack per side).

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -2171,6 +2171,39 @@ initFrame:SetScript("OnEvent", function(self)
             elseif unitKey == "focustarget" then s = db.profile.focustarget
             else s = db.profile.player end
 
+            -- Player/target preview: mirror the live shared aura border style.
+            if unitKey == "player" or unitKey == "target" or unitKey == "boss" then
+                local function ApplyPreviewAuraBorder(icon)
+                    if icon._iconTex then
+                        icon._iconTex:ClearAllPoints()
+                        local inset = (s.auraBorderSize or 1) > 0 and 1 or 0
+                        PP.Point(icon._iconTex, "TOPLEFT", icon, "TOPLEFT", inset, -inset)
+                        PP.Point(icon._iconTex, "BOTTOMRIGHT", icon, "BOTTOMRIGHT", -inset, inset)
+                    end
+                    local border = icon._euiAuraBorder
+                    if not border then
+                        border = CreateFrame("Frame", nil, icon)
+                        border:SetAllPoints(icon)
+                        border:EnableMouse(false)
+                        icon._euiAuraBorder = border
+                    end
+                    if s.auraBorderBehindUnitFrame then
+                        border:SetFrameLevel(0)
+                    else
+                        border:SetFrameLevel(s.auraBorderBehind
+                            and math.max(0, icon:GetFrameLevel() - 1) or (icon:GetFrameLevel() + 1))
+                    end
+                    EllesmereUI.ApplyBorderStyle(border, s.auraBorderSize or 1,
+                        s.auraBorderR or 0, s.auraBorderG or 0, s.auraBorderB or 0, s.auraBorderA or 1,
+                        s.auraBorderTexture or "solid",
+                        s.auraBorderTextureOffset, s.auraBorderTextureOffsetY,
+                        s.auraBorderTextureShiftX, s.auraBorderTextureShiftY,
+                        "unitframes", s.auraBorderSize or 1)
+                end
+                for i = 1, #buffIcons do ApplyPreviewAuraBorder(buffIcons[i]) end
+                for i = 1, #debuffIcons do ApplyPreviewAuraBorder(debuffIcons[i]) end
+            end
+
             -- Donor settings for mini frames (border/texture/font inherit from focus player)
             local isMini = (unitKey == "pet" or unitKey == "boss" or unitKey == "targettarget" or unitKey == "focustarget")
             local ds = s
@@ -10276,6 +10309,99 @@ initFrame:SetScript("OnEvent", function(self)
         end
         end   -- close Debuff row 2 hidden-while-None gate
 
+        -- Built here with the aura section's helpers, but appended only after
+        -- all other buff/debuff controls so the border row stays last.
+        local function AddAuraBorderSettings()
+        if selectedUnit == "player" or selectedUnit == "target" then
+            local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
+            local borderSizeValues = {
+                none = "None", thin = "Thin", normal = "Normal",
+                heavy = "Heavy", strong = "Strong",
+            }
+            local borderSizeOrder = { "none", "thin", "normal", "heavy", "strong" }
+            local sizeToNumber = { none = 0, thin = 1, normal = 2, heavy = 3, strong = 4 }
+            local numberToSize = { [0] = "none", [1] = "thin", [2] = "normal", [3] = "heavy", [4] = "strong" }
+            local auraBorderRow
+            auraBorderRow, h = W:DualRow(parent, y,
+                { type="dropdown", text="Border Style", values=texValues, order=texOrder,
+                  getValue=function() return SVal("auraBorderTexture", "solid") end,
+                  setValue=function(v)
+                      local color, behind, behindUnitFrame = EllesmereUI.GetBorderStyleSelectDefaults(v)
+                      local s = SDB()
+                      s.auraBorderTexture = v
+                      s.auraBorderTextureOffset = nil; s.auraBorderTextureOffsetY = nil
+                      s.auraBorderTextureShiftX = nil; s.auraBorderTextureShiftY = nil
+                      s.auraBorderBehind = behind
+                      s.auraBorderBehindUnitFrame = behindUnitFrame
+                      s.auraBorderR = color.r; s.auraBorderG = color.g; s.auraBorderB = color.b; s.auraBorderA = 1
+                      local defSz = EllesmereUI.GetBorderDefaultSize("unitframes", v)
+                      if defSz then s.auraBorderSize = defSz end
+                      ReloadAndUpdate(); UpdatePreview()
+                  end },
+                { type="dropdown", text="Border Size", values=borderSizeValues, order=borderSizeOrder,
+                  getValue=function() return numberToSize[SVal("auraBorderSize", 1)] or "thin" end,
+                  setValue=function(v) SSetSupported("auraBorderSize", sizeToNumber[v] or 1) end }
+            ); y = y - h
+
+            do
+                local rgn = auraBorderRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title="Border Offset",
+                    rows={
+                        { type="slider", label="Offset X", min=-10, max=10, step=1,
+                          get=function()
+                              local v = SGet("auraBorderTextureOffset"); if v ~= nil then return v end
+                              return EllesmereUI.GetBorderDefaults("unitframes", SVal("auraBorderTexture", "solid"), SVal("auraBorderSize", 1))
+                          end,
+                          set=function(v) SSetSupported("auraBorderTextureOffset", v) end },
+                        { type="slider", label="Offset Y", min=-10, max=10, step=1,
+                          get=function()
+                              local v = SGet("auraBorderTextureOffsetY"); if v ~= nil then return v end
+                              local _, oy = EllesmereUI.GetBorderDefaults("unitframes", SVal("auraBorderTexture", "solid"), SVal("auraBorderSize", 1)); return oy
+                          end,
+                          set=function(v) SSetSupported("auraBorderTextureOffsetY", v) end },
+                        { type="slider", label="Shift X", min=-10, max=10, step=1,
+                          get=function()
+                              local v = SGet("auraBorderTextureShiftX"); if v ~= nil then return v end
+                              local _, _, sx = EllesmereUI.GetBorderDefaults("unitframes", SVal("auraBorderTexture", "solid"), SVal("auraBorderSize", 1)); return sx
+                          end,
+                          set=function(v) SSetSupported("auraBorderTextureShiftX", v == 0 and nil or v) end },
+                        { type="slider", label="Shift Y", min=-10, max=10, step=1,
+                          get=function()
+                              local v = SGet("auraBorderTextureShiftY"); if v ~= nil then return v end
+                              local _, _, _, sy = EllesmereUI.GetBorderDefaults("unitframes", SVal("auraBorderTexture", "solid"), SVal("auraBorderSize", 1)); return sy
+                          end,
+                          set=function(v) SSetSupported("auraBorderTextureShiftY", v == 0 and nil or v) end },
+                        { type="toggle", label="Show Behind",
+                          get=function() return SVal("auraBorderBehind", false) end,
+                          set=function(v) SSetSupported("auraBorderBehind", v) end },
+                        { type="toggle", label="Behind Unit Frame",
+                          get=function() return SVal("auraBorderBehindUnitFrame", false) end,
+                          set=function(v) SSetSupported("auraBorderBehindUnitFrame", v) end },
+                    },
+                })
+                local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.DIRECTIONS_ICON)
+                local function UpdateCogVis()
+                    if SVal("auraBorderTexture", "solid") == "solid" then cogBtn:Hide() else cogBtn:Show() end
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateCogVis); UpdateCogVis()
+            end
+
+            do
+                local rgn = auraBorderRow._rightRegion
+                local swatch, refreshSwatch = EllesmereUI.BuildColorSwatch(
+                    rgn, auraBorderRow:GetFrameLevel() + 3,
+                    function() return SVal("auraBorderR", 0), SVal("auraBorderG", 0), SVal("auraBorderB", 0), SVal("auraBorderA", 1) end,
+                    function(r, g, b, a)
+                        local s = SDB(); s.auraBorderR = r; s.auraBorderG = g; s.auraBorderB = b; s.auraBorderA = a
+                        ReloadAndUpdate(); UpdatePreview()
+                    end, true, 20)
+                PP.Point(swatch, "RIGHT", rgn._control, "LEFT", -8, 0)
+                EllesmereUI.RegisterWidgetRefresh(refreshSwatch)
+            end
+        end
+        end
+
         -- Per-unit aura filters (NOT synced). Labels track the selected section
         -- (Player/Target/Focus). Each is a multi-select checkbox dropdown; checked
         -- classifications OR together at runtime (Own Only = PLAYER, Raid Frames =
@@ -10504,6 +10630,8 @@ initFrame:SetScript("OnEvent", function(self)
                 cogBtn:SetScript("OnClick", function(self) opShow(self) end)
             end
         end
+
+        AddAuraBorderSettings()
 
         -------------------------------------------------------------------
         --  PRIVATE AURAS (player frame only)
@@ -13998,6 +14126,66 @@ initFrame:SetScript("OnEvent", function(self)
                     BossCogBtn(rightRgn, debuffStackCogShow, nil, debuffOff)
                 end
                 end   -- close debuff sizing row hidden-while-None gate
+
+                -- Built alongside the aura controls, then appended at the end
+                -- of this section to keep border settings consistently last.
+                local function AddBossAuraBorderSettings()
+                    local B = db.profile.boss
+                    local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
+                    local sizeValues = { none="None", thin="Thin", normal="Normal", heavy="Heavy", strong="Strong" }
+                    local sizeOrder = { "none", "thin", "normal", "heavy", "strong" }
+                    local toNumber = { none=0, thin=1, normal=2, heavy=3, strong=4 }
+                    local toSize = { [0]="none", [1]="thin", [2]="normal", [3]="heavy", [4]="strong" }
+                    local borderRow
+                    borderRow, hh = Ww:DualRow(pp, yy,
+                        { type="dropdown", text="Border Style", values=texValues, order=texOrder,
+                          getValue=function() return B.auraBorderTexture or "solid" end,
+                          setValue=function(v)
+                              local color, behind, behindUnitFrame = EllesmereUI.GetBorderStyleSelectDefaults(v)
+                              B.auraBorderTexture = v
+                              B.auraBorderTextureOffset = nil; B.auraBorderTextureOffsetY = nil
+                              B.auraBorderTextureShiftX = nil; B.auraBorderTextureShiftY = nil
+                              B.auraBorderBehind = behind
+                              B.auraBorderBehindUnitFrame = behindUnitFrame
+                              B.auraBorderR=color.r; B.auraBorderG=color.g; B.auraBorderB=color.b; B.auraBorderA=1
+                              local ds=EllesmereUI.GetBorderDefaultSize("unitframes",v); if ds then B.auraBorderSize=ds end
+                              ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end
+                          end },
+                        { type="dropdown", text="Border Size", values=sizeValues, order=sizeOrder,
+                          getValue=function() return toSize[B.auraBorderSize or 1] or "thin" end,
+                          setValue=function(v) B.auraBorderSize=toNumber[v] or 1; ReloadAndUpdate(); if ns.RefreshBossPreviewDebuffs then ns.RefreshBossPreviewDebuffs() end end }
+                    ); yy = yy - hh
+                    do
+                        local rgn=borderRow._leftRegion
+                        local _,show=EllesmereUI.BuildCogPopup({ title="Border Offset", rows={
+                            { type="slider",label="Offset X",min=-10,max=10,step=1,
+                              get=function() local v=B.auraBorderTextureOffset;if v~=nil then return v end;return EllesmereUI.GetBorderDefaults("unitframes",B.auraBorderTexture or "solid",B.auraBorderSize or 1) end,
+                              set=function(v) B.auraBorderTextureOffset=v;ReloadAndUpdate() end },
+                            { type="slider",label="Offset Y",min=-10,max=10,step=1,
+                              get=function() local v=B.auraBorderTextureOffsetY;if v~=nil then return v end;local _,y=EllesmereUI.GetBorderDefaults("unitframes",B.auraBorderTexture or "solid",B.auraBorderSize or 1);return y end,
+                              set=function(v) B.auraBorderTextureOffsetY=v;ReloadAndUpdate() end },
+                            { type="slider",label="Shift X",min=-10,max=10,step=1,
+                              get=function() local v=B.auraBorderTextureShiftX;if v~=nil then return v end;local _,_,x=EllesmereUI.GetBorderDefaults("unitframes",B.auraBorderTexture or "solid",B.auraBorderSize or 1);return x end,
+                              set=function(v) B.auraBorderTextureShiftX=v==0 and nil or v;ReloadAndUpdate() end },
+                            { type="slider",label="Shift Y",min=-10,max=10,step=1,
+                              get=function() local v=B.auraBorderTextureShiftY;if v~=nil then return v end;local _,_,_,y=EllesmereUI.GetBorderDefaults("unitframes",B.auraBorderTexture or "solid",B.auraBorderSize or 1);return y end,
+                              set=function(v) B.auraBorderTextureShiftY=v==0 and nil or v;ReloadAndUpdate() end },
+                            { type="toggle",label="Show Behind",get=function() return B.auraBorderBehind or false end,set=function(v) B.auraBorderBehind=v;ReloadAndUpdate() end },
+                            { type="toggle",label="Behind Unit Frame",get=function() return B.auraBorderBehindUnitFrame or false end,set=function(v) B.auraBorderBehindUnitFrame=v;ReloadAndUpdate() end },
+                        } })
+                        local btn=BossCogBtn(rgn,show,EllesmereUI.DIRECTIONS_ICON)
+                        local function vis() if (B.auraBorderTexture or "solid")=="solid" then btn:Hide() else btn:Show() end end
+                        EllesmereUI.RegisterWidgetRefresh(vis);vis()
+                    end
+                    do
+                        local rgn=borderRow._rightRegion
+                        local sw,upd=EllesmereUI.BuildColorSwatch(rgn,borderRow:GetFrameLevel()+3,
+                            function() return B.auraBorderR or 0,B.auraBorderG or 0,B.auraBorderB or 0,B.auraBorderA or 1 end,
+                            function(r,g,b,a) B.auraBorderR=r;B.auraBorderG=g;B.auraBorderB=b;B.auraBorderA=a;ReloadAndUpdate() end,true,20)
+                        PP.Point(sw,"RIGHT",rgn._control,"LEFT",-8,0)
+                        EllesmereUI.RegisterWidgetRefresh(upd)
+                    end
+                end
                 -- Boss Debuff Filter in slot 1. The right slot is the
                 -- 12.1-only Boss Buff Filter; on 12.0 it stays the blank
                 -- label it is today (boss buffs are never filtered there).
@@ -14176,6 +14364,8 @@ initFrame:SetScript("OnEvent", function(self)
                     EllesmereUI.RegisterWidgetRefresh(UpdateDebuffCogDisabled)
                 end
             end
+
+            AddBossAuraBorderSettings()
 
             -- Buff/Debuff text colors now live as inline swatches on the Buff Text
             -- Size / Debuff Text Size sliders above (Duration + Stack per side).
@@ -15136,22 +15326,104 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
         end
 
-        -- Row 3: Border Size (+ inline color swatch) | (empty)
+        -- Row 3: Border Style | Border Size (+ inline color swatch)
         do
+            local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
+            local borderSizeValues = {
+                none = "None", thin = "Thin", normal = "Normal",
+                heavy = "Heavy", strong = "Strong",
+            }
+            local borderSizeOrder = { "none", "thin", "normal", "heavy", "strong" }
+            local borderSizeToNumber = { none = 0, thin = 1, normal = 2, heavy = 3, strong = 4 }
+            local borderNumberToSize = { [0] = "none", [1] = "thin", [2] = "normal", [3] = "heavy", [4] = "strong" }
             local bsRow
             bsRow, h = W:DualRow(parent, y,
-                { type = "slider", text = "Border Size", min = 0, max = 4, step = 1,
-                  getValue = function() return PAGet("borderSize") or 1 end,
-                  setValue = function(v) PASet("borderSize", v) end },
-                { type = "toggle", text = "No Border on Debuffs",
-                  tooltip = "When enabled, debuff icons keep Blizzard's colored border instead of using the custom border.",
-                  getValue = function() return PAGet("noBorderDebuffs") ~= false end,
-                  setValue = function(v) PASet("noBorderDebuffs", v) end }
+                { type = "dropdown", text = "Border Style",
+                  values = texValues, order = texOrder,
+                  getValue = function() return PAGet("borderTexture") or "solid" end,
+                  setValue = function(v)
+                      local color, behind = EllesmereUI.GetBorderStyleSelectDefaults(v)
+                      PASet("borderTexture", v)
+                      PASet("borderTextureOffset", nil); PASet("borderTextureOffsetY", nil)
+                      PASet("borderTextureShiftX", nil); PASet("borderTextureShiftY", nil)
+                      PASet("borderBehind", behind)
+                      PASet("borderR", color.r); PASet("borderG", color.g); PASet("borderB", color.b)
+                      PASet("borderA", 1)
+                      local defSz = EllesmereUI.GetBorderDefaultSize("unitframes", v)
+                      if defSz then PASet("borderSize", defSz) end
+                  end },
+                { type = "dropdown", text = "Border Size",
+                  values = borderSizeValues, order = borderSizeOrder,
+                  getValue = function()
+                      return borderNumberToSize[PAGet("borderSize") or 1] or "thin"
+                  end,
+                  setValue = function(v) PASet("borderSize", borderSizeToNumber[v] or 1) end }
             );  y = y - h
 
-            -- Inline border color swatch on Border Size slider
+            -- Textured-border offset and layer controls.
             do
                 local rgn = bsRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Border Offset",
+                    rows = {
+                        { type = "slider", label = "Offset X", min = -10, max = 10, step = 1,
+                          get = function()
+                              local v = PAGet("borderTextureOffset")
+                              if v ~= nil then return v end
+                              return EllesmereUI.GetBorderDefaults("unitframes", PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
+                          end,
+                          set = function(v) PASet("borderTextureOffset", v) end },
+                        { type = "slider", label = "Offset Y", min = -10, max = 10, step = 1,
+                          get = function()
+                              local v = PAGet("borderTextureOffsetY")
+                              if v ~= nil then return v end
+                              local _, oy = EllesmereUI.GetBorderDefaults("unitframes", PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
+                              return oy
+                          end,
+                          set = function(v) PASet("borderTextureOffsetY", v) end },
+                        { type = "slider", label = "Shift X", min = -10, max = 10, step = 1,
+                          get = function()
+                              local v = PAGet("borderTextureShiftX")
+                              if v ~= nil then return v end
+                              local _, _, sx = EllesmereUI.GetBorderDefaults("unitframes", PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
+                              return sx
+                          end,
+                          set = function(v) PASet("borderTextureShiftX", v == 0 and nil or v) end },
+                        { type = "slider", label = "Shift Y", min = -10, max = 10, step = 1,
+                          get = function()
+                              local v = PAGet("borderTextureShiftY")
+                              if v ~= nil then return v end
+                              local _, _, _, sy = EllesmereUI.GetBorderDefaults("unitframes", PAGet("borderTexture") or "solid", PAGet("borderSize") or 1)
+                              return sy
+                          end,
+                          set = function(v) PASet("borderTextureShiftY", v == 0 and nil or v) end },
+                        { type = "toggle", label = "Show Behind",
+                          get = function() return PAGet("borderBehind") or false end,
+                          set = function(v) PASet("borderBehind", v) end },
+                    },
+                })
+                local cogBtn = CreateFrame("Button", nil, rgn)
+                cogBtn:SetSize(26, 26)
+                cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+                rgn._lastInline = cogBtn
+                cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+                cogBtn:SetAlpha(0.4)
+                local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+                cogTex:SetAllPoints()
+                cogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+                cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+                cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+                cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+                local function UpdateCogVis()
+                    if (PAGet("borderTexture") or "solid") == "solid" then cogBtn:Hide() else cogBtn:Show() end
+                end
+                EllesmereUI.RegisterWidgetRefresh(UpdateCogVis)
+                UpdateCogVis()
+            end
+
+            -- Inline border color swatch on Border Size dropdown
+            do
+                local rgn = bsRow._rightRegion
                 local borderSwatch, updateBorderSwatch = EllesmereUI.BuildColorSwatch(
                     rgn, bsRow:GetFrameLevel() + 3,
                     function()
@@ -15181,6 +15453,17 @@ initFrame:SetScript("OnEvent", function(self)
                 UpdateBorderSwatchState()
             end
         end
+
+        -- Row 4: Blizzard debuff borders | buff-frame expand button.
+        _, h = W:DualRow(parent, y,
+            { type = "toggle", text = "No Border on Debuffs",
+              tooltip = "When enabled, debuff icons keep Blizzard's colored border instead of using the custom border.",
+              getValue = function() return PAGet("noBorderDebuffs") ~= false end,
+              setValue = function(v) PASet("noBorderDebuffs", v) end },
+            { type = "toggle", text = "Show Expand Button",
+              getValue = function() return PAGet("showExpandButton") ~= false end,
+              setValue = function(v) PASet("showExpandButton", v) end }
+        );  y = y - h
 
         -----------------------------------------------------------------------
         --  External Defensives Frame (our own frame; live enable, no reload)
@@ -15275,22 +15558,76 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
         end
 
-        -- Row 3: Border Size (+ inline color swatch) | (empty)
+        -- Row 3: Border Style (+ offset cog) | Border Size (+ color swatch)
         do
+            local texValues, texOrder = EllesmereUI.GetBorderTextureDropdown()
+            local borderSizeValues = { none="None", thin="Thin", normal="Normal", heavy="Heavy", strong="Strong" }
+            local borderSizeOrder = { "none", "thin", "normal", "heavy", "strong" }
+            local sizeToNumber = { none=0, thin=1, normal=2, heavy=3, strong=4 }
+            local numberToSize = { [0]="none", [1]="thin", [2]="normal", [3]="heavy", [4]="strong" }
             local edBsRow
             edBsRow, h = W:DualRow(parent, y,
-                { type = "slider", text = "Border Size", min = 0, max = 4, step = 1,
-                  getValue = function() return EDGet("borderSize") or 1 end,
-                  setValue = function(v) EDSet("borderSize", v) end },
-                { type = "dropdown", text = "Growth Direction",
-                  tooltip = "Which direction new icons extend from the frame's edge.",
-                  values = { right = "Right", left = "Left" },
-                  order = { "right", "left" },
-                  getValue = function() return EDGet("growDirection") or "right" end,
-                  setValue = function(v) EDSet("growDirection", v) end }
+                { type="dropdown", text="Border Style", values=texValues, order=texOrder,
+                  getValue=function() return EDGet("borderTexture") or "solid" end,
+                  setValue=function(v)
+                      local color, behind = EllesmereUI.GetBorderStyleSelectDefaults(v)
+                      local p = db.profile.externalDefensives
+                      p.borderTexture = v
+                      p.borderTextureOffset = nil; p.borderTextureOffsetY = nil
+                      p.borderTextureShiftX = nil; p.borderTextureShiftY = nil
+                      p.borderBehind = behind
+                      p.borderR = color.r; p.borderG = color.g; p.borderB = color.b; p.borderA = 1
+                      local defSz = EllesmereUI.GetBorderDefaultSize("unitframes", v)
+                      if defSz then p.borderSize = defSz end
+                      if ns.RefreshExternalDefensives then ns.RefreshExternalDefensives() end
+                  end },
+                { type="dropdown", text="Border Size", values=borderSizeValues, order=borderSizeOrder,
+                  getValue=function() return numberToSize[EDGet("borderSize") or 1] or "thin" end,
+                  setValue=function(v) EDSet("borderSize", sizeToNumber[v] or 1) end }
             );  y = y - h
+
             do
                 local rgn = edBsRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title="Border Offset",
+                    rows={
+                        { type="slider", label="Offset X", min=-10, max=10, step=1,
+                          get=function()
+                              local v=EDGet("borderTextureOffset"); if v ~= nil then return v end
+                              return EllesmereUI.GetBorderDefaults("unitframes", EDGet("borderTexture") or "solid", EDGet("borderSize") or 1)
+                          end, set=function(v) EDSet("borderTextureOffset", v) end },
+                        { type="slider", label="Offset Y", min=-10, max=10, step=1,
+                          get=function()
+                              local v=EDGet("borderTextureOffsetY"); if v ~= nil then return v end
+                              local _,oy=EllesmereUI.GetBorderDefaults("unitframes", EDGet("borderTexture") or "solid", EDGet("borderSize") or 1); return oy
+                          end, set=function(v) EDSet("borderTextureOffsetY", v) end },
+                        { type="slider", label="Shift X", min=-10, max=10, step=1,
+                          get=function()
+                              local v=EDGet("borderTextureShiftX"); if v ~= nil then return v end
+                              local _,_,sx=EllesmereUI.GetBorderDefaults("unitframes", EDGet("borderTexture") or "solid", EDGet("borderSize") or 1); return sx
+                          end, set=function(v) EDSet("borderTextureShiftX", v == 0 and nil or v) end },
+                        { type="slider", label="Shift Y", min=-10, max=10, step=1,
+                          get=function()
+                              local v=EDGet("borderTextureShiftY"); if v ~= nil then return v end
+                              local _,_,_,sy=EllesmereUI.GetBorderDefaults("unitframes", EDGet("borderTexture") or "solid", EDGet("borderSize") or 1); return sy
+                          end, set=function(v) EDSet("borderTextureShiftY", v == 0 and nil or v) end },
+                        { type="toggle", label="Show Behind",
+                          get=function() return EDGet("borderBehind") or false end,
+                          set=function(v) EDSet("borderBehind", v) end },
+                    },
+                })
+                local cogBtn = CreateFrame("Button", nil, rgn)
+                cogBtn:SetSize(26,26); cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8,0)
+                rgn._lastInline=cogBtn; cogBtn:SetFrameLevel(rgn:GetFrameLevel()+5); cogBtn:SetAlpha(0.4)
+                local tex=cogBtn:CreateTexture(nil,"OVERLAY"); tex:SetAllPoints(); tex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+                cogBtn:SetScript("OnEnter",function(self) self:SetAlpha(0.7) end)
+                cogBtn:SetScript("OnLeave",function(self) self:SetAlpha(0.4) end)
+                cogBtn:SetScript("OnClick",function(self) cogShow(self) end)
+                local function UpdateCogVis() if (EDGet("borderTexture") or "solid") == "solid" then cogBtn:Hide() else cogBtn:Show() end end
+                EllesmereUI.RegisterWidgetRefresh(UpdateCogVis); UpdateCogVis()
+            end
+            do
+                local rgn = edBsRow._rightRegion
                 local borderSwatch, updateBorderSwatch = EllesmereUI.BuildColorSwatch(
                     rgn, edBsRow:GetFrameLevel() + 3,
                     function()
@@ -15319,6 +15656,16 @@ initFrame:SetScript("OnEvent", function(self)
                 UpdateEDBorderSwatchState()
             end
         end
+
+        -- Row 4: icon growth direction.
+        _, h = W:DualRow(parent, y,
+            { type = "dropdown", text = "Growth Direction",
+              tooltip = "Which direction new icons extend from the frame's edge.",
+              values = { right = "Right", left = "Left" }, order = { "right", "left" },
+              getValue = function() return EDGet("growDirection") or "right" end,
+              setValue = function(v) EDSet("growDirection", v) end },
+            nil
+        ); y = y - h
 
         return math.abs(y)
     end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -70,7 +70,9 @@ local defaults = {
             iconSize      = 32,
             showText      = true,
             textSize      = 11,
+            borderTexture = "solid",
             borderSize    = 1,
+            borderBehind  = false,
             borderR       = 0, borderG = 0, borderB = 0, borderA = 1,
             noBorderDebuffs = true,
             buffIconZoom   = 0.055,
@@ -84,7 +86,9 @@ local defaults = {
             growDirection = "right",  -- "right" | "left": which way icons extend from the frame edge
             showText      = true,
             textSize      = 11,
+            borderTexture = "solid",
             borderSize    = 1,
+            borderBehind  = false,
             borderR       = 0, borderG = 0, borderB = 0, borderA = 1,
             durationFormat = "blizzard",
             unlockPos     = nil,
@@ -143,6 +147,11 @@ local defaults = {
             buffSize = 22,
             buffOffsetX = 0,
             buffOffsetY = 0,
+            auraBorderTexture = "solid",
+            auraBorderSize = 1,
+            auraBorderR = 0, auraBorderG = 0, auraBorderB = 0, auraBorderA = 1,
+            auraBorderBehind = false,
+            auraBorderBehindUnitFrame = false,
             buffShowCooldownText = false,
             buffCooldownTextSize = 10,
             debuffAnchor = "none",
@@ -405,6 +414,11 @@ local defaults = {
             buffSize = 22,
             buffOffsetX = 0,
             buffOffsetY = 0,
+            auraBorderTexture = "solid",
+            auraBorderSize = 1,
+            auraBorderR = 0, auraBorderG = 0, auraBorderB = 0, auraBorderA = 1,
+            auraBorderBehind = false,
+            auraBorderBehindUnitFrame = false,
             buffShowCooldownText = false,
             buffCooldownTextSize = 10,
             debuffSize = 22,
@@ -952,6 +966,11 @@ local defaults = {
             simpleDebuffCooldownTextSize = 14,
             simpleDebuffs = "left",  -- "none"/"left"/"right": simple display forces that-side anchor + frame-height-matched debuff size (legacy boolean true=left / false=none honored at read time)
             simpleBuffs = "none",  -- "none"/"left"/"right": simple BUFF display (mirrors simpleDebuffs but defaults off)
+            auraBorderTexture = "solid",
+            auraBorderSize = 1,
+            auraBorderR = 0, auraBorderG = 0, auraBorderB = 0, auraBorderA = 1,
+            auraBorderBehind = false,
+            auraBorderBehindUnitFrame = false,
             simpleBuffShowCooldownText = false,
             simpleBuffCooldownTextSize = 14,
             buffSpacing = 1,
@@ -6059,6 +6078,45 @@ local function CreateTargetAuras(frame, unit)
         ns.UF_GetProfile = ns.UF_GetProfile or function() return db and db.profile end
         return ns.UF_CreateAuraContainers(frame, unit or "target")
     end
+    -- Live (12.0) oUF recycles aura buttons. Border styling must therefore run
+    -- on updates as well as creation; otherwise pooled buttons keep their old
+    -- border (or no border at all) after settings/profile changes.
+    local function ApplyLegacyAuraBorder(button)
+        if not button then return end
+        local s = GetSettingsForUnit(unit or "target")
+        if not button._euiAuraBorder then
+            button._euiAuraBorder = CreateFrame("Frame", nil, button)
+            button._euiAuraBorder:SetAllPoints()
+        end
+        local border = button._euiAuraBorder
+        local auraBorderSize = (s and s.auraBorderSize) or 1
+        if s and s.auraBorderBehindUnitFrame then
+            border:SetFrameLevel(math.max(0, frame:GetFrameLevel() - 1))
+        else
+            border:SetFrameLevel(s and s.auraBorderBehind
+                and math.max(0, button:GetFrameLevel() - 1) or (button:GetFrameLevel() + 1))
+        end
+        EllesmereUI.ApplyBorderStyle(border, auraBorderSize,
+            (s and s.auraBorderR) or 0, (s and s.auraBorderG) or 0,
+            (s and s.auraBorderB) or 0, (s and s.auraBorderA) or 1,
+            (s and s.auraBorderTexture) or "solid",
+            s and s.auraBorderTextureOffset, s and s.auraBorderTextureOffsetY,
+            s and s.auraBorderTextureShiftX, s and s.auraBorderTextureShiftY,
+            "unitframes", auraBorderSize)
+        -- Some live oUF builds provide their own border region. Retire it so it
+        -- cannot cover the configurable frame, then retain the established
+        -- alias used by the legacy dispel-color code below.
+        if button.Border and button.Border ~= border and button.Border.Hide then
+            button.Border:Hide()
+        end
+        button.Border = border
+        if button.Cooldown then
+            button.Cooldown:SetFrameLevel(border:GetFrameLevel() + 2)
+            local countFrame = button.Count and button.Count:GetParent()
+            if countFrame then countFrame:SetFrameLevel(button.Cooldown:GetFrameLevel() + 1) end
+        end
+    end
+
     local function SetupAuraIcon(container, button)
         if not button then return end
 
@@ -6142,12 +6200,7 @@ local function CreateTargetAuras(frame, unit)
             ns.ApplyStackAnchor(button.Count, button, sPos, sOffX, sOffY)
         end
 
-        if not button.Border then
-            button.Border = CreateFrame("Frame", nil, button)
-            button.Border:SetAllPoints()
-            button.Border:SetFrameLevel(button:GetFrameLevel() + 1)
-            PP.CreateBorder(button.Border, 0, 0, 0, 1)
-        end
+        ApplyLegacyAuraBorder(button)
 
         -- Keep the duration and stack text above the icon border. The PP border
         -- textures live on a container ONE level above button.Border, so lifting
@@ -6157,13 +6210,7 @@ local function CreateTargetAuras(frame, unit)
         -- container, then re-park oUF's stack-count frame one level above that so
         -- the stack number stays on top too (its creation-time level was relative
         -- to the cooldown's OLD level, so it no longer tracks after this bump).
-        if button.Cooldown and button.Border then
-            button.Cooldown:SetFrameLevel(button.Border:GetFrameLevel() + 2)
-            local countFrame = button.Count and button.Count:GetParent()
-            if countFrame then
-                countFrame:SetFrameLevel(button.Cooldown:GetFrameLevel() + 1)
-            end
-        end
+        -- Frame-level ordering is applied by ApplyLegacyAuraBorder above.
     end
 
     local gap = 1
@@ -6262,6 +6309,9 @@ local function CreateTargetAuras(frame, unit)
     buffs.growthY = bgy
     ns.ApplyEUIAuraFilter(buffs, "HELPFUL", settings)
     buffs.PostCreateButton = SetupAuraIcon
+    buffs.PostUpdateButton = function(_, button)
+        ApplyLegacyAuraBorder(button)
+    end
     if not showBuffs and not simpleBuffOn then
         buffs:Hide()
         buffs.num = 0
@@ -6347,6 +6397,7 @@ local function CreateTargetAuras(frame, unit)
         -- Dispel-type border recolor; reads the per-unit setting live so the
         -- options toggle applies on the next aura update without a rebuild.
         debuffs.PostUpdateButton = function(_, button, u, data)
+            ApplyLegacyAuraBorder(button)
             if ns.UF_ColorDebuffDispelBorder then ns.UF_ColorDebuffDispelBorder(button, u, data) end
         end
         if settings and settings.onlyPlayerDebuffs then
@@ -14141,7 +14192,9 @@ do
         -- recycle across auras; never churn untouched borders).
         if button._euiDispelTinted then
             button._euiDispelTinted = nil
-            PP.SetBorderColor(border, 0, 0, 0, 1)
+            PP.SetBorderColor(border,
+                (s and s.auraBorderR) or 0, (s and s.auraBorderG) or 0,
+                (s and s.auraBorderB) or 0, (s and s.auraBorderA) or 1)
         end
     end
 

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
@@ -8,6 +8,7 @@ local addon, ns = ...
 local GetFFD = EllesmereUI._GetFFD
 
 local ICON_ZOOM = 0.055  -- fallback crop (same as totem bar); user values in profile
+local BLIZZARD_AURA_ICON_SIZE = 30 -- visible icon inside the native 32px aura button
 
 -------------------------------------------------------------------------------
 --  Settings helper
@@ -145,62 +146,34 @@ local function SkinAuraButton(btn, isDebuff)
         EllesmereUI.ApplyIconTextFont(countFS, fontPath, cfg.textSize or 11, "unitFrames")
     end
 
-    -- Pixel-perfect border using raw texture edges. No BackdropTemplate,
-    -- no GetWidth() calls, so no taint from the Blizzard frame hierarchy.
+    -- The shared border-style engine requires a frame we own. Keep that frame
+    -- anchored to the icon instead of applying a backdrop to Blizzard's button.
     local anchorFrame = iconFrame or btn
-    local PP = EllesmereUI.PP
     local bs = cfg.borderSize or 1
     local skipBorder = isDebuff and cfg.noBorderDebuffs
-    if bs > 0 and PP and not skipBorder then
-        local edges = ffd._paEdges
-        if not edges then
-            edges = {}
-            for _, key in ipairs({ "top", "bottom", "left", "right" }) do
-                local tex = btn:CreateTexture(nil, "OVERLAY", nil, 7)
-                edges[key] = tex
-            end
-            ffd._paEdges = edges
-        end
-        local scaledBS = PP.Scale(bs)
-        local bR = cfg.borderR or 0
-        local bG = cfg.borderG or 0
-        local bB = cfg.borderB or 0
-        local bA = cfg.borderA or 1
-
-        local top = edges.top
-        top:SetColorTexture(bR, bG, bB, bA)
-        top:ClearAllPoints()
-        top:SetPoint("TOPLEFT", anchorFrame, "TOPLEFT", 0, 0)
-        top:SetPoint("TOPRIGHT", anchorFrame, "TOPRIGHT", 0, 0)
-        top:SetHeight(scaledBS)
-        top:Show()
-
-        local bottom = edges.bottom
-        bottom:SetColorTexture(bR, bG, bB, bA)
-        bottom:ClearAllPoints()
-        bottom:SetPoint("BOTTOMLEFT", anchorFrame, "BOTTOMLEFT", 0, 0)
-        bottom:SetPoint("BOTTOMRIGHT", anchorFrame, "BOTTOMRIGHT", 0, 0)
-        bottom:SetHeight(scaledBS)
-        bottom:Show()
-
-        local left = edges.left
-        left:SetColorTexture(bR, bG, bB, bA)
-        left:ClearAllPoints()
-        left:SetPoint("TOPLEFT", anchorFrame, "TOPLEFT", 0, 0)
-        left:SetPoint("BOTTOMLEFT", anchorFrame, "BOTTOMLEFT", 0, 0)
-        left:SetWidth(scaledBS)
-        left:Show()
-
-        local right = edges.right
-        right:SetColorTexture(bR, bG, bB, bA)
-        right:ClearAllPoints()
-        right:SetPoint("TOPRIGHT", anchorFrame, "TOPRIGHT", 0, 0)
-        right:SetPoint("BOTTOMRIGHT", anchorFrame, "BOTTOMRIGHT", 0, 0)
-        right:SetWidth(scaledBS)
-        right:Show()
-    elseif ffd._paEdges then
-        for _, tex in pairs(ffd._paEdges) do tex:Hide() end
+    local border = ffd._paBorder
+    if not border then
+        border = CreateFrame("Frame", nil, btn)
+        border:EnableMouse(false)
+        ffd._paBorder = border
     end
+    border:SetFrameLevel(cfg.borderBehind and math.max(0, btn:GetFrameLevel() - 1) or (btn:GetFrameLevel() + 10))
+    -- Never derive this frame's dimensions through SetAllPoints(anchorFrame):
+    -- Blizzard aura dimensions are secret on Midnight, and BackdropTemplate's
+    -- SetBackdrop then attempts arithmetic on that secret width. AuraContainer
+    -- applies the user's icon size as scale over Blizzard's native 32px button.
+    -- Its visible icon is 30px, so this public constant avoids both the secret
+    -- geometry read and the one-pixel gap left by sizing to the whole button.
+    border:ClearAllPoints()
+    border:SetPoint("CENTER", anchorFrame, "CENTER", 0, 0)
+    border:SetSize(BLIZZARD_AURA_ICON_SIZE, BLIZZARD_AURA_ICON_SIZE)
+    EllesmereUI.ApplySecretSafeBorderStyle(border, ffd,
+        (bs > 0 and not skipBorder) and bs or 0,
+        cfg.borderR or 0, cfg.borderG or 0, cfg.borderB or 0, cfg.borderA or 1,
+        cfg.borderTexture or "solid",
+        cfg.borderTextureOffset, cfg.borderTextureOffsetY,
+        cfg.borderTextureShiftX, cfg.borderTextureShiftY,
+        "unitframes", bs)
 
     ffd._paSkinned = true
 end
@@ -231,6 +204,44 @@ ns.RefreshPlayerAuras = RefreshAll
 --  Scale helper (applies iconSize via SetScale on AuraContainer)
 -------------------------------------------------------------------------------
 local _appliedBuffScale, _appliedDebuffScale
+local _nativeExpandEnabled
+local _appliedShowExpand
+local _savedExpandedState
+
+local function ApplyExpandButtonSetting()
+    local cfg = PA()
+    local button = BuffFrame and BuffFrame.CollapseAndExpandButton
+    if not (cfg and button) then return end
+    if _nativeExpandEnabled == nil then
+        _nativeExpandEnabled = button:IsEnabled() and true or false
+    end
+    local show = cfg.showExpandButton ~= false
+    if _appliedShowExpand == show then
+        if not show then button:Hide() end
+        return
+    end
+    _appliedShowExpand = show
+    if not show then
+        _savedExpandedState = BuffFrame.isExpanded
+        -- Keep the button logically enabled: Blizzard's IsExpanded() treats a
+        -- disabled button as consolidated/collapsed in some configurations.
+        -- Force the model open and hide only the visual control.
+        button:Enable()
+        BuffFrame.isExpanded = true
+        if BuffFrame.Update then pcall(BuffFrame.Update, BuffFrame) end
+        button:Hide()
+    else
+        if _savedExpandedState ~= nil then
+            BuffFrame.isExpanded = _savedExpandedState
+            _savedExpandedState = nil
+        end
+        if _nativeExpandEnabled then button:Enable() else button:Disable() end
+        if BuffFrame.RefreshConsolidationFrameVisibility then
+            BuffFrame:RefreshConsolidationFrameVisibility()
+        end
+    end
+    if BuffFrame.UpdateGridLayout then pcall(BuffFrame.UpdateGridLayout, BuffFrame) end
+end
 
 local function ApplyScale()
     local cfg = PA()
@@ -250,6 +261,7 @@ local function ApplyScale()
             _appliedDebuffScale = scale
         end
     end
+    ApplyExpandButtonSetting()
 end
 ns.ApplyPlayerAuraScale = ApplyScale
 
@@ -327,42 +339,15 @@ local function EDF_StyleButton(btn, cfg)
         EllesmereUI.ApplyIconTextFont(btn._count, fontPath, cfg.textSize or 11, "unitFrames")
     end
 
-    -- Pixel-perfect 4-edge border (same construction as the skin above; these
-    -- are our own frames, drawn on the text host so they render above the
-    -- cooldown swipe).
-    local PP = EllesmereUI.PP
     local bs = cfg.borderSize or 1
-    if bs > 0 and PP then
-        local scaledBS = PP.Scale(bs)
-        local bR, bG, bB, bA = cfg.borderR or 0, cfg.borderG or 0, cfg.borderB or 0, cfg.borderA or 1
-        local e = btn._edges
-        e.top:SetColorTexture(bR, bG, bB, bA)
-        e.top:ClearAllPoints()
-        e.top:SetPoint("TOPLEFT", btn, "TOPLEFT", 0, 0)
-        e.top:SetPoint("TOPRIGHT", btn, "TOPRIGHT", 0, 0)
-        e.top:SetHeight(scaledBS)
-        e.top:Show()
-        e.bottom:SetColorTexture(bR, bG, bB, bA)
-        e.bottom:ClearAllPoints()
-        e.bottom:SetPoint("BOTTOMLEFT", btn, "BOTTOMLEFT", 0, 0)
-        e.bottom:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", 0, 0)
-        e.bottom:SetHeight(scaledBS)
-        e.bottom:Show()
-        e.left:SetColorTexture(bR, bG, bB, bA)
-        e.left:ClearAllPoints()
-        e.left:SetPoint("TOPLEFT", btn, "TOPLEFT", 0, 0)
-        e.left:SetPoint("BOTTOMLEFT", btn, "BOTTOMLEFT", 0, 0)
-        e.left:SetWidth(scaledBS)
-        e.left:Show()
-        e.right:SetColorTexture(bR, bG, bB, bA)
-        e.right:ClearAllPoints()
-        e.right:SetPoint("TOPRIGHT", btn, "TOPRIGHT", 0, 0)
-        e.right:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", 0, 0)
-        e.right:SetWidth(scaledBS)
-        e.right:Show()
-    else
-        for _, tex in pairs(btn._edges) do tex:Hide() end
-    end
+    local host = btn._borderHost
+    host:SetFrameLevel(cfg.borderBehind and math.max(0, btn:GetFrameLevel() - 1) or (btn:GetFrameLevel() + 2))
+    EllesmereUI.ApplyBorderStyle(host, bs,
+        cfg.borderR or 0, cfg.borderG or 0, cfg.borderB or 0, cfg.borderA or 1,
+        cfg.borderTexture or "solid",
+        cfg.borderTextureOffset, cfg.borderTextureOffsetY,
+        cfg.borderTextureShiftX, cfg.borderTextureShiftY,
+        "unitframes", bs)
 end
 
 local function EDF_CreateButton(i)
@@ -380,6 +365,11 @@ local function EDF_CreateButton(i)
     if cd.SetDrawEdge then cd:SetDrawEdge(false) end
     btn._cd = cd
 
+    local borderHost = CreateFrame("Frame", nil, btn)
+    borderHost:SetAllPoints(btn)
+    borderHost:EnableMouse(false)
+    btn._borderHost = borderHost
+
     -- Count + border live on a host above the cooldown, so the permanent-aura
     -- alpha mask on the cd (see EDF_Update) never takes them down with it.
     local txtHost = CreateFrame("Frame", nil, btn)
@@ -388,10 +378,6 @@ local function EDF_CreateButton(i)
     local cnt = txtHost:CreateFontString(nil, "OVERLAY")
     cnt:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", -1, 1)
     btn._count = cnt
-    btn._edges = {}
-    for _, key in ipairs({ "top", "bottom", "left", "right" }) do
-        btn._edges[key] = txtHost:CreateTexture(nil, "OVERLAY", nil, 7)
-    end
 
     edfButtons[i] = btn
     local cfg = ED()
@@ -641,6 +627,15 @@ initFrame:SetScript("OnEvent", function(self, event, arg1)
                 hooksecurefunc(BuffFrame.AuraContainer, "UpdateGridLayout", function()
                     C_Timer.After(0, RefreshAll)
                 end)
+                if BuffFrame.RefreshConsolidationFrameVisibility then
+                    hooksecurefunc(BuffFrame, "RefreshConsolidationFrameVisibility", function()
+                        local cfgNow = PA()
+                        if cfgNow and cfgNow.showExpandButton == false
+                            and BuffFrame.CollapseAndExpandButton then
+                            BuffFrame.CollapseAndExpandButton:Hide()
+                        end
+                    end)
+                end
             end
             if DebuffFrame and DebuffFrame.AuraContainer then
                 hooksecurefunc(DebuffFrame.AuraContainer, "UpdateGridLayout", function()

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -234,7 +234,30 @@ local function ApplyStyleToRegions(button, style)
         local PP = EllesmereUI.PP
         local b = style.border
         if PP and b then
-            if d.borderMade then
+            if b.texture and EllesmereUI.ApplyBorderStyle then
+                -- Aura buttons can expose restricted geometry. Give the owned
+                -- border host an explicit public size (change-guarded because
+                -- anchoring to the aura button is denied while restricted).
+                local borderRect = (style.width or 18) .. "|" .. (style.height or style.width or 18)
+                if d.akBorderRect ~= borderRect then
+                    d.borderHost:ClearAllPoints()
+                    d.borderHost:SetPoint("CENTER", button, "CENTER")
+                    d.borderHost:SetSize(style.width or 18, style.height or style.width or 18)
+                    d.akBorderRect = borderRect
+                end
+                if b.behindUnitFrame then
+                    d.borderHost:SetFrameLevel(math.max(0, (b.unitFrameLevel or 1) - 1))
+                else
+                    d.borderHost:SetFrameLevel(b.behind
+                        and math.max(0, button:GetFrameLevel() - 1)
+                        or (d.cooldown:GetFrameLevel() + 1))
+                end
+                EllesmereUI.ApplySecretSafeBorderStyle(d.borderHost, d, b.size or 1,
+                    b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1,
+                    b.texture or "solid", b.offsetX, b.offsetY, b.shiftX, b.shiftY,
+                    "unitframes", b.size or 1)
+                d.borderMade = true
+            elseif d.borderMade then
                 PP.UpdateBorder(d.borderHost, b.size or 1, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1)
             else
                 PP.CreateBorder(d.borderHost, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1,

--- a/Locales/deDE.lua
+++ b/Locales/deDE.lua
@@ -5,6 +5,7 @@
 
 local L = EllesmereUI.RegisterLocale("deDE")
 if not L then return end
+L["Behind Unit Frame"] = "Hinter dem Einheitenfenster"
 
 L["    Enemy Units"] = "    Feindliche Einheiten"
 L["    Friendly Units"] = "    Freundliche Einheiten"
@@ -3604,6 +3605,7 @@ L["Show Auras Outside Instances"] = "Auren außerhalb von Instanzen anzeigen"
 L["Show Bag Space"] = "Taschenplatz anzeigen"
 L["Show Bags"]   = "Taschen anzeigen"
 L["Show Behind"]  = "Dahinter anzeigen"
+L["Show Expand Button"] = "Erweitern-Schaltfläche anzeigen"
 L["Show black backgrounds behind minimap indicator buttons (tracking, calendar, mail, crafting, addon buttons, flyout toggle)."] = "Zeigt schwarze Hintergründe hinter den Indikator-Buttons der Minimap (Aufspüren, Kalender, Post, Handwerk, Addon-Buttons, Flyout-Umschalter)."
 L["Show Blizzard Elements"]     = "Blizzard Elemente anzeigen"
 L["Show Blizzard Icon Background"] = "Blizzard Symbolhintergrund anzeigen"

--- a/Locales/esES.lua
+++ b/Locales/esES.lua
@@ -5,6 +5,7 @@
 
 local L = EllesmereUI.RegisterLocale("esES")
 if not L then return end
+L["Behind Unit Frame"] = "Detrás del marco de unidad"
 
 -- == Common labels =========================================================
 L["Size"]              = "Tamaño"
@@ -51,6 +52,11 @@ L["Offset Y"]          = "Desplazamiento Y"
 L["Shift X"]           = "Desplazamiento X"
 L["Shift Y"]           = "Desplazamiento Y"
 L["None"]              = "Ninguno"
+L["Border Offset"]     = "Desplazamiento del borde"
+L["Thin"]              = "Fino"
+L["Normal"]            = "Normal"
+L["Heavy"]             = "Grueso"
+L["Strong"]            = "Fuerte"
 L["All"]               = "Todo"
 L["Multiple"]          = "Múltiple"
 L["Left"]              = "Izquierda"
@@ -141,5 +147,6 @@ L["Standard (5m / 32)"] = "Estándar (5m / 32)"
 L["Header Bottom Border"] = "Borde inferior del encabezado"
 L["Include Headerbar"] = "Incluir barra de encabezado"
 L["Show Behind"] = "Mostrar detrás"
+L["Show Expand Button"] = "Mostrar botón de expansión"
 L["Button Background"] = "Fondo del botón"
 L["Button Border Style"] = "Estilo de borde del botón"

--- a/Locales/esMX.lua
+++ b/Locales/esMX.lua
@@ -5,6 +5,7 @@
 
 local L = EllesmereUI.RegisterLocale("esMX")
 if not L then return end
+L["Behind Unit Frame"] = "Detrás del marco de unidad"
 
 -- == Common labels =========================================================
 L["Size"]              = "Tamaño"
@@ -51,6 +52,11 @@ L["Offset Y"]          = "Desplazamiento Y"
 L["Shift X"]           = "Desplazamiento X"
 L["Shift Y"]           = "Desplazamiento Y"
 L["None"]              = "Ninguno"
+L["Border Offset"]     = "Desplazamiento del borde"
+L["Thin"]              = "Fino"
+L["Normal"]            = "Normal"
+L["Heavy"]             = "Grueso"
+L["Strong"]            = "Fuerte"
 L["All"]               = "Todo"
 L["Multiple"]          = "Múltiple"
 L["Left"]              = "Izquierda"
@@ -141,5 +147,6 @@ L["Standard (5m / 32)"] = "Estándar (5m / 32)"
 L["Header Bottom Border"] = "Borde inferior del encabezado"
 L["Include Headerbar"] = "Incluir barra de encabezado"
 L["Show Behind"] = "Mostrar detrás"
+L["Show Expand Button"] = "Mostrar botón de expansión"
 L["Button Background"] = "Fondo del botón"
 L["Button Border Style"] = "Estilo de borde del botón"

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -5,6 +5,7 @@
 
 local L = EllesmereUI.RegisterLocale("frFR")
 if not L then return end
+L["Behind Unit Frame"] = "Derrière le cadre d’unité"
 
 -- == Common labels =========================================================
 L["Size"]              = "Taille"
@@ -3401,6 +3402,7 @@ L["Show Auras In Open World"]   = "Afficher les auras en monde ouvert"
 L["Show Auras Outside Instances"] = "Afficher les auras hors des instances"
 L["Show Bags"]                  = "Afficher les sacs"
 L["Show Behind"]                = "Afficher derrière"
+L["Show Expand Button"]         = "Afficher le bouton de développement"
 L["Show Blizzard Elements"]     = "Afficher les éléments Blizzard"
 L["Show Blizzard Icon Background"] = "Afficher l'arrière-plan d'icône Blizzard"
 L["Show Blizzard's native quest type icons/buttons on the right instead of EllesmereUI's custom icons. Requires a UI reload."] = "Afficher les icônes/boutons de type de quête natifs de Blizzard à droite au lieu des icônes personnalisées d'EllesmereUI. Nécessite un rechargement de l'interface."

--- a/Locales/itIT.lua
+++ b/Locales/itIT.lua
@@ -5,6 +5,7 @@
 
 local L = EllesmereUI.RegisterLocale("itIT")
 if not L then return end
+L["Behind Unit Frame"] = "Dietro il riquadro unità"
 
 -- == Common labels =========================================================
 L["Size"]              = "Dimensione"
@@ -51,6 +52,11 @@ L["Offset Y"]          = "Scostamento Y"
 L["Shift X"]           = "Scostamento X"
 L["Shift Y"]           = "Scostamento Y"
 L["None"]              = "Nessuno"
+L["Border Offset"]     = "Scostamento bordo"
+L["Thin"]              = "Sottile"
+L["Normal"]            = "Normale"
+L["Heavy"]             = "Pesante"
+L["Strong"]            = "Marcato"
 L["All"]               = "Tutto"
 L["Multiple"]          = "Multiplo"
 L["Left"]              = "Sinistra"
@@ -141,5 +147,6 @@ L["Standard (5m / 32)"] = "Standard (5m / 32)"
 L["Header Bottom Border"] = "Bordo inferiore dell’intestazione"
 L["Include Headerbar"] = "Includi barra dell’intestazione"
 L["Show Behind"] = "Mostra dietro"
+L["Show Expand Button"] = "Mostra pulsante di espansione"
 L["Button Background"] = "Sfondo pulsante"
 L["Button Border Style"] = "Stile bordo pulsante"

--- a/Locales/koKR.lua
+++ b/Locales/koKR.lua
@@ -6,6 +6,7 @@
 
 local L = EllesmereUI.RegisterLocale("koKR")
 if not L then return end
+L["Behind Unit Frame"] = "유닛 프레임 뒤에 표시"
 
 -- == Common labels (공용 라벨) =============================================
 L["Anchor"]            = "기준점"
@@ -427,6 +428,7 @@ L["Shift"] = "쉬프트"
 L["Shoulder"] = "어깨"
 L["Show %"] = "% 표시"
 L["Show Behind"] = "뒤에 표시"
+L["Show Expand Button"] = "확장 버튼 표시"
 L["Show Border"] = "테두리 표시"
 L["Show Cast Bar"] = "시전 바 표시"
 L["Show Class Resource"] = "직업 자원 표시"

--- a/Locales/ptBR.lua
+++ b/Locales/ptBR.lua
@@ -5,6 +5,7 @@
 
 local L = EllesmereUI.RegisterLocale("ptBR")
 if not L then return end
+L["Behind Unit Frame"] = "Atrás do quadro de unidade"
 
 -- == Common labels =========================================================
 L["Size"]              = "Tamanho"
@@ -51,6 +52,11 @@ L["Offset Y"]          = "Deslocamento Y"
 L["Shift X"]           = "Deslocamento X"
 L["Shift Y"]           = "Deslocamento Y"
 L["None"]              = "Nenhum"
+L["Border Offset"]     = "Deslocamento da borda"
+L["Thin"]              = "Fina"
+L["Normal"]            = "Normal"
+L["Heavy"]             = "Pesada"
+L["Strong"]            = "Forte"
 L["All"]               = "Tudo"
 L["Multiple"]          = "Múltiplo"
 L["Left"]              = "Esquerda"
@@ -141,5 +147,6 @@ L["Standard (5m / 32)"] = "Padrão curto (5m / 32)"
 L["Header Bottom Border"] = "Borda inferior do cabeçalho"
 L["Include Headerbar"] = "Incluir barra de cabeçalho"
 L["Show Behind"] = "Mostrar atrás"
+L["Show Expand Button"] = "Mostrar botão de expansão"
 L["Button Background"] = "Fundo do botão"
 L["Button Border Style"] = "Estilo da borda do botão"

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -6,6 +6,7 @@
 ---@diagnostic disable:undefined-global
 local L = EllesmereUI.RegisterLocale("ruRU")
 if not L then return end
+L["Behind Unit Frame"] = "За рамкой юнита"
 
 -- == Common vocabulary (highest frequency) =================================
 L["Enable"]            = "Включить"
@@ -1595,6 +1596,7 @@ L["Shift Elements if No Power"] = "Сдвигать без ресурса"
 L["Extra Y Offset"] = "Доп. смещение по Y"
 L["Hide Power Bar if Resource"] = "Скрывать полосу ресурса, если есть основной ресурс"
 L["Show Behind"] = "Показывать сзади"
+L["Show Expand Button"] = "Показывать кнопку разворачивания"
 
 -- Gradient Settings
 L["Enable Gradient"] = "Включить градиент"

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -5,6 +5,7 @@
 ---@diagnostic disable:undefined-global
 local L = EllesmereUI.RegisterLocale("zhCN")
 if not L then return end
+L["Behind Unit Frame"] = "显示在单位框体后方"
 
 -- == Common vocabulary (highest frequency) =================================
 L["Enable"]            = "启用"
@@ -1702,6 +1703,7 @@ L["Shift Elements if No Power"] = "无能量条时移动元素"
 L["Extra Y Offset"] = "额外 Y 偏移"
 L["Hide Power Bar if Resource"] = "显示职业资源条时隐藏能量条"
 L["Show Behind"] = "置于后方"
+L["Show Expand Button"] = "显示展开按钮"
 
 -- Gradient Settings
 L["Enable Gradient"] = "启用渐变"

--- a/Locales/zhTW.lua
+++ b/Locales/zhTW.lua
@@ -4,6 +4,7 @@
 -- to generate the full remaining key list. Untranslated keys fall back to English.
 local L = EllesmereUI.RegisterLocale("zhTW")
 if not L then return end
+L["Behind Unit Frame"] = "顯示於單位框架後方"
 
 -- == Common labels =========================================================
 L["Size"]               = "大小"
@@ -1731,6 +1732,7 @@ L["Shifts any elements anchored to the power bar up or down to offset the missin
 L["Show %"]                        = "顯示 %"
 L["Show a small glowing spark that moves along the leading edge of the fill."] = "顯示一個沿填充前緣移動的小型發光火花。"
 L["Show Behind"]                   = "顯示於後方"
+L["Show Expand Button"]            = "顯示展開按鈕"
 L["Show Hash Line"]                = "顯示刻度線"
 L["Show Hash Lines"]               = "顯示刻度線"
 L["Show Health Bar"]               = "顯示生命條"


### PR DESCRIPTION
## Description

This PR expands aura border customization for Blizzard Player Auras and Unit Frames on both Live 12.0 and PTR 12.1.

### Changes

- Added configurable **Border Style** and **Border Size** for:
  - Blizzard Player Auras
  - Defensive Buffs
  - Player Unit Frame auras
  - Target Unit Frame auras
  - Boss Unit Frame auras
- Added border popover options:
  - Offset X/Y
  - Shift X/Y
  - Show Behind
  - Behind Unit Frame
  - Border color
- Selecting **Shadow** automatically enables both **Show Behind** and **Behind Unit Frame**.
- Added an option to hide the Blizzard buff-frame expand button.
  - All buffs remain expanded when the button is hidden.
- Added profile migration for the previous numeric border-size setting.
- New Unit Frame aura borders default to **Solid** and **Thin**.
- Moved border settings to the end of each Buffs and Debuffs section.
- Fixed border rendering for pooled oUF aura buttons on Live 12.0.
- Consolidated duplicated border rendering into a shared implementation.
- Added all required localizations.

### PTR 12.1 Secret-Value Workaround

PTR 12.1 protects parts of the new aura system with secret values. Reading aura-button dimensions or using `BackdropTemplate` on frames anchored to protected aura geometry can cause taint or secret-number arithmetic errors.

As a workaround, textured aura borders no longer use Blizzard's backdrop renderer. The addon creates an owned border frame with an explicit public size and renders the border manually from eight texture slices: four corners and four edges.

This avoids reading protected aura dimensions while preserving border textures, offsets, colors, and layer settings. AuraKit also uses a style fingerprint and deferred restyling so pooled or protected aura buttons can be updated safely when settings change.

### Performance Considerations

This workaround may have a small performance impact because textured borders require eight additional texture regions per aura button and may need to be restyled when aura settings or frame layers change. The implementation already caches and reuses these regions and avoids unnecessary updates through style fingerprinting and deferred restyling. However, further profiling and optimization may still be useful, and an additional review would be appreciated to confirm whether this approach is appropriate for the new secret-value restrictions.

## Screenshots

Unitframe Aura Borders

<img width="1317" height="965" alt="image" src="https://github.com/user-attachments/assets/9de11208-999b-4d37-8978-d6409800c978" />

Example 1
<img width="392" height="172" alt="image" src="https://github.com/user-attachments/assets/af1b6e6b-fb4f-4fee-9a7d-071773370310" />
Example 2
<img width="324" height="147" alt="image" src="https://github.com/user-attachments/assets/6e441bef-7518-4b14-9e4e-9eb5138f8dd4" />


Blizzard Auras

<img width="1335" height="976" alt="image" src="https://github.com/user-attachments/assets/6d804de0-5348-49bd-b120-dbe05ef0f7b7" />

Example 1
<img width="367" height="76" alt="image" src="https://github.com/user-attachments/assets/c33416f5-66ae-45c3-b083-1c603daedaf7" />

Example 2
<img width="361" height="82" alt="image" src="https://github.com/user-attachments/assets/cfee9f8d-269f-4d04-ac2a-6dc5e835da3b" />

## Testing

- [x] Tested on Live 12.0
- [x] Tested on PTR 12.1
- [x] Tested in combat both Live and PTR 
- [x] Tested with the new PTR aura system
- [x] Existing profile migration tested
- [x] Immediate border restyling tested
- [x] No Lua errors encountered