### PR TITLE
Data bar: fix opacity not working with bar texture

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -1711,7 +1711,7 @@ local function ApplyThemeToHost(host, theme, texKey)
             -- the vertex tint so Bar Opacity keeps working.
             host._edbBarTex:SetTexture(texPath)
             host._edbBarTex:SetVertexColor(c.r or 0.067, c.g or 0.067, c.b or 0.067, c.a or 0.95)
-            host._edbBarTex:SetAlpha(1)
+            host._edbBarTex:SetAlpha(c.a or 0.95)
             host._edbModernBg:SetAlpha(0)
         else
             host._edbBarTex:SetAlpha(0)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->
Bar opacity was not working at all with a custom bar texture (modern background style)

Bug report: https://discord.com/channels/585577383847788554/1528951708850327702

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
12.0.7. Checked if bar opacity was working with `EllesmereUI` background style and with `modern` background style with and without a bar texture.

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
Before:
<img width="823" height="102" alt="image" src="https://github.com/user-attachments/assets/12e6e11d-eec2-4ee1-9b27-8d187096fa6a" />

After:
<img width="835" height="60" alt="image" src="https://github.com/user-attachments/assets/07b446e4-f31d-44b8-9826-9a71048f437f" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- N/A New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [X] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
