### PR TITLE
Stop the DataBars gold tooltip leaking characters through shared profiles

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -159,7 +159,10 @@ local defaults = {
     profile = {
         nextBarId  = 0,   -- monotonic bar id counter; only ever incremented
         bars       = {},  -- ordered array of barCfg
-        characters = {},  -- cross-character gold store, keyed "Name-Realm"
+        -- No cross-character gold store here: it is account-wide, at
+        -- EllesmereUIDB.global.dataBarsCharacters (see GoldStore in
+        -- EllesmereUIDataBars_Blocks.lua). Keeping it per-profile shipped the
+        -- sharer's character names and gold inside exported profiles.
     },
 }
 

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -1125,11 +1125,21 @@ local function GoldCharKey()
     return (UnitName("player") or "Unknown") .. "-" .. (GetRealmName() or "Unknown")
 end
 
+-- ACCOUNT-WIDE, deliberately not per-profile. This is observed character data
+-- (who you have and how much gold they hold), not a setting, so it must never
+-- ride a profile: it used to live at profile.characters, which meant an exported
+-- profile carried the sharer's character names and gold, and everyone importing
+-- it saw those in the Gold tooltip instead of their own. Account scope also
+-- means switching or copying profiles no longer loses the history.
 local function GoldStore()
-    local profile = ns.GetProfile()
-    if not profile then return {} end
-    profile.characters = profile.characters or {}
-    return profile.characters
+    if not EllesmereUIDB then return {} end
+    if type(EllesmereUIDB.global) ~= "table" then EllesmereUIDB.global = {} end
+    local store = EllesmereUIDB.global.dataBarsCharacters
+    if type(store) ~= "table" then
+        store = {}
+        EllesmereUIDB.global.dataBarsCharacters = store
+    end
+    return store
 end
 
 -- Drop a character the player no longer has (renamed, deleted, transferred).

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -4223,3 +4223,33 @@ end
 -- RB addon loads. RB's OnInitialize exports EllesmereUI._RBSectionDefaults
 -- and then invokes MigrateRBAdvancedProfile for every stored profile; the
 -- profile import paths call it directly for imported data.
+
+-- Gold tooltip data leaked through shared profiles: the DataBars cross-character
+-- gold store lived at profile scope, so an exported profile carried the sharer's
+-- character names and gold, and every importer saw those in the Gold tooltip
+-- instead of their own. The store is account-wide now
+-- (EllesmereUIDB.global.dataBarsCharacters), so drop every per-profile copy --
+-- otherwise a stale one rides the next export and the leak repeats.
+--
+-- Deliberately DROP rather than merge into the new store. Any profile may be an
+-- imported one, and nothing durably records that, so a merge could not tell the
+-- user's own characters from a sharer's and would copy strangers' names and gold
+-- into permanent account-wide storage -- worse than the bug being fixed. Nothing
+-- is really lost: each character records itself again on login (the money
+-- watcher), so the list refills as they are played.
+EllesmereUI.RegisterMigration({
+    id          = "databars_gold_store_account_wide_v1",
+    scope       = "global",
+    description = "Drop the per-profile DataBars gold store; it is account-wide now and used to leak into exports.",
+    body        = function(ctx)
+        local db = ctx.db
+        if not db or type(db.profiles) ~= "table" then return end
+        for _, pd in pairs(db.profiles) do
+            local blob = type(pd) == "table" and type(pd.addons) == "table"
+                and pd.addons["EllesmereUIDataBars"]
+            if type(blob) == "table" and blob.characters ~= nil then
+                blob.characters = nil
+            end
+        end
+    end,
+})

--- a/EllesmereUI_Profiles.lua
+++ b/EllesmereUI_Profiles.lua
@@ -114,6 +114,20 @@ for _, entry in ipairs(ADDON_DB_MAP) do
     FOLDER_HOST[entry.folder] = entry.hostAddon or entry.folder
 end
 
