### PR TITLE
Apply saved positions in the frame's own coordinate space

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -851,9 +851,18 @@ function EllesmereUI.RecenterBarAnchor(barKey)
         end
     end
 
+    -- cRelX/cRelY are UIParent units; SetPoint offsets are read in the frame's
+    -- own space. Identical unless the element scales itself (see
+    -- ApplyCenterPosition), so this divide is a no-op for everything unscaled.
+    local setX, setY = cRelX, cRelY
+    if elemScale ~= 1 and elemScale > 0 then
+        setX = cRelX / elemScale
+        setY = cRelY / elemScale
+    end
+
     pcall(function()
         b:ClearAllPoints()
-        b:SetPoint(anchor, UIParent, "CENTER", cRelX, cRelY)
+        b:SetPoint(anchor, UIParent, "CENTER", setX, setY)
     end)
 
     -- Keep mover's stored center in sync so drag/snap logic stays consistent
@@ -3968,6 +3977,18 @@ ApplyCenterPosition = function(barKey, pos)
 
     local cx, cy = pos.x or 0, pos.y or 0
 
+    -- Stored coords are UIParent screen units (ConvertToCenterPos produces them
+    -- by scaling the frame's live edges into UIParent space). SetPoint offsets,
+    -- however, are read in the FRAME's own coordinate space -- identical only
+    -- while the frame sits at UIParent scale. An element that scales ITSELF
+    -- (Raid Tools' Window Scale) therefore lands at offset * scale, i.e. drifts
+    -- toward or away from screen centre on every apply, and Save & Exit then
+    -- stores the drifted spot back. fRatio converts both ways; it is exactly 1
+    -- for every unscaled element, so nothing else changes.
+    local uiS = UIParent:GetEffectiveScale()
+    local fS  = frame:GetEffectiveScale() or uiS
+    local fRatio = (uiS and uiS > 0 and fS and fS > 0) and (fS / uiS) or 1
+
     -- Determine grow anchor from unlock-mode anchor relationship
     local anchorInfo = anchorDB and anchorDB[barKey]
     local anchor = "CENTER"
@@ -3975,8 +3996,8 @@ ApplyCenterPosition = function(barKey, pos)
 
     if anchorInfo and anchorInfo.target and anchorInfo.side then
         local side = anchorInfo.side
-        local fw = (frame:GetWidth() or 0)
-        local fh = (frame:GetHeight() or 0)
+        local fw = (frame:GetWidth() or 0) * fRatio
+        local fh = (frame:GetHeight() or 0) * fRatio
         -- Use raw half-dimensions (fw/2, fh/2) instead of floor().
         -- For odd-pixel-height frames, the center cy is integer + 0.5
         -- (because edges are integer and (top+bottom)/2 is .5). Using
@@ -4007,8 +4028,8 @@ ApplyCenterPosition = function(barKey, pos)
             adjY = ge.y
         else
             local growDir = GetBarGrowDirActual(barKey)
-            local fw = (frame:GetWidth() or 0)
-            local fh = (frame:GetHeight() or 0)
+            local fw = (frame:GetWidth() or 0) * fRatio
+            local fh = (frame:GetHeight() or 0) * fRatio
             -- Skip grow-direction conversion if frame has no dimensions yet
             -- (not laid out). Using CENTER avoids wrong edge placement from
             -- zero-size math. The bar will be re-positioned after LayoutBar runs.
@@ -4038,14 +4059,22 @@ ApplyCenterPosition = function(barKey, pos)
     -- odd-dimension frames that need half-pixel centering.
     local PPap = EllesmereUI and EllesmereUI.PP
     if PPap and PPap.SnapCenterForDim then
-        local es = frame:GetEffectiveScale()
+        -- adjX/adjY and the dimensions handed in are UIParent units, so the
+        -- grid to snap against is UIParent's, not the frame's own.
+        local es = uiS
         if anchor == "CENTER" then
-            adjX = PPap.SnapCenterForDim(adjX, frame:GetWidth() or 0, es)
-            adjY = PPap.SnapCenterForDim(adjY, frame:GetHeight() or 0, es)
+            adjX = PPap.SnapCenterForDim(adjX, (frame:GetWidth() or 0) * fRatio, es)
+            adjY = PPap.SnapCenterForDim(adjY, (frame:GetHeight() or 0) * fRatio, es)
         elseif PPap.SnapForES then
             adjX = PPap.SnapForES(adjX, es)
             adjY = PPap.SnapForES(adjY, es)
         end
+    end
+
+    -- Back into the frame's own space for SetPoint (no-op at fRatio == 1).
+    if fRatio ~= 1 then
+        adjX = adjX / fRatio
+        adjY = adjY / fRatio
     end
 
     pcall(function()

--- a/EllesmereUIQoL/EllesmereUIQoL_RaidTools.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_RaidTools.lua
@@ -1078,6 +1078,16 @@ local function ApplySectionPosition(key)
 end
 
 local function ApplyPositions()
+    -- While an unlock session is open UNLOCK MODE owns these frames: it moves
+    -- them live and only writes the result on Save & Exit. A settings pass
+    -- landing mid-session (the options panel hiding/showing flips the preview,
+    -- and a combat-deferred Apply completes on PLAYER_REGEN_ENABLED) would drag
+    -- the window back to the last SAVED spot -- and because Save & Exit derives
+    -- the value it stores from the frame's LIVE bounds, the drag is then
+    -- written back as the old position and lost for good. Same guard Action
+    -- Bars, Aura Reminders and the Cooldown Manager already carry.
+    if EllesmereUI._unlockActive then return end
+
     -- Each shell is positioned only when the Show as choice can put it on
     -- screen; One Window and Only Group & Pull ride pos.Group, Only Markers
     -- rides pos.Markers.
@@ -1250,9 +1260,13 @@ local function RegisterUnlock()
                 return sections[key]
             end,
             getSize  = function()
+                -- Unlock mode sizes the mover overlay in UIParent units, so
+                -- the Window Scale has to be folded in here -- GetWidth is the
+                -- frame's own (unscaled) size.
+                local s = WindowScale()
                 local f = sections[key]
-                if f then return f:GetWidth(), f:GetHeight() end
-                return PANEL_W, 60
+                if f then return f:GetWidth() * s, f:GetHeight() * s end
+                return PANEL_W * s, 60 * s
             end,
             savePos = function(_, point, relPoint, x, y)
                 if not point then return end


### PR DESCRIPTION
## What does this PR do?

Raid Tools would not stay where it was dropped: every apply pulled it further toward screen centre, and Save & Exit stored the drifted spot back. Stored positions are UIParent screen units, but SetPoint offsets are read in the FRAME's own space -- the two agree only while an element sits at UIParent scale, and Raid Tools is the first to scale itself, so at Window Scale 0.85 each apply landed it at offset * 0.85. The anchor paths in the same file already convert (acRatio = uiS / cS); ApplyCenterPosition and RecenterBarAnchor now do too, a no-op wherever the frame and UIParent scales match. ApplyPositions also stands down while an unlock session is open, since a settings pass landing mid-session would drag the window back to the last saved spot, and getSize reports the mover footprint in UIParent units.

Before: it just snapped back to another position. This only happened after applying a window scale.

## How was it tested?

Tested on 12.0.7 live retail.
NOT tested on 12.1 PTR!

## Checklist

- [ ] New settings default **OFF** (no behavior change without opt-in)
 - No new setting
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
