### PR TITLE
FIX: POI blinking

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -770,6 +770,8 @@ local function ProcessBlockChildren(frame, depth)
     end
 end
 
+local _hookedPOIs = setmetatable({}, { __mode = "k" })
+
 local function SuppressPOI(block)
     if EQT.Cfg("showQuestIcons") then return end
     local pb = block and block.poiButton
@@ -777,6 +779,15 @@ local function SuppressPOI(block)
     if pb:IsShown() then pb:Hide() end
     pb:EnableMouse(false)
 
+    if not _hookedPOIs[pb] then
+        _hookedPOIs[pb] = true
+
+        hooksecurefunc(pb, "Show", function(self)
+            if not EQT.Cfg("showQuestIcons") then
+                self:Hide()
+            end
+        end)
+    end
     -- Do not hook Show on this Blizzard-owned pooled button. A post-hook runs
     -- addon code synchronously inside Blizzard's native POI show/update path,
     -- allowing taint to escape into later quest/map refresh work. Re-suppress


### PR DESCRIPTION
## Summary

Fix quest POI icon briefly appearing when quest icons are disabled.

## Changes

* Prevent Blizzard's pooled quest `poiButton` from briefly appearing after tracking a quest via the context menu.
* Hook each `poiButton`'s `Show()` method once and immediately hide it while **Show Quest Icons** is disabled.
* Keep the hook configuration-aware, so enabling **Show Quest Icons** restores Blizzard's default behavior without requiring a reload.
* Ensure only a single hook is installed per pooled button using a weak-keyed cache.

## Why

When **Show Quest Icons** was disabled, right-clicking a quest and selecting **Track** caused Blizzard to re-show the pooled `poiButton` for a frame before the addon's suppression logic ran again. This resulted in the quest icon briefly appearing and blinking.

By intercepting `Show()` on the pooled button, the icon is suppressed immediately, eliminating the visual flicker while preserving the existing behavior when quest icons are enabled.

## Testing

* [x] Hide quest icons.
* [x] Right-click → **Focus Quest** no longer shows or blinks the Blizzard quest icon.
* [x] Existing quest item and group finder buttons continue to function normally.
* [x] Enabling **Show Quest Icons** restores the default Blizzard icons.
