### PR TITLE
[BugFix] Fix right-click hover-cast binding reverting to the context menu after login/reload

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_ClickCast.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_ClickCast.lua
@@ -1052,7 +1052,6 @@ local function NeutralizeDefaultClicks(frame, bindings)
 end
 
 local function DoRegisterFrame(frame)
-    if registeredFrames[frame] then return end
     if not frame or not frame.RegisterForClicks then return end
     if not header then return end
     -- Hard guarantee: while click-casting is disabled we touch ZERO frames --
@@ -1061,6 +1060,15 @@ local function DoRegisterFrame(frame)
     -- explicitly enable the feature.
     local cc = GetClickCastDB()
     if not (cc and cc.enabled) then return end
+    -- Deliberately NO `if registeredFrames[frame] then return end` early-out:
+    -- re-registration MUST re-apply the click attributes. EUI unit frames are
+    -- first registered mid-spawn (they land in ClickCastFrames as oUF builds
+    -- them); SetupUnitMenu then re-attaches the secure right-click menu
+    -- (AttachSecureUnitMenu wipes type2 and re-sets the *type2 menu wildcard)
+    -- and re-adds the frame to ClickCastFrames. If the re-add short-circuited,
+    -- the menu would stay in charge and the bound right-click spell would
+    -- silently revert to opening the menu after every login/reload. Every step
+    -- below is idempotent or self-guarded, so re-running the apply is safe.
     registeredFrames[frame] = true
     -- Capture the frame's native left-click target attrs once, before we touch
     -- anything, so DoUnregisterFrame restores them exactly (raid -> target, EUI
@@ -1665,6 +1673,32 @@ end
 -------------------------------------------------------------------------------
 --  Events
 -------------------------------------------------------------------------------
+-- At login the specialization / trait data can lag PLAYER_ENTERING_WORLD by a
+-- few frames. Applying bindings before the spec is known makes every
+-- SPEC-scoped binding fall back to its GLOBAL default -- e.g. a spec right-click
+-- spell reverts to the global "menu" default, so right-click opens the context
+-- menu -- with nothing to re-apply it afterwards (PLAYER_SPECIALIZATION_CHANGED
+-- does not fire on a plain login). Poll briefly until GetCurrentSpecID resolves,
+-- then reapply so spec bindings take effect. Safe when there is no spec (new /
+-- low-level characters): the cap stops the poll and a later spec pick fires
+-- PLAYER_SPECIALIZATION_CHANGED, which reapplies.
+local specReadyTicker
+local function ReapplyWhenSpecReady()
+    if InCombatLockdown() then pendingApply = true; return end
+    if GetCurrentSpecID() then ns.CC_ApplyBindings(); return end
+    if specReadyTicker then return end
+    local tries = 0
+    specReadyTicker = C_Timer.NewTicker(0.25, function(t)
+        tries = tries + 1
+        if GetCurrentSpecID() then
+            t:Cancel(); specReadyTicker = nil
+            if not InCombatLockdown() then ns.CC_ApplyBindings() else pendingApply = true end
+        elseif tries >= 20 then  -- ~5s safety cap: give up if the char has no spec
+            t:Cancel(); specReadyTicker = nil
+        end
+    end)
+end
+
 local function OnCCEvent(self, event)
     if event == "PLAYER_REGEN_ENABLED" then
         local cc = GetClickCastDB()
@@ -1688,8 +1722,10 @@ local function OnCCEvent(self, event)
         if not InCombatLockdown() then ns.CC_ApplyBindings() else pendingApply = true end
     elseif event == "PLAYER_ENTERING_WORLD" then
         -- Reapply bindings after zone/loading screen to clear any stuck
-        -- frame-based bindings (OnLeave may not fire during transitions)
-        if not InCombatLockdown() then ns.CC_ApplyBindings() else pendingApply = true end
+        -- frame-based bindings (OnLeave may not fire during transitions).
+        -- Wait for the spec to resolve first so spec-scoped bindings are not
+        -- lost to their global defaults on login (see ReapplyWhenSpecReady).
+        ReapplyWhenSpecReady()
     end
 end
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where a mouse-button hover-cast binding (e.g. a right-click spell) on EUI unit frames silently reverted to opening the context menu after every login or `/reload`. The bound spell only came back after opening the Click Casting options page, which forced a re-apply. Keyboard bindings were unaffected.

**Root cause.** EUI unit frames land in `ClickCastFrames` while oUF is still building them, so the click-cast engine registers each frame and writes its binding (`type2 = macro` + `macrotext2`) mid-spawn. `SetupUnitMenu` then runs and re-attaches the secure right-click menu via `AttachSecureUnitMenu`, which wipes `type2` and re-sets the `*type2 = click` menu wildcard. `SetupUnitMenu` finishes by re-adding the frame to `ClickCastFrames`, but `DoRegisterFrame` short-circuited on its `if registeredFrames[frame] then return end` early-out, so the binding was never re-applied and the menu stayed in charge. Keyboard bindings self-heal because they are rebuilt on every `OnEnter`; mouse-button bindings are written once at register time, which is why only the right click broke.

**Changes:**

1. `DoRegisterFrame` no longer early-outs on an already-registered frame, so the re-registration triggered by `SetupUnitMenu` re-applies the click attributes and wins over the menu. Every step in the function is idempotent or self-guarded (`originalTargetAttrs` nil-check, `wrappedFrames` guard, idempotent `RegisterForClicks`/`SetAttribute`), so re-running the apply is safe.

2. `PLAYER_ENTERING_WORLD` now re-applies through a new `ReapplyWhenSpecReady` helper: it waits for `GetCurrentSpecID()` to resolve before re-applying, so SPEC-scoped bindings are not lost to their GLOBAL defaults on login (`PLAYER_SPECIALIZATION_CHANGED` does not fire on a plain login). When the spec is already known (the normal case) it re-applies immediately with no timer; the short poll only starts when spec data is genuinely unavailable and is bounded (~5s cap) and self-cancelling.

## How was it tested?

- Live retail client (12.0.7), Discipline Priest (spec 256) with a SPEC right-click binding (Power Word: Shield) and "All Unit Frames" enabled.

- Reproduced the bug: after login/`/reload`, right-clicking the player/target/focus/pet EUI frames opened the context menu. An attribute dump showed the EUI frames with `type2 = nil`, `*type2 = click` (menu) while `macrotext2` still held the spell; Blizzard frames were correct.

- Diagnosed with a temporary `SetAttribute` hook tracing every `type2`/`*type2` write with call stacks, which pinpointed the register-then-menu-override ordering above. All diagnostic code has been removed from the final diff.

- After the fix: right-click casts the bound spell on all EUI unit frames immediately after login/`/reload`, with no need to open the options page. Keyboard bindings, hover-cast, and the right-click menu on frames without a right-click binding all still behave as before.

## Screenshots

Not a visual change (click behavior only) - deleted per template.

## Checklist

- [x] **New settings default OFF** - N/A: this is a genuine bug fix with no new settings; the behavior change *is* the fix.

- [x] **Zero cost while disabled** - `DoRegisterFrame` still self-gates on `cc.enabled` before touching anything, so a disabled install registers nothing. The `PLAYER_ENTERING_WORLD` re-apply path already existed on `main`; this PR only gates it behind a spec-readiness check.

- [x] **Cheap while enabled** - Re-application is event-driven (triggered by the `ClickCastFrames` re-add and by `PLAYER_ENTERING_WORLD`). The only timer is a bounded, self-cancelling ~5s spec-readiness poll that runs solely when spec data is not yet available at login; on a normal login it re-applies immediately with no timer, and there are no per-frame allocations.

- [x] **No writes onto Blizzard-owned frames** - The re-apply only writes secure click attributes through the engine's existing path (no `SetScript`, no new hooks). No Blizzard frame is written to by this change that was not already written to before it.

- [x] **Tested in-game on live retail; no load errors.** The changed code paths are version-agnostic (nothing under `IS_121` is touched), but I have not run the 12.1 PTR client myself - flagging in case a maintainer can confirm there.