### PR TITLE
Add absorb text options to Boss frame health-text dropdowns

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -311,7 +311,7 @@ initFrame:SetScript("OnEvent", function(self)
     local healthTextOrder = { "none", "---", "name", "levelname", "namelevel", "level", "perhp", "perhpnosign", "curhpshort", "perhpnum", "both" }
     -- Boss frames also get "Name > Target" (the boss's current target); the other
     -- mini frames (Target of Target / Focus Target / Pet) do not.
-    local healthTextOrderBoss = { "none", "---", "name", "nametotarget", "levelname", "namelevel", "level", "perhp", "perhpnosign", "curhpshort", "perhpnum", "both", "bothdash", "perhpnumdash" }
+    local healthTextOrderBoss = { "none", "---", "name", "nametotarget", "levelname", "namelevel", "level", "perhp", "perhpnosign", "curhpshort", "perhpnum", "both", "bothdash", "perhpnumdash", "absorb", "absorbshort", "healabsorb", "healabsorbshort" }
     local healthTextOrderPlayer = { "none", "---", "name", "nametotarget", "levelname", "namelevel", "level", "perhp", "perhpnosign", "curhpshort", "perhpnum", "both", "bothdash", "perhpnumdash", "absorb", "absorbshort", "healabsorb", "healabsorbshort", "group" }
     -- Target/Focus get the same absorb text options as player, minus "group"
     -- (Group Number is the player's own raid group; it is meaningless on a target/focus).


### PR DESCRIPTION
## What does this PR do?

Adds the absorb text options to the Boss frame's Left/Right/Center text
dropdowns. Boss frames were the only Main Frames unit missing
"absorb", "absorbshort", "healabsorb", "healabsorbshort" -- Player,
Target and Focus already list them. Now boss frames can show shield /
heal-absorb amounts as text like the other frames.

Single-line change: append the four absorb tags to `healthTextOrderBoss`
in `EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua`. The tag
functions are already unit-agnostic (UnitGetTotalAbsorbs /
UnitGetTotalHealAbsorbs accept "bossN"), so no other change is needed.

## How was it tested?

Selected an absorb tag on the Boss frame text, then targeted a boss that
had an absorb shield -- the amount displayed correctly. Also confirmed
the four entries now appear in the Boss frame Left/Right/Center text
dropdowns (they were absent before). No new code path, only an addition
to an existing option list that already works for Player/Target/Focus.

## Screenshots

N/A -- options-list addition only (no visual/layout change to the frame
itself).

## Checklist

- [ ] New settings default **OFF** -- N/A: no new setting; adds existing
  tag options to an existing dropdown, defaults unchanged.
- [ ] Zero cost while disabled -- N/A: no new events/hooks/frames; just a
  table literal entry.
- [x] Cheap while enabled: reuses the existing unit-agnostic tag
  functions; event-driven, no polling or per-frame allocations added.
- [ ] No writes onto Blizzard-owned frames -- N/A: no hooks or frame
  writes at all, only a Lua table addition.
- [x] Tested in-game on live retail: absorb amount displayed on a boss
  that had an absorb shield; no load errors.