### PR TITLE
Quest Tracker: Fixed a bug where the quest tracker background would become unintentionally visible during raid fights

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
@@ -76,6 +76,23 @@ local function ShouldAutoHide()
     return false
 end
 
+-- Single source of truth for "is the tracker visually on screen right now".
+-- otf:IsShown() alone is not enough: HardHide() (below) falls back to
+-- SetAlpha(0) in combat because Show()/Hide() are protected on this
+-- EditMode frame, so IsShown() stays true while the frame is invisible.
+-- Every place that decides whether to show/hide our BG chrome must read
+-- this instead of re-deriving its own partial view of "visible" -- that
+-- drift (some checks knew about alpha/ShouldAutoHide, some didn't) is what
+-- caused the BG to flicker back in during combat.
+local function TrackerIsVisible(otf)
+    if not otf then return false end
+    if not otf:IsShown() then return false end
+    if otf:GetAlpha() <= 0 then return false end
+    if ShouldAutoHide() then return false end
+    return true
+end
+EQT.TrackerIsVisible = TrackerIsVisible
+
 -- Suspend/resume all QT event frames in raids/arenas/M+. Prevents quest
 -- events (QUEST_LOG_UPDATE etc.) from doing skin/resize/classify work when
 -- the tracker is hidden anyway. Re-registers on zone-out / unsuppress.
@@ -355,8 +372,9 @@ local function ResizeBGToContent()
     local bg = _bgFrame
     local otf = GetTracker()
     if not bg or not otf then return end
-    -- Tracker hidden (e.g. raid/arena auto-hide, Blizzard hide): BG follows.
-    if not otf:IsShown() then
+    -- Tracker hidden (e.g. raid/arena auto-hide, Blizzard hide, or the
+    -- combat alpha-fallback in HardHide): BG follows.
+    if not TrackerIsVisible(otf) then
         if bg:IsShown() then bg:Hide() end
         return
     end
@@ -457,7 +475,7 @@ function EQT.InitVisibility()
     -- and OnHide won't fire again, leaving BG + divider visible alone.
     local function SyncBGToTracker()
         if not _bgFrame then return end
-        if otf:IsShown() then _bgFrame:Show() else _bgFrame:Hide() end
+        if TrackerIsVisible(otf) then _bgFrame:Show() else _bgFrame:Hide() end
     end
     SyncBGToTracker()
     C_Timer.After(0.1, SyncBGToTracker)
@@ -496,7 +514,7 @@ function EQT.InitVisibility()
     if EllesmereUI.RegisterMouseoverTarget then
         local moProxy = {}
         moProxy.IsShown = function()
-            return otf and otf:IsShown() and not ShouldAutoHide()
+            return TrackerIsVisible(otf)
         end
         moProxy.IsMouseOver = function()
             if otf and otf:IsMouseOver() then return true end


### PR DESCRIPTION
## Problem 

The quest-tracker's decorative background (`_bgFrame`) would flicker in and out of view during raid encounters. Root cause: `HardHide()` falls back to `otf:SetAlpha(0)` in combat (since `Show()`/`Hide()` are protected on this EditMode-managed frame and blocked mid-fight), but three separate call sites - `ResizeBGToContent`, the post-reload `SyncBGToTracker`, and the mouseover proxy's `IsShown` - each read a different, partial signal for "is the tracker visible" (some checked only `otf:IsShown()`, one additionally checked `ShouldAutoHide()`, none checked alpha). Since `IsShown()` stays true under the alpha fallback, any quest/scenario event firing during combat (`QUEST_LOG_UPDATE`, `SCENARIO_UPDATE` (phase changes), `SUPER_TRACKING_CHANGED`, etc.) re-triggered a resize pass that showed the background back up, fighting the intended hide.

## Fix
Added a single predicate, `TrackerIsVisible(otf)`, in EllesmereUIQuestTracker_Visibility.lua that composes `IsShown()`, `GetAlpha() > 0`, and `ShouldAutoHide()` into one source of truth, exposed as EQT.TrackerIsVisible. Replaced the three ad-hoc visibility checks with calls to it. No new saved-variable flags or module-level state were introduced -  the predicate is pure, built entirely from frame state that already existed.

## What does this PR do?

Background of the quest tracker remains hidden during raid encounters

## How was it tested?

Tested ingame during raid fights. The quest tracker doesn't flicker in and out during the fight for every event called.

## Screenshots
Before:
<img width="892" height="600" alt="billede" src="https://github.com/user-attachments/assets/450ada70-7bcb-43cd-b726-a08c4e58ee04" />

After:
<img width="606" height="528" alt="billede" src="https://github.com/user-attachments/assets/6f718e47-70cb-41cd-b92f-f4eb23c3b414" />



## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ x ] New settings default **OFF** (no behavior change without opt-in)
- [ x ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ x ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ x ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ x ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
