### PR TITLE
fix: scale the options panel and popups to the 1440p reference on high DPI

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -5994,6 +5994,46 @@ local function GetPopupScale()
 end
 EllesmereUI.GetPopupScale = GetPopupScale
 
+-- Dialog popups sit on a dimmer that GetPopupScale has ALREADY scaled, and
+-- used to call SetScale(ppScale) on themselves as well. Being children of that
+-- dimmer they rendered at ppScale SQUARED. Since baseScale is
+-- 768/(physH * uiScale), that works out to panelScale^2 * baseScale physical
+-- pixels per unit instead of panelScale, so popups were oversized on every
+-- display and, with uiScale in the denominator, LOWERING your UI scale made
+-- popups BIGGER. Dialogs now take their scale ONCE, from the dimmer, and set
+-- only their own relative bump (1, or 1.15 for the intro popups), which makes
+-- px/unit == panelScale, exactly matching the options panel.
+--
+-- Careful with the units, it is easy to get wrong: GetEffectiveScale() is NOT
+-- physical pixels per unit. WoW maps the UI through a 768-tall virtual space,
+-- so px/unit = GetEffectiveScale() * physH/768. Work that through and baseScale
+-- is exactly 1 at the pixel-perfect uiScale (768/physH) on every resolution,
+-- which is what makes the corrected formula collapse to panelScale.
+--
+-- NOT folded into GetPopupScale: the popups registered in _popupFrames, the two
+-- raid-frame manager popups and the nameplate filter panel hang off UNSCALED
+-- parents and were never doubled, so a change there would inflate them.
+EllesmereUI.POPUP_DENSITY = 1  -- kept as a named hook; dialogs pass 1 or 1.15
+
+-- Hard ceiling for modal setup popups. They sit on a full-screen dimmer that
+-- eats every click behind it, so one that overflows the display does not just
+-- look wrong: its buttons land off-screen and there is no way back to the game
+-- menu. A 4K tester was left unable to log out.
+--
+-- Measured, not derived: GetEffectiveScale reports what the frame will really
+-- render at, including however many parent scales are stacked above it, so this
+-- holds regardless of what the scale math upstream does. Only ever shrinks.
+function EllesmereUI.ClampPopupToScreen(popup, w, h)
+    if not popup or not w or not h or w <= 0 or h <= 0 then return end
+    local es = popup:GetEffectiveScale()
+    if type(es) ~= "number" or es <= 0 then return end
+    local pw, ph = GetPhysicalScreenSize()
+    if type(pw) ~= "number" or type(ph) ~= "number" or pw <= 0 or ph <= 0 then return end
+    local fit = math.min((pw * 0.92) / (w * es), (ph * 0.92) / (h * es))
+    if fit >= 1 then return end
+    popup:SetScale(popup:GetScale() * fit)
+end
+
 local function RefreshPopupScales()
     local s = GetPopupScale()
     for _, entry in ipairs(_popupFrames) do

--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -68,7 +68,7 @@ local function ShowTransformsPopup()
         dimTex:SetColorTexture(0, 0, 0, 0.25)
 
         local popup = CreateFrame("Frame", nil, dimmer)
-        popup:SetScale(ppScale)
+        popup:SetScale(1)
         popup:SetFrameStrata("FULLSCREEN_DIALOG")
         popup:SetFrameLevel(dimmer:GetFrameLevel() + 10)
         popup:SetSize(POPUP_W, POPUP_H)

--- a/EllesmereUI_FirstInstall.lua
+++ b/EllesmereUI_FirstInstall.lua
@@ -137,10 +137,15 @@ local function ShowFirstInstallPopup()
 
     -- Popup
     local popup = CreateFrame("Frame", "EUIFirstInstallPopup", dimmer)
-    popup:SetScale(ppScale)
+    popup:SetScale(1)
     popup:SetFrameStrata("FULLSCREEN_DIALOG")
     popup:SetFrameLevel(dimmer:GetFrameLevel() + 10)
     PP.Size(popup, POPUP_W, POPUP_H)
+    -- This popup is modal and has no Escape route, so it must never exceed the
+    -- display (see ClampPopupToScreen).
+    if EllesmereUI.ClampPopupToScreen then
+        EllesmereUI.ClampPopupToScreen(popup, POPUP_W, POPUP_H)
+    end
     popup:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
     popup:EnableMouse(true)
 

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -4366,3 +4366,40 @@ EllesmereUI.RegisterMigration({
         end
     end,
 })
