### PR TITLE
fix(cdm): give collided buff slots their own placeholder identity

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -3704,8 +3704,11 @@ local function HideAllInjectedCustomBuffs()
 end
 ns.HideAllInjectedCustomBuffs = HideAllInjectedCustomBuffs
 
-local function GetOrCreatePlaceholderFrame(barKey, spellID, iconID)
-    local fkey = barKey .. ":ph:" .. spellID
+-- identKey: optional pooling identity, defaulting to spellID. Buff
+-- placeholders pass one so two viewer slots that collide on spellID do not
+-- share a single pooled frame (see the collision note at the call site).
+local function GetOrCreatePlaceholderFrame(barKey, spellID, iconID, identKey)
+    local fkey = barKey .. ":ph:" .. tostring(identKey or spellID)
     local f = _placeholderFrames[fkey]
     if not f then
         f = CreateFrame("Frame", nil, UIParent)
@@ -4663,6 +4666,35 @@ local function CollectAndReanchor()
                                     -- toggle on. We never touch Blizzard's hidden frame, so nothing
                                     -- fights its hide state.
                                     local bd = barDataByKey[targetBar]
+                                    -- Placeholder identity. Two viewer slots on one bar can
+                                    -- resolve to the SAME realSID. For split-form talents that
+                                    -- is correct (one live spell, one icon) and the dedup below
+                                    -- must collapse them. But it is ALSO what a viewer-level
+                                    -- COLLISION looks like: Blizzard hands the Demonic Art slot
+                                    -- Diabolic Ritual's id, so unlike the split-identity twins
+                                    -- the clean-read cache above cannot separate them either --
+                                    -- both reads return the same id. Keyed on realSID alone the
+                                    -- second slot is skipped and shares the first's pooled frame,
+                                    -- so the pair renders two icons while active and one while
+                                    -- missing, and the bar's icon count swings as the buffs come
+                                    -- and go.
+                                    -- cooldownID is distinct per viewer slot, which is why the
+                                    -- enumeration dedup was moved onto it; this is the same
+                                    -- identity rule arriving in the placeholder path. The FIRST
+                                    -- claimer keeps the plain realSID key, so every non-colliding
+                                    -- spec (unique sid <=> unique cooldownID) is byte-identical
+                                    -- to before; only a later slot carrying a DIFFERENT
+                                    -- cooldownID takes an id of its own instead of vanishing.
+                                    local phIdent = realSID
+                                    do
+                                        local claimKey = "phsid:" .. tostring(realSID)
+                                        local firstCD = barSeen[claimKey]
+                                        if firstCD == nil then
+                                            barSeen[claimKey] = dedupKey or true
+                                        elseif dedupKey and firstCD ~= dedupKey then
+                                            phIdent = "c" .. tostring(dedupKey)
+                                        end
+                                    end
                                     -- Effective Always Show for THIS buff: a per-icon
                                     -- override (ss.alwaysShow "on"/"off") beats the bar
                                     -- toggle. Lookup only when per-icon settings exist
@@ -4695,7 +4727,7 @@ local function CollectAndReanchor()
                                     -- Icons) for cooldowns).
                                     local hostedMissingVis
                                     if hostCD then
-                                        local phMV = GetOrCreatePlaceholderFrame(targetBar, realSID, nil)
+                                        local phMV = GetOrCreatePlaceholderFrame(targetBar, realSID, nil, phIdent)
                                         local ssMV = ns.ResolveSpellSettings(phMV, realSID, ns.GetBarSpellData(targetBar), targetBar)
                                         local mv = ssMV and ssMV.hostedMissingVis
                                         if mv == "hidden" or mv == "hiddenShift" then hostedMissingVis = mv end
@@ -4728,11 +4760,11 @@ local function CollectAndReanchor()
                                         -- against injecting that single frame twice (a second
                                         -- AcquireEntry reserves a phantom slot and over-sizes the
                                         -- bar). Dedup placeholders per bar by resolved spell.
-                                        local phKey = "ph:" .. realSID
+                                        local phKey = "ph:" .. tostring(phIdent)
                                         if not barSeen[phKey] then
                                             barSeen[phKey] = true
                                             local icon = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(realSID)
-                                            local ph = GetOrCreatePlaceholderFrame(targetBar, realSID, icon)
+                                            local ph = GetOrCreatePlaceholderFrame(targetBar, realSID, icon, phIdent)
                                             -- Per-spell missing-visibility mark (our own
                                             -- frame): "hidden" renders alpha-0 via the
                                             -- opacity passes while the slot stays


### PR DESCRIPTION
## Problem

Warlock Demonology/Diabolist tracks two buffs that Blizzard's cooldown viewer reports
under the same spellID (Diabolic Ritual and Demonic Art -- the collision behind #934).

With **Visibility When Missing** set to **Desaturated**, only one of the two icons keeps
its slot while its buff is missing. The other disappears, so the bar's icon count rises
and falls repeatedly during a fight and the bar changes width with it.

The setting itself is working. The placeholder it controls is never created for the
second slot.

## Cause

Placeholders are pooled AND deduped by spellID:

```lua
local fkey = barKey .. ":ph:" .. spellID   -- pooled frame identity
local phKey = "ph:" .. realSID             -- per-bar injection dedup
```

Both viewer slots resolve to the same `realSID`, so the second is skipped by the dedup
and would have shared the first's pooled frame anyway. The pair renders two icons while
both buffs are active (each active buff routes Blizzard's own frame) and one while either
is missing (a single shared placeholder) -- hence the fluctuating count.

The surrounding code already anticipates this shape. A comment a few lines above warns
that collapsing onto a shared id means "a slot vanishes in combat", and split-identity
twins are defended with a clean-read cache keyed by cooldownID. That defence cannot help
this pair: unlike the twins, both slots return the same id even on a clean read, because
Blizzard hands the Demonic Art slot Diabolic Ritual's id.

This is the same identity drift twice fixed elsewhere. #934 moved the buff enumeration
dedup onto cooldownID; the cd-claim ordering fix moved the order maps onto it. The
placeholder path was still on spellID.

## Fix

Use cooldownID, which is distinct per viewer slot, as the placeholder identity -- but
only where it actually differs:

- The FIRST slot to claim a `realSID` keeps the plain key. Any spec where spellID and
  cooldownID are one-to-one is byte-identical to before.
- A later slot carrying a DIFFERENT cooldownID takes an identity of its own instead of
  being dropped.
- Split-form talents, where two viewer items are genuinely one live spell, still collapse
  to a single icon.

`GetOrCreatePlaceholderFrame` gains an optional pooling identity so the two slots stop
sharing one frame. The preset caller passes none and is unchanged.

The rule was modelled and checked against four cases before wiring: collision keeps both,
non-colliding output unchanged, a repeated sighting of one slot still collapses, and a
three-way collision produces three identities.

## Testing

Verified in game on Warlock Demonology/Diabolist: with Visibility When Missing on
Desaturated, both icons now hold their slots for the whole fight and the bar stops
resizing.

Worth a second pair of eyes on the inverse case: a spec whose two viewer items should
collapse to ONE icon (split-form talents) must still show one. That path is unchanged by
construction -- it collapses on a shared cooldownID, not a shared spellID -- but it is
the regression this change could plausibly cause.
