### PR TITLE
Let the dwarf racial satisfy "Only Dispellable by You"

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
@@ -702,6 +702,17 @@ local DISPEL_SLOTS = {
     { key = "bleed",   colorKey = "dispelColorBleed",   fallback = { 0.75, 0.15, 0.15 },   level = 1 },
 }
 local DISPEL_TYPE_TOKENS = { magic = "Magic", curse = "Curse", disease = "Disease", poison = "Poison", bleed = "Bleed" }
+
+-- A dispel type only the player's RACE can clear (bleeds, via Stoneform) is
+-- rejected by RAID_PLAYER_DISPELLABLE, which knows class and spec dispels
+-- only. Handled here by keeping the PLAIN slot lit for such a type rather than
+-- giving the by-me twin a filter that would match it: two slots declaring one
+-- filter string share a single engine parse batch (see AK.Filter) and both are
+-- not guaranteed to receive the aura. The rule itself lives with the legacy
+-- overlay in EllesmereUIUnitFrames.lua, which needs the same answer.
+local function RacialCoversDispelSlot(slotKey)
+    return ns.UF_RacialClearsDispel ~= nil and ns.UF_RacialClearsDispel(slotKey)
+end
 local GRADIENT_TEXTURE = "Interface\\AddOns\\EllesmereUI\\media\\textures\\gradient-tb.tga"
 local GRADIENT_SHARP_TEXTURE = "Interface\\AddOns\\EllesmereUI\\media\\textures\\gradient-sharp.tga"
 
@@ -767,6 +778,10 @@ local function BuildDispelStyles(frame)
     local op = p.dispelOverlayOpacity or 100
     for i = 1, #DISPEL_SLOTS do
         local slot = DISPEL_SLOTS[i]
