### PR TITLE
fix(uf): stop a legacy boolean absorb style from breaking frame init

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -5656,6 +5656,14 @@ end
 --   fallback  - path to use if nothing resolves (optional)
 function EllesmereUI.ResolveTexturePath(texTable, key, fallback)
     if not key then return fallback end
+    -- A non-string key is legacy data, not a lookup miss: several settings were
+    -- boolean toggles before they became style dropdowns (showPlayerAbsorb is
+    -- one). Callers gate on truthiness, so a stored `true` passes their check
+    -- and arrives here, where the :match below raises. That error fires inside
+    -- unit frame initialisation and aborts the whole build -- a white player
+    -- frame and a settings tab that will not open, from one stale boolean.
+    -- Treat it as unset and let the caller's fallback stand.
+    if type(key) ~= "string" then return fallback end
     local path = texTable and texTable[key]
     if path then return path end
     -- If the key has an "sm:" prefix, try LSM directly

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -2181,6 +2181,29 @@ EllesmereUI.RegisterMigration({
     end,
 })
 
+EllesmereUI.RegisterMigration({
+    id          = "uf_absorb_style_boolean_sweep_v1",
+    scope       = "profile",
+    description = "Normalise any remaining boolean showPlayerAbsorb to a style string. uf_absorb_style_dropdown_v1 walked a fixed unit list and stamps per profile, so a profile that arrived AFTER it ran -- an import or a preset, both of which inherit the recipient's migration flags -- kept the legacy boolean.",
+    body = function(ctx)
+        -- Walk every table in the UF blob rather than a unit list: the earlier
+        -- pass missed whichever units were not named in it, and the crash this
+        -- fixes does not care which unit carried the bad value.
+        local uf = ctx.profile.addons and ctx.profile.addons.EllesmereUIUnitFrames
+        if type(uf) ~= "table" then return end
+        for _, unitCfg in pairs(uf) do
+            if type(unitCfg) == "table" then
+                local v = unitCfg.showPlayerAbsorb
+                if v == true then
+                    unitCfg.showPlayerAbsorb = "striped"   -- v1's mapping for true
+                elseif v ~= nil and type(v) ~= "string" then
+                    unitCfg.showPlayerAbsorb = "none"
+                end
+            end
+        end
+    end,
+})
+
 -- Remove ghost buff bar: buff visibility is now managed by Blizzard CDM
 -- settings. Clean up the bar entry from all profiles and spell data from
 -- all spec profiles. One-time migration.

--- a/EllesmereUI_Profiles.lua
+++ b/EllesmereUI_Profiles.lua
@@ -1142,6 +1142,27 @@ function EllesmereUI.ApplyProfileData(profileData)
                 -- the live accessor + RefreshAllAddons rebuild pick it up.
                 for k in pairs(profile) do profile[k] = nil end
                 for k, v in pairs(snap) do profile[k] = DeepCopy(v) end
+                -- Pre-dropdown imports carry showPlayerAbsorb as the legacy
+                -- boolean toggle. The conversion migrations are SKIPPED for
+                -- imported profiles (inherited migration flags), and a boolean
+                -- reaches the texture resolver as a key -- which used to abort
+                -- unit frame init outright. The resolver now refuses non-string
+                -- keys, so this is no longer fatal, but without the conversion
+                -- the absorb still renders as a fallback texture instead of
+                -- honouring the setting. Normalise on the way in, matching the
+                -- mapping the migrations use.
+                if entry.folder == "EllesmereUIUnitFrames" then
+                    for _, unitCfg in pairs(profile) do
+                        if type(unitCfg) == "table" then
+                            local v = unitCfg.showPlayerAbsorb
+                            if v == true then
+                                unitCfg.showPlayerAbsorb = "striped"
+                            elseif v ~= nil and type(v) ~= "string" then
+                                unitCfg.showPlayerAbsorb = "none"
+                            end
+                        end
+                    end
+                end
                 -- Pre-split imports carry the shared totPet table but no
                 -- targettarget/focustarget. The login split migration is SKIPPED
                 -- for imported profiles (ImportProfile builds merged =


### PR DESCRIPTION
## Problem

Reported by @Fel: the Unit Frames settings tab did not respond to clicks, and the player
unit frame would randomly turn all white, often on loading into an instance, needing
several reloads to clear. They suspected the two were related. They were -- both are the
same error, and it aborts unit frame initialisation.

```
EllesmereUI.lua:5653: attempt to index local 'key' (a boolean value)
[EllesmereUI.lua]:5653: in function <EllesmereUI.lua:5648>
[EllesmereUIUnitFrames.lua]:3747: in function 'ResolveAbsorbStyleTex'
[EllesmereUIUnitFrames.lua]:3767: in function <EllesmereUIUnitFrames.lua:3765>
[EllesmereUIUnitFrames.lua]:12310: in function 'InitializeFrames'

key=true
fallback="Interface\AddOns\EllesmereUIUnitFrames\Media\shield.tga"
```

## Cause

`showPlayerAbsorb` was a boolean toggle before it became a style dropdown. Every call
site gates on truthiness:

```lua
local absStyle = db.profile[uKey] and db.profile[uKey].showPlayerAbsorb
if absStyle and absStyle ~= "none" then
    ApplyAbsorbStyle(f.HealthPrediction.damageAbsorb, absStyle, db.profile[uKey])
```

A stored `true` passes that gate and is handed to `ResolveTexturePath` as a texture KEY,
where `key:match("^sm:(.+)")` indexes a boolean and raises. Because the raise happens
inside `InitializeFrames`, the whole frame build aborts -- hence the white frame and the
dead settings tab from a single stale value.

`uf_absorb_style_dropdown_v1` already converts this, but it walks a fixed unit list and
stamps once per profile. A profile that arrives AFTER it has run is never revisited, and
imports and presets inherit the recipient's migration flags -- so the legacy boolean
survives. Upgrading does not clear it, which matches the reporter still seeing this on
the current version.

Nothing writes a boolean at runtime: the only writers are the `"none"` string defaults.
The value can only be legacy data, so this is fixed at the data and resolver level rather
than by chasing a live writer.

## Fix

Three parts:

- **`ResolveTexturePath` refuses a non-string key** and returns the caller's fallback.
  This is the crash fix, and it covers every consumer of the shared resolver (action
  bars, chat, CDM buff bars, damage meters, nameplates, mythic timer, dragon riding),
  not only absorbs.
- **A new profile migration** sweeps any remaining non-string `showPlayerAbsorb`. It
  walks every table in the Unit Frames blob rather than a fixed unit list, since the
  earlier pass missed whichever units it did not name. Its own id means it runs fresh on
  every profile, including ones the v1 pass already stamped.
- **`ApplyProfileData` normalises the same key on import**, matching the six sibling
  forward-copies already there. Without it an imported profile is no longer fatal but
  still renders a fallback texture instead of honouring its setting.

`true` maps to `"striped"` in both places, matching v1's original mapping.

## Testing

Verified in game by the reporter on the current version: the error is gone, frames build
normally, and the Unit Frames settings tab opens.

## Note for reviewers

`EllesmereUI_Profiles.lua` could not be syntax-checked with a Lua 5.4 `luac`: it rejects
a `\ ` escape inside a preset layout string that 5.1 accepts, and the unmodified file
fails identically, so this is pre-existing rather than introduced here. The added block
was validated standalone, including behaviour (`true` -> `striped`, existing strings
preserved, other non-strings -> `none`, `nil` untouched, non-unit tables skipped). The
other two files pass `luac -p` normally.
