### PR TITLE
Skin context submenu flyouts again, via the menu style mixin

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -854,6 +854,60 @@ end
         C_Timer.After(0.15, skinOpenMenu)
     end
 
+    -- Submenu coverage via the style mixin.
+    --
+    -- The manager hooks above only ever see the ROOT menu: GetOpenMenu returns
+    -- the root even while a flyout is open, a submenu frame is a parentless
+    -- SIBLING of the root, and hovering a submenu parent fires neither OpenMenu
+    -- nor OpenContextMenu. But Blizzard styles every menu level through one
+    -- code path (Menu.lua, MenuManagerMixin:AcquireMenu -> SecureGenerate):
+    --
+    --     Mixin(proxy, menuDescription:GetMenuMixin());
+    --     proxy:Generate();
+    --
+    -- GetMenuMixin() resolves to the GLOBAL MenuStyle1Mixin (MenuStyle2Mixin for
+    -- WowStyle2 dropdowns), and the Mixin() copy happens at every open, so a
+    -- hooksecurefunc placed on the mixin's Generate is copied onto each menu
+    -- frame and hands us that exact frame as self -- root and every flyout, with
+    -- no frame identification at all.
+    --
+    -- Why this is NOT the AddMenuAcquiredCallback mistake: that callback was a
+    -- plain insecure closure stored in Blizzard's table and invoked BARE
+    -- (Menu.lua 2354, no securecallfunction), and the same execution then built
+    -- the entry click handlers, which is exactly how the whisper secret-name
+    -- taint happened. Here the containment is double: hooksecurefunc's contract
+    -- is that the hook's taint does not propagate into the calling execution
+    -- (the wrapper it installs is itself secure, so the Mixin() copy stays
+    -- secure), and Blizzard additionally wraps the call site in
+    -- securecallfunction because addon-supplied menu mixins are an anticipated
+    -- input to this pipeline (see MenuUtil.lua's comment on overriding
+    -- GetDefaultContextMenuMixin). Never ASSIGN into the mixin table -- that
+    -- would plant a tainted function value; only hooksecurefunc.
+    --
+    -- The hook body itself still does nothing but collect and schedule; the
+    -- skinning runs from our own timer after the secure execution has finished.
+    -- One compositor constraint on that pass, already satisfied by
+    -- _menuSkinFrame: while a menu is open the compositor replaces the frame's
+    -- metatable and disallows CreateTexture/CreateFontString/CreateLine on it,
+    -- so only the EXISTING background region may be recoloured.
+    local _stylePending, _styleArmed = {}, false
+    local function _styleFlush()
+        _styleArmed = false
+        for i = #_stylePending, 1, -1 do
+            local f = _stylePending[i]
+            _stylePending[i] = nil
+            -- _menuSkinFrame re-checks IsForbidden and the enable toggle.
+            _menuSkinFrame(f)
+        end
+    end
+    local function _onStyleGenerate(menuFrame)
+        _stylePending[#_stylePending + 1] = menuFrame
+        if not _styleArmed then
+            _styleArmed = true
+            C_Timer.After(0, _styleFlush)
+        end
+    end
+
     local function _menuInit()
         if not _G.Menu or not _G.Menu.GetManager then return end
         local mgr = _G.Menu.GetManager()
@@ -864,6 +918,12 @@ end
         hooksecurefunc(mgr, "OpenContextMenu", function(self, ownerRegion, menuDescription)
             _menuOnOpen(self, ownerRegion, menuDescription)
         end)
+        if _G.MenuStyle1Mixin and type(_G.MenuStyle1Mixin.Generate) == "function" then
+            hooksecurefunc(_G.MenuStyle1Mixin, "Generate", _onStyleGenerate)
+        end
+        if _G.MenuStyle2Mixin and type(_G.MenuStyle2Mixin.Generate) == "function" then
+            hooksecurefunc(_G.MenuStyle2Mixin, "Generate", _onStyleGenerate)
+        end
     end
 
     -- Static popup skinning

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -918,13 +918,6 @@ end
         hooksecurefunc(mgr, "OpenContextMenu", function(self, ownerRegion, menuDescription)
             _menuOnOpen(self, ownerRegion, menuDescription)
         end)
-        -- TEMP verification gate for the style-mixin hook, so a tester can A/B
-        -- it with zero rebuilds: /euimenuhook flips the flag, /reload re-runs
-        -- this init. hooksecurefunc cannot be uninstalled, so the decision has
-        -- to be made here at install time -- a no-op hook body would not test
-        -- the "installing the wrapper itself taints" theory. Strip the gate
-        -- (keep the hooks) once verdict is in.
-        if EllesmereUIDB and EllesmereUIDB.menuStyleHookDisabled then return end
         if _G.MenuStyle1Mixin and type(_G.MenuStyle1Mixin.Generate) == "function" then
             hooksecurefunc(_G.MenuStyle1Mixin, "Generate", _onStyleGenerate)
         end
@@ -2786,14 +2779,4 @@ do
         end)
         EllesmereUI._applyTooltipHealthStrip()
     end
