### PR TITLE
Fix Apply-to-Bar toggle-off discarding custom colours (CDM)

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -9444,6 +9444,22 @@ initFrame:SetScript("OnEvent", function(self)
                             -- isToggle already gates them here; only the rejoin branch
                             -- above needed the payloadValue guard for them.)
                             if scopeActive and (valuesMatch or (ctx.isToggle and not ctx.payloadValue)) then
+                                -- Payload items (custom colour RGB, scalar seconds):
+                                -- the apply swept the per-icon originals, so this
+                                -- scope holds the ONLY copy of the value -- a plain
+                                -- un-apply would discard it and snap the setting to
+                                -- default. Seed the removed value back into the spell
+                                -- in hand first, so toggle-off is an undo for that
+                                -- spell (recreates its pre-apply own value) instead
+                                -- of a silent reset.
+                                if (ctx.scalarApply or ctx.payloadValue) and ss and scopeT then
+                                    for _, k in ipairs(keys) do
+                                        local own
+                                        if allSpecs then own = scopeT[k]
+                                        else own = rawget(scopeT, k) end
+                                        if own ~= nil then rawset(ss, k, own) end
+                                    end
+                                end
                                 AB.RunBarUnapply(keys, allSpecs)
                                 if ctx.refresh then ctx.refresh() end
                                 if s._updateActive then s._updateActive() end


### PR DESCRIPTION
## Problem

Reported for Cooldown Manager Active State > CD Swipe Color: select a custom colour, click "Apply to Bar (All Specs)", then click that same option again - the colour resets to default (yellow). Reproduces for any payload-carrying setting (custom colour RGB, scalar values such as Threshold Seconds) on both "Apply to Bar" and "Apply to Bar (All Specs)".

## Root cause

Clicking an already-active apply scope is a deliberate toggle-off (un-apply). But the original apply sweeps the per-icon copies of the value into the bar tier (that is what the "This replaces N existing value(s)" confirmation covers), so for payload settings the scope being removed holds the only remaining copy. The un-apply then deletes it with no confirmation, and the setting silently snaps to default.

## Fix

In the toggle-off branch, when the setting carries a payload (`scalarApply` / `payloadValue`), seed the scope's values back into the spell whose menu is open before clearing the scope. Toggle-off now acts as an undo for that spell: the bar-wide apply is removed and the spell keeps the custom value as its own, exactly as before the apply. A subsequent apply from the restored value works normally, and non-payload toggles keep their existing un-apply semantics.

## Testing

Verified in-game: custom CD Swipe colour -> Apply to Bar (All Specs) -> click the same option again -> the colour remains on the icon (own value) instead of resetting; re-applying afterwards works; plain toggles unchanged.