### PR TITLE
Fix Burning Rush Movement Alert erroring and not showing when cast in combat

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -26,6 +26,13 @@ local function IsSecret(value)
     return issecretvalue and issecretvalue(value) or false
 end
 
+-- Secret values throw on any comparison (==, <, ...) once execution is
+-- tainted, so route a payload field through this before comparing it.
+local function PlainValue(value)
+    if IsSecret(value) then return nil end
+    return value
+end
+
 local inCombat = false
 
 -------------------------------------------------------------------------------
@@ -758,7 +765,7 @@ local function OnPlayerBuffActiveAuraUpdate(updateInfo)
                 local state = buffActiveState[key]
                 if state and state.instanceID then
                     for _, instanceID in ipairs(updateInfo.removedAuraInstanceIDs) do
-                        if instanceID == state.instanceID then
+                        if PlainValue(instanceID) == state.instanceID then
                             SetBuffActiveState(key, false, nil)
                             expectingBuffAura[key] = nil
                             break
@@ -773,24 +780,30 @@ local function OnPlayerBuffActiveAuraUpdate(updateInfo)
             if entry.checkType == "buffActive" then
                 local key = BuffActiveKey(entry)
                 if expectingBuffAura[key] then
-                    -- Prefer an exact spellId match. Only fall back to
-                    -- accepting a nil/secret spellId (can't compare it
-                    -- directly) when it's the ONLY aura in this batch --
-                    -- otherwise an unrelated aura landing in the same batch
-                    -- as the real one could get matched instead.
-                    local unambiguous = #updateInfo.addedAuras == 1
+                    -- Prefer an exact spellId match, but in combat the field is
+                    -- a secret value we can't read at all. Fall back to the
+                    -- batch's only unreadable aura -- with more than one there
+                    -- is no way to tell which is ours, so leave the expectation
+                    -- standing rather than latch onto an unrelated aura.
+                    local match, unreadable, unreadableCount = nil, nil, 0
                     for _, aura in ipairs(updateInfo.addedAuras) do
-                        local matches = (aura.spellId == key)
-                            or (unambiguous and (not aura.spellId or IsSecret(aura.spellId)))
-                        if matches and aura.auraInstanceID then
-                            SetBuffActiveState(key, true, aura.auraInstanceID)
-                            expectingBuffAura[key] = nil
-                            break
+                        local sid = PlainValue(aura.spellId)
+                        if sid then
+                            if sid == key then match = aura; break end
+                        else
+                            unreadable = aura
+                            unreadableCount = unreadableCount + 1
                         end
+                    end
+                    if not match and unreadableCount == 1 then match = unreadable end
+                    if match and match.auraInstanceID then
+                        SetBuffActiveState(key, true, match.auraInstanceID)
+                        expectingBuffAura[key] = nil
                     end
                 end
                 for _, aura in ipairs(updateInfo.addedAuras) do
-                    if aura.spellId and not IsSecret(aura.spellId) and aura.spellId == key and aura.auraInstanceID then
+                    local sid = PlainValue(aura.spellId)
+                    if sid and sid == key and aura.auraInstanceID then
                         SetBuffActiveState(key, true, aura.auraInstanceID)
                     end
                 end


### PR DESCRIPTION
### Reported by @Setchi (8.5.8, QoL)

Casting an aura-tracked movement spell (Burning Rush) **while already in combat** spammed Lua errors and the text alert never appeared. Out of combat it worked fine.

```
...EllesmereUIQoL_MovementAlert.lua:783: attempt to compare field 'spellId'
(a secret number value, while execution tainted by 'EllesmereUIQoL')
```

1356 occurrences in the reporter's log. "Combat Only" on or off made no difference.

### Root cause

The added-aura matcher in `OnPlayerBuffActiveAuraUpdate` read `aura.spellId` with `==` in the *first* operand, and only checked `IsSecret(aura.spellId)` in the second:

```lua
local matches = (aura.spellId == key)
    or (unambiguous and (not aura.spellId or IsSecret(aura.spellId)))
```

`aura.spellId` is a secret value once execution is tainted, and comparing a secret throws. The compare on the left blew up before the secret-value fallback on the right was ever evaluated, so that guard was dead code. The handler died before it could record the aura, which is why the alert never showed.

### Fix

- Added a `PlainValue()` helper beside `IsSecret` that resolves a secret to nil, so no comparison ever touches one. It avoids an internal `value == nil` for the same reason (`IsSecret(nil)` is already false, so a plain early return covers nil).
- Routed the added-aura compares and the `removedAuraInstanceIDs` compare through it. The latter is the toggle-off-in-combat path.
- Widened the ambiguity rule from "batch contains exactly 1 aura" to "batch contains exactly 1 *unreadable* aura". In combat `spellId` is always unreadable, so under the old rule any unrelated aura landing in the same `UNIT_AURA` batch suppressed the alert. It still declines to guess when more than one aura is unreadable.

### Notes

`UNIT_SPELLCAST_SUCCEEDED`'s spellId and `auraInstanceID` are both non-secret (visible in the reporter's locals dump), and the cast event arrives before the aura batch, so the existing instance-ID tracking for buff removal is unaffected.

`IsBuffActiveDisplayed` still restricts `C_UnitAuras.GetPlayerAuraBySpellID` to out of combat. Calling it in the combat path would give an unambiguous match instead of the heuristic, but its behavior under taint in combat is unverified, so that is left alone here.

No other instance of this compare pattern exists in the aura payload handlers (checked Nameplates, PlayerAuras, RaidFrames, BuffManager).

### Testing

Verified in-game as a Warlock: toggling Burning Rush on and off while in combat now shows and clears the alert with no errors.

### Required Giphy
<img width="198" height="354" alt="gif" src="https://github.com/user-attachments/assets/a0878636-53f1-41bc-bf8a-38293113811e" />
