### PR TITLE
Add cooldown manager desaturate controls

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -11353,6 +11353,23 @@ initFrame:SetScript("OnEvent", function(self)
                                             end
                                         end } })
 
+                        local DESAT_ON_CD_ITEMS = {
+                            { val = nil,   label = "Default" },
+                            { val = "on",  label = "Desaturate" },
+                            { val = "off", label = "Full Color" },
+                        }
+                        MakeSubnavRow("Desaturate on CD", DESAT_ON_CD_ITEMS,
+                            function() return cas.desatOnCD end,
+                            function(v)
+                                SetCasOwn("desatOnCD", v)
+                                if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end
+                                if ns._MarkPresetCdDirty then ns._MarkPresetCdDirty() end
+                            end,
+                            function() return cas.desatOnCD == nil end,
+                            nil,
+                            { apply = { keys = { "desatOnCD" },
+                                        write = function(t, v) t.desatOnCD = v end } })
+
                         -- Threshold Text (preset / custom): decimals / color change
                         -- on this icon's countdowns (item/spell cooldown and the
                         -- fake-active window) below its Threshold Seconds. Stored
@@ -11978,6 +11995,34 @@ initFrame:SetScript("OnEvent", function(self)
                             end
                         end)
                         cdStateRow:SetScript("OnLeave", function()
+                            if EllesmereUI.HideWidgetTooltip then EllesmereUI.HideWidgetTooltip() end
+                        end)
+                    end
+
+                    local DESAT_ON_CD_ITEMS = {
+                        { val = nil,   label = "Default" },
+                        { val = "on",  label = "Desaturate" },
+                        { val = "off", label = "Full Color" },
+                    }
+                    local desatOnCdRow = MakeSubnavRow("Desaturate on CD", DESAT_ON_CD_ITEMS,
+                        function() return ss.desatOnCD end,
+                        function(v)
+                            EnsureSS(); SetOwn("desatOnCD", v)
+                            if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end
+                            if ns._MarkPresetCdDirty then ns._MarkPresetCdDirty() end
+                        end,
+                        function() return ss.desatOnCD == nil end,
+                        nil,
+                        { apply = { keys = { "desatOnCD" },
+                                    write = function(t, v) t.desatOnCD = v end } })
+                    if isCustomInjected and desatOnCdRow then
+                        desatOnCdRow:SetAlpha(0.35)
+                        desatOnCdRow:SetScript("OnEnter", function()
+                            if EllesmereUI.ShowWidgetTooltip then
+                                EllesmereUI.ShowWidgetTooltip(desatOnCdRow, customDisabledTip)
+                            end
+                        end)
+                        desatOnCdRow:SetScript("OnLeave", function()
                             if EllesmereUI.HideWidgetTooltip then EllesmereUI.HideWidgetTooltip() end
                         end)
                     end
