### PR TITLE
Play the CDM cooldown-ready sound on the real cooldown-end edge

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -1196,9 +1196,11 @@ end
 --  fires on login (already ready -> never armed), on a GCD ending (a GCD never
 --  makes a spell "not ready" here), or per render tick.
 --
---  Driven ENTIRELY by the authoritative cooldown/charge events
---  (SPELL_UPDATE_COOLDOWN + SPELL_UPDATE_CHARGES) via the WatchCdReadySoundIfEnabled
---  set -- NOT by the SetDesaturated visual hook. That hook fires at moments unrelated
+--  The expiry edge itself comes from Blizzard's TriggerAvailableAlert (see
+--  HookCdReadyAvailableAlert): the client sends no event when a cooldown runs out,
+--  so the cooldown/charge events below cannot see it on their own. They still drive
+--  arming, charge readiness, and resets via the WatchCdReadySoundIfEnabled set
+--  -- NOT the SetDesaturated visual hook. That hook fires at moments unrelated
 --  to the real cooldown (rage/range/GCD repaint) where C_Spell.GetSpellCooldown can
 --  report a transient isActive=true / isOnGCD=false GCD race; sampling there
 --  false-armed non-charge spells that were never on cooldown (Odyn's Fury etc.),
@@ -1272,15 +1274,57 @@ end
 -- which CDM tracking barely has.
 local CD_READY_MIN_ARM = 1.6
 
+-- Both drivers below (Blizzard's available alert and the event fallback) can land
+-- on the same cooldown end a frame apart -- one shared throttle keeps that single.
+local CD_READY_SOUND_GAP = 0.5
+
 -- Is the spell READY right now? Charge spells: only at MAX charges (recharge not
 -- running). Non-charge: not on a real (non-GCD) cooldown. liveSid = resolved override.
-local function CdReadyIsReady(liveSid)
+--
+-- strict: the GCD does NOT count as ready. ARMING wants the loose read (a GCD must
+-- never arm a spell that was never on cooldown), but FIRING has to be strict: a
+-- CAST-TIME spell puts its own cooldown up only on cast SUCCESS, so from cast start
+-- until then GetSpellCooldown reports the GCD alone (isActive + isOnGCD). That reads
+-- "ready" under the loose test, which fired an armed sound at the exact moment the
+-- spell was cast (Temporal Anomaly, 1.5s cast -- instant spells never show the state).
+local function CdReadyIsReady(liveSid, strict)
     local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(liveSid)
     if ci ~= nil and (ci.maxCharges or 0) > 1 then
         return not ci.isActive
     end
     local cd = C_Spell.GetSpellCooldown(liveSid)
-    return not (cd and cd.isActive and not cd.isOnGCD)
+    if not cd then return true end
+    if strict then return not cd.isActive end
+    return not (cd.isActive and not cd.isOnGCD)
+end
+
+-- Charge spells keep their own ready edge (refill to MAX, off SPELL_UPDATE_CHARGES).
+-- Blizzard's available alert fires when the FIRST charge returns, a different edge,
+-- so the alert driver skips them.
+local function CdReadyIsChargeSpell(liveSid)
+    local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(liveSid)
+    return ci ~= nil and (ci.maxCharges or 0) > 1
+end
+
+-- Single play point for both drivers: throttled, always disarms, carries the
+-- /cdmreadydbg print (src names which driver won the edge).
+local function PlayCdReadySound(fd, key, liveSid, sid, bk, src)
+    fd._cdReadyArmed = false
+    local now = GetTime()
+    local last = fd._cdReadySoundAt
+    if last and (now - last) < CD_READY_SOUND_GAP then return end
+    fd._cdReadySoundAt = now
+    if ns._cdReadySoundDebug then
+        local nm = (C_Spell.GetSpellName and C_Spell.GetSpellName(liveSid)) or "?"
+        local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(liveSid)
+        print(string.format(
+            "|cff0cd29f[CDReady]|r FIRE(%s) live=%s '%s' base=%s bar=%s maxCharges=%s chargeRecharging=%s",
+            tostring(src), tostring(liveSid), tostring(nm), tostring(sid), tostring(bk),
+            ci and tostring(ci.maxCharges) or "-",
+            ci and tostring(ci.isActive) or "-"))
+    end
+    local path = ns.FOCUSKICK_SOUND_PATHS and ns.FOCUSKICK_SOUND_PATHS[key]
+    if path then PlaySoundFile(path, "Master") end
 end
 
 -- Shared evaluator (driven by SPELL_UPDATE_COOLDOWN + SPELL_UPDATE_CHARGES via the
@@ -1319,7 +1363,7 @@ local function EvalCdReadySound(frame, fd, primeOnly)
         if not fd._cdReadyArmed then fd._cdReadyArmedAt = GetTime() end
         fd._cdReadyArmed = true
         fd._cdReadyArmedSid = sid2
-    elseif fd._cdReadyArmed and not primeOnly then
+    elseif fd._cdReadyArmed and not primeOnly and CdReadyIsReady(liveSid, true) then
         if fd._cdReadyArmedSid ~= sid2 then
             -- Spell on this frame changed since arming (spec/talent swap); stale arm.
             fd._cdReadyArmed = false
@@ -1344,7 +1388,7 @@ local function EvalCdReadySound(frame, fd, primeOnly)
                 if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
                     livep = C_SpellBook.FindSpellOverrideByID(sidp) or sidp
                 end
-                if not CdReadyIsReady(livep) then return end  -- not ready (race) -> stay armed
+                if not CdReadyIsReady(livep, true) then return end  -- not ready (race/GCD) -> stay armed
                 if ns._cdmSoundSuppressed() then fd._cdReadyArmed = false; return end  -- a load began mid-defer
                 -- Sub-GCD arm span = transient misread, not a real cooldown ending.
                 local armedAt = fd._cdReadyArmedAt
@@ -1352,29 +1396,61 @@ local function EvalCdReadySound(frame, fd, primeOnly)
                     fd._cdReadyArmed = false
                     return
                 end
-                fd._cdReadyArmed = false
-                if ns._cdReadySoundDebug then
-                    local nm = (C_Spell.GetSpellName and C_Spell.GetSpellName(livep)) or "?"
-                    local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(livep)
-                    print(string.format(
-                        "|cff0cd29f[CDReady]|r FIRE live=%s '%s' base=%s bar=%s maxCharges=%s chargeRecharging=%s",
-                        tostring(livep), tostring(nm), tostring(sidp), tostring(bkp),
-                        ci and tostring(ci.maxCharges) or "-",
-                        ci and tostring(ci.isActive) or "-"))
-                end
-                local path = ns.FOCUSKICK_SOUND_PATHS and ns.FOCUSKICK_SOUND_PATHS[kp]
-                if path then PlaySoundFile(path, "Master") end
+                PlayCdReadySound(fd, kp, livep, sidp, bkp, "event")
             end)
         end
         fd._cdReadyPending:Show()
     end
 end
 
+-- PRIMARY driver for non-charge spells: Blizzard's own "this cooldown just became
+-- available" edge. The client dispatches NO event when a cooldown expires -- Blizzard
+-- says so in TriggerAvailableAlert itself ("this is what simulates the client sending
+-- a final SPELL_UPDATE_COOLDOWN event"), and drives it from the viewer's OnUpdate
+-- against the real endTime instead. Riding SPELL_UPDATE_COOLDOWN alone therefore never
+-- sees the expiry: the sound waited for the next unrelated cooldown event, which for a
+-- spell the player sits on is their next cast. Post-hooking the alert is the same
+-- taint-safe idiom as EnsureBuffSoundHook on TriggerAuraAppliedAlert, needs no secret
+-- duration read, and lands on the exact frame the cooldown ends.
+--
+-- Charge spells are left to the SPELL_UPDATE_CHARGES watcher: this alert fires when the
+-- FIRST charge returns, while CDM's charge readiness means back at MAX.
+local _cdReadyAlertHooked = setmetatable({}, { __mode = "k" })
+local function HookCdReadyAvailableAlert(frame, fd)
+    if _cdReadyAlertHooked[frame] then return end
+    if type(frame.TriggerAvailableAlert) ~= "function" then
+        _cdReadyAlertHooked[frame] = true   -- own placeholder / injected frame: no alert
+        return
+    end
+    _cdReadyAlertHooked[frame] = true
+    hooksecurefunc(frame, "TriggerAvailableAlert", function(f)
+        if not ns._cdmAnyCdReadySound then return end
+        if fd._isProcessingOverride then return end
+        local fca = _ecmeFC[f]
+        local sida = fca and fca.spellID
+        local bka = fca and fca.barKey
+        if not sida or not bka then return end
+        if bka == ns.FOCUSKICK_BAR_KEY then return end
+        if bka:sub(1, 7) == "__ghost" then return end
+        local ssa = ResolveSpellSettings(f, sida, ns.GetBarSpellData(bka))
+        local keya = ssa and ssa.cdReadySoundKey
+        if not keya or keya == "none" then return end
+        if ns._cdmSoundSuppressed() then fd._cdReadyArmed = false; return end
+        local livea = sida
+        if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
+            livea = C_SpellBook.FindSpellOverrideByID(sida) or sida
+        end
+        if CdReadyIsChargeSpell(livea) then return end
+        PlayCdReadySound(fd, keya, livea, sida, bka, "alert")
+    end)
+end
+
 -- Register a spell that has a CD-ready sound into the event-driven watch set. The
--- set is evaluated on SPELL_UPDATE_COOLDOWN (non-charge CD end) and
--- SPELL_UPDATE_CHARGES (charge refill to max) -- the authoritative moments the state
--- actually settles, so isActive/isOnGCD read consistently (no GCD race). BOTH charge
--- and non-charge spells are watched here; there is no SetDesaturated driver anymore.
+-- set is evaluated on SPELL_UPDATE_COOLDOWN and SPELL_UPDATE_CHARGES (charge refill
+-- to max), reading isActive/isOnGCD at the moment the state settles. That covers
+-- arming, charge readiness, and cooldown RESETS; the expiry edge itself belongs to
+-- the available-alert hook above, which the event pass backs up in the gaps between
+-- global cooldowns. There is no SetDesaturated driver anymore.
 -- Called from DecorateFrame for every cd/utility icon.
 function ns.WatchCdReadySoundIfEnabled(frame)
     if not frame then return end
@@ -1399,6 +1475,7 @@ function ns.WatchCdReadySoundIfEnabled(frame)
             end)
             ns._cdReadySoundEventFrame = ef
         end
+        HookCdReadyAvailableAlert(frame, fd)
         EvalCdReadySound(frame, fd, true)  -- prime the arm state only; never plays here
     elseif ns._cdReadySoundWatch[frame] then
         ns._cdReadySoundWatch[frame] = nil


### PR DESCRIPTION
### Reported issue

A "Cooldown Ready Sound" set on **Temporal Anomaly** (Preservation Evoker) never played when the cooldown finished. Instead it played at the exact moment the spell was cast again. The same setting on Verdant Embrace and Dream Breath worked correctly, so it looked spell-specific.

### Cause

Two defects meeting on one spell.

**The expiry edge was never seen.** The per-spell "Audio Effect on CD Ready" was driven only by `SPELL_UPDATE_COOLDOWN` / `SPELL_UPDATE_CHARGES`, but the client dispatches no event when a cooldown expires. Blizzard says so in `CooldownViewerItemMixin:TriggerAvailableAlert` itself:

> Need to refresh the entire button state after the cooldown finishes, this is what simulates the client sending a final SPELL_UPDATE_COOLDOWN event

and drives that edge from the viewer's `OnUpdate` against the real end time instead. So the sound waited for the next *unrelated* cooldown event — which, for a spell the player sits on, is their next cast — and the arm stayed set the whole time.

**The stale arm then fired on the cast.** `CdReadyIsReady` treated "on GCD" as ready, and a cast-time spell only puts its own cooldown up on cast SUCCESS. From cast start until then, `GetSpellCooldown` reports the GCD alone (`isActive` + `isOnGCD`), which read as ready and fired the armed sound. Temporal Anomaly has a 1.5s cast, so it hit this every time; instant spells like Verdant Embrace start their cooldown and GCD together and never show the state, which is why only one spell looked broken.

### Change

- Post-hook `TriggerAvailableAlert` as the primary driver for non-charge spells — the same taint-safe idiom `EnsureBuffSoundHook` already uses on `TriggerAuraAppliedAlert`, and it needs no secret duration read.
- Charge spells stay on `SPELL_UPDATE_CHARGES`: the alert fires when the *first* charge returns, while CDM charge readiness means back at max.
- The event pass keeps arming, charge readiness and cooldown resets, and still backs up the expiry in the gaps between global cooldowns.
- Firing takes a strict ready test (`not isActive`) so a GCD can no longer be mistaken for an expiry; arming keeps the loose read so a GCD still never arms a spell that was never on cooldown.
- Both drivers play through one throttled `PlayCdReadySound`, so an alert and an event landing on the same cooldown end a frame apart cannot double-fire.

EUI only alpha-fades the Blizzard viewers rather than hiding them (`EllesmereUICooldownManager.lua:6812`), so `CooldownViewerMixin:OnUpdate` — and therefore the alert — keeps running behind EUI's own bars.

### Testing

Reporter confirms Temporal Anomaly now sounds at cooldown end and is silent on the cast. `/cdmreadydbg` tags each fire with the driver that won the edge (`FIRE(alert)` / `FIRE(event)`), which is the quickest way to check a given spell.

Worth a second pair of eyes on: cooldown resets, a 2-charge spell, spec/talent swaps, and zone/login boundaries (the loading-screen settle gate is unchanged but the alert is a second path into the sound). One intentional behaviour change: the alert path does not apply the 1.6s minimum-arm floor the event fallback uses — Blizzard requires only >0.75s — so a very short cooldown with a sound assigned can now actually play.