### PR TITLE
fix(questtracker): remove pooled POI Show taint hook

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -770,9 +770,6 @@ local function ProcessBlockChildren(frame, depth)
     end
 end
 
--- Weak-keyed so pooled/recycled poiButtons don't leak or get double-hooked.
-local _hookedPOIButtons = setmetatable({}, { __mode = "k" })
-
 local function SuppressPOI(block)
     if EQT.Cfg("showQuestIcons") then return end
     local pb = block and block.poiButton
@@ -780,18 +777,10 @@ local function SuppressPOI(block)
     if pb:IsShown() then pb:Hide() end
     pb:EnableMouse(false)
 
-    -- Re-hide synchronously whenever Blizzard shows this button again (e.g.
-    -- on SUPER_TRACKING_CHANGED from clicking a quest) so there's no visible
-    -- flash before the next SkinBlock/suppression pass. Hide() only, never
-    -- SetParent -- that's the taint-safe version of this pattern (see
-    -- InstallShowHook's otf Show-hook above, which does the same thing).
-    if not _hookedPOIButtons[pb] then
-        _hookedPOIButtons[pb] = true
-        hooksecurefunc(pb, "Show", function(self)
-            if EQT.Cfg("showQuestIcons") then return end
-            self:Hide()
-        end)
-    end
+    -- Do not hook Show on this Blizzard-owned pooled button. A post-hook runs
+    -- addon code synchronously inside Blizzard's native POI show/update path,
+    -- allowing taint to escape into later quest/map refresh work. Re-suppress
+    -- on each existing SkinBlock pass instead of injecting into Show itself.
 end
 
 local function SkinBlock(block)


### PR DESCRIPTION
## What does this PR do?

Removes the persistent `Show` post-hook from the objective tracker's pooled POI buttons.

The callback ran addon code synchronously inside Blizzard's native POI show/update path. On Retail 12.1 with EllesmereUI v8.5.5, a fresh BugGrabber session recorded 14 blocked calls attributed to `EllesmereUIQuestTracker` at:

```
Button:SetPassThroughButtons()
MapCanvas_DataProviderBase.lua: CheckMouseButtonPassthrough
Blizzard_MapCanvas.lua: AcquirePin
QuestDataProvider.lua: AddQuest / RefreshAllData
```

The same session also recorded AreaPOI tooltip/widget secret-number errors tainted by `EllesmereUIQuestTracker`.

`SuppressPOI` is already called from `SkinBlock` and the existing deferred tracker/update sweeps, so suppression remains in place without retaining a callback on Blizzard's pooled button. A POI may briefly reappear until the next existing suppression pass; this cosmetic trade-off is preferable to sticky map-refresh taint.

The objective-tracker POI pool and world-map pin pools are separate. The issue is addon execution entering the shared quest/super-tracking refresh wave, not a frame being reused across those pools.

## How was it tested?

- Reproduced against the installed v8.5.5 source with current-session BugGrabber evidence.
- Focused regression assertion failed before the change while `hooksecurefunc(pb, "Show", ...)` was present, and passed after removal.
- Parsed the changed file successfully as Lua 5.1 with `luaparse` 0.3.1.
- `git diff --check` passed.
- Locale-key regeneration produced no content change.
- Added lines were checked for the repository's ASCII-only requirement.
- Two independent reviews approved the minimal removal and retaining the bounded `Hide()` / `EnableMouse(false)` calls.

Pending before marking ready: a clean Retail 12.1 `/reload` or login test exercising quest selection/super-tracking, repeated map refresh, combat map updates, and AreaPOI tooltip hover. The client was running during preparation, so the installed addon was not replaced.

## Checklist

- [x] New settings default **OFF** - N/A; no setting added
- [x] Zero cost while disabled - N/A; this removes a hook and adds no work
- [x] Cheap while enabled - removes a persistent hook; no polling or timers added
- [x] No writes onto Blizzard-owned frames - no new writes; removes a `hooksecurefunc` callback from a Blizzard-owned pooled button
- [ ] Tested in-game on Retail 12.1; pending clean-session candidate test before marking ready
