### PR TITLE
Fix nameplate raid mark positioning for secret names

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -1346,15 +1346,6 @@ initFrame:SetScript("OnEvent", function(self)
             local pvNameMarkerReserve = pvNameMarkerEnabled and (pvNameMarkerSize + NAME_RAID_MARKER_GAP) or 0
             local pvNameSlotKey
 
-            local function PreviewNameTextWidth()
-                local fallback = nameFS:GetWidth() or 0
-                local ok, w = pcall(nameFS.GetStringWidth, nameFS)
-                if ok and type(w) == "number" then
-                    return math.min(w, fallback > 0 and fallback or w)
-                end
-                return fallback
-            end
-
             local function LayoutPreviewNameRaidMarker()
                 if not (pvNameMarkerEnabled and pvNameSlotKey and nameFS:IsShown()) then
                     nameRaidFrame:Hide()
@@ -1364,14 +1355,7 @@ initFrame:SetScript("OnEvent", function(self)
                 nameRaidFrame:SetFrameLevel(health:GetFrameLevel() + 8)
                 nameRaidFrame:SetSize(pvNameMarkerSize, pvNameMarkerSize)
                 nameRaidFrame:ClearAllPoints()
-                local textW = PreviewNameTextWidth()
-                if pvNameSlotKey == "textSlotLeft" then
-                    nameRaidFrame:SetPoint("RIGHT", nameFS, "LEFT", -NAME_RAID_MARKER_GAP, 0)
-                elseif pvNameSlotKey == "textSlotRight" then
-                    nameRaidFrame:SetPoint("RIGHT", nameFS, "RIGHT", -textW - NAME_RAID_MARKER_GAP, 0)
-                else
-                    nameRaidFrame:SetPoint("RIGHT", nameFS, "CENTER", -(textW * 0.5) - NAME_RAID_MARKER_GAP, 0)
-                end
+                nameRaidFrame:SetPoint("RIGHT", nameFS, "LEFT", -NAME_RAID_MARKER_GAP, 0)
                 if SetRaidTargetIconTexture then SetRaidTargetIconTexture(nameRaidIcon, 1) end
                 nameRaidFrame:Show()
             end
@@ -1404,7 +1388,7 @@ initFrame:SetScript("OnEvent", function(self)
                         end
                     end
                 end
-                nameFS:SetWidth(math.max((barW - usedWidth - pvNameMarkerReserve) * pvNameWPct / 100, 20))
+                nameFS:SetWidth(pvNameMarkerEnabled and 0 or math.max((barW - usedWidth) * pvNameWPct / 100, 20))
                 nameFS:SetTextColor(cr, cg, cb, 1)
                 nameFS:Show()
             end
@@ -1427,7 +1411,7 @@ initFrame:SetScript("OnEvent", function(self)
                 if showCL and clPos ~= "none" then
                     nameW = nameW - (reIconSz + 4)
                 end
-                nameFS:SetWidth(math.max(nameW * pvNameWPct / 100, 20))
+                nameFS:SetWidth(pvNameMarkerEnabled and 0 or math.max(nameW * pvNameWPct / 100, 20))
                 nameFS:SetTextColor(topC.r, topC.g, topC.b, 1)
                 nameFS:Show()
             else

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -6550,10 +6550,14 @@ function NameplateFrame:UpdateNameWidth()
     -- Width % scales the computed (bar-derived) width; 100 = historical behaviour.
     local pct = (p and p.enemyNameWidthPct) or defaults.enemyNameWidthPct
     local nameSlot = FindSlotForElement("enemyName")
-    local nameMarkerReserve = (self.nameRaidFrame and self.nameRaidFrame:IsShown()) and (((p and p.nameRaidMarkerSize) or defaults.nameRaidMarkerSize or 14) + 3) or 0
+    -- Auto-size marked names so the client can position the marker without exposing secret text width.
+    if self._nameRaidMarkerShown == true then
+        self.name:SetWidth(0)
+        return
+    end
     if nameSlot == "textSlotTop" then
-        -- Above the bar: full bar width minus raid marker if shown
-        local nameW = barW - nameMarkerReserve
+        -- Above the bar: full bar width
+        local nameW = barW
         local rmPos = GetRaidMarkerPos()
         if rmPos ~= "none" and self.raidFrame:IsShown() then
             nameW = nameW - 2 * (GetRaidMarkerSize() - 2) - 7
@@ -6576,7 +6580,7 @@ function NameplateFrame:UpdateNameWidth()
                 end
             end
         end
-        local nameW = barW - usedWidth - nameMarkerReserve
+        local nameW = barW - usedWidth
         PP.Width(self.name, math.max(nameW * pct / 100, 20))
     else
         -- Name not in any slot, use minimal width
@@ -6680,18 +6684,7 @@ function NameplateFrame:RefreshNamePosition(localOnly)
         nameRaid:SetFrameStrata("MEDIUM")
         nameRaid:SetFrameLevel(901)
         nameRaid:ClearAllPoints()
-        local textW = self.name:GetWidth() or 0
-        local ok, renderedW = pcall(self.name.GetStringWidth, self.name)
-        if ok and type(renderedW) == "number" and not (issecretvalue and issecretvalue(renderedW)) then
-            textW = math.min(renderedW, textW)
-        end
-        if nameSlot == "textSlotLeft" then
-            nameRaid:SetPoint("RIGHT", self.name, "LEFT", -3, 0)
-        elseif nameSlot == "textSlotRight" then
-            nameRaid:SetPoint("RIGHT", self.name, "RIGHT", -textW - 3, 0)
-        else
-            nameRaid:SetPoint("RIGHT", self.name, "CENTER", -(textW * 0.5) - 3, 0)
-        end
+        nameRaid:SetPoint("RIGHT", self.name, "LEFT", -3, 0)
         nameRaid:Show()
     elseif nameRaid then
         nameRaid:Hide()


### PR DESCRIPTION
Fixes the name raid marker positioning introduced in #602.

The original implementation read `FontString:GetWidth()` / `GetStringWidth()` and calculated marker offsets from the result. WoW can mark name text geometry as secret, so tainted addon execution received a secret number and errored when Lua attempted arithmetic on it. The previous guard was not sufficient because marker placement still depended on reading that protected width.

Marked names now use native FontString auto-sizing, with the marker anchored directly to the name's left edge. WoW resolves the secret geometry internally, so Lua no longer reads or performs arithmetic on the name width. The settings preview uses the same layout.