### PR TITLE
Preserve name truncation with nameplate raid markers

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -1388,7 +1388,7 @@ initFrame:SetScript("OnEvent", function(self)
                         end
                     end
                 end
-                nameFS:SetWidth(pvNameMarkerEnabled and 0 or math.max((barW - usedWidth) * pvNameWPct / 100, 20))
+                nameFS:SetWidth(math.max((barW - usedWidth - pvNameMarkerReserve) * pvNameWPct / 100, 20))
                 nameFS:SetTextColor(cr, cg, cb, 1)
                 nameFS:Show()
             end
@@ -1411,7 +1411,7 @@ initFrame:SetScript("OnEvent", function(self)
                 if showCL and clPos ~= "none" then
                     nameW = nameW - (reIconSz + 4)
                 end
-                nameFS:SetWidth(pvNameMarkerEnabled and 0 or math.max(nameW * pvNameWPct / 100, 20))
+                nameFS:SetWidth(math.max(nameW * pvNameWPct / 100, 20))
                 nameFS:SetTextColor(topC.r, topC.g, topC.b, 1)
                 nameFS:Show()
             else

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -6505,14 +6505,11 @@ function NameplateFrame:UpdateNameWidth()
     -- Width % scales the computed (bar-derived) width; 100 = historical behaviour.
     local pct = (p and p.enemyNameWidthPct) or defaults.enemyNameWidthPct
     local nameSlot = FindSlotForElement("enemyName")
-    -- Auto-size marked names so the client can position the marker without exposing secret text width.
-    if self._nameRaidMarkerShown == true then
-        self.name:SetWidth(0)
-        return
-    end
+    local nameMarkerReserve = self._nameRaidMarkerShown == true
+        and (((p and p.nameRaidMarkerSize) or defaults.nameRaidMarkerSize or 14) + 3) or 0
     if nameSlot == "textSlotTop" then
-        -- Above the bar: full bar width
-        local nameW = barW
+        -- Above the bar: reserve a fixed slot for the inline raid marker.
+        local nameW = barW - nameMarkerReserve
         local rmPos = GetRaidMarkerPos()
         if rmPos ~= "none" and self.raidFrame:IsShown() then
             nameW = nameW - 2 * (GetRaidMarkerSize() - 2) - 7
@@ -6535,7 +6532,7 @@ function NameplateFrame:UpdateNameWidth()
                 end
             end
         end
-        local nameW = barW - usedWidth
+        local nameW = barW - usedWidth - nameMarkerReserve
         PP.Width(self.name, math.max(nameW * pct / 100, 20))
     else
         -- Name not in any slot, use minimal width


### PR DESCRIPTION
## Summary

- Reserve a fixed marker slot so marked enemy names keep their configured width, truncation, ellipsis, and wrapping behavior.
- Mirror the fixed-slot layout in the options preview.
- Avoid reading or calculating with FontString geometry, keeping the path safe for secret names.

## Tradeoff

The previous native auto-size layout kept the raid marker exactly adjacent to the rendered name and avoided secret-value errors, but disabled width constraints whenever a marker was shown. The new fixed-slot layout restores those constraints and remains secret-safe; short centered or right-aligned names can leave a small visual gap because the marker follows the fixed name region instead of the rendered glyph edge.