### PR TITLE
feat(actionbars): add a Hide option for the proc glow

### DIFF
--- a/EllesmereUIActionBars/EUI_ActionBars_Options.lua
+++ b/EllesmereUIActionBars/EUI_ActionBars_Options.lua
@@ -5425,6 +5425,16 @@ initFrame:SetScript("OnEvent", function(self)
         if loopIdx < 1 or loopIdx > #LOOP then loopIdx = 1 end
         local loopEntry = LOOP[loopIdx]
 
+        -- "Hide": show the icon dimmed with no glow, matching how "None" reads,
+        -- since the point of the option is that nothing is drawn. Without this
+        -- the dispatch below would fall through to the FlipBook arm with an
+        -- entry that has no atlas or texture.
+        if loopEntry and loopEntry.hide then
+            f:Show()
+            f:SetAlpha(0.15)
+            return
+        end
+
         local iconSize = PREVIEW_ICON_SIZE
         local cr, cg, cb
         if p.procGlowUseClassColor then
@@ -5736,7 +5746,16 @@ initFrame:SetScript("OnEvent", function(self)
         -------------------------------------------------------------------
         _, h = W:SectionHeader(parent, SECTION_PROC_GLOW, y);  y = y - h
 
-        local function procGlowOff() return (p.procGlowType == 0) or (p.procGlowEnabled == false) end
+        -- "Hide" counts as off for the dependent controls: there is no glow to
+        -- colour, so the colour swatch and Use Class Color grey out just as
+        -- they do for "None".
+        local function procGlowIsHide()
+            local e = ns.LOOP_GLOW_TYPES and ns.LOOP_GLOW_TYPES[p.procGlowType or 0]
+            return (e and e.hide) and true or false
+        end
+        local function procGlowOff()
+            return (p.procGlowType == 0) or (p.procGlowEnabled == false) or procGlowIsHide()
+        end
 
         -- Check if any bar uses a custom shape (not "none")
         local function AnyBarHasCustomShape()
@@ -5763,7 +5782,11 @@ initFrame:SetScript("OnEvent", function(self)
               getValue=function() if p.procGlowEnabled == false then return 0 end; return p.procGlowType or 1 end,
               setValue=function(v)
                   local wasOff = (p.procGlowType == 0) or (p.procGlowEnabled == false)
-                  local turningOn = wasOff and v ~= 0
+                  -- "Hide" does strictly LESS work than Blizzard's own glow, so
+                  -- it must not trigger the custom-glow performance warning.
+                  local vEntry = ns.LOOP_GLOW_TYPES and ns.LOOP_GLOW_TYPES[v]
+                  local vIsHide = (vEntry and vEntry.hide) and true or false
+                  local turningOn = wasOff and v ~= 0 and not vIsHide
                   if turningOn then
                       EllesmereUI:ShowConfirmPopup({
                           title       = "Custom Proc Glow Settings",

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -8064,6 +8064,12 @@ local LOOP_GLOW_TYPES = {
     { name = "Modern WoW Glow",      atlas = "UI-HUD-ActionBar-Proc-Loop-Flipbook", texPadding = 1.4 },
     { name = "Classic WoW Glow",     texture = "Interface\\SpellActivationOverlay\\IconAlertAnts",
       rows = 5, columns = 5, frames = 25, duration = 0.3, frameW = 48, frameH = 48, texPadding = 1.25 },
+    -- Suppress the glow entirely. Note this is NOT the same as the dropdown's
+    -- "None" (procGlowType 0), which means "do not customise" and therefore
+    -- leaves Blizzard's own gold glow in place. Appended last on purpose:
+    -- procGlowType is stored by INDEX, so inserting anywhere else would
+    -- silently reassign every existing player's chosen style.
+    { name = "Hide",                 hide = true },
 }
 ns.LOOP_GLOW_TYPES = LOOP_GLOW_TYPES
 
@@ -8181,6 +8187,24 @@ local function UpdateFlipbook(btn)
 
     local loopIdx = p.procGlowType or 1
     if loopIdx < 1 or loopIdx > #LOOP_GLOW_TYPES then loopIdx = 1 end
+    -- "Hide": suppress BOTH surfaces and stop. Checked before the custom-shape
+    -- force below, because that force decides HOW a glow is drawn and must not
+    -- resurrect one the player asked not to see.
+    -- Only the visual is suppressed: _procState.active still tracks the button,
+    -- so the assisted-highlight and glow-rescan paths that read proc state stay
+    -- correct. Alpha 0 as well as Hide(), because Blizzard re-Shows its own
+    -- region on the next proc and alpha survives that.
+    if LOOP_GLOW_TYPES[loopIdx] and LOOP_GLOW_TYPES[loopIdx].hide then
+        local gw = fd.glowWrapper
+        if gw then
+            _G_Glows.StopAllGlows(gw)
+            gw:SetAlpha(0)
+            gw:Hide()
+        end
+        if region then region:SetAlpha(0); region:Hide() end
+        fd.customizedFlipbook = true
+        return
+    end
     -- Force Shape Glow for custom shapes regardless of user selection
     if fd.shapeMask and fd.shapeApplied then
         for si, entry in ipairs(LOOP_GLOW_TYPES) do


### PR DESCRIPTION
## Problem

There is no way to turn the proc glow off.

The **Custom Proc Glow** dropdown can replace Blizzard's gold proc glow with a different style, but never suppress it. Its `"None"` entry means "do not customise", so selecting it leaves Blizzard's own glow fully in place. It reads like an off switch that turns nothing off, and players who simply do not want a glow on their buttons have no option.

## Fix

Adds a **Hide** style to the Custom Proc Glow dropdown.

`{ name = "Hide", hide = true }` is **appended last** in `LOOP_GLOW_TYPES` deliberately: `procGlowType` is stored by index, so inserting anywhere else would silently reassign every existing player's chosen style.

Handled in `UpdateFlipbook` before the custom-shape force, because that force decides HOW a glow is drawn and must not resurrect one the player asked not to see.

**Only the visual is suppressed.** `_procState.active` still tracks the button, so the assisted-highlight rescan and the glow rescan that read proc state stay correct. Both surfaces are covered (our glow wrapper and Blizzard's `SpellActivationAlert`), with alpha 0 as well as `Hide()` on the latter, because Blizzard re-Shows its own region on the next proc and alpha survives that.

Options side:

- The dropdown lists it automatically, since it is built from `LOOP_GLOW_TYPES`.
- The custom-glow performance warning no longer fires when selecting it. Hide does strictly less work than Blizzard's own glow, so warning about performance would be misleading.
- Colour and **Use Class Color** grey out, as they already do for `"None"`, because there is no glow to colour.
- The preview icon renders dimmed with no glow, matching how `"None"` reads. Without that the preview dispatch fell through to its FlipBook arm with an entry that has no atlas or texture.

## Testing

Confirmed in game: with Custom Proc Glow set to **Hide**, the proc glow is suppressed as intended.

Also verified: both files compile (`luac -p`), the change applies cleanly to `main`, and the code paths were traced by hand, including that switching to Hide while a proc is already live tears the existing glow down, since `RefreshProcGlows` re-runs `UpdateFlipbook` on any button with an active proc.

## Why the Cooldown Manager did not need this

Worth recording, because it is the clearest argument for the change and it also confirms no equivalent work is needed in CDM.

CDM already offers a real off switch. Its per-spell **Proc Glow** menu has `{ val = 0, label = "None" }`, and the glow starter honours it directly:

```lua
if ss.procGlow == 0 then return end -- proc glow disabled
```

That works because CDM hides Blizzard's own `SpellActivationAlert` on its icons and renders its own glow instead, so returning early leaves nothing drawn.

Action Bars is the opposite case. It does **not** universally suppress Blizzard's region, so its `"None"` (`procGlowType 0`) means "do not customise" and Blizzard's gold glow stays visible. Same label, opposite behaviour between the two modules. This change makes the Action Bars dropdown able to express what CDM could already express.

Verified in game that the CDM side already behaves correctly with **Proc Glow -> None**, so this PR is confined to Action Bars.

One asymmetry left, noted rather than addressed here: CDM's control is **per spell**, whereas this one is global. A bar-level or profile-level CDM default that per-spell values override would be a reasonable follow-up, but it is a separate change.

## Notes for review

Two pre-existing things noticed while working here, neither changed:

- The dropdown is `disabled` when **Blizzard Style Action Bars** is on, or when any bar uses a custom shape (custom shapes always use Shape Glow). Those players cannot reach Hide through the UI. A stored Hide still applies, which seems the right call, but the constraint is worth knowing.
- `PROC_START_TYPES` already contains its own `{ name = "Hide", hide = true }` entry, but that table is defined and exported and then **never consumed anywhere**. It looks like dead code. Left alone here since removing it is unrelated to this change.

<img width="245" height="245" alt="Its Been A Long Time Waiting GIF" src="https://github.com/user-attachments/assets/0a243d0c-625b-4d0e-944c-91904f590281" />