-end
-
--- TEMP: A/B switch for the menu style-mixin hook. Remove with the gate above.
-SLASH_EUIMENUHOOK1 = "/euimenuhook"
-SlashCmdList["EUIMENUHOOK"] = function()
-    if not EllesmereUIDB then return end
-    EllesmereUIDB.menuStyleHookDisabled = not EllesmereUIDB.menuStyleHookDisabled or nil
-    print("|cff66ccff[EUI]|r menu style hook "
-        .. (EllesmereUIDB.menuStyleHookDisabled and "|cffff6666DISABLED|r" or "|cff66ff66ENABLED|r")
-        .. " -- /reload to apply")
 end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -793,8 +793,17 @@ end
     -- Back-compat full init (data + visual), used by the live re-apply path.
     local function _ttInit() _ttInitData(); _ttInitVisual() end
 
-    -- Context menu skinning
-    local _menuSkinned = {}
+    -- Context menu skinning.
+    --
+    -- Deliberately NOT memoised per frame. Menu frames are pooled: Blizzard
+    -- hands the same frame back for the next menu and rebuilds its textures from
+    -- the new description, which silently undoes our background. An "already
+    -- skinned" flag keyed on the frame therefore skips every reuse and leaves
+    -- Blizzard's background showing with our own border frame still drawn over
+    -- it. _menuSkinFrame is idempotent (it skips regions we own and re-anchors
+    -- relative to the frame, so nothing accumulates), so simply letting every
+    -- pass run is both correct across reuse and self-healing when Blizzard
+    -- writes a texture after our first pass.
 
     local function _menuSkinFrame(frame)
         if not frame or frame:IsForbidden() or not _pmEnabled() then return end
@@ -809,7 +818,6 @@ end
                 region:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -1, 1)
             end
         end
-        _menuSkinned[frame] = true
         _applyConfiguredBorder(frame, "popupMenu", 1)
     end
 
@@ -837,7 +845,7 @@ end
         -- after the open, which is what the callback was there for.
         local function skinOpenMenu()
             local menu = manager.GetOpenMenu and manager:GetOpenMenu()
-            if menu and not _menuSkinned[menu] then
+            if menu then
                 _menuSkinFrame(menu)
             end
         end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -918,6 +918,13 @@ end
         hooksecurefunc(mgr, "OpenContextMenu", function(self, ownerRegion, menuDescription)
             _menuOnOpen(self, ownerRegion, menuDescription)
         end)
+        -- TEMP verification gate for the style-mixin hook, so a tester can A/B
+        -- it with zero rebuilds: /euimenuhook flips the flag, /reload re-runs
+        -- this init. hooksecurefunc cannot be uninstalled, so the decision has
+        -- to be made here at install time -- a no-op hook body would not test
+        -- the "installing the wrapper itself taints" theory. Strip the gate
+        -- (keep the hooks) once verdict is in.
+        if EllesmereUIDB and EllesmereUIDB.menuStyleHookDisabled then return end
         if _G.MenuStyle1Mixin and type(_G.MenuStyle1Mixin.Generate) == "function" then
             hooksecurefunc(_G.MenuStyle1Mixin, "Generate", _onStyleGenerate)
         end
@@ -2779,4 +2786,14 @@ do
         end)
         EllesmereUI._applyTooltipHealthStrip()
     end
+end
+
+-- TEMP: A/B switch for the menu style-mixin hook. Remove with the gate above.
+SLASH_EUIMENUHOOK1 = "/euimenuhook"
+SlashCmdList["EUIMENUHOOK"] = function()
+    if not EllesmereUIDB then return end
+    EllesmereUIDB.menuStyleHookDisabled = not EllesmereUIDB.menuStyleHookDisabled or nil
+    print("|cff66ccff[EUI]|r menu style hook "
+        .. (EllesmereUIDB.menuStyleHookDisabled and "|cffff6666DISABLED|r" or "|cff66ff66ENABLED|r")
+        .. " -- /reload to apply")
 end


### PR DESCRIPTION
## Problem

Submenu flyouts in Blizzard context menus (Loot Specialization, Target Marker Icon, Dungeon Difficulty, and so on) are not skinned. They render in Blizzard's default style while the parent menu is skinned, so a right click on a unit frame produces a mismatched pair.

Regressed in 8.6.6, alongside the root-menu bug fixed in #1094. Both come from the same commit, 0c7f1a6e.

## Why it broke, and why the obvious fix is not available

0c7f1a6e removed `menuDescription:AddMenuAcquiredCallback(...)`. That call was the only thing covering flyouts, because Blizzard invoked it for every acquired menu frame and handed over the frame directly.

It had to go. In `Blizzard_Menu/Menu.lua` the acquired callbacks are invoked bare:

```lua
menuDescription:GetMenuAcquiredCallbacks():ExecuteRange(function(index, onAcquired)
    onAcquired(menu:ToProxy());
end);
```

