### PR TITLE
Take the pandemic glow down when its setting is turned off

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -7287,6 +7287,17 @@ function ns.SetupViewerHooks()
                                 -- Pandemic glow: Blizzard's ShowPandemicStateFrame
                                 -- hook sets _pandemicState. User must configure
                                 -- pandemic alerts in Blizzard CDM settings.
+                                -- Only the START side is gated on the setting. The
+                                -- STOP side below must stay reachable with the
+                                -- setting OFF, or a glow that is already running
+                                -- when the user disables it is never taken down
+                                -- and stays lit until something else clears it
+                                -- (field report: red pandemic glow with the option
+                                -- off, cured only by switching it back on, letting
+                                -- the aura lapse, then off again -- which is just
+                                -- the stop branch finally becoming reachable). The
+                                -- buff glow directly above already has this shape.
+                                local inPandemic = false
                                 if pandemicOn and fd then
                                     -- Blizzard Default (-1): no custom glow and no
                                     -- hooks -- Blizzard's native PandemicIcon does
@@ -7296,7 +7307,6 @@ function ns.SetupViewerHooks()
                                     -- a CDM shell, so even install-time work bills
                                     -- CooldownManager.
                                     local pStyle = bd.pandemicGlowStyle or 1
-                                    local inPandemic = false
                                     if pStyle ~= -1 then
                                         if ns._pandemicHooked and not ns._pandemicHooked[frame]
                                            and ns.HookPandemicState then
@@ -7304,42 +7314,42 @@ function ns.SetupViewerHooks()
                                         end
                                         inPandemic = ns._pandemicState and ns._pandemicState[frame]
                                     end
-                                    if inPandemic then
-                                        if not fd.pandemicOverlay then
-                                            local ov = CreateFrame("Frame", nil, frame)
-                                            ov:SetAllPoints(frame)
-                                            ov:EnableMouse(false)
-                                            fd.pandemicOverlay = ov
-                                        end
-                                        -- Same base-level tracking as the buff glow, one
-                                        -- level higher so pandemic sits above buff glow.
-                                        fd.pandemicOverlay:SetFrameLevel(frame:GetFrameLevel() + 17)
-                                        if not fd.pandemicGlowActive then
-                                            local c
-                                            if bd.pandemicGlowMode == "class" then
-                                                c = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
-                                            elseif bd.pandemicGlowMode == "custom" then
-                                                c = bd.pandemicGlowColor
-                                            end
-                                            local style = bd.pandemicGlowStyle or 1
-                                            local glowOpts = (style == 1) and {
-                                                N      = bd.pandemicGlowLines or 8,
-                                                th     = bd.pandemicGlowThickness or 2,
-                                                period = bd.pandemicGlowSpeed or 4,
-                                                bg     = bd.pandemicGlowBackground and {
-                                                    r = (bd.pandemicGlowBackgroundColor and bd.pandemicGlowBackgroundColor.r) or 0,
-                                                    g = (bd.pandemicGlowBackgroundColor and bd.pandemicGlowBackgroundColor.g) or 0,
-                                                    b = (bd.pandemicGlowBackgroundColor and bd.pandemicGlowBackgroundColor.b) or 0,
-                                                } or nil,
-                                            } or nil
-                                            fd.pandemicOverlay:SetAlpha(1)
-                                            ns.StartNativeGlow(fd.pandemicOverlay, style, c and c.r, c and c.g, c and c.b, glowOpts)
-                                            fd.pandemicGlowActive = true
-                                        end
-                                    elseif fd.pandemicGlowActive and fd.pandemicOverlay then
-                                        ns.StopNativeGlow(fd.pandemicOverlay)
-                                        fd.pandemicGlowActive = false
+                                end
+                                if inPandemic and fd then
+                                    if not fd.pandemicOverlay then
+                                        local ov = CreateFrame("Frame", nil, frame)
+                                        ov:SetAllPoints(frame)
+                                        ov:EnableMouse(false)
+                                        fd.pandemicOverlay = ov
                                     end
+                                    -- Same base-level tracking as the buff glow, one
+                                    -- level higher so pandemic sits above buff glow.
+                                    fd.pandemicOverlay:SetFrameLevel(frame:GetFrameLevel() + 17)
+                                    if not fd.pandemicGlowActive then
+                                        local c
+                                        if bd.pandemicGlowMode == "class" then
+                                            c = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
+                                        elseif bd.pandemicGlowMode == "custom" then
+                                            c = bd.pandemicGlowColor
+                                        end
+                                        local style = bd.pandemicGlowStyle or 1
+                                        local glowOpts = (style == 1) and {
+                                            N      = bd.pandemicGlowLines or 8,
+                                            th     = bd.pandemicGlowThickness or 2,
+                                            period = bd.pandemicGlowSpeed or 4,
+                                            bg     = bd.pandemicGlowBackground and {
+                                                r = (bd.pandemicGlowBackgroundColor and bd.pandemicGlowBackgroundColor.r) or 0,
+                                                g = (bd.pandemicGlowBackgroundColor and bd.pandemicGlowBackgroundColor.g) or 0,
+                                                b = (bd.pandemicGlowBackgroundColor and bd.pandemicGlowBackgroundColor.b) or 0,
+                                            } or nil,
+                                        } or nil
+                                        fd.pandemicOverlay:SetAlpha(1)
+                                        ns.StartNativeGlow(fd.pandemicOverlay, style, c and c.r, c and c.g, c and c.b, glowOpts)
+                                        fd.pandemicGlowActive = true
+                                    end
+                                elseif fd and fd.pandemicGlowActive and fd.pandemicOverlay then
+                                    ns.StopNativeGlow(fd.pandemicOverlay)
+                                    fd.pandemicGlowActive = false
                                 end
 
                                 -- Active State Glow integrity, BOTH edges. The


### PR DESCRIPTION
### The report

The red pandemic glow kept showing with the option disabled. The reporter found a workaround that reads as superstition: turn Pandemic Glow back on, switch it to Modern WoW Glow, cast a DoT on a dummy, then disable it again.

### Cause

Both the start and the stop branch sat inside the same gate:

```lua
if pandemicOn and fd then
    if inPandemic then                     -- start the glow
    elseif fd.pandemicGlowActive then      -- stop the glow
    end
end
```

With the setting off, `pandemicOn` is false and the whole block is skipped, so the stop branch is unreachable. A glow already running when the user disables the option is never taken down, and nothing else routinely clears that overlay.

That also explains the workaround. Re-enabling the option is the only way back into the branch that stops the glow; the style change and the DoT were incidental. What mattered was the aura lapsing while the setting was on, which finally reached the `elseif`.

### Fix

Only the start side is gated now; the stop side runs regardless of the setting. This is the shape the buff glow immediately above already uses, where the stop is an `elseif` outside the enable condition.

The diff looks larger than the change because the start branch loses one level of indentation.

### Reaching it

No deliberate action is needed. Several bar templates ship `pandemicGlow` enabled, so a player can have the glow, switch it off, and be left with it burning without ever having turned it on.

### Testing

Verified in-game: with the glow lit, disabling the setting now takes it down immediately instead of leaving it stuck. Re-enabling still lights it, and switching to Blizzard Default clears it as before.

Reported on the 12.1 PTR, but nothing here is version-specific -- the gate structure predates 12.1 and the change touches no API whose behaviour differs between them.
<img width="480" height="480" alt="This Is Fine On Fire GIF by Doge Pound" src="https://github.com/user-attachments/assets/325077e0-8d59-40a9-8fec-99cca004b516" />
