### PR TITLE
fix(nameplates): friendly nameplates not applying correct font flags

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -178,13 +178,12 @@ local function ApplyFriendlyFontOverride()
     end
     local font = GetFont()
     local size = GetFriendlyNameSize()
+    local flags = GetNPOutline()
     if SystemFont_NamePlate and SystemFont_NamePlate.SetFont then
-        local _, _, flags = SystemFont_NamePlate:GetFont()
-        SystemFont_NamePlate:SetFont(font, size, flags or GetNPOutline())
+        SystemFont_NamePlate:SetFont(font, size, flags)
     end
     if SystemFont_NamePlate_Outlined and SystemFont_NamePlate_Outlined.SetFont then
-        local _, _, flags = SystemFont_NamePlate_Outlined:GetFont()
-        SystemFont_NamePlate_Outlined:SetFont(font, size, flags or GetNPOutline())
+        SystemFont_NamePlate_Outlined:SetFont(font, size, flags)
     end
     fontOverrideApplied = true
 end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Fixes the friendly nameplates nameplate font to apply the correct flags

## How was it tested?

12.0.7 & 12.1 PTR, in game with friendly nameplates only show name option turned on. Also works inside instances.

## Screenshots

BEFORE
<img width="242" height="199" alt="before change" src="https://github.com/user-attachments/assets/d009486f-123b-4a80-b3ab-cc53af370627" />

AFTER
<img width="342" height="175" alt="after change" src="https://github.com/user-attachments/assets/4dc69020-d30a-4b67-93d5-19b6a7074304" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