@@ -18753,12 +18798,22 @@ initFrame:SetScript("OnEvent", function(self)
         if not isBuffGlowBar then
         local isCDOrUtility = (barData.barType == "cooldowns" or barData.barType == "utility")
         if isCDOrUtility then
-            local sgcdRow
-            sgcdRow, h = W:DualRow(parent, y,
+            _, h = W:DualRow(parent, y,
+                { type="toggle", text="Desaturate on CD",
+                  tooltip="Desaturate this bar's icons while the ability is on cooldown. Per-icon settings can override this.",
+                  getValue=function() return BD().desaturateOnCD ~= false end,
+                  setValue=function(v)
+                      BD().desaturateOnCD = v and true or false
+                      ns.RefreshCDMIconAppearance(BD().key); Refresh()
+                      if ns._MarkPresetCdDirty then ns._MarkPresetCdDirty() end
+                  end },
                 { type="toggle", text="Suppress GCD",
                   tooltip="Hide the brief GCD swipe that flashes when you cast any spell. The actual ability cooldown swipe still shows.",
                   getValue=function() return BD().suppressGCD == true end,
-                  setValue=function(v) BD().suppressGCD = v and true or false; Refresh() end },
+                  setValue=function(v) BD().suppressGCD = v and true or false; Refresh() end });  y = y - h
+            local sgcdRow
+            sgcdRow, h = W:DualRow(parent, y,
+                { type="label", text="" },
                 { type="slider", text="Pixel Glow Thickness", min=1, max=4, step=1, trackWidth=120,
                   tooltip="Thickness of any Pixel Glow assigned to this bar's buttons. Assign glows by right-clicking an icon in the preview.",
                   getValue=function() return BD().pixelGlowThickness or 2 end,

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -31,6 +31,8 @@ local GetTime = GetTime
 local _, _playerClass = UnitClass("player")
 local _isDruid = (_playerClass == "DRUID")
 
+local IconDesaturatesOnCD
+
 -------------------------------------------------------------------------------
 --  Memory Profiling (temporary)
 -------------------------------------------------------------------------------
@@ -2760,11 +2762,21 @@ local function DecorateFrame(frame, barData)
             fd._desatOverrideHooked = true
             local function onDesatChange()
                 if fd._isProcessingOverride then return end
-                if not fd._hideActiveOverriding then return end
                 fd._isProcessingOverride = true
                 local cdw = fd.cooldown
                 local fc2 = _ecmeFC[frame]
                 local sid2 = fc2 and fc2.spellID
+                local bk2 = fc2 and fc2.barKey
+                local ss2 = sid2 and bk2 and ResolveSpellSettings(frame, sid2, ns.GetBarSpellData(bk2), bk2)
+                if not IconDesaturatesOnCD(frame, ss2) then
+                    if fd.tex then fd.tex:SetDesaturated(false) end
+                    fd._isProcessingOverride = false
+                    return
+                end
+                if not fd._hideActiveOverriding then
+                    fd._isProcessingOverride = false
+                    return
+                end
                 if sid2 and cdw then
                     if cdw.SetUseAuraDisplayTime then
                         cdw:SetUseAuraDisplayTime(false)
@@ -2859,7 +2871,7 @@ local function DecorateFrame(frame, barData)
                         end
                     end
                 end
-                fd.tex:SetDesaturated(onRealCD or false)
+                fd.tex:SetDesaturated((IconDesaturatesOnCD(frame, ss2) and onRealCD) or false)
                 fd._isProcessingOverride = false
             end
             hooksecurefunc(fd.tex, "SetDesaturated", onDesatChange)
@@ -3391,7 +3403,10 @@ local function UpdateTrinketCooldown(slotID)
     local start, dur, enable = GetInventoryItemCooldown("player", slotID)
     if start and dur and dur > 1.5 and enable == 1 then
         f._cooldown:SetCooldown(start, dur)
-        if f._tex then f._tex:SetDesaturated(true) end
+        local fcD = _ecmeFC[f]
+        local bkD = fcD and fcD.barKey
+        local ssD = bkD and ResolveSpellSettings(f, fcD.spellID, ns.GetBarSpellData(bkD), bkD)
+        if f._tex then f._tex:SetDesaturated(IconDesaturatesOnCD(f, ssD)) end
         return true
     else
         f._cooldown:Clear()
@@ -3653,6 +3668,18 @@ local function ApplySpellDesaturation(f, durObj)
     else
         f._tex:SetDesaturation(0)
     end
+end
+
+function IconDesaturatesOnCD(frame, ss)
+    local fc = frame and _ecmeFC[frame]
+    local bd = fc and fc.barKey and barDataByKey[fc.barKey]
+    local on = not bd or bd.desaturateOnCD ~= false
+    if ss and ss.desatOnCD == "on" then on = true
+    elseif ss and ss.desatOnCD == "off" then on = false end
+    local cas = fc and ns.GetEffectiveCustomActiveState and ns.GetEffectiveCustomActiveState(fc.spellID)
+    if cas and cas.desatOnCD == "on" then on = true
+    elseif cas and cas.desatOnCD == "off" then on = false end
+    return on
 end
 
 -------------------------------------------------------------------------------
@@ -4021,7 +4048,14 @@ local function ProcessPresetCooldowns()
                     if cdInfo and cdInfo.isOnGCD and not onRealCD then
                         if f._tex then f._tex:SetDesaturation(0) end
                     else
-                        ApplySpellDesaturation(f, durObj)
+                        local fcD = _ecmeFC[f]
+                        local bkD = fcD and fcD.barKey
+                        local ssD = bkD and ResolveSpellSettings(f, sid, ns.GetBarSpellData(bkD), bkD)
+                        if IconDesaturatesOnCD(f, ssD) then
+                            ApplySpellDesaturation(f, durObj)
+                        elseif f._tex then
+                            f._tex:SetDesaturation(0)
+                        end
                     end
                     -- Resource check: dim vertex color when not enough resources
                     -- Only for custom spells (not racials -- racials don't cost resources)
@@ -4166,7 +4200,11 @@ local function ProcessPresetCooldowns()
                         f._lastItemCount = nil
                     end
                 end
-                local shouldDesat = (total == 0 or itemOnCD or f._inCombatLockout) and true or false
+                local fcD = _ecmeFC[f]
+                local bkD = fcD and fcD.barKey
+                local ssD = bkD and ResolveSpellSettings(f, fcD.spellID, ns.GetBarSpellData(bkD), bkD)
+                local canDesat = IconDesaturatesOnCD(f, ssD)
+                local shouldDesat = (canDesat and (total == 0 or itemOnCD or f._inCombatLockout)) and true or false
                 if shouldDesat ~= f._lastDesat then
                     f._lastDesat = shouldDesat
                     if f._tex then f._tex:SetDesaturated(shouldDesat) end
@@ -4293,8 +4331,12 @@ _racialCdListener:SetScript("OnEvent", function(_, event, unit, _, spellID)
                 if f._isItemPresetFrame and f._presetItemID == targetItemID then
                     f._inCombatLockout = true
                     if f._cooldown then f._cooldown:Clear() end
-                    if f._tex then f._tex:SetDesaturated(true) end
-                    f._lastDesat = true
+                    local fcD = _ecmeFC[f]
+                    local bkD = fcD and fcD.barKey
+                    local ssD = bkD and ResolveSpellSettings(f, fcD.spellID, ns.GetBarSpellData(bkD), bkD)
+                    local shouldDesat = IconDesaturatesOnCD(f, ssD)
+                    if f._tex then f._tex:SetDesaturated(shouldDesat) end
+                    f._lastDesat = shouldDesat
                 end
             end
         end
@@ -5577,17 +5619,22 @@ local function CollectAndReanchor()
                                     end
                                     local spInfo = C_Spell and C_Spell.GetSpellInfo and C_Spell.GetSpellInfo(sid)
                                     if spInfo and spInfo.iconID and f._tex then f._tex:SetTexture(spInfo.iconID) end
+                                    local fc = FC(f)
+                                    fc.barKey = barKey; fc.spellID = sid
                                     if not f._cdSet or f._racialCdDirty then
                                         local durObj = C_Spell.GetSpellCooldownDuration and C_Spell.GetSpellCooldownDuration(sid)
                                         if durObj and f._cooldown.SetCooldownFromDurationObject then
                                             f._cooldown:SetCooldownFromDurationObject(durObj, true)
                                         end
-                                        ApplySpellDesaturation(f, durObj)
+                                        local ssD = ResolveSpellSettings(f, sid, ns.GetBarSpellData(barKey), barKey)
+                                        if IconDesaturatesOnCD(f, ssD) then
+                                            ApplySpellDesaturation(f, durObj)
+                                        elseif f._tex then
+                                            f._tex:SetDesaturation(0)
+                                        end
                                         f._cdSet = true; f._racialCdDirty = false
                                     end
                                     frames[#frames + 1] = f
-                                    local fc = FC(f)
-                                    fc.barKey = barKey; fc.spellID = sid
                                 end
                             end
                         end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -513,6 +513,7 @@ local DEFAULTS = {
                     showCooldownText = true, showItemCount = true, showTooltip = false, showKeybind = false,
                     keybindSize = 10, keybindOffsetX = 2, keybindOffsetY = -2, keybindAlign = "left",
                     keybindR = 1, keybindG = 1, keybindB = 1, keybindA = 0.9,
+                    desaturateOnCD = true,
                 },
                 {
                     key = "utility", name = "Utility", enabled = true,
@@ -532,6 +533,7 @@ local DEFAULTS = {
                     showCooldownText = true, showItemCount = true, showTooltip = false, showKeybind = false,
                     keybindSize = 10, keybindOffsetX = 2, keybindOffsetY = -2, keybindAlign = "left",
                     keybindR = 1, keybindG = 1, keybindB = 1, keybindA = 0.9,
+                    desaturateOnCD = true,
                 },
                 {
                     key = "buffs", name = "Buffs", enabled = true,
@@ -5381,6 +5383,21 @@ local function RefreshCDMIconAppearance(barKey)
                 -- Per-icon Desaturate Inactive override, read by the BuffTicker.
                 fd._desatOverride = (ssb and ssb.desatInactive) or nil
             end
+        elseif tex then
+            local fcCD = _ecmeFC[icon]
+            local sidCD = fcCD and fcCD.spellID
+            local bkCD = fcCD and fcCD.barKey
+            local ssCD = sidCD and bkCD
+                and ns.ResolveSpellSettings and ns.ResolveSpellSettings(icon, sidCD, ns.GetBarSpellData(bkCD), bkCD)
+            local desatOn = barData.desaturateOnCD ~= false
+            if ssCD and ssCD.desatOnCD == "on" then desatOn = true
+            elseif ssCD and ssCD.desatOnCD == "off" then desatOn = false end
+            local casCD = sidCD and ns.GetEffectiveCustomActiveState and ns.GetEffectiveCustomActiveState(sidCD)
+            if casCD and casCD.desatOnCD == "on" then desatOn = true
+            elseif casCD and casCD.desatOnCD == "off" then desatOn = false end
+            if not desatOn and not (ssCD and ssCD.desatNotActive) then
+                tex:SetDesaturated(false)
+            end
         end
         -- Update texture -- fill the entire frame. The border renders on
         -- top via PP.CreateBorder so no inset is needed.
@@ -9524,4 +9541,3 @@ SlashCmdList.CDMBUFFID = function()
     end
     P("=== END PROBE ===")
 end
-


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
