### PR TITLE
Nameplates: add No Tint option for Target/Focus Texture

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_Options.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_Options.lua
@@ -7481,6 +7481,14 @@ initFrame:SetScript("OnEvent", function(self)
         local isTargetTextureNone = function()
             return (DBVal("targetOverlayTexture") or defaults.targetOverlayTexture) == "none"
         end
+        -- No Tint: the target texture pattern becomes the bar's own fill
+        -- texture (SetStatusBarTexture) instead of a tinted overlay drawn on
+        -- top, so the color swatch/opacity below stop applying.
+        local isTargetNoTint = function()
+            local v = DBVal("targetOverlayNoTint")
+            if v == nil then return defaults.targetOverlayNoTint end
+            return v
+        end
         local isFocusColorDisabled = function()
             local db = DB()
             if db and db.focusColorEnabled ~= nil then return not db.focusColorEnabled end
@@ -7488,6 +7496,11 @@ initFrame:SetScript("OnEvent", function(self)
         end
         local isFocusTextureNone = function()
             return (DBVal("focusOverlayTexture") or defaults.focusOverlayTexture) == "none"
+        end
+        local isFocusNoTint = function()
+            local v = DBVal("focusOverlayNoTint")
+            if v == nil then return defaults.focusOverlayNoTint end
+            return v
         end
 
         local targetPrev, focusPrev
@@ -7652,23 +7665,24 @@ initFrame:SetScript("OnEvent", function(self)
             PP.Point(swatch, "RIGHT", leftRgn._control, "LEFT", -12, 0)
             leftRgn._lastInline = swatch
             EllesmereUI.RegisterWidgetRefresh(function()
-                local off = isTargetTextureNone()
+                local off = isTargetTextureNone() or isTargetNoTint()
                 swatch:SetAlpha(off and 0.15 or 1)
                 swatch:EnableMouse(not off)
                 updateSwatch()
             end)
-            local off = isTargetTextureNone()
+            local off = isTargetTextureNone() or isTargetNoTint()
             swatch:SetAlpha(off and 0.15 or 1)
             swatch:EnableMouse(not off)
         end
 
-        -- Inline Target Texture cog (Opacity), to the left of the swatch
+        -- Inline Target Texture cog (Opacity + No Tint), to the left of the swatch
         do
             local leftRgn = textureDualRow._leftRegion
             local _, targetTexCogShow = EllesmereUI.BuildCogPopup({
                 title = "Target Texture",
                 rows = {
                     { type="slider", label="Opacity", min=5, max=100, step=1,
+                      disabled=isTargetNoTint,
                       get=function() return math.floor(((DBVal("targetOverlayAlpha") or defaults.targetOverlayAlpha) * 100) + 0.5) end,
                       set=function(v)
                         DB().targetOverlayAlpha = v / 100
@@ -7676,6 +7690,7 @@ initFrame:SetScript("OnEvent", function(self)
                         if targetPrev and targetPrev.UpdateOverlay then targetPrev.UpdateOverlay() end
                       end },
                     { type="toggle", label="Full alpha on empty part of bar",
+                      disabled=isTargetNoTint,
                       get=function()
                         local v = DBVal("targetOverlayFullBgAlpha")
                         if v == nil then return defaults.targetOverlayFullBgAlpha end
@@ -7684,6 +7699,14 @@ initFrame:SetScript("OnEvent", function(self)
                       set=function(v)
                         DB().targetOverlayFullBgAlpha = v
                         RefreshAllPlates()
+                        if targetPrev and targetPrev.UpdateOverlay then targetPrev.UpdateOverlay() end
+                      end },
+                    { type="toggle", label="Don't tint (keep bar's own color)",
+                      tooltip="Applies this pattern as the health bar's own fill texture instead of a colored overlay on top -- the bar keeps its normal reaction (or custom target) color.",
+                      get=isTargetNoTint,
+                      set=function(v)
+                        DB().targetOverlayNoTint = v
+                        RefreshAllTextures()
                         if targetPrev and targetPrev.UpdateOverlay then targetPrev.UpdateOverlay() end
                       end },
                 },
@@ -7726,29 +7749,31 @@ initFrame:SetScript("OnEvent", function(self)
             PP.Point(swatch, "RIGHT", rightRgn._control, "LEFT", -12, 0)
             rightRgn._lastInline = swatch
             EllesmereUI.RegisterWidgetRefresh(function()
-                local off = isFocusTextureNone()
+                local off = isFocusTextureNone() or isFocusNoTint()
                 swatch:SetAlpha(off and 0.15 or 1)
                 swatch:EnableMouse(not off)
                 updateSwatch()
             end)
-            local off = isFocusTextureNone()
+            local off = isFocusTextureNone() or isFocusNoTint()
             swatch:SetAlpha(off and 0.15 or 1)
             swatch:EnableMouse(not off)
         end
 
-        -- Inline Focus Texture cog (Opacity), to the left of the swatch
+        -- Inline Focus Texture cog (Opacity + No Tint), to the left of the swatch
         do
             local rightRgn = textureDualRow._rightRegion
             local _, focusTexCogShow = EllesmereUI.BuildCogPopup({
                 title = "Focus Texture",
                 rows = {
                     { type="slider", label="Opacity", min=5, max=100, step=1,
+                      disabled=isFocusNoTint,
                       get=function() return math.floor(((DBVal("focusOverlayAlpha") or defaults.focusOverlayAlpha) * 100) + 0.5) end,
                       set=function(v)
                         DB().focusOverlayAlpha = v / 100
                         RefreshFocusPreview()
                       end },
                     { type="toggle", label="Full alpha on empty part of bar",
+                      disabled=isFocusNoTint,
                       get=function()
                         local v = DBVal("focusOverlayFullBgAlpha")
                         if v == nil then return defaults.focusOverlayFullBgAlpha end
@@ -7756,6 +7781,14 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       set=function(v)
                         DB().focusOverlayFullBgAlpha = v
+                        RefreshFocusPreview()
+                      end },
+                    { type="toggle", label="Don't tint (keep bar's own color)",
+                      tooltip="Applies this pattern as the health bar's own fill texture instead of a colored overlay on top -- the bar keeps its normal reaction (or custom focus) color.",
+                      get=isFocusNoTint,
+                      set=function(v)
+                        DB().focusOverlayNoTint = v
+                        RefreshAllTextures()
                         RefreshFocusPreview()
                       end },
                 },

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -172,6 +172,11 @@ local defaults = {
     -- When on, the empty portion of the bar shows the focus texture at full
     -- opacity instead of the dimmed (30%) default, so the pattern reads evenly.
     focusOverlayFullBgAlpha = false,
+    -- No Tint: applies focusOverlayTexture as the health bar's own fill
+    -- pattern (like the main "Bar Texture" dropdown) instead of drawing it
+    -- as a tinted stripe overlay on top. focusOverlayColor/Alpha/FullBgAlpha
+    -- are ignored in this mode -- the bar keeps its normal reaction color.
+    focusOverlayNoTint = false,
     focusLetterEnabled = false,
     focusLetterAnchor = "CENTER",
     focusLetterX = 0,
@@ -185,6 +190,8 @@ local defaults = {
     -- When on, the empty portion of the bar shows the target texture at full
     -- opacity instead of the dimmed (30%) default, so the pattern reads evenly.
     targetOverlayFullBgAlpha = false,
+    -- No Tint: mirrors focusOverlayNoTint above, for the target overlay.
+    targetOverlayNoTint = false,
     hoverOverlayTexture = "none",
     caster  = { r = 0.231, g = 0.510, b = 0.965 },
     miniboss = { r = 0.518, g = 0.243, b = 0.984 },
@@ -650,11 +657,39 @@ do
     }
 end
 
+local function NoTintFlag(db, key)
+    local v = db and db[key]
+    if v == nil then v = defaults[key] end
+    return v
+end
+
+-- No Tint mode reuses the Target/Focus Texture dropdowns (targetOverlayTexture /
+-- focusOverlayTexture): instead of drawing that pattern as a tinted stripe
+-- overlay on top of the bar, it becomes the bar's own fill texture, leaving
+-- SetStatusBarColor (the reaction/custom color) untouched. Path resolved via
+-- ResolveOverlayTexPath since the dropdown also offers the stripe-only keys.
 local function ApplyHealthBarTexture(plate)
     local health = plate.health
     if not health then return end
     local texKey = (p and p.healthBarTexture) or defaults.healthBarTexture or "none"
-    local path   = EllesmereUI.ResolveTexturePath(ns.healthBarTextures, texKey, "Interface\\Buttons\\WHITE8x8")
+    local path
+    local unit = plate.unit
+    if unit then
+        local db = p or defaults
+        local tTex = db.targetOverlayTexture or defaults.targetOverlayTexture
+        local fTex = db.focusOverlayTexture or defaults.focusOverlayTexture
+        if tTex ~= "none" and NoTintFlag(db, "targetOverlayNoTint") and UnitIsUnit(unit, "target") then
+            path = ns.ResolveOverlayTexPath(tTex)
+        elseif fTex ~= "none" and NoTintFlag(db, "focusOverlayNoTint") and UnitIsUnit(unit, "focus") then
+            path = ns.ResolveOverlayTexPath(fTex)
+        end
+    end
+    path = path or EllesmereUI.ResolveTexturePath(ns.healthBarTextures, texKey, "Interface\\Buttons\\WHITE8x8")
+    -- Value-keyed: UpdateHealthColor calls this on every health update while
+    -- the feature is on, so skip the setter when the resolved path hasn't
+    -- changed (mirrors the hr/hg/hb compare a few lines above it).
+    if plate._lastHealthTexPath == path then return end
+    plate._lastHealthTexPath = path
     health:SetStatusBarTexture(path)
 end
 ns.ApplyHealthBarTexture = ApplyHealthBarTexture
@@ -6432,13 +6467,25 @@ function NameplateFrame:UpdateHealthColor()
         self._lastHCr, self._lastHCg, self._lastHCb = hr, hg, hb
         self.health:SetStatusBarColor(hr, hg, hb)
     end
+    -- Target/Focus No Tint mode: near-zero-cost when both are off (two field
+    -- reads). When either is on, re-evaluates on every health update (same
+    -- cadence as the color above) so a target/focus swap swaps the fill
+    -- pattern immediately; ApplyHealthBarTexture itself skips the setter
+    -- when the resolved path is unchanged.
+    if p and (p.targetOverlayNoTint or p.focusOverlayNoTint) then
+        ApplyHealthBarTexture(self)
+    end
     -- Focus overlay: show stripe textures on focus target's health bar
     -- Fill clip frame at full alpha, bg clip frame at half alpha.
     -- Apply is value-keyed: redone only when any component of the
     -- would-be state differs from what this plate last applied.
+    -- Skipped entirely in No Tint mode -- the pattern is already applied as
+    -- the bar's own fill texture above, drawing it again as an overlay would
+    -- double it up.
     local db2 = p or defaults
     local focusTex = db2.focusOverlayTexture or defaults.focusOverlayTexture
-    if focusTex ~= "none" and UnitIsUnit(unit, "focus") then
+    local focusNoTint = NoTintFlag(db2, "focusOverlayNoTint")
+    if focusTex ~= "none" and not focusNoTint and UnitIsUnit(unit, "focus") then
         -- Texture path memoized by texture NAME (no per-call concat;
         -- live dropdown changes rebuild it via the name compare)
         if ns._focusOverlayTexName ~= focusTex then
@@ -6479,9 +6526,11 @@ function NameplateFrame:UpdateHealthColor()
     if db2.focusLetterEnabled or self._focusLetterShown then
         ns.ApplyFocusLetter(self, unit, db2)
     end
-    -- Target overlay: identical to focus overlay but for current target
+    -- Target overlay: identical to focus overlay but for current target.
+    -- Skipped in No Tint mode, same reasoning as the focus overlay above.
     local targetTex = db2.targetOverlayTexture or defaults.targetOverlayTexture
-    if targetTex ~= "none" and UnitIsUnit(unit, "target") then
+    local targetNoTint = NoTintFlag(db2, "targetOverlayNoTint")
+    if targetTex ~= "none" and not targetNoTint and UnitIsUnit(unit, "target") then
         if ns._targetOverlayTexName ~= targetTex then
             ns._targetOverlayTexName = targetTex
             ns._targetOverlayTexPath = ns.ResolveOverlayTexPath(targetTex)


### PR DESCRIPTION
## What does this PR do?

Adds a "Don't tint (keep bar's own color)" toggle inside the existing Target Texture / Focus Texture cog popups (Nameplates -> Display -> "Target, Focus & Hover Effects" section). When enabled, the pattern picked in the Target Texture / Focus Texture dropdown is applied directly as the health bar's own fill texture (like the main "Bar Texture" setting) instead of being drawn as a tinted stripe overlay on top of it. This lets you give your current target/focus a distinct pattern without also forcing a separate overlay color onto it -- the bar keeps its normal reaction color (or the custom target/focus color, if that toggle is enabled).

Both existing behaviors (overlay tint, custom target/focus color) are untouched when the new toggle is off, which is the default.

## How was it tested?

Tested in-game on live retail: enabled "Don't tint" in the Target Texture cog on a training dummy target, picked a fill pattern, and confirmed the targeted nameplate shows that pattern while its health bar color stays the normal reaction color (screenshot below). Also verified toggling it back off reverts to the normal overlay behavior, and that the Opacity / "Full alpha on empty part of bar" rows in the same popup grey out while No Tint is active. Not tested on the 12.1 PTR client.

## Screenshots
<img width="719" height="707" alt="image" src="https://github.com/user-attachments/assets/a75608b0-7f0c-49ce-a9fc-71fd603260b7" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, this only touches EllesmereUI's own health bar / overlay frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client -- tested on live retail only, PTR not verified