### PR TITLE
Upgrade Calculator: fix broken crest totals on non-English clients

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -1869,6 +1869,65 @@ EllesmereUI.TRIPLE_GAP    = TRIPLE_GAP
 EllesmereUI.CLASS_COLOR_MAP = CLASS_COLOR_MAP
 EllesmereUI.CLASS_ART_MAP   = CLASS_ART_MAP
 
+-- Upgrade track identification (locale-agnostic).
+-- Deliberately NOT gated behind a feature check: the QoL upgrade calculator
+-- needs this even when the skin and bag modules are disabled. The table is
+-- tiny and built once, so there is nothing to lazy-init.
+do
+    -- Every localized C_Item.GetItemUpgradeInfo().trackString we know of,
+    -- mapped back to a canonical English key. The upgrade calculator's
+    -- season tables are keyed by these names.
+    local KEYS = {
+        -- Explorer / Delve
+        Explorer = "Explorer", Expedicionario = "Explorer", Forscher = "Explorer",
+        Explorateur = "Explorer", Esploratore = "Explorer", Explorador = "Explorer",
+        Delve = "Explorer",
+        -- Adventurer
+        Adventurer = "Adventurer", Aventurero = "Adventurer", Abenteurer = "Adventurer",
+        Aventurier = "Adventurer", Avventuriero = "Adventurer", Aventureiro = "Adventurer",
+        -- Veteran
+        Veteran = "Veteran", Veterano = "Veteran", ["V\195\169t\195\169ran"] = "Veteran",
+        -- Champion
+        Champion = "Champion", ["Campe\195\179n"] = "Champion", Campione = "Champion",
+        ["Campe\195\163o"] = "Champion",
+        -- Hero
+        Hero = "Hero", ["H\195\169roe"] = "Hero", Held = "Hero",
+        ["H\195\169ros"] = "Hero", Eroe = "Hero", ["Hero\195\173"] = "Hero",
+        -- Myth
+        Myth = "Myth", Mito = "Myth", Mythos = "Myth", Mythe = "Myth",
+        -- ruRU
+        ["\208\152\209\129\209\129\208\187\208\181\208\180\208\190\208\178\208\176\209\130\208\181\208\187\209\140"] = "Explorer",
+        ["\208\152\209\129\208\186\208\176\209\130\208\181\208\187\209\140 \208\191\209\128\208\184\208\186\208\187\209\142\209\135\208\181\208\189\208\184\208\185"] = "Adventurer",
+        ["\208\146\208\181\209\130\208\181\209\128\208\176\208\189"] = "Veteran",
+        ["\208\151\208\176\209\137\208\184\209\130\208\189\208\184\208\186"] = "Champion",
+        ["\208\147\208\181\209\128\208\190\208\185"] = "Hero",
+        ["\208\155\208\181\208\179\208\181\208\189\208\180\208\176"] = "Myth",
+        -- koKR
+        ["\237\131\144\237\151\152\234\176\128"] = "Explorer", ["\235\170\168\237\151\152\234\176\128"] = "Adventurer",
+        ["\235\133\184\235\160\168\234\176\128"] = "Veteran", ["\236\177\148\237\148\188\236\150\184"] = "Champion",
+        ["\236\152\129\236\155\133"] = "Hero", ["\236\139\160\237\153\148"] = "Myth",
+        -- zhCN
+        ["\230\142\162\231\180\162\232\128\133"] = "Explorer", ["\229\134\146\233\153\169\232\128\133"] = "Adventurer",
+        ["\232\128\129\229\133\181"] = "Veteran", ["\229\139\135\229\163\171"] = "Champion",
+        ["\232\139\177\233\155\132"] = "Hero", ["\231\165\158\232\175\157"] = "Myth",
+        -- zhTW
+        ["\230\142\162\233\154\170\232\128\133"] = "Explorer", ["\229\134\146\233\154\170\232\128\133"] = "Adventurer",
+        ["\231\178\190\229\133\181"] = "Veteran", ["\231\165\158\232\169\177"] = "Myth",
+    }
+
+    EllesmereUI.UPGRADE_TRACK_KEYS = KEYS
+
+    -- Returns: trackKey (canonical English name) | nil, currentLevel, maxLevel.
+    -- trackKey is nil for items with no upgrade track (crafted gear, older
+    -- items) or for a trackString we have no translation for.
+    function EllesmereUI.GetUpgradeTrackKey(itemLink)
+        if not itemLink or not (C_Item and C_Item.GetItemUpgradeInfo) then return nil end
+        local info = C_Item.GetItemUpgradeInfo(itemLink)
+        if not info then return nil end
+        return KEYS[info.trackString or ""], info.currentLevel, info.maxLevel
+    end
+end
+
 -- Upgrade track color data (shared by BlizzardSkin character/inspect sheets + Bags)
 -- Only initialized when a consumer feature is actually enabled.
 do
