### PR TITLE
Keep per-character data out of shared profile strings

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -159,7 +159,6 @@ local defaults = {
     profile = {
         nextBarId  = 0,   -- monotonic bar id counter; only ever incremented
         bars       = {},  -- ordered array of barCfg
-        characters = {},  -- cross-character gold store, keyed "Name-Realm"
     },
 }
 
@@ -3046,6 +3045,13 @@ end
 -------------------------------------------------------------------------------
 function WB:OnInitialize()
     self.db = EllesmereUI.Lite.NewDB("EllesmereUIDataBarsDB", defaults)
+    -- The cross-character gold ledger used to live in the profile, which put
+    -- every character's name, realm and balance into shared export strings and
+    -- gave each profile its own separate ledger. It is account data now
+    -- (EllesmereUIDB.dataBarsGold, see GoldStore). Drop the old copy rather
+    -- than migrate it: on anyone who imported a profile it holds the exporter's
+    -- characters, not their own, and the account store refills from live play.
+    self.db.profile.characters = nil
 end
 
 function WB:OnEnable()

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -1125,11 +1125,16 @@ local function GoldCharKey()
     return (UnitName("player") or "Unknown") .. "-" .. (GetRealmName() or "Unknown")
 end
 
+-- ACCOUNT-level, deliberately not the profile: the ledger is a list of the
+-- player's characters with their balances, and profiles get shared. Held in
+-- the profile it rode every export string, so importers saw the exporter's
+-- alts and gold in their own tooltip. Sits top-level in EllesmereUIDB next to
+-- the Bags module's own gold ledger, which is where it should always have
+-- been -- it also means the ledger no longer resets when profiles switch.
 local function GoldStore()
-    local profile = ns.GetProfile()
-    if not profile then return {} end
-    profile.characters = profile.characters or {}
-    return profile.characters
+    if not EllesmereUIDB then EllesmereUIDB = {} end
+    EllesmereUIDB.dataBarsGold = EllesmereUIDB.dataBarsGold or {}
+    return EllesmereUIDB.dataBarsGold
 end
 
 -- Drop a character the player no longer has (renamed, deleted, transferred).

