### PR TITLE
fix(raidframes): stop the unit tooltip mode from hiding aura tooltips

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -897,9 +897,10 @@ local BMSIMPLE_CAP   = 10  -- max buffs the Simple Setup grid can show per butto
 local function BM_TooltipOnEnter(self)
     local u, iid = self._tipUnit, self._tipIID
     if not u or not iid or issecretvalue(iid) then return end
-    -- Honor the same "Show Raid Frames Tooltip" combat-visibility mode as the
-    -- unit/debuff tooltips so one setting governs every raid-frame hover tip.
-    if ns.RaidFrameTooltipAllowed and not ns.RaidFrameTooltipAllowed(self._ownerButton) then return end
+    -- Governed ONLY by the buff "Hide Tooltips" toggle (BM_SetTipTarget leaves
+    -- the frame mouse-transparent while that is on). The "Show Raid Frames
+    -- Tooltip" mode covers the UNIT tooltip and must not veto an aura tip the
+    -- user explicitly enabled in a different section.
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
     if GameTooltip.SetUnitAuraByAuraInstanceID then
         GameTooltip:SetUnitAuraByAuraInstanceID(u, iid)

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -4331,8 +4331,10 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v) SSet("tooltipMode", v) end });  y = y - h
         -- Cog: buff/HoT aura-icon tooltips (Buff Manager). Hidden by default --
         -- matches the long-standing behavior where buff icons showed no tooltip;
-        -- opt in here. When shown, the aura tip still follows the tooltip mode
-        -- on this dropdown (mode governs when, this governs whether).
+        -- opt in here. This is the ONLY gate on the aura tip: the tooltip mode
+        -- on this dropdown governs the UNIT tooltip and must not veto an aura
+        -- tip enabled here (it used to, so a hidden unit tip also killed the
+        -- aura tip -- see ns.RaidFrameTooltipAllowed).
         do
             local rgn = row._rightRegion
             local tipRows

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -879,10 +879,11 @@ ns._ResolveTooltipMode = function(s)
     return "outOfCombat"
 end
 
