### PR TITLE
refresh micro_menu to show after pet_battle

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -4094,6 +4094,7 @@ ns.BlockFactories.micromenu = function(blockCfg, slot, content, barCtx)
         "GUILD_ROSTER_UPDATE", "BN_FRIEND_ACCOUNT_ONLINE", "BN_FRIEND_ACCOUNT_OFFLINE",
         "FRIENDLIST_UPDATE",
         "PLAYER_REGEN_ENABLED", "PLAYER_REGEN_DISABLED", "PLAYER_ENTERING_WORLD",
+        "PET_BATTLE_OPENING_START", "PET_BATTLE_OVER",
     }
 
     -- Per-instance button sets (unique global names per instance).
@@ -4470,6 +4471,8 @@ ns.BlockFactories.micromenu = function(blockCfg, slot, content, barCtx)
             or event == 'BN_FRIEND_ACCOUNT_OFFLINE'
             or event == 'FRIENDLIST_UPDATE' then
             UpdateFriendText()
+        elseif event == 'PET_BATTLE_OPENING_START' or event == 'PET_BATTLE_OVER' then
+            ns.RefreshMicroMenuHider()
         else
             -- REGEN x2 / PLAYER_ENTERING_WORLD: retry deferred button
             -- creation and re-apply the combat state.


### PR DESCRIPTION


<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

fixed micro_menu hidden after pet_battle

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
