### PR TITLE
fix(cdm): light a Bar Glow when an aura is added, not only when one is removed

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -7668,8 +7668,20 @@ function ns.SetupViewerHooks()
         cdmBuffTickFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
         cdmBuffTickFrame:SetScript("OnEvent", function(_, event, _, updateInfo)
             ns._btDirty = true
-            -- Gen bump on anything that can RELEASE a pool frame: aura
-            -- removals/full updates, totem drops/despawns, and world entry.
+            -- Gen bump on anything that can CHANGE which auras are active:
+            -- additions (a glow must LIGHT), plus anything that can release a
+            -- pool frame -- removals/full updates, totem drops/despawns, world
+            -- entry.
+            --
+            -- Additions were missing, and an addition does not necessarily churn
+            -- the pool either: a spell tracked in a COOLDOWN viewer keeps its
+            -- frame acquired permanently, so Blizzard merely sets
+            -- wasSetFromAura/auraInstanceID on the frame that is already there.
+            -- No Acquire, no generation bump, so lighting a Bar Glow fell
+            -- through to the 1s staleness net below -- up to a second late, and
+            -- missed entirely when the proc was consumed inside that window.
+            -- (Killing Machine -> Obliterate; regressed in 8.6.1, correct in
+            -- 8.5.3, which rebuilt the cache every tick.)
             -- Only UNIT_AURA carries an updateInfo table in this slot --
             -- PLAYER_ENTERING_WORLD's second arg is the isReconnect BOOLEAN
             -- (true on /reload), so the payload must never be indexed for
@@ -7692,8 +7704,10 @@ function ns.SetupViewerHooks()
                 else
                     local full    = updateInfo.isFullUpdate
                     local removed = updateInfo.removedAuraInstanceIDs
+                    local added   = updateInfo.addedAuras
                     if issecretvalue(full) or issecretvalue(removed)
-                       or full or removed then
+                       or issecretvalue(added)
+                       or full or removed or added then
                         ns._acGen = (ns._acGen or 0) + 1
                     end
                 end


### PR DESCRIPTION
## Problem

A Bar Glow assigned to a proc can fail to light, or light up to a second late.

Context: Deacon / Inquisitor reported on 8.6.5 that a glow on Obliterate for the Killing Machine proc frequently failed to appear while the buff was up, and bisected it to the week of releases after 8.5.3 (22 July), which behaved correctly.

## Root cause

Bar Glow overlays decide whether to glow from `ns._tickBlizzActiveCache` and nothing else. The sole maintainer of that cache is the 0.1s buff ticker in `EllesmereUICdmHooks.lua`, which walks Blizzard's four viewer pools and marks any frame whose `wasSetFromAura` / `auraInstanceID` indicates a live aura.

That rebuild sits behind a pool-generation gate with a 1s staleness net. `UNIT_AURA` bumped the generation only for things that can RELEASE a pool frame:

```lua
local full    = updateInfo.isFullUpdate
local removed = updateInfo.removedAuraInstanceIDs
if ... or full or removed then
    ns._acGen = (ns._acGen or 0) + 1
end
```

An aura becoming ACTIVE never opened the gate.

Nor does an addition reliably churn the pool on its own. A spell tracked in a cooldown viewer keeps its frame acquired for the whole session, so when the aura lands Blizzard simply sets the aura fields on the frame that is already there. No Acquire, no generation bump. Lighting a glow therefore falls through to the 1s net, so it arrives up to a second late, and not at all when the proc is consumed inside that window.

Removals were covered because a released frame left in the cache would keep a glow lit. Additions are what turn a glow on, and the gate needs both.

Introduced by the pool-generation gate added in 8.6.1. 8.5.3 rebuilt the cache on every tick with no gate, which is why it was unaffected.

## Fix

Bump the generation on `addedAuras` as well.

The new field uses the same secret-safe guard shape as its neighbours: bind to a local (reading a secret is always legal), `issecretvalue`-gate before any boolean test so the short circuit prevents a secret ever being truth-tested, and assume churn when the payload cannot be read.

Still cheaper than the 8.5.3 behaviour it restores. 8.5.3 rebuilt unconditionally on every tick; this rebuilds only when auras actually changed.

## Testing

Verified in game on a Frost Death Knight with a Bar Glow assigned to Killing Machine, using `/euibgdebug` either side of a proc. The assignment was confirmed present in both dumps first, so the observation is attributable to this feature rather than to a similar looking glow from elsewhere.

Aura down:

```
Assignments (enabled=true):
  [cdm_27629#1] spellID=51128 (Killing Machine) mode=ACTIVE
_tickBlizzActiveCache (active spellIDs):
  (empty)
Overlays:
  cdm_27629_1 shown=true sid=51128 lastGlow=false
[BuffIconCooldownViewer] cdID=50939 sid=51128 (Killing Machine)
    AURA: wasSetFromAura=false auraInstanceID=nil  shown=false
```

Aura up:

```
Assignments (enabled=true):
  [cdm_27629#1] spellID=51128 (Killing Machine) mode=ACTIVE
_tickBlizzActiveCache (active spellIDs):
  51128 (Killing Machine)
  51124 (Killing Machine)
Overlays:
  cdm_27629_1 shown=true sid=51128 lastGlow=true
[BuffIconCooldownViewer] cdID=50939 sid=51128 (Killing Machine)
    AURA: wasSetFromAura=false auraInstanceID=339  shown=true
```

The full chain fires: the aura lands, the gate opens on `addedAuras`, the cache picks up 51128, and the overlay's own `lastGlow` state flips to true. Repeated procs lit the glow every time with no misses and no delay.

Note this Killing Machine frame is exactly the case described above. It sits permanently acquired in `BuffIconCooldownViewer`, so a proc only flips `shown` and the aura fields and causes no pool churn. Before this change the cache stayed empty through the proc and the glow depended on the 1s net landing inside the buff's window.

The assignment used here targets a CDM bar icon rather than an action bar button. That does not narrow the result: the defect and the fix are both in the shared aura cache that feeds every Bar Glow, and the assignment target only selects which overlay gets lit once `shouldGlow` is decided.

`/euibgdebug` dumps assignments, the active aura cache, and per-frame aura state for investigating this area.

<img width="500" height="284" alt="_" src="https://github.com/user-attachments/assets/712e1560-b08f-48d7-a713-5840b6dc980a" />

