### PR TITLE
fix(minimap): re-anchor the border host so the border cannot vanish

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -4201,10 +4201,25 @@ local function ApplyMinimap()
         local host = GetFFD(minimap).borderHost
         if not host then
             host = CreateFrame("Frame", nil, minimap)
-            host:SetAllPoints(minimap)
             host:EnableMouse(false)
             GetFFD(minimap).borderHost = host
         end
+        -- Re-anchor on EVERY apply, not just on the create branch. This pass
+        -- queues the Minimap's reparent to UIParent a frame out (see above),
+        -- and a host anchored across that reparent keeps its stored points
+        -- while the engine never resolves them: GetPoint still reports
+        -- TOPLEFT/BOTTOMRIGHT against a valid Minimap, but the host comes out
+        -- 0x0 with IsRectValid false, so it -- and the backdrop anchored to
+        -- it -- draws nothing. Every other property (shown, visible, alpha,
+        -- parent, backdrop table, texture path) reads healthy in that state,
+        -- which is why it presented as a border setting that would not survive
+        -- a reload even though the stored value was never lost. Anchoring only
+        -- at creation made it permanent for the session, and whether it
+        -- happened came down to how much else was loading at login -- so it
+        -- tracked unrelated modules being enabled. Re-setting the points
+        -- forces the layout to recompute and is a no-op when they are fine.
+        host:ClearAllPoints()
+        host:SetAllPoints(minimap)
         -- Same level as the minimap keeps the border under all child buttons
         -- (matching the old strips-on-minimap rendering); Show Behind drops it
         -- under the map surface for the Shadow style.


### PR DESCRIPTION
## Summary

The minimap Border Style would sometimes be gone after a `/reload`, and it could not be
reproduced on demand. One reporter narrowed it to an apparent dependency on an unrelated
module: with EllesmereUI Unit Frames enabled the border was there, with it disabled the
border was missing after every reload.

The setting was never actually lost. Dumping the profile after a bad reload returned the
chosen style intact. The border simply stopped being drawn.

## What was happening

The border is not drawn on the Minimap itself. It is drawn on an invisible host frame
that sits exactly on top of it, and that frame is told to match the Minimap's position
and size. That instruction was only ever given once, on the branch that creates it:

```lua
local host = GetFFD(minimap).borderHost
if not host then
    host = CreateFrame("Frame", nil, minimap)
    host:SetAllPoints(minimap)   -- only ever runs once
    ...
end
```

That branch runs inside the same `ApplyMinimap` pass that queues the Minimap's reparent
to `UIParent` a frame later. If the host is created inside that window, its anchors are
recorded but the engine never resolves them, and it ends up sized `0x0`. A frame with no
rect draws nothing, and the backdrop anchored to that host inherits the dead rect.

Captured from an affected client:

```
host points=2 parent=Minimap
  1: TOPLEFT     -> Minimap [has rect] TOPLEFT     (0.0, 0.0)
  2: BOTTOMRIGHT -> Minimap [has rect] BOTTOMRIGHT (0.0, 0.0)
host geom:    scale=1.0000 effScale=0.7111 size=0.0x0.0     rectValid=false
minimap geom: scale=1.0000 effScale=0.7111 size=140.0x140.0 rectValid=true
```

Correct anchors against a valid target, correct scale, and still `0x0` with an invalid
rect. `GetPoint` reports what was set, not what resolved.

This was awkward to track down because the frame passes every obvious health check while
broken: shown, visible, alpha 1 through the whole chain, correct parent, backdrop table
with the right `edgeFile` and `edgeSize`, texture path resolving. Only the resolved rect
gives it away. Since nothing re-anchors the host after creation, the dead rect lasted the
entire session.

The Unit Frames connection is incidental. That module never touches the Minimap; it is
simply large enough that loading it shifts startup timing, which decided whether the host
was created before or after the reparent settled. That is also why the bug appeared to
come and go at random and could not be reproduced by anyone else.

## Fix

Move the anchoring out of the create branch and re-assert it on every apply. Re-setting
identical points forces the layout to recompute and is a no-op when the rect is already
valid.

## Testing

Verified in game by the reporter who could reproduce it, on the affected character:

- Unit Frames disabled, Shadow border style, previously missing after every login.
- With the fix, the border is present after login.
- Confirmed numerically as well as visually: the host rect now resolves to `140x140`
  with `rectValid=true`, where it previously read `0x0` with `rectValid=false`.

## Required Giphy
<img width="458" height="450" alt="Surprised Cat GIF" src="https://github.com/user-attachments/assets/066d74a1-4d23-46df-92e1-c16f53d11b86" />
