### PR TITLE
fix(actionbars): restore press-and-hold casting on druid/rogue bars

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -8279,14 +8279,17 @@ local function UpdateKeybinds()
             -- button (SetOverrideBindingClick) so the keypress reads our paged
             -- "action" attr -- exactly what empower/flyout already do, and what
             -- ElvUI/Bartender do for every button via LibActionButton.
+            --
+            -- Class-default form paging (Druid/Rogue) is NOT custom paging: it
+            -- rides on bonusbar, a native engine concept that ACTIONBUTTONn
+            -- resolves correctly on its own, so the icon and the native keybind
+            -- already agree in every form. Routing those bars through the button
+            -- instead only costs us press-and-hold repeat casting (a synthetic
+            -- click never reaches UseAction with isKeyPress=true), which is why
+            -- it must stay on the native command -- only genuine user-configured
+            -- paging (bs.paging) needs the click route.
             local bs = EAB and EAB.db and EAB.db.profile and EAB.db.profile.bars[info.key]
             local barHasCustomPaging = (bs and bs.paging and next(bs.paging) ~= nil) and true or false
-            if not barHasCustomPaging and info.key == "MainBar" then
-                local _, cls = UnitClass("player")
-                if cls == "DRUID" or cls == "ROGUE" then
-                    barHasCustomPaging = true
-                end
-            end
             for i, btn in ipairs(btns) do
                 if btn then
                     local cmd = prefix .. i


### PR DESCRIPTION
## Fix: press-and-hold casting broken on Druid/Rogue action bars

### Reported
Press-and-hold casting stopped working on Druid (works on Paladin/DK). Holding
a keybind casts once, then stalls into auto-attack. Also affects Single Button
Assistant / Assisted Combat. Reported on 8.4.9.

### Root cause
`f166dd74` force-flagged every Druid/Rogue MainBar as custom-paged so its
keybinds routed through `SetOverrideBindingClick` (a synthetic button click)
instead of the native `ACTIONBUTTONn` command. That commit was guarding against
the keybind firing the wrong slot while in a form.

The problem: a synthetic click never reaches `UseAction` with `isKeyPress=true`,
which the engine requires for press-and-hold repeat casting. So holding a key
fired once and stopped. Paladin/DK were unaffected because they stayed on native
bindings.

The premise was over-broad. Class-default form paging rides on **bonusbar**, a
native engine concept the `ACTIONBUTTONn` command already resolves correctly, so
the icon and the native keybind agree in every form without click-routing.

### Fix
Drop the Druid/Rogue force-block in `UpdateKeybinds()`. Only genuine
user-configured paging (`bs.paging`) still routes through the button (unchanged).

### Testing (in game)
- Druid Cat/Bear: hold-to-cast repeats, fires the correct form ability
- Rogue Stealth: same
- No-form/manual-page cases: correct slot, repeat works
- Custom-paged bars: still route through the button (unchanged), correct slot