### PR TITLE
fix(cdm): match active-state rules on trinkets after a logout

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -1427,5 +1427,35 @@ if EllesmereUI then
         ns._fakeActiveDebug = not ns._fakeActiveDebug
         print(("|cff0cd29fEUI FakeActive|r debug %s | armed=%s rules=%d"):format(
             ns._fakeActiveDebug and "ON" or "off", tostring(_armed), #_rules))
+
+        -- Per-rule dump. "armed with N rules" reads true in every broken report,
+        -- so on its own it separates nothing. What matters per rule is whether
+        -- its trigger resolved to a cast spell at all, and whether any live icon
+        -- carries its key -- the two independent ways a rule goes inert.
+        local FCt, icons = ns._ecmeFC, ns.cdmBarIcons
+        for i = 1, #_rules do
+            local rule = _rules[i]
+            local triggers = {}
+            for sp, list in pairs(_castMap) do
+                for j = 1, #list do
+                    if list[j] == rule then triggers[#triggers + 1] = sp end
+                end
+            end
+            local matched = 0
+            if FCt and icons then
+                for _, list in pairs(icons) do
+                    for j = 1, #list do
+                        local f = list[j]
+                        local fc = f and FCt[f]
+                        if fc and KeyMatches(rule.spellID, fc.spellID) then matched = matched + 1 end
+                    end
+                end
+            end
+            print(("  rule%d key=%s src=%s dur=%s trigger=%s casts=[%s] frames=%d%s"):format(
+                i, tostring(rule.spellID), tostring(rule.srcKey), tostring(rule.duration),
+                tostring(rule.trigger),
+                (#triggers > 0) and table.concat(triggers, ",") or "|cffff4444NONE|r",
+                matched, (matched == 0) and " |cffff4444<- no icon|r" or ""))
+        end
     end
 end

--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -118,6 +118,43 @@ local ResolveCastSpells
 local PresetOnCD, ApplyCdState, RestoreAllCdState, EnsureCdStateTicker, EvalCdStateNow
 
 -- ---------------------------------------------------------------------------
+--  Icon identity: slot key <-> equipped item key
+-- ---------------------------------------------------------------------------
+-- The same icon can be named by two different tokens. An equipped trinket is
+-- -itemID in the settings store (ResolveCustomActiveKey maps a slot frame to
+-- the equipped item so each item tracks separately) and -13/-14 on the slot
+-- frame itself. Which token a RULE ends up with depends on whether equipment
+-- data was readable at re-arm -- and at login it is not: GetInventoryItemID
+-- returns nil, the equipped-trinket skip in Rearm does not fire, and the rule
+-- is keyed -itemID while the frame that renders moments later carries -13.
+-- Nothing reconciled them, so the rule sat armed against an icon that did not
+-- exist for the rest of the session; any settings touch re-armed with
+-- equipment present and it started working, which is the "dead until I open
+-- the setting again" report.
+--
+-- Comparing through this map fixes every ordering variant at once, because it
+-- resolves at MATCH time (frames render long after equipment is available)
+-- rather than at arm time. Kept as a table so the hot loops below cost a
+-- lookup rather than an API call per frame per rule.
+local _slotItemKey = {}
+
+local function RefreshSlotItemKeys()
+    wipe(_slotItemKey)
+    for slot = 13, 14 do
+        local id = GetInventoryItemID and GetInventoryItemID("player", slot)
+        if id then _slotItemKey[-slot] = -id end
+    end
+end
+
+-- Refreshed lazily while empty (covers the login window, where re-arm ran
+-- before equipment was readable) and on every equipment change.
+local function KeyMatches(ruleKey, frameKey)
+    if ruleKey == frameKey then return true end
+    if not next(_slotItemKey) then RefreshSlotItemKeys() end
+    return _slotItemKey[frameKey] == ruleKey or _slotItemKey[ruleKey] == frameKey
+end
+
+-- ---------------------------------------------------------------------------
 --  Overlay icon: one per underlying icon frame, pooled. Toggled by alpha only.
 -- ---------------------------------------------------------------------------
 GetOverlay = function(iconFrame)
@@ -331,7 +368,7 @@ ApplyRule = function(rule, win)
         for i = 1, #list do
             local f = list[i]
             local fc = f and FCt[f]
-            if fc and fc.spellID == sid and (not rule.barKey or fc.barKey == rule.barKey) then
+            if fc and KeyMatches(sid, fc.spellID) and (not rule.barKey or fc.barKey == rule.barKey) then
                 ApplyToFrame(f, rule, win)
                 if ns._fakeActiveDebug then
                     print(("|cff0cd29fEUI FakeActive|r %s sid=%s"):format(
@@ -460,7 +497,7 @@ if EllesmereUI and EllesmereUI.IS_121 then
                     for i = 1, #list do
                         local f = list[i]
                         local fc = f and FCt[f]
-                        if fc and fc.spellID == rule.spellID then
+                        if fc and KeyMatches(rule.spellID, fc.spellID) then
                             local barKey = fc.barKey
                             bd = barKey and ns.barDataByKey and ns.barDataByKey[barKey]
                             ss = rule.cas
@@ -810,6 +847,7 @@ OnEvent = function(self, event, unit, _, spellID)
         -- A trinket swap re-points a slot's settings to a different item; re-arm
         -- so the slot picks up the newly-equipped trinket's rule (or none).
         if unit == 13 or unit == 14 then
+            RefreshSlotItemKeys()
             ns.FakeActive_Rearm()
         end
     end
@@ -1111,7 +1149,7 @@ EvalCdStateNow = function()
                 for i = 1, #list do
                     local f = list[i]
                     local fc = f and FCt[f]
-                    if fc and fc.spellID == sid then
+                    if fc and KeyMatches(sid, fc.spellID) then
                         hasIcon = true
                         if eff then ApplyCdState(f, fc, cas, eff, onCD, ready) end
                     end
@@ -1257,6 +1295,9 @@ function ns.FakeActive_Rearm()
     RestoreAllCdState()  -- un-hide / un-glow icons from the outgoing rule set
     CloseAll()
     wipe(_rules); wipe(_auraRules); wipe(_customRules); wipe(_castMap); wipe(_cdStateRules)
+    -- Re-read rather than wipe: a re-arm during the login window would leave
+    -- the map empty and the lazy refresh in KeyMatches would just rebuild it.
+    RefreshSlotItemKeys()
     _needAura, _needCast, _armed, _hasUserRules = false, false, false, false
     if FA121 then FA121.BeginSweep() end
 


### PR DESCRIPTION
## Problem

A custom Active State set on a trinket stopped working after a logout, and stayed dead
until the setting was opened again. Reported as a setting that would not persist, which
is how it was chased for a long time -- but the stored value was never lost.

## Cause

An icon can be named by two different tokens:

- `-itemID` in the settings store. `ResolveCustomActiveKey` maps a slot frame to the
  equipped item so each item tracks its own settings.
- `-13` / `-14` on the trinket slot frame itself.

Which one a RULE ends up with depends on whether `GetInventoryItemID` was readable when
rules were armed. **At login it is not.** The equipped-trinket skip in `FakeActive_Rearm`
never fires, so the rule is keyed `-itemID`, while the frame that renders moments later
carries `-13`. `ApplyRule` compares `fc.spellID` by raw equality, so nothing ever matched.

Nothing reconciled the two afterwards, so the rule sat armed against an icon that did not
exist for the rest of the session. Any settings touch forced a rebuild, which re-armed
with equipment present, produced the slot key, and it started working again -- hence
"I have to choose it again".

Captured live on an affected client:

```
rule3 key=-249339 src=-249339 dur=20 trigger=cast casts=[1260633] frames=0 <- no icon
```

The trigger resolved correctly. The rule simply addressed a key no icon carried. `src`
equal to the item key confirms it came from the main loop rather than the slot pass,
which only happens when the equipment lookup returned nil.

## Fix

Compare through a slot-key -> equipped-item-key map instead of raw equality. Resolving at
MATCH time rather than arm time fixes every ordering variant at once, because frames
render long after equipment is readable.

The map is a plain table so the per-frame loops pay a lookup rather than an API call per
frame per rule. It is refreshed on equipment change, at re-arm, and lazily while empty
(which covers the login window).

## Known narrow edge

A profile carrying BOTH a slot-level Apply-to-Bar entry and a per-item entry can arm two
rules during the login window that now resolve to the same frame. The overlay is per
frame, so the later rule wins rather than stacking, and the two entries chain to
near-identical settings. Only a configured CD-ready sound could double there, since the
rules arm under separate `srcKeys`.

## Scope

Item-keyed active states only: trinkets, potions, custom items. Spell keys are positive
and were never exposed to this.

## Testing

Verified in game on an affected character, on a full logout (not a reload), without
opening any settings first:

- Before: `rule9 key=-251787 ... frames=0 <- no icon`, no glow.
- After: `rule9 key=-251787 ... frames=1`, glow runs for its configured 20s.

The second commit is the developer-only diagnostic that identified this; it extends the
existing `EllesmereUI.FakeActiveDebug()` and adds no user-facing surface.
