### PR TITLE
Make releasing Blizzard's cast bar actually restore it

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12549,13 +12549,27 @@ function EllesmereUI._BlizzCastBars()
     for i = 1, #bars do
         local bar = bars[i]
         -- An UnregisterAllEvents outside one of our own Capture/Restore windows
-        -- is another addon claiming the frame, so EUI drops its claim and stops
-        -- treating that silence as something it may undo.
+        -- is another addon claiming the frame: EUI drops its claim and records
+        -- the claim as foreign. "Foreign" is tracked separately from "not ours"
+        -- because those are very different states -- see RestoreBlizzCastBarEvents.
         hooksecurefunc(bar.frame, "UnregisterAllEvents", function()
-            if not EllesmereUI._blizzCastBarSnapshot then bar.owned = false end
+            if not EllesmereUI._blizzCastBarSnapshot then
+                bar.owned = false
+                bar.foreign = true
+                EllesmereUI._CastBarDbg("foreign claim", bar.unit)
+            end
         end)
     end
     return bars
+end
+
+-- Opt-in trace for cast bar ownership. Persisted in EllesmereUIDB so it can be
+-- armed before a relog, which is when the interesting decisions happen:
+--   /run EllesmereUIDB._CBDEBUG = true
+function EllesmereUI._CastBarDbg(...)
+    if EllesmereUIDB and EllesmereUIDB._CBDEBUG then
+        print("|cff33ff99[CastBar]|r", ...)
+    end
 end
 
 function EllesmereUI.CaptureBlizzCastBarEvents()
@@ -12579,29 +12593,68 @@ function EllesmereUI.RestoreBlizzCastBarEvents()
         if live ~= snapshot[i] then
             if not live then
                 bar.owned = true
+                EllesmereUI._CastBarDbg("claimed", bar.unit)
             elseif bar.owned then
                 bar.owned = false
-            else
-                -- Someone else silenced this frame; put it back the way we
-                -- found it instead of resurrecting Blizzard's cast bar.
+                EllesmereUI._CastBarDbg("handed back", bar.unit)
+            elseif bar.foreign then
+                -- Another addon silenced this frame and we just re-registered it
+                -- on the way past; put it back the way we found it instead of
+                -- resurrecting Blizzard's cast bar next to theirs.
+                EllesmereUI._CastBarDbg("re-silencing foreign claim", bar.unit)
                 bar.frame:UnregisterAllEvents()
                 bar.frame:Hide()
+            else
+                -- Registered inside our own window with nobody claiming it.
+                -- That is EUI's own bookkeeping having lost track (a silence
+                -- that produced no transition to observe), NOT another addon,
+                -- so re-silencing here would kill Blizzard's cast bar for the
+                -- session with no way back short of a reload. Leave it armed:
+                -- a visible Blizzard bar is something the user can turn off, a
+                -- dead one is not.
+                EllesmereUI._CastBarDbg("left armed, unclaimed", bar.unit)
             end
         end
     end
 end
 
