### PR TITLE
Stop planting an insecure callback inside Blizzard's menu description

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -793,22 +793,33 @@ end
         if not _pmEnabled() then return end
         -- Defer out of the secure context. The post-hook runs inside
         -- Blizzard's protected menu pipeline; touching Blizzard objects
-        -- here propagates taint to action bar buttons. 
-        -- By the next frame the secure execution
-        -- has finished so AddMenuAcquiredCallback is safe.
-        C_Timer.After(0, function()
+        -- here propagates taint to action bar buttons.
+        --
+        -- NO menuDescription:AddMenuAcquiredCallback(). Deferring the
+        -- REGISTRATION does not make the callback safe: it plants an insecure
+        -- Lua function inside Blizzard's menu description, and Blizzard then
+        -- CALLS it from inside its own menu pipeline, so the pipeline that
+        -- builds the menu (and owns the entry click handlers) runs tainted.
+        -- Field report 2026-07-28: right-clicking a unit and choosing Whisper
+        -- opened the chat edit box with a SECRET target name, and because that
+        -- ChatFrameUtil.OpenChat write (editBox.text / setText) happened under
+        -- that taint, Blizzard's own ChatFrameEditBoxMixin:OnUpdate was then
+        -- refused SetText(self.text) -- repeating every frame, since the
+        -- failed call skips the setText = 0 that would end it.
+        --
+        -- Self-owned staggered passes instead: the menu frame is fetched from
+        -- the manager and skinned by us, with nothing handed to Blizzard.
+        -- Several passes cover submenus and pooled frames acquired a little
+        -- after the open, which is what the callback was there for.
+        local function skinOpenMenu()
             local menu = manager.GetOpenMenu and manager:GetOpenMenu()
-            if menu then
+            if menu and not _menuSkinned[menu] then
                 _menuSkinFrame(menu)
             end
-            if menuDescription and menuDescription.AddMenuAcquiredCallback then
-                menuDescription:AddMenuAcquiredCallback(function(frame)
-                    C_Timer.After(0, function()
-                        _menuSkinFrame(frame)
-                    end)
-                end)
-            end
-        end)
+        end
+        C_Timer.After(0, skinOpenMenu)
+        C_Timer.After(0.05, skinOpenMenu)
+        C_Timer.After(0.15, skinOpenMenu)
     end
 
     local function _menuInit()


### PR DESCRIPTION
### The problem

Context-menu skinning registered `menuDescription:AddMenuAcquiredCallback(fn)` with our own Lua function.

The existing comment claimed that deferring the registration to the next frame made this safe. It does not. The callback still lives inside Blizzard's menu description, and **Blizzard calls it from inside its own menu pipeline**. Blizzard's `Menu.lua` invokes acquired callbacks with a plain call, not `securecallfunction`, so the rest of menu generation runs tainted, including the entry click handlers the menu owns.

Deferring your own execution does not sanitise a callback you hand to Blizzard.

### Field report

Right-clicking a unit and choosing Whisper in an instance opened the edit box with a secret target name. `ChatFrameUtil.OpenChat` writes `editBox.text` and `editBox.setText` from that click, so under the menu taint the text field itself is tainted, and Blizzard's own `ChatFrameEditBoxMixin:OnUpdate` is then refused:

```
ChatFrameEditBox.lua:360: Secret values are only allowed during untainted execution
```

It repeats every frame because the failed call never reaches the `setText = 0` that would end it.

### The fix

The `menuDescription` write is removed. The open menu is fetched from the manager and skinned by us, on self-owned staggered passes, handing Blizzard nothing. The extra passes cover submenus and pooled frames acquired shortly after the open, which is what the callback covered.

`AddMenuAcquiredCallback` had exactly one use in the codebase.

### Testing

Verified in a Mythic+: right-click a guild member, Whisper, send. The edit box opens and the message sends with no error. Menus and submenus are still skinned, including on reopen from the frame pool.