### PR TITLE
Fix: TSM BankUI does not detect bank/warbank switches

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -1189,6 +1189,49 @@ function EUI_Bank:IsWarbandView()
     return false
 end
 
+-------------------------------------------------------------------------------
+--  TradeSkillMaster compatibility
+-------------------------------------------------------------------------------
+-- TSM decides whether its Banking UI targets the character bank or the
+-- warband bank by watching Blizzard's BankPanel, which EUI reparents to a
+-- hidden frame, so TSM never sees bank/warbank switches made in the EUI
+-- sidebar. TSM supports addon-provided bank frames through two globals
+-- (TSM Core/Service/Banking/Core.lua): it calls Addon_GetBankType() to
+-- read the active bank type, and hooksecurefunc's Addon_SetBankType at
+-- init so it can re-check whenever the view changes. Both globals must
+-- exist before TSM initializes; EUI loads first alphabetically. Cost when
+-- TSM is absent is one comparison per RefreshBank. Guarded so another bag
+-- addon that already implements the contract wins.
+
+local _lastTSMBankType = nil
+
+if not _G.Addon_GetBankType then
+    _G.Addon_GetBankType = function()
+        if EUI_Bank:IsVisible() then
+            return EUI_Bank:IsWarbandView() and Enum.BankType.Account
+                or Enum.BankType.Character
+        end
+        if BankFrame and BankFrame.GetActiveBankType then
+            return BankFrame:GetActiveBankType()
+        end
+        return Enum.BankType.Character
+    end
+end
+
+if not _G.Addon_SetBankType then
+    -- Intentionally empty: TSM reacts to the call itself via hooksecurefunc.
+    _G.Addon_SetBankType = function() end
+end
+
+local function NotifyBankTypeForTSM()
+    local bankType = _G.Addon_GetBankType()
+    if bankType ~= _lastTSMBankType then
+        _lastTSMBankType = bankType
+        -- Dynamic lookup so the call goes through TSM's hooked wrapper.
+        _G.Addon_SetBankType(bankType)
+    end
+end
+
 --- Find the first empty slot in a specific bank bag and deposit the cursor
 --- item into it. If no empty slot, try stacking with an existing partial stack.
 --- Returns true if placement was attempted, false if no space found.
@@ -1546,6 +1589,7 @@ end
 -------------------------------------------------------------------------------
 function EUI_Bank:RefreshBank()
     if not EUI_Bank:IsVisible() then return end
+    NotifyBankTypeForTSM()
 
     -- Re-discover tabs if empty (data may not be ready on the same frame as
     -- BANKFRAME_OPENED; BAG_UPDATE fires shortly after with real slot counts).
@@ -2352,6 +2396,7 @@ eventFrame:SetScript("OnEvent", function(_, event)
 
     elseif event == "BANKFRAME_CLOSED" then
         _warbandOnly = false
+        _lastTSMBankType = nil
         WipeTransferState()
         -- Clear search on close
         if EUI_Bank._searchBox then


### PR DESCRIPTION
## What does this PR do?
Fixes TradeSkillMaster's Banking UI not detecting Bank/Warbank switches made
in the EUI bank sidebar. EUI replaces the Blizzard bank window and reparents
BankFrame to a hidden frame, so BankPanel:SetBankType() never fires and TSM
stays stuck on whichever bank type it saw first, moving items against the
wrong bank.

TSM supports addon-provided bank frames via two documented globals (TSM
Core/Service/Banking/Core.lua): it calls Addon_GetBankType() to read the
active bank type, and hooksecurefunc's Addon_SetBankType at init to re-check
when the view changes. This PR implements that contract in
EllesmereUIBags_Bank.lua on top of the existing public
EUI_Bank:IsWarbandView(), notifying from RefreshBank only when the effective
bank type actually changes. Both globals are guarded so another bag addon
that already implements the contract wins. For players without TSM, nothing
changes.

## How was it tested?
Live retail (12.0.7), EllesmereUIBags + current TSM: opened bank, ran
/tsm bankui, switched between Bank, Warbank, and individual warbank tab
views in the EUI sidebar - TSM now tracks the active bank type and moves
items against the correct bank. Also verified normal bank open/close cycles
with TSM disabled (no errors, no behavior change). Portable warbank
(AccountBanker) path works via the existing warband-only view selection.

## Checklist
- [x] New settings default **OFF** (no behavior change without opt-in) - N/A:
      no new setting; genuine bug fix, no player-visible change without TSM
- [x] Zero cost while disabled: no events registered, no polling, no hooks
      doing work, no frames built - two globals defined at load; without TSM
      the added cost is one comparison per RefreshBank call
- [x] Cheap while enabled: event-driven, piggybacks on the existing
      RefreshBank path with a change-guard; no polling, timers, or allocations
- [x] No writes onto Blizzard-owned frames; no SetScript/HookScript on
      anything - only two insecure globals and EUI's own frame are touched
- [X] Tested in-game, works on live retail; no load errors on the 12.1 PTR
      client - tested on live retail; I don't have the PTR client, but the
      change uses no 12.1-divergent paths (Enum.BankType and existing EUI
      functions only, with existence guards)