--- Give Blizzard's player cast bar its own event wiring back, but only when EUI
--- is the one that took it away.
-function EllesmereUI.RearmBlizzPlayerCastBar()
+-- The cast events Blizzard's bars listen on, registered per unit. Mirrors the
+-- set oUF's Castbar element restores when it disables, which is the only path
+-- that has ever successfully re-armed these frames.
+--
+-- SetUnit is deliberately NOT used to re-arm. Its body is guarded on
+-- `self.unit ~= unit`, and the frame still holds the unit Blizzard assigned at
+-- load, so passing that same unit registers nothing at all. Forcing the guard
+-- open is worse: SetUnit runs StopAnims -> StopFinishAnims, which iterates a
+-- table that cannot be accessed while tainted, so from addon execution it
+-- throws outright ("attempted to iterate a table that cannot be accessed while
+-- tainted") and takes down whatever called it. Registering the events directly
+-- is what oUF does, is taint-clean, and touches no Blizzard code at all.
+local BLIZZ_CAST_EVENTS = {
+    "UNIT_SPELLCAST_START", "UNIT_SPELLCAST_CHANNEL_START", "UNIT_SPELLCAST_EMPOWER_START",
+    "UNIT_SPELLCAST_STOP", "UNIT_SPELLCAST_CHANNEL_STOP", "UNIT_SPELLCAST_EMPOWER_STOP",
+    "UNIT_SPELLCAST_DELAYED", "UNIT_SPELLCAST_CHANNEL_UPDATE", "UNIT_SPELLCAST_EMPOWER_UPDATE",
+    "UNIT_SPELLCAST_FAILED", "UNIT_SPELLCAST_INTERRUPTED",
+    "UNIT_SPELLCAST_INTERRUPTIBLE", "UNIT_SPELLCAST_NOT_INTERRUPTIBLE",
+}
+
+-- Give Blizzard's cast bars their event wiring back, unless another addon has
+-- claimed them. Covers the pet bar too: oUF silences both and only re-arms them
+-- from its Castbar element's Disable, so any release path that does not run
+-- that (the element was never enabled to begin with) leaves both dead.
+function EllesmereUI.RearmBlizzCastBars()
     local bars = EllesmereUI._blizzCastBarList
     if not bars then return end
     for i = 1, #bars do
         local bar = bars[i]
-        if bar.unit == "player" and bar.owned and bar.frame.SetUnit
-            and not bar.frame:IsEventRegistered("UNIT_SPELLCAST_START") then
+        if not bar.foreign and not bar.frame:IsEventRegistered("UNIT_SPELLCAST_START") then
             bar.owned = false
-            bar.frame:SetUnit("player", bar.frame.showTradeSkills, bar.frame.showShield)
+            for j = 1, #BLIZZ_CAST_EVENTS do
+                bar.frame:RegisterUnitEvent(BLIZZ_CAST_EVENTS[j], bar.unit)
+            end
+            bar.frame:RegisterEvent("PLAYER_ENTERING_WORLD")
+            if bar.unit == "pet" then bar.frame:RegisterEvent("UNIT_PET") end
+            EllesmereUI._CastBarDbg("re-armed", bar.unit)
         end
     end
 end
@@ -12755,7 +12808,7 @@ function EllesmereUI.SetPlayerCastBarSuppressed(owner, suppressed)
     -- the first place: a standalone cast bar addon silences the same frame, and
     -- re-registering its events is what pops Blizzard's cast bar back on screen
     -- next to theirs once EUI's own cast bar is switched off.
-    EllesmereUI.RearmBlizzPlayerCastBar()
+    EllesmereUI.RearmBlizzCastBars()
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12708,9 +12708,38 @@ function EllesmereUI.SetPlayerCastBarSuppressed(owner, suppressed)
 
     EllesmereUI._GetFFD(blizzBar).castBarSuppressed = false
 
-    if hiddenParent and blizzBar:GetParent() == hiddenParent and EllesmereUI._GetFFD(blizzBar).origParent
+    -- Hand the bar back to the parent EUI took it from -- but never to one that
+    -- is itself hidden. Blizzard parents this bar under PlayerFrame, and Edit
+    -- Mode re-parents it into a layout frame that gets hidden on exit, while EUI
+    -- hides PlayerFrame whenever it renders its own player frame. Restoring
+    -- there leaves Blizzard's cast bar fully armed but permanently invisible,
+    -- which reads exactly like the suppression never lifted. UIParent is where
+    -- Edit Mode positions the bar from anyway, and SetParent keeps the existing
+    -- anchors, so the bar still lands where the user had it.
+    local origParent = EllesmereUI._GetFFD(blizzBar).origParent
+    local currentParent = blizzBar:GetParent()
+    local restoreParent = origParent
+    if not restoreParent or not restoreParent.IsVisible or not restoreParent:IsVisible() then
+        restoreParent = UIParent
+    end
+
+    -- Only ever un-park a bar EUI itself parked: either it is still sitting in
+    -- our hidden parent, or an earlier release handed it back to the captured
+    -- parent and that parent is itself hidden. Matching the captured parent
+    -- exactly is what separates "Blizzard's own parent happens to be hidden"
+    -- from "another addon parked this bar under its own hidden frame" -- the
+    -- latter is left alone, since resurrecting it is the bug this whole
+    -- ownership dance exists to prevent.
+    local parkedByUs = (hiddenParent and currentParent == hiddenParent)
+        or (origParent and currentParent == origParent
+            and currentParent.IsVisible and not currentParent:IsVisible())
+
+    -- The Edit Mode gate can skip this; ApplyBlizzCastbarState re-runs the
+    -- release on PLAYER_ENTERING_WORLD and on Edit Mode close, so a bar left
+    -- parked by a skipped pass is healed as soon as re-parenting is legal.
+    if parkedByUs and currentParent ~= restoreParent
         and not (EditModeManagerFrame and EditModeManagerFrame:IsShown()) then
-        blizzBar:SetParent(EllesmereUI._GetFFD(blizzBar).origParent)
+        blizzBar:SetParent(restoreParent)
     end
 
     local selection = blizzBar.Selection

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -11284,7 +11284,14 @@ function InitializeFrames()
         frames.player = oUF:Spawn("player", "EllesmereUIUnitFrames_Player")
         EllesmereUI.RestoreBlizzCastBarEvents()
     elseif playerFrameSource == "hidden" then
+        -- Wrapped for the same reason as the spawn above: DisableBlizzard
+        -- unregisters PlayerFrame's cast bar child, and an unregister seen
+        -- outside a capture window is read as a third-party addon claiming the
+        -- frame -- EUI would mark its own silence as somebody else's and never
+        -- hand the bar back.
+        EllesmereUI.CaptureBlizzCastBarEvents()
         oUF:DisableBlizzard("player")
+        EllesmereUI.RestoreBlizzCastBarEvents()
     end
 
     -- Visibility wrapper for the player frame only. Parent the player frame


### PR DESCRIPTION
Follow-up to #991. Turning EUI's cast bar off left Blizzard's cast bar unusable, in two different ways depending on how you got there. Both halves are here because neither alone makes the behaviour correct: one fixes where the frame goes, the other fixes whether its events are alive.

## 1. Released into a hidden parent

The release path handed the frame back to the parent it was captured from, and that parent is `PlayerFrame` — which EUI hides whenever it renders its own player frame. Edit Mode does the same from the other side, re-parenting the bar into a layout frame that gets hidden on exit. Either way the bar ends up armed and unreachable, indistinguishable from the suppression never lifting.

The unconditional `SetUnit("player")` that #991 removed had been masking this by making Blizzard re-home the frame as a side effect.

Confirmed in-game by dump, in this order:

| Check | Result |
|---|---|
| `IsEventRegistered("UNIT_SPELLCAST_START")` | `true` — #991's ownership code working |
| `_playerCastBarSuppressors` / `castBarSuppressed` | `{}` / `false` — release ran, ownership cleared |
| `_GetFFD(PlayerCastingBarFrame).origParent` | `PlayerFrame` — restored into a hidden parent |

Release now falls back to `UIParent` when the captured parent is not visible. Edit Mode positions the bar from `UIParent` anyway and `SetParent` leaves anchors intact, so it still lands where the user had it. The un-park is gated on EUI having parked it — still in our hidden parent, or in the captured parent while that parent is hidden. A bar parked under some other frame belongs to another addon and is left alone, which is the case #991 protects.

## 2. The re-arm never re-armed anything

Logging in with the cast bar already off produced a different failure: events unregistered, frame in its normal container. The re-arm called `SetUnit` with the unit the frame already held, and `CastingBarMixin:SetUnit` guards its entire body on `self.unit ~= unit`, so nothing was registered.

Forcing that guard open is not an option — `SetUnit` runs `StopAnims` → `StopFinishAnims`, which iterates a table that cannot be accessed while tainted:

```
attempted to iterate a table that cannot be accessed while tainted (execution tainted by 'EllesmereUI')
[Blizzard_UIPanels_Game/Mainline/CastingBarFrame.lua]:722: in function 'StopFinishAnims'
[Blizzard_UIPanels_Game/Mainline/CastingBarFrame.lua]:119: in function 'SetUnit'
```

That guard is the only reason the original no-op call ever looked harmless. The events are now registered directly, mirroring the set oUF's Castbar element restores when it disables — the one path that has ever actually re-armed these frames, and one that runs no Blizzard code. The pet bar is covered too; oUF silences it alongside the player's.

`RestoreBlizzCastBarEvents` also treated "EUI does not own this" as "another addon owns this" and re-silenced the frame, so the release re-registered the events on the way past and the restore tore them straight back down. A foreign claim is now recorded explicitly when an `UnregisterAllEvents` lands outside a capture window, and only that re-silences. Registered-but-unclaimed means EUI's own bookkeeping lost track, and is left armed: a visible Blizzard cast bar is something the user can switch off, a dead one is not.

`DisableBlizzard("player")` on the hidden player-frame source is now wrapped in a capture window too — it unregisters PlayerFrame's cast bar child, so without the window EUI recorded its own silence as a third-party claim.

Adds an opt-in trace behind `EllesmereUIDB._CBDEBUG`, persisted so it can be armed before a relog, which is when these decisions happen.

## Testing

- Standalone cast bar addon enabled → it keeps the frame, Blizzard's does not reappear beside it (#991's case still holds).
- EUI's cast bar turned off mid-session → Blizzard's cast bar appears and casts normally.
- Logged in with EUI's cast bar already off → Blizzard's cast bar works.
- EUI's cast bar re-enabled → Blizzard's goes away again, no doubling.

Supersedes #999, which carried the second half on its own.

### Required Giphy
<img width="480" height="480" alt="Greatest Of All Time Goat GIF by Nutrena Feed" src="https://github.com/user-attachments/assets/d7f7f4ab-3007-4272-a232-ca4933c358b7" />
