### PR TITLE
Fix whisper secret-value taint errors (chat)

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -2907,7 +2907,15 @@ function ECHAT.ApplyTabLayout()
             -- tainted UpdateHeader's secret width math (2026-07-21).
             if cfOwner and cfOwner.isDocked and not cfOwner.isStaticDocked then
                 local pt, rel, relPt, x, y = tab:GetPoint(1)
-                if pt == "LEFT" and relPt == "LEFT" and y and y ~= 0 then
+                -- A docked temp WHISPER tab whose target is secret (in
+                -- instances / M+) has SECRET geometry: comparing pt/relPt or
+                -- doing arithmetic on x/y under our taint errors, and this pass
+                -- runs on the whisper path. Skip such tabs entirely -- the seat
+                -- normalize is cosmetic. Same issecretvalue belt as the width
+                -- record above (2893).
+                if not (issecretvalue and (issecretvalue(pt) or issecretvalue(relPt)
+                        or issecretvalue(x) or issecretvalue(y)))
+                    and pt == "LEFT" and relPt == "LEFT" and y and y ~= 0 then
                     local es = tab:GetEffectiveScale()
                     local onePhys = PP and PP.SnapForES and PP.SnapForES(1, es) or 1
                     tab:SetPoint(pt, rel, relPt, (x or 0) + onePhys, 0)

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -26,13 +26,21 @@ local ECHAT = ns.ECHAT
 -- ACTIVE; this build's only new variable vs the clean state.
 local BISECT_TAB_GEOMETRY_OFF = false   -- 1: CLEARED (this cycle)
 local BISECT_TAB_PADDING_OFF = false    -- 3: CLEARED (this cycle)
