### PR TITLE
Keep Hidden (CD Ready) icons visible while a charge is recharging

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -9657,6 +9657,17 @@ initFrame:SetScript("OnEvent", function(self)
                         { charge = "chargeHideCdText", label = "+ Hide Duration (Charges > 0)",
                           applyKeys  = { "chargeHideCdText" },
                           applyWrite = function(t, v) t.chargeHideCdText = v and true or false end },
+                        -- Charge reading for the two Hidden (CD Ready) modes only.
+                        -- They normally treat a charge spell as ready at MAX charges,
+                        -- so the icon appears on the first spent charge and tracks the
+                        -- recharge; this opts the spell back into the older reading --
+                        -- stay hidden while any charge is still in hand, i.e. show up
+                        -- only once the ability is fully spent. No effect on the other
+                        -- effects (they already read "no charges left") or on
+                        -- non-charge spells.
+                        { charge = "chargeHideUntilSpent", label = "+ Stay Hidden While Charges Remain",
+                          applyKeys  = { "chargeHideUntilSpent" },
+                          applyWrite = function(t, v) t.chargeHideUntilSpent = v and true or false end },
                         -- Same logic as Hidden (On CD) but with a customizable opacity
                         -- instead of a hard 0. Click prompts for the percent; the label
                         -- shows it (e.g. "50% Lower Alpha (On CD)") while it is selected.
@@ -10062,7 +10073,11 @@ initFrame:SetScript("OnEvent", function(self)
                                                 sLbl:SetTextColor(acR, acG, acB, 1)
                                                 if item.charge == "chargeHideCdText" then
                                                     ns._cdmAnyChargeHideCdText = true
-                                                else
+                                                elseif item.charge ~= "chargeHideUntilSpent" then
+                                                    -- chargeHideUntilSpent needs no session
+                                                    -- gate: it is read inside the cd-state
+                                                    -- evaluator, which only runs for icons
+                                                    -- that have a Hidden (CD Ready) effect.
                                                     ns._cdmAnyChargeStyle = true
                                                 end
                                             else
@@ -11851,7 +11866,7 @@ initFrame:SetScript("OnEvent", function(self)
                             EnsureSS(); SetOwn("cdStateEffect", v)
                             if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end
                         end,
-                        function() return ss.cdStateEffect == nil and not ss.chargeHideSwipe and not ss.hideRechargeEdge and not ss.chargeHideCdText end,
+                        function() return ss.cdStateEffect == nil and not ss.chargeHideSwipe and not ss.hideRechargeEdge and not ss.chargeHideCdText and not ss.chargeHideUntilSpent end,
                         function(si, item, sub)
                             -- Lower Alpha (On CD): clicking prompts for the opacity
                             -- percent, then selects the effect (mirrors the setVal above).

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -64,6 +64,36 @@ initFrame:SetScript("OnEvent", function(self)
     local function GetCDMOptUseShadow()
         return not EllesmereUI or not EllesmereUI.GetFontUseShadow or EllesmereUI.GetFontUseShadow()
     end
+
+    -- Break-out menu auto-width. The subnav flyouts, the Apply-to scope strip and
+    -- the item pickers are all built at a nominal width, so captions longer than it
+    -- either ran past the border (option rows, whose labels have no right anchor --
+    -- which is why a few of them carry a tooltip that just repeats the label) or got
+    -- ellipsised (item rows, whose labels are pinned to their icon). Measure the
+    -- rendered captions and widen to the longest instead.
+    --
+    -- Grow-only from the caller's nominal width, so narrow menus keep their shape,
+    -- and capped so one long translation or item name can't produce a menu wider
+    -- than the screen (past the cap the existing tooltip/ellipsis fallbacks still
+    -- apply). Rows anchor TOPLEFT/TOPRIGHT to their inner frame, so they follow the
+    -- new width with no per-row work; pad is the horizontal space a row needs around
+    -- its text -- the text inset plus whatever sits at the right edge (bar-applied
+    -- arrow, colour swatch, sound-preview button, or an item icon for the pickers).
+    -- Hidden rows are measured too: a menu that resized while you hovered or typed
+    -- in its search box would be worse than one slightly wider than it needs.
+    local function FitMenuWidth(labels, nominalW, pad)
+        local MAX_W = 340
+        local widest = 0
+        for i = 1, #labels do
+            local fs = labels[i]
+            local w = fs and fs:GetStringWidth() or 0
+            if w > widest then widest = w end
+        end
+        local fit = math.ceil(widest + (pad or 40))
+        if fit < nominalW then fit = nominalW end
+        if fit > MAX_W then fit = MAX_W end
+        return fit
+    end
     local function SetPVFont(fs, font, size)
         if not (fs and fs.SetFont) then return end
         if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fs, GetCDMOptUseShadow()) end
@@ -9304,6 +9334,14 @@ initFrame:SetScript("OnEvent", function(self)
                             local total = y + 4
                             sInner:SetHeight(total)
                             s:SetHeight(total)
+                            -- Widen to the longest scope caption. Relayout runs after
+                            -- the Exclude/Include row is re-captioned, so the swapped
+                            -- text is measured; all four rows count, so swapping row 1
+                            -- never resizes the strip under the cursor.
+                            local fitW = FitMenuWidth(
+                                { thisBtn._label, b1._label, b2._label, b3._label }, SUBW)
+                            s:SetWidth(fitW)
+                            sInner:SetWidth(fitW)
                         end
                         -- Accent (and overlay) a scope ONLY when it holds an OWN value
                         -- for these keys that EQUALS the hovered item's value -- so the
@@ -9800,6 +9838,23 @@ initFrame:SetScript("OnEvent", function(self)
                             -- nil so its item reads as selected (false ~= nil otherwise).
                             if curVal == false then curVal = nil end
                             local flyoutEntries = {}
+                            -- Widen the flyout to its longest caption (FitMenuWidth).
+                            -- Run once after the items are built -- before the
+                            -- height/scroll branches below, which all size from subW --
+                            -- and again whenever a dynamic label is recomposed in place
+                            -- (e.g. "Lower Alpha (On CD)" gaining its "50% " prefix), so
+                            -- a caption that grows while the flyout is open still fits.
+                            local function RefitSub()
+                                local labels = {}
+                                for _, e in ipairs(flyoutEntries) do
+                                    if e.label then labels[#labels + 1] = e.label end
+                                end
+                                local fitW = FitMenuWidth(labels, subW)
+                                if fitW == subW then return end
+                                subW = fitW
+                                sub:SetWidth(subW)
+                                subInner:SetWidth(subW)
+                            end
                             -- Re-highlight the selection in place after a value click.
                             -- The flyout stays OPEN (no rebuild -- that would reset
                             -- scroll/search state and kill the apply strip's owner).
@@ -9820,6 +9875,9 @@ initFrame:SetScript("OnEvent", function(self)
                                     -- is the unclickable arrow row -- refresh it in place.
                                     if e.updateArrow then e.updateArrow() end
                                 end
+                                -- A recomposed dynamic label may be wider than the
+                                -- flyout was built for.
+                                RefitSub()
                             end
                             -- Reachable from onItemCreated closures (color swatches),
                             -- which live outside this scope but capture `sub`.
@@ -10203,6 +10261,10 @@ initFrame:SetScript("OnEvent", function(self)
                                 subH = subH + ITEM_H
                                 end -- item.divider / else
                             end
+
+                            -- Fit the width to the longest caption before anything below
+                            -- sizes from subW.
+                            RefitSub()
 
                             -- Cap height + scroll for long lists (e.g. the Audio Effect
                             -- sound list), matching the Focus Cast Sound dropdown and the
@@ -12894,6 +12956,9 @@ initFrame:SetScript("OnEvent", function(self)
                 local subW = 220
                 local SUB_ITEM_H = 26
                 local SUB_MAX_H = 260
+                -- Item captions collected as the rows are built, so the frame can be
+                -- widened to the longest bag-item name instead of ellipsising it.
+                local subLabels = {}
                 _customTrackingSub:SetSize(subW, 10)
                 _customTrackingSub:ClearAllPoints()
                 _customTrackingSub:SetPoint("TOPLEFT", ctItem, "TOPRIGHT", 2, 0)
@@ -12931,6 +12996,7 @@ initFrame:SetScript("OnEvent", function(self)
                         sLbl:SetPoint("RIGHT", sIco, "LEFT", -5, 0)
                         sLbl:SetJustifyH("LEFT"); sLbl:SetWordWrap(false); sLbl:SetMaxLines(1)
                         sLbl:SetText(EllesmereUI.L(it.name)); sLbl:SetTextColor(tDimR, tDimG, tDimB, tDimA)
+                        subLabels[#subLabels + 1] = sLbl
                         local sHl = si:CreateTexture(nil, "ARTWORK")
                         sHl:SetAllPoints(); sHl:SetColorTexture(1, 1, 1, 0); sHl:SetAlpha(0)
                         si:SetScript("OnEnter", function()
@@ -12946,6 +13012,11 @@ initFrame:SetScript("OnEvent", function(self)
                         subH = subH + SUB_ITEM_H
                     end
                 end
+                -- Widen to the longest item name (pad leaves room for the text inset
+                -- and the row's right-hand item icon).
+                subW = FitMenuWidth(subLabels, subW, 48)
+                _customTrackingSub:SetWidth(subW)
+                subInner:SetWidth(subW)
                 local totalSubH = subH + 4
                 subInner:SetHeight(totalSubH)
                 if totalSubH > SUB_MAX_H then
@@ -13228,6 +13299,9 @@ initFrame:SetScript("OnEvent", function(self)
 
                     local subW = 220
                     local SUB_ITEM_H = 26
+                    -- Captions collected as the rows are built so the frame can be
+                    -- widened to the longest preset name instead of ellipsising it.
+                    local subLabels = {}
                     _potionsSub:SetSize(subW, 10)
                     _potionsSub:ClearAllPoints()
                     _potionsSub:SetPoint("TOPLEFT", potItem, "TOPRIGHT", 2, 0)
@@ -13271,6 +13345,7 @@ initFrame:SetScript("OnEvent", function(self)
                         sLbl:SetWordWrap(false)
                         sLbl:SetMaxLines(1)
                         sLbl:SetText(EllesmereUI.L(preset.name))
+                        subLabels[#subLabels + 1] = sLbl
 
                         local sHl = si:CreateTexture(nil, "ARTWORK")
                         sHl:SetAllPoints()
@@ -13307,6 +13382,11 @@ initFrame:SetScript("OnEvent", function(self)
                         end -- healthstone filter
                     end
 
+                    -- Widen to the longest preset name (pad leaves room for the text
+                    -- inset and the row's right-hand item icon).
+                    subW = FitMenuWidth(subLabels, subW, 48)
+                    _potionsSub:SetWidth(subW)
+                    subInner:SetWidth(subW)
                     local totalSubH = subH + 4
                     subInner:SetHeight(totalSubH)
                     _potionsSub:SetHeight(totalSubH)

--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -969,6 +969,22 @@ PresetOnCD = function(key)
     return (dur > 1.5 and now < start + dur) or false
 end
 
+-- "Ready" for the Hidden (CD Ready) effects, which must not dismiss a charge
+-- spell that is still recharging: a custom SPELL preset can have charges, so it
+-- defers to the shared charge-aware read (ns.CdmCdStateReady). Items (key < 0)
+-- have no charges, so onCD alone answers it. The override walk mirrors
+-- PresetOnCD above -- the charges live on the override id (e.g. the transform),
+-- not the base one.
+local function PresetCdReady(key, onCD)
+    if key <= 0 then return not onCD end
+    local effKey = key
+    if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
+        local ov = C_SpellBook.FindSpellOverrideByID(key)
+        if ov and ov > 0 and ov ~= key then effKey = ov end
+    end
+    return ns.CdmCdStateReady(effKey, onCD)
+end
+
 -- Normal (shown) alpha for a frame, from its bar's opacity (out-of-combat
 -- fade folded in via EffectiveBarAlpha so restores don't clobber the fade).
 -- Overflow-diverted frames render inside the target bar, so their restore
@@ -984,7 +1000,7 @@ end
 -- cas is the rule's styling entry (passed in so a trinket, whose frame key is a
 -- slot, still gets the per-item glow colour). Marks the frame "touched" so the
 -- restore pass below can find it even after the trinket has been swapped out.
-ApplyCdState = function(frame, fc, cas, eff, onCD)
+ApplyCdState = function(frame, fc, cas, eff, onCD, ready)
     local fd = ns._hookFrameData and ns._hookFrameData[frame]
     if fd then fd._presetCdTouched = true end
     if eff == "hiddenOnCD" or eff == "hiddenReady"
@@ -994,7 +1010,9 @@ ApplyCdState = function(frame, fc, cas, eff, onCD)
         if eff == "hiddenOnCD" or eff == "hiddenOnCDShift" then
             hide = onCD
         else
-            hide = not onCD
+            -- ready, not "not onCD": a charge spell is only READY at max charges,
+            -- so the icon keeps tracking a running recharge (PresetCdReady).
+            hide = ready
         end
         frame:SetAlpha(hide and 0 or FrameBaseAlpha(fc))
         -- Set the SAME flag the layout / visibility / refresh code already honors,
@@ -1082,6 +1100,9 @@ EvalCdStateNow = function()
         if soundKey == "none" then soundKey = nil end
         if eff or soundKey then
             local onCD = PresetOnCD(rule.spellID)
+            -- Separate read for the Hidden (CD Ready) effects: a charge spell is
+            -- ready only at max charges (items fall through to "not onCD").
+            local ready = PresetCdReady(rule.spellID, onCD)
             local sid = rule.spellID
             -- Sound only fires while the ability's icon is present on a bar.
             local hasIcon = false
@@ -1091,7 +1112,7 @@ EvalCdStateNow = function()
                     local fc = f and FCt[f]
                     if fc and fc.spellID == sid then
                         hasIcon = true
-                        if eff then ApplyCdState(f, fc, cas, eff, onCD) end
+                        if eff then ApplyCdState(f, fc, cas, eff, onCD, ready) end
                     end
                 end
             end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -1534,6 +1534,178 @@ function ns.WatchChargeCdTextIfEnabled(frame)
 end
 
 -------------------------------------------------------------------------------
+--  Cooldown State Effect -- charge-aware readiness for Hidden (CD Ready)
+--
+--  For a CHARGE spell "CD Ready" must mean AT MAX CHARGES, not "a charge is in
+--  hand". C_Spell.GetSpellCooldown() reports isActive == false for a charge spell
+--  that still has a charge left (see CdmShouldHideCountdown above), so the plain
+--  cooldown read calls a spell that is still recharging "ready" and the Hidden
+--  (CD Ready) modes dismiss the icon mid-recharge -- exactly the charge and
+--  countdown the player turned the mode on to watch. Read the recharge flag
+--  instead (GetSpellCharges().isActive: true from the first spent charge until
+--  the last one refills -- the clean signal Max Stacks Glow uses). maxCharges > 1
+--  is the charge-spell test, stable through the GCD unlike
+--  HasVisualDataSource_Charges; non-charge spells keep the caller's cooldown
+--  read. The secret currentCharges is never read.
+--
+--  Per-spell "+ Stay Hidden While Charges Remain" (ss.chargeHideUntilSpent) opts
+--  a spell back into the legacy reading, for players who only want the icon once
+--  the ability is fully spent.
+--
+--  Deliberately NOT used by the other cd-state effects: every one of those
+--  answers "can I press this?" -- Hidden (On CD) and Lower Alpha (On CD) suppress
+--  what the player cannot cast, the ready-glows highlight what they can -- and a
+--  charge spell down one stack IS castable, so "no charges left" is already the
+--  right reading there. Hidden (CD Ready) is the only mode whose job is tracking
+--  the countdown itself.
+-------------------------------------------------------------------------------
+function ns.CdmCdStateReady(liveSid, onCD, hideUntilSpent)
+    if hideUntilSpent then return not onCD end
+    local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(liveSid)
+    if ci and (ci.maxCharges or 0) > 1 then return not ci.isActive end
+    return not onCD
+end
+
+-- Deferred cd-state evaluator for the hide / lower-alpha modes, shared by the
+-- SetDesaturated hook (which fires on every cooldown transition) and the charge
+-- watch below. Deferred by one frame because SetDesaturated fires inside
+-- Blizzard's secure CDM chain, where C_Spell.GetSpellCooldown can briefly
+-- disagree with Blizzard's own evaluation (charge spells report isActive while
+-- charges remain, GCD tail races) -- letting the API settle is what makes the
+-- read trustworthy. The OnUpdate script is installed ONCE per frame object: the
+-- hook fires on every repaint, so the per-arm work stays at plain field writes,
+-- never closure creation.
+local function ArmCdStateEval(frame, fd, cse, cseShift, lowAlpha, hideUntilSpent)
+    local pending = fd._cdStatePending
+    if not pending then
+        pending = CreateFrame("Frame")
+        pending:Hide()
+        fd._cdStatePending = pending
+        pending:SetScript("OnUpdate", function(self)
+            self:Hide()
+            local fc3 = _ecmeFC[frame]
+            local sid3 = fc3 and fc3.spellID
+            local bk3 = fc3 and fc3.barKey
+            if not sid3 or not bk3 then return end
+            local liveSid = sid3
+            if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
+                liveSid = C_SpellBook.FindSpellOverrideByID(sid3) or sid3
+            end
+            local cseInfo = C_Spell.GetSpellCooldown(liveSid)
+            local onCD = cseInfo and cseInfo.isActive and not cseInfo.isOnGCD
+            local myCse = self.cse
+            local bd3 = barDataByKey and barDataByKey[bk3]
+            local baseA = ns.IconShownAlpha(fc3, bd3)
+            if myCse == "lowerAlphaOnCD" then
+                -- Lowered (not hidden): reuse _cdStateHidden as the
+                -- "cd-state owns this alpha" flag so the opacity appliers
+                -- leave the lowered value in place, exactly like hiddenOnCD.
+                -- A visibility-hidden bar (baseA 0) stays at 0 in both states.
+                frame:SetAlpha(baseA == 0 and 0
+                    or (onCD and (self.lowAlpha or 0.5) or baseA))
+                if fc3 then
+                    fc3._cdStateHidden = onCD or false
+                    if ns.SetCdStateShiftHidden then
+                        ns.SetCdStateShiftHidden(fc3, false)
+                    end
+                end
+            else
+                local hide
+                if myCse == "hiddenOnCD" then
+                    hide = onCD
+                else
+                    -- Hidden (CD Ready): on a charge spell "ready" is max
+                    -- charges, so the icon keeps tracking the recharge.
+                    hide = ns.CdmCdStateReady(liveSid, onCD, self.hideUntilSpent)
+                end
+                frame:SetAlpha(hide and 0 or baseA)
+                if fc3 then
+                    fc3._cdStateHidden = hide or false
+                    if ns.SetCdStateShiftHidden then
+                        ns.SetCdStateShiftHidden(fc3, self.shift and hide or false)
+                    end
+                end
+            end
+        end)
+    end
+    -- All captured at arm time (settings, not volatile state); only
+    -- lowerAlphaOnCD reads lowAlpha, only the CD-Ready modes read hideUntilSpent.
+    pending.cse = cse
+    pending.lowAlpha = lowAlpha
+    pending.shift = cseShift
+    pending.hideUntilSpent = hideUntilSpent
+    pending:Show()
+end
+
+-------------------------------------------------------------------------------
+--  Hidden (CD Ready) on charge spells: refill-edge coverage
+--
+--  The mode is driven by the SetDesaturated hook, which fires when a charge is
+--  SPENT (Blizzard repaints the icon) but NOT when the last charge REFILLS to max
+--  -- the same gap Max Stacks Glow and Hide CD Text (Charges) already close with
+--  SPELL_UPDATE_CHARGES (that event fires on both charge transitions and nothing
+--  else, so it is far cheaper than SPELL_UPDATE_COOLDOWN). Without it a charge
+--  spell that topped off would stay visible for good: at max charges nothing
+--  repaints the icon again. Only icons actually running the mode on a charge
+--  spell enter the set, and it self-drains -- the eval unwatches a frame whose
+--  effect or spell went away, so each event iterates a tiny table.
+-------------------------------------------------------------------------------
+ns._cdStateChargeWatch = ns._cdStateChargeWatch or setmetatable({}, { __mode = "k" })
+
+local function EvalCdStateChargeFrame(frame, fd)
+    local fcw = _ecmeFC[frame]
+    local sidw = fcw and fcw.spellID
+    local bkw = fcw and fcw.barKey
+    if not sidw or not bkw then
+        ns._cdStateChargeWatch[frame] = nil
+        return
+    end
+    local ssw = ResolveSpellSettings(frame, sidw, ns.GetBarSpellData(bkw))
+    local csew = ssw and ssw.cdStateEffect
+    if csew ~= "hiddenReady" and csew ~= "hiddenReadyShift" then
+        -- Effect changed to something else (or cleared): the desat hook owns
+        -- every other mode, so drop the watch.
+        ns._cdStateChargeWatch[frame] = nil
+        return
+    end
+    ArmCdStateEval(frame, fd, "hiddenReady", csew == "hiddenReadyShift",
+        nil, ssw.chargeHideUntilSpent)
+end
+
+-- Register an icon whose resolved effect is Hidden (CD Ready) -- callers check
+-- that -- when its spell actually has charges. Non-charge spells never enter the
+-- set: their real CD-end edge already fires the desat hook. Called from the
+-- SetDesaturated hook (on spell rebinding) and RefreshCDMIconAppearance.
+function ns.WatchCdStateChargeIfEnabled(frame)
+    local fd = hookFrameData[frame]
+    if not fd then return end
+    local fcw = _ecmeFC[frame]
+    local sidw = fcw and fcw.spellID
+    if not sidw then return end
+    local liveSid = sidw
+    if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
+        liveSid = C_SpellBook.FindSpellOverrideByID(sidw) or sidw
+    end
+    -- Charge-spell test via static charge data (stable through the GCD).
+    local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(liveSid)
+    if not (ci and (ci.maxCharges or 0) > 1) then
+        ns._cdStateChargeWatch[frame] = nil
+        return
+    end
+    ns._cdStateChargeWatch[frame] = fd
+    if not ns._cdStateChargeEventFrame then
+        local ef = CreateFrame("Frame")
+        ef:RegisterEvent("SPELL_UPDATE_CHARGES")
+        ef:SetScript("OnEvent", function()
+            for f, d in pairs(ns._cdStateChargeWatch) do
+                EvalCdStateChargeFrame(f, d)
+            end
+        end)
+        ns._cdStateChargeEventFrame = ef
+    end
+end
+
+-------------------------------------------------------------------------------
 --  Swiftmend brightness: Blizzard dims the icon via SetVertexColor when
 --  Efflorescence / HoTs drop. Hook the icon texture once to force bright.
 --  Recursion guard only -- never compare incoming args (secret values).
@@ -2720,68 +2892,23 @@ local function DecorateFrame(frame, barData)
                         ns.SetCdStateShiftHidden(fc2, false)
                     end
                 end
-                -- For hidden cdState modes, defer the evaluation by one
-                -- frame. Blizzard's SetDesaturated fires inside the secure
-                -- CDM chain where C_Spell.GetSpellCooldown can briefly
-                -- disagree with Blizzard's own evaluation (charge spells
-                -- report isActive while charges remain, GCD tail races).
-                -- Deferring lets the API settle before we query it.
+                -- Hidden / lower-alpha modes: hand off to the shared deferred
+                -- evaluator (ArmCdStateEval -- see the comment on it for why the
+                -- read has to wait a frame). cse is normalized, so the Shift
+                -- variants arrive here as their base mode plus cseShift.
                 if cse == "hiddenOnCD" or cse == "hiddenReady" or cse == "lowerAlphaOnCD" then
-                    if not fd._cdStatePending then
-                        fd._cdStatePending = CreateFrame("Frame")
-                        fd._cdStatePending:Hide()
+                    ArmCdStateEval(frame, fd, cse, cseShift,
+                        (ss2 and ss2.cdStateLowerAlpha) or 0.5,
+                        ss2 and ss2.chargeHideUntilSpent)
+                    -- Hidden (CD Ready) on a charge spell also needs the
+                    -- refill-to-max edge, which this hook never fires. Registered
+                    -- once per spell binding (a pooled frame can be handed a
+                    -- different spell), so the steady-state cost stays one field
+                    -- compare per repaint.
+                    if cse == "hiddenReady" and fd._cdStateChargeBoundSid ~= sid2 then
+                        fd._cdStateChargeBoundSid = sid2
+                        ns.WatchCdStateChargeIfEnabled(frame)
                     end
-                    fd._cdStatePending.cse = cse
-                    -- Captured at arm time (a setting, not volatile); only lowerAlphaOnCD reads it.
-                    fd._cdStatePending.lowAlpha = (ss2 and ss2.cdStateLowerAlpha) or 0.5
-                    -- Shift-Icons variant: the evaluator also maintains the
-                    -- bar-relayout flag (cleared for the non-shift modes).
-                    fd._cdStatePending.shift = cseShift
-                    fd._cdStatePending:SetScript("OnUpdate", function(self)
-                        self:Hide()
-                        local fc3 = _ecmeFC[frame]
-                        local sid3 = fc3 and fc3.spellID
-                        local bk3 = fc3 and fc3.barKey
-                        if not sid3 or not bk3 then return end
-                        local liveSid = sid3
-                        if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
-                            liveSid = C_SpellBook.FindSpellOverrideByID(sid3) or sid3
-                        end
-                        local cseInfo = C_Spell.GetSpellCooldown(liveSid)
-                        local onCD = cseInfo and cseInfo.isActive and not cseInfo.isOnGCD
-                        local myCse = self.cse
-                        local bd3 = barDataByKey and barDataByKey[bk3]
-                        local baseA = ns.IconShownAlpha(fc3, bd3)
-                        if myCse == "lowerAlphaOnCD" then
-                            -- Lowered (not hidden): reuse _cdStateHidden as the
-                            -- "cd-state owns this alpha" flag so the opacity appliers
-                            -- leave the lowered value in place, exactly like hiddenOnCD.
-                            -- A visibility-hidden bar (baseA 0) stays at 0 in both states.
-                            frame:SetAlpha(baseA == 0 and 0
-                                or (onCD and (self.lowAlpha or 0.5) or baseA))
-                            if fc3 then
-                                fc3._cdStateHidden = onCD or false
-                                if ns.SetCdStateShiftHidden then
-                                    ns.SetCdStateShiftHidden(fc3, false)
-                                end
-                            end
-                        else
-                            local hide
-                            if myCse == "hiddenOnCD" then
-                                hide = onCD
-                            else
-                                hide = not onCD
-                            end
-                            frame:SetAlpha(hide and 0 or baseA)
-                            if fc3 then
-                                fc3._cdStateHidden = hide or false
-                                if ns.SetCdStateShiftHidden then
-                                    ns.SetCdStateShiftHidden(fc3, self.shift and hide or false)
-                                end
-                            end
-                        end
-                    end)
-                    fd._cdStatePending:Show()
                     return
                 end
                 -- Query cooldown on the live override (e.g. Shimmer, not

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -5726,7 +5726,19 @@ local function RefreshCDMIconAppearance(barKey)
                 local cseInfo = C_Spell.GetSpellCooldown(csLive)
                 local onCD = cseInfo and cseInfo.isActive and not cseInfo.isOnGCD
                 if cse == "hiddenOnCD" or cse == "hiddenReady" then
-                    local hide = (cse == "hiddenOnCD") == onCD
+                    local hide
+                    if cse == "hiddenOnCD" then
+                        hide = onCD and true or false
+                    else
+                        -- Hidden (CD Ready): on a charge spell "ready" means AT MAX
+                        -- charges, so the icon keeps tracking the recharge instead
+                        -- of vanishing with a charge still down (ns.CdmCdStateReady).
+                        hide = ns.CdmCdStateReady(csLive, onCD, csSs.chargeHideUntilSpent)
+                        -- The refill-to-max edge fires no visual hook, so register
+                        -- the SPELL_UPDATE_CHARGES watch that re-hides the icon when
+                        -- it tops off. Self-skips non-charge spells.
+                        ns.WatchCdStateChargeIfEnabled(icon)
+                    end
                     icon:SetAlpha(hide and 0 or IconShownAlpha(fc, barData))
                     if fc then
                         fc._cdStateHidden = hide or false


### PR DESCRIPTION
## Problem

A multi-charge spell with **Cooldown State Effect → Hidden CD Ready** is dismissed while a charge is still recharging. The icon pops up when a charge is spent, then disappears a second or two later — or the moment the next GCD spell is cast, or when the buff that charge granted falls off — and only comes back once every charge is gone.

Reported independently three times across different classes, all tracked natively through the Blizzard Cooldown Manager rather than added by spell ID:

- **Hunter** — Survival of the Fittest: hides on its own ~1-2s after a charge is used
- **Demon Hunter** — Blur / Shift: shows correctly, then hides on the next GCD cast or when the buff expires
- **Evoker** — Hover / Scales: same as DH

## Cause

Three sites derived readiness from the cooldown read alone:

```lua
onCD = cseInfo.isActive and not cseInfo.isOnGCD
```

For a charge spell that is true only at **zero charges**. A charge spell with a charge in hand reports `isActive == false` — or `true` with `isOnGCD` during the global cooldown right after a cast — the same asymmetry `CdmShouldHideCountdown` already documents. So "CD Ready" matched a spell that was still recharging, and hid it.

The icon appeared at all only because the deferred read sometimes caught the transient GCD state. The next repaint re-evaluated and got the settled answer, which is why the dismissal trigger looks different per class — it's whatever repaints the icon next.

## Fix

Read the recharge flag for charge spells instead: `GetSpellCharges().isActive`, true from the first spent charge until the last one refills — the clean signal Max Stacks Glow already runs on. Non-charge spells keep the cooldown read, and the secret `currentCharges` is never touched.

**Scoped to Hidden (CD Ready) and its Shift Icons variant.** Every other cooldown state effect answers *"can I press this?"* — Hidden (On CD) and Lower Alpha (On CD) suppress what can't be cast, the ready glows highlight what can — and a charge spell down one stack **is** castable, so "no charges left" is already the right reading for them. Hidden (CD Ready) is the only mode whose job is tracking the countdown itself.

| Charge spell, 2 max charges | 2/2 | 1/2 recharging | 0/2 |
|---|---|---|---|
| Hidden (CD Ready) — **changed** | hidden | **shown** | shown |
| Hidden (On CD) | shown | shown | hidden |
| Lower Alpha (On CD) | full | full | dimmed |
| Ready glows | glowing | glowing | off |

That fix needs the refill edge to exist, and it didn't: `SetDesaturated` fires when a charge is spent but not when the last charge tops off, so a corrected icon would have shown once and stayed. Charge spells running the mode now sit in a `SPELL_UPDATE_CHARGES` watch, matching Max Stacks Glow and Hide CD Text (Charges). The deferred evaluator moved out of the hook closure so both drivers share one path — which also stops it reinstalling its `OnUpdate` script on every repaint.

### Opt-out

New per-spell **+ Stay Hidden While Charges Remain** restores the previous reading for anyone who only wants the icon once the ability is fully spent. Fourth `+` toggle in the same menu, wired into Apply-to-Bar like its siblings.

## Also: break-out menu widths

Noticed while adding that toggle. The subnav flyouts and Apply-to scope strip were a fixed 180px and the two item pickers 220px, so longer captions either ran past the border (option rows anchor their label LEFT only — the Resource Aware glow entries carry a tooltip that exists purely to repeat their own label) or were ellipsised (item rows pin their label to the row icon). Longer translations hit it far more often than enUS.

They now measure their captions and widen to the longest: grow-only from each nominal width, capped at 340px so a long translation or item name can't push a menu off screen, and hidden rows are measured too so a menu never resizes under the cursor or while a search box filters.

## Testing

Please confirm in-game before merging — I can't verify runtime behaviour from source:

- [ ] Hunter / DH / Evoker: icon stays visible for the whole recharge, hides again at max charges
- [ ] Shift Icons variant relayouts cleanly on both the spend and refill edges
- [ ] A non-charge spell with Hidden (CD Ready) is unchanged
- [ ] **+ Stay Hidden While Charges Remain** reproduces the old behaviour
- [ ] Menus fit their longest caption (worth a look in deDE/frFR, where captions are longest)

## Notes

Includes a `chore: regenerate Locales/_keys.txt` commit — static extraction had drifted 22 keys behind `main` (bar management, per-addon profile export, resource bar and threshold captions), which fails the locale-keys gate on any PR touching Lua. None of those keys come from this branch: the new toggle is localized through `L(item.label)`, a variable the static extractor can't see, so it reaches translators via the in-game `/euiloc` harvester like every other menu item label.
