### PR TITLE
Fix Cooldown Manager not building on a fresh install (same missed-login-PEW cause as #931)

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8180,8 +8180,24 @@ function ECME:OnEnable()
         _cdmSetupStarted = true
         EnsureMappings(GetStore())
         if self._needsCapture then
-            -- Defer one more step so Edit Mode has applied positions
+            -- Capture Blizzard's Edit Mode layout once it has applied positions
+            -- (at/after PLAYER_ENTERING_WORLD). But OnEnable/TryBuildCDM now run
+            -- deferred past the login PEW -- the Lite enable-flush dispatches
+            -- OnEnable from a C_Timer past PLAYER_LOGIN (Edit Mode taint fix),
+            -- and a spec-change wakeup can defer this further still -- so on a
+            -- fresh install that login PLAYER_ENTERING_WORLD has already fired.
+            -- A plain RegisterEvent would then wait for the next zone change, so
+            -- OnCDMFirstLogin/CDMFinishSetup would never run this session and the
+            -- tracker stays unbuilt (same class as the fresh-install action-bar
+            -- regression). Keep the event as a backstop and, since we're already
+            -- in the world with Edit Mode applied, capture now; the _needsCapture
+            -- guard keeps the two paths idempotent.
             self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnCDMFirstLogin")
+            if IsLoggedIn() then
+                C_Timer.After(0, function()
+                    if self._needsCapture then self:OnCDMFirstLogin() end
+                end)
+            end
         else
             self:CDMFinishSetup()
         end


### PR DESCRIPTION
## Bug

Same class as #931 (action bars invisible on fresh install), found by sweeping every module's `OnEnable` for the pattern. On a **fresh install** the Cooldown Manager can fail to build for the same reason.

## Root cause

On a first install (or Reset) CDM defers its build to `OnCDMFirstLogin` on `PLAYER_ENTERING_WORLD`, which captures Blizzard's Edit Mode layout and then calls `CDMFinishSetup()`. That path assumed `OnEnable` runs before the login PEW.

Since the Edit Mode secret-taint fix, the Lite enable-flush dispatches `OnEnable` from a `C_Timer` deferred past `PLAYER_LOGIN`, and CDM's own spec-change wakeup can defer the build further still. So on a fresh install the login `PLAYER_ENTERING_WORLD` has already fired by the time the `_needsCapture` branch is reached — `RegisterEvent` then waits for the next zone change and `OnCDMFirstLogin`/`CDMFinishSetup` never run, leaving the tracker unbuilt.

## Fix

When the capture branch is reached already logged in (past the login PEW, Edit Mode applied), capture now instead of only waiting for an event that already fired. The `PLAYER_ENTERING_WORLD` registration stays as a backstop and the `_needsCapture` guard keeps both idempotent. Mirrors the action-bar fix.

## Note

These two (#931 action bars, this) were the only *login-dependent one-time-capture* uses of the pattern in the sweep. Two other `self:RegisterEvent("PLAYER_ENTERING_WORLD")` uses in `OnEnable` (action-bar post-loading-screen keybind reset; cursor visibility updater) are *ongoing* handlers where missing the login firing is harmless, so they're intentionally left alone.