### PR TITLE
Skip guild roster entries whose fields are secret

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -4574,7 +4574,15 @@ local function MMBuildGuildTip()
 
     for i = 1, GetNumGuildMembers() do
         local name, _, _, level, _, zone, _, _, isOnline, status, class = GetGuildRosterInfo(i)
-        if isOnline then
+        -- Roster fields are SECRET in restricted content (Mythic+, raid, or the
+        -- forced addon-restriction CVars). This row matches the name, formats
+        -- it with the level, and uses the class as a table key -- none of which
+        -- a secret allows -- so an entry we cannot read is skipped. The whisper
+        -- action below is separately suppressed in the same content.
+        local secretRow = issecretvalue and (issecretvalue(name) or issecretvalue(class)
+            or issecretvalue(isOnline) or issecretvalue(status)
+            or issecretvalue(level) or issecretvalue(zone))
+        if not secretRow and isOnline then
             local cc  = class and RAID_CLASS_COLORS[class]
             local clr, clg, clb = 1, 1, 1
             if cc then clr, clg, clb = cc.r, cc.g, cc.b end

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -2216,6 +2216,13 @@ end
 -------------------------------------------------------------------------------
 local FRIENDS_ATLAS = "housefinder_neighborhood-friends-icon"
 
+-- Guild roster fields come back SECRET in restricted content (Mythic+, raid,
+-- or the forced addon-restriction CVars). Reading the tag is safe; matching,
+-- comparing or using the value as a table key is not.
+local function _isSecretVal(v)
+    return issecretvalue ~= nil and issecretvalue(v)
+end
+
 local function GatherOnlineFriends()
     local guild, favorites, friends = {}, {}, {}
     local seenBNet = {}
@@ -2226,10 +2233,19 @@ local function GatherOnlineFriends()
         local total = GetNumGuildMembers() or 0
         for i = 1, total do
             local name, _, _, level, _, zone, _, _, online, _, classFile = GetGuildRosterInfo(i)
-            if online and name then
+            -- name is matched and compared, and classFile is later used as a
+            -- table key for the class color, so an entry whose identity we
+            -- cannot read is skipped rather than erroring out of the sweep.
+            if not (_isSecretVal(name) or _isSecretVal(classFile) or _isSecretVal(online))
+                and online and name then
                 local short = name:match("^([^%-]+)") or name
                 if short ~= myName then
-                    guild[#guild + 1] = { name = short, full = name, class = classFile, zone = zone or "", level = level, kind = "guild" }
+                    guild[#guild + 1] = {
+                        name = short, full = name, class = classFile,
+                        zone = (not _isSecretVal(zone)) and (zone or "") or "",
+                        level = (not _isSecretVal(level)) and level or nil,
+                        kind = "guild",
+                    }
                 end
             end
         end

--- a/EllesmereUIQoL/EllesmereUIQoL_Keys.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Keys.lua
@@ -75,9 +75,16 @@ local function BuildClassColorMap()
         local total = GetNumGuildMembers()
         for i = 1, total do
             local gName, _, _, _, _, _, _, _, _, _, classFile = GetGuildRosterInfo(i)
-            if gName and classFile then
+            -- Roster fields are SECRET in restricted content (Mythic+, raid, or
+            -- the forced addon-restriction CVars). The short name is produced by
+            -- a string operation and then used as a TABLE KEY, and neither is
+            -- allowed on a secret, so an unreadable entry is skipped.
+            if gName and classFile
+                and not (issecretvalue and (issecretvalue(gName) or issecretvalue(classFile))) then
                 local gShort = Ambiguate and Ambiguate(gName, "short") or gName:match("^([^%-]+)")
-                if gShort then map[gShort] = classFile end
+                if gShort and not (issecretvalue and issecretvalue(gShort)) then
+                    map[gShort] = classFile
+                end
             end
         end
     end


### PR DESCRIPTION
Three features read the roster with GetGuildRosterInfo and then operate on the result in ways a secret value does not permit: the minimap friends list matches the short name and compares it to the player's, the keystone popup's class-color map runs the name through Ambiguate and uses the result as a TABLE KEY, and the data bar guild tooltip matches the name, formats it together with the level, and looks the class up in RAID_CLASS_COLORS.

In restricted content -- Mythic+, raid, or with the addon restriction CVars forced on -- those fields come back secret, and every one of those operations throws. The failure is not confined to the bad entry: it aborts the sweep, so the whole list is lost rather than one row.

Each site now reads only the secret tag, which is always allowed, and skips an entry it cannot identify. Where a field is merely decorative the row survives without it: the minimap entry keeps its name and class and drops a secret zone or level.

Nothing changes outside restricted content, where no roster field is secret and every entry is kept exactly as before.

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
