### PR TITLE
fix(blizzskin): guild rank SetGuildRankOrder taint from menu/roster skin

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -758,45 +758,85 @@ end
     -- Back-compat full init (data + visual), used by the live re-apply path.
     local function _ttInit() _ttInitData(); _ttInitVisual() end
 
-    -- Context menu skinning
-    local _menuSkinned = {}
+    -- Context menus: UIParent overlay only (menu frames are pooled; parenting taints picks)
+    local _menuOverlay, _menuOverlayTarget
 
-    local function _menuSkinFrame(frame)
-        if not frame or frame:IsForbidden() or not _pmEnabled() then return end
-        for i = 1, _select("#", frame:GetRegions()) do
-            local region = _select(i, frame:GetRegions())
-            if region and region:IsObjectType("Texture") and not GetFFD(region).owned then
-                local RS = EllesmereUI.RESKIN
-                region:SetColorTexture(RS.BG_R, RS.BG_G, RS.BG_B, 1)
-                region:SetAlpha(RS.CTX_ALPHA)
-                region:ClearAllPoints()
-                region:SetPoint("TOPLEFT", frame, "TOPLEFT", 1, -1)
-                region:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -1, 1)
-            end
-        end
-        _menuSkinned[frame] = true
-        _applyConfiguredBorder(frame, "popupMenu", 1)
+    local function _menuTagIsProtected(tag)
+        return tag == "MENU_GUILD_RANKS"
     end
 
-    local function _menuOnOpen(manager, _, menuDescription)
+    local function _menuDescriptionProtected(menuDescription)
+        if not menuDescription or type(menuDescription.GetTag) ~= "function" then return false end
+        local ok, tag = pcall(menuDescription.GetTag, menuDescription)
+        return ok and _menuTagIsProtected(tag)
+    end
+
+    local function _menuOpenTagsProtected()
+        if not Menu or not Menu.GetOpenMenuTags then return false end
+        local ok, tags = pcall(Menu.GetOpenMenuTags)
+        if not ok or type(tags) ~= "table" then return false end
+        for i = 1, #tags do
+            if _menuTagIsProtected(tags[i]) then return true end
+        end
+        return false
+    end
+
+    local function _menuOverlayHide()
+        _menuOverlayTarget = nil
+        if _menuOverlay then _menuOverlay:Hide() end
+    end
+
+    local function _menuOverlayEnsure()
+        if _menuOverlay then return _menuOverlay end
+        local host = CreateFrame("Frame", nil, UIParent)
+        host:EnableMouse(false)
+        host:Hide()
+        local bg = host:CreateTexture(nil, "BACKGROUND", nil, -8)
+        bg:SetAllPoints(host)
+        GetFFD(bg).owned = true
+        GetFFD(host).menuBg = bg
+        host:SetScript("OnUpdate", function(self)
+            local menu = _menuOverlayTarget
+            if not menu or not menu.IsShown or not menu:IsShown() then
+                _menuOverlayHide()
+                return
+            end
+            local l, b, w, h = menu:GetLeft(), menu:GetBottom(), menu:GetWidth(), menu:GetHeight()
+            if not (l and b and w and h) then return end
+            self:ClearAllPoints()
+            self:SetPoint("BOTTOMLEFT", UIParent, "BOTTOMLEFT", l, b)
+            self:SetSize(w, h)
+            if menu.GetFrameStrata then self:SetFrameStrata(menu:GetFrameStrata()) end
+            local fl = menu.GetFrameLevel and menu:GetFrameLevel() or 1
+            self:SetFrameLevel(math.max(0, fl - 1))
+        end)
+        _menuOverlay = host
+        return host
+    end
+
+    local function _menuSkinOpen(manager)
+        if _menuOpenTagsProtected() then
+            _menuOverlayHide()
+            return
+        end
+        local menu = manager.GetOpenMenu and manager:GetOpenMenu()
+        if not menu or (menu.IsForbidden and menu:IsForbidden()) then
+            _menuOverlayHide()
+            return
+        end
+        local host = _menuOverlayEnsure()
+        local RS = EllesmereUI.RESKIN
+        GetFFD(host).menuBg:SetColorTexture(RS.BG_R, RS.BG_G, RS.BG_B, RS.CTX_ALPHA)
+        _applyConfiguredBorder(host, "popupMenu", 1)
+        _menuOverlayTarget = menu
+        host:Show()
+    end
+
+    local function _menuOnContextOpen(manager, _, menuDescription)
         if not _pmEnabled() then return end
