### PR TITLE
fix(actionbars): make In Party visibility exclusive of raid groups

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12358,7 +12358,7 @@ function EllesmereUI.CheckVisibilityMode(mode, state)
     if mode == "in_combat" then return state.inCombat end
     if mode == "out_of_combat" then return not state.inCombat end
     if mode == "in_raid" then return state.inRaid end
-    if mode == "in_party" then return state.inParty or state.inRaid end
+    if mode == "in_party" then return state.inParty end
     if mode == "solo" then return not state.inRaid and not state.inParty end
     if mode == "show_dragonriding" then
         -- Approximates the secure-macro [advflyable,flying] driver: show only

--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -1286,7 +1286,7 @@ initFrame:SetScript("OnEvent", function(self)
                   end,
                   legacyKey = "barVisibility",
                   label = leftLabel,
-                  caps = { partyIncludesRaid = true, luaDragonriding = true },
+                  caps = { partyIncludesRaid = false, luaDragonriding = true },
                   applyScalarFn = function(s, mode) ApplyVisibilityKey(s, mode) end,
                   disabledFn = disabledFn, disabledTooltip = disTip, rawTooltip = disTip and true or nil,
                   onChanged = function()
@@ -1700,7 +1700,7 @@ initFrame:SetScript("OnEvent", function(self)
 
             -- Pet Bar structurally cannot express group modes: lock them
             -- with an explanation instead of offering silent no-ops.
-            local visCaps = { partyIncludesRaid = true }
+            local visCaps = { partyIncludesRaid = false }
             if SelectedKey() == "PetBar" then
                 visCaps.noGroupModes = true
                 visCaps.lockedTooltips = {

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -6145,7 +6145,7 @@ local function BuildVisibilityString(info, s, visOverride)
     elseif vis == "in_raid" then
         return hidePrefix .. "[group:raid] show; hide"
     elseif vis == "in_party" then
-        return hidePrefix .. "[group:party] show; [group:raid] show; hide"
+        return hidePrefix .. "[group:party] show; hide"
     elseif vis == "solo" then
         return hidePrefix .. "[nogroup] show; hide"
     elseif vis == "show_dragonriding" then

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -6145,7 +6145,9 @@ local function BuildVisibilityString(info, s, visOverride)
     elseif vis == "in_raid" then
         return hidePrefix .. "[group:raid] show; hide"
     elseif vis == "in_party" then
-        return hidePrefix .. "[group:party] show; hide"
+        -- [group:party] alone is TRUE inside a raid; nogroup:raid narrows it
+        -- to a real party so unchecking In Raid Group actually hides in raids.
+        return hidePrefix .. "[group:party,nogroup:raid] show; hide"
     elseif vis == "solo" then
         return hidePrefix .. "[nogroup] show; hide"
     elseif vis == "show_dragonriding" then

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -16614,7 +16614,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- matching the old VIS_VALUES_CDM list.
         local visRow, visH = EllesmereUI.BuildVisibilityModeRow(W, parent, y,
             { getStore = BD, legacyKey = "barVisibility",
-              caps = { partyIncludesRaid = true, noMouseover = true, luaDragonriding = true },
+              caps = { partyIncludesRaid = false, noMouseover = true, luaDragonriding = true },
               onChanged = function()
                   ns.CDMApplyVisibility()
               end },

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6576,7 +6576,7 @@ _CDMApplyVisibility = function()
             elseif vis == "in_raid" then
                 shouldHide = not inRaid
             elseif vis == "in_party" then
-                shouldHide = not (inParty or inRaid)
+                shouldHide = not inParty
             elseif vis == "solo" then
                 shouldHide = inRaid or inParty
             end

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -2291,7 +2291,7 @@ end
 --  one enabled bar exists. Mouseover reveal goes through per-bar plain-table
 --  poll proxies (never EnableMouse on the real bar).
 -------------------------------------------------------------------------------
-ns.EDB_VIS_CAPS = { partyIncludesRaid = true, luaDragonriding = true }
+ns.EDB_VIS_CAPS = { partyIncludesRaid = false, luaDragonriding = true }
 
 -- Bar visibility = ALPHA ONLY, applied directly. A bar hosting a secure
 -- block (micromenu passthrough buttons, travel hearth) is an IMPLICITLY
@@ -2387,7 +2387,7 @@ do
     }
 
     -- Legacy scalar evaluation for the modes the multi engine declines.
-    -- in_party matches party-or-raid (caps.partyIncludesRaid semantics).
+    -- in_party and in_raid are disjoint: a raid group only matches in_raid.
     local function LegacyScalar(mode)
         mode = mode or "always"
         if mode == "always" then return true end
@@ -2398,7 +2398,7 @@ do
         local inRaid = IsInRaid()
         local inGroup = IsInGroup()
         if mode == "in_raid" then return inRaid end
-        if mode == "in_party" then return inGroup end
+        if mode == "in_party" then return inGroup and not inRaid end
         if mode == "solo" then return not inGroup end
         return true
     end

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -7233,7 +7233,7 @@ initFrame:SetScript("OnEvent", function(self)
         visRow, h = EllesmereUI.BuildVisibilityModeRow(W, parent, y,
             { getStore = function() local p = DB(); return p and p.secondary end,
               legacyKey = "visibility",
-              caps = { partyIncludesRaid = true, luaDragonriding = true },
+              caps = { partyIncludesRaid = false, luaDragonriding = true },
               applyScalarFn = ApplyVisScalarAll,
               onChanged = function()
                   MirrorVisModes()

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -5443,7 +5443,7 @@ local function ShouldShowSecondary()
     if vis == "in_raid" then return IsInRaid and IsInRaid() or false end
     if vis == "in_party" then
         local inRaid = IsInRaid and IsInRaid() or false
-        return inRaid or (IsInGroup and IsInGroup() or false)
+        return not inRaid and (IsInGroup and IsInGroup() or false)
     end
     if vis == "solo" then
         return not (IsInRaid and IsInRaid()) and not (IsInGroup and IsInGroup())
@@ -5475,7 +5475,7 @@ local function ShouldShowBar(barProfile)
     if vis == "in_raid" then return IsInRaid and IsInRaid() or false end
     if vis == "in_party" then
         local inRaid = IsInRaid and IsInRaid() or false
-        return inRaid or (IsInGroup and IsInGroup() or false)
+        return not inRaid and (IsInGroup and IsInGroup() or false)
     end
     if vis == "solo" then
         return not (IsInRaid and IsInRaid()) and not (IsInGroup and IsInGroup())

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -4341,7 +4341,7 @@ initFrame:SetScript("OnEvent", function(self)
             local g1, g2, g3 = vm.in_raid, vm.in_party, vm.solo
             if not (g1 or g2 or g3) or (g1 and g2 and g3) then return true end
             if g1 and inRaid then return true end
-            if g2 and (inParty or inRaid) then return true end
+            if g2 and inParty then return true end
             if g3 and not inRaid and not inParty then return true end
             return false
         end
@@ -4364,7 +4364,7 @@ initFrame:SetScript("OnEvent", function(self)
             elseif v == "in_raid" then
                 s.showInRaid = true; s.showInParty = false; s.showSolo = false
             elseif v == "in_party" then
-                s.showInRaid = true; s.showInParty = true; s.showSolo = false
+                s.showInRaid = false; s.showInParty = true; s.showSolo = false
             elseif v == "solo" then
                 s.showInRaid = false; s.showInParty = false; s.showSolo = true
             end
@@ -4373,7 +4373,7 @@ initFrame:SetScript("OnEvent", function(self)
         visRow, h = EllesmereUI.BuildVisibilityModeRow(W, parent, y,
             { getStore = function() return UNIT_DB_MAP[selectedUnit]() end,
               legacyKey = "barVisibility",
-              caps = { partyIncludesRaid = true, luaDragonriding = true },
+              caps = { partyIncludesRaid = false, luaDragonriding = true },
               refreshPageArg = true,
               -- Visibility owns only the hidden/not-hidden axis: "never"
               -- disables the frame; any visible mode re-enables it. The

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -12240,7 +12240,7 @@ function InitializeFrames()
                     elseif vis == "in_raid" then
                         shouldShow = inRaid
                     elseif vis == "in_party" then
-                        shouldShow = inRaid or inParty
+                        shouldShow = inParty
                     elseif vis == "solo" then
                         shouldShow = solo
                     else

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -230,10 +230,11 @@ EUI.VIS_AXES = {
     dragon = { "show_dragonriding", "show_not_dragonriding" },
 }
 
--- Shared caps table for the modules whose legacy "In Party" means
--- party-or-raid (Action Bars, CDM, Unit Frames, Resource Bars). Kept on the
--- namespace so files at the Lua 5.1 200-local cap don't need a new local.
-EUI.VIS_CAPS_INCLUSIVE = { partyIncludesRaid = true }
+-- Shared caps table for Action Bars, CDM, Unit Frames, and Resource Bars.
+-- In Party and In Raid Group are disjoint here, same as every other module --
+-- checking one does not implicitly check the other. Kept on the namespace so
+-- files at the Lua 5.1 200-local cap don't need a new local.
+EUI.VIS_CAPS_INCLUSIVE = { partyIncludesRaid = false }
 
 -- Copy-target caps for elements that cannot express group modes (Pet Bar).
 EUI.VIS_CAPS_NO_GROUP = { partyIncludesRaid = true, noGroupModes = true }
@@ -369,8 +370,10 @@ end
 
 -- Pure axis evaluation. state = { inCombat, inRaid, inParty } with inParty
 -- meaning party-exclusive-of-raid (the disjoint pair, as CDM computes it).
--- caps.partyIncludesRaid widens the in_party item to also match raids,
--- mirroring what "In Party" already means in each module's legacy evaluator.
+-- caps.partyIncludesRaid, when a caller opts in, would widen the in_party
+-- item to also match raids; no current caller sets it -- In Party and In
+-- Raid Group are disjoint everywhere, so unchecking In Raid Group actually
+-- excludes raid.
 function EUI.EvalVisibilityModes(selection, state, caps)
     local incRaid = caps and caps.partyIncludesRaid
 
@@ -505,8 +508,9 @@ end
 -- Compiles the driver tail appended after `prefix` (caller-supplied leading
 -- hide gates: unit existence, pet battle, vehicle, option clauses...).
 -- Group-axis disjuncts distribute into separate bracket groups, each
--- carrying the shared AND terms -- the same grammar the legacy in_party
--- driver string already uses ([group:party] show; [group:raid] show).
+-- carrying the shared AND terms. in_raid and in_party are disjoint --
+-- checking In Party alone does not also show in a raid group; In Raid
+-- Group must be checked separately for that.
 function EUI.BuildVisibilityDriverString(prefix, vm)
     local conj, negGate = EUI.BuildVisModeConjuncts(vm)
     prefix = prefix .. negGate
@@ -521,7 +525,7 @@ function EUI.BuildVisibilityDriverString(prefix, vm)
             out = out .. "[" .. conj .. tok .. "] show; "
         end
         if g1 then emit("group:raid") end
-        if g2 then emit("group:party"); emit("group:raid") end
+        if g2 then emit("group:party") end
         if g3 then emit("nogroup") end
         return out .. "hide"
     end

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -525,7 +525,10 @@ function EUI.BuildVisibilityDriverString(prefix, vm)
             out = out .. "[" .. conj .. tok .. "] show; "
         end
         if g1 then emit("group:raid") end
-        if g2 then emit("group:party") end
+        -- [group:party] alone is TRUE inside a raid; nogroup:raid narrows the
+        -- party disjunct to a real party (a separate group:raid clause, when
+        -- In Raid Group is also checked, still shows there).
+        if g2 then emit("group:party,nogroup:raid") end
         if g3 then emit("nogroup") end
         return out .. "hide"
     end


### PR DESCRIPTION
## Summary
- "In Party" visibility treated party-or-raid as one condition across every module sharing the visibility checklist (Action Bars, CDM, Unit Frames, Resource Bars, Data Bars), so unchecking "In Raid Group" alone had no effect and bars stayed visible in a raid.
- Made In Party and In Raid Group disjoint everywhere: the shared multi-select evaluator, each module's legacy scalar evaluator, and every options page's `caps.partyIncludesRaid`.
- Follow-up fix: `[group:party]` is still true while in a raid at the macro-conditional level, so the Lua-side disjoint fix alone didn't change actual in-game behavior. Added `nogroup:raid` to the compiled party disjunct in the shared visibility driver compiler and Action Bars' single-mode string builder.

## Test plan
- [x] Set an Action Bar's visibility to In Party (In Raid Group unchecked) and confirm it hides in a raid group and still shows in a party
- [x] Verified in-game