-local BISECT_TAB_BORDERS_OFF = false    -- 4: RETEST -- dirty on first clear;
-                                        --    tab getters removed since
--- 4b: gate-4 stayed dirty with all tab getters gone. This flag skips ONLY
--- the border-engine call (EllesmereUI.ApplyBorderStyle + PP solid border)
--- on the tab hosts; host management, FCF_IsDocked, and separators all
--- still run. The engine's scale walk + PP pixel-snap machinery have never
--- executed on a gdm-chained frame in any clean build.
+local BISECT_TAB_BORDERS_OFF = false    -- 4: EXONERATED 2026-07-25 (field-
+                                        --    dirty with the engine off, so
+                                        --    the border engine is not the
+                                        --    injector; see ladder below)
+-- 2026-07-25 ladder (whisper secret-taint, FCFManager_GetChatTarget /
+-- GetDecoratedSenderName secret errors, always via the temp-window
+-- open+refire stack): CONVICTED = init-time ECHAT.ApplyBorders() --
+-- TIMING, not content. Run synchronously inside PLAYER_LOGIN it plants the
+-- panel-border anchors while Blizzard's login dock pass still resolves
+-- layout; that pass reads the insecure anchors, runs tainted, and its
+-- persistent dock state poisons every later temp-whisper open. Fix = defer
+-- to PEW + C_Timer (the deferred passes' field-proven cadence). Exonerated
+-- en route: gate-4 border engine, gdm anchor ties, sfc pin, BNToast block,
+-- FCFDock_SelectWindow hook, frame HookScripts, temp Skin*, eb anchors,
+-- whisper URL filter.
 local BISECT_EXT_BG_OFF = false         -- 5: CLEARED (this cycle)
 local BISECT_DEFERRED_PASSES_OFF = false -- 6: CLEARED (this cycle)
 local BISECT_EB_ANCHORS_OFF = false     -- 7: CLEARED (this cycle)
@@ -4345,7 +4353,23 @@ initFrame:SetScript("OnEvent", function(self)
     --  8. Apply all visual settings from DB
     ---------------------------------------------------------------------------
     ECHAT.ApplySidebarVisibility()
-    ECHAT.ApplyBorders()
+    -- ApplyBorders is DEFERRED out of the PLAYER_LOGIN execution (field-
+    -- bisected 2026-07-25, ladder B3-B15): running it synchronously here
+    -- chains into ApplyExtendedBackground, which plants the panel border's
+    -- anchors in ChatFrame1's rect web WHILE Blizzard's login dock pass is
+    -- still resolving layout -- that pass then reads our insecure anchors,
+    -- runs tainted, and its persistent dock state poisons every later
+    -- temp-whisper open (FCFManager_GetChatTarget /GetDecoratedSenderName
+    -- secret errors). The deferred tab passes (PEW + C_Timer) are the
+    -- field-proven-clean home for this work -- same cadence, one tick later.
+    do
+        local bordersDefer = CreateFrame("Frame")
+        bordersDefer:RegisterEvent("PLAYER_ENTERING_WORLD")
+        bordersDefer:SetScript("OnEvent", function(self)
+            self:UnregisterAllEvents()
+            C_Timer.After(0, function() ECHAT.ApplyBorders() end)
+        end)
+    end
     -- ECHAT.ApplySidebarIcons() -- causes taint (full layout chain)
     -- Apply individual icon visibility from DB without the layout chain.
     do


### PR DESCRIPTION
## Problem

Multiple testers reported LUA errors on whispers (worst after dungeons / in instanced content), all `execution tainted by 'EllesmereUIChat'` detonating on 12.x secret values inside Blizzard's own whisper processing:

- `ChatFrameUtil.lua:1002 GetDecoratedSenderName` — boolean test on the secret `senderGUID` (regular whispers)
- `FloatingChatFrame.lua:2455 FCFManager_GetChatTarget` — string conversion on the secret BN target (Battle.net whispers)
- `EllesmereUIChat.lua ApplyTabLayout` — direct compare of a secret anchor point on docked temporary whisper tabs

Every Blizzard-side stack ran through `FloatingChatFrame.lua:2531` — the temporary-window open + event re-fire path — meaning each new whisper conversation's window was created under taint.

## Root cause

Field-bisected over a 13-build in-game ladder (marker-verified builds, one variable per cycle): the injector is the init-time `ECHAT.ApplyBorders()` call — a **timing** problem, not a content one. Run synchronously inside the `PLAYER_LOGIN` handler it chains into `ApplyExtendedBackground`, planting the panel border's anchors in ChatFrame1's rect dependency web while Blizzard's login dock pass is still resolving chat layout. That secure pass reads the insecure anchors, runs tainted, and its persistent dock state poisons every later `FCF_OpenTemporaryWindow`: each new whisper window re-fires its event into `MessageEventHandler` already tainted and is blocked on the secret sender values.

The same work run from the module's existing deferred tab-pass cadence (`PLAYER_ENTERING_WORLD` + `C_Timer`) has always been field-clean.

Exonerated along the way (no changes shipped): the whisper URL message filter, chat-frame HookScripts, temp-frame skinning, the tab border engine, GeneralDockManager anchoring, and the `FCFDock_SelectWindow` hook.

## Fix (2 commits)

1. **Guard the secret geometry read in `ApplyTabLayout`** — the docked temp-whisper tab seat-normalize compared `GetPoint()` results that are secret for whisper tabs; now `issecretvalue`-guarded (skips the cosmetic 1px nudge for that tab).
2. **Defer the login border pass** — `ApplyBorders()` now runs once from a one-shot `PLAYER_ENTERING_WORLD` handler + `C_Timer.After(0)` instead of synchronously inside `PLAYER_LOGIN`. Identical visuals, one frame later, and Blizzard's login dock pass completes untainted.

## Testing

Verified in-game across the full ladder and the final build: regular + Battle.net whispers, incoming and outgoing, in and out of instanced content, including closing whisper tabs and reopening new conversations (pooled frame reuse) — no taint errors, chat behavior identical to stock.

Huge thanks to **Kulia** for 3+ hours of live whisper testing across thirteen diagnostic builds — this one was only findable in the field. GREEN BAG!