### PR TITLE
fix(actionbars): show unlock movers for Never bars surfaced by the toggle keybind

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -9541,7 +9541,14 @@ local function RegisterWithUnlockMode()
             order = orderBase + idx,
             isHidden = function()
                 local s = EAB.db.profile.bars[info.key]
-                return s and s.alwaysHidden
+                if not s then return false end
+                -- Honor the runtime "Toggle Action Bar" override the same way
+                -- RefreshRuntimeVisibility does: a bar saved as Never but
+                -- surfaced by the keybind is on screen, so it needs a mover;
+                -- a saved-Always bar toggled off does not.
+                local ov = EAB._visOverride and EAB._visOverride[info.key]
+                if ov then return ov == "never" end
+                return s.alwaysHidden
             end,
             getFrame = function() return barFrames[info.key] end,
             getSize = function()
@@ -13060,7 +13067,10 @@ local function RegisterExtraBarsWithUnlockMode()
                 noAnchorTarget = isBlizzOwned,
                 isHidden = function()
                     local s = EAB.db.profile.bars[bk]
-                    return s and s.alwaysHidden
+                    if not s then return false end
+                    local ov = EAB._visOverride and EAB._visOverride[bk]
+                    if ov then return ov == "never" end
+                    return s.alwaysHidden
                 end,
                 getFrame = function() return extraBarHolders[bk] end,
                 getSize = function()


### PR DESCRIPTION
## What does this PR do?

An action bar set to **Visibility = Never** can now be positioned in Unlock Mode
while the **Toggle Action Bar Visibility** keybind has it on screen. Previously
such a bar got no mover at all, so a bar you had just revealed with the keybind
was immovable.

The unlock element's `isHidden` read only the saved `alwaysHidden` flag, which is
true for every bar set to Never. `CreateMover` skips any element whose `isHidden`
returns true, so the bar never got a mover -- and the toggle keybind could not
help, because that override is runtime-only and never writes `barVisibility`.
`isHidden` now consults `EAB._visOverride` first, the same precedence
`RefreshRuntimeVisibility` already uses.

Bars left hidden are unchanged: still no mover, so the Bar9/Bar10 Never defaults
stay out of Unlock Mode. An Always bar toggled *off* by the keybind now correctly
loses its mover, which is the symmetric case.

Reported by @Espyr against 8.6.4 (Action Bars).

## How was it tested?

Live retail 8.6.4, in game:

- Never + keybind on, then open Unlock Mode -> mover present on open, drags, and
  the bar stays at the new position afterwards.
- Never + hidden, then open Unlock Mode -> no mover. Unchanged and intended.
- Toggle the keybind while Unlock Mode is already open -> the mover appears,
  picked up by the existing mover retry ticker in `EUI_UnlockMode.lua`.
- Always -> unchanged.

Not tested on the 12.1 PTR client. The change touches no `IS_121`-gated path.

## Screenshots

<img width="900" height="506" alt="ab6-full" src="https://github.com/user-attachments/assets/9757c2f5-c5c4-4f25-9119-f042f284596f" />

Never bar revealed with the keybind, Unlock Mode opened, mover present and dragged
to a new position.

## Checklist

- [x] Zero cost while disabled -- N/A, no new feature; the added code is two table
      lookups inside an existing predicate that only runs in Unlock Mode
- [x] Cheap while enabled -- two table lookups, no new events, hooks, timers or frames
- [x] No writes onto Blizzard-owned frames -- N/A, no Blizzard frames touched
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
      -- live retail yes, PTR not tested
