### PR TITLE
Leave Blizzard cast bar events alone for third-party cast bars

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12527,6 +12527,86 @@ function EllesmereUI.SetElementVisibility(frame, visible)
 end
 
 -------------------------------------------------------------------------------
+--  Blizzard Cast Bar Event Ownership
+--  Standalone cast bar addons claim Blizzard's player/pet cast bars by
+--  unregistering their events. oUF's Castbar element writes the same state --
+--  it silences those frames when it enables on the player frame and re-arms
+--  them when it disables -- so EUI can hand a user's cast bar back to Blizzard
+--  on top of the addon they replaced it with. EUI hides Blizzard's bar by
+--  re-parenting it (see SetPlayerCastBarSuppressed), so it never needs the
+--  event state changed: wrap anything that flips it in Capture/Restore and only
+--  ever undo EUI's own writes.
+-------------------------------------------------------------------------------
+function EllesmereUI._BlizzCastBars()
+    local bars = EllesmereUI._blizzCastBarList
+    if bars then return bars end
+
+    bars = {}
+    if PlayerCastingBarFrame then bars[#bars + 1] = { frame = PlayerCastingBarFrame, unit = "player" } end
+    if PetCastingBarFrame then bars[#bars + 1] = { frame = PetCastingBarFrame, unit = "pet" } end
+    EllesmereUI._blizzCastBarList = bars
+
+    for i = 1, #bars do
+        local bar = bars[i]
+        -- An UnregisterAllEvents outside one of our own Capture/Restore windows
+        -- is another addon claiming the frame, so EUI drops its claim and stops
+        -- treating that silence as something it may undo.
+        hooksecurefunc(bar.frame, "UnregisterAllEvents", function()
+            if not EllesmereUI._blizzCastBarSnapshot then bar.owned = false end
+        end)
+    end
+    return bars
+end
+
+function EllesmereUI.CaptureBlizzCastBarEvents()
+    local bars = EllesmereUI._BlizzCastBars()
+    local snapshot = {}
+    for i = 1, #bars do
+        snapshot[i] = bars[i].frame:IsEventRegistered("UNIT_SPELLCAST_START") and true or false
+    end
+    EllesmereUI._blizzCastBarSnapshot = snapshot
+end
+
+function EllesmereUI.RestoreBlizzCastBarEvents()
+    local snapshot = EllesmereUI._blizzCastBarSnapshot
+    if not snapshot then return end
+    EllesmereUI._blizzCastBarSnapshot = nil
+
+    local bars = EllesmereUI._blizzCastBarList
+    for i = 1, #bars do
+        local bar = bars[i]
+        local live = bar.frame:IsEventRegistered("UNIT_SPELLCAST_START") and true or false
+        if live ~= snapshot[i] then
+            if not live then
+                bar.owned = true
+            elseif bar.owned then
+                bar.owned = false
+            else
+                -- Someone else silenced this frame; put it back the way we
+                -- found it instead of resurrecting Blizzard's cast bar.
+                bar.frame:UnregisterAllEvents()
+                bar.frame:Hide()
+            end
+        end
+    end
+end
+
+-- Give Blizzard's player cast bar its own event wiring back, but only when EUI
+-- is the one that took it away.
+function EllesmereUI.RearmBlizzPlayerCastBar()
+    local bars = EllesmereUI._blizzCastBarList
+    if not bars then return end
+    for i = 1, #bars do
+        local bar = bars[i]
+        if bar.unit == "player" and bar.owned and bar.frame.SetUnit
+            and not bar.frame:IsEventRegistered("UNIT_SPELLCAST_START") then
+            bar.owned = false
+            bar.frame:SetUnit("player", bar.frame.showTradeSkills, bar.frame.showShield)
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
 --  Shared Player Cast Bar Suppression
 --  Multiple EUI modules can temporarily suppress Blizzard's player cast bar
 --  while they render their own. We centralize that ownership here so modules
@@ -12634,18 +12714,19 @@ function EllesmereUI.SetPlayerCastBarSuppressed(owner, suppressed)
     end
 
     local selection = blizzBar.Selection
-    if selection then
+    if selection and EllesmereUI._GetFFD(selection).suppressed then
         EllesmereUI._GetFFD(selection).suppressed = false
         selection:SetAlpha(EllesmereUI._GetFFD(selection).restoreAlpha or 1)
         selection:EnableMouse(EllesmereUI._GetFFD(selection).restoreMouse or false)
     end
 
-    -- Let Blizzard rebuild its normal event wiring and pick up any active cast
-    -- without forcing visibility back on. This keeps profile switches and
-    -- UnitFrames/oUF teardown compatible with Blizzard's own cast bar logic.
-    if blizzBar.SetUnit then
-        blizzBar:SetUnit("player")
-    end
+    -- Let Blizzard rebuild its normal event wiring without forcing visibility
+    -- back on, so profile switches and UnitFrames/oUF teardown stay compatible
+    -- with Blizzard's own cast bar logic. Only when EUI silenced the frame in
+    -- the first place: a standalone cast bar addon silences the same frame, and
+    -- re-registering its events is what pops Blizzard's cast bar back on screen
+    -- next to theirs once EUI's own cast bar is switched off.
+    EllesmereUI.RearmBlizzPlayerCastBar()
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -9323,9 +9323,7 @@ local function ReloadFrames()
                     if frame.Castbar then
                         local castbarBg = frame.Castbar:GetParent()
                         if settings.showPlayerCastbar then
-                            if not frame:IsElementEnabled("Castbar") then
-                                frame:EnableElement("Castbar")
-                            end
+                            ns.SetCastbarElement(frame, true)
                             if castbarBg then
                                 local cbW = db.profile.player.playerCastbarWidth or 181
                                 local cbH = db.profile.player.playerCastbarHeight or 14
@@ -9406,9 +9404,7 @@ local function ReloadFrames()
                                 end
                             end
                         else
-                            if frame:IsElementEnabled("Castbar") then
-                                frame:DisableElement("Castbar")
-                            end
+                            ns.SetCastbarElement(frame, false)
                             frame.Castbar:Hide()
                             if castbarBg then castbarBg:Hide() end
                         end
@@ -11072,6 +11068,23 @@ local function ReloadFrames()
     end
 end
 
+-- Toggle a frame's oUF Castbar element without rewriting Blizzard's cast bar
+-- event registration. oUF silences PlayerCastingBarFrame/PetCastingBarFrame
+-- when the element enables on the player frame and re-arms them when it
+-- disables; the shared helpers keep whatever a standalone cast bar addon set.
+-- On ns (not a new file-scope local) to respect the Lua 200-locals cap.
+function ns.SetCastbarElement(frame, enable)
+    if not frame or not frame.Castbar then return end
+    if (frame:IsElementEnabled("Castbar") and true or false) == (enable and true or false) then return end
+    EllesmereUI.CaptureBlizzCastBarEvents()
+    if enable then
+        frame:EnableElement("Castbar")
+    else
+        frame:DisableElement("Castbar")
+    end
+    EllesmereUI.RestoreBlizzCastBarEvents()
+end
+
 -- Manage Blizzard's player cast bar ownership based on whether UnitFrames is
 -- rendering its own player cast bar. oUF already handles the event plumbing
 -- for its own castbar element; this helper only coordinates suppression with
@@ -11265,7 +11278,11 @@ function InitializeFrames()
     -- it, so oUF never disables it); "hidden" removes Blizzard's frame too.
     oUF:SetActiveStyle("EllesmerePlayer")
     if playerFrameSource == "eui" then
+        -- Spawning enables the Castbar element, which silences Blizzard's
+        -- player/pet cast bars. Keep whatever a standalone cast bar addon set.
+        EllesmereUI.CaptureBlizzCastBarEvents()
         frames.player = oUF:Spawn("player", "EllesmereUIUnitFrames_Player")
+        EllesmereUI.RestoreBlizzCastBarEvents()
     elseif playerFrameSource == "hidden" then
         oUF:DisableBlizzard("player")
     end
@@ -12299,9 +12316,7 @@ function InitializeFrames()
     -- Player castbar: disable oUF element if not wanted (always created now)
     if frames.player and frames.player.Castbar then
         if not db.profile.player.showPlayerCastbar then
-            if frames.player:IsElementEnabled("Castbar") then
-                frames.player:DisableElement("Castbar")
-            end
+            ns.SetCastbarElement(frames.player, false)
             frames.player.Castbar:Hide()
             local castbarBg = frames.player.Castbar:GetParent()
             if castbarBg then castbarBg:Hide() end
@@ -12540,13 +12555,9 @@ function InitializeFrames()
                                     wantsCastbar = s.showCastbar ~= false
                                 end
                                 if wantsCastbar then
-                                    if not frame:IsElementEnabled("Castbar") then
-                                        frame:EnableElement("Castbar")
-                                    end
+                                    ns.SetCastbarElement(frame, true)
                                 else
-                                    if frame:IsElementEnabled("Castbar") then
-                                        frame:DisableElement("Castbar")
-                                    end
+                                    ns.SetCastbarElement(frame, false)
                                     frame.Castbar:Hide()
                                     local castbarBg = frame.Castbar:GetParent()
                                     if castbarBg then castbarBg:Hide() end
@@ -12559,11 +12570,12 @@ function InitializeFrames()
                         if frame:IsShown() then
                             -- Disable oUF elements before hiding to prevent a
                             -- single-frame flash when the unit attribute is cleared
-                            for _, elem in ipairs({"Health", "Power", "Portrait", "Castbar", "Buffs", "Debuffs", "HealthPrediction"}) do
+                            for _, elem in ipairs({"Health", "Power", "Portrait", "Buffs", "Debuffs", "HealthPrediction"}) do
                                 if frame[elem] and frame:IsElementEnabled(elem) then
                                     frame:DisableElement(elem)
                                 end
                             end
+                            ns.SetCastbarElement(frame, false)
                             frame:Hide()
                             frame:SetAttribute("unit", nil)
                         end

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -287,8 +287,6 @@ INDEPENDENT BARS
 Icon ID always shown for this spell (empty removes)
 Icon opacity while on cooldown (1-100%)
 Icon:
-Import 1080p
-Import 2K (1440p)
 Import Addons
 Import Failed
 Import Profile
@@ -434,6 +432,7 @@ Ready
 Reagent Bag (%d / %d)
 Recent Colors
 Recent Items
+Regular Import
 Reload Now
 Reload Required
 Remove
@@ -567,6 +566,7 @@ Trinket 1
 Trinket 2
 UI Scale Issue: Profile was made at %1$d%%, yours is %2$d%%
 UI Scale Mismatch
+Ultrawide Import
 Unavailable with Enhancement 5-bar style.
 Uncheck All
 Unknown


### PR DESCRIPTION
### Problem

Reported in bug reports (duplicate of an earlier "Default Blizzard's Cast Bar" report): with a standalone cast bar addon installed and EUI's cast bar disabled, Blizzard's own cast bar shows up on every cast. Disabling EUI entirely, or manually running `PlayerCastingBarFrame:UnregisterAllEvents()`, makes it go away.

### Cause

Standalone cast bar addons claim `PlayerCastingBarFrame` by unregistering its events. EUI wrote that same state back from two places:

1. `EllesmereUI.SetPlayerCastBarSuppressed` called `blizzBar:SetUnit("player")` when the last EUI owner released the bar. Blizzard's `CastingBarMixin:SetUnit` re-registers every cast event (and, called with no flags, also cleared `showTradeSkills` / `showShield`).
2. oUF's Castbar element unregisters `PlayerCastingBarFrame` / `PetCastingBarFrame` when it enables on the player frame and **re-registers** them when it disables. That fires at login whenever `showPlayerCastbar` is off, which is the default, so it also hit users who never touched the setting.

### Fix

EUI hides Blizzard's bar by re-parenting it to a hidden frame, so it never needs the event registration changed at all.

- `CaptureBlizzCastBarEvents` / `RestoreBlizzCastBarEvents` in `EllesmereUI.lua` wrap every EUI call that can flip the registration: the player frame spawn, and each player Castbar element toggle (`ns.SetCastbarElement`). Restore keeps EUI's own silence, hands back what EUI took, or re-silences a frame another addon had claimed.
- A `hooksecurefunc` on each bar's `UnregisterAllEvents` outside one of those windows means another addon just took over, which drops EUI's claim. That covers the mid-session case where EUI silenced the frame first and the other addon second.
- `RearmBlizzPlayerCastBar` replaces the unconditional `SetUnit` and preserves the mixin's trade-skill / shield flags instead of clearing them.
- The `Selection` restore on release is gated on having suppressed it, so EUI stops writing alpha it never captured.

Behaviour with no third-party cast bar addon is unchanged: EUI owns the silence in that case, so turning EUI's cast bar off still gives Blizzard's back.

### Testing

Verified in-game by the reporter with a standalone cast bar addon:

- cast with EUI's cast bar disabled, Blizzard's bar stays gone
- toggle EUI's cast bar off mid-session, Blizzard's bar stays gone
- control case with no third-party cast bar addon, turning EUI's cast bar off still restores Blizzard's own


### New Required GIF for all PR's
<img width="480" height="480" alt="Cat Dancing GIF" src="https://github.com/user-attachments/assets/81a6a8f0-a1fa-43ec-b355-fc0249cca138" />
