### PR TITLE
Localize dropdown, popup, and sort labels that bypassed EllesmereUI.L()

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -233,7 +233,7 @@ initFrame:SetScript("OnEvent", function(self)
                 menuFrame:Hide()
             end)
 
-            rl:SetText(ri.label)
+            rl:SetText(EllesmereUI.L(ri.label))
             radioRows[#radioRows + 1] = rr
             mY = mY - MH
         end
@@ -295,7 +295,7 @@ initFrame:SetScript("OnEvent", function(self)
             rl:SetFont(FONT, 13, "")
             rl:SetPoint("LEFT", row, "LEFT", 20, 0)
             rl:SetJustifyH("LEFT")
-            rl:SetText(cb.label)
+            rl:SetText(EllesmereUI.L(cb.label))
             rl:SetTextColor(0.75, 0.75, 0.75, 1)
             row._lbl = rl
 

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -1048,7 +1048,7 @@ initFrame:SetScript("OnEvent", function(self)
             { type = "segmented", label = EllesmereUI.L("Mode"),
               disabled = HashOff,
               disabledTooltip = DIS_TIP,
-              keys = { "percent", "value" }, labels = { "%", EllesmereUI.L("Value") },
+              keys = { "percent", "value" }, labels = { percent = "%", value = "Value" },
               get = function() local c = getBarData(); return (c and c.hashMode) or "percent" end,
               set = function(k) local c = getBarData(); if not c then return end
                   c.hashMode = k; refreshFn() end },
@@ -2113,7 +2113,7 @@ initFrame:SetScript("OnEvent", function(self)
             local titleFS = EllesmereUI.MakeFont(popup, 13, nil, 1, 1, 1)
             titleFS:SetAlpha(0.55)
             titleFS:SetPoint("TOP", popup, "TOP", 0, curY)
-            titleFS:SetText(cfg.popupTitle or EllesmereUI.L("Threshold Settings"))
+            titleFS:SetText(EllesmereUI.L(cfg.popupTitle or "Threshold Settings"))
             curY = curY - 25
 
             -- Mode switch (druid power bar): Single per-spec vs three per-form


### PR DESCRIPTION
Three UI strings rendered in English regardless of locale because their display path never ran through `EllesmereUI.L()`. Translations for all of them already exist in the locale files — these are wiring fixes, not new strings.

**Raid Frames — Sort By dropdown** (`EUI_RaidFrames_Options.lua`)
The Sort By control is a custom, hand-rolled dropdown (not the shared widget). Its closed-button label was localized, but the expanded menu set item text verbatim: the radio items (Group / Role) and the drag-to-reorder role rows (Tank / Healer / DPS). Both now wrap in `L()`.

**Resource Bars — Threshold popup title** (`EUI_ResourceBars_Options.lua`)
The shared threshold-settings builder only wrapped the *fallback* title; a caller-supplied `popupTitle` ("Power Bar Threshold" / "Health Bar Threshold") was passed straight to `SetText`. Now `L()` wraps the resolved title.

**Resource Bars — Hash-line Mode segmented control** (same file)
The Mode toggle declared `labels = { "%", L("Value") }` as a positional array, but the segmented widget resolves display text via `labels[key]` keyed by the option key ("percent"/"value"). The positional entries were never hit, so it fell back to showing the raw keys. Re-keyed to `{ percent = "%", value = "Value" }`, matching the sibling callsite.

Four-line change total; verified the two files still compile.
