### PR TITLE
Raid frames: add missing health text

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -505,8 +505,9 @@ initFrame:SetScript("OnEvent", function(self)
         ["number"]        = "Number",
         ["numberPercent"] = "Number | Percent",
         ["percentNumber"] = "Percent | Number",
+        ["missing"]       = "Missing Number",
     }
-    local healthTextOrder = { "none", "percent", "percentNoSign", "number", "numberPercent", "percentNumber" }
+    local healthTextOrder = { "none", "percent", "percentNoSign", "number", "numberPercent", "percentNumber", "missing" }
 
     local absorbStyleValues = {
         ["none"]            = "None",
@@ -822,6 +823,14 @@ initFrame:SetScript("OnEvent", function(self)
                                         local fakeHP = st.current * 12000
                                         local numStr = AbbreviateNumbers and AbbreviateNumbers(fakeHP) or tostring(fakeHP)
                                         f._healthText:SetFormattedText("%d%% | %s", st.current, numStr)
+                                    elseif mode == "missing" then
+                                        local fakeHP = (100 - st.current) * 12000
+                                        f._healthText:SetText(C_StringUtil.TruncateWhenZero(fakeHP))
+                                        if f._healthText:GetText() then
+                                            if AbbreviateNumbers then
+                                                f._healthText:SetText(AbbreviateNumbers(fakeHP))
+                                            end
+                                        end
                                     end
                                 end
 

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -4414,6 +4414,18 @@ local function UpdateButton(button)
             d.healthText:SetFormattedText("%.0f%% | %s", pct, numStr)
             local htr, htg, htb = GetHealthTextColor(unit, s)
             d.healthText:SetTextColor(htr, htg, htb, 0.9)
+        elseif mode == "missing" then
+            local curr = UnitHealthMissing(unit, true)
+            d.healthText:SetText(C_StringUtil.TruncateWhenZero(curr))
+            if d.healthText:GetText() then
+                if curr and AbbreviateNumbers then
+                    d.healthText:SetText(AbbreviateNumbers(curr))
+                elseif curr then
+                    d.healthText:SetFormattedText("%s", curr)
+                end
+            end
+            local htr, htg, htb = GetHealthTextColor(unit, s)
+            d.healthText:SetTextColor(htr, htg, htb, 0.9)
         else
             d.healthText:SetText("")
         end
@@ -6208,6 +6220,18 @@ ns._UpdateButtonHealth = function(button)
             d.healthText:SetFormattedText("%.0f%% | %s", pct, numStr)
             local htr, htg, htb = GetHealthTextColor(unit, s)
             d.healthText:SetTextColor(htr, htg, htb, 0.9)
+        elseif mode == "missing" then
+            local curr = UnitHealthMissing(unit, true)
+            d.healthText:SetText(C_StringUtil.TruncateWhenZero(curr))
+            if d.healthText:GetText() then
+                if curr and AbbreviateNumbers then
+                    d.healthText:SetText(AbbreviateNumbers(curr))
+                elseif curr then
+                    d.healthText:SetFormattedText("%s", curr)
+                end
+            end
+            local htr, htg, htb = GetHealthTextColor(unit, s)
+            d.healthText:SetTextColor(htr, htg, htb, 0.9)
         else
             d.healthText:SetText("")
         end
@@ -6479,6 +6503,18 @@ FB.Update = function(b)
             local curr = UnitHealth(unit, true)
             local numStr = (curr and AbbreviateNumbers) and AbbreviateNumbers(curr) or tostring(curr or 0)
             b._healthText:SetFormattedText("%.0f%% | %s", pct, numStr)
+        elseif mode == "missing" then
+            local curr = UnitHealthMissing(unit, true)
+            b._healthText:SetText(C_StringUtil.TruncateWhenZero(curr))
+            if b._healthText:GetText() then
+                if curr and AbbreviateNumbers then
+                    b._healthText:SetText(AbbreviateNumbers(curr))
+                elseif curr then
+                    b._healthText:SetFormattedText("%s", curr)
+                end
+            end
+            local htr, htg, htb = GetHealthTextColor(unit, s)
+            b._healthText:SetTextColor(htr, htg, htb, 0.9)
         else
             b._healthText:SetText("")
         end
@@ -14003,6 +14039,15 @@ local function ApplyPreviewData(f, index)
             local fakeHP = healthPct * 12000
             local numStr = AbbreviateNumbers and AbbreviateNumbers(fakeHP) or tostring(fakeHP)
             f._healthText:SetFormattedText("%d%% | %s", healthPct, numStr)
+            f._healthText:SetTextColor(htr, htg, htb, 0.9)
+        elseif mode == "missing" then
+            local fakeHP = (100 - healthPct) * 12000
+            f._healthText:SetText(C_StringUtil.TruncateWhenZero(fakeHP))
+            if f._healthText:GetText() then
+                if AbbreviateNumbers then
+                    f._healthText:SetText(AbbreviateNumbers(fakeHP))
+                end
+            end
             f._healthText:SetTextColor(htr, htg, htb, 0.9)
         else
             f._healthText:SetText("")


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->
Add missing health on raid/party frames. **Not displayed if value is 0.**

Feature request: https://discord.com/channels/585577383847788554/1518657126711689457

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
12.0.7. With /euidev + follower dungeons.

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
<img width="453" height="231" alt="image" src="https://github.com/user-attachments/assets/e0b91fe0-77df-4052-95c3-22260afc692a" />

<img width="910" height="320" alt="image" src="https://github.com/user-attachments/assets/fd0027c2-b7fa-47f4-9336-d2cdb8b23e28" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