-        -- Defer out of the secure context. The post-hook runs inside
-        -- Blizzard's protected menu pipeline; touching Blizzard objects
-        -- here propagates taint to action bar buttons. 
-        -- By the next frame the secure execution
-        -- has finished so AddMenuAcquiredCallback is safe.
+        if _menuDescriptionProtected(menuDescription) then return end
         C_Timer.After(0, function()
-            local menu = manager.GetOpenMenu and manager:GetOpenMenu()
-            if menu then
-                _menuSkinFrame(menu)
-            end
-            if menuDescription and menuDescription.AddMenuAcquiredCallback then
-                menuDescription:AddMenuAcquiredCallback(function(frame)
-                    C_Timer.After(0, function()
-                        _menuSkinFrame(frame)
-                    end)
-                end)
-            end
+            _menuSkinOpen(manager)
         end)
     end
 
@@ -804,11 +844,12 @@ end
         if not _G.Menu or not _G.Menu.GetManager then return end
         local mgr = _G.Menu.GetManager()
         if not mgr then return end
-        hooksecurefunc(mgr, "OpenMenu", function(self, ownerRegion, menuDescription)
-            _menuOnOpen(self, ownerRegion, menuDescription)
-        end)
+        if mgr.CloseMenus then
+            hooksecurefunc(mgr, "CloseMenus", _menuOverlayHide)
+        end
+        -- OpenMenu (dropdowns / guild ranks) intentionally not hooked
         hooksecurefunc(mgr, "OpenContextMenu", function(self, ownerRegion, menuDescription)
-            _menuOnOpen(self, ownerRegion, menuDescription)
+            _menuOnContextOpen(self, ownerRegion, menuDescription)
         end)
     end
 

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -758,28 +758,10 @@ end
     -- Back-compat full init (data + visual), used by the live re-apply path.
     local function _ttInit() _ttInitData(); _ttInitVisual() end
 
-    -- Context menus: UIParent overlay only (menu frames are pooled; parenting taints picks)
+    -- Context menus: UIParent overlay only. Menu frames are pooled — parenting
+    -- chrome or AddMenuAcquiredCallback taints later protected picks
+    -- (SetGuildRankOrder via RankDropdown OpenMenu). Dropdown OpenMenu is not hooked.
     local _menuOverlay, _menuOverlayTarget
-
-    local function _menuTagIsProtected(tag)
-        return tag == "MENU_GUILD_RANKS"
-    end
-
-    local function _menuDescriptionProtected(menuDescription)
-        if not menuDescription or type(menuDescription.GetTag) ~= "function" then return false end
-        local ok, tag = pcall(menuDescription.GetTag, menuDescription)
-        return ok and _menuTagIsProtected(tag)
-    end
-
-    local function _menuOpenTagsProtected()
-        if not Menu or not Menu.GetOpenMenuTags then return false end
-        local ok, tags = pcall(Menu.GetOpenMenuTags)
-        if not ok or type(tags) ~= "table" then return false end
-        for i = 1, #tags do
-            if _menuTagIsProtected(tags[i]) then return true end
-        end
-        return false
-    end
 
     local function _menuOverlayHide()
         _menuOverlayTarget = nil
@@ -815,10 +797,6 @@ end
     end
 
     local function _menuSkinOpen(manager)
-        if _menuOpenTagsProtected() then
-            _menuOverlayHide()
-            return
-        end
         local menu = manager.GetOpenMenu and manager:GetOpenMenu()
         if not menu or (menu.IsForbidden and menu:IsForbidden()) then
             _menuOverlayHide()
@@ -832,9 +810,8 @@ end
         host:Show()
     end
 
-    local function _menuOnContextOpen(manager, _, menuDescription)
+    local function _menuOnContextOpen(manager)
         if not _pmEnabled() then return end
-        if _menuDescriptionProtected(menuDescription) then return end
         C_Timer.After(0, function()
             _menuSkinOpen(manager)
         end)
@@ -847,9 +824,8 @@ end
         if mgr.CloseMenus then
             hooksecurefunc(mgr, "CloseMenus", _menuOverlayHide)
         end
