### PR TITLE
Fix Pet Bar visibility modes being ignored or inverted

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -6121,33 +6121,37 @@ local function BuildVisibilityString(info, s, visOverride)
     -- Pet bar has unique logic: it only shows when a pet is active and
     -- the player is not in a vehicle/override/possess state.
     if info.isPetBar then
+        -- Both paths fold the mode's AND terms INTO the pet wrapper bracket.
+        -- Adjacent bracket groups are OR in macro grammar, so a mode clause
+        -- placed beside the wrapper ("[...pet...] [combat] show") matched on
+        -- the pet term alone and ignored the mode entirely -- which inverted
+        -- the two dragonriding modes. A negated axis has no AND token, so it
+        -- becomes a leading hide gate instead (same technique as visOptHide).
+        local conj, negGate
         if vm then
-            -- Multi path: combat/dragon conjuncts join the pet wrapper
-            -- bracket (AND); group modes are structurally unsupported here
-            -- (locked in the UI, stripped by sync copies).
-            local conj, negGate = EAB.BuildVisModeConjuncts(vm)
-            local bracket = "[novehicleui,pet,nooverridebar,nopossessbar"
-            if conj ~= "" then bracket = bracket .. "," .. conj:sub(1, -2) end
-            bracket = bracket .. "]"
-            return "[petbattle] hide; " .. visOptHide .. negGate .. bracket .. " show; hide"
-        end
-        local petShow
-        if vis == "in_combat" then
-            petShow = "[combat] show; hide"
-        elseif vis == "out_of_combat" then
-            petShow = "[nocombat] show; hide"
-        elseif vis == "show_dragonriding" then
-            petShow = "[advflyable,flying] show; hide"
-        elseif vis == "show_not_dragonriding" then
-            petShow = "[advflyable,flying] hide; show"
-        elseif s.combatShowEnabled then
-            petShow = "[combat] show; hide"
-        elseif s.combatHideEnabled then
-            petShow = "[combat] hide; show"
+            -- Group modes are structurally unsupported here (locked in the
+            -- UI, stripped by sync copies).
+            conj, negGate = EAB.BuildVisModeConjuncts(vm)
         else
-            petShow = "show"
+            conj, negGate = "", ""
+            if vis == "in_combat" then
+                conj = "combat,"
+            elseif vis == "out_of_combat" then
+                conj = "nocombat,"
+            elseif vis == "show_dragonriding" then
+                conj = "advflyable,flying,"
+            elseif vis == "show_not_dragonriding" then
+                negGate = "[advflyable,flying] hide; "
+            elseif s.combatShowEnabled then
+                conj = "combat,"
+            elseif s.combatHideEnabled then
+                negGate = "[combat] hide; "
+            end
         end
-        return "[petbattle] hide; " .. visOptHide .. "[novehicleui,pet,nooverridebar,nopossessbar] " .. petShow .. "; hide"
+        local bracket = "[novehicleui,pet,nooverridebar,nopossessbar"
+        if conj ~= "" then bracket = bracket .. "," .. conj:sub(1, -2) end
+        bracket = bracket .. "]"
+        return "[petbattle] hide; " .. visOptHide .. negGate .. bracket .. " show; hide"
     end
 
     -- Build the hide-prefix based on bar type


### PR DESCRIPTION
### Problem

Reported by @Moshwan (8.5.9, Action Bars): with **When Not Dragon Riding** selected, the Pet Bar hides while grounded and shows while skyriding, the exact inverse of every other bar set to the same option.

### Cause

The Pet Bar builds its own `state-visibility` driver in `BuildVisibilityString`, because it also has to gate on `[pet]` and the vehicle/override/possess states. The legacy single-mode path appended the mode clause *next to* that wrapper bracket:

```
[petbattle] hide; [novehicleui,pet,nooverridebar,nopossessbar] [advflyable,flying] hide; show; hide
```

Adjacent bracket groups are **OR** in macro-conditional grammar, not AND. With a pet out, `[novehicleui,pet,nooverridebar,nopossessbar]` matched on its own and the driver took `hide` while grounded, so the mode clause never got a say.

The same string broke the other single modes on the Pet Bar for the same reason:

| Mode | Actual driver behaviour before this PR |
|---|---|
| When Dragon Riding | shown whenever a pet is out, grounded included |
| When Not Dragon Riding | hidden whenever a pet is out, inverted |
| In Combat / Out of Combat | shown unconditionally |
| legacy `combatShowEnabled` / `combatHideEnabled` | shown unconditionally |

The multi-select path (two or more checked items) was already correct: `BuildVisModeConjuncts` folds its terms **into** the wrapper bracket. Only single selections hit the broken string.

### Fix

The single-mode path now builds the same `conj` / `negGate` pair as the multi-select path and folds the terms into one bracket so they AND. A negated axis has no AND token, so it is emitted as a leading hide gate instead, the same technique the existing `visOptHide` clauses already use:

```
[petbattle] hide; [advflyable,flying] hide; [novehicleui,pet,nooverridebar,nopossessbar] show; hide
```

`Always` produces a byte-identical string to before. Group modes stay structurally unsupported on the Pet Bar, unchanged, they are locked in the UI and stripped by sync copies.

### Testing

- `luac -p` clean.
- In-game: pet out, Pet Bar set to **When Not Dragon Riding** as a single selection. Bar is visible on the ground and hides once actually skyriding. **When Dragon Riding** and **In Combat** verified on the Pet Bar as well.

### Required Giphy
<img width="450" height="450" alt="Squirrel Coding GIF by JetBrains" src="https://github.com/user-attachments/assets/b48e1e02-4fee-4be4-a7d0-99dda8b8167c" />

