### PR TITLE
Fix CDM crash when hosting a collided buff (Diabolist Diabolic Ritual) on a Cooldown/Utility bar

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -5139,16 +5139,29 @@ local function CollectAndReanchor()
                                     end
                                 else
                                     if not spellOrder[sid] then spellOrder[sid] = idx end
-                                    if _FindOverride then
-                                        local ovr = _FindOverride(sid)
-                                        if ovr and ovr > 0 and ovr ~= sid and not spellOrder[ovr] then
-                                            spellOrder[ovr] = idx
+                                    -- Resolve override/base forms only for a REAL
+                                    -- spellID. sid can be a cd-claim marker here (a
+                                    -- collided-buff slot, -(CD_CLAIM_MARKER_BASE+cdID),
+                                    -- well outside int32): FindSpellOverrideByID errors
+                                    -- outright on an out-of-range id, and a marker has no
+                                    -- override/base anyway (its frame routes by cooldownID
+                                    -- and orders via the buff-family "c"..cdID key). Same
+                                    -- sid>0 guard the sibling order loops already use; this
+                                    -- one branch was missed, so hosting a collided buff
+                                    -- (Diabolist Diabolic Ritual) on a CD/util bar threw
+                                    -- every RefreshLayout and broke CDM.
+                                    if sid > 0 then
+                                        if _FindOverride then
+                                            local ovr = _FindOverride(sid)
+                                            if ovr and ovr > 0 and ovr ~= sid and not spellOrder[ovr] then
+                                                spellOrder[ovr] = idx
+                                            end
                                         end
-                                    end
-                                    if C_Spell and C_Spell.GetBaseSpell then
-                                        local base = C_Spell.GetBaseSpell(sid)
-                                        if base and base > 0 and base ~= sid and not spellOrder[base] then
-                                            spellOrder[base] = idx
+                                        if C_Spell and C_Spell.GetBaseSpell then
+                                            local base = C_Spell.GetBaseSpell(sid)
+                                            if base and base > 0 and base ~= sid and not spellOrder[base] then
+                                                spellOrder[base] = idx
+                                            end
                                         end
                                     end
                                 end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -5192,11 +5192,15 @@ local function CollectAndReanchor()
                         end
                     end
                     for _, sid in ipairs(spellList) do
-                        if sid and ns.HostedBuffMarkerToSpell and ns.HostedBuffMarkerToSpell(sid) then
-                            -- Hosted-buff marker: the buff renders via the reparent
-                            -- path (route map -> cdFrames), never as an injected
-                            -- custom frame. Must be tested before the item-preset
-                            -- branch (markers are also <= -100).
+                        if sid and ((ns.HostedBuffMarkerToSpell and ns.HostedBuffMarkerToSpell(sid))
+                                 or (ns.CdClaimMarkerToCdID and ns.CdClaimMarkerToCdID(sid))) then
+                            -- Hosted-buff OR cd-claim (collided-buff slot) marker: the
+                            -- buff renders via the reparent/diversion path (route map ->
+                            -- cdFrames), never as an injected custom frame. Must be tested
+                            -- before the item-preset branch: both marker kinds are also
+                            -- <= -100, so -sid would otherwise be taken as an itemID and
+                            -- fed to GetItemCooldown, which errors outside int32 range
+                            -- (cd-claim markers are -(CD_CLAIM_MARKER_BASE + cooldownID)).
                         elseif sid and ns.SlotIDFromKey(sid) then
                             -- Equipment slot (trinkets -13/-14, user-added slots)
                             local slot = ns.SlotIDFromKey(sid)


### PR DESCRIPTION
## Bug

Reported by @MisterWikipedia (v8.5.5, Demonology Warlock / **Diabolist**): adding **Diabolic Ritual** as a custom buff to the **Utility Bar** breaks CDM — it throws on every refresh and the tracker appears disabled.

Error (open world, target dummy — so not a secret-value issue):
```
53x EllesmereUICdmHooks.lua:5143: bad argument #1 to '_FindOverride'
    (outside of expected range ... FindSpellOverrideByID)
  ... in function 'RefreshLayout'
  sid = -3000009472
```

## Cause

A collided Diabolist buff (two cooldown-viewer slots share one canonical spellID) hosted on a CD/Util bar is tracked by a **cd-claim marker**: `-(CD_CLAIM_MARKER_BASE + cooldownID)` = `-3000009472`, a value well outside int32. The reanchor spell-order loop iterates the bar's `assignedSpells` (which holds that marker) and, in its non-hosted-buff `else` branch, passed the **raw marker** to `C_SpellBook.FindSpellOverrideByID` / `C_Spell.GetBaseSpell`. `FindSpellOverrideByID` errors outright on an out-of-range id, so `RefreshLayout` threw every refresh and CDM broke.

## Fix

Guard those two lookups with `sid > 0` — a marker is not a real spellID, has no override/base form, and its frame routes by cooldownID and orders via the buff-family `"c"..cooldownID` key. The **sibling order loops already use this exact `sid > 0` guard** (and one even decodes the cd-claim marker); this single `else` branch missed it. The `spellOrder[marker]` slot entry is unchanged, so ordering is unaffected — only the erroring API calls are skipped.

## Testing

Repro is deterministic (no instance needed): as Diabolist, add Diabolic Ritual to the Utility Bar. Before: 53x `FindSpellOverrideByID` error + broken CDM. After: no error, CDM refreshes normally. Worth an in-game confirm that the buff also renders on the Util bar.