### PR TITLE
fix(blizzskin): defer guild roster row-width sync off the secure Update chain

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -3367,10 +3367,23 @@ local function Skin_Guild()
         -- elsewhere in this file: ForEachFrame errors inside Blizzard's code
         -- if the view doesn't exist yet (e.g. this pass runs at ADDON_LOADED,
         -- before the roster has ever been shown).
-        local function SyncRowWidths()
+        --
+        -- box2:ForEachFrame walks Blizzard's secure row pool internally; a
+        -- hooksecurefunc post-hook only guarantees Blizzard won't block the
+        -- *call*, not that we've left the secure chain that triggered the
+        -- Update (guild-frame open, tab switch) -- calling ForEachFrame here
+        -- still runs nested inside it and taints later secret-value reads on
+        -- the roster (confirmed via bisection). So this only flags dirty; the
+        -- OnUpdate watcher below applies it on its own tick, outside any
+        -- secure call chain.
+        local rowsDirty = false
+        local function ApplyRowSync()
             if box2.ForEachFrame and box2.GetView and box2:GetView() then
                 pcall(box2.ForEachFrame, box2, ApplyRowLayout)
             end
+        end
+        local function SyncRowWidths()
+            rowsDirty = true
         end
         hooksecurefunc(box2, "Update", WSkin.Debounce(SyncRowWidths))
         -- Swap column widths on roster<->chat view change WITHOUT a HookScript
@@ -3380,6 +3393,7 @@ local function Skin_Guild()
         -- root-caused via bisection). A self-driven throttled OnUpdate on OUR
         -- OWN frame polls cd2's shown state and applies the swap, so it never
         -- runs inside that secure execution. Idles when the window is closed.
+        -- Row-width sync (above) rides the same OnUpdate for the same reason.
         if not GetFFD(cd2)._euiWidthWatcher then
             GetFFD(cd2)._euiWidthWatcher = true
             -- Parented to the window: the OnUpdate handler stops entirely
@@ -3388,6 +3402,10 @@ local function Skin_Guild()
             local wasShown, acc = nil, 0
             watcher:SetScript("OnUpdate", function(_, elapsed)
                 if f and not f:IsShown() then return end
+                if rowsDirty then
+                    rowsDirty = false
+                    ApplyRowSync()
+                end
                 acc = acc + elapsed
                 if acc < 0.1 then return end
                 acc = 0
@@ -3399,7 +3417,7 @@ local function Skin_Guild()
                 else
                     applyPts(box2, boxStock); ml:SetWidth(mlStockWidth)
                 end
-                SyncRowWidths()
+                ApplyRowSync()
             end)
         end
         if cd2:IsShown() then


### PR DESCRIPTION
## Summary
Follow-up to #853 (guild note taint). New reports on live: reordering guild ranks threw `ADDON_ACTION_FORBIDDEN` on `SetGuildRankOrder()` (stack: `Blizzard_Menu/MenuTemplates.lua -> Menu.lua Pick -> securecallfunction -> GuildRoster.lua`), plus a large secret-value warning cascade during ordinary guild roster refresh / row expand (`C_Club.GetMemberInfo`, the `role` field compare, `C_CreatureInfo.GetClassInfo`), all blamed on EllesmereUIBlizzardSkin.

**Root cause:** `hooksecurefunc(box2, "Update", SyncRowWidths)` in the guild window pack. `hooksecurefunc` only guarantees Blizzard won't block the *call* into `box2:ForEachFrame` — it does **not** mean the callback has left the secure call chain that triggered `Update` (guild-frame open, Communities tab switch). `ForEachFrame` walks Blizzard's secure row pool internally (`secureexecuterange`), so running it from the post-hook executes nested inside that same chain and taints later secret-value reads on the roster. This is the same class of bug as #853, one level subtler: there it was a `HookScript`; here it's a `hooksecurefunc` callback that does secure-pool work synchronously.

Confirmed by bisection: unconditionally disabling this exact `SyncRowWidths` call cleared both the rank-reorder error and the roster-refresh cascade (tester confirmed clean).

## Fix
The `hooksecurefunc` hook (and the two other call sites) now only set a `rowsDirty` flag. The actual row-layout work (renamed `ApplyRowSync`) moves into the **existing self-owned `OnUpdate` watcher** already used for the roster↔chat column-width swap — which was introduced in the #853 fix for exactly this reason, since `OnUpdate` ticks run top-level from the render loop, never nested in a secure call chain. The watcher applies the layout on its own tick, outside any secure execution.

No visual or behavioral change when the window isn't tainted: rows still re-stamp to width, just one frame later via the watcher instead of synchronously in the hook.

## Testing
- **Bisection-confirmed:** the blunt version (unconditionally disabling the `SyncRowWidths` call) was tested in-game by a reporter and cleared both the `SetGuildRankOrder` error and the roster-refresh secret-value cascade.
- This PR is the taint-safe re-architecture of that same call (defer into the proven `OnUpdate` watcher rather than delete). The deferral mechanism is identical to the one already shipped and verified in #853 for the column-width swap.
- Lua syntax verified.

## Note
The `AddMenuAcquiredCallback` write in `EllesmereUIBlizzardSkin.lua` (the original r1 theory from the #853 saga) is **not** touched here — the bisection traced this cascade to `ToggleGuildFrame -> Show -> UpdateMemberList`, never through `Blizzard_Menu`/Pick, so it was not evidenced as a vector for this bug. Left as a separate open question pending a dedicated rank-reorder-via-menu repro.
