### PR TITLE
Fix missing L() wrappers for user-facing strings

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -10746,28 +10746,32 @@ function EllesmereUI._applySidebarSearch(text)
         end
     end
 
+    -- Bilingual: index the localized form too, only when it differs from the
+    -- original, so the English haystack stays byte-identical on English clients.
+    local function addLocalized(parts, s)
+        s = tostring(s)
+        parts[#parts + 1] = s:lower()
+        local loc = tostring(EllesmereUI.L(s))
+        if loc ~= s then parts[#parts + 1] = loc:lower() end
+    end
+
     local function childMatches(info)
         if #queryWords == 0 then return true end
-        local parts = { (info.display or ""):lower() }
-        -- Bilingual: index localized module/page names too (only when they differ,
-        -- so the English haystack is byte-identical on English clients).
-        local dispLoc = EllesmereUI.L(info.display or "")
-        if dispLoc ~= (info.display or "") then parts[#parts + 1] = dispLoc:lower() end
+        local parts = {}
+        addLocalized(parts, info.display or "")
         local mod = modules[info.folder]
         if mod and mod.pages then
             for _, p in ipairs(mod.pages) do
-                parts[#parts + 1] = tostring(p):lower()
-                local pLoc = EllesmereUI.L(p)
-                if pLoc ~= p then parts[#parts + 1] = tostring(pLoc):lower() end
+                addLocalized(parts, p)
             end
         end
         if mod and mod.searchTerms then
             if type(mod.searchTerms) == "table" then
                 for _, t in ipairs(mod.searchTerms) do
-                    parts[#parts + 1] = tostring(t):lower()
+                    addLocalized(parts, t)
                 end
             else
-                parts[#parts + 1] = tostring(mod.searchTerms):lower()
+                addLocalized(parts, mod.searchTerms)
             end
         end
         local haystack = table.concat(parts, " ")

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -16103,7 +16103,7 @@ initFrame:SetScript("OnEvent", function(self)
                     -- the only visible reading is "specs of this character".
                     -- Kept to one line: the subtitle has room for two before it
                     -- runs into the Check All / Uncheck All row.
-                    subtitle    = "Choose which specs sync with " .. srcName .. ", including your alts' specs (the source is always included)",
+                    subtitle    = EllesmereUI.Lf("Choose which specs sync with %1$s, including your alts' specs (the source is always included)", srcName),
                     confirmText = "Sync",
                     specs       = specs,
                     lockedSpecs = { [sourceKey] = "This is the spec you're syncing from -- it's always included." },
@@ -16117,7 +16117,7 @@ initFrame:SetScript("OnEvent", function(self)
                             -- sync, and confirming with one spec ticked is the
                             -- natural first guess at "sync FROM this spec".
                             if ns.ClearRPTSync then ns.ClearRPTSync() end
-                            EllesmereUI.Print("|cff0cd29fEllesmereUI CDM:|r Sync cleared -- only one spec was selected. Tick at least two specs (including other characters' specs) to sync between them.")
+                            EllesmereUI.Print("|cff0cd29fEllesmereUI CDM:|r " .. EllesmereUI.L("Sync cleared -- only one spec was selected. Tick at least two specs (including other characters' specs) to sync between them."))
                             EllesmereUI:RefreshPage(true)
                             return
                         end
@@ -16127,7 +16127,7 @@ initFrame:SetScript("OnEvent", function(self)
                         -- not, so every spec keeps its own ordering. Reported as
                         -- a bug ("some were right, some were wrong order"), so
                         -- it is stated where the subtitle has no room for it.
-                        EllesmereUI.Print(("|cff0cd29fEllesmereUI CDM:|r Syncing generic CDs/buffs across %d specs. Icon order is not synced -- each spec keeps its own arrangement."):format(cnt))
+                        EllesmereUI.Print("|cff0cd29fEllesmereUI CDM:|r " .. EllesmereUI.Lf("Syncing generic CDs/buffs across %d specs. Icon order is not synced -- each spec keeps its own arrangement.", cnt))
                         EllesmereUI:RefreshPage(true)
                     end,
                 })
@@ -16165,7 +16165,7 @@ initFrame:SetScript("OnEvent", function(self)
                         -- Announced for the same reason as the setup path: the
                         -- sync is discarded here, not merely left unchanged.
                         if ns.ClearRPTSync then ns.ClearRPTSync() end
-                        EllesmereUI.Print("|cff0cd29fEllesmereUI CDM:|r Sync cleared -- fewer than two specs remained selected.")
+                        EllesmereUI.Print("|cff0cd29fEllesmereUI CDM:|r " .. EllesmereUI.L("Sync cleared -- fewer than two specs remained selected."))
                         EllesmereUI:RefreshPage(true)
                         return
                     end

--- a/EllesmereUIFriends/EUI_Friends_Groups_121.lua
+++ b/EllesmereUIFriends/EUI_Friends_Groups_121.lua
@@ -370,7 +370,7 @@ local function PromptDeleteGroup(name)
     if not EllesmereUI.ShowConfirmPopup then return end
     EllesmereUI:ShowConfirmPopup({
         title       = "Delete Friend Group",
-        message     = format("Delete group \"%s\"?\nFriends in this group will be moved to the default list.", name),
+        message     = EllesmereUI.Lf("Delete group \"%s\"?\nFriends in this group will be moved to the default list.", name),
         confirmText = "Delete",
         cancelText  = "Cancel",
         onConfirm   = function() DeleteGroup(name) end,
@@ -399,17 +399,17 @@ local function OpenGroupMenu(anchorFrame, accountInfo)
     MenuUtil.CreateContextMenu(anchorFrame, function(_owner, root)
         local ar, ag, ab = AccentRGB()
         root:CreateTitle(format("|cff%02x%02x%02x%s|r", ar * 255, ag * 255, ab * 255,
-            "EUI Friend Groups"))
+            EllesmereUI.L("EUI Friend Groups")))
 
         -- Favorites are Blizzard's own bucket and always render there.
         if accountInfo.isFavorite then
-            root:CreateTitle("Favorites are managed by Battle.net")
+            root:CreateTitle(EllesmereUI.L("Favorites are managed by Battle.net"))
             return
         end
 
-        local addLabel = current and "Move to Group" or "Add to Group"
+        local addLabel = EllesmereUI.L(current and "Move to Group" or "Add to Group")
         local addTo = root:CreateButton(addLabel)
-        addTo:CreateButton("|cff00ff00+|r Add New Group", function()
+        addTo:CreateButton("|cff00ff00+|r " .. EllesmereUI.L("Add New Group"), function()
             PromptNewGroup(tag, bnetID)
         end)
         if #fg.friendGroups > 0 then
@@ -425,7 +425,7 @@ local function OpenGroupMenu(anchorFrame, accountInfo)
             end
         end
 
-        local removeBtn = root:CreateButton("Remove from Group", function()
+        local removeBtn = root:CreateButton(EllesmereUI.L("Remove from Group"), function()
             SetFriendGroupByTag(tag, nil)
             RebuildGroups("direct")
         end)

--- a/EllesmereUIFriends/EUI_Friends_Tiles_121.lua
+++ b/EllesmereUIFriends/EUI_Friends_Tiles_121.lua
@@ -385,7 +385,7 @@ local function BuildCharLine(accountInfo)
         if SOCIAL_UI_RECENT_ALLIES_CARD_LEVEL_DISPLAY_FORMAT then
             levelText = format(SOCIAL_UI_RECENT_ALLIES_CARD_LEVEL_DISPLAY_FORMAT, lvl)
         else
-            levelText = format("(Level %d)", lvl)
+            levelText = EllesmereUI.Lf("(Level %d)", lvl)
         end
         local c = LocationColor(accountInfo)
         if c and c.WrapTextInColorCode then

--- a/EllesmereUI_Presets.lua
+++ b/EllesmereUI_Presets.lua
@@ -555,12 +555,12 @@ do
 
         -- Update title / subtitle
         if opts.title then
-            specPopup._title:SetText(opts.title)
+            specPopup._title:SetText(EllesmereUI.L(opts.title))
         else
             specPopup._title:SetText(EllesmereUI.L("Assign Preset to Specs"))
         end
         if opts.subtitle then
-            specPopup._subtitle:SetText(opts.subtitle)
+            specPopup._subtitle:SetText(EllesmereUI.L(opts.subtitle))
         else
             local presetName
             if presetKey == "custom" then presetName = EllesmereUI.L("Custom")
@@ -596,7 +596,7 @@ do
 
         -- Update Done button text
         if specPopup._closeLbl then
-            specPopup._closeLbl:SetText(opts.buttonText or EllesmereUI.L("Done"))
+            specPopup._closeLbl:SetText(EllesmereUI.L(opts.buttonText or "Done"))
         end
 
         -- Populate columns


### PR DESCRIPTION
## Summary
- Friend group context menu, delete-group confirmation, and tile level suffix now go through `L()`/`Lf()` instead of raw English literals.
- `ShowSpecAssignPopup` (Presets.lua) now translates `opts.title`/`opts.subtitle`/`opts.buttonText`, so callers that pass their own strings (e.g. the CDM generic CD/buff sync popups) get localized instead of always showing English. The sync subtitle also switched from string concatenation to `Lf()` with a placeholder, since `L()` only does exact-table lookup and a concatenated string can never match a locale key.
- Sidebar search now indexes the localized form of `mod.searchTerms` (previously only display names and page names were bilingual), so non-English search aliases can match.

## Test plan
- [x] `luasyntax.py` (real Lua 5.1 compile) passes on all 5 changed files
- [x] `diagnose.py --root` locale round-trip passes for all locales, no new orphan/duplicate keys introduced
- [ ] In-game verification on a zhTW client (not tested live)