### PR TITLE
fix(cdm): Suppress GCD now covers racials and user-added spells

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -4292,6 +4292,70 @@ for _, preset in ipairs(ns.CDM_ITEM_PRESETS or {}) do
     end
 end
 
+-------------------------------------------------------------------------------
+--  Per-bar "Suppress GCD" for EUI's OWN preset frames.
+--
+--  The setting is implemented as a hooksecurefunc on the cooldown's
+--  SetSwipeColor (see DecorateFrame). That reaches BLIZZARD-owned CDM icons
+--  only: Blizzard repaints their swipe colour as the cooldown state changes,
+--  so the hook gets a chance to alpha-0 it. Preset frames (racials and
+--  user-added custom spells) are painted by US -- their swipe colour is
+--  written once at decorate time and only their GEOMETRY is driven afterwards
+--  -- so the hook never fires for them and the GCD swipe stayed at full alpha
+--  while the rest of the bar suppressed it. EVERY place that drives a preset
+--  frame's SPELL cooldown must call this right after pushing the geometry.
+--
+--  ITEM-backed preset frames (trinket slots, potion/item presets) deliberately
+--  do NOT route through here: they drop the GCD out of the GEOMETRY with a
+--  dur > 1.5 test before SetCooldown, so there is no GCD swipe to hide.
+--
+--  cdInfo and barKey are optional: callers that already hold them pass them in
+--  rather than paying for the lookup twice. barKey must be passed by callers
+--  that run BEFORE the frame's cache entry is stamped.
+-------------------------------------------------------------------------------
+local function ApplyPresetGCDSwipe(f, sid, cdInfo, barKey)
+    local cdF = f and f._cooldown
+    if not (sid and cdF and cdF.SetSwipeColor) then return end
+    if not barKey then
+        local fc = _ecmeFC[f]
+        barKey = fc and fc.barKey
+    end
+    local bd = barKey and barDataByKey[barKey]
+    local hide = false
+    if bd and bd.suppressGCD then
+        if cdInfo == nil and C_Spell and C_Spell.GetSpellCooldown then
+            cdInfo = C_Spell.GetSpellCooldown(sid)
+        end
+        if cdInfo and cdInfo.isOnGCD then
+            -- Same charge carve-out as the hook: a charge spell mid-recharge is
+            -- showing its RECHARGE, never a GCD, and alpha-0'ing that would
+            -- blank the recharge for a whole GCD every time another ability is
+            -- pressed. Read it from the stable charge data (maxCharges +
+            -- isActive), never the secret currentCharges.
+            local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(sid)
+            hide = not (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true)
+        end
+    end
+    -- Re-assert while suppressed rather than only on the rising edge: an
+    -- appearance refresh repaints the swipe from bar data and would otherwise
+    -- un-hide it until the next state change. The restore arm fires on the
+    -- falling edge alone, so a frame we never suppressed keeps its own paint
+    -- and nothing else is fought for ownership of the colour.
+    local fd = FD(f)
+    if hide then
+        f._gcdSwipeHidden = true
+        fd._isProcessingOverride = true
+        cdF:SetSwipeColor(0, 0, 0, 0)
+        fd._isProcessingOverride = false
+    elseif f._gcdSwipeHidden then
+        f._gcdSwipeHidden = nil
+        fd._isProcessingOverride = true
+        cdF:SetSwipeColor(0, 0, 0, (bd and bd.swipeAlpha) or 0.7)
+        fd._isProcessingOverride = false
+    end
+end
+ns.ApplyPresetGCDSwipe = ApplyPresetGCDSwipe
+
 -- Dirty flag: high-frequency events (SPELL_UPDATE_COOLDOWN, BAG_UPDATE_COOLDOWN)
 -- just set this flag. The BuffTicker (10Hz) processes it, coalescing dozens of
 -- per-GCD events into a single update pass.
@@ -4324,42 +4388,9 @@ local function ProcessPresetCooldowns()
                     else
                         ApplySpellDesaturation(f, durObj)
                     end
