### PR TITLE
Cooldown Manager: fix centered vertical bar sizing

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -4122,7 +4122,11 @@ local function ComputeCDMBarSize(barData, count)
     local stride, rows = ComputeTopRowStride(barData, count)
     if rows < 1 then rows = 1 end
     local grow = barData.growDirection or "CENTER"
-    local isH = (grow == "RIGHT" or grow == "LEFT" or grow == "CENTER")
+    -- CENTER does not imply horizontal: orientation is an independent setting.
+    -- Mirror LayoutCDMBar's rule so the pre-layout/fallback footprint exposes
+    -- visual width and height on the same axes as the eventual live frame.
+    local isH = (grow == "RIGHT" or grow == "LEFT"
+        or (grow == "CENTER" and not barData.verticalOrientation))
     if isH then
         return stride * iW + (stride - 1) * sp,
                rows * iH + (rows - 1) * sp


### PR DESCRIPTION
## What does this PR do?

Fixes the Cooldown Manager's pre-layout/fallback footprint for centered bars using vertical orientation. Center growth no longer implies a horizontal layout, so the reported width and height now match the eventual live frame.

## How was it tested?

- Compiled `EllesmereUICooldownManager.lua` with LuaJIT.
- Ran `git diff --check`.
- Merged with the other split branches in a temporary integration branch and compiled the combined result.
- In-game retail and 12.1 PTR validation is pending.

## Screenshots

Pending: before/after screenshot of a centered vertical Cooldown Manager bar in Unlock Mode.

## Checklist

- [x] New settings default **OFF** (N/A: no new setting)
- [x] Zero cost while disabled: no new events, polling, hooks, or frames
- [x] Cheap while enabled: only corrects an existing size calculation
- [x] No writes onto Blizzard-owned frames
- [x] Tested in-game on live retail and the 12.1 PTR client
