### PR TITLE
fix(bags): stop merged duplicates blocking mail, and add a Merge Duplicate Items toggle

### DIFF
--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -209,7 +209,7 @@ initFrame:SetScript("OnEvent", function(self)
             -- Merge Duplicate Items
             _, h = W:DualRow(parent, y,
                 { type="toggle", text="Merge Duplicate Items",
-                  tooltip="Show copies of the same item that sit in separate bag slots as one icon with their counts added together. Turn this off to keep every slot separate, for example when you deliberately split stacks. Merging is always paused while the mail, trade, auction house, bank, void storage or guild bank window is open, since those take one bag slot at a time.",
+                  tooltip="Show copies of the same item that sit in separate bag slots as one icon with their counts added together. Turn this off to keep every slot separate, for example when you deliberately split stacks. Merging is always paused while the mail, trade, auction house, bank or guild bank window is open, since those take one bag slot at a time.",
                   getValue=function() return db.profile.bagMergeDuplicates ~= false end,
                   setValue=function(v)
                       db.profile.bagMergeDuplicates = v

--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -21,6 +21,7 @@ local BAGS_DEFAULTS = {
         bagShowTrackRank      = false,
         itemlevelUseCustomColor = false,
         bagHideEmptyCategories = true,
+        bagMergeDuplicates    = true,
         bagSidebarCollapsed   = false,
         bankSidebarCollapsed  = false,
         bagShowPinnedItems    = true,
@@ -202,6 +203,17 @@ initFrame:SetScript("OnEvent", function(self)
                           _G.EUI_Bags._asMaxH = nil
                           if _G.EUI_Bags.RefreshInventory then _G.EUI_Bags:RefreshInventory() end
                       end
+                  end }
+            ); y = y - h
+
+            -- Merge Duplicate Items
+            _, h = W:DualRow(parent, y,
+                { type="toggle", text="Merge Duplicate Items",
+                  tooltip="Show copies of the same item that sit in separate bag slots as one icon with their counts added together. Turn this off to keep every slot separate, for example when you deliberately split stacks. Merging is always paused while the mail, trade, auction house, bank, void storage or guild bank window is open, since those take one bag slot at a time.",
+                  getValue=function() return db.profile.bagMergeDuplicates ~= false end,
+                  setValue=function(v)
+                      db.profile.bagMergeDuplicates = v
+                      if _G.EUI_Bags and _G.EUI_Bags.RefreshInventory then _G.EUI_Bags:RefreshInventory() end
                   end }
             ); y = y - h
 

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -340,6 +340,10 @@ end
 -- merging off outright (bagMergeDuplicates).
 local _openItemPanels = {}
 local _anyItemPanelOpen = false
+-- Unmerge state the CURRENT painted layout was built with. MergeDuplicates
+-- stamps it; the bags OnShow compares against it so a flip that happened while
+-- the bags were hidden still repaints (closing a mailbox hides both at once).
+local _paintedPanelOpen = false
 -- Returns true when the aggregate state flipped, so the caller can refresh.
 local function SetItemPanelOpen(key, open)
     _openItemPanels[key] = open or nil
@@ -357,6 +361,9 @@ local function MergeDuplicates(items)
     -- Clear stale _mergedCount from prior merge passes in the same refresh
     -- (the same data table can be merged in multiple sections: category + pinned/recent)
     for _, data in ipairs(items) do data._mergedCount = nil end
+    -- Record what this paint was built with, so the bags OnShow can tell that
+    -- the state changed while they were hidden and repaint (see OnShow).
+    _paintedPanelOpen = _anyItemPanelOpen
     if _anyItemPanelOpen or BP().bagMergeDuplicates == false then return items end
     local seen = {}
     local out = {}
@@ -6470,6 +6477,15 @@ local function StartAddon()
 
     EUI_Bags:HookScript("OnShow", function()
         CaptureTrackedGold()
+        -- Repaint if the unmerge state changed while we were hidden. The
+        -- flag-flip refresh is gated on IsVisible, and closing a mailbox hides
+        -- the bags in the same breath, so the un-flip repaint was thrown away
+        -- and the next open still showed the split slots. Cheap: one boolean
+        -- compare, and RefreshInventory only runs when the state actually
+        -- differs from what is currently painted.
+        if _paintedPanelOpen ~= _anyItemPanelOpen then
+            EUI_Bags:RefreshInventory()
+        end
     end)
 
     EUI_Bags:HookScript("OnHide", function()
@@ -6685,8 +6701,12 @@ local function StartAddon()
 
     -- Panels that move items one bag slot at a time (see SetItemPanelOpen).
     local ITEM_PANEL_EVENTS = {
-        MAIL_SHOW             = { "mail",      true  },
-        MAIL_CLOSED           = { "mail",      false },
+        -- No MAIL_SHOW: opening the mailbox lands on the Inbox, which never
+        -- takes items OUT of the bags, so unmerging there churns the layout
+        -- for nothing. Only the Send Mail tab matters -- hooked below.
+        -- MAIL_CLOSED stays as a belt so the flag cannot stick if the frame
+        -- goes away without its OnHide running.
+        MAIL_CLOSED           = { "sendmail",  false },
         TRADE_SHOW            = { "trade",     true  },
         TRADE_CLOSED          = { "trade",     false },
         AUCTION_HOUSE_SHOW    = { "auction",   true  },
@@ -6707,6 +6727,25 @@ local function StartAddon()
         local ok = pcall(EUI_Bags.RegisterEvent, EUI_Bags, evt)
         if not ok then ITEM_PANEL_EVENTS[evt] = nil end
     end
+
+    -- Send Mail is driven off the frame, not MAIL_SHOW, so switching tabs
+    -- inside an open mailbox flips the state too -- an event fired once at
+    -- mailbox-open cannot see that. Blizzard_MailFrame is DefaultState:enabled
+    -- with no LoadOnDemand, so the frame exists by now; the guard is belt.
+    local function HookSendMail(frame)
+        if not frame or not frame.HookScript then return end
+        local function flip(open)
+            if SetItemPanelOpen("sendmail", open) and EUI_Bags:IsVisible() then
+                EUI_Bags:RefreshInventory()
+            end
+        end
+        frame:HookScript("OnShow", function() flip(true) end)
+        frame:HookScript("OnHide", function() flip(false) end)
+        -- Already on the Send Mail tab when we hooked (a /reload with the
+        -- mailbox open): OnShow has been and gone, so seed from live state.
+        if frame:IsShown() then flip(true) end
+    end
+    HookSendMail(_G.SendMailFrame)
 
     -- Pre-warm the secure item-button pool while out of combat. Creating a
     -- ContainerFrameItemButtonTemplate button during combat lockdown taints it,

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -332,8 +332,8 @@ local function IsGearCategory(catIdx)
     return _gearCatSet[catIdx]
 end
 
--- Item-management panels (mail, trade, auction house, bank, void storage,
--- guild bank) take one real bag slot at a time, so a merged button only ever
+-- Item-management panels (mail, trade, auction house, bank, guild bank)
+-- take one real bag slot at a time, so a merged button only ever
 -- hands over the single slot behind it: a merged count of 3 mails as 1.
 -- Duplicates are left unmerged while any of them is open, so every slot is
 -- reachable. Players who keep duplicates deliberately apart can also turn
@@ -6691,14 +6691,22 @@ local function StartAddon()
         TRADE_CLOSED          = { "trade",     false },
         AUCTION_HOUSE_SHOW    = { "auction",   true  },
         AUCTION_HOUSE_CLOSED  = { "auction",   false },
-        VOID_STORAGE_OPEN     = { "void",      true  },
-        VOID_STORAGE_CLOSE    = { "void",      false },
         BANKFRAME_OPENED      = { "bank",      true  },
         BANKFRAME_CLOSED      = { "bank",      false },
         GUILDBANKFRAME_OPENED = { "guildbank", true  },
         GUILDBANKFRAME_CLOSED = { "guildbank", false },
     }
-    for evt in pairs(ITEM_PANEL_EVENTS) do EUI_Bags:RegisterEvent(evt) end
+    -- pcall belt: RegisterEvent on a name the client no longer knows is a HARD
+    -- error, and this loop runs BEFORE the OnEvent wiring below -- an invalid
+    -- name here killed the rest of StartAddon and shipped a bags window with
+    -- no event handler at all (field-caught: VOID_STORAGE_OPEN, removed with
+    -- Warbands, froze the whole refresh pipeline). A panel event lost to a
+    -- future patch rename must degrade to "that panel doesn't unmerge", never
+    -- to a dead bags addon.
+    for evt in pairs(ITEM_PANEL_EVENTS) do
+        local ok = pcall(EUI_Bags.RegisterEvent, EUI_Bags, evt)
+        if not ok then ITEM_PANEL_EVENTS[evt] = nil end
+    end
 
     -- Pre-warm the secure item-button pool while out of combat. Creating a
     -- ContainerFrameItemButtonTemplate button during combat lockdown taints it,

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -336,7 +336,8 @@ end
 -- guild bank) take one real bag slot at a time, so a merged button only ever
 -- hands over the single slot behind it: a merged count of 3 mails as 1.
 -- Duplicates are left unmerged while any of them is open, so every slot is
--- reachable.
+-- reachable. Players who keep duplicates deliberately apart can also turn
+-- merging off outright (bagMergeDuplicates).
 local _openItemPanels = {}
 local _anyItemPanelOpen = false
 -- Returns true when the aggregate state flipped, so the caller can refresh.
@@ -356,7 +357,7 @@ local function MergeDuplicates(items)
     -- Clear stale _mergedCount from prior merge passes in the same refresh
     -- (the same data table can be merged in multiple sections: category + pinned/recent)
     for _, data in ipairs(items) do data._mergedCount = nil end
-    if _anyItemPanelOpen then return items end
+    if _anyItemPanelOpen or BP().bagMergeDuplicates == false then return items end
     local seen = {}
     local out = {}
     for _, data in ipairs(items) do
@@ -2103,7 +2104,7 @@ local function GetOrCreateSlot(idx)
         if button ~= "LeftButton" and button ~= "RightButton" then return end
         if not IsShiftKeyDown() then return end
         if selectedCategoryIndex == -1 or selectedCategoryIndex == -2 then return end
-        if _anyItemPanelOpen then return end
+        if _anyItemPanelOpen or BP().bagMergeDuplicates == false then return end
         local bagID = self:GetParent():GetID()
         local slotID = self:GetID()
         if not bagID or not slotID or slotID == 0 then return end

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -332,6 +332,22 @@ local function IsGearCategory(catIdx)
     return _gearCatSet[catIdx]
 end
 
+-- Item-management panels (mail, trade, auction house, bank, void storage,
+-- guild bank) take one real bag slot at a time, so a merged button only ever
+-- hands over the single slot behind it: a merged count of 3 mails as 1.
+-- Duplicates are left unmerged while any of them is open, so every slot is
+-- reachable.
+local _openItemPanels = {}
+local _anyItemPanelOpen = false
+-- Returns true when the aggregate state flipped, so the caller can refresh.
+local function SetItemPanelOpen(key, open)
+    _openItemPanels[key] = open or nil
+    local any = next(_openItemPanels) ~= nil
+    if any == _anyItemPanelOpen then return false end
+    _anyItemPanelOpen = any
+    return true
+end
+
 -- Merge duplicate non-gear items by itemLink within an already-ordered list.
 -- itemLink encodes stats/bonuses, so items with different stats stay separate.
 -- Must run AFTER ApplySavedOrder so the first occurrence in visual order wins.
@@ -340,6 +356,7 @@ local function MergeDuplicates(items)
     -- Clear stale _mergedCount from prior merge passes in the same refresh
     -- (the same data table can be merged in multiple sections: category + pinned/recent)
     for _, data in ipairs(items) do data._mergedCount = nil end
+    if _anyItemPanelOpen then return items end
     local seen = {}
     local out = {}
     for _, data in ipairs(items) do
@@ -2086,6 +2103,7 @@ local function GetOrCreateSlot(idx)
         if button ~= "LeftButton" and button ~= "RightButton" then return end
         if not IsShiftKeyDown() then return end
         if selectedCategoryIndex == -1 or selectedCategoryIndex == -2 then return end
+        if _anyItemPanelOpen then return end
         local bagID = self:GetParent():GetID()
         local slotID = self:GetID()
         if not bagID or not slotID or slotID == 0 then return end
@@ -6664,6 +6682,23 @@ local function StartAddon()
     -- Replays a refresh that was deferred during combat (secure-button taint guard).
     EUI_Bags:RegisterEvent("PLAYER_REGEN_ENABLED")
 
+    -- Panels that move items one bag slot at a time (see SetItemPanelOpen).
+    local ITEM_PANEL_EVENTS = {
+        MAIL_SHOW             = { "mail",      true  },
+        MAIL_CLOSED           = { "mail",      false },
+        TRADE_SHOW            = { "trade",     true  },
+        TRADE_CLOSED          = { "trade",     false },
+        AUCTION_HOUSE_SHOW    = { "auction",   true  },
+        AUCTION_HOUSE_CLOSED  = { "auction",   false },
+        VOID_STORAGE_OPEN     = { "void",      true  },
+        VOID_STORAGE_CLOSE    = { "void",      false },
+        BANKFRAME_OPENED      = { "bank",      true  },
+        BANKFRAME_CLOSED      = { "bank",      false },
+        GUILDBANKFRAME_OPENED = { "guildbank", true  },
+        GUILDBANKFRAME_CLOSED = { "guildbank", false },
+    }
+    for evt in pairs(ITEM_PANEL_EVENTS) do EUI_Bags:RegisterEvent(evt) end
+
     -- Pre-warm the secure item-button pool while out of combat. Creating a
     -- ContainerFrameItemButtonTemplate button during combat lockdown taints it,
     -- which gets UseContainerItem() blocked in M+/Delves. Building all the
@@ -6765,6 +6800,15 @@ local function StartAddon()
                 if EUI_BagsReagent:IsVisible() and EUI_BagsReagent.RefreshInventory then
                     EUI_BagsReagent:RefreshInventory()
                 end
+            end
+            return
+        end
+        local panel = ITEM_PANEL_EVENTS[event]
+        if panel then
+            -- Tracked even while the bags are hidden: the panel that opens them
+            -- (OpenAllBags) can fire in either order with this event.
+            if SetItemPanelOpen(panel[1], panel[2]) and EUI_Bags:IsVisible() then
+                EUI_Bags:RefreshInventory()
             end
             return
         end


### PR DESCRIPTION
### Problem

Category views merge duplicate non-gear items into one button showing the combined count, even though the copies live in separate bag slots. That button is still backed by a **single** slot, so any panel that takes items slot by slot only ever receives that one slot's contents.

Reported twice, and it is the same defect at two magnitudes:

- three copies of an item in separate slots display as one button reading 3, and mailing it attaches 1
- 1050 Sandglass Vials (max stack 1000, stored as 1000 + 50) display as one button reading 1050, and mailing it sends 1000

Worth stating plainly because it misleads the repro hunt: this is not about non-stackable items or max stack size. It is about copies the game never merged into one slot.

### Fix

Leave duplicates unmerged while a panel that moves items one slot at a time is open, so every slot is reachable, then merge again once it closes.

**Send Mail specifically, not the mailbox.** `MAIL_SHOW` fires when the mailbox opens, which lands on the Inbox -- reading mail never takes items out of the bags, so unmerging there churns the layout for nothing, and a single event at open cannot see a later switch to the Send Mail tab. This drives off `SendMailFrame`'s own OnShow/OnHide, which covers tab switches and opening straight onto Send Mail, and seeds from the live shown-state so a `/reload` with Send Mail already open arms correctly. `MAIL_CLOSED` is kept only as a belt so the flag cannot stick if the frame disappears without its OnHide.

Trade, auction house, bank and guild bank use their show/close events. Merchant is deliberately excluded: selling works per click, and vendors are the most common bag interaction, so flattening there would change the layout for everyone. The scrapping machine is excluded only because its event names were not verified.

**Recombining.** The flag-flip refresh is gated on the bags being visible, and closing a mailbox hides the bags in the same breath, so the un-flip repaint was discarded and the next open still showed split slots. `MergeDuplicates` now stamps the state each paint was built with, and the bags' OnShow repaints when it no longer matches.

### Second commit: Merge Duplicate Items toggle

The merge is a display choice. Some players separate duplicates deliberately (vantus runes, split stacks) and the merge hid that with no escape short of OneBag view. Adds `bagMergeDuplicates` under Bags > Display, default true (unchanged behaviour).

Option strings reaching `EllesmereUI.L` through `cfg.text` are invisible to the locale extractor, so this does not change `Locales/_keys.txt` and the locale CI stays green.

### Note for review: an event name that killed the whole module

The first version of this registered `VOID_STORAGE_OPEN` / `VOID_STORAGE_CLOSE`. Those no longer exist on 12.0 (void storage went away with Warbands), and `RegisterEvent` on an unknown name is a **hard error**. The registration loop runs before `EUI_Bags` gets its OnEvent script, so the throw aborted the rest of `StartAddon`: no event handler at all, no `BAG_UPDATE` processing, display frozen at its first paint, secure button pool never pre-warmed.

Every registered name is now verified against the 12.0 generated event docs, and the registrations are wrapped in `pcall` with the panel dropped from the table on failure -- a panel event lost to a future patch rename degrades to "that panel does not unmerge" rather than a dead bags addon. Worth flagging since the same trap applies to any future event added here.

### Testing

`luac -p` clean on both files.

Verified in game: with the fix in place a 1050-vial pile splits into its real slots at the mailbox and each attaches, where before it mailed 1000 and the remaining 50 never repainted.

<img width="480" height="480" alt="Amazon Prime Delivery GIF" src="https://github.com/user-attachments/assets/94cb1b4e-a641-4311-93b8-049dfb7b8bc1" />
