### PR TITLE
fix(blizzskin): stop the inspect sheet showing the last target's item levels

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
@@ -74,9 +74,29 @@ local INSPECT_ENCHANT_SLOTS = {
     [INVSLOT_MAINHAND] = true,
 }
 
+-- Drop every label a previous styling pass left on this slot.
+local function EUI_ClearSlotLabels(slot)
+    local d = GetFFD(slot)
+    if d.iLvlText then d.iLvlText:Hide(); d.iLvlText = nil end
+    if d.enchantText then d.enchantText:Hide(); d.enchantText = nil end
+    if d.enchantHoverFrame then d.enchantHoverFrame:Hide(); d.enchantHoverFrame = nil end
+    if d.upgradeText then d.upgradeText:Hide(); d.upgradeText = nil end
+end
+
 local function EUI_UpdateSlotStyle(slotName, slotID, textOverlayFrame, isRightColumn)
     local slot = _G[slotName]
     if not slot or not textOverlayFrame then return end
+
+    -- Blizzard reuses the SAME global slot frames (InspectHeadSlot etc) for
+    -- every target, so a label belongs to whoever was inspected last until
+    -- something clears it. The create-once guards below are no-ops while a
+    -- stale label exists, which left the previous target's numbers sitting
+    -- next to the new target's icons. Only RefreshSlotStyles used to clear,
+    -- so a sheet opened without a following INSPECT_READY (the client already
+    -- had that unit cached) kept the old values indefinitely -- the reported
+    -- "shows the first player's item levels". Clear here instead, so EVERY
+    -- styling pass rebuilds from the live item link no matter who calls.
+    EUI_ClearSlotLabels(slot)
 
     local skipLabels = (slotName == "InspectShirtSlot" or slotName == "InspectTabardSlot")
 
@@ -1321,25 +1341,8 @@ if EllesmereUI then
         for slotName, gridPos in pairs(slotGridMap) do
             local slot = _G[slotName]
             if slot then
-                -- Hide and clear old labels BEFORE creating new ones
-                if GetFFD(slot).iLvlText then
-                    GetFFD(slot).iLvlText:Hide()
-                    GetFFD(slot).iLvlText = nil
-                end
-                if GetFFD(slot).enchantText then
-                    GetFFD(slot).enchantText:Hide()
-                    GetFFD(slot).enchantText = nil
-                end
-                if GetFFD(slot).enchantHoverFrame then
-                    GetFFD(slot).enchantHoverFrame:Hide()
-                    GetFFD(slot).enchantHoverFrame = nil
-                end
-                if GetFFD(slot).upgradeText then
-                    GetFFD(slot).upgradeText:Hide()
-                    GetFFD(slot).upgradeText = nil
-                end
-
-                -- Clear old styling
+                -- Label clearing now lives in EUI_UpdateSlotStyle, so it covers
+                -- ApplyThemedInspectSheet's styling pass too, not just this one.
                 GetFFD(slot).border = false
                 -- Re-style (right column = col 1)
                 local isRightColumn = gridPos.col == 1


### PR DESCRIPTION
### Problem

Inspecting players in sequence left the per-slot item level, enchant and upgrade-track labels showing the **previously inspected** player's gear, sitting next to the new target's icons. Two field reports:

- 8.2.6: "text beside the item is often out of sync with the item itself"
- 8.5.3: "after inspecting the first player and then inspecting the second player the itemlevels in the character sheet is displaying the itemlevels of the first player"

Both noted it was intermittent, that re-inspecting the same person guaranteed nothing, and that it never happened on their own character.

### Root cause

Blizzard reuses the same global slot frames (`InspectHeadSlot` and friends) for every target, and the labels were create-once:

```lua
if itemLink and not GetFFD(slot).iLvlText and not skipLabels then
```

While a previous target's label survived, that guard is false and the whole styling pass is a no-op.

Only `RefreshSlotStyles` cleared, and it is reached solely from `INSPECT_READY` behind an `InspectFrame:IsShown()` check. But `InspectFrame_Show` calls `HideUIPanel`, and it is Blizzard's own `INSPECT_READY` handler that calls `ShowUIPanel` (`Blizzard_InspectUI.lua:41`). On the opening event the frame is therefore still hidden, our handler bails, and the only clearing pass is skipped by construction every single time a sheet opens.

Labels were corrected only when a **second** `INSPECT_READY` happened to arrive while the sheet was already up. That is the entire source of the reported intermittency, and why targets the client had already cached stayed wrong indefinitely. Inspecting yourself goes through CharacterSheet, a different file, which is why it never reproduced there.

### Fix

Clear in `EUI_UpdateSlotStyle` itself, via a small `EUI_ClearSlotLabels` helper, so every styling pass rebuilds from the live item link regardless of which path calls it. This covers `ApplyThemedInspectSheet`, which styles on `OnShow` and never cleared, as well as `RefreshSlotStyles`. The now-duplicated clearing block in `RefreshSlotStyles` is removed.

The enchant and upgrade-track labels had the identical create-once pattern and are covered by the same helper.

### Notes

The average item level shown at the top of the sheet was never affected: it reads `C_PaperDollInfo.GetInspectItemLevel(unit)` live per unit, which is why it disagreed so visibly with the stale per-slot numbers.

Not included: `EllesmereUIBlizzardSkin_InspectSheet.lua:723` calls `GetInventoryItemLink("inspect", ...)`, and `"inspect"` is not a valid unit token, so it always returns nil and the initial border falls back to grey. It is invisible in practice because `EUI_UpdateSlotStyle` sets the real border colour on every later pass. Left out rather than folded into a bug fix.

### Testing

`luac -p` clean. Verified in game.

Repro used: inspect a well geared player, close, inspect an obviously worse geared player, and compare the per-slot numbers against the average shown at the top of the same sheet. Before the fix the per-slot labels stay on the previous target; after, they track the average on every open including the instant the sheet appears.

<img width="480" height="480" alt="No Idea What GIF" src="https://github.com/user-attachments/assets/c3bbcdf1-4fc0-4dc7-9034-43c5771802e7" />
