### PR TITLE
Resource Bars: add vertical player cast bars

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -903,7 +903,8 @@ EllesmereUI.RegisterSyncExclusions("EllesmereUIResourceBars", {
     "primary.width", "primary.height", "primary.offsetX", "primary.offsetY", "primary.orientation",
     "secondary.pipWidth", "secondary.pipHeight", "secondary.pipSpacing", "secondary.pipOrientation",
     "secondary.offsetX", "secondary.offsetY",
-    "castBar.width", "castBar.height", "castBar.anchorX", "castBar.anchorY", "castBar.unlockPos",
+    "castBar.width", "castBar.height", "castBar.orientation",
+    "castBar.anchorX", "castBar.anchorY", "castBar.unlockPos",
     "totemBar.iconSize", "totemBar.spacing", "totemBar.unlockPos",
     "general.anchorX", "general.anchorY", "general.orientation",
 })

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -7863,7 +7863,7 @@ initFrame:SetScript("OnEvent", function(self)
         return _castBarIconPool[_castBarIconIdx]
     end
 
-    local function UpdateCastBarPreview()
+    local function UpdateCastBarPreview(skipHeaderResize)
         local p = DB()
         if not p then return end
         local cb = p.castBar
@@ -7880,28 +7880,48 @@ initFrame:SetScript("OnEvent", function(self)
 
         local w, h = Snap(cb.width), Snap(cb.height)
         local bs = cb.borderSize
+        local orientation = cb.orientation or "HORIZONTAL"
+        local isVertical = orientation == "VERTICAL_UP"
+            or orientation == "VERTICAL_DOWN"
 
-        -- Container size: icon (hxh) + bar (only when icon shown)
+        -- Width remains cast length and height remains thickness; vertical
+        -- modes swap those axes only for the rendered preview.
         local hasIcon = cb.showIcon ~= false
-        local iconW = hasIcon and Snap(h) or 0
-        pf.container:SetSize(w + iconW, h)
+        local iconLength = hasIcon and Snap(h) or 0
+        local totalLength = w + iconLength
+        local containerW = isVertical and h or totalLength
+        local containerH = isVertical and totalLength or h
+        pf.container:SetSize(containerW, containerH)
 
-        -- Scale down to fit when the cast bar is wider than the panel
+        -- Scale down to fit either axis. Vertical previews receive a taller
+        -- header so their direction remains easy to see.
         local PAD = EllesmereUI.CONTENT_PAD or 10
         local hdr = pf.container:GetParent()
+        local hintH = (_previewHintFS and _previewHintFS:IsShown()) and 35 or 0
         local availW = (hdr:GetWidth() - PAD * 2) / _castBarPreviewScale
-        local fitScale = 1
-        if (w + iconW) > availW and (w + iconW) > 0 and availW > 0 then
-            fitScale = availW / (w + iconW)
-        end
+        local previewH = isVertical and 180 or 80
+        _headerBaseH = previewH
+        local availH = (previewH - 12) / _castBarPreviewScale
+        local fitScale = math.min(1,
+            (containerW > 0 and availW > 0) and (availW / containerW) or 1,
+            (containerH > 0 and availH > 0) and (availH / containerH) or 1)
         pf.container:SetScale(_castBarPreviewScale * fitScale)
 
-        pf.container:ClearAllPoints(); pf.container:SetPoint("CENTER", hdr, "CENTER", 0, 0)
-        -- Bar frame (sits beside the icon; iconOnRight puts the icon on the right)
-        local iconOnRight = hasIcon and cb.iconOnRight
-        pf.barFrame:SetSize(w, h)
+        pf.container:ClearAllPoints()
+        pf.container:SetPoint("CENTER", hdr, "CENTER", 0, hintH / 2)
+        -- "Icon on fill end" maps to right, top, or bottom based on direction.
+        local iconOnEnd = hasIcon and cb.iconOnRight
+        local iconAtTop = isVertical and hasIcon and
+            ((orientation == "VERTICAL_UP" and iconOnEnd) or
+             (orientation ~= "VERTICAL_UP" and not iconOnEnd))
+        pf.barFrame:SetSize(isVertical and h or w, isVertical and w or h)
         pf.barFrame:ClearAllPoints()
-        pf.barFrame:SetPoint("LEFT", pf.container, "LEFT", iconOnRight and 0 or iconW, 0)
+        if isVertical then
+            pf.barFrame:SetPoint(iconAtTop and "BOTTOM" or "TOP", pf.container,
+                iconAtTop and "BOTTOM" or "TOP", 0, 0)
+        else
+            pf.barFrame:SetPoint("LEFT", pf.container, "LEFT", iconOnEnd and 0 or iconLength, 0)
+        end
 
         -- Background
         local texKey = cb.texture
@@ -7928,7 +7948,6 @@ initFrame:SetScript("OnEvent", function(self)
         -- Status bar: full bar frame, no inset
         pf.bar:ClearAllPoints()
         pf.bar:SetAllPoints(pf.barFrame)
-        pf.bar:SetValue(_castBarPreviewFill)
 
         -- Bar texture
         local texLookup = _G._ERB_CastBarTextures or {}
@@ -7941,6 +7960,20 @@ initFrame:SetScript("OnEvent", function(self)
         else
             pf.bar:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
         end
+        if orientation == "VERTICAL_UP" then
+            pf.bar:SetOrientation("VERTICAL")
+            pf.bar:SetRotatesTexture(true)
+            pf.bar:SetReverseFill(false)
+        elseif isVertical then
+            pf.bar:SetOrientation("VERTICAL")
+            pf.bar:SetRotatesTexture(true)
+            pf.bar:SetReverseFill(true)
+        else
+            pf.bar:SetOrientation("HORIZONTAL")
+            pf.bar:SetRotatesTexture(false)
+            pf.bar:SetReverseFill(false)
+        end
+        pf.bar:SetValue(_castBarPreviewFill)
 
         -- Bar color / gradient
         local fillTex = pf.bar:GetStatusBarTexture()
@@ -7963,8 +7996,16 @@ initFrame:SetScript("OnEvent", function(self)
         if texKey ~= "blizzard" then
             pf.bg:ClearAllPoints()
             if (cb.fillOpacity or 100) < 100 then
-                pf.bg:SetPoint("TOPLEFT", fillTex, "TOPRIGHT", 0, 0)
-                pf.bg:SetPoint("BOTTOMRIGHT", pf.barFrame, "BOTTOMRIGHT", 0, 0)
+                if orientation == "VERTICAL_UP" then
+                    pf.bg:SetPoint("TOPLEFT", pf.barFrame, "TOPLEFT", 0, 0)
+                    pf.bg:SetPoint("BOTTOMRIGHT", fillTex, "TOPRIGHT", 0, 0)
+                elseif isVertical then
+                    pf.bg:SetPoint("TOPLEFT", fillTex, "BOTTOMLEFT", 0, 0)
+                    pf.bg:SetPoint("BOTTOMRIGHT", pf.barFrame, "BOTTOMRIGHT", 0, 0)
+                else
+                    pf.bg:SetPoint("TOPLEFT", fillTex, "TOPRIGHT", 0, 0)
+                    pf.bg:SetPoint("BOTTOMRIGHT", pf.barFrame, "BOTTOMRIGHT", 0, 0)
+                end
             else
                 pf.bg:SetAllPoints(pf.barFrame)
             end
@@ -7972,20 +8013,26 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Spark
         if cb.showSpark then
-            pf.spark:SetSize(8, h)
+            pf.spark:SetSize(isVertical and h or 8, isVertical and 8 or h)
+            pf.spark:SetRotation(isVertical and math.pi / 2 or 0)
             pf.spark:ClearAllPoints()
-            pf.spark:SetPoint("CENTER", fillTex, "RIGHT", 0, 0)
+            local sparkPoint = orientation == "VERTICAL_UP" and "TOP"
+                or (isVertical and "BOTTOM" or "RIGHT")
+            pf.spark:SetPoint("CENTER", fillTex, sparkPoint, 0, 0)
             pf.spark:Show()
         else
             pf.spark:Hide()
         end
 
-        -- Icon: left or right side of container, full size
+        -- Icon: at the start or end of the selected cast axis.
         do
             local iSize = Snap(h)
             pf.iconFrame:SetSize(iSize, iSize)
             pf.iconFrame:ClearAllPoints()
-            if iconOnRight then
+            if isVertical then
+                pf.iconFrame:SetPoint(iconAtTop and "TOP" or "BOTTOM", pf.container,
+                    iconAtTop and "TOP" or "BOTTOM", 0, 0)
+            elseif iconOnEnd then
                 pf.iconFrame:SetPoint("TOPRIGHT", pf.container, "TOPRIGHT", 0, 0)
             else
                 pf.iconFrame:SetPoint("TOPLEFT", pf.container, "TOPLEFT", 0, 0)
@@ -8001,10 +8048,18 @@ initFrame:SetScript("OnEvent", function(self)
         -- Timer / duration text
         if cb.showTimer then
             SetPVFont(pf.timerText, FONT_PATH, cb.timerSize or 11)
-            local pt, xb, jh = ns.GetCastTextAnchor(cbDurSide, false, cbTimerW)
             pf.timerText:ClearAllPoints()
-            pf.timerText:SetJustifyH(jh)
-            pf.timerText:SetPoint(pt, pf.bar, pt, xb + (cb.timerX or 0), cb.timerY or 0)
+            if isVertical and cbDurSide ~= "center" then
+                local pt = cbDurSide == "left" and "RIGHT" or "LEFT"
+                local rel = cbDurSide == "left" and "LEFT" or "RIGHT"
+                local xb = cbDurSide == "left" and -4 or 4
+                pf.timerText:SetJustifyH(cbDurSide == "left" and "RIGHT" or "LEFT")
+                pf.timerText:SetPoint(pt, pf.bar, rel, xb + (cb.timerX or 0), cb.timerY or 0)
+            else
+                local pt, xb, jh = ns.GetCastTextAnchor(cbDurSide, false, cbTimerW)
+                pf.timerText:SetJustifyH(jh)
+                pf.timerText:SetPoint(pt, pf.bar, pt, xb + (cb.timerX or 0), cb.timerY or 0)
+            end
             -- Preview total cast time is 3.0s; mirror the live "elapsed / total" mode.
             if cb.showTotalDuration then
                 pf.timerText:SetText(string.format("%.1f / %.1f", 3.0 * _castBarPreviewFill, 3.0))
@@ -8019,14 +8074,27 @@ initFrame:SetScript("OnEvent", function(self)
         -- Spell name text
         if cb.showSpellText then
             SetPVFont(pf.spellText, FONT_PATH, cb.spellTextSize or 11)
-            local pt, xb, jh = ns.GetCastTextAnchor(cbSpellSide, cb.showTimer and cbDurSide == cbSpellSide, cbTimerW)
             pf.spellText:ClearAllPoints()
-            pf.spellText:SetJustifyH(jh)
-            pf.spellText:SetPoint(pt, pf.bar, pt, xb + (cb.spellTextX or 0), cb.spellTextY or 0)
-            if cbSpellSide == "center" then
-                pf.spellText:SetWidth(cbBarW * 0.6)
-            elseif cbBarW > 0 then
-                pf.spellText:SetWidth(cbBarW - 8 - (cb.showTimer and cbTimerW or 0))
+            if isVertical and cbSpellSide ~= "center" then
+                local pt = cbSpellSide == "left" and "RIGHT" or "LEFT"
+                local rel = cbSpellSide == "left" and "LEFT" or "RIGHT"
+                local xb = cbSpellSide == "left" and -4 or 4
+                local sharedSideY = (cb.showTimer and cbDurSide == cbSpellSide)
+                    and -((cb.timerSize or 11) + 2) or 0
+                pf.spellText:SetJustifyH(cbSpellSide == "left" and "RIGHT" or "LEFT")
+                pf.spellText:SetPoint(pt, pf.bar, rel, xb + (cb.spellTextX or 0),
+                    (cb.spellTextY or 0) + sharedSideY)
+                pf.spellText:SetWidth(math.max(50, cb.width * 0.6))
+            else
+                local pt, xb, jh = ns.GetCastTextAnchor(cbSpellSide,
+                    cb.showTimer and cbDurSide == cbSpellSide, cbTimerW)
+                pf.spellText:SetJustifyH(jh)
+                pf.spellText:SetPoint(pt, pf.bar, pt, xb + (cb.spellTextX or 0), cb.spellTextY or 0)
+                if cbSpellSide == "center" then
+                    pf.spellText:SetWidth((isVertical and cb.width or cbBarW) * 0.6)
+                elseif cbBarW > 0 then
+                    pf.spellText:SetWidth(cbBarW - 8 - (cb.showTimer and cbTimerW or 0))
+                end
             end
             pf.spellText:SetText(EllesmereUI.L("Spell Name"))
             pf.spellText:Show()
@@ -8037,9 +8105,11 @@ initFrame:SetScript("OnEvent", function(self)
         ns.ReflowFontString(pf.timerText)
         ns.ReflowFontString(pf.spellText)
 
-        -- Update header height: 80px preview + optional hint text
-        local hintH = (_previewHintFS and _previewHintFS:IsShown()) and 35 or 0
-        EllesmereUI:UpdateContentHeaderHeight(80 + hintH)
+        -- Update header height: vertical previews need enough room to show
+        -- direction, while horizontal previews keep the compact header.
+        if not skipHeaderResize then
+            EllesmereUI:UpdateContentHeaderHeight(previewH + hintH)
+        end
     end
 
     local _castBarPreviewBuilder = function(hdr, hdrW)
@@ -8199,7 +8269,10 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         -- Hint text
-        local TOTAL_H = 80
+        local orientation = cb.orientation or "HORIZONTAL"
+        local isVertical = orientation == "VERTICAL_UP"
+            or orientation == "VERTICAL_DOWN"
+        local TOTAL_H = isVertical and 180 or 80
         _headerBaseH = TOTAL_H
         local hintShown = not IsPreviewHintDismissed()
         if hintShown then
@@ -8220,6 +8293,9 @@ initFrame:SetScript("OnEvent", function(self)
             _previewHintFS:Hide()
         end
 
+        -- The preview objects are all available now; apply the current
+        -- orientation before the header's first rendered frame.
+        UpdateCastBarPreview(true)
         return TOTAL_H
     end
 
@@ -8289,8 +8365,14 @@ initFrame:SetScript("OnEvent", function(self)
         -- Strata dropdown values for the Cast Bar Frame Strata control.
         local cbStrataValues = { BACKGROUND = "Background", LOW = "Low", MEDIUM = "Medium", HIGH = "High", DIALOG = "Dialog" }
         local cbStrataOrder = { "BACKGROUND", "LOW", "MEDIUM", "HIGH", "DIALOG" }
+        local cbOrientationValues = {
+            HORIZONTAL = "Horizontal",
+            VERTICAL_UP = "Vertical Up",
+            VERTICAL_DOWN = "Vertical Down",
+        }
+        local cbOrientationOrder = { "HORIZONTAL", "VERTICAL_UP", "VERTICAL_DOWN" }
 
-        -- Row 1: Enable Player Cast Bar | Frame Strata
+        -- Row 1: Enable Player Cast Bar | Orientation
         local castEnableRow
         castEnableRow, h = W:DualRow(parent, y,
             { type = "toggle", text = "Enable Player Cast Bar",
@@ -8300,17 +8382,19 @@ initFrame:SetScript("OnEvent", function(self)
                   p.castBar.enabled = v; RefreshCast()
                   EllesmereUI:RefreshPage()
               end },
-            { type = "dropdown", text = "Frame Strata",
-              tooltip = "Controls the order that overlapping elements display in. Set higher to show above other elements.",
+            { type = "dropdown", text = "Orientation",
+              tooltip = "Choose whether the cast fills horizontally, upward, or downward.",
               disabled = castOff,
               disabledTooltip = "Player Cast Bar",
-              values = cbStrataValues, order = cbStrataOrder,
+              values = cbOrientationValues, order = cbOrientationOrder,
               getValue = function()
-                  local p = DB(); return p and p.castBar.frameStrata or "MEDIUM"
+                  local p = DB()
+                  return p and p.castBar.orientation or "HORIZONTAL"
               end,
               setValue = function(v)
                   local p = DB(); if not p then return end
-                  p.castBar.frameStrata = v; RefreshCast()
+                  p.castBar.orientation = v; RefreshCast()
+                  EllesmereUI:RefreshPage()
               end }
         );  y = y - h
         -- (No position cog here: the cast bar is positioned via Unlock Mode;
@@ -8318,10 +8402,15 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Row 2: Height | Width (sync icons push to power + health bars)
         local classSizeRow
-        local cbhDis, cbhTip, cbhRaw = EllesmereUI.MatchGuard("ERB_CastBar", "Height", castOff, "Player Cast Bar")
-        local cbwDis, cbwTip, cbwRaw = EllesmereUI.MatchGuard("ERB_CastBar", "Width", castOff, "Player Cast Bar")
+        local castOrientation = (DB() and DB().castBar.orientation) or "HORIZONTAL"
+        local castVertical = castOrientation == "VERTICAL_UP"
+            or castOrientation == "VERTICAL_DOWN"
+        local cbhDis, cbhTip, cbhRaw = EllesmereUI.MatchGuard("ERB_CastBar",
+            castVertical and "Width" or "Height", castOff, "Player Cast Bar")
+        local cbwDis, cbwTip, cbwRaw = EllesmereUI.MatchGuard("ERB_CastBar",
+            castVertical and "Height" or "Width", castOff, "Player Cast Bar")
         classSizeRow, h = W:DualRow(parent, y,
-            { type = "slider", text = "Height",
+            { type = "slider", text = castVertical and "Width" or "Height",
               min = 1, max = 60, step = 1,
               disabled = cbhDis, disabledTooltip = cbhTip, rawTooltip = cbhRaw,
               getValue = function() local p = DB(); return p and p.castBar.height or 20 end,
@@ -8329,7 +8418,7 @@ initFrame:SetScript("OnEvent", function(self)
                   local p = DB(); if not p then return end
                   p.castBar.height = v; RefreshCast()
               end },
-            { type = "slider", text = "Width",
+            { type = "slider", text = castVertical and "Height" or "Width",
               min = 50, max = 800, step = 1,
               disabled = cbwDis, disabledTooltip = cbwTip, rawTooltip = cbwRaw,
               getValue = function() local p = DB(); return p and p.castBar.width or 220 end,
@@ -8339,7 +8428,7 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        -- Row 3: Show Spell Icon (cog: Icon on Right) | Show Spark
+        -- Row 3: Show Spell Icon (cog: Icon at Fill End) | Show Spark
         local iconRow
         iconRow, h = W:DualRow(parent, y,
             { type = "toggle", text = "Show Spell Icon",
@@ -8360,14 +8449,14 @@ initFrame:SetScript("OnEvent", function(self)
                   p.castBar.showSpark = v; RefreshCast()
               end }
         );  y = y - h
-        -- Inline cog on Show Spell Icon: Icon on Right
+        -- Inline cog on Show Spell Icon: Icon at Fill End
         do
             local rgn = iconRow._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Spell Icon Settings",
                 rows = {
-                    { type = "toggle", label = "Icon on Right",
-                      tooltip = "Attach the spell icon to the right of the cast bar instead of the left.",
+                    { type = "toggle", label = "Icon at Fill End",
+                      tooltip = "Attach the spell icon to the end of the fill direction instead of its starting edge.",
                       get = function() local p = DB(); return p and p.castBar.iconOnRight end,
                       set = function(v)
                           local p = DB(); if not p then return end
@@ -8395,7 +8484,7 @@ initFrame:SetScript("OnEvent", function(self)
             UpdateCogDisIcon()
         end
 
-        -- Row 4: Always Show
+        -- Row 4: Always Show | Frame Strata
         _, h = W:DualRow(parent, y,
             { type = "toggle", text = "Always Show",
               tooltip = "Keep the cast bar visible (sitting empty) when you are not casting, instead of hiding it.",
@@ -8406,7 +8495,18 @@ initFrame:SetScript("OnEvent", function(self)
                   local p = DB(); if not p then return end
                   p.castBar.alwaysShow = v; RefreshCast()
               end },
-            { type = "spacer" }
+            { type = "dropdown", text = "Frame Strata",
+              tooltip = "Controls the order that overlapping elements display in. Set higher to show above other elements.",
+              disabled = castOff,
+              disabledTooltip = "Player Cast Bar",
+              values = cbStrataValues, order = cbStrataOrder,
+              getValue = function()
+                  local p = DB(); return p and p.castBar.frameStrata or "MEDIUM"
+              end,
+              setValue = function(v)
+                  local p = DB(); if not p then return end
+                  p.castBar.frameStrata = v; RefreshCast()
+              end }
         );  y = y - h
 
         _, h = W:Spacer(parent, y, 16);  y = y - h

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1211,8 +1211,9 @@ local DEFAULTS = {
         castBar = {
             enabled       = true,
             alwaysShow    = false,  -- keep the bar on screen (sitting empty) while nothing is being cast
+            orientation   = "HORIZONTAL", -- "HORIZONTAL","VERTICAL_UP","VERTICAL_DOWN"
             showIcon      = true,
-            iconOnRight   = false,  -- attach the spell icon to the right of the bar instead of the left
+            iconOnRight   = false,  -- attach the spell icon to the fill end instead of the fill start
             width         = 220,
             height        = 20,
             anchorX       = 0,
@@ -2296,16 +2297,49 @@ local function RegisterUnlockElements()
             getFrame = function() return castBarFrame end,
             getSize  = function()
                 local cb = S()
-                local iconW = (cb.showIcon ~= false) and cb.height or 0
-                return cb.width + iconW, cb.height
+                local iconLength = (cb.showIcon ~= false) and cb.height or 0
+                return OrientedSize(cb.width + iconLength, cb.height,
+                    cb.orientation or "HORIZONTAL")
             end,
             setWidth = function(_, w)
                 local cb = S()
-                local iconW = (cb.showIcon ~= false) and cb.height or 0
-                cb.width = PP.Snap(math.max(w - iconW, 10))
+                if IsVerticalOrientation(cb.orientation) then
+                    local newThickness = PP.Snap(math.max(w, 1))
+                    -- With an icon, changing thickness also changes the
+                    -- rendered length. Preserve a simultaneous height match;
+                    -- its propagation is suppressed while this width setter
+                    -- runs, so it cannot repair the coupled axis itself.
+                    if cb.showIcon ~= false and EllesmereUI.GetHeightMatchTarget
+                       and EllesmereUI.GetHeightMatchTarget("ERB_CastBar") then
+                        local totalLength = cb.width + cb.height
+                        cb.width = PP.Snap(math.max(totalLength - newThickness, 10))
+                    end
+                    cb.height = newThickness
+                else
+                    local iconLength = (cb.showIcon ~= false) and cb.height or 0
+                    cb.width = PP.Snap(math.max(w - iconLength, 10))
+                end
                 Rebuild()
             end,
-            setHeight = function(_, h) S().height = PP.Snap(h); Rebuild() end,
+            setHeight = function(_, h)
+                local cb = S()
+                if IsVerticalOrientation(cb.orientation) then
+                    local iconLength = (cb.showIcon ~= false) and cb.height or 0
+                    cb.width = PP.Snap(math.max(h - iconLength, 10))
+                else
+                    local newThickness = PP.Snap(math.max(h, 1))
+                    -- Horizontal is the symmetric case: icon thickness
+                    -- contributes to rendered width, so keep an active width
+                    -- match stable when only the height source changes.
+                    if cb.showIcon ~= false and EllesmereUI.GetWidthMatchTarget
+                       and EllesmereUI.GetWidthMatchTarget("ERB_CastBar") then
+                        local totalLength = cb.width + cb.height
+                        cb.width = PP.Snap(math.max(totalLength - newThickness, 10))
+                    end
+                    cb.height = newThickness
+                end
+                Rebuild()
+            end,
             savePos = castSave, loadPos = castLoad, clearPos = castClear, applyPos = castApply,
         })
     end
@@ -6398,9 +6432,13 @@ BuildCastBar = function()
 
     -- Apply settings
     local w, h = cb.width, cb.height
+    local orientation = cb.orientation or "HORIZONTAL"
+    local isVertical = IsVerticalOrientation(orientation)
     local hasIcon = cb.showIcon ~= false
-    -- Total frame width includes icon (h x h) only when icon is shown
-    local totalW = hasIcon and (w + h) or w
+    -- Width remains the saved bar length and height remains its thickness.
+    -- Vertical modes swap those logical axes only for the rendered frame.
+    local totalLength = hasIcon and (w + h) or w
+    local frameW, frameH = OrientedSize(totalLength, h, orientation)
     if cb.unlockPos and cb.unlockPos.point then
         -- Position managed by unlock mode -- only animate size changes.
         -- Skip reposition during unlock mode so resize does not snap the bar.
@@ -6408,23 +6446,23 @@ BuildCastBar = function()
         local px, py = cb.unlockPos.x or 0, cb.unlockPos.y or 0
         local anchored = EllesmereUI.IsUnlockAnchored("ERB_CastBar")
         if EllesmereUI._unlockActive then
-            castBarFrame:SetSize(totalW, h)
+            castBarFrame:SetSize(frameW, frameH)
         elseif anchored and castBarFrame:GetLeft() then
             -- Anchor system owns position; just set size directly
-            castBarFrame:SetSize(totalW, h)
+            castBarFrame:SetSize(frameW, frameH)
         else
             local function ApplyCastUnlockTransform()
-                local aw = castBarFrame["_barAnim_w"] or totalW
-                local ah = castBarFrame["_barAnim_h"] or h
+                local aw = castBarFrame["_barAnim_w"] or frameW
+                local ah = castBarFrame["_barAnim_h"] or frameH
                 castBarFrame:SetSize(aw, ah)
                 castBarFrame:ClearAllPoints()
                 castBarFrame:SetPoint(cb.unlockPos.point, UIParent, rp, px, py)
             end
-            SmoothBarAnimate(castBarFrame, "w", totalW, function() ApplyCastUnlockTransform() end)
-            SmoothBarAnimate(castBarFrame, "h", h, function() ApplyCastUnlockTransform() end)
+            SmoothBarAnimate(castBarFrame, "w", frameW, function() ApplyCastUnlockTransform() end)
+            SmoothBarAnimate(castBarFrame, "h", frameH, function() ApplyCastUnlockTransform() end)
         end
     else
-        castBarFrame:SetSize(totalW, h)
+        castBarFrame:SetSize(frameW, frameH)
         if not EllesmereUI._unlockActive then
             castBarFrame:ClearAllPoints()
             castBarFrame:SetPoint("CENTER", UIParent, "CENTER", cb.anchorX, cb.anchorY)
@@ -6444,13 +6482,20 @@ BuildCastBar = function()
             cb.borderTextureShiftX, cb.borderTextureShiftY, "resourcebars", bs)
     end
 
-    -- Icon: left or right side (iconOnRight), full height, no inset
+    -- Icon follows the cast axis. "Icon on fill end" means right for
+    -- horizontal, top for vertical-up, and bottom for vertical-down.
     local iconFrame = castBarFrame._iconFrame
-    local iconOnRight = hasIcon and cb.iconOnRight
+    local iconOnEnd = hasIcon and cb.iconOnRight
+    local iconAtTop = isVertical and hasIcon and
+        ((orientation == "VERTICAL_UP" and iconOnEnd) or
+         (orientation ~= "VERTICAL_UP" and not iconOnEnd))
     if hasIcon then
         iconFrame:SetSize(h, h)
         iconFrame:ClearAllPoints()
-        if iconOnRight then
+        if isVertical then
+            iconFrame:SetPoint(iconAtTop and "TOP" or "BOTTOM", castBarFrame,
+                iconAtTop and "TOP" or "BOTTOM", 0, 0)
+        elseif iconOnEnd then
             iconFrame:SetPoint("TOPRIGHT", castBarFrame, "TOPRIGHT", 0, 0)
         else
             iconFrame:SetPoint("TOPLEFT", castBarFrame, "TOPLEFT", 0, 0)
@@ -6469,10 +6514,20 @@ BuildCastBar = function()
     -- is interior, no border draws there, and insetting it exposed a 1px
     -- background column next to the icon (visible with light bg colors).
     -- Outer edges keep the inset so the fill never bleeds past the border.
-    local clipLeft  = (hasIcon and not iconOnRight) and h or bdrInset
-    local clipRight = iconOnRight and h or bdrInset
-    clipFrame:SetPoint("TOPLEFT", castBarFrame, "TOPLEFT", clipLeft, -bdrInset)
-    clipFrame:SetPoint("BOTTOMRIGHT", castBarFrame, "BOTTOMRIGHT", -clipRight, bdrInset)
+    local clipLeft, clipRight, clipTop, clipBottom
+    if isVertical then
+        clipLeft = bdrInset
+        clipRight = bdrInset
+        clipTop = iconAtTop and h or bdrInset
+        clipBottom = (hasIcon and not iconAtTop) and h or bdrInset
+    else
+        clipLeft = (hasIcon and not iconOnEnd) and h or bdrInset
+        clipRight = iconOnEnd and h or bdrInset
+        clipTop = bdrInset
+        clipBottom = bdrInset
+    end
+    clipFrame:SetPoint("TOPLEFT", castBarFrame, "TOPLEFT", clipLeft, -clipTop)
+    clipFrame:SetPoint("BOTTOMRIGHT", castBarFrame, "BOTTOMRIGHT", -clipRight, clipBottom)
     clipFrame:SetFrameLevel(castBarFrame:GetFrameLevel() + 1)
     bar:ClearAllPoints()
     bar:SetAllPoints(clipFrame)
@@ -6492,6 +6547,17 @@ BuildCastBar = function()
         castBarFrame._bg:SetTexture(nil)
         castBarFrame._bg:SetColorTexture(cb.bgR, cb.bgG, cb.bgB, cb.bgA)
         ns.ApplyCastBgAnchor()
+    end
+    -- Texture and rotation both reset vertex color, so orientation must be
+    -- applied after the texture and before the color/gradient pass below.
+    -- Leave the legacy horizontal path untouched until a vertical mode has
+    -- actually been used; reverting from vertical restores the defaults once.
+    if isVertical then
+        ApplyBarOrientation(bar, orientation)
+        castBarFrame._castVerticalApplied = true
+    elseif castBarFrame._castVerticalApplied then
+        ApplyBarOrientation(bar, "HORIZONTAL")
+        castBarFrame._castVerticalApplied = nil
     end
 
     -- Bar color / gradient. Fill Opacity multiplies into the fill alpha
@@ -6542,15 +6608,26 @@ end
     -- Spark
     local spark = castBarFrame._spark
     if cb.showSpark then
-        spark:SetSize(8, h)
+        spark:SetSize(isVertical and h or 8, isVertical and 8 or h)
+        if isVertical then
+            spark:SetRotation(math.pi / 2)
+            spark._erbRotated = true
+        elseif spark._erbRotated then
+            spark:SetRotation(0)
+            spark._erbRotated = nil
+        end
         spark:ClearAllPoints()
 
+        local sparkPoint = orientation == "VERTICAL_UP" and "TOP"
+            or (isVertical and "BOTTOM" or "RIGHT")
         if cb.gradientEnabled and castBarFrame._gradClip then
-            spark:SetPoint("CENTER", castBarFrame._gradClip, "RIGHT", 0, 0)
+            spark:SetPoint("CENTER", castBarFrame._gradClip, sparkPoint, 0, 0)
         else
-            spark:SetPoint("CENTER", fillTex, "RIGHT", 0, 0)
+            spark:SetPoint("CENTER", fillTex, sparkPoint, 0, 0)
         end
 
+        castBarFrame._sparkAnchor = nil
+        castBarFrame._sparkPoint = sparkPoint
         spark:Show()
     else
         spark:Hide()
@@ -6574,6 +6651,13 @@ end
         else
             lo:SetColorTexture(lR, lG, lB, lA)
         end
+        if isVertical then
+            lo:SetRotation(math.pi / 2)
+            lo._erbRotated = true
+        elseif lo._erbRotated then
+            lo:SetRotation(0)
+            lo._erbRotated = nil
+        end
     else
         if castBarFrame._latencyOverlay then castBarFrame._latencyOverlay:Hide() end
         castBarFrame._latencySuffix = nil
@@ -6582,7 +6666,7 @@ end
     -- and border insets are accounted for. Falls back to cb.width if
     -- the bar hasn't been laid out yet.
     local barW = bar:GetWidth()
-    if not barW or barW < 10 then barW = cb.width end
+    if not barW or barW < 1 then barW = cb.width end
 
     -- Cast text side-aware layout (mirrors nameplates / unit frames). The duration
     -- reserves a slot on its side and pushes the spell text inward when they share a
@@ -6596,10 +6680,18 @@ end
     local timerText = castBarFrame._timerText
     if cb.showTimer then
         SetRBFont(timerText, GetRBFont(), cb.timerSize or 11)
-        local pt, xb, jh = ns.GetCastTextAnchor(durSide, false, timerW)
         timerText:ClearAllPoints()
-        timerText:SetJustifyH(jh)
-        timerText:SetPoint(pt, bar, pt, xb + (cb.timerX or 0), cb.timerY or 0)
+        if isVertical and durSide ~= "center" then
+            local pt = durSide == "left" and "RIGHT" or "LEFT"
+            local rel = durSide == "left" and "LEFT" or "RIGHT"
+            local xb = durSide == "left" and -4 or 4
+            timerText:SetJustifyH(durSide == "left" and "RIGHT" or "LEFT")
+            timerText:SetPoint(pt, bar, rel, xb + (cb.timerX or 0), cb.timerY or 0)
+        else
+            local pt, xb, jh = ns.GetCastTextAnchor(durSide, false, timerW)
+            timerText:SetJustifyH(jh)
+            timerText:SetPoint(pt, bar, pt, xb + (cb.timerX or 0), cb.timerY or 0)
+        end
         timerText:Show()
     else
         timerText:Hide()
@@ -6609,14 +6701,27 @@ end
     local nameText = castBarFrame._nameText
     if cb.showSpellText then
         SetRBFont(nameText, GetRBFont(), cb.spellTextSize or 11)
-        local pt, xb, jh = ns.GetCastTextAnchor(spellSide, cb.showTimer and durSide == spellSide, timerW)
         nameText:ClearAllPoints()
-        nameText:SetJustifyH(jh)
-        nameText:SetPoint(pt, bar, pt, xb + (cb.spellTextX or 0), cb.spellTextY or 0)
-        if spellSide == "center" then
-            nameText:SetWidth(barW * 0.6)
+        if isVertical and spellSide ~= "center" then
+            local pt = spellSide == "left" and "RIGHT" or "LEFT"
+            local rel = spellSide == "left" and "LEFT" or "RIGHT"
+            local xb = spellSide == "left" and -4 or 4
+            local sharedSideY = (cb.showTimer and durSide == spellSide)
+                and -((cb.timerSize or 11) + 2) or 0
+            nameText:SetJustifyH(spellSide == "left" and "RIGHT" or "LEFT")
+            nameText:SetPoint(pt, bar, rel, xb + (cb.spellTextX or 0),
+                (cb.spellTextY or 0) + sharedSideY)
+            nameText:SetWidth(max(50, cb.width * 0.6))
         else
-            nameText:SetWidth(barW - 8 - (cb.showTimer and timerW or 0))
+            local pt, xb, jh = ns.GetCastTextAnchor(spellSide,
+                cb.showTimer and durSide == spellSide, timerW)
+            nameText:SetJustifyH(jh)
+            nameText:SetPoint(pt, bar, pt, xb + (cb.spellTextX or 0), cb.spellTextY or 0)
+            if spellSide == "center" then
+                nameText:SetWidth((isVertical and cb.width or barW) * 0.6)
+            else
+                nameText:SetWidth(barW - 8 - (cb.showTimer and timerW or 0))
+            end
         end
         nameText:Show()
     else
@@ -6643,6 +6748,11 @@ end
         ns.ShowIdleCastBar()
     else
         ns.ActivateCastBar()
+        -- A live options rebuild replaces texture/orientation geometry and
+        -- hides pooled ticks/pips above. Re-arm the active cast decorations
+        -- after that layout change so flipping orientation mid-cast does not
+        -- leave stale horizontal overlays until the next spell.
+        if ns.RefreshActiveCastLayout then ns.RefreshActiveCastLayout() end
     end
 end
 
@@ -6676,6 +6786,9 @@ ShowChannelTicks = function(spellID)
     local barWidth = bar:GetWidth()
     local barHeight = bar:GetHeight()
     if barWidth <= 0 or barHeight <= 0 then return end
+    local orientation = cb.orientation or "HORIZONTAL"
+    local isVertical = IsVerticalOrientation(orientation)
+    local barLength = isVertical and barHeight or barWidth
 
     -- Pixel-snap helpers (same approach as empower pips)
     local effectiveScale = bar:GetEffectiveScale()
@@ -6683,6 +6796,7 @@ ShowChannelTicks = function(spellID)
     local tickWidth = max(pixelSize, floor(2 * effectiveScale + 0.5) / effectiveScale)
     local highlightWidth = max(pixelSize, floor(3 * effectiveScale + 0.5) / effectiveScale)
     local snappedHeight = floor(barHeight * effectiveScale + 0.5) / effectiveScale
+    local snappedWidth = floor(barWidth * effectiveScale + 0.5) / effectiveScale
 
     -- Tick marks
     if wantTicks then
@@ -6719,18 +6833,32 @@ ShowChannelTicks = function(spellID)
                     castBarFrame._ticks[i] = tick
                 end
 
-                local snappedOffset = floor(barWidth * (numTicks - i) / numTicks * effectiveScale + 0.5) / effectiveScale
+                local snappedOffset = floor(barLength * (numTicks - i) / numTicks * effectiveScale + 0.5) / effectiveScale
 
                 if isLastTick and showLastTick then
                     tick:SetColorTexture(ltR, ltG, ltB, ltA)
-                    tick:SetSize(highlightWidth, snappedHeight)
+                    if isVertical then
+                        tick:SetSize(snappedWidth, highlightWidth)
+                    else
+                        tick:SetSize(highlightWidth, snappedHeight)
+                    end
                 else
                     tick:SetColorTexture(tmR, tmG, tmB, tmA)
-                    tick:SetSize(tickWidth, snappedHeight)
+                    if isVertical then
+                        tick:SetSize(snappedWidth, tickWidth)
+                    else
+                        tick:SetSize(tickWidth, snappedHeight)
+                    end
                 end
 
                 tick:ClearAllPoints()
-                tick:SetPoint("CENTER", bar, "LEFT", snappedOffset, 0)
+                if orientation == "VERTICAL_UP" then
+                    tick:SetPoint("CENTER", bar, "BOTTOM", 0, snappedOffset)
+                elseif isVertical then
+                    tick:SetPoint("CENTER", bar, "TOP", 0, -snappedOffset)
+                else
+                    tick:SetPoint("CENTER", bar, "LEFT", snappedOffset, 0)
+                end
                 tick:Show()
             end
         end
@@ -6951,7 +7079,7 @@ UpdateCastBar = function(dt)
         end
     end
 
-    -- Spark position. The spark is anchored to the RIGHT edge of the fill, and
+    -- Spark position. The spark is anchored to the leading edge of the fill, and
     -- the engine already moves it as the fill grows, so re-anchoring to the same
     -- target every frame achieves nothing and costs two frame API calls. The
     -- target only changes when gradient mode toggles.
@@ -6965,7 +7093,8 @@ UpdateCastBar = function(dt)
         if castBarFrame._sparkAnchor ~= target then
             castBarFrame._sparkAnchor = target
             castBarFrame._spark:ClearAllPoints()
-            castBarFrame._spark:SetPoint("CENTER", target, "RIGHT", 0, 0)
+            castBarFrame._spark:SetPoint("CENTER", target,
+                castBarFrame._sparkPoint or "RIGHT", 0, 0)
         end
     end
 end
@@ -6996,9 +7125,12 @@ local function ShowLatencyOverlay(castType)
     if latencyMs <= 0 then latencyMs = latencyHome end
     local latencySec = latencyMs / 1000
     local castDur = castBarFrame._endTime - castBarFrame._startTime
-    local barWidth = castBarFrame._bar:GetWidth()
+    local orientation = cb.orientation or "HORIZONTAL"
+    local isVertical = IsVerticalOrientation(orientation)
+    local barLength = isVertical and castBarFrame._bar:GetHeight()
+        or castBarFrame._bar:GetWidth()
 
-    if latencySec <= 0 or castDur <= 0 or barWidth <= 0 then
+    if latencySec <= 0 or castDur <= 0 or barLength <= 0 then
         overlay:Hide(); castBarFrame._latencySuffix = nil; return
     end
 
@@ -7011,19 +7143,36 @@ local function ShowLatencyOverlay(castType)
 
     -- Size as a fraction of the cast, clamped to [1px, full bar] so it always
     -- renders something and never overruns the bar on a lag spike.
-    local width = barWidth * (latencySec / castDur)
-    if width < 1 then width = 1 elseif width > barWidth then width = barWidth end
+    local length = barLength * (latencySec / castDur)
+    if length < 1 then length = 1 elseif length > barLength then length = barLength end
 
     local clip = castBarFrame._barClip
     overlay:ClearAllPoints()
-    if castType == "channel" then
-        overlay:SetPoint("TOPLEFT", clip, "TOPLEFT", 0, 0)
-        overlay:SetPoint("BOTTOMLEFT", clip, "BOTTOMLEFT", 0, 0)
+    if isVertical then
+        local atTop
+        if castType == "channel" then
+            atTop = orientation ~= "VERTICAL_UP"
+        else
+            atTop = orientation == "VERTICAL_UP"
+        end
+        if atTop then
+            overlay:SetPoint("TOPLEFT", clip, "TOPLEFT", 0, 0)
+            overlay:SetPoint("TOPRIGHT", clip, "TOPRIGHT", 0, 0)
+        else
+            overlay:SetPoint("BOTTOMLEFT", clip, "BOTTOMLEFT", 0, 0)
+            overlay:SetPoint("BOTTOMRIGHT", clip, "BOTTOMRIGHT", 0, 0)
+        end
+        overlay:SetHeight(length)
     else
-        overlay:SetPoint("TOPRIGHT", clip, "TOPRIGHT", 0, 0)
-        overlay:SetPoint("BOTTOMRIGHT", clip, "BOTTOMRIGHT", 0, 0)
+        if castType == "channel" then
+            overlay:SetPoint("TOPLEFT", clip, "TOPLEFT", 0, 0)
+            overlay:SetPoint("BOTTOMLEFT", clip, "BOTTOMLEFT", 0, 0)
+        else
+            overlay:SetPoint("TOPRIGHT", clip, "TOPRIGHT", 0, 0)
+            overlay:SetPoint("BOTTOMRIGHT", clip, "BOTTOMRIGHT", 0, 0)
+        end
+        overlay:SetWidth(length)
     end
-    overlay:SetWidth(width)
     overlay:Show()
 end
 
@@ -7031,6 +7180,25 @@ local function HideLatencyOverlay()
     if not castBarFrame then return end
     if castBarFrame._latencyOverlay then castBarFrame._latencyOverlay:Hide() end
     castBarFrame._latencySuffix = nil
+end
+
+-- Re-arm geometry/state that a live BuildCastBar style pass invalidates.
+-- This only runs while a cast is already active and only from a settings
+-- rebuild; the normal event handlers remain the steady-state path.
+function ns.RefreshActiveCastLayout()
+    if not castBarFrame then return end
+    castBarFrame._cstKey = nil
+    if castBarFrame._empowering then
+        OnEmpowerStart()
+    elseif castBarFrame._channeling then
+        ns.ApplyCastTimer("channel")
+        local _, _, _, _, _, _, _, spellID = UnitChannelInfo("player")
+        if spellID then ShowChannelTicks(spellID) end
+        ShowLatencyOverlay("channel")
+    elseif castBarFrame._casting then
+        ns.ApplyCastTimer("cast")
+        ShowLatencyOverlay("cast")
+    end
 end
 
 -------------------------------------------------------------------------------
@@ -7052,8 +7220,8 @@ function ns.ApplyCastBgAnchor()
     local casting = castBarFrame._casting or castBarFrame._channeling or castBarFrame._empowering
     castBarFrame._bg:ClearAllPoints()
     if casting and (cb.fillOpacity or 100) < 100 then
-        castBarFrame._bg:SetPoint("TOPLEFT", bar:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
-        castBarFrame._bg:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", 0, 0)
+        ns.AnchorBgToFillEdge(castBarFrame._bg, bar:GetStatusBarTexture(), bar,
+            cb.orientation or "HORIZONTAL")
     else
         castBarFrame._bg:SetAllPoints(castBarFrame)
     end
@@ -7389,6 +7557,9 @@ OnEmpowerStart = function()
         local bar = castBarFrame._bar
         local barWidth = bar:GetWidth()
         local barHeight = bar:GetHeight()
+        local orientation = cb.orientation or "HORIZONTAL"
+        local isVertical = IsVerticalOrientation(orientation)
+        local barLength = isVertical and barHeight or barWidth
         local numStages = #stages
         castBarFrame._numStages = numStages
 
@@ -7406,14 +7577,25 @@ OnEmpowerStart = function()
                 pip:SetColorTexture(1, 1, 1, 0.85)
                 castBarFrame._pips[i] = pip
             end
-            local rawOffset = lastOffset + (barWidth * stages[i])
+            local rawOffset = lastOffset + (barLength * stages[i])
             lastOffset = rawOffset
             -- Snap offset to nearest physical pixel
             local snappedOffset = floor(rawOffset * effectiveScale + 0.5) / effectiveScale
             local snappedHeight = floor(barHeight * effectiveScale + 0.5) / effectiveScale
-            pip:SetSize(pipWidth, snappedHeight)
+            local snappedWidth = floor(barWidth * effectiveScale + 0.5) / effectiveScale
+            if isVertical then
+                pip:SetSize(snappedWidth, pipWidth)
+            else
+                pip:SetSize(pipWidth, snappedHeight)
+            end
             pip:ClearAllPoints()
-            pip:SetPoint("CENTER", bar, "LEFT", snappedOffset, 0)
+            if orientation == "VERTICAL_UP" then
+                pip:SetPoint("CENTER", bar, "BOTTOM", 0, snappedOffset)
+            elseif isVertical then
+                pip:SetPoint("CENTER", bar, "TOP", 0, -snappedOffset)
+            else
+                pip:SetPoint("CENTER", bar, "LEFT", snappedOffset, 0)
+            end
             pip:Show()
         end
 

--- a/EllesmereUI_SpecOverrides.lua
+++ b/EllesmereUI_SpecOverrides.lua
@@ -399,8 +399,8 @@ end
 -- link exists for the element -- checked against the account-global link
 -- tables, which ApplyLayer keeps swapped to the active layer's set.
 -- Static map, Resource Bars only for now (the reported corruption
--- family). The GCD bar's setters swap dims by orientation, so either
--- link kind owns both of its keys.
+-- family). The Cast and GCD bar setters swap dims by orientation, so either
+-- link kind owns both keys for those bars.
 local MATCH_OWNED_FKEYS = {
     ["EllesmereUIResourceBars\31health\30width"]        = { elem = "ERB_Health",        dim = "w" },
     ["EllesmereUIResourceBars\31health\30height"]       = { elem = "ERB_Health",        dim = "h" },
@@ -408,8 +408,8 @@ local MATCH_OWNED_FKEYS = {
     ["EllesmereUIResourceBars\31primary\30height"]      = { elem = "ERB_Power",         dim = "h" },
     ["EllesmereUIResourceBars\31secondary\30pipWidth"]  = { elem = "ERB_ClassResource", dim = "w" },
     ["EllesmereUIResourceBars\31secondary\30pipHeight"] = { elem = "ERB_ClassResource", dim = "h" },
-    ["EllesmereUIResourceBars\31castBar\30width"]       = { elem = "ERB_CastBar",       dim = "w" },
-    ["EllesmereUIResourceBars\31castBar\30height"]      = { elem = "ERB_CastBar",       dim = "h" },
+    ["EllesmereUIResourceBars\31castBar\30width"]       = { elem = "ERB_CastBar",       dim = "both" },
+    ["EllesmereUIResourceBars\31castBar\30height"]      = { elem = "ERB_CastBar",       dim = "both" },
     ["EllesmereUIResourceBars\31gcdBar\30width"]        = { elem = "ERB_GCDBar",        dim = "both" },
     ["EllesmereUIResourceBars\31gcdBar\30height"]       = { elem = "ERB_GCDBar",        dim = "both" },
 }


### PR DESCRIPTION
## What does this PR do?

Adds horizontal, vertical-up, and vertical-down layouts for the player cast bar. Vertical layouts update the live bar and options preview together, including:

- frame and icon placement
- spell text and timer positioning
- spark and fill direction
- channel ticks and empower-stage markers
- latency overlays and partially transparent backgrounds
- Unlock Mode sizing and width/height matching
- Spec Overrides ownership for matched dimensions
- profile-sync exclusions for the layout-owned orientation

The orientation defaults to horizontal, preserving existing behavior until a vertical mode is selected.

## How was it tested?

- Compiled all four changed Lua files with LuaJIT.
- Ran `git diff --check`.
- Regenerated locale keys and confirmed `Locales/_keys.txt` remains current at 636 keys.
- Merged with the other split branches in a temporary integration branch and compiled the combined result.
- In-game retail and 12.1 PTR validation is pending.

## Screenshots

Pending: before/after screenshots for horizontal, vertical-up, and vertical-down layouts.

## Checklist

- [x] New setting preserves existing behavior by default (horizontal until explicitly changed)
- [x] Zero cost while unused: no new events, polling, hooks, or frames
- [x] Cheap while enabled: reuses the existing event and update paths without new allocations in hot paths
- [x] No writes onto Blizzard-owned frames
- [ ] Tested in-game on live retail and the 12.1 PTR client
