### PR TITLE
Fix Movement Alert decimals not toggling off with legacy string precision

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_MovementAlert_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_MovementAlert_Options.lua
@@ -702,7 +702,11 @@ local function BuildMovementAlertPage(pageName, parent, yOffset)
                 { type="toggle", label="Show Decimal",
                   disabled=function() return ma.displayMode == "icon" end,
                   disabledTooltip="Not used in Icon display mode", rawTooltip=true,
-                  get=function() return (ma.precision or 1) > 0 end,
+                  -- tonumber guard: an older numeric-input build could store
+                  -- precision as a string ("1"), and `"1" > 0` is a hard error
+                  -- in Lua 5.1 -- it would throw here before set could run, so
+                  -- the toggle silently did nothing until a value was written.
+                  get=function() return (tonumber(ma.precision) or 1) > 0 end,
                   set=function(v) ma.precision = v and 1 or 0; Refresh() end },
             },
         })

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -926,7 +926,11 @@ local function ShowMovementSlot(index, cdInfo, spellEntry, duration)
     local slot = GetDisplaySlot(index)
     StyleSlot(slot)
     local displayMode = ma.displayMode or "text"
-    local precision   = tonumber(ma.precision) or 1
+    -- Clamp to a clean 0/1 (matches the binary Show Decimal toggle). A legacy
+    -- numeric-input value could be a string ("1") or a stored -0; feeding -0 to
+    -- the format below builds an invalid "%.-0f". This local drives all three
+    -- format sites (precFmt and the two bar-text SetFormattedText calls).
+    local precision   = ((tonumber(ma.precision) or 1) > 0) and 1 or 0
     local spellName   = spellEntry.customText or spellEntry.spellName or "Movement"
     local spellIcon   = spellEntry.spellIcon
     local precFmt     = "%." .. precision .. "f"

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -926,7 +926,7 @@ local function ShowMovementSlot(index, cdInfo, spellEntry, duration)
     local slot = GetDisplaySlot(index)
     StyleSlot(slot)
     local displayMode = ma.displayMode or "text"
-    local precision   = ma.precision or 1
+    local precision   = tonumber(ma.precision) or 1
     local spellName   = spellEntry.customText or spellEntry.spellName or "Movement"
     local spellIcon   = spellEntry.spellIcon
     local precFmt     = "%." .. precision .. "f"

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -3669,6 +3669,22 @@ EllesmereUI.RegisterMigration({
     end,
 })
 
+EllesmereUI.RegisterMigration({
+    id          = "qol_movement_alert_precision_number",
+    scope       = "profile",
+    description = "Coerce Movement Alert precision to a number. An older numeric-input control could store it as a string (e.g. \"1\"); the Show Decimal toggle's getter compares it with `> 0`, which is a hard error on a string in Lua 5.1, so the toggle silently failed and decimals could not be turned off. Recurred every reload because the bad value persisted on disk.",
+    body = function(ctx)
+        local qol = ctx.profile.addons and ctx.profile.addons.EllesmereUIQoL
+        local ma = qol and qol.movementAlert
+        if type(ma) ~= "table" then return end
+        if ma.precision ~= nil and type(ma.precision) ~= "number" then
+            -- Any positive value -> decimals on (1); zero/garbage -> off/default,
+            -- matching the current binary Show Decimal toggle (0 | 1).
+            ma.precision = (tonumber(ma.precision) or 1) > 0 and 1 or 0
+        end
+    end,
+})
+
 local migrationFrame = CreateFrame("Frame")
 migrationFrame:RegisterEvent("ADDON_LOADED")
 migrationFrame:SetScript("OnEvent", function(self, event, addonName)

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -3670,18 +3670,14 @@ EllesmereUI.RegisterMigration({
 })
 
 EllesmereUI.RegisterMigration({
-    id          = "qol_movement_alert_precision_number",
+    id          = "qol_movement_alert_precision_normalize_v2",
     scope       = "profile",
-    description = "Coerce Movement Alert precision to a number. An older numeric-input control could store it as a string (e.g. \"1\"); the Show Decimal toggle's getter compares it with `> 0`, which is a hard error on a string in Lua 5.1, so the toggle silently failed and decimals could not be turned off. Recurred every reload because the bad value persisted on disk.",
+    description = "Normalize Movement Alert precision to a clean 0 or 1. A legacy numeric-input control could leave a non-binary value -- the string \"1\", or a stored -0 -- that the Show Decimal toggle mishandled and that built an invalid \"%.-0f\" format string. Normalized unconditionally (no type guard) because -0 is a number, so the earlier number-only guard skipped it. Positive -> 1 (decimals on); zero/negative/garbage -> 0 (off).",
     body = function(ctx)
         local qol = ctx.profile.addons and ctx.profile.addons.EllesmereUIQoL
         local ma = qol and qol.movementAlert
-        if type(ma) ~= "table" then return end
-        if ma.precision ~= nil and type(ma.precision) ~= "number" then
-            -- Any positive value -> decimals on (1); zero/garbage -> off/default,
-            -- matching the current binary Show Decimal toggle (0 | 1).
-            ma.precision = (tonumber(ma.precision) or 1) > 0 and 1 or 0
-        end
+        if type(ma) ~= "table" or ma.precision == nil then return end
+        ma.precision = (tonumber(ma.precision) or 1) > 0 and 1 or 0
     end,
 })
 


### PR DESCRIPTION
## Summary

The Movement Alert **Show Decimal** toggle would not turn decimals off for some users: clicking it did nothing, toggling on/off/on/off was needed to make it stick, and the problem returned after every reload. It affected only profiles carrying a legacy `precision` value.

## Root cause

Before this control was a binary toggle it was a numeric-input spinner, which could leave `movementAlert.precision` as a non-binary value on disk. Two such legacy values break the current code, in different ways:

1. **String** (e.g. `"1"`) — the toggle getter did `(ma.precision or 1) > 0`, and `"1" > 0` (string vs number) is a hard error in Lua 5.1, so `get()` threw before `set()` could run.
2. **IEEE negative zero** (`-0`) — the renderer builds its format by concatenation: `"%." .. precision .. "f"`. `tostring(-0.0)` is `"-0"` under Lua 5.1's `%.14g`, producing `"%.-0f"`, an invalid conversion specification that errors every render tick.

In both cases the value persisted on disk, so the issue recurred on every reload. Profiles that already stored a plain `0`/`1` were unaffected.

## Fix

- **Render clamps to a clean 0/1**: `((tonumber(ma.precision) or 1) > 0) and 1 or 0`. This guarantees a valid `"%.0f"` / `"%.1f"` for *any* legacy value — string, `-0`, negative, or fractional — and drives all three format sites in the function. This alone resolves the on-screen bug for everyone immediately.
- **Toggle getter hardened** with `tonumber()` so a stored string can no longer throw.
- **Profile-scoped migration** (`qol_movement_alert_precision_normalize_v2`) normalizes a non-binary `precision` to `0`/`1` across all profiles, scrubbing the stored value so the checkbox reads correctly with no click needed. Normalized unconditionally (no `type ~= "number"` guard, which would skip `-0`), via `ctx.profile.addons.EllesmereUIQoL` (the real central store).

All changes are no-ops on profiles that already store a numeric `0`/`1`.

## Testing

- Lua-verified: `string.format("%.-0f", x)` errors; the clamp yields `"%.0f"` and renders correctly for `-0`, negatives, fractions, and string inputs.
- Both source files pass a Lua 5.1 syntax check.
