### PR TITLE
Add grow-direction option to the Totem Bar

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -691,6 +691,12 @@ local GetPositionDB
 -------------------------------------------------------------------------------
 local function GetBarGrowDirActual(barKey)
     if barKey == "EQT_Tracker" then return "DOWN" end
+    if barKey == "ERB_TotemBar" then
+        local erb = EllesmereUI.Lite.GetAddon("EllesmereUIResourceBars", true)
+        local tb = erb and erb.db and erb.db.profile and erb.db.profile.totemBar
+        local vertical = tb and tb.orientation == "VERTICAL"
+        return (tb and tb.growDirection or (vertical and "DOWN" or "RIGHT")):upper()
+    end
     if barKey:sub(1, 4) == "CDM_" then
         local rawKey = barKey:sub(5)
         local cdm = EllesmereUI.Lite.GetAddon("EllesmereUICooldownManager", true)
@@ -721,6 +727,14 @@ end
 -------------------------------------------------------------------------------
 local function GetBarGrowDir(barKey)
     if barKey == "EQT_Tracker" then return "DOWN" end
+    if barKey == "ERB_TotemBar" then
+        local erb = EllesmereUI.Lite.GetAddon("EllesmereUIResourceBars", true)
+        local tb = erb and erb.db and erb.db.profile and erb.db.profile.totemBar
+        local vertical = tb and tb.orientation == "VERTICAL"
+        local g = (tb and tb.growDirection or (vertical and "DOWN" or "RIGHT")):upper()
+        if g == "CENTER" then return nil end   -- centered = no direction indicator
+        return g
+    end
     if barKey:sub(1, 4) == "CDM_" then
         local rawKey = barKey:sub(5)
         local cdm = EllesmereUI.Lite.GetAddon("EllesmereUICooldownManager", true)
@@ -6034,6 +6048,7 @@ local function CreateMover(barKey)
         MainBar = true, Bar2 = true, Bar3 = true, Bar4 = true,
         Bar5 = true, Bar6 = true, Bar7 = true, Bar8 = true,
         StanceBar = true, PetBar = true,
+        ERB_TotemBar = true,   -- totem bar: align active icons left/right/center
     }
     local canGrow = _GROW_KEYS[barKey] or barKey:sub(1, 4) == "CDM_"
 
@@ -6733,6 +6748,10 @@ local function CreateMover(barKey)
                     if b3.key == barKey:sub(5) then isVert = b3.verticalOrientation == true; break end
                 end
             end
+        elseif barKey == "ERB_TotemBar" then
+            local erb3 = EllesmereUI.Lite.GetAddon("EllesmereUIResourceBars", true)
+            local tb3 = erb3 and erb3.db and erb3.db.profile and erb3.db.profile.totemBar
+            isVert = tb3 and tb3.orientation == "VERTICAL"
         else
             local eab3 = EllesmereUI.Lite.GetAddon("EllesmereUIActionBars", true)
             local s3 = eab3 and eab3.db and eab3.db.profile and eab3.db.profile.bars and eab3.db.profile.bars[barKey]
@@ -6758,6 +6777,10 @@ local function CreateMover(barKey)
                     if b4.key == barKey:sub(5) then currentVal = b4.growDirection or "CENTER"; break end
                 end
             end
+        elseif barKey == "ERB_TotemBar" then
+            local erb4 = EllesmereUI.Lite.GetAddon("EllesmereUIResourceBars", true)
+            local tb4 = erb4 and erb4.db and erb4.db.profile and erb4.db.profile.totemBar
+            currentVal = (tb4 and tb4.growDirection or (isVert and "DOWN" or "RIGHT")):upper()
         else
             local eab4 = EllesmereUI.Lite.GetAddon("EllesmereUIActionBars", true)
             local s4 = eab4 and eab4.db and eab4.db.profile and eab4.db.profile.bars
@@ -6837,6 +6860,12 @@ local function CreateMover(barKey)
                         if EllesmereUI.LayoutCDMBar then
                             EllesmereUI.LayoutCDMBar(rawKey)
                         end
