### PR TITLE
Fix party power bars not updating in combat when Power Bar section is unsynced

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -11031,6 +11031,11 @@ ns.ReloadPartyFrames = function()
     -- Re-layout header
     ns._LayoutPartyFrames()
     ns._RebuildPartyUnitMap()
+    -- Re-sync UNIT_POWER_UPDATE registration: a Power Bar section sync/unsync
+    -- (or a party-side role-flag edit) changes the party's effective power
+    -- gating, same reasoning as UpdateCombatEventRegistration above. Must run
+    -- after the temp-swap restore so raid reads see raid values.
+    if ns.UpdatePowerEventRegistration then ns.UpdatePowerEventRegistration() end
     ns._UpdateAllPartyButtons()
 
     -- Re-register private aura anchors
@@ -15968,18 +15973,33 @@ function ERF:OnEnable()
 
     -- Dynamically register/unregister UNIT_POWER_UPDATE per unit based on
     -- role and power display settings. Called after roster changes and
-    -- when the user changes power bar role filters.
+    -- when the user changes power bar role filters. The trackers are shared
+    -- by raid AND party frames: player/party1-4 tokens also drive the party
+    -- buttons, whose Power Bar section can be unsynced from raid -- those
+    -- must consult the party proxy too, or raid-off/party-on would strip
+    -- their events and freeze the party power bars mid-combat.
     local function UpdatePowerEventRegistration()
-        local s = db.profile
-        local anyPower = IsPowerBarEnabled(s)
+        local rs = db.profile
+        local ps = ns._partyProxy
+        local function wantsPower(s, role)
+            return (role == "HEALER" and s.powerShowForHealer)
+                or (role == "TANK" and s.powerShowForTank)
+                or (role == "DAMAGER" and s.powerShowForDPS)
+                or (role == "NONE" and s.powerShowForDPS)
+        end
         for unit, tracker in pairs(unitTrackers) do
             local wantPower = false
-            if anyPower and UnitExists(unit) then
+            if UnitExists(unit) then
                 local role = ns._ResolvePowerRole(unit)
-                wantPower = (role == "HEALER" and s.powerShowForHealer)
-                    or (role == "TANK" and s.powerShowForTank)
-                    or (role == "DAMAGER" and s.powerShowForDPS)
-                    or (role == "NONE" and s.powerShowForDPS)
+                wantPower = IsPowerBarEnabled(rs) and wantsPower(rs, role)
+                -- player/party tokens always count as party-displayable; the
+                -- routing-map check additionally covers arena, where the party
+                -- header binds raid1-5.
+                if not wantPower and IsPowerBarEnabled(ps)
+                    and (unit == "player" or unit:match("^party%d$")
+                        or (ns._partyUnitToButton and ns._partyUnitToButton[unit])) then
+                    wantPower = wantsPower(ps, role)
+                end
             end
             if wantPower then
                 tracker:RegisterUnitEvent("UNIT_POWER_UPDATE", unit)


### PR DESCRIPTION
## Summary
Bug report: with the raid/party Power Bar section **unsynced**, power bars turned **off for raid** but **on for party**, the party power bars stop updating while in combat. Syncing the section makes them work again.

**Root cause:** `UpdatePowerEventRegistration` gated each unit tracker's `UNIT_POWER_UPDATE` registration on the raid profile's "Show Power Bar For" role flags only. The per-unit event trackers are shared by raid and party frames (the `player`/`party1-4` tokens drive the party buttons), so with the raid role flags all off it unregistered the event for every unit, including the party's. The party bars still rendered a correct snapshot on full-update paths (roster changes etc.), but received no live power events, so they sat frozen mid-combat.

## Fix
- `UpdatePowerEventRegistration` now also consults the party settings proxy for units the party frames can display: `player`/`partyN` tokens, plus any unit currently mapped to a party button (covers arena, where the party header binds `raid1-5`). This mirrors how `UpdateCombatEventRegistration` already handles the raid/party split for `UNIT_FLAGS`.
- `ReloadPartyFrames` now re-runs `UpdatePowerEventRegistration()` after its temp-swap restore, so syncing/unsyncing the Power Bar section (or editing party-side role filters) takes effect immediately instead of waiting for the next roster change. Same reasoning as the existing `UpdateCombatEventRegistration` call at its top.

Event (un)registration is combat-safe; no secure-frame code is touched.

## Testing
- Repro setup (Power Bar section unsynced, raid power off, party power on): party power bars now update live in combat. Confirmed in-game by the reporting tester.
- Synced behaviour unchanged (party reads raid flags, exactly as before).
- Raid-on/party-off still hides the party power bars.
- Flipping the Power Bar sync checkbox mid-session now re-registers events without a reload.