@@ -1891,54 +1950,22 @@ do
         EllesmereUI._TRACK_WHITE = W
         EllesmereUI._TRACK_RANK = { [GR] = 1, [W] = 2, [VE] = 3, [CH] = 4, [HE] = 5, [MY] = 6 }
 
-        -- Locale-agnostic track color lookup (all known localized trackString values)
+        -- Canonical track key -> hue. The localized trackString translation
+        -- lives in EllesmereUI.UPGRADE_TRACK_KEYS above, so the list of
+        -- localized names exists in exactly one place.
         local map = {
-            -- Explorer / Delve (gray)
-            Explorer = GR, Expedicionario = GR, Forscher = GR,
-            Explorateur = GR, Esploratore = GR, Explorador = GR, Delve = GR,
-            -- Adventurer (white)
-            Adventurer = W, Aventurero = W, Abenteurer = W,
-            Aventurier = W, Avventuriero = W, Aventureiro = W,
-            -- Veteran (green)
-            Veteran = VE, Veterano = VE, ["V\195\169t\195\169ran"] = VE,
-            -- Champion (blue)
-            Champion = CH, ["Campe\195\179n"] = CH, Campione = CH,
-            ["Campe\195\163o"] = CH,
-            -- Hero (purple)
-            Hero = HE, ["H\195\169roe"] = HE, Held = HE,
-            ["H\195\169ros"] = HE, Eroe = HE, ["Hero\195\173"] = HE,
-            -- Myth (orange)
-            Myth = MY, Mito = MY, Mythos = MY, Mythe = MY,
-            -- ruRU
-            ["\208\152\209\129\209\129\208\187\208\181\208\180\208\190\208\178\208\176\209\130\208\181\208\187\209\140"] = GR,
-            ["\208\152\209\129\208\186\208\176\209\130\208\181\208\187\209\140 \208\191\209\128\208\184\208\186\208\187\209\142\209\135\208\181\208\189\208\184\208\185"] = W,
-            ["\208\146\208\181\209\130\208\181\209\128\208\176\208\189"] = VE,
-            ["\208\151\208\176\209\137\208\184\209\130\208\189\208\184\208\186"] = CH,
-            ["\208\147\208\181\209\128\208\190\208\185"] = HE,
-            ["\208\155\208\181\208\179\208\181\208\189\208\180\208\176"] = MY,
-            -- koKR
-            ["\237\131\144\237\151\152\234\176\128"] = GR, ["\235\170\168\237\151\152\234\176\128"] = W,
-            ["\235\133\184\235\160\168\234\176\128"] = VE, ["\236\177\148\237\148\188\236\150\184"] = CH,
-            ["\236\152\129\236\155\133"] = HE, ["\236\139\160\237\153\148"] = MY,
-            -- zhCN
-            ["\230\142\162\231\180\162\232\128\133"] = GR, ["\229\134\146\233\153\169\232\128\133"] = W,
-            ["\232\128\129\229\133\181"] = VE, ["\229\139\135\229\163\171"] = CH,
-            ["\232\139\177\233\155\132"] = HE, ["\231\165\158\232\175\157"] = MY,
-            -- zhTW
-            ["\230\142\162\233\154\170\232\128\133"] = GR, ["\229\134\146\233\154\170\232\128\133"] = W,
-            ["\231\178\190\229\133\181"] = VE, ["\231\165\158\232\169\177"] = MY,
+            Explorer   = GR,
+            Adventurer = W,
+            Veteran    = VE,
+            Champion   = CH,
+            Hero       = HE,
+            Myth       = MY,
         }
 
         function EllesmereUI.GetUpgradeTrack(itemLink)