--- a/EllesmereUIQoL/EUI_UpgradeCalc.lua
+++ b/EllesmereUIQoL/EUI_UpgradeCalc.lua
@@ -1705,17 +1705,24 @@ _firstRunEvt:SetScript("OnEvent", function(self)
         local profileDB = EllesmereUI.Lite.NewDB("EllesmereUIQoLDB", {
             profile = {
                 upgradeCalcOpts = {},
-                chars           = {},
             },
         })
         _euicProfileRef = profileDB.profile
-        -- Store character data under a per-character key so alts on the same
-        -- profile each have their own queue, scan cache, and crest offsets.
+        -- Per-character queue, scan cache and crest offsets are ACCOUNT data
+        -- keyed by character name: profiles get shared, so holding this in the
+        -- profile put the player's character names and realms into every
+        -- export string. Options stay in the profile (they are settings); the
+        -- per-character state moves top-level. The old profile copy is dropped
+        -- rather than migrated -- on anyone who imported a profile it holds the
+        -- exporter's characters, and this state rebuilds from the next scan.
         local charKey = UnitName("player") .. " - " .. GetRealmName()
         local store = _euicProfileRef
-        store.chars             = store.chars           or {}
-        store.chars[charKey]    = store.chars[charKey]  or {}
-        local charStore         = store.chars[charKey]
+        store.chars = nil
+        if not EllesmereUIDB then EllesmereUIDB = {} end
+        local chars             = EllesmereUIDB.qolUpgradeCalcChars or {}
+        EllesmereUIDB.qolUpgradeCalcChars = chars
+        chars[charKey]          = chars[charKey]        or {}
+        local charStore         = chars[charKey]
         charStore.upgradeCalc   = charStore.upgradeCalc or {}
         local db                = charStore.upgradeCalc
         db.cache                = db.cache              or { slots = {}, ts = 0 }

--- a/EllesmereUI_Profiles.lua
+++ b/EllesmereUI_Profiles.lua
@@ -137,6 +137,40 @@ local function CanonToLocal(addons)
 end
 
 -------------------------------------------------------------------------------
+--  Account data that must never travel in a profile string
+--
+--  These keys held per-character state -- character names, realms, classes,
+--  gold balances, scan caches -- inside a module's profile blob, so a shared
+--  profile carried the exporter's character list to everyone who imported it
+--  (visible in the DataBars gold tooltip). They live top-level in EllesmereUIDB
+--  now, but strings exported by older versions still carry them, and an
+--  imported blob would otherwise sit in the recipient's profile and ride THEIR
+--  next export -- propagating one player's characters indefinitely. So strip
+--  on the way out AND on the way in.
+--
+--  The folder literals contain "EllesmereUI", which the standalone packager
+--  renames to the build token, so they match the local keyspace on every
+--  build; the canon lookup covers a decoded payload's canonical keys.
+-------------------------------------------------------------------------------
+local PRIVATE_ADDON_KEYS = {
+    ["EllesmereUIDataBars"] = { "characters" },  -- gold ledger -> EllesmereUIDB.dataBarsGold
+    ["EllesmereUIQoL"]      = { "chars" },       -- upgrade calc -> EllesmereUIDB.qolUpgradeCalcChars
+}
+
+-- Strip account data from an addons table, in place. Accepts either keyspace
+-- (local folder keys before canonicalization on export, canonical keys in a
+-- decoded payload), so one pass serves both directions.
+local function StripPrivateAddonData(addons)
+    if type(addons) ~= "table" then return end
+    for folder, keys in pairs(PRIVATE_ADDON_KEYS) do
+        local blob = addons[folder] or addons[FOLDER_TO_CANON[folder] or folder]
+        if type(blob) == "table" then
+            for _, key in ipairs(keys) do blob[key] = nil end
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
 --  Unlock-element key -> owning module (LOCAL folder) resolver
 --
 --  The selective-layout export/import attributes each anchor / size-match
@@ -1981,6 +2015,10 @@ function EllesmereUI.ExportProfile(profileName, includedFolders, includeLayout, 
     if includedFolders then
         exportData.partialImport = true
     end
+    -- Per-character account data (gold ledger, upgrade-calc caches) never rides
+    -- a shared string -- see PRIVATE_ADDON_KEYS. exportData is already a deep
+    -- copy, so this strips the payload without touching the stored profile.
+    StripPrivateAddonData(exportData.addons)
     -- Normalize local db.folder keys -> canonical (suite) keys so the string
     -- imports correctly into any build. No-op in the suite (canon == folder).
     exportData.addons = AddonsToCanon(exportData.addons)
@@ -2213,6 +2251,12 @@ function EllesmereUI.ExportCurrentProfile(includeLayout, includeCDM, cdmSpecs)
     profileData.assignedSpecs = CollectAssignedSpecs(activeName)
     -- HoverCast (click-cast) bindings are account-global, not per-profile; never export.
     profileData.clickCast = nil
+    -- Per-character account data (gold ledger, upgrade-calc caches) likewise
+    -- never rides a shared string -- see PRIVATE_ADDON_KEYS. SnapshotAllAddons
+    -- deep-copies each module's live profile blob, so a profile still holding
+    -- the legacy keys (any profile other than the one cleaned at login) would
+    -- otherwise ship its character list through this path.
+    StripPrivateAddonData(profileData.addons)
     -- UI scale (account-wide) rides with the full profile (see ExportProfile).
     profileData.uiScale = (EllesmereUIDB and type(EllesmereUIDB.ppUIScale) == "number")
         and EllesmereUIDB.ppUIScale or nil
@@ -2266,6 +2310,12 @@ function EllesmereUI.DecodeImportString(importStr)
     if payload.version > 3 then
         return nil, "This profile was created with a newer version of EllesmereUI. Please update your addon."
     end
+    -- Drop account data an older exporter left in the string, before any
+    -- consumer (preview UI, ImportProfile, Wago) can write it to a profile.
+    -- Type-checked, not just truthy: a corrupt string can deserialize to a
+    -- non-table data field, and indexing that would raise instead of letting
+    -- the caller report its own decode failure.
+    if type(payload.data) == "table" then StripPrivateAddonData(payload.data.addons) end
     return payload, nil
 end
 
@@ -2397,6 +2447,8 @@ do
             if payload.version > 3 then
                 return nil, "This profile was created with a newer version of EllesmereUI. Please update your addon."
             end
+            -- Same strip as the sync path: account data never reaches a profile.
+            if type(payload.data) == "table" then StripPrivateAddonData(payload.data.addons) end
             return payload, nil
         end)
 


### PR DESCRIPTION
## What does this PR do?

Fixes two reported bugs where profile exports carried the exporter's character
list to everyone who imported the string. Reporters saw other people's
characters and gold amounts in their own Gold databar tooltip.

`ExportProfile` deep-copies the whole profile, including every module's
`addons[folder]` blob, so any per-character runtime data a module kept in its
profile travelled with the string. Two modules did that:

- **DataBars** stored the cross-character gold ledger (name, realm, class,
  balance) at `profile.characters`. This is the reported bug.
- **QoL upgrade calculator** stored per-character scan caches and queues at
  `profile.chars["Name - Realm"]`. Same leak, not user-visible, found while
  auditing for the first one.

Both move to account-level storage in `EllesmereUIDB`, which is the pattern
`EllesmereUIBags` already uses for its own gold ledger. `upgradeCalcOpts` stays
in the profile because it is genuine settings. Side benefit: the gold ledger no
longer resets when profiles switch.

All four string paths now strip these keys: `ExportProfile`,
`ExportCurrentProfile`, `DecodeImportString` and `DecodeImportStringAsync`.
Stripping on import matters as much as on export, because a blob from an
already-circulating string would otherwise land in the recipient's profile and
ride *their* next export, propagating one player's character list indefinitely.

`ExportCurrentProfile` needed it as much as `ExportProfile` did: it snapshots
the live profile blob, it is a public export API for partner addons, and the
legacy keys are only deleted from whichever profile was active at login.

### Two decisions worth a maintainer's eye

**The old data is dropped, not migrated.** Anyone who already imported a
profile has the *exporter's* characters in that table rather than their own, so
migrating would carry the reported bug forward for exactly the affected users.
Cost: everyone's alt gold list clears once and rebuilds as they log in each
character. This is a deliberate tradeoff and easy to reverse if you would
rather preserve the data.

**Legacy blobs survive in non-active profiles.** The cleanup only runs against
the profile active at login, so other profiles keep their `characters` /
`chars` bytes on disk. Nothing reads them and all four paths strip them, so
they cannot leave the machine, but they are still there. Clearing them would
mean a sweep over `EllesmereUIDB.profiles[*]` at load. Happy to add that if you
want it.

## How was it tested?

Live retail. Exported a profile on the current release, imported it on this
build, and confirmed the Gold tooltip lists only characters actually played on
the receiving account.

Alpha build for wider testing:
https://github.com/nulltyto/EllesmereUI/releases/tag/v8.5.8-alpha1

Also verified statically: `luac -p` on all four changed files, and the
key-mapping logic extracted into a standalone harness and run against both
keyspaces, including a simulated standalone-build rename, since export strips
before `AddonsToCanon` (local folder keys) while a decoded payload carries
canonical keys.

**Not tested on the 12.1 PTR client.** The change touches no aura rendering and
no `IS_121`-gated path, but I have not loaded it there and am not claiming the
box.

## Screenshots

N/A. No visual or layout change; the Gold tooltip renders identically, it just
no longer contains characters that are not yours.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new settings. This is a bug fix, which criterion 2 exempts.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no new events, hooks or frames
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - the strip is two table lookups, only on export/import
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A, touches no Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client - live retail yes, PTR not tested
