### PR TITLE
Paint the castable's art for a replaced tracked buff, not the aura's

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -3976,12 +3976,23 @@ local function ResolvePlaceholderIconSID(sid, cdID)
     -- name is in the book and this slot's own name is not, the linked form is
     -- what the player actually casts. Requiring the slot's name to be absent
     -- keeps this from firing while both forms are available.
+    --
+    -- Return the BOOK id, not the linked id. A linked id is the variant's AURA
+    -- (Wither's DoT 445474) while the book id is the CASTABLE the player
+    -- actually has (Wither 445468), and the two carry different art. The branch
+    -- above returns a castable too (FindSpellOverrideByID of a castable is a
+    -- castable), so returning an aura here made the two paths paint different
+    -- icons for the same spell. That is visible as a flicker across a hero
+    -- talent swap: until the debounced rebuild wipes the name cache, the
+    -- pre-swap book still lists the base spell, the castable branch above runs
+    -- and paints the right art, then the rebuilt cache drops through to here
+    -- and repaints the aura's art instead.
     if info and info.linkedSpellIDs and not castable then
         for _, lid in ipairs(info.linkedSpellIDs) do
             if type(lid) == "number" and lid > 0
-               and not (issecretvalue and issecretvalue(lid))
-               and BookIDForName(NameOf and NameOf(lid)) then
-                return lid
+               and not (issecretvalue and issecretvalue(lid)) then
+                local book = BookIDForName(NameOf and NameOf(lid))
+                if book then return book end
             end
         end
     end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -9064,6 +9064,13 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
         -- The spell set may have changed: let the post-rebuild reanchor
         -- re-run the automatic base-bar materialization for this spec.
         if ns._reseededSpecsSession then wipe(ns._reseededSpecsSession) end
+        -- Drop the spellbook name map NOW, not only in the debounced rebuild.
+        -- It answers "which form does the player have", which is exactly what
+        -- just changed, and anything repainting inside the debounce window
+        -- would otherwise resolve against the pre-swap book. The rebuild wipes
+        -- it again, which still matters: this early rebuild can read a book the
+        -- client has not finished updating, and that second wipe corrects it.
+        if ns.WipeCdmBookNameCache then ns.WipeCdmBookNameCache() end
         ScheduleTalentRebuild()
         return
     end
@@ -9713,9 +9720,15 @@ SlashCmdList.CDMBUFFID = function(msg)
                 nBridged = nBridged + 1
                 bridgeTag = "  " .. GOOD .. "BRIDGED" .. OFF
             end
-            P(string.format("  [%d] sid=%s cdID=%s info.sID=%s info.ovr=%s linked=%s icon=%s(%s) name=%s%s",
+            -- Print the TEXTURE id too, not just the spell name. A reporter
+            -- quotes the icon they can see, and two ids can share a name while
+            -- carrying different art (Wither's castable and its DoT aura), so a
+            -- name-only line cannot tell a right icon from a wrong one.
+            local _GT = C_Spell and C_Spell.GetSpellTexture
+            local texNow = _GT and _GT(iconSID)
+            P(string.format("  [%d] sid=%s cdID=%s info.sID=%s info.ovr=%s linked=%s icon=%s(%s) tex=%s name=%s%s",
                 i, SN(e.sid), SN(e.cdID), SN(infoSpell), SN(infoOvr),
-                linked or "none", SN(iconSID), NM(iconSID), NM(e.sid), bridgeTag))
+                linked or "none", SN(iconSID), NM(iconSID), SN(texNow), NM(e.sid), bridgeTag))
         end
         P(string.format("  placeholder icon bridge: %d of %d entries resolve to a replacing spell",
             nBridged, #entries))


### PR DESCRIPTION
## Problem

Reported by Hellsy (8.6.6). Switching Diabolist -> Hellcaller on a Warlock shows the **correct** Wither icon (`5927632`) briefly, then it swaps to a **wrong** one (`6712965`). Affects Destruction and Affliction.

Follow-up to #1067, which fixed the same slot painting Immolate and was verified by spell NAME. The name was right; the art was not.

## Cause

`ResolvePlaceholderIconSID` bridges a tracked buff's inactive placeholder to the form a replacing talent gives the player. It has two branches, and they disagreed about **which id kind** to return:

- **castable branch** -- `FindSpellOverrideByID(castable)` returns a castable (Wither `445468`, texture `5927632`).
- **linked branch** -- returned the *linked* id, which is the variant's **aura** (Wither's DoT `445474`, texture `6712965`).

Same spell, same name, different art.

That disagreement is the whole of the reported flicker, because a hero talent swap runs the two branches in order:

1. Immediately after the swap the spellbook name cache still holds the **pre-swap** book, which lists Immolate. The slot's own name resolves, the castable branch answers, and the icon paints correctly.
2. The debounced talent rebuild wipes that cache. Rebuilt from the post-swap book, Immolate is gone, so the lookup finds nothing to follow and control drops to the linked branch, which repaints with the aura's art.

Correct, then wrong, exactly as reported.

## Fix

The linked branch now returns the **book id it had already looked up** (the castable) instead of the linked aura id, so both branches resolve to the same spell and there is nothing left to flicker between.

Art only, unchanged from #1067: pooling, dedup and per-icon settings stay keyed on `realSID`, and the returned value is consumed only as a texture and a display id.

Also wipes the spellbook name cache when the talent event arrives, not only inside the debounced rebuild. That cache answers "which form does the player have", which is precisely what just changed, so nothing repainting during the debounce window should still be reading the pre-swap book. The rebuild wipes it a second time and that still matters: an early wipe can be refilled from a book the client has not finished updating.

## Verification

Confirmed in game on a Hellcaller Warlock against the reporter's own quoted icon IDs, rather than by spell name:

```
[1] sid=157736 cdID=133441 info.ovr=157736 linked=445474  icon=445468(Wither)  tex=5927632  BRIDGED
    placeholder icon bridge: 1 of 16 entries resolve to a replacing spell
```

`tex=5927632` is the icon the reporter identified as correct. Exactly one entry of sixteen bridges, so no collateral, and the guard still holds on the near misses: Summon Infernal has its own name *and* its link both present in the book and correctly does not bridge; the passive procs resolve to nothing on both sides and also do not bridge. Curse of the Satyr (`info.sID=702 info.ovr=442804`) still resolves through the first branch, so real overrides are untouched.

Swapping Diabolist <-> Hellcaller repeatedly now settles on the correct icon with no visible change afterwards, on both Destruction and Affliction.

## Note on the diagnostic

`/cdmbuffid` now prints the resolved **texture id** next to the spell name. Two ids can share a name while carrying different art, which is what let #1067 look correct in its own probe output, and a reporter quotes the icon they can see.

<img width="176" height="220" alt="Mr Bean GIF" src="https://github.com/user-attachments/assets/b9b8f837-f2d7-4412-b5bd-091b2d21b1d0" />


