### PR TITLE
Increase Crosshair max size in EUI_QoL_Options.lua

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -2032,13 +2032,13 @@ initFrame:SetScript("OnEvent", function(self)
             end
 
             local chCogRows = {
-                    { type="slider", label="H Length", min=1, max=100, step=1,
+                    { type="slider", label="H Length", min=1, max=500, step=1,
                       get=function() return cget("crosshairHLength") or 40 end,
                       set=function(v) dbset("crosshairHLength", v) end },
                     { type="slider", label="H Width", min=1, max=20, step=1,
                       get=function() return cget("crosshairHWidth") or presetThick() end,
                       set=function(v) dbset("crosshairHWidth", v); refreshSizeLabel() end },
-                    { type="slider", label="V Length", min=1, max=100, step=1,
+                    { type="slider", label="V Length", min=1, max=500, step=1,
                       get=function() return cget("crosshairVLength") or 40 end,
                       set=function(v) dbset("crosshairVLength", v) end },
                     { type="slider", label="V Width", min=1, max=20, step=1,


### PR DESCRIPTION
I like a bigger crosshair and the current 100 max is not doing it for me. I suggested the number 500 because around 300 is the sweetspot for me. Maybe a higher number is optimal for people who want the crosshair over their entire screen? 

In my personal test, I could not find any disadvantage to increasing the number and I will keep rolling with 300, but I don't want to edit the code after every update 😄

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

It increases the maximum value of the "H Length" and "V Length" Sliders in the Character Crosshair Settings of the "Quality of Life" Addon from 100 to 500.

## How was it tested?

I changed the values in the .lua on my normal WoW Installation [12.0.7 (68887) (Release x64) ] with EUI 8.6.4 on the 27.07.2026 and was able to move the slider beyond 100, could still manually enter values above and below 100 and the Crosshair changed accordingly.

## Screenshots

<img width="1368" height="650" alt="grafik" src="https://github.com/user-attachments/assets/407fb6e9-2d56-4c93-b456-09a78a0ebc15" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ N/A ] New settings default **OFF** (no behavior change without opt-in)
- [ N/A ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ N/A ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ N/A ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ OK ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
