### PR TITLE
Fix Burning Rush tracking in Movement Alerts, offer it as a preset

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_MovementAlert_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_MovementAlert_Options.lua
@@ -87,6 +87,7 @@ local MOVEMENT_PRESETS = {
     { class = "SHAMAN", ids = { 192063 } },                -- Gust of Wind
     { class = "SHAMAN", ids = { 58875, 90328 } },          -- Spirit Walk
     { class = "WARLOCK", ids = { 48020 } },                -- Demonic Circle: Teleport
+    { class = "WARLOCK", ids = { 111400 } },               -- Burning Rush (buff-active, ships unchecked)
     { class = "WARRIOR", ids = { 6544 } },                 -- Heroic Leap
 }
 

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -62,10 +62,15 @@ local MOVEMENT_ABILITIES = {
     WARRIOR = {[71] = {6544}, [72] = {6544}, [73] = {6544}},
 }
 
--- Buff-active spells (label shown while the aura is up instead of a
--- cooldown countdown). Currently empty -- Burning Rush was removed from
--- tracking -- but the machinery stays for future aura-style mobility spells.
-local BUFF_ACTIVE_SPELLS = {}
+-- Buff-active spells (label shown while the aura is up instead of a cooldown
+-- countdown). Membership here does NOT add a spell to any class's defaults --
+-- those come from MOVEMENT_ABILITIES above -- it only says how a spell is
+-- tracked once it is in the list. Burning Rush is not a warlock default, but
+-- users add it manually, and it has no cooldown and no duration to count down,
+-- so it can only be tracked by the presence of its aura.
+local BUFF_ACTIVE_SPELLS = {
+    [111400] = "Burning Rush Active!",
+}
 
 local SPELL_ALIAS_GROUPS = {
     {102401, 16979, 102417, 252216},
@@ -644,21 +649,36 @@ local function GetPlayerMovementSpells()
                     local baseId = (displayId ~= spellId) and spellId or nil
                     if not isCharge and baseId then isCharge, maxCh, rechDur = SafeGetChargeInfo(baseId) end
                     if spellInfo then
-                        local rawBaseDur = SafeGetBaseDuration(displayId)
-                        if rawBaseDur <= 0 and baseId then rawBaseDur = SafeGetBaseDuration(baseId) end
-                        if not isCharge and rawBaseDur <= 0 and rechDur > 0 then rawBaseDur = rechDur end
-                        if rawBaseDur <= 0 then rawBaseDur = GetKnownCategoryDuration(displayId) end
-                        table.insert(result, {
-                            spellId = displayId,
-                            baseSpellId = baseId,
-                            spellName = spellInfo.name,
-                            spellIcon = spellInfo.iconID,
-                            customText = override.customText ~= "" and override.customText or nil,
-                            isChargeSpell = isCharge,
-                            maxCharges = maxCh,
-                            rechargeDuration = rechDur,
-                            baseDuration = isCharge and rechDur or rawBaseDur,
-                        })
+                        -- Same buff-active branch the default path takes above.
+                        -- Without it a user-added aura-toggle spell was always
+                        -- built as a cooldown entry, and since it has no cooldown
+                        -- the display loop had nothing to show.
+                        local defaultCustom = BUFF_ACTIVE_SPELLS[displayId] or BUFF_ACTIVE_SPELLS[spellId]
+                        if defaultCustom then
+                            table.insert(result, {
+                                spellId = displayId,
+                                spellName = spellInfo.name,
+                                spellIcon = spellInfo.iconID,
+                                customText = override.customText ~= "" and override.customText or defaultCustom,
+                                checkType = "buffActive",
+                            })
+                        else
+                            local rawBaseDur = SafeGetBaseDuration(displayId)
+                            if rawBaseDur <= 0 and baseId then rawBaseDur = SafeGetBaseDuration(baseId) end
+                            if not isCharge and rawBaseDur <= 0 and rechDur > 0 then rawBaseDur = rechDur end
+                            if rawBaseDur <= 0 then rawBaseDur = GetKnownCategoryDuration(displayId) end
+                            table.insert(result, {
+                                spellId = displayId,
+                                baseSpellId = baseId,
+                                spellName = spellInfo.name,
+                                spellIcon = spellInfo.iconID,
+                                customText = override.customText ~= "" and override.customText or nil,
+                                isChargeSpell = isCharge,
+                                maxCharges = maxCh,
+                                rechargeDuration = rechDur,
+                                baseDuration = isCharge and rechDur or rawBaseDur,
+                            })
+                        end
                     end
                 end
             end

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -691,7 +691,9 @@ end
 local function UpdateCachedCharges()
     if inCombat or InCombatLockdown() then return end
     for _, entry in ipairs(cachedMovementSpells) do
-        if entry.isChargeSpell then
+        if entry.checkType == "buffActive" then
+            -- Aura-tracked: no cooldown and no charges to cache.
+        elseif entry.isChargeSpell then
             local chargeId = entry.baseSpellId or entry.spellId
             local chargeInfo = C_Spell.GetSpellCharges(chargeId)
             if chargeInfo and chargeInfo.currentCharges and not IsSecret(chargeInfo.currentCharges) then

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -56,18 +56,17 @@ local MOVEMENT_ABILITIES = {
     ROGUE = {[259] = {36554, 2983}, [260] = {195457, 2983}, [261] = {36554, 2983}},
     SHAMAN = {[262] = {79206, 90328, 192063, 58875}, [263] = {90328, 192063, 58875}, [264] = {79206, 90328, 192063, 58875}},
     WARLOCK = {
-        [265] = {48020}, [266] = {48020}, [267] = {48020},
+        [265] = {48020, 111400}, [266] = {48020, 111400}, [267] = {48020, 111400},
         filter = {[385899] = {385899}},
     },
     WARRIOR = {[71] = {6544}, [72] = {6544}, [73] = {6544}},
 }
 
--- Buff-active spells (label shown while the aura is up instead of a cooldown
--- countdown). Membership here does NOT add a spell to any class's defaults --
--- those come from MOVEMENT_ABILITIES above -- it only says how a spell is
--- tracked once it is in the list. Burning Rush is not a warlock default, but
--- users add it manually, and it has no cooldown and no duration to count down,
--- so it can only be tracked by the presence of its aura.
+-- Buff-active spells: the label shown while the aura is up, in place of a
+-- cooldown countdown. Membership here decides HOW a spell is tracked, never
+-- whether it is on -- Burning Rush ships unchecked via MOVEMENT_DEFAULT_OFF
+-- below. It has no cooldown and no duration to count down, so the presence of
+-- its aura is the only thing there is to track.
 local BUFF_ACTIVE_SPELLS = {
     [111400] = "Burning Rush Active!",
 }
@@ -107,6 +106,7 @@ local MOVEMENT_DEFAULT_OFF = {
     [212552] = true,               -- Wraith Walk
     [79206]  = true,               -- Spiritwalker's Grace
     [58875]  = true, [90328] = true, -- Spirit Walk
+    [111400] = true,               -- Burning Rush (off by default since 8.5.3)
 }
 EllesmereUI._MovementDefaultOff = MOVEMENT_DEFAULT_OFF
 


### PR DESCRIPTION
## Problem

Reported by a demonology warlock: adding Burning Rush as a custom tracked spell
in Movement Alerts does nothing. It draws in the options preview but never in
the world.

## Root cause

Movement Alerts builds its tracked list in two loops. The default-class loop
classifies a spell through `BUFF_ACTIVE_SPELLS` and, on a match, builds an entry
with `checkType = "buffActive"` that is tracked by the presence of its aura. The
user-override loop had no equivalent branch, so a custom spell was always built
as a cooldown entry. The display loop only draws a cooldown entry when
`C_Spell.GetSpellCooldown` reports a live recovery, and Burning Rush has no
cooldown and no duration to count down, so nothing was ever drawn. The preview
does not go through the tracker, which is why it looked fine there.

`BUFF_ACTIVE_SPELLS` had also been empty since v8.5.3, which removed Burning
Rush from tracking but deliberately kept the machinery.

## Fix

- Give the override loop the same buff-active branch the default loop has, so
  any aura-toggle spell added by ID is tracked correctly.
- Restore Burning Rush to `BUFF_ACTIVE_SPELLS`, and offer it as a preset
  checkbox rather than requiring users to know the spell ID. It is added to the
  warlock spec lists so the tracker polls it, and to `MOVEMENT_DEFAULT_OFF` so
  the box ships **unchecked**. The v8.5.3 decision not to track it by default is
  preserved; the box is off until a user ticks it.
- Skip the cooldown/charge cache poll for aura-tracked entries, which have
  neither and never read the result.

The surrounding machinery was already intact: `UNIT_AURA` is registered whenever
the feature is on, the display loop already branches on
`checkType == "buffActive"`, and the combat-start resync still referenced
Burning Rush by name.

## Compatibility

Profiles that already added Burning Rush by ID keep working. The custom-add path
writes `enabled = true` explicitly, so the preset checkbox reads as checked and
the tracker still picks it up; the cell moves out of the user-added section into
the warlock preset row.

This also closes a gap between the three tables the options file asks to be kept
in sync: Burning Rush was already present in the raid-frame movement filter but
missing from `MOVEMENT_ABILITIES` and `MOVEMENT_PRESETS`.

## Testing

Confirmed in-game. The box ships unchecked on an untouched profile; ticking it
shows the icon and label while the buff is up, in and out of combat, and clears
on toggle off. Untalenting leaves the preference intact and simply stops
tracking, matching how every other talent-based preset behaves.
