### PR TITLE
[Feature Request] Name font option

### DIFF
--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -2538,6 +2538,8 @@ initFrame:SetScript("OnEvent", function(self)
                       -- nil, not the sentinel, so the startup code can tell
                       -- "leave Blizzard alone" without knowing the key.
                       fdb.unitNameFont = (v ~= NAME_FONT_DEFAULT) and v or nil
+                      fdb.unitNameFontPath = (v ~= NAME_FONT_DEFAULT)
+                          and nameFontValues[v].font or nil
                       -- No apply call here: the engine has already cached the
                       -- global by this point, so the change lands on the next
                       -- login either way. Same as Combat Text Font above.

--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -2487,6 +2487,28 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.RegisterWidgetRefresh(cbDDRefresh)
         end
 
+        -- Name Font: the text floating above characters and NPCs. Deliberately
+        -- independent of Global Font, and modelled on Combat Text Font rather
+        -- than the settings around it: both drive a Blizzard global the engine
+        -- reads once at login (UNIT_NAME_FONT / DAMAGE_TEXT_FONT), so both need
+        -- a logout rather than the reload FontReload offers, and both treat
+        -- "Blizzard Default" as leave-it-alone instead of using a toggle.
+        -- Applied in EllesmereUI_Startup.lua.
+        local NAME_FONT_DEFAULT = "__default"
+        local nameFontValues, nameFontOrder = {}, {}
+        do
+            -- Same faces the Global Font dropdown offers, SharedMedia included,
+            -- but a private copy: prepending the default entry to the shared
+            -- tables would put it in the Global Font list too.
+            nameFontValues[NAME_FONT_DEFAULT] = { text = "Blizzard Default", font = "Fonts\\FRIZQT__.TTF" }
+            nameFontOrder[1] = NAME_FONT_DEFAULT
+            nameFontOrder[2] = "---"
+            for _, k in ipairs(fontDropOrder) do
+                nameFontOrder[#nameFontOrder + 1] = k
+                if k ~= "---" then nameFontValues[k] = fontDropValues[k] end
+            end
+        end
+
         -- Never Show Slug: per-profile toggle (rides profile export/import) that
         -- drops the SLUG token from every outline the UI produces -- body text and
         -- icon/aura text across all modules, plus the global Outline Mode itself.
@@ -2501,7 +2523,31 @@ initFrame:SetScript("OnEvent", function(self)
                       EllesmereUI.GetFontsDB().neverShowSlug = v and true or false
                       FontReload()
                   end },
-                { type="label", text="" }
+                { type="dropdown", text="Name Font",
+                  -- Coloured inline rather than via tooltipOpts.color, which
+                  -- would tint the explanation red along with the warning.
+                  tooltip="Sets the font for the names that float above players, NPCs and enemies in the world.\n\nSeparate from Global Font - changing this does not affect the rest of the UI, and Global Font does not affect it.\n\nBlizzard Default leaves the name text completely untouched.\n\n|cffff4d4dRequires a re-log or restart of WoW to take effect.|r",
+                  values=nameFontValues, order=nameFontOrder,
+                  getValue=function()
+                      local n = EllesmereUI.GetFontsDB().unitNameFont
+                      if not n or not nameFontValues[n] then return NAME_FONT_DEFAULT end
+                      return n
+                  end,
+                  setValue=function(v)
+                      local fdb = EllesmereUI.GetFontsDB()
+                      -- nil, not the sentinel, so the startup code can tell
+                      -- "leave Blizzard alone" without knowing the key.
+                      fdb.unitNameFont = (v ~= NAME_FONT_DEFAULT) and v or nil
+                      -- No apply call here: the engine has already cached the
+                      -- global by this point, so the change lands on the next
+                      -- login either way. Same as Combat Text Font above.
+                      EllesmereUI:ShowConfirmPopup({
+                          title       = "Logout Required",
+                          message     = "Name font changes require a logout to character select to take effect. This is a WoW engine limitation.",
+                          confirmText = "Okay",
+                          cancelText  = "Later",
+                      })
+                  end }
             );  y = y - h
         end
 

--- a/EllesmereUI_Startup.lua
+++ b/EllesmereUI_Startup.lua
@@ -167,8 +167,11 @@ local function ApplyUnitNameFont()
     local fonts = EllesmereUIDB and EllesmereUIDB.fonts
     local name = fonts and fonts.unitNameFont
     if not name or name == "" then return end
-    if not (EllesmereUI and EllesmereUI.ResolveFontName) then return end
-    local path = EllesmereUI.ResolveFontName(name)
+    local path = fonts.unitNameFontPath
+    if (type(path) ~= "string" or path == "")
+       and EllesmereUI and EllesmereUI.ResolveFontName then
+        path = EllesmereUI.ResolveFontName(name)
+    end
     if type(path) == "string" and path ~= "" then
         _G.UNIT_NAME_FONT = path
     end

--- a/EllesmereUI_Startup.lua
+++ b/EllesmereUI_Startup.lua
@@ -149,6 +149,31 @@ do
     end)
 end
 
