### PR TITLE
Say what the generic CDs/buffs sync did and did not do

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -16078,7 +16078,13 @@ initFrame:SetScript("OnEvent", function(self)
                 end
                 EllesmereUI:ShowCDMSpecPickerPopup({
                     title       = "Sync Generic CDs/Buffs",
-                    subtitle    = "Choose which specs sync with " .. srcName .. " (the source is always included)",
+                    -- The grid lists every class, not just the one being played,
+                    -- so an alt's specs are ticked from here. Saying so matters:
+                    -- a profile is shared across characters, and without this
+                    -- the only visible reading is "specs of this character".
+                    -- Kept to one line: the subtitle has room for two before it
+                    -- runs into the Check All / Uncheck All row.
+                    subtitle    = "Choose which specs sync with " .. srcName .. ", including your alts' specs (the source is always included)",
                     confirmText = "Sync",
                     specs       = specs,
                     lockedSpecs = { [sourceKey] = "This is the spec you're syncing from -- it's always included." },
@@ -16087,13 +16093,22 @@ initFrame:SetScript("OnEvent", function(self)
                         local cnt = 0
                         for _, v in pairs(selectedSpecs) do if v then cnt = cnt + 1 end end
                         if cnt <= 1 then
-                            -- Only the source picked -> nothing to sync; clear any sync.
+                            -- Only the source picked -> nothing to sync; clear any
+                            -- sync. Say so: this silently discarded an existing
+                            -- sync, and confirming with one spec ticked is the
+                            -- natural first guess at "sync FROM this spec".
                             if ns.ClearRPTSync then ns.ClearRPTSync() end
+                            EllesmereUI.Print("|cff0cd29fEllesmereUI CDM:|r Sync cleared -- only one spec was selected. Tick at least two specs (including other characters' specs) to sync between them.")
                             EllesmereUI:RefreshPage(true)
                             return
                         end
                         if ns.SetupRPTSync then ns.SetupRPTSync(selectedSpecs, sourceKey) end
                         if ns.FullCDMRebuild then ns.FullCDMRebuild("profile_import") end
+                        -- Which bar each entry sits on is synced; its SLOT is
+                        -- not, so every spec keeps its own ordering. Reported as
+                        -- a bug ("some were right, some were wrong order"), so
+                        -- it is stated where the subtitle has no room for it.
+                        EllesmereUI.Print(("|cff0cd29fEllesmereUI CDM:|r Syncing generic CDs/buffs across %d specs. Icon order is not synced -- each spec keeps its own arrangement."):format(cnt))
                         EllesmereUI:RefreshPage(true)
                     end,
                 })
@@ -16128,7 +16143,10 @@ initFrame:SetScript("OnEvent", function(self)
                     for _, v in pairs(selectedSpecs) do if v then cnt = cnt + 1 end end
                     if cnt <= 1 then
                         -- One or zero specs left -> nothing to sync; clear it.
+                        -- Announced for the same reason as the setup path: the
+                        -- sync is discarded here, not merely left unchanged.
                         if ns.ClearRPTSync then ns.ClearRPTSync() end
+                        EllesmereUI.Print("|cff0cd29fEllesmereUI CDM:|r Sync cleared -- fewer than two specs remained selected.")
                         EllesmereUI:RefreshPage(true)
                         return
                     end


### PR DESCRIPTION
### The report

A user set up a bar with potions and a healthstone, wanted it on all their characters, pressed **Sync Generic CDs/Buffs**, and reported that nothing happened. Following up, they said it later "randomly started working partially -- some were right, some were wrong order", and asked what the correct way to use the feature actually is.

Nothing was broken. Two behaviours are invisible until they surprise someone, and together they read as a feature that does not work.

### 1. Confirming with one spec ticked CLEARS the sync, silently

`if cnt <= 1 then ClearRPTSync()` on both the setup and edit paths, with no output.

Ticking only the spec you want to copy *from* is the natural first guess at "sync from this spec". Doing that discarded the sync the user was trying to create, and told them nothing. Their first attempt did not merely fail, it deleted state.

Both paths now say what happened and what to do instead.

### 2. Icon order is deliberately not synced

`ApplyRPT` syncs bar membership and per-icon settings, but never slot position, so a sync can't shove a trinket or potion back to a default slot on a spec somebody already arranged:

> Bar MEMBERSHIP and per-icon settings are synced, but the SLOT POSITION (order within a bar) is NOT.

That is the right call, but from outside it looks like a half-finished copy. A successful sync now states it, along with how many specs were included.

### 3. The subtitle never mentioned other characters

The grid is built from a hardcoded table of all 13 classes, so an alt's specs are already tickable, and a profile is shared across characters. But "Choose which specs sync with Fire" only ever implied the specs of the character being played, so nothing indicated that ticking an alt's specs is how sharing across characters works. The setup subtitle now says so.

### Notes

No behaviour change: same code paths, same data, three messages and one reworded subtitle.

The subtitle addition is deliberately short. That FontString wraps but has room for two lines before it reaches the Check All / Uncheck All row, and the edit-path text is already close to that limit, so the longer explanation goes to chat rather than into the popup.

### Testing

In-game across all three paths: confirming with only the source ticked, confirming with several specs ticked, and unticking an existing sync down to one spec. Subtitle checked on one line with the longest spell name the string can take.