### PR TITLE
fix(clickcast): dispatch the hovercast state driver

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_ClickCast.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_ClickCast.lua
@@ -2485,8 +2485,12 @@ function ns.CC_BuildPage(pageName, parent, yOffset)
                 local mItems = {}
                 for _, m in ipairs(macros) do mItems[#mItems + 1] = { name = m.name, icon = m.icon, macroName = m.name } end
                 PopulateGridG(mItems, function(itm)
+                    -- Macros default to BOTH reactions, unlike a spell binding
+                    -- (friendly only, the click-cast healing case). A macro is
+                    -- general purpose and commonly a mouseover focus/target one,
+                    -- so a friendly-only default would leave it dead on enemies.
                     ns.CC_AddGlobalBinding({ type = "macro", macroName = itm.macroName, icon = itm.icon,
-                        enabled = true, oocOnly = false, hovercast = false, hoverFriendly = true, hoverEnemy = false })
+                        enabled = true, oocOnly = false, hovercast = false, hoverFriendly = true, hoverEnemy = true })
                     ns._ccSelSide = "global"; ns._ccSelIndex = #(GetGlobalBindings()); RebuildPage()
                 end)
             else
@@ -3100,7 +3104,8 @@ function ns.CC_BuildPage(pageName, parent, yOffset)
                     ns.CC_AddSpecBinding({
                         type = "macro", macroName = item.macroName, icon = item.icon,
                         enabled = true, oocOnly = false, hovercast = false,
-                        hoverFriendly = true, hoverEnemy = false,
+                        -- Both reactions: see the global macro add above.
+                        hoverFriendly = true, hoverEnemy = true,
                     })
                     ns._ccSelSide = "spec"; ns._ccSelIndex = #(GetSpecBindings()); RebuildPage()
                 end)

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_ClickCast.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_ClickCast.lua
@@ -143,7 +143,7 @@ local KEY_DISPLAY = {
 -------------------------------------------------------------------------------
 --  State
 -------------------------------------------------------------------------------
-local header           = nil   -- SecureHandlerBaseTemplate (frame bindings)
+local header           = nil   -- SecureHandlerStateTemplate (frame bindings + eui_cc driver)
 local bindProxy          = nil   -- SecureActionButtonTemplate (unnamed frame fallback)
 local globalBtn        = nil   -- SecureActionButtonTemplate (hovercast bindings)
 local registeredFrames = {}
@@ -459,6 +459,17 @@ local function BuildBaseMacroText(binding)
         end
         if isHC then
             body = "/stopmacro [mounted][flying]\n" .. body
+            -- The body is the user's macro, so the friendly/enemy filter cannot be
+            -- folded into its conditionals the way the /cast above is assembled.
+            -- Gate the whole macro instead. Same net effect, and a missing
+            -- mouseover also stops it, matching the spell path's exists check.
+            -- Without this the two Hovercast target toggles were built and shown
+            -- for macro bindings but silently did nothing.
+            if binding.hoverFriendly and not binding.hoverEnemy then
+                body = "/stopmacro [@mouseover,nohelp]\n" .. body
+            elseif binding.hoverEnemy and not binding.hoverFriendly then
+                body = "/stopmacro [@mouseover,noharm]\n" .. body
+            end
         end
         return body
     elseif binding.type == "item" then
@@ -1370,8 +1381,8 @@ function ns.CC_ApplyBindings()
     --    never lose the race against the binding being set. (This is the part the
     --    old design lacked: it relied solely on the state driver to set, which
     --    lags on arrival and -- worse -- could stay stuck cleared.)
-    --  * The state driver also SETS on "1", covering NON-EUI mouseover targets
-    --    (nameplates / Blizzard frames that have no OnEnter wrap), and on "0"
+    --  * The state driver also SETS on "on", covering NON-EUI mouseover targets
+    --    (nameplates / Blizzard frames that have no OnEnter wrap), and on "off"
     --    CLEARS the hover bindings AND runs the frame-based keyboard failsafe.
     --  * The "0" clear is GUARDED: skipped while the last-hovered EUI frame is
     --    still physically under the cursor, so a transient [@mouseover,exists]==0
@@ -1456,7 +1467,7 @@ function ns.CC_ApplyBindings()
     if #hoverSetLines > 0 or #kbClearLines > 0 then
         local fbFailsafe = table.concat(kbClearLines, "\n")
         header:SetAttribute("_onstate-eui_cc", [[
-            if newstate == "1" then
+            if newstate == "on" then
                 if not eui_hoveractive then
                     self:RunAttribute("eui_hover_set")
                     eui_hoveractive = true
@@ -1468,7 +1479,12 @@ function ns.CC_ApplyBindings()
 
             end
         ]])
-        RegisterStateDriver(header, "eui_cc", "[@mouseover,exists] 1; 0")
+        -- State values are deliberately non-numeric. Blizzard's driver runs
+        -- newValue = tonumber(newValue) or newValue before setting the state, so a
+        -- "1; 0" driver arrives as the NUMBER 1 and never matches a quoted "1" --
+        -- which silently made the set branch above unreachable, leaving nameplates
+        -- (no OnEnter wrap, so the driver is their only path) permanently unbound.
+        RegisterStateDriver(header, "eui_cc", "[@mouseover,exists] on; off")
     end
 
     -- Store for next cleanup
@@ -1742,7 +1758,14 @@ function ns.CC_Init()
     if not ns.db then return end
     GetClickCastDB()
 
-    header = CreateFrame("Frame", "EUIClickCastHeader", UIParent, "SecureHandlerBaseTemplate")
+    -- StateTemplate, not BaseTemplate: only the state template carries the
+    -- OnAttributeChanged script (SecureHandler_StateOnAttributeChanged) that
+    -- dispatches "_onstate-<id>" snippets. Under BaseTemplate the eui_cc driver
+    -- still wrote state-eui_cc, but nothing listened, so the hover set/clear
+    -- handler never ran and hovercast worked only where the OnEnter wrap set the
+    -- binding directly -- i.e. everywhere except nameplates. It inherits the same
+    -- SecureHandler_OnLoad, so Execute / WrapScript / RunAttribute are unchanged.
+    header = CreateFrame("Frame", "EUIClickCastHeader", UIParent, "SecureHandlerStateTemplate")
     ns._ccHeader = header
 
     bindProxy = CreateFrame("Button", "EUIClickCastBindProxy", UIParent,

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -203,6 +203,43 @@ function EllesmereUI.RunRegisteredMigrations()
     end
 end
 
+--------------------------------------------------------------------------------
+--  Registered migrations
+--------------------------------------------------------------------------------
+
+-- Hovercast macro bindings ignored their own Friendly/Enemy toggles: the
+-- friend/harm filter was only ever applied when building a spell binding, so a
+-- macro fired on whatever was under the cursor regardless of what the two
+-- toggles said. Now that the filter is honored, a stored binding left at the
+-- creation defaults (hoverFriendly = true, hoverEnemy = false) would suddenly
+-- stop working on enemies -- a silent regression on data the user never touched,
+-- e.g. every mouseover focus macro. Seed both flags so existing bindings keep
+-- the unfiltered behavior they have actually had, and let the toggles take
+-- effect from here on.
+EllesmereUI.RegisterMigration({
+    id          = "clickcast_macro_hover_reaction_v1",
+    scope       = "profile",
+    description = "Keep existing hovercast macro bindings unfiltered now that Friendly/Enemy applies to them",
+    body        = function(ctx)
+        local rf = ctx.profile.addons and ctx.profile.addons.EllesmereUIRaidFrames
+        local cc = rf and rf.clickCast
+        if type(cc) ~= "table" then return end
+        local function seed(list)
+            if type(list) ~= "table" then return end
+            for _, b in ipairs(list) do
+                if type(b) == "table" and b.type == "macro" and b.hovercast then
+                    b.hoverFriendly = true
+                    b.hoverEnemy    = true
+                end
+            end
+        end
+        seed(cc.globals)
+        if type(cc.specs) == "table" then
+            for _, list in pairs(cc.specs) do seed(list) end
+        end
+    end,
+})
+
 -- Inspection helper for the slash command.
 function EllesmereUI.GetMigrationStatus()
     local out = {


### PR DESCRIPTION
## Problem

HoverCast bindings never fired over nameplates. Reported by @Alarius on 8.6.4: a
focus macro bound under Raid Frames > HoverCast set focus only when a target was
already selected, never off a bare enemy nameplate.

## Root cause

The click-cast header was created with `SecureHandlerBaseTemplate`, which carries
no `OnAttributeChanged` script. Only `SecureHandlerStateTemplate` installs
`SecureHandler_StateOnAttributeChanged`, the handler that dispatches
`_onstate-<id>` snippets.

`RegisterStateDriver` therefore wrote `state-eui_cc` on every mouseover change and
nothing listened, so the hover set/clear snippet never ran. No error, no warning.

HoverCast still worked on EUI unit frames because their secure `OnEnter` wrap sets
the override binding directly, bypassing the driver. Nameplates are excluded from
click-cast registration, so the dead driver was their only path: the key stayed
bound to whatever the player's normal keybind was. A focus macro pressed over a
nameplate fell through to its own fallback clause and set focus to the current
target, which read as "only works when I already have a target selected".

## Second defect on the same path

Blizzard's `resolveDriver` runs `newValue = tonumber(newValue) or newValue` before
setting the state, so a `"1; 0"` driver delivers `newstate` as the number `1` and a
snippet testing `newstate == "1"` never matches. Moved to non-numeric `"on; off"`
states, which the coercion leaves alone.

This was masked by the template bug and would have broken the handler again as soon
as it started running. Both fixes are required.

## Also included

HoverCast's Friendly/Enemy toggles were ignored for macro bindings: the friend/harm
filter was only applied when assembling a spell binding, so both toggles were built
and shown for macros but did nothing. A macro body belongs to the user and cannot
take injected conditionals, so the filter gates the whole macro with `/stopmacro`
instead.

Existing stored bindings sit at the old creation defaults (`hoverFriendly = true`,
`hoverEnemy = false`) and have always run unfiltered, so profile migration
`clickcast_macro_hover_reaction_v1` seeds both flags. Without it, honouring the
toggles would silently disable every existing mouseover macro on enemies, including
the one this PR fixes.

New macro bindings now default to both reactions for the same reason. Spell
bindings keep friendly-only, which suits the click-cast healing case.

Note for follow-up: the same filter is still absent for item, trinket, dispel,
external, and dynamicrez bindings, which also display both toggles.

## Testing

Verified in-game on 8.6.4:

- HoverCast binding goes live over an enemy nameplate and the focus macro fires;
  previously the key stayed bound to its action bar slot
- Migration reports as run across all 8 profiles
- Toggling Enemy Units off adds `/stopmacro [@mouseover,nohelp]` to the generated
  macrotext; toggling it back on removes it
- A newly created macro binding defaults to both reactions on
