### PR TITLE
Stop Blizzard's invisible action bar pager from eating clicks

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -904,6 +904,47 @@ end
 --  ActionBarController call chain.
 -------------------------------------------------------------------------------
 do
+    -- Make Blizzard's action bar pager unclickable.
+    --
+    -- MainActionBar is kept in Blizzard's parent chain (see the disposal block
+    -- below) and hidden with alpha rather than Hide(), so its children are still
+    -- live objects -- and ActionBarPageNumber sits at frameLevel 100, above our own
+    -- buttons, with UpButton / DownButton that page the main bar on click. Invisible
+    -- but fully clickable.
+    --
+    -- Reached by parentKey, not by a global: the modern frame has no global name.
+    -- (The legacy MainMenuBarPageNumber global handled elsewhere is from the old
+    -- bar and no longer exists on current clients.) Every step is guarded so a
+    -- future rename degrades to a no-op instead of an error.
+    --
+    -- Mouse state only, never Hide(): this frame's parent has a documented taint
+    -- history around its protected shown state, and these are ordinary UI buttons
+    -- (QuickKeybindButtonTemplate), so disabling their mouse is unprotected, safe in
+    -- combat, and enough. Nothing of ours depends on them -- EUI's own paging arrows
+    -- drive secure macrotext buttons of their own and never click these.
+    local function KillPagerMouse(bar)
+        local pager = bar and bar.ActionBarPageNumber
+        if not pager then return end
+        local function killOne(f)
+            if not f or type(f.IsMouseEnabled) ~= "function" then return end
+            -- Guard so the re-assert on every Show is a no-op after the first pass.
+            if not f:IsMouseEnabled() then return end
+            f:EnableMouse(false)
+            if f.EnableMouseClicks then f:EnableMouseClicks(false) end
+            if f.EnableMouseMotion then f:EnableMouseMotion(false) end
+        end
+        killOne(pager)
+        killOne(pager.UpButton)
+        killOne(pager.DownButton)
+        -- Anything else Blizzard parents in here later (the frame is a
+        -- ResizeLayoutFrame and has gained children before).
+        if type(pager.GetChildren) == "function" then
+            for i = 1, pager:GetNumChildren() do
+                killOne((select(i, pager:GetChildren())))
+            end
+        end
+    end
+
     local framesToHide = {
         "MainActionBar",
         "MultiBar5",
@@ -945,6 +986,10 @@ do
                 -- children, and works in combat, so the bar stays hidden taint-free.
                 hooksecurefunc(frame, "Show", function(self)
                     self:SetAlpha(0)
+                    -- Re-assert the pager kill: a layout apply can re-enable
+                    -- mouse on those buttons. Guarded so every later Show is a
+                    -- no-op rather than a repeated write.
+                    KillPagerMouse(self)
                 end)
                 -- Disable mouse on MainActionBar so it never eats clicks.
                 -- During combat, Blizzard can Show() this frame (mount/dismount
@@ -953,6 +998,18 @@ do
                 frame:EnableMouse(false)
                 if frame.EnableMouseClicks then frame:EnableMouseClicks(false) end
                 if frame.EnableMouseMotion then frame:EnableMouseMotion(false) end
+                -- ...but EnableMouse(false) on a parent does NOT disable its
+                -- children, and MainActionBar owns a real pager: an
+                -- ActionBarPageNumber frame (frameLevel 100, above our buttons)
+                -- holding UpButton / DownButton, which change the action bar
+                -- page when clicked. Alpha 0 hides them and nothing else here
+                -- touched them, so once Blizzard re-Showed the bar there were two
+                -- invisible, clickable arrows sitting over an apparently empty
+                -- stretch of screen. Reported as "clicking an empty area flips my
+                -- main bar to another page", confirmed with /fstack, and worked
+                -- around by turning the Action Bar Pager off in Edit Mode -- which
+                -- removes the frame that this now neutralises.
+                KillPagerMouse(frame)
                 -- Hide Edit Mode selection/mover frame
                 if frame.Selection then frame.Selection:Hide(); frame.Selection:SetAlpha(0) end
                 -- Hide artwork children (gryphons/endcaps/border)
@@ -1481,6 +1538,9 @@ local function HideBlizzardBars()
     end
     -- ActionBarController retains all events so Blizzard's vehicle/override
     -- transition system (ValidateActionBarTransition) works correctly.
+    -- Legacy global from the pre-Dragonflight bar, absent on current clients.
+    -- Left in place for older builds; the live pager is MainActionBar's
+    -- ActionBarPageNumber child, neutralised by KillPagerMouse at disposal.
     if MainMenuBarPageNumber then MainMenuBarPageNumber:Hide() end
 
     -- Replace ActionBar_PageUp / ActionBar_PageDown with versions that
@@ -2061,7 +2121,10 @@ local function SetupPagingFrame()
     pageText:SetText("1")
     f._pageText = pageText
 
-    -- Up arrow (clicks Blizzard's ActionBarUpButton securely)
+    -- Up arrow. Drives our own secure macrotext (WireSecurePagingButton),
+    -- NOT Blizzard's ActionBarUpButton -- an older comment here claimed it
+    -- did, which matters because Blizzard's pager buttons are deliberately
+    -- mouse-dead (see KillPagerMouse).
     local upBtn = CreateFrame("Button", "EABPagingUp", f, "SecureActionButtonTemplate")
     upBtn:SetSize(18, 18)
     upBtn:RegisterForClicks("AnyUp", "AnyDown")
@@ -2072,7 +2135,7 @@ local function SetupPagingFrame()
     f._upBtn = upBtn
     InitPagingQuickKeybindButton(upBtn, "UI-HUD-ActionBar-PageUpArrow-Mouseover")
 
-    -- Down arrow (clicks Blizzard's ActionBarDownButton securely)
+    -- Down arrow. Same: our own secure macrotext, not Blizzard's button.
     local downBtn = CreateFrame("Button", "EABPagingDown", f, "SecureActionButtonTemplate")
     downBtn:SetSize(18, 18)
     downBtn:RegisterForClicks("AnyUp", "AnyDown")


### PR DESCRIPTION
## Problem

Reported by Friberg (8.6.5): left-clicking an **empty** area of an action bar sometimes flips the main bar to another page. Nothing is visible there, so it behaves like an invisible button.

Their own diagnosis was the key to this one. They confirmed with `/fstack` that an invisible pager and action bar sit exactly where Blizzard's default bar would be, and they found a workaround: disable EllesmereUI, turn **Action Bar Pager** off in Blizzard's Edit Mode, re-enable EllesmereUI, and the phantom clicks stop.

## Cause

`MainActionBar` gets deliberately careful treatment in the early disposal block:

- it stays in Blizzard's parent chain rather than being reparented, because pet battle restoration of the micro menu depends on it;
- it is hidden with **alpha**, not `Hide()`, because touching its protected shown state from an insecure hook has a documented history of blocking `ValidateActionBarTransition` in combat;
- its own mouse is disabled so it cannot eat clicks.

The gap: **`EnableMouse(false)` on a parent does not disable its children.** This bar owns a real pager -- an `ActionBarPageNumber` frame at frameLevel 100, above our own buttons, holding `UpButton` and `DownButton` that change the action bar page on click. Alpha 0 makes them invisible, not inert.

Nothing had ever touched them. The only pager line in the file targets `MainMenuBarPageNumber`, a legacy global from the pre-Dragonflight bar that does not exist on current clients, so it silently did nothing. The result is two invisible, fully clickable arrows sitting over an apparently empty stretch of screen.

That accounts for every part of the report, including the odd bits: **"sometimes"**, because the buttons only start mattering once Blizzard has re-Shown the bar (mount, bonus bar, spec change); the exact location; the `/fstack` result; and why the Edit Mode toggle works, since it removes the very frame this change neutralises.

## Fix

`KillPagerMouse` disables mouse on `ActionBarPageNumber` and its `UpButton` / `DownButton`, plus any other child it may gain (it is a `ResizeLayoutFrame` and has grown children before). Reached by `parentKey`, since the modern frame has no global name, and every step is guarded so a future rename degrades to a no-op rather than an error.

**Mouse state only, never `Hide()`.** These are ordinary `QuickKeybindButtonTemplate` buttons, so this is unprotected and safe in combat, and it leaves the parent's protected shown state untouched -- which is the constraint that shaped the rest of that block.

Re-asserted from the existing `Show` hook in case a layout apply re-enables them, guarded on `IsMouseEnabled` so every later Show is a no-op rather than a repeated write.

Lives inside the disposal `do` block rather than at file scope, because this file's main chunk is at Lua's 200-local cap.

## Nothing of ours depended on those buttons

EUI's paging arrows and its `NEXTACTIONPAGE` / `PREVIOUSACTIONPAGE` overrides both drive **their own** secure macrotext buttons (`WireSecurePagingButton`, `EABPageNext` / `EABPagePrev`) and never click Blizzard's.

Two comments claiming the arrows "click Blizzard's ActionBarUpButton securely" were stale and are corrected here, since left alone they read as if this change breaks paging.

## Testing

Verified with a direct read of the button's mouse state, after mounting and dismounting to force Blizzard's re-Show (without that step the buttons are not yet live and any test passes):

```
/run local p=MainActionBar and MainActionBar.ActionBarPageNumber local u=p and p.UpButton print("pager clickable:",u and u:IsMouseEnabled())
```

- on this branch: **false**
- on current main: **true**

So the change does what it claims, and the check genuinely distinguishes fixed from broken rather than passing either way.

`luac -p` clean. Applies to current main (8.6.7).