+                        EllesmereUI.RecenterBarAnchor(barKey)
+                    elseif barKey == "ERB_TotemBar" then
+                        local erb = EllesmereUI.Lite.GetAddon("EllesmereUIResourceBars", true)
+                        local tb = erb and erb.db and erb.db.profile and erb.db.profile.totemBar
+                        if tb then tb.growDirection = sideVal end
+                        if EllesmereUI.LayoutTotemBar then EllesmereUI.LayoutTotemBar() end
                         EllesmereUI.RecenterBarAnchor(barKey)
                     else
                         local eab = EllesmereUI.Lite.GetAddon("EllesmereUIActionBars", true)

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --  EllesmereUIResourceBars.lua
 --  Custom class resource, health, and mana bar display
 --  Features: Health bar, primary resource bar (mana/rage/energy/etc),
@@ -7670,8 +7670,29 @@ local function LayoutTotemBar()
     -- Reparent and position TotemFrame every call (Blizzard's Update can reset these)
     TotemFrame:SetParent(totemBarFrame)
     TotemFrame:SetFrameStrata("HIGH")
+    -- Grow direction. Horizontal: RIGHT (default, original left-anchored/grows-right)
+    -- / LEFT (fixed right edge, grows left) / CENTER (group centered). Vertical:
+    -- DOWN (default) / UP (fixed bottom edge, grows up) / CENTER. Invalid combos for
+    -- the current orientation fall back to that orientation's default.
+    local _growDir = (tb.growDirection or (vertical and "DOWN" or "RIGHT")):upper()
+    if vertical then
+        if _growDir ~= "UP" and _growDir ~= "DOWN" and _growDir ~= "CENTER" then _growDir = "DOWN" end
+    else
+        if _growDir ~= "LEFT" and _growDir ~= "RIGHT" and _growDir ~= "CENTER" then _growDir = "RIGHT" end
+    end
+    -- Persist the clamped value so a set-but-stale direction (e.g. RIGHT left over
+    -- after switching to vertical) is corrected once; readers can then trust it.
+    if tb.growDirection and tb.growDirection:upper() ~= _growDir then
+        tb.growDirection = _growDir
+    end
     TotemFrame:ClearAllPoints()
-    TotemFrame:SetPoint(vertical and "TOP" or "LEFT", totemBarFrame, vertical and "TOP" or "LEFT", 0, 0)
+    if vertical then
+        TotemFrame:SetPoint(_growDir == "UP" and "BOTTOM" or "TOP", totemBarFrame,
+            _growDir == "UP" and "BOTTOM" or "TOP", 0, 0)   -- DOWN/CENTER anchored TOP (CENTER re-anchored below)
+    else
+        TotemFrame:SetPoint(_growDir == "LEFT" and "RIGHT" or "LEFT", totemBarFrame,
+            _growDir == "LEFT" and "RIGHT" or "LEFT", 0, 0)  -- RIGHT/CENTER anchored LEFT (CENTER re-anchored below)
+    end
     TotemFrame:Show()
 
     -- Only re-apply scale when setting changed
@@ -7694,6 +7715,18 @@ local function LayoutTotemBar()
     -- Trim stale entries
     for i = count + 1, #buttons do buttons[i] = nil end
 
+    -- CENTER grow: re-anchor TotemFrame so the icon group is centered on the frame.
+    -- Total visual width is in frame (screen) space: count icons + gaps.
+    if _growDir == "CENTER" and count > 0 then
+        local total = count * iconSize + math.max(0, count - 1) * spacing
+        TotemFrame:ClearAllPoints()
+        if vertical then
+            TotemFrame:SetPoint("TOP", totemBarFrame, "CENTER", 0, total / 2)
+        else
+            TotemFrame:SetPoint("LEFT", totemBarFrame, "CENTER", -total / 2, 0)
+        end
+    end
+
     local scaledSpacing = spacing / iconScale
     local zoom = 0.055
     local timerSize = tb.timerSize or 11
@@ -7707,9 +7740,21 @@ local function LayoutTotemBar()
 
         btn:ClearAllPoints()
         if i == 1 then
-            btn:SetPoint(vertical and "TOP" or "LEFT", TotemFrame, vertical and "TOP" or "LEFT", 0, 0)
+            if vertical then
+                local a = (_growDir == "UP") and "BOTTOM" or "TOP"
+                btn:SetPoint(a, TotemFrame, a, 0, 0)
+            else
+                local a = (_growDir == "LEFT") and "RIGHT" or "LEFT"
+                btn:SetPoint(a, TotemFrame, a, 0, 0)
+            end
         elseif vertical then
-            btn:SetPoint("TOP", buttons[i - 1], "BOTTOM", 0, -scaledSpacing)
+            if _growDir == "UP" then
+                btn:SetPoint("BOTTOM", buttons[i - 1], "TOP", 0, scaledSpacing)
+            else
+                btn:SetPoint("TOP", buttons[i - 1], "BOTTOM", 0, -scaledSpacing)
+            end
+        elseif _growDir == "LEFT" then
+            btn:SetPoint("RIGHT", buttons[i - 1], "LEFT", -scaledSpacing, 0)
         else
             btn:SetPoint("LEFT", buttons[i - 1], "RIGHT", scaledSpacing, 0)
         end
@@ -7803,6 +7848,10 @@ local function LayoutTotemBar()
         totemBarFrame:SetSize(maxDim, iconSize)
     end
 end
+
+-- Expose so unlock-mode's grow-direction menu can re-run the layout after
+-- changing totemBar.growDirection (LayoutTotemBar is file-local).
+EllesmereUI.LayoutTotemBar = LayoutTotemBar
 
 local function BuildTotemBar()
     local tb = GetTotemSettings()


### PR DESCRIPTION
## What does this PR do?
Adds a grow-direction option to the Totem Bar, matching the unlock-mode grow-direction menu that action bars and CDM bars already have.

The unlock-mode right-click "grow direction" menu now appears for the Totem Bar (ERB_TotemBar) — it was previously offered only for action bars and CDM bars.
It is orientation-aware, exactly like the other bars:
Horizontal: Centered / Left / Right — Right is the default and reproduces the original left-anchored, grows-rightward layout; Left fixes the right edge and grows left; Centered centers the active-icon group.
Vertical: Centered / Up / Down — Down is the default (original top-to-bottom); Up fixes the bottom edge and grows up; Centered centers the group.
Wired into the existing grow-direction plumbing (GetBarGrowDirActual / GetBarGrowDir / RecenterBarAnchor) so edge-fixing and the on-screen direction indicator behave consistently with every other bar.
Files touched:

EllesmereUIResourceBars/EllesmereUIResourceBars.lua — LayoutTotemBar honors totemBar.growDirection for both orientations (anchor + button-chain direction, plus a centered path); exposes EllesmereUI.LayoutTotemBar so the menu can re-run the layout after a change (the function is file-local). Invalid direction/orientation combos fall back to that orientation's default.
EllesmereUI/EUI_UnlockMode.lua — adds ERB_TotemBar to the grow-capable key set, to both grow-direction readers, to the menu's orientation + current-value detection, and to the menu's on-click writer.
The default (Right for horizontal, Down for vertical) is byte-for-byte the previous behavior, so existing/unset profiles are unchanged.


## How was it tested?
Tested in game on live retail:

Unlocked the UI, right-clicked the Totem Bar — the grow-direction menu now appears; a horizontal bar shows Centered / Left / Right, and after switching the totem bar to vertical it shows Centered / Up / Down.
Switched between all options in both orientations; active totem icons re-align (left/right/up/down/centered) within the 5-slot frame, the bar's fixed edge stays put (no jump), and the direction indicator shows for the four edge directions (none for Centered), matching action bars.
Verified the default (unset profile) is identical to the previous layout, and that dropping/refreshing totems re-lays out correctly.
File parses clean (Lua syntax checked), UTF-8/BOM encoding preserved. No taint or load errors; the change reuses the same SetPoint layout path the totem bar already used (no new writes onto Blizzard frame tables).


## Screenshots
The screenshots show the horizontal totem bar only (the grow-direction menu and the Left / Right / Centered icon alignment). Vertical orientation works the same way — the menu shows Up / Down / Centered — it just isn't pictured here.
<img width="297" height="226" alt="totem" src="https://github.com/user-attachments/assets/bfecd76f-9137-419a-8ac9-9868deeaafa8" />


## Checklist
- [x] New settings default **OFF** -- N/A (locale data only, no settings added)
- [x] Zero cost while disabled -- N/A (no events, hooks, frames, or code; translation table only)
- [x] Cheap while enabled -- N/A (same single catalog lookup path as every existing locale)
- [x] No writes onto Blizzard-owned frames -- N/A (no frame code)
- [x] Tested in-game, works on live retail; no load errors (data-only table, no API calls; not separately run on 12.1 PTR)