### PR TITLE
Restore the micro menu and bag bar after a wild pet battle

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7514,6 +7514,47 @@ function EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s)
     return vis ~= "never"
 end
 
+-- Deferred completion for a petbattle unsuppress that lands during combat.
+--
+-- Wild pet battles keep the character in combat lockdown for their whole
+-- duration, and the [petbattle] driver flips back to "show" at battle close,
+-- BEFORE PLAYER_REGEN_ENABLED. The unsuppress below then defers on
+-- InCombatLockdown() -- but the driver never fires again (its state is already
+-- "show") and every other caller uses reason "visibility", which is a
+-- different key pair. So without this, the micro menu / bag bar stayed hidden
+-- after every wild pet battle until a /reload.
+--
+-- One shared shell frame; pending frames are re-tried once combat drops. If a
+-- new battle began before regen, the pending set is dropped: the suppression
+-- flags are still set (re-suppressing keeps the ORIGINAL pre-battle shown
+-- state, see the `if not ffd[suppressKey]` guard below), so that battle's own
+-- close transition completes or re-defers as usual.
+-- (In a do-block with the state as block locals: this file's main chunk sits
+-- at the 200-local cap, so the helper is exported on the vtable instead.)
+do
+    local pending, shell
+    EAB_VTABLE.ExtraBars.QueuePetBattleUnsuppress = function(frame)
+        pending = pending or {}
+        pending[frame] = true
+        if not shell then
+            shell = ns.TakeShell()
+            shell:SetScript("OnEvent", function(self)
+                self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+                local p = pending
+                pending = nil
+                if not p then return end
+                if C_PetBattles and C_PetBattles.IsInBattle and C_PetBattles.IsInBattle() then
+                    return -- back in a battle; its close transition owns the rest
+                end
+                for f in pairs(p) do
+                    EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(f, "petbattle", false)
+                end
+            end)
+        end
+        shell:RegisterEvent("PLAYER_REGEN_ENABLED")
+    end
+end
+
 function EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, reason, suppressed)
     if not frame then return end
 
@@ -7550,7 +7591,19 @@ function EAB_VTABLE.ExtraBars.SetManagedBlizzOwnedSuppressed(frame, reason, supp
     end
 
     if ffd[suppressKey] then
-        if InCombatLockdown() then ns._eabApplyDeferred = true return end -- keep bookkeeping; re-apply after combat
+        if InCombatLockdown() then
+            -- Keep bookkeeping, and mark the combat-drop ApplyAll as owed.
+            -- That heals "visibility", which RefreshRuntimeVisibility re-issues
+            -- on its own. It cannot heal "petbattle": ApplyAll only ever calls
+            -- back in with reason "visibility", a different key pair, and the
+            -- state driver already sits at "show" so it never fires again.
+            -- That reason needs its own completion on the same event.
+            ns._eabApplyDeferred = true
+            if reason == "petbattle" then
+                EAB_VTABLE.ExtraBars.QueuePetBattleUnsuppress(frame)
+            end
+            return
+        end
         local wasShown = ffd[shownKey]
         ffd[suppressKey] = nil
         ffd[shownKey] = nil


### PR DESCRIPTION
## Problem

Reported by Jetro (7.5.5, reproduced on current code): after every pet battle, the micro menu bar is gone until the player does a `/reload`.

Two report videos show the same thing on two different setups (one English client, one French): micro menu bar present before the battle, "Battle finished" on screen, bar gone. The bag bar is affected the same way, since it shares the code path.

## Cause

Extra bars whose visibility Blizzard owns (`MicroMenuContainer`, `BagsBar`) are hidden during pet battles through a secure `[petbattle]` state driver, with paired suppress/unsuppress bookkeeping in `SetManagedBlizzOwnedSuppressed`.

The unsuppress had a combat deferral:

```lua
if InCombatLockdown() then return end -- keep bookkeeping; re-apply after combat
```

That promise was never kept, and the timing makes it fire on every wild battle:

- **Wild pet battles keep the character in combat lockdown for their whole duration.**
- The `[petbattle]` driver flips back to "show" at battle close, which arrives **before** `PLAYER_REGEN_ENABLED`.
- So the unsuppress always defers, and nothing retries it. The state driver never fires again, because its state already **is** "show". The comment pointed at `RefreshRuntimeVisibility`, but that path passes reason `"visibility"`, which reads and writes a **different** bookkeeping key pair and never touches the petbattle keys.

Result: `suppressedByPetBattle` stays set, the frame stays hidden, and only a `/reload` (which rebuilds everything) recovers it.

Trainer battles do not lock combat, which is why casual testing against a trainer never reproduced it, and why the reporter sees it on **each** wild battle.

## Fix

When a petbattle unsuppress defers on combat, arm a one-shot `PLAYER_REGEN_ENABLED` that completes it.

Edge cases handled:

- **A new battle starts before regen fires:** the pending set is dropped. The suppression flags are still in place, and re-suppression keeps the *original* pre-battle shown state (the existing `if not ffd[suppressKey]` guard only records it on a real transition), so that battle's own close transition completes or re-defers as usual.
- **The unsuppress already completed out of combat:** the retry is a no-op, since the suppressed flag is already clear.
- The retry covers every `blizzOwnedVisibility` extra bar that was pending, not just the micro menu.

The `"visibility"` reason keeps its existing behaviour: its retry genuinely does arrive through the frequent `RefreshRuntimeVisibility` re-runs.

The helper lives in a `do` block and is exported on the vtable because this file's main chunk sits at Lua's 200-local cap.

## Testing

Verified in game: after a wild pet battle, the micro menu and bag bar reappear on their own as combat drops, no `/reload` needed, across consecutive battles.

`luac -p` clean. Applies to current main (8.6.7).