+
+-- The options panel is pinned to physical pixels (baseScale =
+-- GetScreenWidth()/physW) so it holds a constant physical size and does NOT
+-- follow the UI Scale slider. That reads fine at 1080p, but on a 1440p or 4K
+-- display the same pixel count covers far less of the screen: the panel arrives
+-- small and the UI Scale slider appears to do nothing to it. New installs seed
+-- panelScale from the display height in EllesmereUI_Startup.lua; this brings
+-- existing high-DPI users up to the same value.
+--
+-- 1440p is the reference: seed physH/1440, floored at 1 so 1080p keeps its
+-- current, slightly larger fraction. 4K seeds 1.5 and reads like a 2K monitor.
+--
+-- Only touches an EXACTLY-default 1.0 (or absent) panelScale, so anyone who
+-- picked a value keeps it. One exception: a v1 of this seed (physH/1080) went
+-- out in pre-release branch builds to testers and never in a release, so a
+-- stored value matching v1's output ON a save carrying v1's stamp is that
+-- seed's residue, not a choice, and is re-seeded. Without the stamp the same
+-- number is respected. Runs once via the global scope flag.
+EllesmereUI.RegisterMigration({
+    id          = "panel_scale_highdpi_seed_v2",
+    scope       = "global",
+    description = "Match the options-panel and popup screen fraction to the 1440p reference on larger displays.",
+    body        = function(ctx)
+        local db = ctx.db
+        if not db then return end
+        local _, physH = GetPhysicalScreenSize()
+        if type(physH) ~= "number" or physH <= 0 then return end
+        local cur = db.panelScale
+        local isDefault = (cur == nil or cur == 1.0)
+        local v1Ran = db._migrations and db._migrations.panel_scale_highdpi_seed_v1
+        local oldSeed = math.max(1, math.min(physH / 1080, 2))
+        local isV1Residue = v1Ran and cur ~= nil and math.abs(cur - oldSeed) < 0.001
+        if not isDefault and not isV1Residue then return end
+        local seeded = math.max(1, math.min(physH / 1440, 2))
+        if seeded ~= (cur or 1.0) then db.panelScale = seeded end
+    end,
+})

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -4369,37 +4369,57 @@ EllesmereUI.RegisterMigration({
 
 -- The options panel is pinned to physical pixels (baseScale =
 -- GetScreenWidth()/physW) so it holds a constant physical size and does NOT
--- follow the UI Scale slider. That reads fine at 1080p, but on a 1440p or 4K
--- display the same pixel count covers far less of the screen: the panel arrives
--- small and the UI Scale slider appears to do nothing to it. New installs seed
--- panelScale from the display height in EllesmereUI_Startup.lua; this brings
--- existing high-DPI users up to the same value.
+-- follow the UI Scale slider. That reads fine at 1080p, but above it the same
+-- pixel count covers far less of the screen: the panel arrives small and the
+-- UI Scale slider appears to do nothing to it. New installs seed panelScale
+-- from the display height in EllesmereUI_Startup.lua; this brings existing
+-- displays onto the same value.
 --
--- 1440p is the reference: seed physH/1440, floored at 1 so 1080p keeps its
--- current, slightly larger fraction. 4K seeds 1.5 and reads like a 2K monitor.
+-- 1440p is the reference: a panel of H units covers H*panelScale/physH of the
+-- screen, so physH/1440 reproduces 1440p's screen fraction anywhere. 4K seeds
+-- 1.5 and reads exactly like a 2K monitor.
 --
--- Only touches an EXACTLY-default 1.0 (or absent) panelScale, so anyone who
--- picked a value keeps it. One exception: a v1 of this seed (physH/1080) went
--- out in pre-release branch builds to testers and never in a release, so a
--- stored value matching v1's output ON a save carrying v1's stamp is that
--- seed's residue, not a choice, and is re-seeded. Without the stamp the same
--- number is respected. Runs once via the global scope flag.
+-- The two halves are deliberately asymmetric, because "the user picked this"
+-- means different things above and below the reference:
+--
+--   ABOVE 1440p -- ONE-TIME RESET, overwriting whatever is stored. On these
+--   displays the old default (1.0) rendered the panel at a fraction of the
+--   reference size, so a raised value there is a WORKAROUND for that bug, not
+--   a preference, and leaving it would strand the user on a stale compensation
+--   now that the default is correct (and oversized, since popups no longer
+--   scale quadratically with it). Migrations stamp done and never run again,
+--   so this fires exactly once; anything chosen afterwards is kept forever.
+--
+--   AT OR BELOW 1440p -- nothing was ever broken, the seed is 1.0 anyway, and a
+--   stored value can only be a genuine preference. Left alone, except for
+--   residue from a v1 seed (physH/1080) that went out in pre-release branch
+--   builds and never in a release: a value matching v1's output ON a save
+--   carrying v1's stamp is that seed's leftover rather than a choice.
 EllesmereUI.RegisterMigration({
-    id          = "panel_scale_highdpi_seed_v2",
+    id          = "panel_scale_highdpi_reset_v3",
     scope       = "global",
-    description = "Match the options-panel and popup screen fraction to the 1440p reference on larger displays.",
+    description = "Reset the options-panel scale on displays above 1440p to the corrected default, and seed it elsewhere.",
     body        = function(ctx)
         local db = ctx.db
         if not db then return end
         local _, physH = GetPhysicalScreenSize()
         if type(physH) ~= "number" or physH <= 0 then return end
+        local seeded = math.max(1, math.min(physH / 1440, 2))
+
+        if seeded > 1 then
+            -- Above the reference: one-time reset (see above).
+            db.panelScale = seeded
+            return
+        end
+
+        -- At or below the reference: only fill in an unset/default value, or
+        -- clear v1 residue.
         local cur = db.panelScale
         local isDefault = (cur == nil or cur == 1.0)
         local v1Ran = db._migrations and db._migrations.panel_scale_highdpi_seed_v1
         local oldSeed = math.max(1, math.min(physH / 1080, 2))
         local isV1Residue = v1Ran and cur ~= nil and math.abs(cur - oldSeed) < 0.001
         if not isDefault and not isV1Residue then return end
-        local seeded = math.max(1, math.min(physH / 1440, 2))
         if seeded ~= (cur or 1.0) then db.panelScale = seeded end
     end,
 })

--- a/EllesmereUI_PTRManagersPopup.lua
+++ b/EllesmereUI_PTRManagersPopup.lua
@@ -78,7 +78,7 @@ local function ShowPTRManagersPopup()
 
     -- Panel
     local popup = CreateFrame("Frame", "EUIPTRManagersIntroPopup", dimmer)
-    popup:SetScale(ppScale * 1.15)
+    popup:SetScale(1.15)
     popup:SetFrameStrata("FULLSCREEN_DIALOG")
     popup:SetFrameLevel(dimmer:GetFrameLevel() + 10)
     PP.Size(popup, POPUP_W, POPUP_H)

--- a/EllesmereUI_PatchNotesPopup.lua
+++ b/EllesmereUI_PatchNotesPopup.lua
@@ -79,7 +79,7 @@ local function ShowPatchNotesPopup()
 
     -- Panel
     local popup = CreateFrame("Frame", "EUIPatchNotesIntroPopup", dimmer)
-    popup:SetScale(ppScale * 1.15)
+    popup:SetScale(1.15)
     popup:SetFrameStrata("FULLSCREEN_DIALOG")
     popup:SetFrameLevel(dimmer:GetFrameLevel() + 10)
     PP.Size(popup, POPUP_W, POPUP_H)

--- a/EllesmereUI_Presets.lua
+++ b/EllesmereUI_Presets.lua
@@ -219,7 +219,7 @@ do
 
             -- Popup frame
             local popup = CreateFrame("Frame", "EUISpecAssignPopup", dimmer)
-            popup:SetScale(ppScale)
+            popup:SetScale(1)
             popup:SetFrameStrata("FULLSCREEN_DIALOG")
             popup:SetFrameLevel(dimmer:GetFrameLevel() + 10)
 

--- a/EllesmereUI_RaidFramesPopup.lua
+++ b/EllesmereUI_RaidFramesPopup.lua
@@ -81,7 +81,7 @@ local function ShowRaidFramesPopup()
 
     -- Panel
     local popup = CreateFrame("Frame", "EUIRaidFramesIntroPopup", dimmer)
-    popup:SetScale(ppScale * 1.15)
+    popup:SetScale(1.15)
     popup:SetFrameStrata("FULLSCREEN_DIALOG")
     popup:SetFrameLevel(dimmer:GetFrameLevel() + 10)
     PP.Size(popup, POPUP_W, POPUP_H)

--- a/EllesmereUI_SpecOverridesPopup.lua
+++ b/EllesmereUI_SpecOverridesPopup.lua
@@ -102,7 +102,7 @@ local function ShowSpecOverridesPopup()
 
     -- Panel
     local popup = CreateFrame("Frame", "EUISpecOvIntroPopup", dimmer)
-    popup:SetScale(ppScale * 1.15)
+    popup:SetScale(1.15)
     popup:SetFrameStrata("FULLSCREEN_DIALOG")
     popup:SetFrameLevel(dimmer:GetFrameLevel() + 10)
     PP.Size(popup, POPUP_W, POPUP_H)

--- a/EllesmereUI_Startup.lua
+++ b/EllesmereUI_Startup.lua
@@ -140,6 +140,27 @@ do
                 local clamped = max(0.4, min(blizzScale, 1.15))
                 EllesmereUIDB.ppUIScale = clamped
                 EllesmereUIDB.ppUIScaleAuto = false
+
+            -- Seed the options-panel scale from the display height. The panel is
+            -- deliberately pinned to physical pixels (baseScale =
+            -- GetScreenWidth()/physW) so it holds a constant physical size and
+            -- does NOT follow the UI Scale slider. At 1080p that reads fine, but
+            -- on a 4K screen the same pixel count covers half as much of the
+            -- display: the panel arrives unreadably small and the UI Scale
+            -- slider appears to do nothing to it.
+            --
+            -- 1440p is the reference look: a panel of H units covers
+            -- H*panelScale/physH of the screen, so physH/1440 reproduces 1440p's
+            -- screen fraction on any display, and 4K seeds 1.5 to read exactly
+            -- like a 2K monitor. Floored at 1 so 1080p (which runs a slightly
+            -- larger fraction, uncomplained-about) keeps its current size rather
+            -- than shrinking. Only when unset, so a chosen value is kept.
+            if EllesmereUIDB.panelScale == nil then
+                local _, physH = GetPhysicalScreenSize()
+                if type(physH) == "number" and physH > 0 then
+                    EllesmereUIDB.panelScale = max(1, min(physH / 1440, 2))
+                end
+            end
             end
 
             local scale = EllesmereUIDB.ppUIScale

--- a/EllesmereUI_VideoGuides.lua
+++ b/EllesmereUI_VideoGuides.lua
@@ -363,7 +363,7 @@ local function Show(id)
     BuildShell()
     local ppScale = (EllesmereUI.GetPopupScale and EllesmereUI.GetPopupScale()) or 1
     ui.dimmer:SetScale(ppScale)
-    ui.popup:SetScale(ppScale * 1.15)
+    ui.popup:SetScale(1.15)
     SetGuide(id, def)
     ui.dimmer:Show()
     -- Pre-select the URL so the only keystroke needed is Ctrl+C.

--- a/EllesmereUI_WindowSkinsPopup.lua
+++ b/EllesmereUI_WindowSkinsPopup.lua
@@ -85,7 +85,7 @@ local function ShowWindowSkinsPopup()
 
     -- Panel
     local popup = CreateFrame("Frame", "EUIWindowSkinsIntroPopup", dimmer)
-    popup:SetScale(ppScale * 1.15)
+    popup:SetScale(1.15)
     popup:SetFrameStrata("FULLSCREEN_DIALOG")
     popup:SetFrameLevel(dimmer:GetFrameLevel() + 10)
     PP.Size(popup, POPUP_W, POPUP_H)


### PR DESCRIPTION
### Problem

Two related defects on anything above 1080p.

**The options panel arrives too small on high DPI.** It is pinned to physical pixels (`baseScale = GetScreenWidth()/physW`) so it holds a constant physical size and deliberately does not follow the UI Scale slider. At 1080p that reads fine. At 4K the same pixel count covers half as much of the display, so the panel is unreadably small and the UI Scale slider appears to do nothing to it.

**Dialog popups were scaled twice.** Each sits on a dimmer that `GetPopupScale` has already scaled, and then called `SetScale(ppScale)` on itself as well. Being a child of that dimmer, it rendered at `ppScale` **squared**, which works out to `panelScale^2 * baseScale` physical pixels per unit instead of `panelScale`. Two consequences: popups were oversized on every display, and with `uiScale` in the denominator, **lowering** your UI scale made popups **bigger**.

Together these put a 4K tester's first-install popup past the screen edge, with its buttons off-display and a click-eating modal dimmer behind it, leaving them unable to reach the game menu to log out.

### Fix

**Seed `panelScale` from display height, with 1440p as the reference look.** A panel of H units covers `H * panelScale / physH` of the screen, so `physH/1440` reproduces 1440p's screen fraction on any display and 4K seeds 1.5, reading exactly like a 2K monitor. Floored at 1 so 1080p keeps its current, slightly larger fraction rather than shrinking by a quarter. Applied in `EllesmereUI_Startup.lua` for new installs and backfilled by a migration for existing ones, both only when the value is unset or an untouched default, so a chosen value is never overwritten.

| display | seeded panelScale | vs today |
|---|---|---|
| 1080p | 1.0 | unchanged |
| 1440p / 3440x1440 | 1.0 | unchanged (the reference) |
| 4K | 1.5 | was 1.0 and half-size |
| 5K | 2.0 (cap) | |

**Apply popup scale once, on the dimmer.** Each popup now carries only its own relative bump (`1`, or `1.15` for the intro popups), so `px/unit == panelScale` and popups match the options panel exactly, which is what the existing "popups grow and shrink with the main panel" note always intended.

Left alone deliberately: the popups registered in `_popupFrames`, the two raid-frame manager popups and the nameplate filter panel all hang off **unscaled** parents and were never doubled, so folding the change into `GetPopupScale` would have inflated those by 40%.

**Adds `ClampPopupToScreen`**, used by the modal first-install popup. That popup has no Escape route, so one that overflows the display is not merely ugly. It measures the frame's real `GetEffectiveScale()`, which accounts for however many parent scales are stacked above it, so the guard holds regardless of the scale math upstream of it, and it only ever shrinks.

### A units trap worth recording

`GetEffectiveScale()` is **not** physical pixels per unit. WoW maps the UI through a 768-tall virtual space, so `px/unit = GetEffectiveScale() * physH/768`. Working that factor through is what shows `baseScale` is exactly 1 at the pixel-perfect UI scale (`768/physH`) on every resolution, which is why the corrected formula collapses cleanly to `panelScale`. Deriving it without that factor produces a plausible-looking constant that is 40% wrong; this is noted in the code comment so it is not reintroduced.

### Scope

Scaling only. No new locale keys, so the locale check has nothing to verify, and no `.toc` change.

### Testing

`luac -p` clean on all 12 files.

Verified in game at 2560x1440 by measuring rather than by eye: with `panelScale` at 1.0 the overrides intro popup reports an effective scale of 0.6133, identical to current live, confirming the claim that nothing below 4K changes size. The migration was confirmed to seed correctly on the same client.

Pending: a 4K tester confirming the panel and popups now read like a 2K monitor. Expected there: `panelScale` 1.5, first-install popup roughly 29% of screen width.

Reviewers can check any client with:

```
/euioverridesintro
/reload
/run print(EllesmereUIDB.panelScale, EUISpecOvIntroPopup:GetEffectiveScale())
```

## Ellesmere 
<img width="300" height="350" alt="Chicago Bulls Basketball GIF" src="https://github.com/user-attachments/assets/28485413-9bfb-4679-9039-8bb4cc051176" />


### Who sees a visible change

**Above 1440p: a deliberate one-time reset.** The migration overwrites whatever `panelScale` is stored. On these displays the old default rendered the panel at a fraction of the reference size, so a raised value there is a workaround for that bug rather than a preference, and keeping it would strand the user on a stale compensation now that the default is correct. It fires exactly once (migrations stamp done and never re-run), so anything chosen afterwards is kept.

**At or below 1440p: untouched.** Nothing was ever broken there, the seed is 1.0 anyway, and a stored value can only be a genuine preference. The sole exception is residue from a v1 seed that went out in pre-release branch builds and never in a release.

The options panel itself is unaffected by the popup half of this PR either way: `SetPanelScale` is `baseScale * userScale`, exactly `userScale` physical pixels per unit, linear, and untouched.

Popups are where an existing custom scale shows a change, and it is worth being explicit. They currently scale as `panelScale^2` and will now scale as `panelScale`, so the difference is invisible at the default and grows with how far the slider was pushed:

| user's panelScale | popup px/unit before | after | change |
|---|---|---|---|
| 1.0 (default) | 1.00 | 1.00 | none |
| 1.5 | 2.25 | 1.50 | -33% |
| 2.0 | 4.00 | 2.00 | -50% |

That is the defect being corrected (popups are currently larger relative to the panel than the existing "popups grow and shrink together with the main panel" note intends), but it is a visible change and there is no separate control to restore the old proportion. Flagged as a deliberate call rather than an oversight.

Migration behaviour was verified by simulating the body across every combination of display height and stored value:

```
1080p default                      stored=1.0     -> 1.0000  (no-op)
1080p user chose 1.5               stored=1.5     -> 1.5000  (kept)
1440p user chose 1.75              stored=1.75    -> 1.7500  (kept)
1440p v1 tester residue            stored=1.3333  -> 1.0000  (seeded)
4K default (the tiny-panel case)   stored=1.0     -> 1.5000  (RESET)
4K user workaround 2.0             stored=2.0     -> 1.5000  (RESET)
5K default                         stored=1.0     -> 2.0000  (RESET)
```
