### PR TITLE
Keep the crafting-order quality tier icon visible under the EUI skin

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -6007,7 +6007,13 @@ local function SkinOrderView(ov)
     end
     local od = ov.OrderDetails
     if od then
-        WSkin.FadeRegions(od)
+        -- Preserve the profession quality-tier icon (the pentagon next to the
+        -- recipe name showing the order's required quality). It's a direct
+        -- OVERLAY texture region of OrderDetails, so the blanket region fade
+        -- would otherwise alpha-zero it and the quality indicator vanishes
+        -- under the skin (reported: quality not visible on crafting orders).
+        local keep = od.MinimumQualityIcon and { [od.MinimumQualityIcon] = true } or nil
+        WSkin.FadeRegions(od, keep)
         WSkin.Register(od, true)
         if od.Background then od.Background:SetAlpha(0) end
         SkinSchematic(od.SchematicForm)


### PR DESCRIPTION
## Bug

Reported by @Svart: with the EUI Blizzard skin enabled, the **profession quality tier icon** (the pentagon next to the recipe name showing an order's required quality) is missing on the crafting orders page. It's present on the default UI.

## Cause

The crafter order view's `OrderDetails` frame has `MinimumQualityIcon` — a **direct OVERLAY texture region** (per `Blizzard_ProfessionsCrafterOrderView.xml`) that draws the required quality tier. `SkinOrderView` blanket-fades every direct texture region of `OrderDetails` to strip its decorative art, which also alpha-zeroed `MinimumQualityIcon`, so the quality indicator vanished.

## Fix

Add `MinimumQualityIcon` to the `FadeRegions` keep-set so it stays visible. The decorative `Background` is still faded (handled explicitly on the next line). One-line, purely additive.

## Testing

Change is a targeted allowlist entry; the icon is a standard Blizzard region so it renders as on the default UI once excluded from the fade.