No `securecallfunction`. Seven lines later the same, now tainted, execution constructs the `OnMouseDown` / `OnEnter` / `OnLeave` closures handed to `menu.Open`, so every entry click ran tainted. That is the mechanism behind the field report 0c7f1a6e fixed: in an instance, right click a unit and choose Whisper, and the chat edit box received a **secret** target name, after which Blizzard's own `ChatFrameEditBoxMixin:OnUpdate` was refused `SetText(self.text)` every frame. Deferring the registration does not help, and the pre-8.6.6 code already deferred.

Nothing else obvious reaches a flyout. Verified in game rather than assumed:

- `Menu.GetManager():GetOpenMenu()` returns the **root** even while a flyout is open.
- A submenu frame has **no parent**. It is a top level sibling of the root, not a descendant, so nothing reachable from the open menu leads to it.
- Hovering a submenu parent fires neither `OpenMenu` nor `OpenContextMenu`.
- A menu description exposes no frame accessor, only further descriptions.
- No reference to the open flyout is stored on the root frame or on any of its entry buttons (dumped live with a flyout open: only ScrollBox and ScrollBar furniture).
- The manager exposes only `OpenMenu`, `OpenContextMenu` and a closure private `private`.

Identifying flyout frames heuristically was prototyped and rejected. It works out of combat, but it requires reading frame properties, and inside instances (and from the guild and communities panel) a menu frame's `GetWidth`, `GetHeight`, `GetNumChildren` and `GetFrameStrata` are **secret** values, so it produced real errors: `attempt to perform numeric conversion on a secret number value` in a key, and a secret frame strata comparison when whispering from the communities panel.

## Fix

Blizzard styles every menu level, root and flyout alike, through one path in `MenuManagerMixin:AcquireMenu`:

```lua
local function SecureGenerate(proxy, menuDescription)
	Mixin(proxy, menuDescription:GetMenuMixin());
	proxy:Generate();
end
...
securecallfunction(SecureGenerate, proxy, menuDescription);
```

`GetMenuMixin()` resolves to a **named global**, `MenuStyle1Mixin` (and `MenuStyle2Mixin` for WowStyle2 dropdowns), and the `Mixin()` copy happens on every open because pooled frames are reset on release. The submenu path (`GenerateSubmenu` to `GenerateSubmenuInternal` to `GenerateMenuInternal`) reaches the same `AcquireMenu`.

So a `hooksecurefunc` on that mixin's `Generate` receives the exact menu frame as `self`, for every level, with **no frame identification at all**: no frame walk, no structural guessing, and no property reads, therefore nothing that can encounter a secret value.

The hook body only records the frame and arms a single `C_Timer.After(0)`. Skinning runs from our own timer, once the secure execution has finished, through the same idempotent `_menuSkinFrame` used today.

### Why this is not the mechanism that was removed

Two independent reasons:

1. `hooksecurefunc` is the engine primitive whose contract is that the hook's taint does not propagate into the calling execution, and the wrapper it installs is itself secure, so the `Mixin()` copy carries a secure function value. This is the same guarantee the existing `OpenMenu` and `OpenContextMenu` hooks in this file already depend on. Note the code only ever hooks; plainly assigning `MenuStyle1Mixin.Generate = fn` would plant a tainted value and is deliberately avoided.
2. The call site is additionally wrapped in `securecallfunction`. Blizzard armored this path on purpose, because addon supplied menu mixins are an anticipated input: `Menu.CreateRootMenuDescription` accepts an arbitrary mixin, every consumer of mixin methods is wrapped, and `MenuUtil.lua` documents overriding `GetDefaultContextMenuMixin` as something an addon may choose to do. Tainted style mixins are expected here. Tainted acquired callbacks are not.

### Compositor constraints observed

While a menu is open the compositor replaces the frame's metatable and disallows `CreateTexture`, `CreateFontString` and `CreateLine` on it. The skinner therefore recolours only the **existing** background region, which is what it already did. Field writes on an open menu frame land in the compositor's discard table and evaporate on close, so no state is kept on the frame.

## Scope

- Covers every menu level, so it also supersedes the root only `GetOpenMenu()` pass for skinning purposes. That pass is left in place, since it is what #1094 fixes and is independently correct.
- Menus opened by another addon with its own custom mixin will not fire the hook. That seems like correct scope: Blizzard UI menus get skinned, other addons' custom menus are left alone.

## Testing status

**Verified in game.**

- Submenu flyouts (Loot Specialization and friends) are skinned, matching the root menu.
- The gating check passed: with the hook loaded, whispering a secret-named player from the right click menu **opened the edit box cleanly**, which is the exact flow the removed callback used to break. The session progressed further down the whisper path than the pre-8.6.6 builds ever could. The only errors seen were at the *send* stage, raised by a third party library that global-hooks `SendChatMessage` and string-converts the secret destination, plus a follow-on parse error from the edit box retaining that secret text.
- **Control run: with EllesmereUI disabled entirely, the identical errors reproduce.** They occur without us loaded, so they are not introduced by this change, or by this addon at all.
- No error in the session attributed anything to EllesmereUI.
- `luac -p` clean. Applies on top of #1094.

## Relationship to #1094

This branch contains #1094's commit as its base. Merge #1094 first and this reduces to the `Generate` hook commit (plus a reverted pair from a temporary A/B switch used during verification).