-            if not itemLink or not (C_Item and C_Item.GetItemUpgradeInfo) then
-                return "", W
-            end
-            local info = C_Item.GetItemUpgradeInfo(itemLink)
-            if not info then return "", W end
-            local cur, maxL = info.currentLevel, info.maxLevel
+            local key, cur, maxL = EllesmereUI.GetUpgradeTrackKey(itemLink)
             local text = (cur and maxL and maxL > 0) and (cur .. "/" .. maxL) or ""
-            local color = map[info.trackString or ""] or W
-            return text, color
+            return text, map[key or ""] or W
         end
 
         -- Resolve the item-level text color using the exact same precedence as

--- a/EllesmereUIQoL/EUI_UpgradeCalc.lua
+++ b/EllesmereUIQoL/EUI_UpgradeCalc.lua
@@ -204,7 +204,14 @@ function Calc:GetEquippedGear(unit)
     return gear
 end
 
-Calc._tipCache = {}   -- [link] = { track, rank, isCrafted, craftBand, craftMaxIlvl, isVoidforged }
+Calc._tipCache = {}   -- [link] = { track, rank, maxRank, isCrafted, craftBand, craftMaxIlvl, isVoidforged }
+
+-- "Made by <name>" as a Lua pattern, built from the client's own global string
+-- so it matches on every locale. Colour codes are stripped first because the
+-- lines we test have already been through Plain(). Falls back to the enUS literal.
+local CREATED_BY_PATTERN = Plain(ITEM_CREATED_BY or "Made by %s")
+    :gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
+    :gsub("%%%%s", ".+")
 
 function Calc:ScanItemLink(link)
     if not link then return nil end
@@ -212,24 +219,36 @@ function Calc:ScanItemLink(link)
     if cached then return cached end
 
     local result = {
-        track = nil, rank = nil,
+        track = nil, rank = nil, maxRank = nil,
         isCrafted = false, craftBand = nil, craftMaxIlvl = nil,
         isVoidforged = false,
     }
 
+    -- Primary source: the upgrade API, which reports the track in the client's
+    -- locale. EllesmereUI.GetUpgradeTrackKey translates it back to the English
+    -- key our season tables use. Tooltip text is only a fallback -- parsing it
+    -- directly is enUS-only and silently mislabels every item on other clients.
+    local apiTrack, apiRank, apiMax = nil, nil, nil
+    if EllesmereUI and EllesmereUI.GetUpgradeTrackKey then
+        apiTrack, apiRank, apiMax = EllesmereUI.GetUpgradeTrackKey(link)
+    end
+
     local lines = GetTooltipLines(link)
-    local foundTrack, foundRank, foundVoid = nil, nil, false
+    local foundTrack, foundRank, foundVoid = apiTrack, apiRank, false
     ForEachTooltipLine(lines, function(text)
         if not foundTrack and text:find("Upgrade Level") then
             local t, r = text:match("Upgrade Level:%s+(%a+)%s+(%d+)/%d+")
             if t then foundTrack = t; foundRank = tonumber(r) end
         end
+        -- enUS-only: no API exposes the Voidforged modifier. On other locales
+        -- this stays false and the ilvl-band fallback covers the max ilvl.
         if not foundVoid and Plain(text):find("Ascendant Voidforged") then
             foundVoid = true
         end
     end)
     result.track = foundTrack
     result.rank  = foundRank
+    result.maxRank = (foundTrack == apiTrack) and apiMax or nil
     result.isVoidforged = foundVoid
 
     -- Only scan the crafted tooltip if no upgrade track was found.