-        -- OpenMenu (dropdowns / guild ranks) intentionally not hooked
-        hooksecurefunc(mgr, "OpenContextMenu", function(self, ownerRegion, menuDescription)
-            _menuOnContextOpen(self, ownerRegion, menuDescription)
+        hooksecurefunc(mgr, "OpenContextMenu", function(self)
+            _menuOnContextOpen(self)
         end)
     end
 

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowEngine.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowEngine.lua
@@ -1215,6 +1215,7 @@ end
 function WSkin.ButtonsIn(frame, depth)
     depth = depth or 0
     if not frame or depth > 9 or not frame.GetChildren or frame:IsForbidden() then return end
+    if depth > 0 and WSkin.IsArtExempt(frame) then return end
     for i = 1, select("#", frame:GetChildren()) do
         local child = select(i, frame:GetChildren())
         if child and not WSkin.IsForeignFrame(child, frame) then
@@ -1238,6 +1239,7 @@ local CONTROL_KEYS = {
 function WSkin.ControlsIn(frame, depth)
     depth = depth or 0
     if not frame or depth > 9 or not frame.GetChildren or frame:IsForbidden() then return end
+    if depth > 0 and WSkin.IsArtExempt(frame) then return end
     if depth > 0 and WSkin.IsForeignFrame(frame) then return end
     for _, key in ipairs(CONTROL_KEYS) do
         local el = frame[key]

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -3070,10 +3070,24 @@ local function Skin_Guild()
     if ml and ml.MemberCount and ml.MemberCount.SetTextColor then
         WSkin.White(ml.MemberCount)
     end
-    -- View dropdowns: visual skin only (no SetScale/SetPoint — taint-adjacent)
+    -- Member-list view dropdowns (guild + community variants): scaled-down
+    -- with slightly smaller text, seated 8px lower (one-shot; label keeps
+    -- its stock font size, the 0.85 scale is the only text shrink).
     for _, ddKey in ipairs({ "GuildMemberListDropdown", "CommunityMemberListDropdown" }) do
         local dd2 = f[ddKey]
-        if dd2 then WSkin.Dropdown(dd2) end
+        if dd2 then
+            WSkin.Dropdown(dd2)
+            local gdd = GetFFD(dd2)
+            if not gdd.scaled then
+                gdd.scaled = true
+                dd2:SetScale(0.85)
+                local p, rel, rp, x, y = dd2:GetPoint(1)
+                if p then
+                    dd2:ClearAllPoints()
+                    dd2:SetPoint(p, rel, rp, x or 0, (y or 0) - 8)
+                end
+            end
+        end
     end
     if ml and ml.ShowOfflineButton then SkinGuildCheck(ml.ShowOfflineButton) end
     SkinGuildPopup(_G.CommunitiesAddDialog)
@@ -3239,9 +3253,190 @@ local function Skin_Guild()
         GetFFD(ml).colRefreshHooked = true
         hooksecurefunc(ml, "RefreshListDisplay", WSkin.Debounce(SkinRosterColumns))
     end
-    -- Roster ScrollBox lift / widen / row SetWidth removed: those writes taint
-    -- MemberList and break protected rank picks (SetGuildRankOrder) even without
-    -- HookScripts on ColumnDisplay.
+    -- Member-name list rides up 2px (one-shot, every anchor preserved).
+    local mlBox = ml and ml.ScrollBox
+    if mlBox and not GetFFD(mlBox).lifted then
+        local numPts = mlBox:GetNumPoints()
+        if numPts and numPts > 0 then
+            local pts, ok = {}, true
+            for i = 1, numPts do
+                local p, rel, rp, x, y = mlBox:GetPoint(i)
+                if not p then ok = false break end
+                pts[i] = { p, rel, rp, x or 0, (y or 0) + 2 }
+            end
+            if ok then
+                GetFFD(mlBox).lifted = true
+                mlBox:ClearAllPoints()
+                for i = 1, #pts do
+                    local t = pts[i]
+                    mlBox:SetPoint(t[1], t[2], t[3], t[4], t[5])
+                end
+            end
+        end
+    end
+
+    -- Roster-view widening, applied ONLY while the roster is up. The
+    -- MemberList is SHARED with the chat view's narrow names column, where
+    -- an unconditional widen overflowed the scrollbar and covered the chat
+    -- input. The sort-header row exists only on the roster view, so its
+    -- visibility gates the swap between the stock and widened anchor sets.
+    local cd2 = ml and ml.ColumnDisplay
+    local box2 = ml and ml.ScrollBox
+    if cd2 and box2 and not GetFFD(cd2).widenGate then
+        GetFFD(cd2).widenGate = true
+        local function capturePts(part)
+            local n2 = part:GetNumPoints()
+            if not n2 or n2 == 0 then return nil end
+            local pts2 = {}
+            for i = 1, n2 do
+                local p, rel, rp, x, y = part:GetPoint(i)
+                if not p then return nil end
+                pts2[i] = { p, rel, rp, x or 0, y or 0 }
+            end
+            return pts2
+        end
+        local function widePts(pts2, dl, dr)
+            local w2 = {}
+            for i = 1, #pts2 do
+                local t = pts2[i]
+                local nx = t[4]
+                if t[1]:find("LEFT", 1, true) then
+                    nx = nx - dl
+                elseif t[1]:find("RIGHT", 1, true) then
+                    nx = nx + dr
+                end
+                w2[i] = { t[1], t[2], t[3], nx, t[5] }
+            end
+            return w2
+        end
+        local function applyPts(part, pts2)
+            if not pts2 then return end
+            part:ClearAllPoints()
+            for i = 1, #pts2 do
+                local t = pts2[i]
+                part:SetPoint(t[1], t[2], t[3], t[4], t[5])
+            end
+        end
+        local boxStock = capturePts(box2)
+        local cdStock = capturePts(cd2)
+        local boxWide = boxStock and widePts(boxStock, 23, 20)
+        local cdWide = cdStock and widePts(cdStock, 23, 23)
+        -- Also widen `ml` (MemberList) itself at the source, since Blizzard's
+        -- own row-sizing below (SetWidth(GetMemberList():GetWidth())) reads
+        -- ml's width directly. RefreshLayout only ever gives `ml` a single
+        -- positional anchor (not a LEFT+RIGHT pair like box2/cd2), so it's
+        -- resized with a plain SetWidth rather than the capturePts/widePts
+        -- anchor-nudge technique above. This works alongside the per-row
+        -- SetWidth override below, not instead of it: the two are
+        -- belt-and-braces, so rows stay correctly sized whether Blizzard's
+        -- layout picks up the widened ml on its own or not.
+        local mlStockWidth = ml:GetWidth()
+        local mlWideWidth = mlStockWidth + 23 + 20
+        -- Every roster row is sized by Blizzard to MemberList's own width
+        -- (CommunitiesMemberListEntryMixin:SetExpanded -> SetWidth(GetMemberList()
+        -- :GetWidth())), a frame this pass never touches -- only its ScrollBox
+        -- and ColumnDisplay children get widened above. Left alone, rows stay
+        -- stock width while the header grows, so each row's GuildInfo text
+        -- (RIGHT-anchored to the row, -4) sits in a box that ends well short of
+        -- the widened header -- the Achievement Points / M+ Rating value renders
+        -- under the Note column instead of the far-right stat column. Re-stamp
+        -- every live row to the ScrollBox's actual current width so it always
+        -- matches. GuildInfo is also LEFT-justified in that box by default, so
+        -- widening it alone never moves the visible text -- center it and nudge
+        -- it left while the roster is showing, and put both back to Blizzard's
+        -- stock LEFT/20/-4 layout when it's not, since MemberList/ScrollBox is
+        -- shared with the Chat tab's narrower names column and a row must not
+        -- stay stranded in the roster's styling after the swap.
+        local GUILD_INFO_NUDGE = 20
+        local function ApplyRowLayout(row)
+            if not row then return end
+            if row.SetWidth then row:SetWidth(box2:GetWidth()) end
+            local gi = row.GuildInfo
+            if gi and row.Note and gi.SetJustifyH and gi.ClearAllPoints then
+                gi:ClearAllPoints()
+                if cd2:IsShown() then
+                    gi:SetJustifyH("CENTER")
+                    gi:SetPoint("LEFT", row.Note, "RIGHT", 20 - GUILD_INFO_NUDGE, 0)
+                    gi:SetPoint("RIGHT", row, "RIGHT", -4 - GUILD_INFO_NUDGE, 0)
+                else
+                    gi:SetJustifyH("LEFT")
+                    gi:SetPoint("LEFT", row.Note, "RIGHT", 20, 0)
+                    gi:SetPoint("RIGHT", row, "RIGHT", -4, 0)
+                end
+            end
+        end
+        -- Same uninitialized-ScrollBox guard used for the AH summary/rail rows
+        -- elsewhere in this file: ForEachFrame errors inside Blizzard's code
+        -- if the view doesn't exist yet (e.g. this pass runs at ADDON_LOADED,
+        -- before the roster has ever been shown).
+        local function SyncRowWidths()
+            if box2.ForEachFrame and box2.GetView and box2:GetView() then
+                pcall(box2.ForEachFrame, box2, ApplyRowLayout)
+            end
+        end
+        hooksecurefunc(box2, "Update", WSkin.Debounce(SyncRowWidths))
+        -- Swap column widths on roster<->chat view change WITHOUT a HookScript
+        -- on the secure ColumnDisplay (cd2): its OnShow/OnHide fires inside the
+        -- secure roster refresh a protected guild action triggers, tainting
+        -- SetNote / SetGuildRankOrder (the guild-note ADDON_ACTION_FORBIDDEN,
+        -- root-caused via bisection). A self-driven throttled OnUpdate on OUR
+        -- OWN frame polls cd2's shown state and applies the swap, so it never
+        -- runs inside that secure execution. Idles when the window is closed.
+        if not GetFFD(cd2)._euiWidthWatcher then
+            GetFFD(cd2)._euiWidthWatcher = true
+            -- Parented to the window: the OnUpdate handler stops entirely
+            -- while the guild window is closed (hidden parents don't tick).
+            local watcher = CreateFrame("Frame", nil, f)
+            local wasShown, acc = nil, 0
+            watcher:SetScript("OnUpdate", function(_, elapsed)
+                if f and not f:IsShown() then return end
+                acc = acc + elapsed
+                if acc < 0.1 then return end
+                acc = 0
+                local shown = cd2:IsShown()
+                if shown == wasShown then return end
+                wasShown = shown
+                if shown then
+                    applyPts(box2, boxWide); applyPts(cd2, cdWide); ml:SetWidth(mlWideWidth)
+                else
+                    applyPts(box2, boxStock); ml:SetWidth(mlStockWidth)
+                end
+                SyncRowWidths()
+            end)
+        end
+        if cd2:IsShown() then
+            applyPts(box2, boxWide)
+            applyPts(cd2, cdWide)
+            ml:SetWidth(mlWideWidth)
+        else
+            applyPts(box2, boxStock)
+            ml:SetWidth(mlStockWidth)
+        end
+        SyncRowWidths()
+    end
+
+    -- Chat view's names-column scrollbar sits 5px right (one-shot, every
+    -- anchor preserved).
+    local mlSB = ml and ml.ScrollBar
+    if mlSB and not GetFFD(mlSB).nudged then
+        local numPts = mlSB:GetNumPoints()
+        if numPts and numPts > 0 then
+            local pts, ok = {}, true
+            for i = 1, numPts do
+                local p, rel, rp, x, y = mlSB:GetPoint(i)
+                if not p then ok = false break end
+                pts[i] = { p, rel, rp, (x or 0) + 5, y or 0 }
+            end
+            if ok then
+                GetFFD(mlSB).nudged = true
+                mlSB:ClearAllPoints()
+                for i = 1, #pts do
+                    local t = pts[i]
+                    mlSB:SetPoint(t[1], t[2], t[3], t[4], t[5])
+                end
+            end
+        end
+    end
 
     local mm = f.MaximizeMinimizeFrame
     if mm then

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -2688,6 +2688,9 @@ local _guildNewsHook = false
 local function Skin_Guild()
     local f = _G.CommunitiesFrame
     if not f then return end
+    -- Leave GuildMemberDetailFrame 100% stock (RankDropdown → SetGuildRankOrder)
+    local gmdEarly = f.GuildMemberDetailFrame
+    if gmdEarly then GetFFD(gmdEarly).artExempt = true end
     WSkin.Shell("guild", f)
     WSkin.RemovePortrait(f)
     WSkin.CommonChrome(f)
@@ -3067,27 +3070,12 @@ local function Skin_Guild()
     if ml and ml.MemberCount and ml.MemberCount.SetTextColor then
         WSkin.White(ml.MemberCount)
     end
-    -- Member-list view dropdowns (guild + community variants): scaled-down
-    -- with slightly smaller text, seated 8px lower (one-shot; label keeps
-    -- its stock font size, the 0.85 scale is the only text shrink).
+    -- View dropdowns: visual skin only (no SetScale/SetPoint — taint-adjacent)
     for _, ddKey in ipairs({ "GuildMemberListDropdown", "CommunityMemberListDropdown" }) do
         local dd2 = f[ddKey]
-        if dd2 then
-            WSkin.Dropdown(dd2)
-            local gdd = GetFFD(dd2)
-            if not gdd.scaled then
-                gdd.scaled = true
-                dd2:SetScale(0.85)
-                local p, rel, rp, x, y = dd2:GetPoint(1)
-                if p then
-                    dd2:ClearAllPoints()
-                    dd2:SetPoint(p, rel, rp, x or 0, (y or 0) - 8)
-                end
-            end
-        end
+        if dd2 then WSkin.Dropdown(dd2) end
     end
     if ml and ml.ShowOfflineButton then SkinGuildCheck(ml.ShowOfflineButton) end
-    SkinGuildPopup(f.GuildMemberDetailFrame)
     SkinGuildPopup(_G.CommunitiesAddDialog)
     SkinGuildPopup(_G.CommunitiesCreateCommunityDialog)
     -- Add/Create Community dialogs: their globals are NOT live frames at
@@ -3251,190 +3239,9 @@ local function Skin_Guild()
         GetFFD(ml).colRefreshHooked = true
         hooksecurefunc(ml, "RefreshListDisplay", WSkin.Debounce(SkinRosterColumns))
     end
-    -- Member-name list rides up 2px (one-shot, every anchor preserved).
-    local mlBox = ml and ml.ScrollBox
-    if mlBox and not GetFFD(mlBox).lifted then
-        local numPts = mlBox:GetNumPoints()
-        if numPts and numPts > 0 then
-            local pts, ok = {}, true
-            for i = 1, numPts do
-                local p, rel, rp, x, y = mlBox:GetPoint(i)
-                if not p then ok = false break end
-                pts[i] = { p, rel, rp, x or 0, (y or 0) + 2 }
-            end
-            if ok then
-                GetFFD(mlBox).lifted = true
-                mlBox:ClearAllPoints()
-                for i = 1, #pts do
-                    local t = pts[i]
-                    mlBox:SetPoint(t[1], t[2], t[3], t[4], t[5])
-                end
-            end
-        end
-    end
-
-    -- Roster-view widening, applied ONLY while the roster is up. The
-    -- MemberList is SHARED with the chat view's narrow names column, where
-    -- an unconditional widen overflowed the scrollbar and covered the chat
-    -- input. The sort-header row exists only on the roster view, so its
-    -- visibility gates the swap between the stock and widened anchor sets.
-    local cd2 = ml and ml.ColumnDisplay
-    local box2 = ml and ml.ScrollBox
-    if cd2 and box2 and not GetFFD(cd2).widenGate then
-        GetFFD(cd2).widenGate = true
-        local function capturePts(part)
-            local n2 = part:GetNumPoints()
-            if not n2 or n2 == 0 then return nil end
-            local pts2 = {}
-            for i = 1, n2 do
-                local p, rel, rp, x, y = part:GetPoint(i)
-                if not p then return nil end
-                pts2[i] = { p, rel, rp, x or 0, y or 0 }
-            end
-            return pts2
-        end
-        local function widePts(pts2, dl, dr)
-            local w2 = {}
-            for i = 1, #pts2 do
-                local t = pts2[i]
-                local nx = t[4]
-                if t[1]:find("LEFT", 1, true) then
-                    nx = nx - dl
-                elseif t[1]:find("RIGHT", 1, true) then
-                    nx = nx + dr
-                end
-                w2[i] = { t[1], t[2], t[3], nx, t[5] }
-            end
-            return w2
-        end
-        local function applyPts(part, pts2)
-            if not pts2 then return end
-            part:ClearAllPoints()
-            for i = 1, #pts2 do
-                local t = pts2[i]
-                part:SetPoint(t[1], t[2], t[3], t[4], t[5])
-            end
-        end
-        local boxStock = capturePts(box2)
-        local cdStock = capturePts(cd2)
-        local boxWide = boxStock and widePts(boxStock, 23, 20)
-        local cdWide = cdStock and widePts(cdStock, 23, 23)
-        -- Also widen `ml` (MemberList) itself at the source, since Blizzard's
-        -- own row-sizing below (SetWidth(GetMemberList():GetWidth())) reads
-        -- ml's width directly. RefreshLayout only ever gives `ml` a single
-        -- positional anchor (not a LEFT+RIGHT pair like box2/cd2), so it's
-        -- resized with a plain SetWidth rather than the capturePts/widePts
-        -- anchor-nudge technique above. This works alongside the per-row
-        -- SetWidth override below, not instead of it: the two are
-        -- belt-and-braces, so rows stay correctly sized whether Blizzard's
-        -- layout picks up the widened ml on its own or not.
-        local mlStockWidth = ml:GetWidth()
-        local mlWideWidth = mlStockWidth + 23 + 20
-        -- Every roster row is sized by Blizzard to MemberList's own width
-        -- (CommunitiesMemberListEntryMixin:SetExpanded -> SetWidth(GetMemberList()
-        -- :GetWidth())), a frame this pass never touches -- only its ScrollBox
-        -- and ColumnDisplay children get widened above. Left alone, rows stay
-        -- stock width while the header grows, so each row's GuildInfo text
-        -- (RIGHT-anchored to the row, -4) sits in a box that ends well short of
-        -- the widened header -- the Achievement Points / M+ Rating value renders
-        -- under the Note column instead of the far-right stat column. Re-stamp
-        -- every live row to the ScrollBox's actual current width so it always
-        -- matches. GuildInfo is also LEFT-justified in that box by default, so
-        -- widening it alone never moves the visible text -- center it and nudge
-        -- it left while the roster is showing, and put both back to Blizzard's
-        -- stock LEFT/20/-4 layout when it's not, since MemberList/ScrollBox is
-        -- shared with the Chat tab's narrower names column and a row must not
-        -- stay stranded in the roster's styling after the swap.
-        local GUILD_INFO_NUDGE = 20
-        local function ApplyRowLayout(row)
-            if not row then return end
-            if row.SetWidth then row:SetWidth(box2:GetWidth()) end
-            local gi = row.GuildInfo
-            if gi and row.Note and gi.SetJustifyH and gi.ClearAllPoints then
-                gi:ClearAllPoints()
-                if cd2:IsShown() then
-                    gi:SetJustifyH("CENTER")
-                    gi:SetPoint("LEFT", row.Note, "RIGHT", 20 - GUILD_INFO_NUDGE, 0)
-                    gi:SetPoint("RIGHT", row, "RIGHT", -4 - GUILD_INFO_NUDGE, 0)
-                else
-                    gi:SetJustifyH("LEFT")
-                    gi:SetPoint("LEFT", row.Note, "RIGHT", 20, 0)
-                    gi:SetPoint("RIGHT", row, "RIGHT", -4, 0)
-                end
-            end
-        end
-        -- Same uninitialized-ScrollBox guard used for the AH summary/rail rows
-        -- elsewhere in this file: ForEachFrame errors inside Blizzard's code
-        -- if the view doesn't exist yet (e.g. this pass runs at ADDON_LOADED,
-        -- before the roster has ever been shown).
-        local function SyncRowWidths()
-            if box2.ForEachFrame and box2.GetView and box2:GetView() then
-                pcall(box2.ForEachFrame, box2, ApplyRowLayout)
-            end
-        end
-        hooksecurefunc(box2, "Update", WSkin.Debounce(SyncRowWidths))
-        -- Swap column widths on roster<->chat view change WITHOUT a HookScript
-        -- on the secure ColumnDisplay (cd2): its OnShow/OnHide fires inside the
-        -- secure roster refresh a protected guild action triggers, tainting
-        -- SetNote / SetGuildRankOrder (the guild-note ADDON_ACTION_FORBIDDEN,
-        -- root-caused via bisection). A self-driven throttled OnUpdate on OUR
-        -- OWN frame polls cd2's shown state and applies the swap, so it never
-        -- runs inside that secure execution. Idles when the window is closed.
-        if not GetFFD(cd2)._euiWidthWatcher then
-            GetFFD(cd2)._euiWidthWatcher = true
-            -- Parented to the window: the OnUpdate handler stops entirely
-            -- while the guild window is closed (hidden parents don't tick).
-            local watcher = CreateFrame("Frame", nil, f)
-            local wasShown, acc = nil, 0
-            watcher:SetScript("OnUpdate", function(_, elapsed)
-                if f and not f:IsShown() then return end
-                acc = acc + elapsed
-                if acc < 0.1 then return end
-                acc = 0
-                local shown = cd2:IsShown()
-                if shown == wasShown then return end
-                wasShown = shown
-                if shown then
-                    applyPts(box2, boxWide); applyPts(cd2, cdWide); ml:SetWidth(mlWideWidth)
-                else
-                    applyPts(box2, boxStock); ml:SetWidth(mlStockWidth)
-                end
-                SyncRowWidths()
-            end)
-        end
-        if cd2:IsShown() then
-            applyPts(box2, boxWide)
-            applyPts(cd2, cdWide)
-            ml:SetWidth(mlWideWidth)
-        else
-            applyPts(box2, boxStock)
-            ml:SetWidth(mlStockWidth)
-        end
-        SyncRowWidths()
-    end
-
-    -- Chat view's names-column scrollbar sits 5px right (one-shot, every
-    -- anchor preserved).
-    local mlSB = ml and ml.ScrollBar
-    if mlSB and not GetFFD(mlSB).nudged then
-        local numPts = mlSB:GetNumPoints()
-        if numPts and numPts > 0 then
-            local pts, ok = {}, true
-            for i = 1, numPts do
-                local p, rel, rp, x, y = mlSB:GetPoint(i)
-                if not p then ok = false break end
-                pts[i] = { p, rel, rp, (x or 0) + 5, y or 0 }
-            end
-            if ok then
-                GetFFD(mlSB).nudged = true
-                mlSB:ClearAllPoints()
-                for i = 1, #pts do
-                    local t = pts[i]
-                    mlSB:SetPoint(t[1], t[2], t[3], t[4], t[5])
-                end
-            end
-        end
-    end
+    -- Roster ScrollBox lift / widen / row SetWidth removed: those writes taint
+    -- MemberList and break protected rank picks (SetGuildRankOrder) even without
+    -- HookScripts on ColumnDisplay.
 
     local mm = f.MaximizeMinimizeFrame
     if mm then


