### PR TITLE
Do not anchor a tooltip to a forbidden owner

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2006,6 +2006,29 @@ end
 --  so it's a no-op (Blizzard's default anchor stands) when toggled back off, and
 --  the cursor-tracking frame only ticks while a tooltip is actually shown.
 -------------------------------------------------------------------------------
+
+-- Is a tooltip owner handed to us by a Blizzard hook safe to anchor to?
+--
+-- It can be a FORBIDDEN frame. Blizzard's nameplate aura buttons are forbidden
+-- and call GameTooltip_SetDefaultAnchor on hover, so passing one straight to
+-- SetOwner from our own (tainted) hook raises "Attempt to access forbidden
+-- object from code tainted by an AddOn" -- reported 25x during a single key.
+--
+-- Testing the tooltip alone was not enough: the tooltip is GameTooltip and
+-- perfectly fine, it is the OWNER that is off limits. Nothing can be anchored
+-- to a forbidden frame, so both anchor modes leave Blizzard's own anchoring
+-- alone in that case. IsForbidden is the only method safe to call on such a
+-- frame, so it is asked first and nothing else is touched.
+--
+-- File scope on purpose: the cursor and fixed anchor modes live in separate
+-- do-blocks and both need it.
+local function TooltipOwnerUsable(parent)
+    if not parent then return false end
+    local fn = parent.IsForbidden
+    if type(fn) == "function" and fn(parent) then return false end
+    return true
+end
+
 do
     -- Selected position = where the tooltip sits relative to the cursor, so the
     -- tooltip corner that touches the cursor is the opposite one.
@@ -2064,7 +2087,9 @@ do
         -- disabling the reskin restores the default tooltip position.
         if EllesmereUIDB and EllesmereUIDB.customTooltips == false then return end
         if not (EllesmereUIDB and EllesmereUIDB.tooltipAnchorCursor) then return end
-        if not parent or tooltip:IsForbidden() then return end
+        -- Owner checked as well as the tooltip: a forbidden owner cannot be
+        -- passed to SetOwner below. See TooltipOwnerUsable.
+        if not TooltipOwnerUsable(parent) or tooltip:IsForbidden() then return end
         -- "Show Tooltips" suppression parks the tip in a hidden host (see the
         -- Show Tooltips block below): it stays alive and invisible so the
         -- peek modifier can reveal it. Anchor it normally -- it must already
@@ -2292,7 +2317,16 @@ do
     local function ApplyFixedAnchor(tooltip, parent)
         if tooltip ~= GameTooltip then return end
         if not WantFixed() then return end
-        if not parent or tooltip:IsForbidden() then return end
+        if tooltip:IsForbidden() then return end
+        -- A forbidden owner (a nameplate aura button) cannot be anchored to, so
+        -- leave Blizzard's anchoring alone AND disarm the SetPoint enforcement:
+        -- the arming happens in the SetDefaultAnchor hook before this runs, and
+        -- leaving it armed would let EnforceFixed yank the tooltip into our box
+        -- with no matching SetOwner. See TooltipOwnerUsable.
+        if not TooltipOwnerUsable(parent) then
+            _fixedArmed = false
+            return
+        end
         -- While an Unlock Mode session is open, the session owns the anchor
         -- frame (live drags + uncommitted pending edits); re-parking from the
         -- saved position would snap the frame back mid-session. Pin the


### PR DESCRIPTION
## Problem

Reported by thesharp (8.6.6): repeating Lua errors in combat during a Mythic+ key.

```
25x Attempt to access forbidden object from code tainted by an AddOn
[EllesmereUIBlizzardSkin.lua]:2281: in function <...:2268>
[EllesmereUIBlizzardSkin.lua]:2288: in function <...:2285>
[C]: in function 'GameTooltip_SetDefaultAnchor'
[Blizzard_NamePlates/Blizzard_NamePlateAuras.lua]:11
```

## Cause

The reporter's line numbers map onto the current file at a constant offset of 24, with both stack gaps matching exactly (3 and 13), which pins the raise to the `SetOwner` call in `ApplyFixedAnchor`. Its guard tested the **tooltip** for forbidden, and never the **owner**:

```lua
if not parent or tooltip:IsForbidden() then return end
...
tooltip:SetOwner(parent, "ANCHOR_NONE")
```

The tooltip is `GameTooltip` and perfectly fine. The owner is not: it is a nameplate aura button, visible in the report's own locals as a frame from `Blizzard_NamePlateAuras.lua` carrying a secret `spellID`. Those buttons are forbidden, and they call `GameTooltip_SetDefaultAnchor` on hover, so handing one to `SetOwner` from our (tainted) hook raises.

That accounts for every characteristic of the report: it needs an instance, because that is where those auras carry secret data and become forbidden; it happens in combat, because that is when they appear; and it repeats, because it fires once per hover.

The reporter's guess that their new Name Font setting was involved is unrelated.

## Fix

Test the owner as well as the tooltip, in one shared file-scope helper, because nothing can be anchored to a forbidden frame. `IsForbidden` is asked first and nothing else on the frame is touched, since it is the only method that may safely be called on one.

**Both anchor modes carried the same defect.** The reporter was on the fixed anchor; the cursor anchor mode has the identical unguarded `SetOwner` and raises the same way for anyone using it, with no report on file. Both are fixed. They live in separate do-blocks, hence the shared helper at file scope.

When the fixed mode bails it also **disarms its `SetPoint` enforcement**. Arming happens in the `SetDefaultAnchor` hook before `ApplyFixedAnchor` runs, so leaving it armed would let `EnforceFixed` pull the tooltip into our anchor box with no matching `SetOwner` -- a tooltip positioned by half an anchor.

In both cases the tooltip simply keeps Blizzard's own anchoring for that hover.

## Testing

Confirmed in game: with EUI's Nameplates module disabled so Blizzard's own nameplate aura icons are hoverable, hovering them in combat inside an instance no longer raises. Verified on both the fixed and the cursor anchor modes.

Note on reproducing it: EUI's nameplate module normally suppresses Blizzard's aura row entirely (parked offscreen when EUI owns auras, alpha-0 and mouse-dead when it does not), so the icons cannot be hovered while that module is managing plates. The bug reaches users whose nameplates EUI is not handling.

`luac -p` clean. Applies to current main (8.6.7).
