### PR TITLE
Stop Blizzard's hidden nameplate aura row eating clicks and camera turns

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -5274,6 +5274,23 @@ local function RestoreFromOffscreen(element)
         storedParents[element] = nil
     end
 end
+-- Blizzard's plate aura item frames are created mouse-enabled with tooltip
+-- handlers (Blizzard_NamePlateAuras.xml), so an alpha-0 aura row kept on the
+-- plate still shows tooltips and takes the clicks aimed through it at the
+-- plate or the world. Sweep the kept-alive row's subtree mouse-dead; pool
+-- frames persist, so one write per frame sticks, and the recursion re-runs
+-- per refresh only to catch newly pooled items.
+local mouseDeadAuraItems = setmetatable({}, { __mode = "k" })
+local function KillAuraRowMouse(frame)
+    if not frame or frame:IsForbidden() then return end
+    if not mouseDeadAuraItems[frame] then
+        mouseDeadAuraItems[frame] = true
+        frame:EnableMouse(false)
+    end
+    for i = 1, frame:GetNumChildren() do
+        KillAuraRowMouse((select(i, frame:GetChildren())))
+    end
+end
 local function HideBlizzardFrame(nameplate, unit)
     if not nameplate then return end
     local uf = nameplate.UnitFrame
@@ -5288,12 +5305,23 @@ local function HideBlizzardFrame(nameplate, unit)
     -- the AurasFrame, which our RefreshAuras hook below reads. Re-home it on
     -- the nameplate and alpha it out so Blizzard keeps updating it while its
     -- rows stay invisible. (The WidgetContainer is likewise kept, further down.)
+    -- 12.1: our containers own plate auras and these lists are taint-locked
+    -- and unused (see the RefreshAuras gate below), so nothing needs the frame
+    -- live -- and its item frames are mouse-enabled Blizzard templates with
+    -- tooltip handlers, which made the alpha-0 keep-alive an invisible
+    -- tooltip/click trap parked above every plate (/fstack-convicted:
+    -- BuffListFrame). Park it offscreen with the other children instead.
     if uf.AurasFrame then
-        if not storedParents[uf.AurasFrame] then
-            storedParents[uf.AurasFrame] = uf.AurasFrame:GetParent()
+        if ns.NPC_OwnsAuras then
+            MoveToOffscreen(uf.AurasFrame, unit)
+        else
+            if not storedParents[uf.AurasFrame] then
+                storedParents[uf.AurasFrame] = uf.AurasFrame:GetParent()
+            end
+            uf.AurasFrame:SetParent(nameplate)
+            uf.AurasFrame:SetAlpha(0)
+            KillAuraRowMouse(uf.AurasFrame)
         end
-        uf.AurasFrame:SetParent(nameplate)
-        uf.AurasFrame:SetAlpha(0)
     end
     -- Park the UnitFrame's child frames on the hidden holder, discovered
     -- generically -- whatever Blizzard parents under the UnitFrame is swept, so