### PR DESCRIPTION
## Bug report
(https://discord.com/channels/585577383847788554/1528850388860534785)
https://discord.com/channels/585577383847788554/1529094117404180633
## Summary

Fixes `ADDON_ACTION_FORBIDDEN` on `SetGuildRankOrder()` when changing a guild member's rank from the roster detail popup (`Menu.Pick` → `GuildRoster.lua`).

### Why we leave the member detail popup unskinned (instead of "fixing" its skin)

`GuildMemberDetailFrame` owns `RankDropdown`, which builds `MENU_GUILD_RANKS` and calls the protected `C_GuildInfo.SetGuildRankOrder` from `Menu.Pick`. Any addon write on that frame tree (backdrop `CreateTexture`, `AddBorder`, `FadeRegions`/`SetAlpha` on BG/Border, `CloseButton` skin, recursive `ButtonsIn`/`ControlsIn`) can leave the rank pick path tainted — BugGrabber then blames `EllesmereUIBlizzardSkin`.

We tried narrower approaches first (skip only the rank menu tag, owned chrome on the menu, fade-only detail chrome). They either still errored or broke the popup visually (no background) while still tainting. Blizzard's menu frames are also **pooled**, so parenting skin chrome onto a menu used for a safe context menu can poison a later rank dropdown pick.

So for this surface we deliberately **do not skin** `GuildMemberDetailFrame` at all and mark it `artExempt` so guild-window sweeps skip it. Stock Blizzard chrome here is preferable to a broken promote/demote action. A future taint-safe restyle would need an overlay that never writes Blizzard regions on that frame (same idea as the context-menu UIParent overlay) and would need in-game bisection before shipping.

### What this PR changes

- **Context menus**: stop mutating pooled `Menu` frames / `AddMenuAcquiredCallback`; paint via a UIParent overlay. Do **not** hook dropdown `OpenMenu` (guild ranks use that path).
- **Guild member detail**: remove `SkinGuildPopup(GuildMemberDetailFrame)`; `artExempt` so `ButtonsIn` / `ControlsIn` / art sweeps leave it alone.
- **Not reverted**: roster widen / ScrollBox lift / column header skin from #853 stay — those were the taint-*safe* layout path for notes/ranks and were not shown to be the `Menu.Pick` failure mode.

## Test plan
- [x] `/reload` with Guild & Communities skin + Reskin Popups/Menus enabled
- [x] Open guild roster → click a member → detail popup is **stock Blizzard** (background intact)
- [x] Change rank via the rank dropdown — applies with no `SetGuildRankOrder` / `ADDON_ACTION_FORBIDDEN`
- [x] Spot-check a normal right-click context menu still gets the dark overlay/border
- [x] Roster widen / Achievement Points column alignment still behaves as on main (#853 path)
