### PR TITLE
fix(actionbars): charge spells flicker out of cooldown desaturation on every press

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -3408,6 +3408,17 @@ do
                                     if (active ~= (fd.cdWasActive or false)) or chargeShown or fd.chargeWasLive
                                        or (active and fd.visGen ~= ns._gcdGen) then
                                         if active then fd.visGen = ns._gcdGen end
+                                        -- durObj is only fetched on the once-per-cast
+                                        -- swipe push above, but charge buttons re-enter
+                                        -- here on EVERY walk (chargeShown). Passing the
+                                        -- stale nil made the shared function read the
+                                        -- live cooldown as inactive and snap a
+                                        -- recharging charge spell back to full color,
+                                        -- then the next cast generation re-desaturated
+                                        -- it: grey-color-grey flicker on every press.
+                                        if active and not durObj then
+                                            durObj = C_ActionBar.GetActionCooldownDuration(action)
+                                        end
                                         RefreshCooldownVisuals(btn, action, cdInfo or false, durObj, chargeInfo or false)
                                     end
                                     -- Count text rides the ~2s sub-pass; charge


### PR DESCRIPTION
## Problem

With Desaturate on Cooldown enabled, every multi-charge spell (Druid
Incarnation, Evoker Prescience, DH Immolation Aura, and so on) that is
recharging flickers from cooldown grey to full color and back on every press
of any other button. Reported on 8.6.4; regression from the 8.6.x action bar
idle-CPU optimization pass.

## Root cause

The ACTIONBAR_UPDATE_COOLDOWN walk splits its work behind two gates that
disagree:

- The action's duration object is fetched only on the once-per-cast swipe
  push (the `fd.pushGen` generation gate). That gate exists so 140 buttons do
  not re-push engine-live swipe objects on every event, and it is correct for
  the swipe.
- The desat/dim visuals call runs on every walk for charge buttons: the
  `chargeShown` term holds them in the gate so recharge edges always repaint.

On the second and later walks of a cast generation, a recharging charge
button therefore reaches `RefreshCooldownVisuals` with cooldown info that
says `isActive` but a nil duration object. The function derives its active
state as `cdInfo and cdInfo.isActive and durObj`, which collapses to nil, so
it writes `SetDesaturation(0)` and the icon snaps to full color. The next
cast bumps the generation, the first walk of that generation fetches the
duration object again and re-desaturates, producing the per-press
grey-color-grey flicker.

Non-charge buttons never flickered because they skip the visuals call
entirely between generations (the `visGen` gate), which is why the report
was specifically "every spell with stacks".

## Fix

Fetch the duration object at the visuals call site when the cooldown is
active and the swipe-push gate did not already fetch it this walk. One extra
fetch per walk, only for buttons that pass the visuals gate, on a walk that
is already rate-capped, so the optimization's idle savings are untouched.

The other two RefreshCooldownVisuals call sites (the SPELL_UPDATE_CHARGES
branch and the per-button cooldown-done edge) pass nil cooldown info, which
makes the function fetch everything fresh itself, so they were already
correct.

## Testing

Verified in-game on the reporting scenario and the two adjacent behaviors
the same function owns:

- Multi-charge spell at zero charges stays desaturated while spamming other
  spells, and resaturates exactly when a charge returns (was: flashed to
  full color on every press)
- Multi-charge spell with a banked charge stays fully colored during GCD
  spam
- A normal no-charge cooldown spell still desaturates on cast and recovers
  on its cooldown-done edge

## Required Giphy
<img width="482" height="360" alt="pinky and the brain childhood GIF" src="https://github.com/user-attachments/assets/0351a942-27ae-4871-bd76-d71002d8108d" />
