### PR TITLE
fix(specov): post-combat full-refresh storm from stowaway Dragon Riding capture

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -1538,6 +1538,18 @@ end
 function EllesmereUI.ScheduleSettleReapply()
     if isUnlocked then return end                            -- unlock owns positioning
     if EllesmereUI._settleReapplyInProgress then return end  -- never re-arm from our own pass
+    -- The in-progress flag only covers the SYNCHRONOUS pass. Everything the
+    -- pass spawns -- anchor batches, SetPoint move checks -- is After(0)
+    -- deferred and lands after the flag clears, so on a layout whose forced
+    -- re-apply is not pixel-stable (snap deltas of 1 physical px exceed the
+    -- 0.5 UI-unit change epsilon at low UI scale) the tail re-armed the timer
+    -- and the settle pass ran itself forever at the debounce rate: a
+    -- permanent ~5Hz full anchor re-apply, burning the client down in combat.
+    -- Suppress re-arms for a window long enough to swallow the deferred tail.
+    -- A REAL disturbance inside the window loses only the belt-and-braces
+    -- settle pass; the normal notify/batch path has already handled it.
+    local su = EllesmereUI._settleSuppressUntil
+    if su and GetTime() < su then return end
     if EllesmereUI._settleTimer then EllesmereUI._settleTimer:Cancel() end
     EllesmereUI._settleTimer = C_Timer.NewTimer(0.25, function()
         EllesmereUI._settleTimer = nil
@@ -1556,6 +1568,7 @@ function EllesmereUI.ScheduleSettleReapply()
         end
         if EllesmereUI.ReapplyAllUnlockAnchorsForced then
             EllesmereUI._settleReapplyInProgress = true
+            EllesmereUI._settleSuppressUntil = GetTime() + 0.75
             pcall(EllesmereUI.ReapplyAllUnlockAnchorsForced)
             EllesmereUI._settleReapplyInProgress = false
         end

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -550,6 +550,51 @@ EllesmereUI.RegisterMigration({
     end,
 })
 
+-- The Skyriding HUD's sub-DB registers its own folder
+-- (EllesmereUIDragonRiding), dodging the BlizzardSkin capture blacklist, so
+-- a width-match engine write to its width key could be auto-captured into an
+-- unrelated override entry (field case: riding a CDM Icon Scale capture).
+-- Applying such an entry touches a folder with no targeted refresher, and
+-- the unmapped-folder fallback escalates every apply into a full
+-- RefreshAllAddons -- under spec-changed event traffic that meant minutes of
+-- continuous full-suite refresh after combat. The folder is now
+-- capture-and-apply blacklisted; strip already-banked keys from both stores.
+-- Only the foreign keys are removed -- the entry's own settings survive; an
+-- entry left with an empty default map is dropped whole.
+EllesmereUI.RegisterMigration({
+    id          = "specov_strip_dragonriding_fkeys_v1",
+    scope       = "profile",
+    description = "Strip stowaway Dragon Riding fkeys from spec/conditional override stores (unmapped-folder RefreshAllAddons storm).",
+    body        = function(ctx)
+        local prof = ctx.profile
+        if not prof then return end
+        local PREFIX = "EllesmereUIDragonRiding\31"
+        local function strip(store)
+            if type(store) ~= "table" then return end
+            for i = #store, 1, -1 do
+                local e = store[i]
+                local vals = type(e) == "table" and e.values
+                if type(vals) == "table" then
+                    for _, m in pairs(vals) do
+                        if type(m) == "table" then
+                            for fkey in pairs(m) do
+                                if type(fkey) == "string" and fkey:sub(1, #PREFIX) == PREFIX then
+                                    m[fkey] = nil
+                                end
+                            end
+                        end
+                    end
+                    if type(vals.default) ~= "table" or next(vals.default) == nil then
+                        table.remove(store, i)
+                    end
+                end
+            end
+        end
+        strip(prof.specOverrides)
+        strip(prof.condOverrides)
+    end,
+})
+
 EllesmereUI.RegisterMigration({
     id          = "cdm_per_profile_spell_store_v1",
     scope       = "global",

--- a/EllesmereUI_SpecOverrides.lua
+++ b/EllesmereUI_SpecOverrides.lua
@@ -69,6 +69,17 @@ local LIST_PAGE = "Overrides"
 -- PruneOrphanEntries (strips persisted paths + drops emptied entries).
 local FOLDER_BLACKLIST = {
     EllesmereUIBlizzardSkin      = true,
+    -- The Skyriding HUD registers its own sub-DB (EllesmereUIDragonRidingDB)
+    -- from inside BlizzardSkin, so its registry folder dodges the
+    -- BlizzardSkin entry above. A width-match write to its width key was
+    -- auto-captured into a user's CDM Icon Scale override; the per-spec
+    -- apply then touched a folder with no REFRESH_FNS entry, and the
+    -- unmapped-folder fallback escalated EVERY such apply into a full
+    -- RefreshAllAddons -- spec-changed event traffic after combat became
+    -- minutes of continuous full-suite refresh (the 2026-07 post-combat
+    -- lag storm). Blacklisting blocks both future captures and the apply
+    -- of already-banked entries; a migration strips those from stores.
+    EllesmereUIDragonRiding      = true,
     EllesmereUIDamageMeters      = true,
     EllesmereUIMythicTimer       = true,
     EllesmereUIQuestTracker      = true,
@@ -105,6 +116,10 @@ local REFRESH_FNS = {
     EllesmereUIDamageMeters      = { "_EDM_Apply" },
     EllesmereUIDataBars          = { "_EDB_Apply" },
     EllesmereUIAuraBuffReminders = { "_EABR_RequestRefresh", "_EABR_ApplyUnlockPos" },
+    -- Folder is capture/apply-blacklisted (see FOLDER_BLACKLIST); this entry
+    -- is insurance so a key that slips through any future path can never hit
+    -- the unmapped-folder fallback and escalate into a full RefreshAllAddons.
+    EllesmereUIDragonRiding      = { "_EDR_Rebuild" },
 }
 
 -- Class glyph sprite (toolbar button) + modern class sprite (group icons)


### PR DESCRIPTION
## Problem

Severe sustained frame-rate drop with visibly jittering bars, reported with a
video by a user and reproduced by testers. The drop runs for around two minutes
after leaving combat, restarts after a reload, and was correlated with three
stored "Icon Scale - CDM Bars" spec overrides on Warrior: deleting them stopped
it, recreating them from scratch did not bring it back.

## Root cause

The Skyriding HUD registers its own sub-DB (EllesmereUIDragonRidingDB), so its
registry folder is EllesmereUIDragonRiding and the EllesmereUIBlizzardSkin entry
in the spec-override capture blacklist never matched it. When the user
originally dragged the CDM Icon Scale slider, the resize cascaded through a
width-match link and the match engine wrote the Dragon Riding bar width; the
edit-session watcher attributed that write to the slider and banked it into the
Icon Scale override entry as a stowaway fkey with divergent per-spec values.

Applying that entry on any spec event touches a folder that has no REFRESH_FNS
mapping, and the unmapped-folder fallback in RunRefreshers escalates every such
apply into a full RefreshAllAddons. Under the spec-changed event traffic that
follows combat, that meant minutes of continuous full-suite refresh: every
action bar relaid out at the resize-notify throttle cap and Blizzard's combat
script execution limiter tripping repeatedly.

A field stack capture pinned the chain end to end:
NotifyElementResized <- _EAB_Apply <- RefreshAllAddons <- RunRefreshers
(unmapped-folder fallback) <- SpecOverrides_Apply <- the
PLAYER_SPECIALIZATION_CHANGED handler.

Freshly created overrides never reproduced the problem because they carry no
stowaway; only stores that banked the width during the original edit session do.

## Fix

Three layers in `EllesmereUI_SpecOverrides.lua` / `EllesmereUI_Migration.lua`:

- Blacklist the `EllesmereUIDragonRiding` folder for capture and apply.
- Migration `specov_strip_dragonriding_fkeys_v1` strips already-banked Dragon
  Riding keys from both override stores (spec and conditional). Only the
  foreign keys are removed; each entry's own settings survive, and an entry is
  dropped only if its default map ends up empty. Verified by dry-running the
  migration body against the reporting user's actual SavedVariables: all 12
  entries survive, Icon Scale keeps only its iconSize values.
- Map the folder to `_EDR_Rebuild` in REFRESH_FNS as insurance, so any future
  slip-through gets a targeted refresh instead of reaching the full-refresh
  fallback.

## Also fixed: settle re-apply self-arming

Found while chasing the same report. `ScheduleSettleReapply` guards against
re-arming from its own forced pass with `_settleReapplyInProgress`, but the
flag only covers the synchronous call; the anchor batches and SetPoint move
checks the pass spawns are `C_Timer.After(0)` deferred, land after the flag
clears, and re-armed the timer. On a layout whose forced re-apply is not
pixel-stable (a one-physical-pixel snap delta exceeds the fixed 0.5 UI-unit
change epsilon at low UI scale, e.g. 0.83-1.11 UI units per pixel at 0.64
scale) the settle pass re-ran itself at the debounce rate indefinitely; field
counters showed 51 forced full anchor re-applies in ten seconds. Re-arms are
now suppressed for 0.75s from the start of a forced pass, long enough to
swallow the deferred tail; real disturbances after the window re-arm normally.

## Testing

Verified in-game by two testers on the reporting user's profile:

- Post-combat lag storm gone on the previously reproducing Warrior setup;
  before the fix the same fight produced roughly two minutes of severe frame
  drop and repeated script-execution-limit warnings
- Migration reports OK; the Icon Scale override entry retains only its
  cdmBars iconSize values and the per-spec icon sizes still apply
- Forced settle re-apply counters dropped from ~5 per second to the capped
  rate under the same conditions
  
  ## Required Giphy
<img width="480" height="458" alt="Baby Success GIF" src="https://github.com/user-attachments/assets/0131b0c4-f106-4800-b7cb-e25e8b99d5a6" />

