### PR TITLE
Re-arm custom active states after login

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -1455,6 +1455,42 @@ ns.FullCDMRebuild = function(reason)
     ns.FakeActive_Rearm()
 end
 
+-- Re-arm once after world entry.
+--
+-- A custom active state on an EQUIPPED TRINKET is stored under the item
+-- (-itemID), while the live icon carries the SLOT key (-13 / -14). The two are
+-- bridged in the slot pass of FakeActive_Rearm, which reads
+-- GetInventoryItemID -- so a re-arm that runs before the client can answer that
+-- builds no slot rule, and the icon it was meant to drive matches nothing.
+--
+-- The login re-arm rides FullCDMRebuild, which is early enough for that to
+-- happen, and nothing re-arms afterwards: PLAYER_EQUIPMENT_CHANGED is only
+-- registered once user rules exist and in any case needs a real gear swap. So
+-- the state stayed dormant for the whole session, and the only thing that
+-- revived it was opening the options, which re-arms as a side effect. That is
+-- exactly the reported shape: "works until you log out, then you have to choose
+-- it again".
+--
+-- Once per session, deferred, and only for the FIRST world entry: re-arming is
+-- a teardown and rebuild of every rule, so doing it on later zone-ins could cut
+-- short an overlay that is currently running. Nothing is running this early.
+-- Re-arm is idempotent, so this costs one rebuild of a small rule set.
+do
+    local rearmed = false
+    local f = ns.TakeShell()
+    f:RegisterEvent("PLAYER_ENTERING_WORLD")
+    f:SetScript("OnEvent", function(self)
+        if rearmed then return end
+        rearmed = true
+        self:UnregisterEvent("PLAYER_ENTERING_WORLD")
+        if C_Timer then
+            C_Timer.After(2, function()
+                if ns.FakeActive_Rearm then ns.FakeActive_Rearm() end
+            end)
+        end
+    end)
+end
+
 -- Debug toggle: /run EllesmereUI.FakeActiveDebug()
 if EllesmereUI then
     function EllesmereUI.FakeActiveDebug()


### PR DESCRIPTION
## Problem

Reported by DazZul (8.6.2): a chosen Active State stops working after a reload, and has to be picked again to come back.

Clarified into a concrete repro by meza: put a **20 second active state with a button glow on a trinket** (Puzzle Box), use it and confirm it works, then log out and back in. It stays dead until the settings are opened again.

## Cause

"Until the settings are opened again" is the tell. Opening them re-arms the custom active state engine as a side effect, and after login that is the **only** thing that re-arms it:

- the login re-arm rides `FullCDMRebuild`, which runs early;
- `PLAYER_ENTERING_WORLD` only drives `FA121.Rescan`, not a re-arm;
- `PLAYER_EQUIPMENT_CHANGED` is registered only once user rules already exist, and needs a real gear swap in any case.

That timing matters because of how a trinket's rule is built. The per-trinket setting is stored under the **item** (`-itemID`), while the live icon carries the **slot** key (`-13` / `-14`). The two are bridged in the slot pass of `FakeActive_Rearm`, which resolves the slot through `GetInventoryItemID`. A re-arm that runs before the client can answer that builds no slot rule at all, so the icon it was meant to drive matches nothing, and the state stays dormant for the rest of the session.

Hence the exact reported shape: configure it and it works, log out and back in and it is gone, touch the setting and it returns.

## Fix

Re-arm once, deferred, on the first world entry.

Later zone-ins are skipped deliberately: a re-arm tears down and rebuilds every rule, so running it mid-session could cut short an overlay that is currently active. Nothing is running that early in a session, and `FakeActive_Rearm` is idempotent, so the cost is one rebuild of a small rule set.

## Testing

Reproduced and verified in game with meza's steps: 20 second active state with a button glow on a trinket, used, logged out and back in, and the state now works on the next use without opening the settings. On current main the same sequence leaves it dead until the options are touched.

`luac -p` clean. Applies to current main (8.6.7).

## Relationship to #1026

That PR fixed a genuine orphaned-flag hazard on the shared glow overlay, found while reading this code, and it was explicit at the time that it had never reproduced DazZul's report. This is the report itself: a different mechanism (load-time arming rather than a runtime flag), which is why the earlier fix did not resolve it.

Closes DazZul's report.

<img width="211" height="374" alt="Big Dog GIF by MOODMAN" src="https://github.com/user-attachments/assets/a8a5ab10-1982-4dff-be49-18e43e844899" />

