### PR TITLE
Fix attached power border edges after resnap

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2459,12 +2459,10 @@ do
             return
         end
 
-        -- Seam suppression for the cast-bar wrap border: a container can flag its
-        -- TOP or BOTTOM edge to stay hidden AND have the side strips run all the way
-        -- to that corner (no inset), so two stacked borders fuse into one outline
-        -- with no edge line and no corner notch. The flags live on the container, so
-        -- they survive every re-snap (the 2-tick OnUpdate, PP.SetBorderSize,
-        -- ResnapAllBorders) -- a one-shot :Hide() gets clobbered by the next snap.
+        -- Edge suppression for joined bars: flags live on the container so they
+        -- survive every re-snap; a one-shot :Hide() gets clobbered by the next snap.
+        -- Hidden top/bottom edges also remove the matching side-strip inset so two
+        -- stacked borders fuse with no corner notch.
         local topInset, botInset = -edgeSize, edgeSize
         if container._hideTop then topInset = 0 end
         if container._hideBottom then botInset = 0 end
@@ -2484,14 +2482,22 @@ do
             b:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 0, 0)
             b:SetHeight(edgeSize); b:Show()
         end
-        l:ClearAllPoints()
-        l:SetPoint("TOPLEFT", frame, "TOPLEFT", 0, topInset)
-        l:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, botInset)
-        l:SetWidth(edgeSize); l:Show()
-        r:ClearAllPoints()
-        r:SetPoint("TOPRIGHT", frame, "TOPRIGHT", 0, topInset)
-        r:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 0, botInset)
-        r:SetWidth(edgeSize); r:Show()
+        if container._hideLeft then
+            l:Hide()
+        else
+            l:ClearAllPoints()
+            l:SetPoint("TOPLEFT", frame, "TOPLEFT", 0, topInset)
+            l:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, botInset)
+            l:SetWidth(edgeSize); l:Show()
+        end
+        if container._hideRight then
+            r:Hide()
+        else
+            r:ClearAllPoints()
+            r:SetPoint("TOPRIGHT", frame, "TOPRIGHT", 0, topInset)
+            r:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 0, botInset)
+            r:SetWidth(edgeSize); r:Show()
+        end
 
         local bc = container._bdColor
         if bc then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -4439,14 +4439,13 @@ function ns.UpdatePowerBorder(power, settings)
     EllesmereUI.ApplyBorderStyle(border, size, c.r, c.g, c.b, alpha, style,
         settings.powerBorderOffsetX, settings.powerBorderOffsetY,
         settings.powerBorderShiftX, settings.powerBorderShiftY, "unitframes", size)
-    if isAttached then
-        local edges = PP.GetBorders(border)
-        if edges then
-            if edges._left then edges._left:SetAlpha(0) end
-            if edges._right then edges._right:SetAlpha(0) end
-            if edges._top then edges._top:SetAlpha(pos == "below" and alpha or 0) end
-            if edges._bottom then edges._bottom:SetAlpha(pos == "above" and alpha or 0) end
-        end
+    local edges = PP.GetBorders(border)
+    if edges then
+        edges._hideLeft = isAttached or nil
+        edges._hideRight = isAttached or nil
+        edges._hideTop = (isAttached and pos == "above") or nil
+        edges._hideBottom = (isAttached and pos == "below") or nil
+        PP.SetBorderSize(border, size)
     end
     local borderLevel = settings.powerBorderBehind
         and math.max(0, power:GetFrameLevel() - 1) or (power:GetFrameLevel() + 5)


### PR DESCRIPTION
## Summary

- preserve hidden edge state when pixel-perfect borders resnap
- keep attached Unit Frame power borders limited to the health/power divider

<img width="301" height="111" alt="image" src="https://github.com/user-attachments/assets/50c39d4d-8304-4226-a100-9734dbcfbd91" />

