### PR TITLE
Fix nameplate aura icons swallowing target-switch clicks

### DIFF
--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -491,9 +491,17 @@ function AK.MakeInitializer(styleKey, extra)
         -- Level order above the swipe: border first (as close to the icon
         -- as possible), then the text carrier -- duration/stack text must
         -- never render behind the border strips.
+        -- The three holders below are pure art/text carriers stacked over the
+        -- whole button, so none of them may take mouse input: on a NAMEPLATE
+        -- aura they sit between the cursor and the plate's own click region,
+        -- and a click that lands on one is swallowed instead of switching
+        -- target -- unmissable in M+, where every enemy plate is covered in
+        -- debuff icons. The button itself keeps its mouse for tooltips.
+        -- (EUI_Nameplates_AuraContainers does the same for its glow host.)
         d.borderHost = CreateFrame("Frame", nil, button)
         d.borderHost:SetAllPoints(button)
         d.borderHost:SetFrameLevel(d.cooldown:GetFrameLevel() + 1)
+        d.borderHost:EnableMouse(false)
 
         -- Dispel-ring holder: its own frame between the border host and the
         -- text carrier so the engine-tinted ring ALWAYS WINS over every
@@ -507,14 +515,28 @@ function AK.MakeInitializer(styleKey, extra)
         d.dispelHolder = CreateFrame("Frame", nil, button)
         d.dispelHolder:SetAllPoints(button)
         d.dispelHolder:SetFrameLevel(d.borderHost:GetFrameLevel() + 3)
+        d.dispelHolder:EnableMouse(false)
 
         -- Stack and duration text ride a carrier frame above the cooldown,
         -- borders and dispel ring so none of them can cover the text.
         d.stackCarrier = CreateFrame("Frame", nil, button)
         d.stackCarrier:SetAllPoints(button)
         d.stackCarrier:SetFrameLevel(d.borderHost:GetFrameLevel() + 4)
+        d.stackCarrier:EnableMouse(false)
         d.stack = d.stackCarrier:CreateFontString(nil, "OVERLAY")
         d.duration = d.stackCarrier:CreateFontString(nil, "OVERLAY")
+
+        -- Engine aura buttons come CLICK-enabled, and these are pure displays:
+        -- no style in the suite has a click action, and on nameplates a
+        -- click-alive icon sits between the cursor and the plate's click
+        -- region, eating target-switch clicks (measured in-game: the M+
+        -- "takes several clicks to swap target" report was an EUI plate aura
+        -- icon with clicks on). This is the ONLY reliable place to turn them
+        -- off: post-creation writes on the button are denied in secret
+        -- contexts (12.x DenyTaintedAccessWhenAurasAreSecret), which is
+        -- combat -- exactly when it matters. Motion stays per-style so
+        -- tooltips keep working where styles want them.
+        pcall(button.SetMouseClickEnabled, button, false)
 
         ApplyStyleToRegions(button, style)
 


### PR DESCRIPTION
## Problem

Reported repeatedly, and reproduced by two players: in M+ it took several clicks
on an enemy's nameplate to switch target. Any class, any spec. Only with the
Nameplates module enabled, and only from 8.5.4 onward -- 8.5.3 was fine.

## Cause

EUI's aura icons on nameplates were swallowing the clicks.

Engine aura buttons are created with mouse clicks **enabled**, and every AuraKit
consumer is a pure display -- no style in the suite wires a click action to one.
Nothing ever turned clicks off, so each aura on a unit put an invisible
click-catcher over its nameplate. In M+ every mob is covered in debuffs, so most
clicks aimed at the plate landed on an icon and did nothing; the ones that
"worked" landed between icons or on the mob's 3D model. That is why it took
several attempts, and why it never reproduced on a lone target.

The 8.5.4 boundary matches: that is when the aura icon holder frames were added
to AuraKit.

## Fix

Disable clicks on the button in the creation window, plus the three art/text
holders in the same block.

The creation window is the only place this reliably works: after creation,
writes to the button object are denied in secret-value contexts
(`DenyTaintedAccessWhenAurasAreSecret`), which includes combat -- exactly when
the interception matters. Runtime approaches were tried during diagnosis and
silently failed for that reason.

Mouse **motion** is untouched, so tooltips keep working wherever a style wants
them. Nameplate aura styles set `noTooltips = true` and so never had tooltips,
before or after this change.

The three holders (`borderHost`, `dispelHolder`, `stackCarrier`) were not the
culprit, but they are pure art/text carriers anchored over the whole button and
should never take mouse input either. `EUI_Nameplates_AuraContainers` already
does the same for its glow host.

## How it was confirmed

Measured on an affected client rather than inferred from the diff. Hovering a
nameplate that refused to swap reported a 25x25 frame with clicks enabled under
the cursor; a nameplate that worked reported nothing there. `GetRegions` on that
frame named its art, which identified it as an aura icon. The same player has
confirmed the symptom is gone with this change installed, with nameplate icons
still rendering and party/player aura tooltips still working.

## Side effect, an improvement

The same defect applied to raid frame aura icons: clicking a debuff icon on a
party frame was swallowed instead of passing through to the frame, so
click-casting over an icon did nothing. That now works.
