### PR TITLE
Report resource bar size on the axes it is drawn on

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -3017,8 +3017,14 @@ initFrame:SetScript("OnEvent", function(self)
         -- via Unlock Mode) is a global relationship that greys the slider in BOTH
         -- modes -- you can't per-spec override a matched dimension. Only the
         -- "apply to all bars" sync icons below are Simple-only.
+        -- Orientation-aware: on a vertical bar the drawn axes are swapped, so
+        -- the slider labelled Height controls what the match calls Width.
+        local function healthOri()
+            local c, p = cfg(), DB()
+            return (c and c.orientation) or (p and p.general and p.general.orientation)
+        end
         local function guard(propKey)
-            return EllesmereUI.MatchGuard("ERB_Health", propKey, healthOff, "Health Bar")
+            return ns.OrientedMatchGuard("ERB_Health", propKey, healthOri, healthOff, "Health Bar")
         end
         local hhDis, hhTip, hhRaw = guard("Height")
         local hwDis, hwTip, hwRaw = guard("Width")
@@ -3792,8 +3798,13 @@ initFrame:SetScript("OnEvent", function(self)
         -- toggle's DependentSetValue forces the rebuild on flips).
         if not powerOff() then
         -- Row 2: Height | Width (MatchGuard both modes; sync icons Simple-only).
+        -- Orientation-aware, as on the health bar above.
+        local function powerOri()
+            local c, p = cfg(), DB()
+            return (c and c.orientation) or (p and p.general and p.general.orientation)
+        end
         local function guard(propKey)
-            return EllesmereUI.MatchGuard("ERB_Power", propKey, powerOff, powerDisTip)
+            return ns.OrientedMatchGuard("ERB_Power", propKey, powerOri, powerOff, powerDisTip)
         end
         local phDis, phTip, phRaw = guard("Height")
         local pwDis, pwTip, pwRaw = guard("Width")
@@ -4704,8 +4715,16 @@ initFrame:SetScript("OnEvent", function(self)
         local classColorRow
         if not classOff() then
         -- Row 2: Height | Width (MatchGuard both modes; sync icons Simple-only).
+        -- Orientation-aware. This bar has its OWN orientation key and its
+        -- renderer counts anything that is not HORIZONTAL as vertical, so the
+        -- value is normalised before the shared helper sees it.
+        local function classOri()
+            local c = cfg()
+            local o = (c and c.pipOrientation) or "HORIZONTAL"
+            return o ~= "HORIZONTAL" and "VERTICAL_UP" or "HORIZONTAL"
+        end
         local function classGuard(propKey)
-            return EllesmereUI.MatchGuard("ERB_ClassResource", propKey, classOff, "Class Resource")
+            return ns.OrientedMatchGuard("ERB_ClassResource", propKey, classOri, classOff, "Class Resource")
         end
         local chDis, chTip, chRaw = classGuard("Height")
         local cwDis, cwTip, cwRaw = classGuard("Width")
@@ -9480,8 +9499,15 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         -- Row: Height | Width
-        local ghDis, ghTip, ghRaw = EllesmereUI.MatchGuard("ERB_GCDBar", "Height", gcdOff, "GCD Bar")
-        local gwDis, gwTip, gwRaw = EllesmereUI.MatchGuard("ERB_GCDBar", "Width", gcdOff, "GCD Bar")
+        -- Orientation-aware. This bar's size callbacks have always reported the
+        -- drawn axes, so its sliders were guarded on the wrong one for vertical
+        -- orientations before the other bars were brought in line.
+        local function gcdOri()
+            local p = DB()
+            return p and p.gcdBar and p.gcdBar.orientation
+        end
+        local ghDis, ghTip, ghRaw = ns.OrientedMatchGuard("ERB_GCDBar", "Height", gcdOri, gcdOff, "GCD Bar")
+        local gwDis, gwTip, gwRaw = ns.OrientedMatchGuard("ERB_GCDBar", "Width", gcdOri, gcdOff, "GCD Bar")
         _, h = W:DualRow(parent, y,
             { type = "slider", text = "Height", min = 1, max = 60, step = 1,
               disabled = ghDis, disabledTooltip = ghTip, rawTooltip = ghRaw,

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1402,6 +1402,36 @@ end
 local function IsVerticalOrientation(ori)
     return ori == "VERTICAL_UP" or ori == "VERTICAL_DOWN"
 end
+-- Shared with the options file, which has to know a bar's drawn axes to grey
+-- the right size slider when a dimension is matched. Exported rather than
+-- duplicated so the two never drift.
+ns.IsVerticalOrientation = IsVerticalOrientation
+
+-- Orientation-aware MatchGuard.
+--
+-- The size sliders are labelled and stored in HORIZONTAL terms, but a match
+-- locks the axis the bar is DRAWN on. On a vertical bar those are swapped, so
+-- guarding by the slider's own label greys the field the match does not write
+-- and leaves the field it does write editable -- the player's change then
+-- disappears on the next apply.
+--
+-- Both guards are built and the right one is chosen when the widget asks, not
+-- when the page is built, so flipping orientation with the panel open is
+-- honoured. getOri returns the bar's effective orientation.
+ns.OrientedMatchGuard = function(barKey, propKey, getOri, existingDisabled, existingTooltip)
+    local hD, hT, hR = EllesmereUI.MatchGuard(barKey, "Height", existingDisabled, existingTooltip)
+    local wD, wT, wR = EllesmereUI.MatchGuard(barKey, "Width",  existingDisabled, existingTooltip)
+    local function pick(sameAxis, swappedAxis)
+        return function(...)
+            if IsVerticalOrientation(getOri and getOri()) then return swappedAxis(...) end
+            return sameAxis(...)
+        end
+    end
+    if propKey == "Height" then
+        return pick(hD, wD), pick(hT, wT), pick(hR, wR)
+    end
+    return pick(wD, hD), pick(wT, hT), pick(wR, hR)
+end
 
 -- Cached empower stage thresholds (set once at empower start, avoids per-frame API call)
 local cachedStageThresholds

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -2108,11 +2108,34 @@ local function RegisterUnlockElements()
             key = "ERB_Health", label = "Health Bar", group = "Resource Bars", order = 500,
             getFrame = function() return healthBar end,
             isHidden = function() local s = S(); return not s.enabled or IsSpecDisabled(s) end,
+            -- Reported through the ON-SCREEN axes, not the stored ones. A
+            -- vertical bar renders through OrientedSize, so stored width is
+            -- what the player sees as height; handing the unlock mover and the
+            -- W/H match the raw stored pair made both act on a bar that is
+            -- still horizontal.
             getSize  = function()
-                local s = SS(); return s.width, s.height
+                local s, g = SS(), ERB.db.profile.general
+                return OrientedSize(s.width, s.height,
+                    s.orientation or (g and g.orientation) or "HORIZONTAL")
             end,
-            setWidth = function(_, w) SS().width = PP.Snap(w); Rebuild() end,
-            setHeight = function(_, h) SS().height = PP.Snap(h); Rebuild() end,
+            setWidth = function(_, w)
+                local s, g = SS(), ERB.db.profile.general
+                if IsVerticalOrientation(s.orientation or (g and g.orientation)) then
+                    s.height = PP.Snap(w)
+                else
+                    s.width = PP.Snap(w)
+                end
+                Rebuild()
+            end,
+            setHeight = function(_, h)
+                local s, g = SS(), ERB.db.profile.general
+                if IsVerticalOrientation(s.orientation or (g and g.orientation)) then
+                    s.width = PP.Snap(h)
+                else
+                    s.height = PP.Snap(h)
+                end
+                Rebuild()
+            end,
             isAnchored = function() local s = S(); return s.anchorTo and s.anchorTo ~= "none" end,
             keepMoverWhenAnchored = true,
             onLiveMove = LiveMove,
@@ -2129,11 +2152,30 @@ local function RegisterUnlockElements()
             key = "ERB_Power", label = "Power Bar", group = "Resource Bars", order = 501,
             getFrame = function() return primaryBar end,
             isHidden = function() local s = S(); return s.enabled == false or IsSpecDisabled(s) end,
+            -- On-screen axes, as with the health bar above.
             getSize  = function()
-                local s = SS(); return s.width or 214, s.height or 14
+                local s, g = SS(), ERB.db.profile.general
+                return OrientedSize(s.width or 214, s.height or 14,
+                    s.orientation or (g and g.orientation) or "HORIZONTAL")
             end,
-            setWidth = function(_, w) SS().width = PP.Snap(w); Rebuild() end,
-            setHeight = function(_, h) SS().height = PP.Snap(h); Rebuild() end,
+            setWidth = function(_, w)
+                local s, g = SS(), ERB.db.profile.general
+                if IsVerticalOrientation(s.orientation or (g and g.orientation)) then
+                    s.height = PP.Snap(w)
+                else
+                    s.width = PP.Snap(w)
+                end
+                Rebuild()
+            end,
+            setHeight = function(_, h)
+                local s, g = SS(), ERB.db.profile.general
+                if IsVerticalOrientation(s.orientation or (g and g.orientation)) then
+                    s.width = PP.Snap(h)
+                else
+                    s.height = PP.Snap(h)
+                end
+                Rebuild()
+            end,
             isAnchored = function() local s = S(); return s.anchorTo and s.anchorTo ~= "none" end,
             keepMoverWhenAnchored = true,
             onLiveMove = LiveMove,
@@ -2149,16 +2191,34 @@ local function RegisterUnlockElements()
         elements[#elements + 1] = MK({
             key = "ERB_ClassResource", label = "Class Resource", group = "Resource Bars", order = 502,
             getFrame = function() return secondaryFrame end,
+            -- On-screen axes. This bar carries its OWN orientation key
+            -- (pipOrientation, what the dropdown writes) and takes no fallback
+            -- from general, and its renderer treats anything that is not
+            -- HORIZONTAL as vertical -- both mirrored here so the mover and the
+            -- W/H match agree with what is drawn.
             getSize  = function()
                 local s = SS()
-                return s.pipWidth, s.pipHeight
+                return OrientedSize(s.pipWidth, s.pipHeight,
+                    (s.pipOrientation or "HORIZONTAL") ~= "HORIZONTAL" and "VERTICAL_UP" or "HORIZONTAL")
             end,
             setWidth = function(_, w)
                 local s = SS()
-                s.pipWidth = PP.Snap(w)
+                if (s.pipOrientation or "HORIZONTAL") ~= "HORIZONTAL" then
+                    s.pipHeight = PP.Snap(w)
+                else
+                    s.pipWidth = PP.Snap(w)
+                end
                 Rebuild()
             end,
-            setHeight = function(_, h) SS().pipHeight = PP.Snap(h); Rebuild() end,
+            setHeight = function(_, h)
+                local s = SS()
+                if (s.pipOrientation or "HORIZONTAL") ~= "HORIZONTAL" then
+                    s.pipWidth = PP.Snap(h)
+                else
+                    s.pipHeight = PP.Snap(h)
+                end
+                Rebuild()
+            end,
             isHidden = function() local s = S(); return s.enabled == false or IsSpecDisabled(s) end,
             isAnchored = function() local s = S(); return s.anchorTo and s.anchorTo ~= "none" end,
             keepMoverWhenAnchored = true,


### PR DESCRIPTION
### The report

Matching a vertical power or class resource bar to another element did not match it. The bar also changed shape on entering Unlock Mode. Both behaved as though the bar were still horizontal, which made a vertical resource bar impossible to line up against a vertical Cooldown Manager.

### Cause

These bars store `width` and `height` in horizontal terms and swap them at draw time through `OrientedSize`, so a vertical bar's stored width is what the player sees as its height.

The unlock element callbacks handed the stored pair over untouched:

```lua
getSize  = function() local s = SS(); return s.width, s.height end,
setWidth = function(_, w) SS().width = PP.Snap(w); Rebuild() end,
```

Everything downstream then measured the wrong axis. The mover sizes itself from `getSize`, which is the shape change on entering Unlock Mode, and W Match / H Match feed the matched value to `setWidth` / `setHeight`, which wrote back to the axis the player was not adjusting.

The **GCD Bar has always done this correctly** -- its callbacks check orientation. Health, Power and Class Resource never got the same treatment, though Health and Power already render through `OrientedSize`.

### Second, related defect

The size sliders are labelled and stored in horizontal terms, but a match locks the axis the bar is *drawn* on. Guarding each slider by its own label greys the field the match does not write and leaves editable the one it does -- so a player could still move the matched value and lose it again on the next apply.

Both guards are now built and the right one chosen when the widget asks rather than when the page is built, so changing orientation with the panel open is honoured.

This was already true of the GCD Bar, whose callbacks always reported drawn axes. It is fixed here rather than left as the only bar guarding the wrong slider.

### Coverage

| Element | Change |
|---|---|
| Health, Power, Class Resource | size callbacks and slider guards |
| GCD Bar | slider guard only; callbacks were already correct |
| Cast Bar | untouched, no orientation setting |
| Totem Bar | untouched, `getSize` already reported drawn axes, no size sliders to guard |

Class Resource is deliberately not identical to the others: it carries its own `pipOrientation` key rather than falling back to the general setting, and its renderer counts anything that is not `HORIZONTAL` as vertical. Both quirks are mirrored so the mover, the match and the guard agree with what is drawn.

`IsVerticalOrientation` is exported on `ns` rather than duplicated into the options file so the two cannot drift. No new file-level locals were added.

### Known consequence

Spec Override layers **already captured** for a vertical resource bar recorded their sizes in stored axes, and will apply transposed once until re-captured. A migration is not included deliberately: a pre-change capture cannot be distinguished from a post-change one, and the bar's orientation may have changed since, so a blind swap could transpose correct data instead.

### Testing

In-game across all variations: vertical and horizontal, W Match and H Match and both at once, on each affected bar, including toggling orientation with the options panel open. Horizontal behaviour is unchanged -- `OrientedSize` returns the pair unaltered and both setters write the fields they always wrote.

<img width="480" height="480" alt="This Is Fine On Fire GIF by Magic Eden" src="https://github.com/user-attachments/assets/dafa7f7c-2600-4dba-9938-64e608d27e80" />
