### PR TITLE
Fix context menus losing their skin after the first one opened

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -793,8 +793,17 @@ end
     -- Back-compat full init (data + visual), used by the live re-apply path.
     local function _ttInit() _ttInitData(); _ttInitVisual() end
 
-    -- Context menu skinning
-    local _menuSkinned = {}
+    -- Context menu skinning.
+    --
+    -- Deliberately NOT memoised per frame. Menu frames are pooled: Blizzard
+    -- hands the same frame back for the next menu and rebuilds its textures from
+    -- the new description, which silently undoes our background. An "already
+    -- skinned" flag keyed on the frame therefore skips every reuse and leaves
+    -- Blizzard's background showing with our own border frame still drawn over
+    -- it. _menuSkinFrame is idempotent (it skips regions we own and re-anchors
+    -- relative to the frame, so nothing accumulates), so simply letting every
+    -- pass run is both correct across reuse and self-healing when Blizzard
+    -- writes a texture after our first pass.
 
     local function _menuSkinFrame(frame)
         if not frame or frame:IsForbidden() or not _pmEnabled() then return end
@@ -809,7 +818,6 @@ end
                 region:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -1, 1)
             end
         end
-        _menuSkinned[frame] = true
         _applyConfiguredBorder(frame, "popupMenu", 1)
     end
 
@@ -837,7 +845,7 @@ end
         -- after the open, which is what the callback was there for.
         local function skinOpenMenu()
             local menu = manager.GetOpenMenu and manager:GetOpenMenu()
-            if menu and not _menuSkinned[menu] then
+            if menu then
                 _menuSkinFrame(menu)
             end
         end


### PR DESCRIPTION
## Problem

Left-clicking a unit frame shows Blizzard's own menu background with a stray white border around it, from 8.6.6 on. Reported by Blazen (Global Settings, 8.6.6).

The tell: only the **first** context menu after login looks right. Every one after that is broken.

## Cause

A regression in 0c7f1a6e (the 8.6.6 fix that stopped planting an insecure callback inside Blizzard's menu description). Replacing the callback with self-owned staggered passes was correct, but it also added a gate the code it replaced never had:

```lua
if menu and not _menuSkinned[menu] then
```

`_menuSkinned` is never cleared, and **menu frames are pooled**. Blizzard hands the same frame back for the next menu and rebuilds its textures from the new description, which undoes our background. The gate saw that frame as "already skinned" and skipped it forever after the first menu.

Confirmed live rather than inferred: debug logging showed one frame address serving every menu, with its child count changing (19 -> 20 -> 23) as different menus were built onto it.

Our border lives on a child frame we keep attached, so it survived the pool reset and kept drawing. Its default colour is white. Hence Blizzard's background plus a white border.

## Fix

Drop the memo. One line of behaviour, restoring what the pre-8.6.6 code did.

Dropped entirely rather than scoped per-open: `_menuSkinFrame` is idempotent (it skips regions we own, and re-anchors relative to the frame rather than insetting cumulatively), so letting all three passes run is correct across reuse and also repairs a texture Blizzard writes after our first pass.

**The 8.6.6 taint fix itself is untouched.** Nothing is handed to Blizzard; the skinning passes remain self-owned.

## Testing

Verified in game across repeated opens: the white border is gone and every menu skins, not just the first. The pre-fix signature (first menu right, rest wrong) was also confirmed before the fix, matching the diagnosis.

`luac -p` clean. Applies to current main (8.6.7).

## Known gap, deliberately not addressed here

**Submenu flyouts** (Loot Specialization, Target Marker Icon, ...) are not skinned. This also dates from the 8.6.6 change: the removed `AddMenuAcquiredCallback` fired for every acquired frame including flyouts, and its replacement only reaches `manager:GetOpenMenu()`.

Restoring them was investigated to exhaustion, live-testing each candidate:

- `GetOpenMenu()` returns the **root** even while a flyout is open.
- A submenu is a **parentless sibling** of the root, not a descendant -- nothing reachable from the open menu leads to it.
- Menu descriptions expose no frame accessor (only further descriptions, verified against the live object), and every `Add*Callback` route means Blizzard invoking our code inside its menu pipeline -- exactly what caused the 8.6.6 whisper secret-taint that 0c7f1a6e fixed.
- No reference to the open flyout is stored on the root frame or any entry button (dumped live with a flyout open; only ScrollBox/ScrollBar furniture).
- Identifying submenu frames structurally (parentless + anonymous + single texture region) works out of combat but requires reading frame properties, and in instances those go **secret**: it produced real crashes in a Mythic+ key (`attempt to perform numeric conversion on a secret number value`) and from the communities panel (secret frame strata) before being withdrawn.

Conclusion: Blizzard keeps submenu frames in closure-private manager state with no safe way in. The flyout gap is cosmetic; the crashes and taint risk of the workarounds are not. If a future client exposes the frame (an accessor, or acquired-frame events outside the secure pipeline), it becomes a small follow-up.

<img width="480" height="480" alt="Swag Success GIF by Grant Cardone" src="https://github.com/user-attachments/assets/e8f4caa0-4a17-4f49-bcc8-715af0526dd0" />