--- Whether raid-frame hover tooltips are allowed right now, per the "Show Raid
--- Frames Tooltip" mode + current combat state. Shared by the unit tooltip and
--- the buff/debuff aura-icon tooltips so one setting governs every raid-frame
--- tip (an aura tip is still gated by its own "Hide Tooltips" toggle on top).
+-- Whether the raid/party frame's UNIT tooltip is allowed right now, per the
+-- "Show Raid Frames Tooltip" mode + current combat state. Scope is the unit tip
+-- only: the buff/debuff aura-icon tips are governed solely by their own section's
+-- "Hide Tooltips" toggle, so turning the unit tooltip off never silently
+-- overrides an aura tooltip the user enabled elsewhere.
 function ns.RaidFrameTooltipAllowed(button)
     local fd = button and ns.GetFFD and ns.GetFFD(button)
     local s = (fd and (fd._isParty and ns._scaledPartyProxy
@@ -3530,8 +3531,11 @@ local function StyleButton(button)
                 fd._hovered = true
                 if fd.ApplyBorderColor then fd.ApplyBorderColor() end
             end
-            -- Aura tooltip honors the same combat-visibility mode as the unit tip.
-            if not ns.RaidFrameTooltipAllowed(b) then return end
+            -- Governed ONLY by the Debuff Display "Hide Tooltips" toggle (the
+            -- icon is mouse-transparent while that is on, so reaching here means
+            -- the user asked for this tip). The "Show Raid Frames Tooltip" mode
+            -- covers the UNIT tooltip and must not veto an aura tip the user
+            -- explicitly enabled in a different section.
             GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
             if GameTooltip.SetUnitAuraByAuraInstanceID then
                 GameTooltip:SetUnitAuraByAuraInstanceID(u, iid)
@@ -3936,23 +3940,18 @@ local function StyleButton(button)
                 if mf ~= self and mf._tipIID ~= nil then return end
             end
         end
-        -- Read through the party-aware proxy (like every other render path), not
-        -- raw db.profile -- otherwise party_<key> overrides written by a custom
-        -- party "Range & Tooltip" section are never seen and the tooltip mode
-        -- dropdown appears to do nothing on party frames.
-        local s = fd._isParty and ns._scaledPartyProxy or (fd._isExtra and ns._scaledExtraProxy) or ns._scaledProfile
-        -- Raid/party frame tooltips are governed by the "Show Raid Frames
+        -- Raid/party frame UNIT tooltips are governed by the "Show Raid Frames
         -- Tooltip" mode, and ONLY these frames -- no other unit tooltips are
-        -- touched. never = no tooltip; outOfCombat = hidden in any combat;
-        -- outOfBossCombat = hidden during an encounter; always = always shown.
-        -- The peek modifier (Blizz UI Enhanced) lifts the mode while held so a
-        -- hidden tip can be read on hover, in step with the global tooltips.
-        if not (EllesmereUI._tooltipPeekHeld and EllesmereUI._tooltipPeekHeld()) then
-            local ttMode = ns._ResolveTooltipMode(s)
-            if ttMode == "never" then return end
-            if ttMode == "outOfCombat" and inCombat then return end
-            if ttMode == "outOfBossCombat" and ns._inBossCombat then return end
-        end
+        -- touched, and the aura-icon tips have their own toggles. never = no
+        -- tooltip; outOfCombat = hidden in any combat; outOfBossCombat = hidden
+        -- during an encounter; always = always shown. The peek modifier (Blizz
+        -- UI Enhanced) lifts the mode while held so a hidden tip can be read on
+        -- hover, in step with the global tooltips. The helper reads through the
+        -- party-aware proxy (like every other render path), not raw db.profile
+        -- -- otherwise party_<key> overrides written by a custom party "Range &
+        -- Tooltip" section are never seen and the dropdown appears to do
+        -- nothing on party frames.
+        if not ns.RaidFrameTooltipAllowed(self) then return end
         local u = self:GetAttribute("unit")
         if u and UnitExists(u) then
             GameTooltip_SetDefaultAnchor(GameTooltip, self)


### PR DESCRIPTION
## Raid/party frame tooltip mode no longer hides aura tooltips

Reported by @Nihyo (Party Frames): with raid/party frame tooltips hidden,
debuff tooltips were hidden too, even with "Hide Tooltips" explicitly
unchecked in the Debuff Display section. Noticed while healing, hovering an
unknown debuff on a party frame produced no tooltip at all.

### Cause

Both aura-icon tooltip handlers AND-gated themselves against the unit
tooltip's visibility mode via the shared `RaidFrameTooltipAllowed`:

- the debuff icon `OnEnter` in `EllesmereUIRaidFrames.lua`
- `BM_TooltipOnEnter` in `EUI_RaidFrames_BuffManager.lua`

So "Show Raid Frames Tooltip" set to Never, or to an out-of-combat mode
while in combat, vetoed the aura tooltip regardless of that display's own
"Hide Tooltips" toggle.

Each aura display already leaves its icon fully mouse-transparent while its
own toggle is on, so reaching either handler at all means the user asked for
that tip. A setting in a different section should not override it.

### Fix

Drop the gate from both handlers. The unit tooltip keeps the visibility mode
and now routes through the shared helper instead of an inlined copy of the
same logic.

This also brings 12.0 in line with the 12.1 aura-container path, where debuff
tooltips are already governed only by `debuffHideTooltips`.

### Notes

- Private auras were unaffected: `paHideTooltip` works by collapsing the slot
  frame to a sub-pixel point and never consults the tooltip mode.
- Third commit is comment-only, correcting a note on the buff tooltip cog that
  still described the old "mode governs when" behavior.

### Testing

Verified in-game on 12.0 (build 120007), party frames in a follower dungeon:

- Mode **Never** + Debuff Display "Hide Tooltips" unchecked: debuff tooltip now
  appears (previously nothing), while the unit tooltip stays suppressed.
- Mode **Always**: unit tooltip appears as normal on the frame body, and hovering
  an aura icon still yields the aura tooltip rather than the unit tooltip.
- Buff/HoT half: cog "Hide Buff Tooltips" unchecked, HoT tooltip appears.