### PR TITLE
fix(cdm): keep a transformed charge spell greyed when it is out of charges

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2937,12 +2937,23 @@ local function DecorateFrame(frame, barData)
                 -- in this tainted hook (can't be compared), so use Blizzard's clean
                 -- isOnActualCooldown flag instead -- false means at least one charge
                 -- is usable, so stay saturated until the spell is genuinely out.
+                -- Resolved as a TRI-STATE (true = genuinely out of charges, false =
+                -- a charge is still usable, nil = not a charge frame / unreadable)
+                -- because the transform guard below needs the same answer.
+                local outOfCharges
                 if onRealCD and type(frame.HasVisualDataSource_Charges) == "function"
                    and frame:HasVisualDataSource_Charges() then
                     local actualCD = frame.isOnActualCooldown
-                    if (not issecretvalue or not issecretvalue(actualCD)) and actualCD == false then
-                        onRealCD = false
+                    if not issecretvalue or not issecretvalue(actualCD) then
+                        if actualCD == false then
+                            outOfCharges = false
+                        elseif actualCD == true then
+                            outOfCharges = true
+                        end
                     end
+                end
+                if outOfCharges == false then
+                    onRealCD = false
                 end
                 -- Hero-talent transform to a usable follow-up: while a live spell
                 -- override is showing (e.g. Bestial Wrath -> Wailing Arrow, Trueshot
@@ -2953,7 +2964,17 @@ local function DecorateFrame(frame, barData)
                 -- above: only ever CLEARS onRealCD, never sets it -- so every
                 -- non-transform icon, and every transform whose proc is itself on a
                 -- real CD (oc.isActive), is byte-identical. Clean bools only.
-                if onRealCD and sid2 and C_SpellBook and C_SpellBook.FindSpellOverrideByID
+                -- A CHARGE frame that is genuinely OUT of charges is never a
+                -- castable proc, whatever the override reports about itself, so it
+                -- skips this guard entirely. Judgment -> Hammer of Wrath under
+                -- Wings keeps its charges on the BASE spell, so the override
+                -- answers "no real cooldown of my own" and this cleared onRealCD on
+                -- an icon sitting at zero charges: the transformed button never
+                -- greyed while plain Judgment (no override, guard never reached)
+                -- greyed correctly. outOfCharges is Blizzard's clean
+                -- isOnActualCooldown, the same signal the charge guard above trusts.
+                if onRealCD and outOfCharges ~= true
+                   and sid2 and C_SpellBook and C_SpellBook.FindSpellOverrideByID
                    and C_Spell and C_Spell.GetSpellCooldown then
                     local ovrID = C_SpellBook.FindSpellOverrideByID(sid2)
                     if ovrID and ovrID > 0 and ovrID ~= sid2 then


### PR DESCRIPTION
## The bug

With **Hide Active State** set on Judgment, the icon stops desaturating at 0 charges while Avenging Wrath is up. Plain Judgment greys correctly; only the transformed button (Hammer of Wrath under Wings) does not. Reported on 8.5.6.

Context for the setup: the Paladin class passive **Judgment of Justice** (403495) gives the player a 5 second movement speed buff on every Judgment cast. CDM reads that buff as the spell being active and lights the icon, which is why Hide Active State was turned on for Judgment in the first place.

## Cause

Hide Active State takes over the icon's saturation itself. It computes `onRealCD` from the base spell and then runs two guards that may only ever CLEAR that verdict:

1. **Charge guard.** A charge spell reports its cooldown as active while a recharge runs even though a banked charge is still castable, so an icon with charges left must stay saturated. It reads Blizzard's clean `isOnActualCooldown` rather than the secret `currentCharges`.
2. **Transform guard.** For a hero-talent transform to a castable follow-up (Bestial Wrath to Wailing Arrow, Trueshot to Moonlight Chakram), the base spell is on its real cooldown but the proc being shown is free, so the icon should stay saturated. It answers that by asking the OVERRIDE about its own cooldown.

Judgment keeps its charges on the **base** spell. So under Wings the override, Hammer of Wrath, truthfully answers "I have no real cooldown of my own", and the transform guard cleared the verdict for an icon sitting at zero charges. Plain Judgment has no override, so the guard was never reached and it greyed correctly, which is exactly the split in the report.

The transform itself was already known to this file: the swipe path documents "Judgment -> Hammer of Wrath under Wings". Only the desaturation path was missing the charge awareness.

## Fix

A charge frame that is genuinely out of charges is never a castable proc, whatever the override reports about itself, so it now skips the transform guard.

The charge state is resolved once as a tri-state (out of charges / a charge is usable / not a charge frame) and shared by both guards, so the two can no longer disagree about the same icon. The existing charge guard keeps byte-identical behaviour: it still only fires on a readable `isOnActualCooldown == false`.

## Audited

Checked the sibling sites for the same "let the override veto the base" shape:

* The Hide Active State swipe-alpha guard already has its own charge carve-out.
* `PresetOnCD` in the Fake Active engine prefers the override but falls back to the base id, so the override cannot veto a base cooldown there.

Neither needed changing. Every other `FindSpellOverrideByID` call in the module is plain id resolution.

## Testing

Verified in game by the reporter: the transformed icon now greys at 0 charges under Wings and re-saturates as a charge returns, and plain Judgment is unchanged.

Scope is one file, +24/-3. No user-facing strings added, so no new locale keys.
