### PR TITLE
Fix Crafting Orders order-type tab highlight stuck on Public

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -6254,28 +6254,36 @@ local function Skin_Professions()
         if bf then
             -- Order-type tabs populate LAZILY -- some aren't created until you
             -- click through the types -- so a one-time pass leaves the
-            -- later-created ones unstyled until a full re-skin. Re-run after
-            -- each tab click (deferred, once the new tabs exist) and on the
-            -- browse OnShow. WSkin.Tab is guarded, so re-runs only skin NEW
-            -- tabs; each tab's OnClick is hooked once to trigger the re-run.
+            -- later-created ones unstyled until a full re-skin. WSkin.Tab is
+            -- guarded, so re-runs only skin NEW tabs.
             local ORDER_TAB_KEYS = { "PublicOrdersButton", "NpcOrdersButton",
                                      "GuildOrdersButton", "PersonalOrdersButton" }
             local function SkinOrderTabs()
                 for _, k in ipairs(ORDER_TAB_KEYS) do
                     local b = bf[k]
-                    if b then
-                        WSkin.Tab(b, { darkActive = true })
-                        if not GetFFD(b).clickReskin then
-                            GetFFD(b).clickReskin = true
-                            b:HookScript("OnClick", function()
-                                if C_Timer then C_Timer.After(0, SkinOrderTabs) end
-                            end)
-                        end
-                    end
+                    if b then WSkin.Tab(b, { darkActive = true }) end
                 end
             end
             SkinOrderTabs()
             if C_Timer then C_Timer.After(0, SkinOrderTabs) end
+            -- Re-skin AND repaint selection on every order-type switch. These
+            -- tabs carry no tabID and BrowseFrame is no TabSystem, so nothing
+            -- tied to an order-type switch reaches them: the engine's global
+            -- PanelTemplates / TabSystem hooks only repaint them incidentally,
+            -- when something ELSE in the UI happens to fire them. A per-tab
+            -- OnClick hook doesn't survive either -- Blizzard's
+            -- InitOrderTypeTabs() re-SetScript's each tab's OnClick, and it
+            -- re-runs on PLAYER_ENTERING_WORLD / PLAYER_GUILD_UPDATE (both in
+            -- its always-listen set), so the hook is wiped for good and the
+            -- underline freezes on whichever type was live at skin time
+            -- (Public, from OnLoad). Hook the authoritative setter instead: a
+            -- method hook survives SetScript and also catches programmatic
+            -- switches (the leave-guild fallback to Public). hooksecurefunc
+            -- runs after the original, so isSelected is already current.
+            if op.SetCraftingOrderType and not GetFFD(op).orderTypeHook then
+                GetFFD(op).orderTypeHook = true
+                hooksecurefunc(op, "SetCraftingOrderType", SkinOrderTabs)
+            end
             -- Tab row starts where the sort header starts: shift the chain
             -- root right by the measured delta (one-shot; the other three
             -- tabs chain off it). Rects only exist once the browse frame has


### PR DESCRIPTION
## What does this PR do?

Fixes the selection highlight on the crafter-side Crafting Orders order-type tabs (Public / Guild / Patron / Personal).

Clicking Guild, Patron, or Personal switched the content correctly, but the skinned selection indicator (accent underline + full-opacity label) stayed on **Public** forever, so the panel and the tab row disagreed about which order type you were looking at.

Root cause is the repaint trigger, not the selection read:

- These tabs inherit `TabSystemButtonArtTemplate`, not `TabSystemButtonTemplate`, so they carry no `tabID`, and `BrowseFrame` is not a `TabSystem`. Nothing tied to an order-type switch reached them -- the engine's global `PanelTemplates_*` / `TabSystem` hooks only repainted them incidentally, when something else in the UI happened to fire them.
- That left a per-tab `OnClick` hook as the only real trigger, and it does not survive: Blizzard's `ProfessionsCraftingOrderPageMixin:InitOrderTypeTabs()` calls `typeTab:SetScript("OnClick", ...)`, which replaces the script chain and destroys the hook. `InitOrderTypeTabs()` re-runs on `PLAYER_ENTERING_WORLD` and `PLAYER_GUILD_UPDATE`, both in `ProfessionsCraftingOrderPageAlwaysListenEvents` (registered unconditionally in `OnLoad`), so after any loading screen the hook is gone for good.
- The underline therefore froze on whatever was live at skin time, which is Public, set by `OnLoad`'s `SetCraftingOrderType(Enum.CraftingOrderType.Public)`.

The fix hooks `SetCraftingOrderType` instead. It is the only writer of `self.orderType` and the only caller of `SetTabSelected` on these tabs, a method hook survives `SetScript`, and it also catches programmatic switches such as the leave-guild fallback to Public. `hooksecurefunc` runs after the original, so `isSelected` is already current when the repaint reads it.

The now-superseded `OnClick` hook is removed rather than left behind as dead machinery -- its `clickReskin` guard was never cleared, so once Blizzard wiped the script it was never reinstalled.

## How was it tested?

Live retail, Engineering crafting table, on a character in a guild with Patron orders available. After a `/reload`, the order-type tabs update correctly: the underline and the full-opacity label follow the selected tab (see the GIF, Public -> Patron -> Public). The original report reproduced consistently before the change.

Not yet verified: behaviour after a zone-change loading screen specifically, and the 12.1 PTR client. Since `Blizzard_Professions` is load-on-demand and loads after `PLAYER_ENTERING_WORLD`, a `/reload` test does not by itself exercise the re-`InitOrderTypeTabs()` path -- though the fix is immune to it by construction, as a method hook cannot be removed by `SetScript`.

The tab-selection read path was traced against Blizzard's source to confirm `TabIsSelected` correctly falls through to `tab.isSelected` for these tabs -- that part was already correct and is unchanged.

## Screenshots

<img width="800" height="498" alt="professions-order-tabs-fix" src="https://github.com/user-attachments/assets/b03b40d9-1512-402f-b6fa-6c3226df2c1a" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting; this is a bug fix to existing skin behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- the hook is installed only from `Skin_Professions`, which only runs when the Blizzard skin is applying to `Blizzard_Professions`
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- fires only on an actual order-type switch; net removal of one deferred `C_Timer.After` per tab click
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- uses `hooksecurefunc` and stores its guard flag in the existing `GetFFD` weak table
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client -- confirmed working on live retail; **not** checked on the 12.1 PTR client