@@ -238,7 +257,9 @@ function Calc:ScanItemLink(link)
         local isCrafted, sawHero, sawMyth = false, false, false
         ForEachTooltipLine(lines, function(raw)
             local t = Plain(raw)
-            if t:find("Crafted") or t:find("Optional Reagents") or t:find("Recrafting") or t:find("Made by") then
+            if t:find(CREATED_BY_PATTERN)
+                or t:find("Crafted") or t:find("Optional Reagents")
+                or t:find("Recrafting") or t:find("Made by") then
                 isCrafted = true
             end
             if t:find("Hero") then sawHero = true end
@@ -258,10 +279,16 @@ function Calc:ScanItemLink(link)
     return result
 end
 
--- Returns: trackName (string|nil), rank (number|nil).
+-- Returns: trackName (string|nil), rank (number|nil), maxRank (number|nil).
 function Calc:GetItemTrackAndRank(link)
     local r = self:ScanItemLink(link)
-    return r and r.track, r and r.rank
+    return r and r.track, r and r.rank, r and r.maxRank
+end
+
+-- Number of ranks in a track: the API's maxLevel when we have it, otherwise the
+-- season table's length. Data.tracks has no Explorer entry, so td may be nil.
+local function TrackMaxRank(td, maxRank)
+    return maxRank or (td and #td.ranks) or 6
 end
 
 -- Shared helper: given an ilvl, returns band ("Myth"/"Hero"/"None") and maxIlvl.
@@ -315,10 +342,10 @@ end
 -- Returns the ilvl gain from the next upgrade step, or nil if already at max.
 -- (Reserved for future use; not currently called by PopulateGear.)
 function Calc:GetNextUpgradeGain(item)
-    local track, rank = self:GetItemTrackAndRank(item.link)
+    local track, rank, maxRank = self:GetItemTrackAndRank(item.link)
     if not track or not rank then return nil end
     local td = Data.tracks[track]
-    if not td or rank >= #td.ranks then return nil end
+    if not td or rank >= TrackMaxRank(td, maxRank) then return nil end
     return (td.ranks[rank + 1] or 0) - (td.ranks[rank] or 0)
 end
 
@@ -344,7 +371,7 @@ end
 -- Non-crafted: trackName, rank, crestCost, maxIlvl
 -- Crafted:     "Crafted", nil, nil, maxIlvl, tierLabel, band
 function Calc:GetItemUpgradeCost(item)
-    local track, rank = self:GetItemTrackAndRank(item.link)
+    local track, rank, maxRank = self:GetItemTrackAndRank(item.link)
 
     if not track then
         local isCrafted, band, tier, maxIlvl = self:GetCraftedInfo(item.link, item.ilvl)
@@ -378,7 +405,7 @@ function Calc:GetItemUpgradeCost(item)
     end
 
     -- Priority 2: raw estimate (upgrader scan not available for this slot).
-    local upgradesLeft = #td.ranks - rank
+    local upgradesLeft = math.max(0, TrackMaxRank(td, maxRank) - (rank or 0))
     return track, rank, upgradesLeft * 20, expectedMax
 end
 
@@ -1244,7 +1271,9 @@ PopulateGear = function()
                 end
             elseif track then
                 local td = Data.tracks[track]
-                totalMissing = totalMissing + ((td and #td.ranks or 6) - (rank or 0))
+                local scan = Calc:ScanItemLink(item.link)
+                local maxRank = TrackMaxRank(td, scan and scan.maxRank)
+                totalMissing = totalMissing + math.max(0, maxRank - (rank or 0))
                 local cn_map = slotCrestMap[item.slot]
                 if cn_map then
                     for cn, amt in pairs(cn_map) do
@@ -1254,8 +1283,8 @@ PopulateGear = function()
                     crestNeeds[td.crestName] = (crestNeeds[td.crestName] or 0) + crestCost
                 end
                 dt = track; dm = maxIlvl or item.ilvl
-                du = rank and (rank .. "/" .. (td and #td.ranks or 6)) or "-"
-                isAtMax = (rank == (td and #td.ranks or 6))
+                du = rank and (rank .. "/" .. maxRank) or "-"
+                isAtMax = (rank == maxRank)
             else
                 if Calc:IsVoidforged(item.link) then
                     dt = "Voidforged"; dm = item.ilvl; du = "Max"; isAtMax = true
@@ -1691,8 +1720,10 @@ end
 -- On PLAYER_LOGIN we call NewDB so our data lives inside EllesmereUIDB.profiles
 -- (the same place Cursor, BattleRes etc store theirs).  Without this, NewDB
 -- wipes EllesmereUIQoLDB and our saved data is lost every session.
--- The first-run filter runs once (guarded by opts.firstRunDone) to auto-hide
+-- The first-run filter runs once (guarded by opts.firstRunV2) to auto-hide
 -- crest tracks that have no upgradeable items on the player's current gear.
+-- The guard is versioned so the bad verdict written by the v1 enUS-only scan
+-- gets discarded and recomputed.
 local _firstRunEvt = CreateFrame("Frame")
 _firstRunEvt:RegisterEvent("PLAYER_LOGIN")
 _firstRunEvt:SetScript("OnEvent", function(self)
@@ -1740,17 +1771,26 @@ _firstRunEvt:SetScript("OnEvent", function(self)
         _optsCache = store.upgradeCalcOpts
     end
     local opts = Opts()
-    if opts.firstRunDone then return end
-    -- Brief delay so the client has fully loaded item data before tooltip scanning.
+    if opts.firstRunV2 then return end
+    -- The v1 auto-filter ran on the old enUS-only tooltip scan, so on every
+    -- other locale it detected no track at all and permanently hid every crest
+    -- row. Wipe that verdict (and the per-slot costs derived from it) before
+    -- re-running the scan against the upgrade API.
+    if opts.firstRunDone then
+        opts.crestFilter = nil
+        Calc:ClearCache()
+    end
+    -- Brief delay so the client has fully loaded item data before scanning.
     C_Timer.After(1.5, function()
         opts.firstRunDone = true
+        opts.firstRunV2   = true
         local tracksNeeded = {}
         for _, slotID in ipairs(Data.equipSlots) do
             local link = GetInventoryItemLink("player", slotID)
             if link then
                 local r = Calc:ScanItemLink(link)
                 local td = r and r.track and Data.tracks[r.track]
-                if td and (r.rank or 0) < #td.ranks then
+                if td and (r.rank or 0) < TrackMaxRank(td, r.maxRank) then
                     tracksNeeded[r.track] = true
                 end
             end


### PR DESCRIPTION
## What does this PR do?

Fixes the QoL Upgrade Calculator, which was completely broken on every non-English client (frFR, deDE, esES/esMX, itIT, ptBR, ruRU, koKR, zhCN, zhTW).

The calculator determined an item's upgrade track (Adventurer/Veteran/Champion/Hero/Myth) by pattern-matching the English tooltip string `"Upgrade Level: <track> <rank>/<max>"`. On a localized client this string never appears (e.g. frFR shows `"Niveau d'amelioration : Champion 1/6"`), so every equipped item was silently misclassified as "Crafted" with an incorrect max item level. As a result:
- `Total Missing Upgrades` always read 0
- `Total Crests Needed` always read "None"
- every item in the upgrade queue showed a green "Max" cost
- the first-run auto-filter permanently hid every crest row, compounding the bug for existing users

The character sheet nearby, which reads the same data through `C_Item.GetItemUpgradeInfo` (a locale-agnostic API) instead of the tooltip text, displayed the correct track the whole time.

Fix: `Calc:ScanItemLink` now sources track/rank from the API first (via a new `EllesmereUI.GetUpgradeTrackKey` helper, itself using localized-string tables already maintained for the character sheet's track-color lookup), falling back to the English tooltip match only as a safety net. Crafted-item detection is also localized, via the client's own `ITEM_CREATED_BY` global string instead of a hardcoded English literal. Existing users' poisoned crest filter and cached per-slot costs are cleared once (versioned `firstRunV2` guard) so the bad state left by the old broken scan doesn't linger.

## How was it tested?

- `luac -p` syntax check on both changed files.
- Standalone Lua harness exercising `EllesmereUI.GetUpgradeTrackKey` against mocked `C_Item.GetItemUpgradeInfo` return values for frFR/deDE trackStrings, confirming correct canonical-key + rank/maxRank resolution.
- Tested in-game on live retail on a frFR client: character sheet and Upgrade Calculator now agree (e.g. head slot correctly shows Champion 1/6, max ilvl 263), crest totals and the upgrade queue populate correctly.

## Screenshots

N/A -- not a visual/layout change, just a locale-detection bug fix.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, pure bug fix, no new setting
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A, no toggle; the corrected scan runs unconditionally, same as the old broken one
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- replaces a string pattern-match with an API call + table lookup already used elsewhere in the file
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, no frame writes; data/text only
- [x] Tested in-game, works on live retail