### PR TITLE
fix(unitframes): stop force-removed auras leaving a dead icon behind

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraElement.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraElement.lua
@@ -368,19 +368,55 @@ local function UpdateSide(el, unit, updateInfo, isFullUpdate, forcedFull, defaul
         if updateInfo.updatedAuraInstanceIDs then
             for _, auraInstanceID in next, updateInfo.updatedAuraInstanceIDs do
                 if el.all[auraInstanceID] then
-                    el.all[auraInstanceID] = processData(el, unit, C_UnitAuras.GetAuraDataByAuraInstanceID(unit, auraInstanceID), filter)
-
-                    if el.active[auraInstanceID] then
-                        el.active[auraInstanceID] = true
-                        if stableOrder then
-                            updated = true
-                            if not updatedIDs then
-                                updatedIDs = table.wipe(el._updatedIDs or {})
-                                el._updatedIDs = updatedIDs
+                    local data = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                    if not data then
+                        -- Update racing its own removal: a forcibly removed aura
+                        -- (dispel, trap break, absorb consumed) can appear in
+                        -- updatedAuraInstanceIDs of the SAME payload that removes
+                        -- it, and the fetch comes back nil. Storing that nil
+                        -- silently deleted the el.all entry while active/sorted
+                        -- still held the aura -- and the removal loop below is
+                        -- gated on el.all, so it then skipped it, orphaning the
+                        -- icon permanently (field-reported: dead icon with no
+                        -- tooltip, duplicated once the aura is reapplied; the
+                        -- prune can't recover it either, it iterates el.all).
+                        -- Treat the nil fetch as the removal it really is, with
+                        -- the exact bookkeeping of the removal branch; the
+                        -- removal loop stays consistent whether or not the id
+                        -- also arrives there.
+                        el.all[auraInstanceID] = nil
+                        el._allN = math.max(0, (el._allN or 1) - 1)
+                        if el.active[auraInstanceID] then
+                            el.active[auraInstanceID] = nil
+                            local s = canEdge and el.sorted
+                            local idx
+                            if s then
+                                for i = 1, #s do
+                                    if s[i].auraInstanceID == auraInstanceID then idx = i; break end
+                                end
                             end
-                            updatedIDs[auraInstanceID] = true
-                        else
-                            changed = true
+                            if idx then
+                                table.remove(s, idx)
+                                if not edgeDirty or idx < edgeDirty then edgeDirty = idx end
+                            else
+                                changed = true
+                            end
+                        end
+                    else
+                        el.all[auraInstanceID] = processData(el, unit, data, filter)
+
+                        if el.active[auraInstanceID] then
+                            el.active[auraInstanceID] = true
+                            if stableOrder then
+                                updated = true
+                                if not updatedIDs then
+                                    updatedIDs = table.wipe(el._updatedIDs or {})
+                                    el._updatedIDs = updatedIDs
+                                end
+                                updatedIDs[auraInstanceID] = true
+                            else
+                                changed = true
+                            end
                         end
                     end
                 end


### PR DESCRIPTION
### Problem

Force-removed debuffs on the target/focus frames could leave a dead icon that never clears: no tooltip on hover, survives until the frame repaints for some other reason, and shows doubled once the aura is reapplied. Field reports (MT dungeon, then reproduced on a training dummy): only happens on force removal (dispel, trap breaking, absorb consumed), never on natural expiry.

### Root cause

One UNIT_AURA payload can list the same aura instance in `updatedAuraInstanceIDs` and `removedAuraInstanceIDs` -- exactly what force removal produces. In `EUI_UnitFrames_AuraElement.lua` updates are processed before removes:

1. The update loop fetches `C_UnitAuras.GetAuraDataByAuraInstanceID`, which returns nil because the aura is already gone client-side, and stores that nil into `el.all[id]` -- silently deleting the bookkeeping entry while `active`/`sorted` still display the aura.
2. The remove loop in the same payload is gated on `if el.all[id]`, so it skips.
3. The orphan is then unrecoverable: the full-pass prune iterates `el.all`, where the id no longer exists, so `active[id]` leaks forever.

Reapplication under a fresh instance id adds a second icon next to the orphan, which is the duplication in the reports.

The nil-store is inherited from the vendored oUF element, which has the identical hole -- but oUF rebuilds its sorted list on nearly every event, so the orphan was dropped within a frame and never seen. The 8.6.8 incremental edge path removed those rebuilds and unmasked it, which matches the reporters dating the bug to "the latest fixes".

### Fix

A nil fetch in the update loop is treated as the removal it actually is, with the removal branch's exact bookkeeping (`all` / `_allN` / `active` / `sorted` / `edgeDirty`). The real remove loop then no-ops safely whether or not the id also arrives there, since it only acts while `el.all` still holds the entry.

Checked the other aura paths for the same shape: the PlayerAuras EDF path never nils its cache from a fetch, and the nameplate pipeline reselects from live data on every rebuild. This file was the only instance.

### Testing

`luac -p` clean. Verified in game by a tester: force-removing a debuff (trap break / dispel) on the target frame now clears the icon immediately; before the fix it stuck and doubled on reapply.
<img width="480" height="480" alt="sleepy dog GIF" src="https://github.com/user-attachments/assets/4af26f73-44d9-4f9e-914e-7cacb5b1a630" />
