### PR TITLE
Prioritize offline raid frame status over dead

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -1463,21 +1463,21 @@ end
 function ns._ApplyHealthBg(d, health, s, unit)
     local EllesmereUI = ns.EllesmereUI  -- upvalue read, not a global read (see taint note at top)
     local bg = d.bg
-    if UnitIsDeadOrGhost(unit) then
-        if bg then
-            local c = s.statusColorDead or { r = 0x24/255, g = 0x17/255, b = 0x17/255 }
-            bg:ClearAllPoints(); bg:SetAllPoints(health)
-            bg:SetColorTexture(c.r, c.g, c.b, 1)
-        end
-        if health then health:SetStatusBarColor(0.3, 0.3, 0.3, 0.5) end
-        return
-    elseif not UnitIsConnected(unit) then
+    if not UnitIsConnected(unit) then
         if bg then
             local c = s.statusColorOffline or { r = 0x66/255, g = 0x66/255, b = 0x66/255 }
             bg:ClearAllPoints(); bg:SetAllPoints(health)
             bg:SetColorTexture(c.r, c.g, c.b, 1)
         end
         if health then health:SetStatusBarColor(0.3, 0.3, 0.3, 0.3) end
+        return
+    elseif UnitIsDeadOrGhost(unit) then
+        if bg then
+            local c = s.statusColorDead or { r = 0x24/255, g = 0x17/255, b = 0x17/255 }
+            bg:ClearAllPoints(); bg:SetAllPoints(health)
+            bg:SetColorTexture(c.r, c.g, c.b, 1)
+        end
+        if health then health:SetStatusBarColor(0.3, 0.3, 0.3, 0.5) end
         return
     end
     if not bg then return end
@@ -4602,15 +4602,15 @@ local function UpdateButton(button)
         if s.statusTextPosition == "none" then
             d.statusText:Hide()
         elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
-            -- Being resurrected: hide DEAD so the incoming-rez icon (shown in the same
+            -- Being resurrected: hide the status text so the incoming-rez icon (shown in the same
             -- spot by UpdateReadyCheck) isn't covered by the status text.
             d.statusText:Hide()
-        elseif UnitIsDeadOrGhost(unit) then
-            d.statusText:SetText(EllesmereUI.L("DEAD"))
-            d.statusText:SetTextColor(stc.r, stc.g, stc.b)
-            d.statusText:Show()
         elseif not UnitIsConnected(unit) then
             d.statusText:SetText(EllesmereUI.L("OFFLINE"))
+            d.statusText:SetTextColor(stc.r, stc.g, stc.b)
+            d.statusText:Show()
+        elseif UnitIsDeadOrGhost(unit) then
+            d.statusText:SetText(EllesmereUI.L("DEAD"))
             d.statusText:SetTextColor(stc.r, stc.g, stc.b)
             d.statusText:Show()
         elseif s.statusShowAFK and UnitIsAFK and not issecretvalue(UnitIsAFK(unit)) and UnitIsAFK(unit) then
@@ -6518,14 +6518,14 @@ ns._UpdateButtonHealth = function(button)
         if s.statusTextPosition == "none" then
             d.statusText:Hide()
         elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
-            -- Being resurrected: hide DEAD so the incoming-rez icon isn't covered.
+            -- Being resurrected: hide the status text so the incoming-rez icon isn't covered.
             d.statusText:Hide()
-        elseif UnitIsDeadOrGhost(unit) then
-            d.statusText:SetText(EllesmereUI.L("DEAD"))
-            d.statusText:SetTextColor(stc.r, stc.g, stc.b)
-            d.statusText:Show()
         elseif not UnitIsConnected(unit) then
             d.statusText:SetText(EllesmereUI.L("OFFLINE"))
+            d.statusText:SetTextColor(stc.r, stc.g, stc.b)
+            d.statusText:Show()
+        elseif UnitIsDeadOrGhost(unit) then
+            d.statusText:SetText(EllesmereUI.L("DEAD"))
             d.statusText:SetTextColor(stc.r, stc.g, stc.b)
             d.statusText:Show()
         elseif s.statusShowAFK and UnitIsAFK and not issecretvalue(UnitIsAFK(unit)) and UnitIsAFK(unit) then


### PR DESCRIPTION
## What does this PR do?

Prioritizes the disconnected state when a raid-frame unit is both offline and dead or a ghost.

The frame now shows `OFFLINE` with the configured offline tint instead of `DEAD` with the dead tint. The full button update, lightweight health update, and shared health-background resolver use the same priority.

This is a focused bug fix with no new settings, events, hooks, migrations, or localization changes.

## How was it tested?

- Tested in-game on live retail.
- Parsed the changed file with stock Lua 5.1.5.
- Verified ASCII-only source and `git diff --check`.
- Verified the status matrix: online/alive remains normal, online/dead shows `DEAD`, offline/alive shows `OFFLINE`, and offline/dead shows `OFFLINE`.
- 12.1 PTR was not tested.

## Screenshots

Not included. This change reuses the existing `OFFLINE`/`DEAD` text and status colors and only changes which existing state wins when both are true.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) — N/A: no settings were added; this is a bug fix.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built — N/A: no feature or runtime machinery was added.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) — existing branches were reordered only.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames — no new writes or hooks were added.
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client — live retail tested; PTR not tested.