+-- Apply the saved unit name font -- the names that float above players, NPCs
+-- and enemies. UNIT_NAME_FONT is a plain path string the engine reads once at
+-- login, so a UI reload is not enough and the change shows after a full relog.
+--
+-- Opt-in: while no name font is chosen the global is never written, so
+-- Blizzard's default is left exactly as it was.
+--
+-- Rides the combat text font's event frame below rather than creating its own.
+-- Both drive a Blizzard global cached at login and want the same timing, and a
+-- feature nobody enabled must not register events or build frames of its own.
+--
+-- Reads EllesmereUIDB.fonts directly rather than going through GetFontsDB():
+-- that helper lazy-creates the table, and this can run at the ADDON_LOADED of
+-- Blizzard_CombatText, before our SavedVariables have been restored.
+local function ApplyUnitNameFont()
+    local fonts = EllesmereUIDB and EllesmereUIDB.fonts
+    local name = fonts and fonts.unitNameFont
+    if not name or name == "" then return end
+    if not (EllesmereUI and EllesmereUI.ResolveFontName) then return end
+    local path = EllesmereUI.ResolveFontName(name)
+    if type(path) == "string" and path ~= "" then
+        _G.UNIT_NAME_FONT = path
+    end
+end
+
 -- Apply the saved combat text font immediately at file scope.
 -- DAMAGE_TEXT_FONT must be set before the engine caches it at login.
 -- CombatTextFont may not exist yet here, so we also hook ADDON_LOADED
@@ -192,6 +217,7 @@ do
         end
 
         ApplyCombatTextFont()
+        ApplyUnitNameFont()
 
         if event == "PLAYER_LOGIN" then
             self:UnregisterEvent("PLAYER_LOGIN")


### PR DESCRIPTION
## What does this PR do?

Adds a **Name Font** dropdown under Fonts & Colors → GLOBAL FONT.

It lets players choose a font for floating world unit names—players, NPCs, and enemies—independently of Global Font. The default is **Blizzard Default**, which leaves the game’s name font unchanged.

Name Font changes require logging out to character select (or restarting WoW) to take effect.

## How was it tested?

Tested in-game on live retail and the 12.1 PTR client by selecting a Name Font, logging out to character select and back in, and confirming floating unit names use the selected font.


## Screenshots
<img width="1018" height="621" alt="default font" src="https://github.com/user-attachments/assets/36105824-2072-4a53-9cbc-a82312fd494e" />
<img width="815" height="624" alt="KMT Kimberly" src="https://github.com/user-attachments/assets/025c0748-c1cf-4eaf-9bb7-b61edda55990" />
<img width="1327" height="959" alt="meny" src="https://github.com/user-attachments/assets/2cca1179-9738-4d4b-9c54-3094cb7b04f1" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client