-                    -- Per-bar "Suppress GCD" for OUR OWN frames. Blizzard's CDM
-                    -- icons get this from the SetSwipeColor hook in DecorateFrame,
-                    -- but a preset frame's swipe COLOUR is written once at decorate
-                    -- time and never again (this pass drives only its GEOMETRY), so
-                    -- that hook never fires here and the GCD swipe stayed on while
-                    -- the rest of the bar suppressed it -- racials were the visible
-                    -- case, Arcane Torrent being the report. Same isOnGCD predicate
-                    -- and same charge carve-out as the hook: a charge spell
-                    -- mid-recharge is showing its recharge, never a GCD.
-                    local fcS = _ecmeFC[f]
-                    local bdS = fcS and fcS.barKey and barDataByKey[fcS.barKey]
-                    local hideGCD = false
-                    if bdS and bdS.suppressGCD and cdInfo and cdInfo.isOnGCD then
-                        local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(sid)
-                        hideGCD = not (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true)
-                    end
-                    local cdF = f._cooldown
-                    if cdF and cdF.SetSwipeColor then
-                        local fdS = FD(f)
-                        -- Re-assert while suppressed rather than only on the edge:
-                        -- an appearance refresh repaints the swipe from bar data and
-                        -- would otherwise un-hide it until the next state change.
-                        -- The restore arm fires on the falling edge alone, so a
-                        -- frame we never touched is left entirely to its own paint.
-                        if hideGCD then
-                            f._gcdSwipeHidden = true
-                            fdS._isProcessingOverride = true
-                            cdF:SetSwipeColor(0, 0, 0, 0)
-                            fdS._isProcessingOverride = false
-                        elseif f._gcdSwipeHidden then
-                            f._gcdSwipeHidden = nil
-                            fdS._isProcessingOverride = true
-                            cdF:SetSwipeColor(0, 0, 0, (bdS and bdS.swipeAlpha) or 0.7)
-                            fdS._isProcessingOverride = false
-                        end
-                    end
+                    -- Suppress GCD: this pass drives the geometry, so it also owns
+                    -- hiding the swipe when that geometry is only a GCD.
+                    ApplyPresetGCDSwipe(f, sid, cdInfo)
                     -- Resource check: dim vertex color when not enough resources
                     -- Only for custom spells (not racials -- racials don't cost resources)
                     if f._isCustomSpellFrame and f._tex then
@@ -5988,6 +6019,12 @@ local function CollectAndReanchor()
                                             f._cooldown:SetCooldownFromDurationObject(durObj, true)
                                         end
                                         ApplySpellDesaturation(f, durObj)
+                                        -- This push can land mid-GCD (a bar rebuild
+                                        -- while a GCD is running), so it owns the
+                                        -- swipe the same way the 10Hz pass does.
+                                        -- barKey is passed explicitly: the frame's
+                                        -- cache entry is only stamped further down.
+                                        ApplyPresetGCDSwipe(f, sid, nil, barKey)
                                         f._cdSet = true; f._racialCdDirty = false
                                     end
                                     frames[#frames + 1] = f

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -4324,6 +4324,42 @@ local function ProcessPresetCooldowns()
                     else
                         ApplySpellDesaturation(f, durObj)
                     end
+                    -- Per-bar "Suppress GCD" for OUR OWN frames. Blizzard's CDM
+                    -- icons get this from the SetSwipeColor hook in DecorateFrame,
+                    -- but a preset frame's swipe COLOUR is written once at decorate
+                    -- time and never again (this pass drives only its GEOMETRY), so
+                    -- that hook never fires here and the GCD swipe stayed on while
+                    -- the rest of the bar suppressed it -- racials were the visible
+                    -- case, Arcane Torrent being the report. Same isOnGCD predicate
+                    -- and same charge carve-out as the hook: a charge spell
+                    -- mid-recharge is showing its recharge, never a GCD.
+                    local fcS = _ecmeFC[f]
+                    local bdS = fcS and fcS.barKey and barDataByKey[fcS.barKey]
+                    local hideGCD = false
+                    if bdS and bdS.suppressGCD and cdInfo and cdInfo.isOnGCD then
+                        local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(sid)
+                        hideGCD = not (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true)
+                    end
+                    local cdF = f._cooldown
+                    if cdF and cdF.SetSwipeColor then
+                        local fdS = FD(f)
+                        -- Re-assert while suppressed rather than only on the edge:
+                        -- an appearance refresh repaints the swipe from bar data and
+                        -- would otherwise un-hide it until the next state change.
+                        -- The restore arm fires on the falling edge alone, so a
+                        -- frame we never touched is left entirely to its own paint.
+                        if hideGCD then
+                            f._gcdSwipeHidden = true
+                            fdS._isProcessingOverride = true
+                            cdF:SetSwipeColor(0, 0, 0, 0)
+                            fdS._isProcessingOverride = false
+                        elseif f._gcdSwipeHidden then
+                            f._gcdSwipeHidden = nil
+                            fdS._isProcessingOverride = true
+                            cdF:SetSwipeColor(0, 0, 0, (bdS and bdS.swipeAlpha) or 0.7)
+                            fdS._isProcessingOverride = false
+                        end
+                    end
                     -- Resource check: dim vertex color when not enough resources
                     -- Only for custom spells (not racials -- racials don't cost resources)
                     if f._isCustomSpellFrame and f._tex then


### PR DESCRIPTION
## The bug

On a custom Cooldown Manager bar with **Suppress GCD** enabled, Arcane Torrent kept showing the GCD swipe while every other ability on the same bar suppressed it correctly. Reported on 8.6.3.

## Cause

Suppress GCD is implemented as a `hooksecurefunc` on the cooldown's `SetSwipeColor`. That only reaches **Blizzard-owned** CDM icons: Blizzard repaints their swipe colour as the cooldown state changes, which is what gives the hook a chance to alpha-0 it.

A CDM bar actually holds two kinds of icon. The second kind is EUI's own **preset frames** (racials, potions, trinket slots, user-added custom spells), injected when Blizzard's CDM does not already carry the spell. Their swipe colour is written once at decorate time, and from then on only their *geometry* is driven, via `SetCooldownFromDurationObject`. Nothing ever calls `SetSwipeColor` on them again, so the hook never fired and the GCD swipe stayed at full alpha.

A racial is exactly the spell that lands on a preset frame instead of a Blizzard one, which is why Arcane Torrent was the odd icon out and ordinary class abilities were fine. The same gap applied to any user-added custom spell on that bar.

## Fix

Two drivers push a spell cooldown onto a preset frame, and both were missing the suppression:

* the 10Hz `ProcessPresetCooldowns` pass (the reported case)
* the one-shot push when a racial or custom-spell frame is created or its cooldown is marked dirty, which can land mid-GCD on a bar rebuild

Both now call one shared helper immediately after pushing the geometry, using the same `isOnGCD` predicate and the same charge carve-out as the hook (a charge spell mid-recharge is showing its recharge, never a GCD, so alpha-0'ing it would blank the recharge for a whole GCD every time another ability is pressed).

The suppressed arm re-asserts on every pass rather than only on the rising edge, because an appearance refresh repaints the swipe from bar data and would otherwise un-hide it until the next state change. The restore arm fires on the falling edge alone, so a frame the helper never suppressed keeps whatever painted it and nothing else is fought for ownership of the colour.

## Audited and deliberately unchanged

Recorded in the helper's header so the reasoning does not have to be rediscovered:

* **Blizzard-owned CDM icons** keep using the `SetSwipeColor` hook, which works correctly for them.
* **Item-backed preset frames** (trinket slots, potion and item presets) do not route through the helper on purpose. They drop the GCD out of the *geometry* with a `dur > 1.5` test before `SetCooldown`, so there is no GCD swipe to hide. Note this is unconditional: item frames hide the GCD even when Suppress GCD is off. That asymmetry predates this PR and is left alone, since changing it would add GCD swipes for everyone currently running with the setting off.
* **Custom buff frames** stay excluded. Their swipe is an aura duration rather than a cooldown, and the hook already carves them out for the same reason.
* Per-spell **Cooldown Swipe Color** (class/custom) applies only to buff frames, never to CD frames, so the helper's restore to the bar's swipe colour stomps nothing.

## Testing

Verified in game by the reporter:

* Arcane Torrent no longer shows the GCD swipe on a custom bar with Suppress GCD on
* Casting Arcane Torrent still shows its real cooldown swipe afterwards (the falling-edge restore)
* A trinket on the same bar behaves correctly

Scope is one file, +73 lines, no deletions. No user-facing strings added, so no new locale keys.
