### PR TITLE
Fix: CDM Pandemic Glow "None" option was unreachable and ineffective

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -19157,7 +19157,21 @@ initFrame:SetScript("OnEvent", function(self)
                 { type="dropdown", text="Pandemic Glow",
                   values=PAN_GLOW_VALUES, order=PAN_GLOW_ORDER,
                   getValue=function()
-                      if pandemicOff() then return 0 end
+                      -- nil means NEVER CONFIGURED, which renders as Blizzard
+                      -- Default (-1), not None (0). The three built-in bars never
+                      -- seed pandemicGlow, while every template that does seed it
+                      -- ships true + style -1 (custom bars
+                      -- EllesmereUICdmSpellPicker.lua ~1916, tracking bars
+                      -- EllesmereUICdmBuffBars.lua ~313). Reporting nil as None
+                      -- made this control claim the glow was already off while
+                      -- Blizzard's PandemicIcon was plainly still drawing -- and
+                      -- because the dropdown already showed the value the user
+                      -- wanted, picking it fired no change, so there was no way to
+                      -- turn the glow off at all (reported against a tracked Fire
+                      -- Breath buff). Only an explicit false is None.
+                      local pg = BD().pandemicGlow
+                      if pg == false then return 0 end
+                      if pg == nil then return -1 end
                       local raw = BD().pandemicGlowStyle
                       if type(raw) ~= "number" then return 1 end
                       return raw

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -7448,21 +7448,57 @@ function ns.SetupViewerHooks()
                                 -- the stop branch finally becoming reachable). The
                                 -- buff glow directly above already has this shape.
                                 local inPandemic = false
-                                if pandemicOn and fd then
-                                    -- Blizzard Default (-1): no custom glow and no
-                                    -- hooks -- Blizzard's native PandemicIcon does
-                                    -- the whole job, so the default config costs
-                                    -- zero. For custom styles the hooks install
-                                    -- lazily HERE on first need; this tick runs on
-                                    -- a CDM shell, so even install-time work bills
+                                if fd then
+                                    -- Blizzard Default (-1) is the ONLY config that
+                                    -- needs no hook: Blizzard's native PandemicIcon
+                                    -- does the whole job, so that config still costs
+                                    -- zero. EVERY other config needs the hook --
+                                    -- custom styles (>0) to REPLACE the icon, and
+                                    -- None (pandemicGlow off) to SUPPRESS it.
+                                    --
+                                    -- Installing was gated on `pandemicOn`, so None
+                                    -- got no hook at all and _PandemicShow -- which
+                                    -- is what hides Blizzard's icon -- never ran.
+                                    -- Blizzard's PandemicIcon then rendered
+                                    -- unopposed and the option could not be turned
+                                    -- off (reported for a tracked Fire Breath buff).
+                                    -- Same shape as the stop-branch bug: the code
+                                    -- that acts when the setting is OFF must not sit
+                                    -- behind the gate that requires it ON.
+                                    --
+                                    -- For custom styles the hooks still install
+                                    -- lazily HERE on first need; this tick runs on a
+                                    -- CDM shell, so even install-time work bills
                                     -- CooldownManager.
+                                    -- nil is NOT the same as false here. A bar that
+                                    -- was never configured has pandemicGlow == nil
+                                    -- and must keep behaving as Blizzard Default:
+                                    -- the three built-in bars simply never seed the
+                                    -- key, while every template that DOES seed it
+                                    -- ships true + style -1. Only an EXPLICIT false
+                                    -- (the user picking None) suppresses, so this
+                                    -- fix cannot silently strip Blizzard's pandemic
+                                    -- icon from everyone who never touched it.
                                     local pStyle = bd.pandemicGlowStyle or 1
-                                    if pStyle ~= -1 then
+                                    local custom = pandemicOn and pStyle ~= -1
+                                    local isNone = (bd.pandemicGlow == false)
+                                    if custom or isNone then
                                         if ns._pandemicHooked and not ns._pandemicHooked[frame]
                                            and ns.HookPandemicState then
                                             ns.HookPandemicState(frame)
                                         end
+                                    end
+                                    if custom then
                                         inPandemic = ns._pandemicState and ns._pandemicState[frame]
+                                    elseif isNone then
+                                        -- The hook only fires on the NEXT
+                                        -- ShowPandemicStateFrame, so an icon already
+                                        -- lit when the user picked None would stay up
+                                        -- until the aura lapsed. Take it down here
+                                        -- too; Hide is idempotent and this only runs
+                                        -- for bars actually set to None.
+                                        local pi = frame.PandemicIcon
+                                        if pi and pi:IsShown() then pi:Hide() end
                                     end
                                 end
                                 if inPandemic and fd then


### PR DESCRIPTION
## Problem

Reported by @Braumance (8.6.2): the pandemic glow on a tracked Fire Breath buff could not be turned off.

Repro: add Fire Breath to CDM, add Fire Breath to tracked buffs, cast it, wait a couple of seconds, it glows, and nothing in the options stops it.

## Cause

Two defects stacked, which is why there was no way out.

**1. The dropdown misreported a never-configured bar as "None".**

`getValue` keyed off `pandemicGlow ~= true`, and the three built-in bars (cooldowns, utility, buffs) never seed that key. So `nil` displayed as **None** while Blizzard's `PandemicIcon` was still drawing. Because the control already showed the value the user wanted, selecting it fired no change event, so the setter was unreachable.

`nil` now reports **Blizzard Default (-1)**, which is what it actually renders as, and what every template that does seed the key already ships (`pandemicGlow = true, pandemicGlowStyle = -1` in `EllesmereUICdmSpellPicker.lua` ~1916 and `EllesmereUICdmBuffBars.lua` ~313). The built-in bars simply never got seeded.

**2. Selecting "None" would not have worked either.**

`_PandemicShow` is what hides Blizzard's `PandemicIcon`, and it already handled all three configurations correctly. But installing its hook was gated on `pandemicOn`, the exact condition None makes false. None therefore installed no hook, `_PandemicShow` never ran, and Blizzard's icon rendered unopposed.

The hook now installs for custom styles **and** for None. An icon already lit when the user picks None is taken down on the tick, rather than waiting for a `ShowPandemicStateFrame` that may not fire again until the aura relapses.

Same shape as the stop-branch bug fixed in #1063: code that has to act when a setting is OFF must not sit behind the gate that requires it ON.

## Deliberate scope limit

`nil` is **not** treated as None in the runtime. Only an explicit `false` suppresses.

Treating `nil` as None would also have fixed the report, but it would silently strip Blizzard's pandemic icon from every user who never touched the setting, which is a change to defaults rather than a bug fix. Blizzard Default continues to install no hook, so that path still costs zero per frame.

## Testing

Truth table over `nil` / `false` / `true` for both edited expressions, 8/8, including an explicit assertion that `nil` and `false` no longer produce the same result:

| pandemicGlow | style | dropdown | hook | custom glow | suppress |
|---|---|---|---|---|---|
| nil | any | Blizzard Default | no | no | no |
| false | any | None | yes | no | yes |
| true | -1 | Blizzard Default | no | no | no |
| true | 1/3 | that style | yes | yes | no |

Both files pass `luac -p`.

Confirmed working in game by the maintainer.
