### PR TITLE
fix(chat): Fix inner borders in chat

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -510,6 +510,14 @@ local function SidebarParticipatesInLayout(cfg)
         or (mode == "mouseover" and _sidebarMouseoverLayoutVisible)
 end
 
+local function ShouldShowSidebarDivider(cfg)
+    return not cfg.hideBorders
+        and cfg.sidebarSeparate ~= true
+        -- Without the sidebar background this becomes an exposed edge line,
+        -- not a divider between two panel backgrounds, on either side.
+        and not cfg.hideSidebarBg
+end
+
 -- Extend the chat background up behind the tab strip (and the sidebar by the
 -- same amount) so the tabs sit on one continuous panel instead of floating over
 -- empty space. Opt-in via cfg.extendBgBehindTabs (default off, reload on toggle).
@@ -844,7 +852,7 @@ function ECHAT.ApplyBorders()
         end
         if CFD(cf1).sidebarDiv then
             CFD(cf1).sidebarDiv:SetColorTexture(r, g, b, a)
-            CFD(cf1).sidebarDiv:SetShown(not hide)
+            CFD(cf1).sidebarDiv:SetShown(ShouldShowSidebarDivider(cfg))
         end
     end
     -- Mirror border visibility onto the behind-tabs divider continuation.
@@ -1087,7 +1095,7 @@ function ECHAT.ApplySidebarPosition()
             CFD(cf1).sidebarDiv:SetPoint("TOPRIGHT", sb, "TOPRIGHT", 0, 0)
             CFD(cf1).sidebarDiv:SetPoint("BOTTOMRIGHT", sb, "BOTTOMRIGHT", 0, 0)
         end
-        CFD(cf1).sidebarDiv:SetShown(cfg.sidebarSeparate ~= true)
+        CFD(cf1).sidebarDiv:SetShown(ShouldShowSidebarDivider(cfg))
     end
 
     -- Re-place the behind-tabs divider continuation onto the new edge.
@@ -1189,6 +1197,9 @@ function ECHAT.ApplySidebarBackground()
     end
     if PP.GetBorders(sb) then
         PP.GetBorders(sb):SetShown(show)
+    end
+    if CFD(cf1).sidebarDiv then
+        CFD(cf1).sidebarDiv:SetShown(ShouldShowSidebarDivider(cfg))
     end
     -- Hide the sidebar extension too when the sidebar background is hidden.
     if ECHAT.ApplyExtendedBackground then ECHAT.ApplyExtendedBackground() end

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -72,10 +72,14 @@ local BISECT_TEX_SHIFT_OFF = false      -- 8: CLEARED (this cycle) -- textures
 -- chat frame) as parent. Textures created directly on tabs (bg/hover)
 -- are fine -- they existed in 8.5.2, field-clean.
 local _tabHostClip
+-- Keep tab borders/dividers above the chat tabs via frame level, not via a
+-- global DIALOG strata. DIALOG made these small chat-only visuals win against
+-- unrelated UI (most visibly the minimap) whenever their rectangles overlap.
+local TAB_HOST_STRATA = "LOW"
 local function GetTabHostClip()
     if _tabHostClip then return _tabHostClip end
     local clip = CreateFrame("Frame", nil, UIParent)
-    clip:SetFrameStrata("DIALOG")
+    clip:SetFrameStrata(TAB_HOST_STRATA)
     clip:EnableMouse(false)
     clip:SetClipsChildren(true)
     local gdm = _G.GeneralDockManager
@@ -2737,10 +2741,11 @@ function ECHAT.ApplyTabBorders()
             if host:GetParent() ~= wantedParent then
                 host:SetParent(wantedParent)
             end
-            host:SetFrameStrata("DIALOG")
-            -- Constant level: hosts render on our clip at DIALOG strata,
-            -- so a tab-derived level is meaningless -- and tab:GetFrameLevel
-            -- was an un-exonerated tab getter in this (dirty-tested) pass.
+            host:SetFrameStrata(TAB_HOST_STRATA)
+            -- Constant level: hosts render above the tabs on the normal chat
+            -- strata without covering unrelated higher-strata UI. A tab-derived
+            -- level is meaningless here, and tab:GetFrameLevel was an
+            -- un-exonerated tab getter in this (dirty-tested) pass.
             local level = 100
             host:SetFrameLevel(level)
             -- No alpha writes here at all: hosts default to 1, docked hosts
@@ -2814,7 +2819,7 @@ function ECHAT.ApplyTabSeparators()
         end
         if not ns._tabPanelSepHost then
             local host = CreateFrame("Frame", nil, clip)
-            host:SetFrameStrata("DIALOG")
+            host:SetFrameStrata(TAB_HOST_STRATA)
             host:SetFrameLevel(90)
             host:EnableMouse(false)
             host:SetHeight((PP and PP.mult) or 1)
@@ -2900,7 +2905,7 @@ local function SkinTab(cf)
 
     local separatorHost = CreateFrame("Frame", nil, hostParent)
     separatorHost:Hide()
-    separatorHost:SetFrameStrata("DIALOG")
+    separatorHost:SetFrameStrata(TAB_HOST_STRATA)
     separatorHost:SetFrameLevel(90)
     separatorHost:EnableMouse(false)
     local onePx = (PP and PP.mult) or 1
@@ -2925,7 +2930,7 @@ local function SkinTab(cf)
 
     local underlineHost = CreateFrame("Frame", nil, hostParent)
     underlineHost:Hide()
-    underlineHost:SetFrameStrata("DIALOG")
+    underlineHost:SetFrameStrata(TAB_HOST_STRATA)
     underlineHost:SetFrameLevel(95)
     underlineHost:EnableMouse(false)
     local activeUnderline = underlineHost:CreateTexture(nil, "OVERLAY", nil, 7)


### PR DESCRIPTION
## Summary

Fixes two inner-border rendering issues:

- Fixed the inner border strata so it renders in the correct layer and remains visible above the relevant panel backgrounds.
- Fixed the sidebar divider rendering: the inner border is no longer shown when the sidebar background is disabled, preventing an unnecessary divider and incorrect layout.

## Notes

These changes are visual-only and do not change chat frame layout or positioning.

## Checklist
- [x] New settings default OFF 
- [x] Zero cost while disabled
- [x] Cheap while enabled
- [x] No writes onto Blizzard-owned frame
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client