### PR TITLE
QoL: Update secondary stats frame size based on content

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -1402,6 +1402,7 @@ do
         end
 
         statsText:SetText(txt)
+        statsFrame:SetSize(statsText:GetStringWidth() + 2, statsText:GetStringHeight() + 2)
     end
 
     local function ApplySecondaryStats()


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

Secondary stats frame size in unlock mode was a set number instead of changing based on content.

Bug report: https://discord.com/channels/585577383847788554/1524771282816602132

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
12.0.7. With and without tertiaty stats, changing scaling to all possible values

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
Before:
<img width="290" height="243" alt="image" src="https://github.com/user-attachments/assets/8dd022f3-df99-4b38-8687-5e67040eb3b7" />

After:
<img width="317" height="240" alt="image" src="https://github.com/user-attachments/assets/b5071c1c-b50e-4150-9eae-f8919857f388" />
<img width="187" height="105" alt="image" src="https://github.com/user-attachments/assets/6eedeac1-b02f-45fa-ac77-08fe7b2c9ca2" />



## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- N/A New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
