### PR TITLE
Fix action bars invisible on a fresh install (missed login PEW after enable-flush defer)

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -9438,10 +9438,29 @@ end
 
 function EAB:OnEnable()
     -- If this is a first install (or reset), we need to capture Blizzard's
-    -- Edit Mode layout BEFORE hiding bars. Defer the full setup to
-    -- PLAYER_ENTERING_WORLD so Edit Mode has applied positions.
+    -- Edit Mode layout BEFORE hiding bars. The capture must run once Edit Mode
+    -- has applied bar positions/sizes, i.e. at/after PLAYER_ENTERING_WORLD.
+    --
+    -- OnEnable itself is now dispatched from the Lite enable-flush, which is
+    -- gated on IsLoggedIn() and deferred one tick past PLAYER_LOGIN (the Edit
+    -- Mode secret-taint fix). So on a fresh install the login
+    -- PLAYER_ENTERING_WORLD has ALREADY fired by the time we run here -- a plain
+    -- RegisterEvent would then wait for the next zone change, so OnFirstLogin
+    -- (and the FinishSetup it calls) would never run this session and the bars
+    -- stay built-but-invisible (reported on fresh 8.5.4 installs; a downgrade to
+    -- 8.5.3 then upgrade "fixes" it only because the capture then already ran).
+    --
+    -- Since the flush guarantees we're logged in and past the login PEW (Edit
+    -- Mode has applied its layout), capture now. Keep the event as a backstop
+    -- for the rare case we somehow enable before login; the _needsCapture guard
+    -- keeps the two paths idempotent (OnFirstLogin clears it + unregisters PEW).
     if self._needsCapture then
         self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnFirstLogin")
+        if IsLoggedIn() then
+            C_Timer_After(0, function()
+                if self._needsCapture then self:OnFirstLogin() end
+            end)
+        end
     else
         self:FinishSetup()
     end


### PR DESCRIPTION
## Bug

Widely reported on **v8.5.4 fresh installs**: with the Action Bars module enabled, the EUI action bars are **invisible** — present in `/fstack` but not drawn. Disabling the module shows Blizzard's default bars. Reported by @Pansophist / @Svart; several more in #eui-general. Workaround users found: **downgrade to 8.5.3, then upgrade to 8.5.4.**

## Root cause

On a first install (or Reset to Defaults) EAB defers its entire setup to a `PLAYER_ENTERING_WORLD` handler, `OnFirstLogin`, which captures Blizzard's Edit Mode layout and then calls `FinishSetup()` to actually build the bars. `OnEnable` registered that event and, on first install, did **nothing else**.

The Edit Mode secret-taint fix (v8.5.4) changed the Lite enable-flush to dispatch `OnEnable` from a `C_Timer` deferred one tick past `PLAYER_LOGIN` (gated on `IsLoggedIn()`), so module bodies don't run inside a secure demand-load chain. A necessary change — but it means on a fresh install the **login `PLAYER_ENTERING_WORLD` has already fired** by the time `EAB:OnEnable` runs. `RegisterEvent` then waits for the *next* zone change, so `OnFirstLogin`/`FinishSetup` never run and the bars are built but never shown.

Upgrades skip this entirely (`_capturedOnce_EAB` is already set → `OnEnable` calls `FinishSetup()` directly), which is exactly why the downgrade-then-upgrade workaround fixed it.

## Fix

When `OnEnable` runs already logged in (past the login PEW, so Edit Mode's layout is applied), run the capture immediately instead of only waiting for an event that already fired. The `PLAYER_ENTERING_WORLD` registration stays as a backstop for the rare enable-before-login case, and the `_needsCapture` guard keeps both paths idempotent (`OnFirstLogin` clears the flag and unregisters the event). Upgrade path unchanged.

## Testing

Repro requires a fresh capture state: remove `EllesmereUIActionBarsDB` from SavedVariables (or a clean install), enable the module, log in. Before: bars invisible. After: bars build and show on first login. Worth an in-game confirm from an affected reporter.

## Note

This is a general hazard of the deferred enable-flush: any module that registers `PLAYER_ENTERING_WORLD`/`PLAYER_LOGIN` in `OnEnable` to catch the *login* firing will now miss it. Action Bars is the one that surfaced; a follow-up sweep for the same pattern in other modules is worthwhile.