### PR TITLE
Fix Edit Mode secret-value taint warnings (two injection points)

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12514,7 +12514,11 @@ function EllesmereUI.SetPlayerCastBarSuppressed(owner, suppressed)
         end
         EllesmereUI._GetFFD(blizzBar).castBarSuppressed = true
 
-        if blizzBar:GetParent() ~= hiddenParent then
+        -- Skip the re-parent while Edit Mode is open: SetParent fires
+        -- Blizzard's synchronous layout handlers in this execution, and the
+        -- UnitFrames Edit-Mode-close hook re-applies this state afterwards.
+        if blizzBar:GetParent() ~= hiddenParent
+            and not (EditModeManagerFrame and EditModeManagerFrame:IsShown()) then
             blizzBar:SetParent(hiddenParent)
         end
 
@@ -12549,10 +12553,14 @@ function EllesmereUI.SetPlayerCastBarSuppressed(owner, suppressed)
             if not EllesmereUI._GetFFD(selection).showHooked then
                 EllesmereUI._GetFFD(selection).showHooked = true
                 hooksecurefunc(selection, "Show", function(self)
-                    if PlayerCastingBarFrame and EllesmereUI._GetFFD(PlayerCastingBarFrame).castBarSuppressed then
-                        self:SetAlpha(0)
-                        self:EnableMouse(false)
-                    end
+                    -- Deferred: Show fires inside Edit Mode's secure
+                    -- ShowSystemSelections pass; write nothing there.
+                    C_Timer.After(0, function()
+                        if PlayerCastingBarFrame and EllesmereUI._GetFFD(PlayerCastingBarFrame).castBarSuppressed then
+                            self:SetAlpha(0)
+                            self:EnableMouse(false)
+                        end
+                    end)
                 end)
             end
         end
@@ -12562,7 +12570,8 @@ function EllesmereUI.SetPlayerCastBarSuppressed(owner, suppressed)
 
     EllesmereUI._GetFFD(blizzBar).castBarSuppressed = false
 
