### PR TITLE
Refresh widget state when a slider value is typed, not only dragged

### DIFF
--- a/EllesmereUI_Widgets.lua
+++ b/EllesmereUI_Widgets.lua
@@ -1541,16 +1541,38 @@ local function BuildSliderCore(parent, trackW, trackH, thumbSz, inputW, inputH, 
         end
     end
 
+    -- Re-entrancy guard: ClearFocus() below fires OnEditFocusLost, which calls
+    -- straight back in here. Harmless while this only re-set the same value, but
+    -- it would double the refresh sweep added at the end.
+    local committingInput = false
+
     local function CommitInput()
+        if committingInput then return end
+        committingInput = true
         local raw = tonumber(valBox:GetText())
+        local changed = false
         if raw then
             raw = math.max(minVal, math.min(maxVal, raw))
             local snapped = math.max(minVal, math.min(maxVal, math.floor(raw / step + 0.5) * step))
+            changed = snapped ~= currentVal
             setValue(snapped); currentVal = snapped; rawDragVal = snapped; UpdateSliderVisual(snapped)
         else
             valBox:SetText(FormatVal(currentVal))
         end
         valBox:ClearFocus()
+        committingInput = false
+        -- Typing a value has to re-evaluate widget state exactly as finishing a
+        -- drag does, or anything driven by the refresh sweep silently misses the
+        -- change: the "Apply to: All" sync indicator, disabled overlays, and the
+        -- like. EndDrag does this; without it here, dragging a cog slider showed
+        -- "Apply to: All" while typing the same value into the box did not.
+        --
+        -- Only when the value actually changed, so tabbing or clicking away from
+        -- an untouched box stays free. Deferred while any slider is mid-drag, to
+        -- match EndDrag, which only refreshes once every drag has ended.
+        if changed and not EllesmereUI._sliderDragging and EllesmereUI.RefreshPage then
+            EllesmereUI:RefreshPage()
+        end
     end
 
     valBox:SetScript("OnEnterPressed", function() CommitInput() end)


### PR DESCRIPTION
## Problem

Reported by zac (8.6.6): editing a slider by **dragging** makes the "Apply to: All" sync indicator appear on the owning row, but **typing the same value into the number box** does not. Reproducible in any cog popup, e.g. Border Style -> Border Offset on the CDM Bars page.

Confirmed frame by frame from the report video: with Offset X dragged to 3, the Border Style row shows "Apply to: All" with its label shifted up; with Offset X typed as 10, the label stays centred and no indicator appears.

The indicator is only the visible symptom. Anything driven by the widget refresh sweep was equally stale after a typed edit, including disabled overlays that grey out dependent controls.

## Cause

`EndDrag` in the shared slider core finishes with `EllesmereUI:RefreshPage()`, which re-runs every widget's refresh callback precisely so sync indicators and disabled state re-evaluate once a drag ends.

`CommitInput`, the typed path, called `setValue` and updated the slider's own visual, but never triggered that sweep. Every other widget on the page kept rendering against the pre-edit state until something else happened to refresh it.

## Fix

`CommitInput` now runs the same refresh, under two conditions:

- **Only when the value actually changed**, so tabbing or clicking away from an untouched box stays free.
- **Not while any slider is mid-drag**, matching `EndDrag`, which refreshes only once every drag has finished.

Also adds a re-entrancy guard: `ClearFocus()` fires `OnEditFocusLost`, which calls `CommitInput` again. That was harmless while it merely re-set the same value, but it would otherwise have run the new refresh sweep twice per commit.

`RefreshPage()` without `force` is the fast path (re-runs callbacks in place, no frame teardown), so the open cog popup is not rebuilt and focus is not disturbed.

## Scope

One change in `BuildSliderCore` covers every slider in the addon: cog popups (`BuildCogPopup`), `DualRow`, `TripleSlider` and the mini sliders all build on it.

Noted, not changed: the generic text-input widget's own commit path has the same omission, but it sets strings and has no sync-indicator rows, so refreshing on every text commit would be cost with no known benefit.

## Testing

Verified in game: typing a value into the Border Offset number box now surfaces "Apply to: All" exactly as dragging does, dragging behaves as before, and clicking away from an untouched box causes no flicker.

`luac -p` clean. Applies to current main (8.6.7).
