### PR TITLE
Fix Tip of the Spear overcounting Takedown with Twin Fangs

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4461,7 +4461,8 @@ end
 
 -- Tip of the Spear tracker (Survival Hunter)
 -- Kill Command (259489) grants 1 stack (2 with Primal Surge talent 1272154).
--- Takedown (1250646) grants 2 stacks when Twin Fang (1272139) is known.
+-- Takedown (1250646) grants 3 stacks when Twin Fangs (1272139) is known and
+-- spends one on its own impact (1253859), so the cast nets 2.
 -- Various spender abilities consume 1 stack each.
 -- Buff duration: 10 seconds, max 3 stacks.
 -- Talent spell: 260285
@@ -4472,8 +4473,10 @@ do
     local TALENT     = 260285
     local KILL_CMD   = 259489
     local PRIMAL     = 1272154
-    local TAKEDOWN   = 1250646
-    local TWIN_FANG  = 1272139
+    local TAKEDOWN     = 1250646
+    local TAKEDOWN_HIT = 1253859
+    local TWIN_FANG    = 1272139
+    local TWIN_FANG_GAIN = 3
 
     local SPENDERS = {
         [186270]  = true,  -- Raptor Strike
@@ -4484,7 +4487,7 @@ do
         [193265]  = true,  -- Hatchet Toss
         [1264949] = true,  -- Chakram
         [1261193] = true,  -- Boomstick
-        [1253859] = true,  -- Takedown (also spends)
+        [TAKEDOWN_HIT] = true,  -- Takedown's impact (only spends without Twin Fangs)
         [1251592] = true,  -- Flamefang Pitch
     }
 
@@ -4501,9 +4504,19 @@ do
             stacks = min(MAX, stacks + gain)
             expiresAt = GetTime() + DURATION
         elseif spellID == TAKEDOWN and C_SpellBook.IsSpellKnown(TWIN_FANG) then
-            stacks = min(MAX, stacks + 2)
+            -- Twin Fangs grants 3 and the impact spends one, so the cast nets 2
+            -- from any starting count -- the grant alone always hits the cap.
+            -- Both halves are resolved here rather than waiting for the impact
+            -- event: at melee range the two arrive in the same frame and the
+            -- impact can be handled first, where an empty tracker swallows it
+            -- and the bar then sticks a stack high for the buff's full duration.
+            stacks = min(MAX, stacks + TWIN_FANG_GAIN) - 1
             expiresAt = GetTime() + DURATION
         elseif SPENDERS[spellID] and stacks > 0 then
+            -- With Twin Fangs the cast above already spent for this impact.
+            if spellID == TAKEDOWN_HIT and C_SpellBook.IsSpellKnown(TWIN_FANG) then
+                return
+            end
             stacks = stacks - 1
             if stacks == 0 then expiresAt = nil end
         end


### PR DESCRIPTION
## What does this PR do?

Fixes the Survival Hunter **Tip of the Spear** resource tracker disagreeing with the buff when Takedown is cast with the **Twin Fangs** talent.

Twin Fangs grants 3 stacks on Takedown, and Takedown's own impact (`1253859`) spends one of them, so a cast nets 2. The tracker granted only 2 on the cast and then spent another on the impact, landing on 1 while the buff showed 2.

From a partially filled bar the 3-stack cap hid the missing stack (`1+2` and `2+2` both clamp to 3, then spend to 2), which is why this only reproduced when opening from an empty bar — and why it read as a range-dependent bug in the original report rather than an opener-vs-midrotation one.

The fix resolves both halves of the cast at once and ignores the paired impact event while Twin Fangs is known. Waiting for the impact event is not reliable: at melee range the cast and the impact arrive in the same frame, and if the impact is handled first the `stacks > 0` guard discards it — the cast then grants 3 with nothing left to take the stack back, and the bar sits a stack high for the buff's full 10 seconds.

Trade-off worth naming: at range the tracker now reads 2 for the ~0.6s the spear is in flight, where the buff reads 3. That is a brief one-stack under-read once per 60–90s cooldown, in exchange for removing a 10-second one-stack over-read on every melee Takedown. Survival is a melee spec and Takedown is 15yd, so the melee case was weighted as the common one.

With Twin Fangs untalented, behavior is unchanged from shipping code.

## How was it tested?

Live retail, Survival Hunter with Twin Fangs specced, against training dummies. Each scenario was screen-recorded and stepped through frame by frame, comparing the tracker against the buff icon's own stack count:

| Scenario | Tracker | Buff | |
|---|---|---|---|
| Kill Command → Takedown (ranged) | 2 throughout | 2 → 3 → 2 | pass |
| Takedown at max range, from 0 stacks | 0 → 2 | 3 for ~0.8s → 2 | pass |
| Takedown at melee, from 0 stacks | 0 → 2 | 2 | pass |

Measured cast→impact separation was ~600ms at range and ~100ms at melee, which is what collapses the two events into one frame and produced the original failure.

Also covered by a 21-case offline harness run against the tracker block verbatim: both event orderings, the cap from every starting count, duplicate impact events, spender drain, 10s expiry, `PLAYER_DEAD` reset, Primal Surge, and the full untalented and no-Twin-Fangs paths.

## Screenshots

Melee Takedown from an empty bar — previously the bar stuck at 3 against a 2-stack buff, now both sit at 2:

<img width="720" height="518" alt="tots-melee" src="https://github.com/user-attachments/assets/8b5ef4fe-dc17-4da9-8d30-26e367d04e7f" />

Takedown at max range from an empty bar (the originally reported scenario):

<img width="720" height="518" alt="tots-max-range" src="https://github.com/user-attachments/assets/b12b775c-6b1c-4bbb-8310-e78073a9c830" />

Kill Command → Takedown:

<img width="720" height="518" alt="tots-killcommand-takedown" src="https://github.com/user-attachments/assets/e10fd912-f53a-42d3-850a-0077ba1e6e68" />


## Checklist

- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] Tested in-game, works on live retail — verified frame by frame. Not exercised against the 12.1 PTR client; the change is a few lines inside an existing handler with no new API surface.