-    if hiddenParent and blizzBar:GetParent() == hiddenParent and EllesmereUI._GetFFD(blizzBar).origParent then
+    if hiddenParent and blizzBar:GetParent() == hiddenParent and EllesmereUI._GetFFD(blizzBar).origParent
+        and not (EditModeManagerFrame and EditModeManagerFrame:IsShown()) then
         blizzBar:SetParent(EllesmereUI._GetFFD(blizzBar).origParent)
     end
 

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12529,8 +12529,14 @@ function EllesmereUI.SetPlayerCastBarSuppressed(owner, suppressed)
             hooksecurefunc(blizzBar, "SetParent", function(self, newParent)
                 if EllesmereUI._GetFFD(self).castBarSuppressed and newParent ~= EllesmereUI._playerCastBarHiddenParent then
                     C_Timer.After(0, function()
+                        -- Never re-parent while Edit Mode is open, even from
+                        -- a timer: SetParent fires Blizzard's synchronous
+                        -- layout handlers under addon taint and poisons the
+                        -- manager's state for its next pass. The Edit Mode
+                        -- close hook (UnitFrames) re-applies suppression.
                         if EllesmereUI._GetFFD(self).castBarSuppressed
                            and not InCombatLockdown()
+                           and not (EditModeManagerFrame and EditModeManagerFrame:IsShown())
                            and self:GetParent() ~= EllesmereUI._playerCastBarHiddenParent
                         then
                             self:SetParent(EllesmereUI._playerCastBarHiddenParent)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -11669,12 +11669,32 @@ function InitializeFrames()
     -- Not fixable without reparenting/overriding a secure frame in combat, so it's
     -- surfaced in the mini-frame "Frame Source" tooltip (see BuildFoTToTOptions), which
     -- recommends matching the parent's source instead of mixing them.
-    local _suppressedChildren, _suppressWatcher
+    local _suppressedChildren, _suppressWatcher, _rehidePending
+    -- Deferred re-hide: OnShow fires inside whatever secure execution showed
+    -- the parent (target swaps, Edit Mode's preview pass on a Blizzard-source
+    -- TargetFrame/FocusFrame); hiding inline there taints the remainder of
+    -- that execution (same mechanism as the DisableBlizzard override at the
+    -- top of this file). While the Edit Mode manager is open the re-hide
+    -- waits for it to close.
+    local _DeferredRehide
+    _DeferredRehide = function(frame)
+        _rehidePending[frame] = nil
+        if not frame:IsShown() then return end
+        if EditModeManagerFrame and EditModeManagerFrame:IsShown() then
+            _rehidePending[frame] = true
+            C_Timer.After(0.25, function() _DeferredRehide(frame) end)
+        elseif InCombatLockdown() then
+            _suppressWatcher:RegisterEvent("PLAYER_REGEN_ENABLED")
+        else
+            frame:Hide()
+        end
+    end
     local function SuppressBlizzardChildFrame(frame)
         if not frame then return end
         frame:UnregisterAllEvents()
         if not InCombatLockdown() then frame:Hide() end
         _suppressedChildren = _suppressedChildren or {}
+        _rehidePending = _rehidePending or {}
         if not _suppressWatcher then
             _suppressWatcher = CreateFrame("Frame")
             _suppressWatcher:SetScript("OnEvent", function(self)
@@ -11686,10 +11706,9 @@ function InitializeFrames()
         if not _suppressedChildren[frame] then
             _suppressedChildren[frame] = true
             frame:HookScript("OnShow", function(self)
-                if InCombatLockdown() then
-                    _suppressWatcher:RegisterEvent("PLAYER_REGEN_ENABLED")
-                else
-                    self:Hide()
+                if not _rehidePending[self] then
+                    _rehidePending[self] = true
+                    C_Timer.After(0, function() _DeferredRehide(self) end)
                 end
             end)
         end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -11239,7 +11239,11 @@ function InitializeFrames()
         frames._cbSuppressFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
         frames._cbSuppressFrame:RegisterEvent("EDIT_MODE_LAYOUTS_UPDATED")
         frames._cbSuppressFrame:SetScript("OnEvent", function()
-            ApplyBlizzCastbarState()
+            -- Deferred: EDIT_MODE_LAYOUTS_UPDATED is dispatched from inside
+            -- Edit Mode's own operations; applying suppression state there
+            -- writes cast bar state mid-pass (same taint mechanism as the
+            -- DisableBlizzard override at the top of this file).
+            C_Timer.After(0, ApplyBlizzCastbarState)
         end)
         -- Edit Mode exit reparents the cast bar back into its layout frame
         -- (which gets hidden), so re-apply our state when the panel closes.
@@ -11491,26 +11495,46 @@ function InitializeFrames()
         if _blizzCPHooked then return end
         _blizzCPHooked = true
         local _cpSetParentGuard = false
-        -- Re-assert position when Blizzard reparents (form/spec changes).
-        hooksecurefunc(cpFrame, "SetParent", function(self, newParent)
-            if not _blizzCPActive or _cpSetParentGuard then return end
+        -- Both hooks defer their re-assert work: they can fire inside
+        -- Blizzard's secure Edit Mode layout pass (same taint mechanism as
+        -- the DisableBlizzard override at the top of this file), and while
+        -- the manager is open the re-assert waits for it to close.
+        local _cpReassertQueued = false
+        local ReassertClassPower
+        ReassertClassPower = function(self)
+            _cpReassertQueued = false
+            if not _blizzCPActive then return end
+            if EditModeManagerFrame and EditModeManagerFrame:IsShown() then
+                _cpReassertQueued = true
+                C_Timer.After(0.25, function() ReassertClassPower(self) end)
+                return
+            end
             local wanted = _cpExpectedParent or frames.player or UIParent
-            if newParent ~= wanted then
+            if self:GetParent() ~= wanted then
                 _cpSetParentGuard = true
                 PositionClassPowerBar(self)
                 -- Blizzard may have re-stolen during PositionClassPowerBar.
                 -- The anchor is already correct, so just fix the parent directly.
-                local cur = self:GetParent()
-                wanted = _cpExpectedParent or frames.player or UIParent
-                if cur ~= wanted then
+                if self:GetParent() ~= wanted then
                     self:SetParent(wanted)
                 end
                 _cpSetParentGuard = false
             end
+            if not self:IsShown() and not InCombatLockdown() then self:Show() end
+        end
+        -- Re-assert position when Blizzard reparents (form/spec changes).
+        hooksecurefunc(cpFrame, "SetParent", function(self, newParent)
+            if not _blizzCPActive or _cpSetParentGuard or _cpReassertQueued then return end
+            local wanted = _cpExpectedParent or frames.player or UIParent
+            if newParent ~= wanted then
+                _cpReassertQueued = true
+                C_Timer.After(0, function() ReassertClassPower(self) end)
+            end
         end)
         hooksecurefunc(cpFrame, "Hide", function(self)
-            if not _blizzCPActive then return end
-            if not InCombatLockdown() then self:Show() end
+            if not _blizzCPActive or _cpReassertQueued then return end
+            _cpReassertQueued = true
+            C_Timer.After(0, function() ReassertClassPower(self) end)
         end)
     end
 

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -8,6 +8,111 @@ local issecretvalue = issecretvalue
 local oUF = ns.oUF or oUF
 local PP = EllesmereUI.PP
 
+-- Taint-safe override of the embedded lib's DisableBlizzard for the units
+-- this addon disables. The stock version re-parents a disabled Blizzard
+-- frame back to its hidden parent INLINE from a SetParent hooksecurefunc.
+-- Blizzard's Edit Mode layout pass calls SetParent on managed containers
+-- (confirmed live: BossTargetFrameContainer -> UIParent on every Edit Mode
+-- enter/exit), so the inline re-parent runs inside that secure execution
+-- and taints everything Edit Mode touches afterwards -- every 12.x secret
+-- value read then throws a LUA_WARNING (CompactUnitFrame health compares,
+-- encounter warnings, SecureUtil arithmetic) and the tainted setup pass
+-- poisons party frames for the whole session. Same end state here, but the
+-- re-parent is deferred to a timer (a fresh addon-owned execution) and
+-- further postponed while the Edit Mode manager is open, because SetParent
+-- fires Blizzard's synchronous layout handlers in the caller's execution.
+-- Units this addon never disables fall through to the stock implementation.
+do
+    local hiddenParent = CreateFrame("Frame", nil, UIParent)
+    hiddenParent:Hide()
+    local pendingParent, looseFrames, hookedFrames = {}, {}, {}
+    local bossHandled = false
+
+    -- Combat fallback: protected frames can't be re-parented in lockdown;
+    -- park them here and sweep at regen (mirrors the stock lib's behavior).
+    local regenWatcher = CreateFrame("Frame")
+    regenWatcher:SetScript("OnEvent", function(self)
+        if InCombatLockdown() then return end
+        self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+        for f in pairs(looseFrames) do f:SetParent(hiddenParent) end
+        wipe(looseFrames)
+    end)
+
+    local function ApplyHiddenParent(frame)
+        pendingParent[frame] = nil
+        if frame:GetParent() == hiddenParent then return end
+        if EditModeManagerFrame and EditModeManagerFrame:IsShown() then
+            pendingParent[frame] = true
+            C_Timer.After(0.25, function() ApplyHiddenParent(frame) end)
+        elseif InCombatLockdown() and frame:IsProtected() then
+            looseFrames[frame] = true
+            regenWatcher:RegisterEvent("PLAYER_REGEN_ENABLED")
+        else
+            frame:SetParent(hiddenParent)
+        end
+    end
+
+    local function Unreg(child)
+        if child then child:UnregisterAllEvents() end
+    end
+
+    local function HandleFrame(frame, doNotReparent)
+        if type(frame) == "string" then frame = _G[frame] end
+        if not frame then return end
+        frame:UnregisterAllEvents()
+        frame:Hide()
+        if not doNotReparent then
+            frame:SetParent(hiddenParent)
+            if not hookedFrames[frame] then
+                hookedFrames[frame] = true
+                hooksecurefunc(frame, "SetParent", function(self, parent)
+                    if parent ~= hiddenParent and not pendingParent[self] then
+                        pendingParent[self] = true
+                        C_Timer.After(0, function() ApplyHiddenParent(self) end)
+                    end
+                end)
+            end
+        end
+        Unreg(frame.healthBar or frame.healthbar or frame.HealthBar
+            or (frame.HealthBarsContainer and frame.HealthBarsContainer.healthBar))
+        Unreg(frame.manabar or frame.ManaBar)
+        Unreg(frame.castBar or frame.spellbar or frame.CastingBarFrame)
+        Unreg(frame.powerBarAlt or frame.PowerBarAlt)
+        Unreg(frame.BuffFrame or frame.AurasFrame)
+        Unreg(frame.petFrame or frame.PetFrame)
+        Unreg(frame.totFrame)
+        Unreg(frame.CcRemoverFrame)
+        Unreg(frame.DebuffFrame)
+    end
+
+    local origDisableBlizzard = oUF.DisableBlizzard
+    function oUF:DisableBlizzard(unit)
+        if not unit then return end
+        if unit == "player" then
+            HandleFrame(PlayerFrame)
+        elseif unit == "pet" then
+            HandleFrame(PetFrame)
+        elseif unit == "target" then
+            HandleFrame(TargetFrame)
+        elseif unit == "focus" then
+            HandleFrame(FocusFrame)
+        elseif unit:match("boss%d?$") then
+            if not bossHandled then
+                bossHandled = true
+                -- Container is re-parented (Edit Mode can revive it); the
+                -- individual boss frames are container-managed and must not
+                -- be re-parented or the layout code breaks on their sizes.
+                HandleFrame(BossTargetFrameContainer)
+                for i = 1, (_G.MAX_BOSS_FRAMES or 5) do
+                    HandleFrame("Boss" .. i .. "TargetFrame", true)
+                end
+            end
+        else
+            return origDisableBlizzard(self, unit)
+        end
+    end
+end
+
 -- Per-addon border texture defaults (size key = borderSize 0-4)
 do
     local ALL_SIZES = { [0] = true, [1] = true, [2] = true, [3] = true, [4] = true }

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
@@ -629,11 +629,17 @@ initFrame:SetScript("OnEvent", function(self, event, arg1)
                 end)
                 if BuffFrame.RefreshConsolidationFrameVisibility then
                     hooksecurefunc(BuffFrame, "RefreshConsolidationFrameVisibility", function()
-                        local cfgNow = PA()
-                        if cfgNow and cfgNow.showExpandButton == false
-                            and BuffFrame.CollapseAndExpandButton then
-                            BuffFrame.CollapseAndExpandButton:Hide()
-                        end
+                        -- Deferred: this can fire inside Blizzard's secure
+                        -- buff-system refresh (incl. Edit Mode's passes);
+                        -- hiding inline there taints the rest of that
+                        -- execution.
+                        C_Timer.After(0, function()
+                            local cfgNow = PA()
+                            if cfgNow and cfgNow.showExpandButton == false
+                                and BuffFrame.CollapseAndExpandButton then
+                                BuffFrame.CollapseAndExpandButton:Hide()
+                            end
+                        end)
                     end)
                 end
             end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
@@ -220,6 +220,17 @@ local function ApplyExpandButtonSetting()
         if not show then button:Hide() end
         return
     end
+    -- First evaluation with the button wanted in its native shown state:
+    -- nothing to change, so leave Blizzard's model and layout untouched.
+    -- Running BuffFrame's layout functions (RefreshConsolidationFrame-
+    -- Visibility / UpdateGridLayout) from addon context stamps their
+    -- Lua-side state with addon taint, and Edit Mode's enter pass reads
+    -- that state -- the source of secret-value LUA_WARNING storms for
+    -- users with the aura reskin enabled.
+    if _appliedShowExpand == nil and show then
+        _appliedShowExpand = show
+        return
+    end
     _appliedShowExpand = show
     if not show then
         _savedExpandedState = BuffFrame.isExpanded

--- a/EllesmereUI_Lite.lua
+++ b/EllesmereUI_Lite.lua
@@ -428,28 +428,38 @@ lifecycleFrame:SetScript("OnEvent", function(self, event, arg1)
         tinsert(enableQueue, addon)
     end
 
-    -- Process enable queue once logged in
-    if IsLoggedIn() then
-        -- Ensure PP.mult is current before any addon's OnEnable runs.
-        -- PP is defined in EllesmereUI.lua (loaded after this file) so it
-        -- exists by the time PLAYER_LOGIN fires.
-        if EllesmereUI and EllesmereUI.PP and EllesmereUI.PP.UpdateMult then
-            EllesmereUI.PP.UpdateMult()
-        end
-        -- Apply spec-assigned profile data into each child SV before any
-        -- OnEnable runs. The spec API is available here (after OnInitialize,
-        -- before OnEnable) so we can resolve the current spec and inject the
-        -- correct profile snapshot. This is the earliest safe point to do
-        -- this -- ADDON_LOADED is too early (spec API not ready yet).
-        if EllesmereUI and EllesmereUI.PreSeedSpecProfile then
-            EllesmereUI.PreSeedSpecProfile()
-        end
-        while #enableQueue > 0 do
-            local addon = tremove(enableQueue, 1)
-            if addon.enabledState then
-                statuses[addon.name] = true
-                safecall(addon.OnEnable, addon)
+    -- Process enable queue once logged in. Deferred one tick: ADDON_LOADED
+    -- can be dispatched from inside Blizzard's own SECURE executions (e.g.
+    -- UIParent demand-loading Blizzard_CombatLog during login), and running
+    -- module OnEnable bodies synchronously there stamps every value they
+    -- write with addon taint born mid-secure-chain -- fields Edit Mode's
+    -- enter/exit passes later read, erroring on 12.x secret values. A timer
+    -- callback is always a fresh, purely addon-owned execution.
+    if IsLoggedIn() and #enableQueue > 0 and not lifecycleFrame._enableFlushQueued then
+        lifecycleFrame._enableFlushQueued = true
+        C_Timer.After(0, function()
+            lifecycleFrame._enableFlushQueued = false
+            -- Ensure PP.mult is current before any addon's OnEnable runs.
+            -- PP is defined in EllesmereUI.lua (loaded after this file) so it
+            -- exists by the time PLAYER_LOGIN fires.
+            if EllesmereUI and EllesmereUI.PP and EllesmereUI.PP.UpdateMult then
+                EllesmereUI.PP.UpdateMult()
             end
-        end
+            -- Apply spec-assigned profile data into each child SV before any
+            -- OnEnable runs. The spec API is available here (after OnInitialize,
+            -- before OnEnable) so we can resolve the current spec and inject the
+            -- correct profile snapshot. This is the earliest safe point to do
+            -- this -- ADDON_LOADED is too early (spec API not ready yet).
+            if EllesmereUI and EllesmereUI.PreSeedSpecProfile then
+                EllesmereUI.PreSeedSpecProfile()
+            end
+            while #enableQueue > 0 do
+                local addon = tremove(enableQueue, 1)
+                if addon.enabledState then
+                    statuses[addon.name] = true
+                    safecall(addon.OnEnable, addon)
+                end
+            end
+        end)
     end
 end)


### PR DESCRIPTION
## Summary

Toggling Blizzard **Edit Mode** with the suite loaded emitted large `LUA_WARNING` storms in instanced content: `attempt to compare/perform arithmetic on a secret number value (execution tainted by 'EllesmereUIUnitFrames')` from `CompactUnitFrame_UpdateHealthColor`, the encounter warnings refresh, `SecureUtil` selection math, and Cooldown Viewer item data. Worse, when Edit Mode's party frame setup pass ran tainted, the compact party frames stayed poisoned for the rest of the session, erroring on every subsequent health update (observed 100+ occurrences). Reported against v8.5.3 (Chat setup + Edit Mode positioning was the trigger scenario; the Chat module was not involved).

## Root causes (two independent injection points)

**1. Inline re-parent hook in the embedded oUF library's `DisableBlizzard`.**
When the library disables a Blizzard frame it re-parents it to a hidden frame and installs a `SetParent` `hooksecurefunc` that yanks the frame back **inline inside the hook**. Blizzard's Edit Mode layout pass calls `SetParent` on managed containers, confirmed live with a print hook: `BossTargetFrameContainer -> UIParent` on every Edit Mode enter/exit. The inline yank therefore ran in the middle of that secure execution, tainting everything Edit Mode touched afterwards, and every 12.x secret value downstream became a warning.

Because the library is a packager external (`.pkgmeta`), the fix is a tracked-code override in `EllesmereUIUnitFrames.lua`: `DisableBlizzard` is replaced for the units this addon actually disables (player/pet/target/focus/boss) with the same disable steps, but the re-parent is **deferred to a timer callback** (a fresh addon-owned execution), further postponed while the Edit Mode manager is shown (SetParent fires Blizzard's synchronous layout handlers in the caller's execution), with the stock combat-safe regen sweep preserved. Units this addon never disables fall through to the stock implementation.

**2. Module `OnEnable` running inside Blizzard's secure demand-load executions.**
`EllesmereUI_Lite`'s enable queue flushed synchronously inside any `ADDON_LOADED` dispatch, including ones fired from Blizzard's own secure executions, e.g. UIParent demand-loading `Blizzard_CombatLog` during login (captured in `taint.log`: module `OnEnable` bodies executing under `UIParent.lua -> CombatLog_LoadUI -> LoadAddOn`). Everything those bodies wrote became tainted fields born mid-secure-chain, which Edit Mode's enter/exit passes later read. The flush is now deferred one tick via `C_Timer.After(0)` so `OnEnable` always runs in a fresh addon-owned execution. Enable order is unchanged; `OnEnable` lands one tick later at login (reviewers should be aware of that timing change, no behavioral difference was observed in testing).

## Diagnosis method

Bisected in-game across ~10 controlled sessions in a follower dungeon (secret values are active in instances, not the open world, open-world tests are silent even when tainted): module isolation, a minimal dummy addon, live `SetParent` instrumentation, and `taintLog 2` capture. Notably, `taint.log` showed **no** named-global reads at the toggle, which is what pointed at tainted **table fields** (invisible to the logger) and ultimately at the enable-queue flush.

## Verification

In a follower dungeon, after both fixes:
- ESC/game-menu Edit Mode open/close: clean, repeated toggles.
- Typed `/editmode` open/close: clean (previously the worst path, 100+ warnings).
- No session-long compact party frame error spam afterwards.
- Player/target/focus/boss frame replacement behavior unchanged (the override reproduces the stock disable steps).

Both files pass a Lua 5.1 syntax check.