+        -- A type only the player's RACE can clear keeps using the PLAIN slot in
+        -- "by me" mode: the engine token can never match it, so its by-me twin
+        -- stays dark and would swallow the setting entirely.
+        local racial = RacialCoversDispelSlot(slot.key)
         local col = p[slot.colorKey]
         local color = { r = col and col.r or slot.fallback[1], g = col and col.g or slot.fallback[2], b = col and col.b or slot.fallback[3] }
         AK.styles[DispelStyleKey(slot.key)] = {
@@ -774,7 +789,7 @@ local function BuildDispelStyles(frame)
             noRegions = true,
             mode = mode,
             color = color,
-            opacity = byMe and 0 or op,
+            opacity = (byMe and not racial) and 0 or op,
             level = slot.level,
             healthFrame = frame.Health,
             applyExtra = ApplyDispelSlotStyle,
@@ -784,7 +799,7 @@ local function BuildDispelStyles(frame)
             noRegions = true,
             mode = mode,
             color = color,
-            opacity = byMe and op or 0,
+            opacity = (byMe and not racial) and op or 0,
             level = slot.level,
             healthFrame = frame.Health,
             applyExtra = ApplyDispelSlotStyle,

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -14836,6 +14836,28 @@ end
 do
     local olTex
     local curve
+    local racialCurve
+
+    -- RAID_PLAYER_DISPELLABLE only knows class and spec dispels, so it answers
+    -- no for every bleed: nothing a class learns removes one, only the dwarf
+    -- racial does. Without this, "Only Dispellable by You" can never light up
+    -- for a bleed, for anyone. A racial cleans its own caster, so this is the
+    -- player frame's business alone and other units are right to ignore it.
+    -- Bleed only, deliberately: Stoneform also clears poison, disease and
+    -- curse, but a class that dispels those already passes the token, and
+    -- treating a two-minute racial as a dispel would put an overlay on most of
+    -- what a dwarf ever catches.
+    local RACIAL_DISPEL_TYPES = {
+        bleed = { Dwarf = true },  -- Stoneform
+    }
+    -- Shared with the 12.1 container slots (EUI_UnitFrames_AuraContainers.lua),
+    -- which apply the same rule by choosing which slot style stays visible.
+    function ns.UF_RacialClearsDispel(typeKey)
+        local races = RACIAL_DISPEL_TYPES[typeKey]
+        if not races then return false end
+        local _, raceToken = UnitRace("player")
+        return raceToken ~= nil and races[raceToken] == true
+    end
 
     local function RebuildCurve()
         if not (C_CurveUtil and C_CurveUtil.CreateColorCurve) then return end
@@ -14853,6 +14875,24 @@ do
         add(4,  "dispelColorPoison",  0.0,   0.706, 0.286)
         add(9,  "dispelColorBleed",   0.75,  0.15,  0.15)
         add(11, "dispelColorBleed",   0.75,  0.15,  0.15)
+
+        -- Racial detection curve. The type a racial clears carries the user's
+        -- opacity; every other index resolves to alpha 0, so an aura of any
+        -- other type paints nothing. The ALPHA does the branching the addon is
+        -- not allowed to do: the type stays secret and unread, and the RGBA
+        -- goes straight into SetColorTexture/SetVertexColor, never into Lua
+        -- arithmetic. Opacity is baked in here for that reason -- scaling a
+        -- secret alpha afterwards is exactly the arithmetic that throws.
+        local a = (p and p.dispelOverlayOpacity or 100) / 100
+        racialCurve = C_CurveUtil.CreateColorCurve()
+        racialCurve:SetType(Enum.LuaCurveType.Step)
+        local bleedCol = p and p.dispelColorBleed
+        local br, bg, bb = bleedCol and bleedCol.r or 0.75, bleedCol and bleedCol.g or 0.15, bleedCol and bleedCol.b or 0.15
+        local bleedAlpha = ns.UF_RacialClearsDispel("bleed") and a or 0
+        for _, idx in ipairs({ 0, 1, 2, 3, 4, 9 }) do
+            racialCurve:AddPoint(idx, CreateColor(br, bg, bb, 0))
+        end
+        racialCurve:AddPoint(11, CreateColor(br, bg, bb, bleedAlpha))
     end
 
     local function Update()
@@ -14894,19 +14934,49 @@ do
                 break
             end
         end
-        if not found then olTex:Hide(); return end
+
+        -- Racial fallback: the token rejected everything, but a type this
+        -- player's RACE can clear would be rejected even when it is present
+        -- (see RACIAL_DISPEL_TYPES). Re-scan unfiltered and let racialCurve
+        -- decide by alpha -- a non-matching type resolves to 0 and paints
+        -- nothing, so no Lua code ever asks what type this aura is.
+        -- Known limit: this takes the FIRST typed aura, so a bleed sitting
+        -- behind another typed debuff paints nothing rather than wrongly. The
+        -- 12.1 container path has a real per-type slot and no such limit.
+        local racialFound
+        if not found and p.dispelOverlayByMe and ns.UF_RacialClearsDispel("bleed") then
+            for i = 1, 40 do
+                local ad = C_UnitAuras.GetAuraDataByIndex("player", i, "HARMFUL")
+                if not ad then break end
+                if ad.dispelName ~= nil then
+                    racialFound = ad
+                    break
+                end
+            end
+        end
+        if not found and not racialFound then olTex:Hide(); return end
 
         -- Resolve the color through the curve. The components may be secret;
         -- they pass straight into SetColorTexture/SetVertexColor natively.
         if not curve then RebuildCurve() end
         local r, g, b = 0.349, 0.475, 1.0
-        if curve and C_UnitAuras.GetAuraDispelTypeColor then
+        local alpha = (p.dispelOverlayOpacity or 100) / 100
+        if racialFound then
+            -- Alpha comes from the curve (opacity already baked in) and may be
+            -- secret: it is only ever handed to a texture setter below.
+            alpha = 0
+            if racialCurve and C_UnitAuras.GetAuraDispelTypeColor then
+                local col = C_UnitAuras.GetAuraDispelTypeColor("player", racialFound.auraInstanceID, racialCurve)
+                if col then
+                    r, g, b, alpha = col:GetRGBA()
+                end
+            end
+        elseif curve and C_UnitAuras.GetAuraDispelTypeColor then
             local col = C_UnitAuras.GetAuraDispelTypeColor("player", found.auraInstanceID, curve)
             if col then
                 r, g, b = col:GetRGB()
             end
         end
-        local alpha = (p.dispelOverlayOpacity or 100) / 100
 
         olTex:ClearAllPoints()
         olTex:SetVertexColor(1, 1, 1, 1)


### PR DESCRIPTION
Unit Frames: let the dwarf racial satisfy "Only Dispellable by You"

The player dispel overlay decides "can I remove this" with the engine's
RAID_PLAYER_DISPELLABLE token, which only evaluates class and spec dispels.
No class learns a bleed removal, so the token answers no for every bleed and
the overlay could never light up for one, for anyone. Dwarves are simply the
players in a position to notice, since Stoneform is the one thing in the game
that clears a bleed off you: with the option checked a dwarf saw nothing, and
unchecking it brought the overlay back.

Both display paths are fixed, because they are live on different clients.

12.0 (legacy index scan, EllesmereUIUnitFrames.lua): the token pass is
unchanged. When it finds nothing and the player's race clears a type the
token always rejects, it re-scans unfiltered and resolves color through a
second Step curve that gives Bleed the user's opacity and every other dispel
index alpha 0. The alpha performs the type test the addon may not perform
itself -- dispelName can be secret, so it is never compared, and the RGBA
goes straight into the texture setter. Opacity is baked into the curve
because scaling a possibly-secret alpha is the arithmetic that throws.
Documented limit: the fallback takes the first typed aura, so a bleed behind
another typed debuff paints nothing rather than painting something wrong.

12.1 (container slots, EUI_UnitFrames_AuraContainers.lua): each dispel type
already declares a plain slot and a by-me twin, switched by style opacity. A
racially-cleared type now keeps the PLAIN slot lit in "by me" mode instead of
its twin. Giving the twin a matching filter looked simpler but does not work:
two slots declaring one filter string share a single engine parse batch, and
both are not guaranteed to receive the aura.

Scoped to the player frame and to bleeds on purpose. A racial only ever
cleans its caster, so other units' dispel displays are right to ignore it,
and although Stoneform also clears poison, disease and curse, classes that
dispel those already pass the token, so counting a two-minute racial would
put an overlay on most of what a dwarf catches.

## Gif of Kulia working on Chat Taints
<img width="500" height="281" alt="Sad Family Time GIF by Lifetime" src="https://github.com/user-attachments/assets/836cb437-f2e6-413c-a0f1-72ed038b3db1" />

