### PR TITLE
Fix player-aura reskin tainting Blizzard's BuffFrame (raid lag + border revert)

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuras.lua
@@ -204,54 +204,26 @@ ns.RefreshPlayerAuras = RefreshAll
 --  Scale helper (applies iconSize via SetScale on AuraContainer)
 -------------------------------------------------------------------------------
 local _appliedBuffScale, _appliedDebuffScale
-local _nativeExpandEnabled
-local _appliedShowExpand
-local _savedExpandedState
 
 local function ApplyExpandButtonSetting()
     local cfg = PA()
     local button = BuffFrame and BuffFrame.CollapseAndExpandButton
     if not (cfg and button) then return end
-    if _nativeExpandEnabled == nil then
-        _nativeExpandEnabled = button:IsEnabled() and true or false
-    end
     local show = cfg.showExpandButton ~= false
-    if _appliedShowExpand == show then
-        if not show then button:Hide() end
-        return
-    end
-    -- First evaluation with the button wanted in its native shown state:
-    -- nothing to change, so leave Blizzard's model and layout untouched.
-    -- Running BuffFrame's layout functions (RefreshConsolidationFrame-
-    -- Visibility / UpdateGridLayout) from addon context stamps their
-    -- Lua-side state with addon taint, and Edit Mode's enter pass reads
-    -- that state -- the source of secret-value LUA_WARNING storms for
-    -- users with the aura reskin enabled.
-    if _appliedShowExpand == nil and show then
-        _appliedShowExpand = show
-        return
-    end
-    _appliedShowExpand = show
+    -- Purely visual: hide the expand/collapse button when the user opts to.
+    -- We deliberately do NOT write BuffFrame.isExpanded or call BuffFrame:Update
+    -- / UpdateGridLayout / RefreshConsolidationFrameVisibility from addon code.
+    -- Driving Blizzard's aura machinery from addon context runs it under our
+    -- taint, so Blizzard's own UpdateExpirationTime compares the secret
+    -- expirationTime and errors on every aura update -- 2000+ errors and heavy
+    -- lag in raid combat -- and that tainted Update also throws before our
+    -- border re-skin hook runs, so the icon borders revert on reload. Auras keep
+    -- Blizzard's native expand state (default is expanded, so all auras show);
+    -- when hidden, the button also stays hidden via the deferred
+    -- RefreshConsolidationFrameVisibility hook installed at init.
     if not show then
-        _savedExpandedState = BuffFrame.isExpanded
-        -- Keep the button logically enabled: Blizzard's IsExpanded() treats a
-        -- disabled button as consolidated/collapsed in some configurations.
-        -- Force the model open and hide only the visual control.
-        button:Enable()
-        BuffFrame.isExpanded = true
-        if BuffFrame.Update then pcall(BuffFrame.Update, BuffFrame) end
         button:Hide()
-    else
-        if _savedExpandedState ~= nil then
-            BuffFrame.isExpanded = _savedExpandedState
-            _savedExpandedState = nil
-        end
-        if _nativeExpandEnabled then button:Enable() else button:Disable() end
-        if BuffFrame.RefreshConsolidationFrameVisibility then
-            BuffFrame:RefreshConsolidationFrameVisibility()
-        end
     end
-    if BuffFrame.UpdateGridLayout then pcall(BuffFrame.UpdateGridLayout, BuffFrame) end
 end
 
 local function ApplyScale()


### PR DESCRIPTION
## Bug

Reported by @TowerRangers (v8.5.4, Unit Frames): with the Blizzard buff/debuff reskin enabled, the icon borders revert to default on reload (until a settings tweak re-applies them), and in raid combat Blizzard's own aura update errors thousands of times:

```
2418x Blizzard_BuffFrame/BuffFrame.lua:1056: attempt to compare field 'expirationTime'
      (a secret number value, while execution tainted by 'EllesmereUIUnitFrames')
  ... UpdateExpirationTime -> Update -> UpdateAuraButtons -> RefreshLayout
```

Disabling the Blizzard Aura Frames reskin "fixes" it. The error causes heavy lag.

## Cause

The "Hide expand button" path in `ApplyExpandButtonSetting` drove Blizzard's aura layout **from addon code**: it wrote `BuffFrame.isExpanded` and called `BuffFrame:Update` / `UpdateGridLayout` / `RefreshConsolidationFrameVisibility`. Running Blizzard's aura machinery under addon taint makes its own `UpdateExpirationTime` compare the **secret** `expirationTime` and error on every aura update — the 2418× storm and the lag. The tainted `Update` also throws before the border re-skin hook runs, so the borders revert on reload.

There is no taint-safe way to force-expand auras from an addon: any write to `isExpanded`, or any call into Blizzard's aura layout, taints it. (Confirmed against Blizzard's `BuffFrame.lua`: reads go through the `isExpanded` field / `GetCVarValueBool`, and the field write is what's taint-tracked.)

## Fix

Make the setting **purely visual** — just hide the expand/collapse button. The deferred `RefreshConsolidationFrameVisibility` hook (already present, taint-safe) keeps it hidden across Blizzard's own refreshes. Auras keep Blizzard's native expand state, which defaults to expanded, so all auras still show.

**Only affects users with "Show Expand Button" off; default config is untouched.** Trade-off: a user who had *manually collapsed* their auras beforehand would see those stay collapsed (no taint-free way to force them open).

## Testing

Verified in-game with the reskin on + "Show Expand Button" off, in an instance: no `BuffFrame.lua:1056` errors, no lag, borders persist through `/reload`, button hidden, all auras shown.