### PR TITLE
Blizzskin: Fix Y offset for AchievementFrameObjectives

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -4192,9 +4192,19 @@ local function AchAccentBar(bar)
             if not rd.lowered then
                 local p, rel, rp, x, y = fs:GetPoint(1)
                 if p then
+                    local offsetY = -3
+                    if bar and bar.GetParent then
+                        local parent = bar:GetParent()
+                        -- For AchievementFrameAchievementsObjectives, bar is the progress bar itself not the holder so retrieve the parent
+                        -- to match the parent name
+                        -- It does NOT need the offset
+                        if parent and parent.GetName and parent:GetName() == "AchievementFrameAchievementsObjectives" then
+                            offsetY = 0
+                        end
+                    end
                     rd.lowered = true
                     fs:ClearAllPoints()
-                    fs:SetPoint(p, rel, rp, x or 0, (y or 0) - 3)
+                    fs:SetPoint(p, rel, rp, x or 0, (y or 0) + offsetY)
                 end
             end
         end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->
The objective frame had a wrong Y offset, resulting in the text being slightly hidden depending on font used.

Bug report: https://discord.com/channels/585577383847788554/1529542956804214856

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
12.0.7, browsing through achievement to make sure nothing else is affected.

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
Before:
<img width="528" height="95" alt="image" src="https://github.com/user-attachments/assets/cd997e5a-fc47-463a-8f48-ea345d372b0d" />

After:
<img width="538" height="99" alt="image" src="https://github.com/user-attachments/assets/ef700ed0-adf3-420d-b277-ce54a22f335e" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- N/A New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
