### PR TITLE
Fix oversized AuraBuff reminders after dungeon reload

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -2060,6 +2060,8 @@ local function LayoutIcons()
     local sz = floor(ICON_SIZE * baseScale + 0.5)
     local totalW = (count * sz) + ((count-1) * spacing)
     for i, btn in ipairs(allIcons) do
+        btn:SetIgnoreParentScale(true)
+        btn:SetScale(UIParent:GetEffectiveScale())
         btn:SetSize(sz, sz)
         btn:SetAlpha(p.opacity or 1.0)
         btn:ClearAllPoints()


### PR DESCRIPTION
## Summary
- Normalize AuraBuff Reminder button scaling during layout.
- Prevent secure reminder icons from rendering oversized after reloading inside a dungeon.
<img width="737" height="377" alt="image" src="https://github.com/user-attachments/assets/25e8413a-2b4b-48a3-a891-11e85d59e99e" />
<img width="626" height="266" alt="image" src="https://github.com/user-attachments/assets/5560c13c-9cb9-4407-900e-ad07c61947fc" />


## Why this is needed
When the UI is reloaded inside a dungeon, the protected reminder buttons can keep an effective scale of 1 even though UIParent and the reminder anchor use the configured UI scale. Their logical icon size remains correct, but they render much larger than intended. Reloading outside and then entering the dungeon does not trigger the problem.

The fix avoids the unreliable inherited scale on these secure buttons and explicitly applies UIParent's current effective scale. This keeps icon sizing consistent in both reload paths.

The screenshots show the oversized icons after an in-dungeon reload and the expected icon size after a normal outside reload.