+-- The DataBars cross-character gold store is account-wide
+-- (EllesmereUIDB.global.dataBarsCharacters) and must never travel: a profile
+-- written by an older build still holds a copy at profile scope, and shipping it
+-- showed importers the sharer's character names and gold in the Gold tooltip.
+-- Call this on any addons table before it is serialized or stored. Expects LOCAL
+-- folder keys, so run it before AddonsToCanon / after CanonToLocal (the literal
+-- below is renamed by the standalone packager, matching that build's folder).
+local function StripSharedCharacterData(addons)
+    if type(addons) ~= "table" then return addons end
+    local dbars = addons["EllesmereUIDataBars"]
+    if type(dbars) == "table" then dbars.characters = nil end
+    return addons
+end
+
 -- Re-key an addons table from this build's local db.folder keys to canonical
 -- keys (used on export). Unknown keys pass through unchanged.
 local function AddonsToCanon(addons)
@@ -1886,15 +1900,7 @@ function EllesmereUI.ExportProfile(profileName, includedFolders, includeLayout, 
     -- Exclude spec-specific data from export
     exportData.trackedBuffBars = nil
     exportData.tbbPositions = nil
-    -- Never share the sharer's characters. The DataBars cross-character gold
-    -- store is account-wide now, but a profile written by an older build still
-    -- holds a copy, and shipping it showed importers the sharer's character
-    -- names and gold in the Gold tooltip. Strip it here so exports taken before
-    -- the migration runs are clean too.
-    do
-        local dbars = exportData.addons and exportData.addons["EllesmereUIDataBars"]
-        if type(dbars) == "table" then dbars.characters = nil end
-    end
+    StripSharedCharacterData(exportData.addons)
     -- Legacy account-wide spell store never travels (the per-profile snapshot below
     -- carries CDM content instead).
     exportData.spellAssignments = nil
@@ -2241,6 +2247,7 @@ function EllesmereUI.ExportCurrentProfile(includeLayout, includeCDM, cdmSpecs)
         screenH  = sh and math.floor(sh) or 0,
     }
     -- Normalize local db.folder keys -> canonical (suite) keys (no-op in suite).
+    StripSharedCharacterData(profileData.addons)
     profileData.addons = AddonsToCanon(profileData.addons)
     local payload = { version = 3, type = "full", data = profileData, meta = meta }
     local serialized = Serializer.Serialize(payload)
@@ -2696,13 +2703,10 @@ function EllesmereUI.ImportProfile(importStr, profileName)
     -- before all downstream addon-key handling. No-op in the suite.
     if payload.data and payload.data.addons then
         payload.data.addons = CanonToLocal(payload.data.addons)
-        -- Never store someone else's characters. Strings written by builds from
-        -- before the gold store moved account-wide carry the sharer's character
-        -- names and gold in the DataBars blob; the runtime ignores it now, but
-        -- drop it at the boundary so it is not written to disk at all (and so it
-        -- cannot ride a re-export).
-        local dbars = payload.data.addons["EllesmereUIDataBars"]
-        if type(dbars) == "table" then dbars.characters = nil end
+        -- Never store someone else's characters: the runtime ignores an imported
+        -- copy now, but dropping it here keeps it off disk entirely and stops it
+        -- riding a re-export.
+        StripSharedCharacterData(payload.data.addons)
     end
 
     -- Reconcile media references against locally installed SharedMedia before

--- a/EllesmereUI_Profiles.lua
+++ b/EllesmereUI_Profiles.lua
@@ -1886,6 +1886,15 @@ function EllesmereUI.ExportProfile(profileName, includedFolders, includeLayout, 
     -- Exclude spec-specific data from export
     exportData.trackedBuffBars = nil
     exportData.tbbPositions = nil
+    -- Never share the sharer's characters. The DataBars cross-character gold
+    -- store is account-wide now, but a profile written by an older build still
+    -- holds a copy, and shipping it showed importers the sharer's character
+    -- names and gold in the Gold tooltip. Strip it here so exports taken before
+    -- the migration runs are clean too.
+    do
+        local dbars = exportData.addons and exportData.addons["EllesmereUIDataBars"]
+        if type(dbars) == "table" then dbars.characters = nil end
+    end
     -- Legacy account-wide spell store never travels (the per-profile snapshot below
     -- carries CDM content instead).
     exportData.spellAssignments = nil
@@ -2687,6 +2696,13 @@ function EllesmereUI.ImportProfile(importStr, profileName)
     -- before all downstream addon-key handling. No-op in the suite.
     if payload.data and payload.data.addons then
         payload.data.addons = CanonToLocal(payload.data.addons)
+        -- Never store someone else's characters. Strings written by builds from
+        -- before the gold store moved account-wide carry the sharer's character
+        -- names and gold in the DataBars blob; the runtime ignores it now, but
+        -- drop it at the boundary so it is not written to disk at all (and so it
+        -- cannot ride a re-export).
+        local dbars = payload.data.addons["EllesmereUIDataBars"]
+        if type(dbars) == "table" then dbars.characters = nil end
     end
 
     -- Reconcile media references against locally installed SharedMedia before


### PR DESCRIPTION
## Problem

Reported by @TeoDaTank and reproduced locally: importing someone's profile showed
**their** characters and gold in the DataBars Gold tooltip.

## Cause

The cross-character gold store was declared in `defaults.profile`:

```lua
characters = {},  -- cross-character gold store, keyed "Name-Realm"
```

So it lived in the DataBars addon blob, and exports deep-copy those blobs
wholesale. Every exported profile carried the author's character names and gold,
and because the tooltip read the store from the active profile, importers saw the
author's characters instead of their own.

This is observed character data, not a setting, so profile scope was wrong to
begin with.

## Fix

Moved to `EllesmereUIDB.global.dataBarsCharacters`, the account-wide store the
Friends module already uses. Every read and write funnelled through `GoldStore()`,
so the move is contained to that accessor.

Three touch points, because stale data and old export strings are already out
there:

- **Migration** drops the per-profile copies, so nothing stale can re-export.
- **Export** strips the key (both export paths), so a string taken before the
  migration runs is clean too.
- **Import** strips it, so a sharer's characters never reach the recipient's
  SavedVariables at all.

The three call one `StripSharedCharacterData` helper, which documents the key
ordering it depends on: local folder keys, so before `AddonsToCanon` and after
`CanonToLocal`. That matters because the folder literal is rewritten by the
standalone packager, so getting the order wrong would no-op on standalone builds
only.

## Deliberate decision: the migration drops rather than merges

It would be nicer to merge the old per-profile stores into the new account-wide
one so no history is lost. It is not safe: any profile may be an imported one and
nothing durably records that, so a merge cannot tell the user's own characters
from a sharer's and would copy strangers' names and gold into permanent
account-wide storage -- worse than the bug being fixed. Little is lost in
practice, since each character records itself again on login via the money
watcher.

## Side effects

- Switching or copying profiles no longer loses gold history (account scope).
- Resetting a profile no longer clears it either, which follows from the same
  change.
- A full UI Reset still wipes it, unchanged from today. The reset preserves
  specific `global` keys (friend groups/notes/assignments) and this is not among
  them; happy to add it if you'd rather it survived like friend data does.

## Testing

- Import the reporter's profile, hover Gold: only your own characters listed.
- Export via the options Export button, import elsewhere: only that account's
  characters listed.
- Log two characters, switch profiles: history survives (it did not before).
- Ctrl+Alt+left-click a character row still forgets it.
- `/eui migrations` shows `databars_gold_store_account_wide_v1` applied cleanly.