@@ -5357,6 +5385,9 @@ local function HideBlizzardFrame(nameplate, unit)
         hookedAurasFrames[uf.AurasFrame] = true
         hooksecurefunc(uf.AurasFrame, "RefreshAuras", function(af)
             if af:IsForbidden() then return end
+            -- Newly pooled item frames arrive mouse-enabled; keep the
+            -- kept-alive row mouse-dead as it grows.
+            KillAuraRowMouse(af)
             local parent = af:GetParent()
             if not parent then return end
             local ufUnit = parent.unit or (parent.GetUnit and parent:GetUnit())

--- a/EllesmereUIResourceBars/EUI_ResourceBars_EbonMight121.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_EbonMight121.lua
@@ -111,6 +111,15 @@ local function Build()
             -- subtree. Two-point anchoring sizes the button by anchors
             -- forever; all repositioning is proxy moves.
             button:SetAllPoints(S.proxy)
+            -- Both halves, and inside the creation window: this is the only
+            -- legal moment to set them. The slot button is an engine Button, so
+            -- mouse is on by default -- motion alone only suppresses the
+            -- tooltip. With clicks still enabled it is an invisible click
+            -- blocker over the bar's whole rect for as long as Ebon Might is
+            -- up, swallowing clicks meant for the world (nameplates behind the
+            -- bar stop responding mid-combat). It is a display-only overlay and
+            -- has no OnClick, so it should never take mouse input at all.
+            if button.SetMouseClickEnabled then button:SetMouseClickEnabled(false) end
             if button.SetMouseMotionEnabled then button:SetMouseMotionEnabled(false) end
 
             local bar = CreateFrame("StatusBar", nil, button)

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -409,14 +409,24 @@ local function ApplyStyleToRegions(button, style)
         end
     end
 
-    -- Re-assert the click disable from the initializer. It has to run AFTER the
+    -- Re-assert the mouse state the style wants. It has to run AFTER the
     -- tooltip calls above: configuring tooltip behaviour on an engine button
     -- turns its mouse back on, which silently re-opened the nameplate
-    -- click-eater. Running it here also covers every Restyle, so a settings
-    -- change cannot re-open it either. Same deferral as its neighbours when the
-    -- button is locked down while auras are secret.
+    -- click-eater. Motion needs the same treatment: the module motion passes
+    -- are change-guarded by stamps that still read "off" after the engine
+    -- flips it back, so they never repair it (field evidence: debuff tooltips
+    -- appearing over empty space beside nameplates, whose styles set
+    -- noTooltips). Running here also covers every Restyle, so a settings
+    -- change cannot re-open either one. Same deferral as the neighbours above
+    -- when the button is locked down while auras are secret.
     if not style.cancelButtons and button.SetMouseClickEnabled then
         if not pcall(button.SetMouseClickEnabled, button, false)
+            and d.styleKey and AK.AurasRestricted() then
+            deferredRestyles[d.styleKey] = true
+        end
+    end
+    if style.noTooltips and button.SetMouseMotionEnabled then
+        if not pcall(button.SetMouseMotionEnabled, button, false)
             and d.styleKey and AK.AurasRestricted() then
             deferredRestyles[d.styleKey] = true
         end

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -386,25 +386,31 @@ local function ApplyStyleToRegions(button, style)
     -- overrides from the 4-state tooltip mode (style.tooltipCombatHide /
     -- style.tooltipAnchor = "cursor"). Button-surface calls: change-guarded,
     -- stamped on success only, deferred to the restriction lift when denied.
-    -- API-existence guards keep stale builds inert.
-    if button.SetHideTooltipInCombat then
-        local wantCombat = style.tooltipCombatHide and true or false
-        if d.akTipCombat ~= wantCombat then
-            if pcall(button.SetHideTooltipInCombat, button, wantCombat) then
-                d.akTipCombat = wantCombat
-            elseif d.styleKey and AK.AurasRestricted() then
-                deferredRestyles[d.styleKey] = true
+    -- API-existence guards keep stale builds inert. Skipped entirely for
+    -- noTooltips styles: these buttons must never show a tooltip, and
+    -- configuring tooltip behaviour re-arms the button's mouse as a side
+    -- effect (the nameplate click/tooltip eater), so never touch the tooltip
+    -- surface of a button that has no tooltip to configure.
+    if not style.noTooltips then
+        if button.SetHideTooltipInCombat then
+            local wantCombat = style.tooltipCombatHide and true or false
+            if d.akTipCombat ~= wantCombat then
+                if pcall(button.SetHideTooltipInCombat, button, wantCombat) then
+                    d.akTipCombat = wantCombat
+                elseif d.styleKey and AK.AurasRestricted() then
+                    deferredRestyles[d.styleKey] = true
+                end
             end
         end
-    end
-    if button.SetTooltipAnchorPoint then
-        local wantAnchor = (style.tooltipAnchor == "cursor")
-            and "ANCHOR_CURSOR" or "ANCHOR_BOTTOMLEFT"
-        if d.akTipAnchor ~= wantAnchor then
-            if pcall(button.SetTooltipAnchorPoint, button, wantAnchor) then
-                d.akTipAnchor = wantAnchor
-            elseif d.styleKey and AK.AurasRestricted() then
-                deferredRestyles[d.styleKey] = true
+        if button.SetTooltipAnchorPoint then
+            local wantAnchor = (style.tooltipAnchor == "cursor")
+                and "ANCHOR_CURSOR" or "ANCHOR_BOTTOMLEFT"
+            if d.akTipAnchor ~= wantAnchor then
+                if pcall(button.SetTooltipAnchorPoint, button, wantAnchor) then
+                    d.akTipAnchor = wantAnchor
+                elseif d.styleKey and AK.AurasRestricted() then
+                    deferredRestyles[d.styleKey] = true
+                end
             end
         end
     end

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -409,6 +409,19 @@ local function ApplyStyleToRegions(button, style)
         end
     end
 
+    -- Re-assert the click disable from the initializer. It has to run AFTER the
+    -- tooltip calls above: configuring tooltip behaviour on an engine button
+    -- turns its mouse back on, which silently re-opened the nameplate
+    -- click-eater. Running it here also covers every Restyle, so a settings
+    -- change cannot re-open it either. Same deferral as its neighbours when the
+    -- button is locked down while auras are secret.
+    if not style.cancelButtons and button.SetMouseClickEnabled then
+        if not pcall(button.SetMouseClickEnabled, button, false)
+            and d.styleKey and AK.AurasRestricted() then
+            deferredRestyles[d.styleKey] = true
+        end
+    end
+
     -- Module-specific styling pass; runs at init and on every Restyle.
     if style.applyExtra then
         style.applyExtra(button, d, style)

--- a/Locales/_keys.txt
+++ b/Locales/_keys.txt
@@ -287,8 +287,6 @@ INDEPENDENT BARS
 Icon ID always shown for this spell (empty removes)
 Icon opacity while on cooldown (1-100%)
 Icon:
-Import 1080p
-Import 2K (1440p)
 Import Addons
 Import Failed
 Import Profile
@@ -434,6 +432,7 @@ Ready
 Reagent Bag (%d / %d)
 Recent Colors
 Recent Items
+Regular Import
 Reload Now
 Reload Required
 Remove
@@ -567,6 +566,7 @@ Trinket 1
 Trinket 2
 UI Scale Issue: Profile was made at %1$d%%, yours is %2$d%%
 UI Scale Mismatch
+Ultrawide Import
 Unavailable with Enhancement 5-bar style.
 Uncheck All
 Unknown


### PR DESCRIPTION
### Problem

Reported repeatedly since 8.5.4: in Mythic+, clicking a nameplate to switch target takes several attempts, and at the same spots the camera refuses to turn. Some reporters also saw aura tooltips appear over apparently empty space beside a nameplate.

### Cause

When EUI takes over a nameplate it hides Blizzard's `UnitFrame` and parks its children on a hidden holder, but the aura row was deliberately exempted:

```lua
uf.AurasFrame:SetParent(nameplate)
uf.AurasFrame:SetAlpha(0)
```

It was kept alive on the plate so Blizzard would keep `debuffList`/`buffList` current for the legacy renderer's important-aura filter.

Alpha hides pixels, not mouse input. Blizzard builds those aura items from `Blizzard_NamePlateAuras.xml` with `enableMouse="true"` and `OnEnter`/`OnLeave` tooltip handlers, so every plate carried an invisible but fully interactive aura row anchored above it. It answered hover with a tooltip from empty space, and it swallowed the clicks and camera drags aimed through that space at the plate or the world behind it.

Convicted with `/fstack` parked on the dead spot, which named `NamePlate<n>...BuffListFrame` with source `Blizzard_NamePlates\Blizzard_NamePlateAuras.xml`.

### Fix

`EllesmereUINameplates.lua`:

- **12.1**: the engine containers own plate auras and the legacy path is inert (`UpdateAuras` early-returns on `ns.NPC_OwnsAuras`, the `UNIT_AURA` re-registration and the `RefreshAuras` hook are already gated on it, and both `debuffList`/`buffList` reads live inside that dead path). Nothing reads the kept-alive frame any more, so it is parked on the hidden holder with the `UnitFrame`'s other children. The existing restore path is generic over `storedParents`, so plate recycling is unchanged.
- **Pre-12.1**: the lists are genuinely consumed there, so the frame stays on the plate and the row's subtree is swept mouse-dead instead. The sweep also runs from the existing `RefreshAuras` hook, because the item frames are pooled and new ones arrive mouse-enabled as the row grows. A weak-keyed table keeps it to one write per frame.

### Also included

Three AuraKit commits and one ResourceBars commit that are **hardening, not the fix above**. Happy to split these into a separate PR if preferred:

- Re-assert click, and mouse motion for `noTooltips` styles, at the end of `ApplyStyleToRegions`. The initializer disables them at creation, but that runs before `ApplyStyleToRegions`, and the module motion passes are change-guarded by stamps that would not repair a state flipped from outside.
- Skip the tooltip block entirely for `noTooltips` styles: a button that must never show a tooltip should never have its tooltip surface configured.
- The 12.1 Ebon Might slot button is `SetAllPoints` over the whole bar rect with only motion disabled. It is an engine Button, so mouse is on by default and clicks stayed enabled, leaving an invisible click blocker over the bar while Ebon Might is up. Disabled in the creation window alongside the motion call.

### Testing

- Reproduced on stock 8.5.8 on a target dummy: aura tooltip in the empty space above/top-left of the plate, `/fstack` there listing `BuffListFrame`, clicks and camera dead at that spot.
- With the fix: no tooltip, no `BuffListFrame` in the stack, clicks and camera work at the same spot.
- Field verification on 12.1 PTR in progress, plus affected reporters testing a build of the same change.

Worth a second pair of eyes on the 12.1 parking in particular: friendly plates (EUI never takes those over), plate recycling on rapid target swaps, and EUI's important-debuff filtering.

### Required Giphy
<img width="480" height="254" alt="Explode Michael Bay GIF" src="https://github.com/user-attachments/assets/bd8a4e48-9a88-4313-a0fb-f3b655daa697" />
