### PR TITLE
[Feature] VERTICAL HEALTH BARS!!!!

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_Options.lua
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --  EUI_RaidFrames_Options.lua
 --  Registers the Raid Frames module with EllesmereUI options panel.
 --  Two tabs: Raid Frames (layout, health, power, text, border, absorbs,
@@ -1240,6 +1240,17 @@ initFrame:SetScript("OnEvent", function(self)
         ns._editTargets.threat = smoothThreatRow
         ns._editTargets.animateBars = smoothThreatRow
 
+        -- Row 5: Vertical Fill. Part of the Health Bar party-sync section, so an
+        -- unsynced party tab keeps its own value.
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Vertical Fill",
+              tooltip="Fill the health bar bottom-to-top instead of left-to-right. Absorbs, heal prediction and the bar background follow the same axis.",
+              getValue=function() return SVal("healthVerticalFill", false) end,
+              -- RefreshPage re-labels the Absorbs Placement dropdowns for the new
+              -- axis (their cog popups bake the labels in on first build).
+              setValue=function(v) SSet("healthVerticalFill", v); EllesmereUI:RefreshPage() end },
+            { type="spacer" });  y = y - h
+
         -------------------------------------------------------------------
         --  ABSORBS
         --  Own party-sync section ("absorbs"). Pre-split profiles inherit
@@ -1374,16 +1385,38 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline cog: absorb placement (overlay / right edge / left edge)
         do
             local rgn = absorbRow._leftRegion
+            -- Placement labels follow the FILL AXIS. The saved values stay right/left --
+            -- they have always meant the FAR / NEAR end of the fill -- but on a vertical
+            -- bar "From Left Edge" describes nothing, so the wording becomes top/bottom.
+            -- MUTATED IN PLACE, never rebuilt: RefreshPage's fast path does not rebuild
+            -- the page, and a cog popup is built once then cached, so a freshly-built
+            -- table would never reach the widget. The popup re-reads values[get()] on
+            -- every show, and _invalidateMenu makes an already-built menu rebuild its
+            -- entries from this same table on the next click.
+            local absorbEdgeLabels = { overlay = "Overlay" }
+            local absorbEdgeLabelsVert  -- last applied axis; nil until the first sync
+            -- Returns true only when the axis actually flipped, so the caller can
+            -- skip _invalidateMenu on unrelated refreshes (it nils the cached menu
+            -- and would break the wired click if one were open).
+            local function SyncAbsorbEdgeLabels()
+                local vert = (SVal("healthVerticalFill", false)) and true or false
+                if absorbEdgeLabelsVert == vert then return false end
+                absorbEdgeLabelsVert = vert
+                absorbEdgeLabels.right = vert and "From Top Edge"    or "From Right Edge"
+                absorbEdgeLabels.left  = vert and "From Bottom Edge" or "From Left Edge"
+                return true
+            end
+            SyncAbsorbEdgeLabels()
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Absorb Rendering",
                 rows = {
                     { type="dropdown", label="Placement",
-                      values = { overlay = "Overlay", right = "From Right Edge", left = "From Left Edge" },
+                      values = absorbEdgeLabels,
                       order = { "overlay", "right", "left" },
                       disabled = function() return SVal("absorbStyle", "none") == "blizzardModern" end,
                       disabledTooltip = "Default Blizz Frames uses a fixed placement",
                       rawTooltip = true,
-                      get=function() return SVal("absorbEdgeMode", "overlay") end,
+                      get=function() SyncAbsorbEdgeLabels(); return SVal("absorbEdgeMode", "overlay") end,
                       set=function(v) SSet("absorbEdgeMode", v) end },
                     { type="toggle", label="Show Overshield",
                       tooltip="Show the part of an absorb that exceeds your empty health and backfills over your current health. When off, absorbs only fill the empty part of the health bar; on Default Blizz Frames the glow line stays pinned at the right edge.",
@@ -1391,6 +1424,17 @@ initFrame:SetScript("OnEvent", function(self)
                       set=function(v) SSet("showOvershield", v) end },
                 },
             })
+            -- Re-label on every page refresh (the Vertical Fill toggle fires one) and
+            -- drop any built menu so its entries rebuild with the new wording.
+            EllesmereUI.RegisterWidgetRefresh(function()
+                if not SyncAbsorbEdgeLabels() then return end
+                local pf = cogShow and cogShow._popupFrame
+                if pf and pf.GetChildren then
+                    for _, child in ipairs({ pf:GetChildren() }) do
+                        if child._invalidateMenu then child._invalidateMenu() end
+                    end
+                end
+            end)
             local cogBtn = CreateFrame("Button", nil, rgn)
             cogBtn:SetSize(26, 26)
             cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
@@ -1555,13 +1599,35 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline cog: heal absorb placement (independent of shield absorb)
         do
             local rgn = healAbsorbRow._leftRegion
+            -- Placement labels follow the FILL AXIS. The saved values stay right/left --
+            -- they have always meant the FAR / NEAR end of the fill -- but on a vertical
+            -- bar "From Left Edge" describes nothing, so the wording becomes top/bottom.
+            -- MUTATED IN PLACE, never rebuilt: RefreshPage's fast path does not rebuild
+            -- the page, and a cog popup is built once then cached, so a freshly-built
+            -- table would never reach the widget. The popup re-reads values[get()] on
+            -- every show, and _invalidateMenu makes an already-built menu rebuild its
+            -- entries from this same table on the next click.
+            local healAbsorbEdgeLabels = { overlay = "Overlay" }
+            local healAbsorbEdgeLabelsVert  -- last applied axis; nil until the first sync
+            -- Returns true only when the axis actually flipped, so the caller can
+            -- skip _invalidateMenu on unrelated refreshes (it nils the cached menu
+            -- and would break the wired click if one were open).
+            local function SyncHealAbsorbEdgeLabels()
+                local vert = (SVal("healthVerticalFill", false)) and true or false
+                if healAbsorbEdgeLabelsVert == vert then return false end
+                healAbsorbEdgeLabelsVert = vert
+                healAbsorbEdgeLabels.right = vert and "From Top Edge"    or "From Right Edge"
+                healAbsorbEdgeLabels.left  = vert and "From Bottom Edge" or "From Left Edge"
+                return true
+            end
+            SyncHealAbsorbEdgeLabels()
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Heal Absorb Rendering",
                 rows = {
                     { type="dropdown", label="Placement",
-                      values = { overlay = "Overlay", right = "From Right Edge", left = "From Left Edge" },
+                      values = healAbsorbEdgeLabels,
                       order = { "overlay", "right", "left" },
-                      get=function() return SVal("healAbsorbEdgeMode", "overlay") end,
+                      get=function() SyncHealAbsorbEdgeLabels(); return SVal("healAbsorbEdgeMode", "overlay") end,
                       set=function(v) SSet("healAbsorbEdgeMode", v) end },
                     { type="slider", label="Backing Opacity", min=0, max=100, step=1,
                       get=function() return SVal("healAbsorbBgOpacity", 25) end,
@@ -1571,6 +1637,17 @@ initFrame:SetScript("OnEvent", function(self)
                       set=function(v) SSet("healAbsorbOverDispel", v) end },
                 },
             })
+            -- Re-label on every page refresh (the Vertical Fill toggle fires one) and
+            -- drop any built menu so its entries rebuild with the new wording.
+            EllesmereUI.RegisterWidgetRefresh(function()
+                if not SyncHealAbsorbEdgeLabels() then return end
+                local pf = cogShow and cogShow._popupFrame
+                if pf and pf.GetChildren then
+                    for _, child in ipairs({ pf:GetChildren() }) do
+                        if child._invalidateMenu then child._invalidateMenu() end
+                    end
+                end
+            end)
             local cogBtn = CreateFrame("Button", nil, rgn)
             cogBtn:SetSize(26, 26)
             cogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -500,6 +500,10 @@ local defaults = {
         customBgColor    = { r = 17/255, g = 17/255, b = 17/255 },
         bgClassColored   = false,
         bgDarkness       = 50,
+        -- Fill axis. Off = the classic left-to-right bar; on = the bar fills
+        -- bottom-to-top instead. Party frames can hold their own value (the
+        -- key is in the healthBar party-override section).
+        healthVerticalFill = false,
 
         -- Power bar (on when any powerShowFor* role is true)
         showPowerBar     = true,
@@ -1241,6 +1245,45 @@ ns.healthBarTextures     = healthBarTextures
 ns.healthBarTextureNames = healthBarTextureNames
 ns.healthBarTextureOrder = healthBarTextureOrder
 
+-- Vertical health fill. SetOrientation drives the bar's fill AXIS. Raid and
+-- party resolve their own value through the settings table the caller passes
+-- (party gets its own when the Health Bar section is unsynced). On ns, not
+-- file-scope locals -- this file is at the Lua 5.1 200-local cap.
+ns.RF_IsVerticalFill = function(s)
+    return ((s or db.profile).healthVerticalFill) and true or false
+end
+
+-- Fill-texture rotation, DERIVED -- never set on its own, so it can never go
+-- stale against the bar's axis or a texture swap. Two texture families live on
+-- these bars and they want opposite treatment on a vertical bar:
+--
+--   stretch (shield.tga, striped3, blizzard, WHITE8X8, every health texture):
+--     one image scaled to the fill rect. Designed wide-and-short, so on a tall
+--     bar it must be ROTATED or it smears into a stretched mess.
+--   tiled (stripedReversed, the large* stripe sets, striped-maxhp, the modern
+--     absorb): repeats at native pixel size on BOTH axes, so it already reads
+--     correctly at any bar shape. Rotating it fights the tiling and is exactly
+--     what produced the stretched look -- leave these alone.
+--
+-- Tiling is read back off the live fill texture rather than passed in, so this
+-- stays correct no matter which style function last touched the bar.
+ns.RF_ApplyFillRotation = function(bar)
+    if not (bar and bar.SetRotatesTexture) then return end
+    local vert = bar.GetOrientation and bar:GetOrientation() == "VERTICAL"
+    local fill = bar.GetStatusBarTexture and bar:GetStatusBarTexture()
+    local tiled = fill and ((fill.GetHorizTile and fill:GetHorizTile())
+                         or (fill.GetVertTile and fill:GetVertTile()))
+    bar:SetRotatesTexture((vert and not tiled) and true or false)
+end
+
+ns.RF_ApplyHealthOrientation = function(bar, s)
+    if not bar then return false end
+    local vert = ns.RF_IsVerticalFill(s)
+    bar:SetOrientation(vert and "VERTICAL" or "HORIZONTAL")
+    ns.RF_ApplyFillRotation(bar)
+    return vert
+end
+
 -- Resolve an absorb/heal/max-health style key to a texture path. Built-in
 -- styles come from ABSORB_STYLE_TEX; "sm:" SharedMedia keys (shared with the
 -- Bar Texture dropdown, appended into healthBarTextures) fall through to the
@@ -1482,8 +1525,16 @@ function ns._ApplyHealthBg(d, health, s, unit)
     end
     if not bg then return end
     bg:ClearAllPoints()
-    bg:SetPoint("TOPLEFT", health:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
-    bg:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+    -- The bg covers only the MISSING health, so it hangs off the far side of the
+    -- fill: the fill's right edge normally, its top edge on a vertical bar. Read
+    -- the axis off the bar itself so this needs no settings lookup.
+    if health.GetOrientation and health:GetOrientation() == "VERTICAL" then
+        bg:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
+        bg:SetPoint("BOTTOMRIGHT", health:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
+    else
+        bg:SetPoint("TOPLEFT", health:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
+        bg:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+    end
     if s.healthColorMode == "dark" then
         bg:SetColorTexture(EllesmereUI.GetDarkModeBg())
     else
@@ -1967,6 +2018,7 @@ ns.ApplyModernAbsorbBar = function(bar, mask)
         local base = bar._modernBase
         if base then base:SetAllPoints(fill); base:Show() end
     end
+    ns.RF_ApplyFillRotation(bar)  -- tiled: stays unrotated on a vertical bar
 end
 
 -- Hide the modern solid base whenever a non-modern style is applied so that
@@ -2014,6 +2066,9 @@ local function ApplyAbsorbStyle(absorbBar, style, settings)
         fill:SetVertTile(tiled)
         if mask then fill:AddMaskTexture(mask) end
     end
+    -- New fill object + new tiling state: re-derive rotation (stretch styles
+    -- rotate on a vertical bar, tiled ones must not).
+    ns.RF_ApplyFillRotation(absorbBar)
     if fw then
         fw:SetStatusBarTexture(tex)
         fw:SetStatusBarColor(ac.r, ac.g, ac.b, alpha)
@@ -2024,6 +2079,7 @@ local function ApplyAbsorbStyle(absorbBar, style, settings)
             fwFill:SetVertTile(tiled)
             if mask then fwFill:AddMaskTexture(mask) end
         end
+        ns.RF_ApplyFillRotation(fw)
     end
 end
 
@@ -2046,6 +2102,7 @@ ns.ApplyHealAbsorbStyle = function(haBar, style, settings)
         fill:SetVertTile(tiled)
         if mask then fill:AddMaskTexture(mask) end
     end
+    ns.RF_ApplyFillRotation(haBar)
 end
 
 -- Reduced max-health overlay style. A 1:1 set of the heal-absorb textures plus
@@ -2075,6 +2132,7 @@ ns.ApplyMaxHealthStyle = function(bar, style, settings)
         fill:SetHorizTile(tiled)
         fill:SetVertTile(tiled)
     end
+    ns.RF_ApplyFillRotation(bar)
 end
 
 -------------------------------------------------------------------------------
@@ -2216,12 +2274,104 @@ local function CreateAbsorbBar(button, healthBar)
     -- nil guards inside ReanchorAbsorbToFill simply skip them. Without this,
     -- they resolved to globals (nil) inside the closure, so the heal absorb
     -- never re-anchored to the right edge in "Show Absorbs from Right Edge".
-    local healAbsorbBar, healPredBar, healClip
+    -- reducedBar joins them: ReanchorAbsorbToFill flips its orientation too, and
+    -- an undeclared name inside the closure would resolve to a nil global.
+    local healAbsorbBar, healPredBar, healClip, reducedBar
 
     -- Re-anchor clip frames and forward bar to the current health fill texture.
     -- Must be called whenever SetStatusBarTexture replaces the fill object.
     local function ReanchorAbsorbToFill()
         local fill = healthBar:GetStatusBarTexture()
+
+        -- Vertical fill: the whole HP cluster rotates with the health bar. Every
+        -- anchor below is the horizontal layout with its axis swapped -- the
+        -- fill's RIGHT edge (the "HP edge" the shields, heal absorb and heal
+        -- prediction hang off) becomes its TOP edge, and the frame's right/left
+        -- edges become its top/bottom. Resolved live off the button's own
+        -- settings source so party frames honour their own Health Bar section.
+        local vs = d._isParty and ns._scaledPartyProxy
+            or (d._isExtra and ns._scaledExtraProxy) or ns._scaledProfile
+        local isVert = ns.RF_ApplyHealthOrientation(healthBar, vs)
+        backfillBar._axisVert = isVert  -- read by the blizzardModern spark block
+        -- Indexed, not ipairs: the creation-time call runs before the heal/max
+        -- bars exist, and ipairs would stop at the first nil.
+        local axisBars = { backfillBar, forwardBar, healAbsorbBar, healPredBar, reducedBar }
+        for i = 1, 5 do
+            local b = axisBars[i]
+            if b then
+                b:SetOrientation(isVert and "VERTICAL" or "HORIZONTAL")
+                ns.RF_ApplyFillRotation(b)  -- derived: rotate stretch styles only
+            end
+        end
+
+        if isVert then
+            curClip:ClearAllPoints()
+            curClip:SetPoint("BOTTOMLEFT", healthBar, "BOTTOMLEFT", 0, 0)
+            curClip:SetPoint("TOPRIGHT", fill, "TOPRIGHT", 0, 0)
+            missClip:ClearAllPoints()
+            missClip:SetPoint("BOTTOMLEFT", fill, "TOPLEFT", 0, -1)
+            missClip:SetPoint("TOPRIGHT", healthBar, "TOPRIGHT", 0, 0)
+            forwardBar:ClearAllPoints()
+            forwardBar:SetPoint("BOTTOMLEFT", fill, "TOPLEFT", 0, 0)
+            forwardBar:SetPoint("BOTTOMRIGHT", fill, "TOPRIGHT", 0, 0)
+            if healPredBar then
+                healPredBar:ClearAllPoints()
+                healPredBar:SetPoint("BOTTOMLEFT", fill, "TOPLEFT", 0, 0)
+                healPredBar:SetPoint("BOTTOMRIGHT", fill, "TOPRIGHT", 0, 0)
+            end
+            -- Edge modes keep their key names: "right" is the far edge of the
+            -- fill axis (the top when vertical), "left" the near one (bottom).
+            local vAbsorbMode = db.profile.absorbEdgeMode or "overlay"
+            backfillBar:ClearAllPoints()
+            if vAbsorbMode == "right" or vAbsorbMode == "left" then
+                curClip:ClearAllPoints()
+                curClip:SetPoint("TOPLEFT", healthBar, "TOPLEFT", 0, 0)
+                curClip:SetPoint("BOTTOMRIGHT", healthBar, "BOTTOMRIGHT", 0, 0)
+                if vAbsorbMode == "left" then
+                    backfillBar:SetReverseFill(false)
+                    backfillBar:SetPoint("BOTTOMLEFT", healthBar, "BOTTOMLEFT", 0, 0)
+                    backfillBar:SetPoint("BOTTOMRIGHT", healthBar, "BOTTOMRIGHT", 0, 0)
+                else
+                    backfillBar:SetReverseFill(true)
+                    backfillBar:SetPoint("TOPLEFT", healthBar, "TOPLEFT", 0, 0)
+                    backfillBar:SetPoint("TOPRIGHT", healthBar, "TOPRIGHT", 0, 0)
+                end
+            else
+                backfillBar:SetReverseFill(true)
+                backfillBar:SetPoint("TOPLEFT", healthBar, "TOPLEFT", 0, 0)
+                backfillBar:SetPoint("TOPRIGHT", healthBar, "TOPRIGHT", 0, 0)
+            end
+
+            if healAbsorbBar then
+                local vHealMode = db.profile.healAbsorbEdgeMode or "overlay"
+                if healClip then
+                    healClip:ClearAllPoints()
+                    if vHealMode == "right" or vHealMode == "left" then
+                        healClip:SetPoint("TOPLEFT", healthBar, "TOPLEFT", 0, 0)
+                        healClip:SetPoint("BOTTOMRIGHT", healthBar, "BOTTOMRIGHT", 0, 0)
+                    else
+                        healClip:SetPoint("BOTTOMLEFT", healthBar, "BOTTOMLEFT", 0, 0)
+                        healClip:SetPoint("TOPRIGHT", fill, "TOPRIGHT", 0, 0)
+                    end
+                end
+                healAbsorbBar:ClearAllPoints()
+                if vHealMode == "right" then
+                    healAbsorbBar:SetReverseFill(true)
+                    healAbsorbBar:SetPoint("TOPLEFT", healthBar, "TOPLEFT", 0, 0)
+                    healAbsorbBar:SetPoint("TOPRIGHT", healthBar, "TOPRIGHT", 0, 0)
+                elseif vHealMode == "left" then
+                    healAbsorbBar:SetReverseFill(false)
+                    healAbsorbBar:SetPoint("BOTTOMLEFT", healthBar, "BOTTOMLEFT", 0, 0)
+                    healAbsorbBar:SetPoint("BOTTOMRIGHT", healthBar, "BOTTOMRIGHT", 0, 0)
+                else
+                    healAbsorbBar:SetReverseFill(true)
+                    healAbsorbBar:SetPoint("TOPLEFT", fill, "TOPLEFT", 0, 0)
+                    healAbsorbBar:SetPoint("TOPRIGHT", fill, "TOPRIGHT", 0, 0)
+                end
+            end
+            return
+        end
+
         curClip:ClearAllPoints()
         curClip:SetPoint("TOPLEFT", healthBar, "TOPLEFT", 0, 0)
         curClip:SetPoint("BOTTOMRIGHT", fill, "BOTTOMRIGHT", 0, 0)
@@ -2361,7 +2511,8 @@ local function CreateAbsorbBar(button, healthBar)
     healPredBar:Hide()
 
     -- Reduced max health bar: black bg + red striped overlay on right side
-    local reducedBar = CreateFrame("StatusBar", nil, healthBar)
+    -- (forward-declared above so ReanchorAbsorbToFill can reach it).
+    reducedBar = CreateFrame("StatusBar", nil, healthBar)
     reducedBar:SetStatusBarTexture("Interface\\AddOns\\EllesmereUIRaidFrames\\Media\\striped-maxhp.png")
     local rmhFill = reducedBar:GetStatusBarTexture()
     if rmhFill then
@@ -2747,7 +2898,14 @@ local function UpdateAbsorb(button, unit)
     -- while overshielding. isClamped (the Missing-Health-clamp overshield boolean) flips
     -- between them secret-safely, so exactly one is ever visible.
     if absStyle == "blizzardModern" then
-        if fw then
+        -- Vertical fill: the shield itself rotates, but these two edge glows are
+        -- 16px-wide strips pinned to the shield's LEFT edge and re-sized to the
+        -- bar height on every update, so they cannot follow a vertical seam.
+        -- Hide them rather than render a sideways glow; the shield is unaffected.
+        if ab._axisVert and fw then
+            if fw._edgeSpark then fw._edgeSpark:Hide() end
+            if fw._bfSpark then fw._bfSpark:Hide() end
+        elseif fw then
             -- Fill-rect anchors are permanent (statusbar textures persist
             -- across SetValue); sizes are size-gated; the overshield spark's
             -- anchor moves only when the Show Overshield toggle flips.
@@ -3082,6 +3240,10 @@ local function StyleButton(button)
     health:SetStatusBarTexture(texPath)
     health:GetStatusBarTexture():SetHorizTile(false)
     if PP then PP.DisablePixelSnap(health) end
+    -- Fill axis. StyleButton runs before d._isParty is set, so this uses the raid
+    -- value; ReanchorAbsorbToFill re-resolves it against the button's real
+    -- settings source (raid / party / extra) on every update.
+    ns.RF_ApplyHealthOrientation(health, s)
     health:SetMinMaxValues(0, 100)
     health:SetValue(100)
     d.health = health
@@ -7037,6 +7199,10 @@ FB.ApplyStyle = function(owner)
         b._health:SetStatusBarTexture(texPath)
         local ft = b._health:GetStatusBarTexture()
         if ft then ft:SetHorizTile(false) end
+        -- Fill axis follows the raid Health Bar setting, like every other
+        -- element these buttons borrow. The bg is a full-button texture here
+        -- (not fill-tracking), so nothing else needs re-anchoring.
+        ns.RF_ApplyHealthOrientation(b._health, s)
         -- No power bar / top name bar here: health fills the button.
         b._health:SetHeight(h)
 
@@ -10557,6 +10723,7 @@ do
             "customFillColor", "dynamicColor100", "dynamicColor50", "dynamicColor0",
             "customBgColor", "bgClassColored", "bgDarkness", "smoothBars",
             "healPrediction", "healPredOpacity", "healPredColor",
+            "healthVerticalFill",
         },
         absorbs = {
             "absorbStyle", "absorbOpacity", "absorbColor", "absorbEdgeMode", "showOvershield",
@@ -13601,6 +13768,7 @@ local function ApplyPreviewData(f, index)
     if f._health then
         f._health:SetStatusBarTexture(ResolveHealthTexture())
         f._health:GetStatusBarTexture():SetHorizTile(false)
+        ns.RF_ApplyHealthOrientation(f._health, s)
         f._health:SetMinMaxValues(0, 100)
         f._health:SetValue(healthPct)
         f._healthPct = healthPct
@@ -13648,18 +13816,27 @@ local function ApplyPreviewData(f, index)
 
     -- Background
     if f._bg then
-        if s.healthColorMode == "dark" then
+        -- BG covers the missing-health portion only (never behind the fill), so
+        -- it hangs off the far side of the fill -- its right edge normally, its
+        -- top edge on a vertical bar. Mirrors the live UpdateHealthBg.
+        local pvVert = ns.RF_IsVerticalFill(s)
+        local function AnchorPreviewBg()
             f._bg:ClearAllPoints()
-            f._bg:SetPoint("TOPLEFT", f._health:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
-            f._bg:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+            if pvVert then
+                f._bg:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                f._bg:SetPoint("BOTTOMRIGHT", f._health:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
+            else
+                f._bg:SetPoint("TOPLEFT", f._health:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
+                f._bg:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+            end
+        end
+        if s.healthColorMode == "dark" then
+            AnchorPreviewBg()
             f._bg:SetColorTexture(EllesmereUI.GetDarkModeBg())
         else
-            -- BG covers the missing-health portion only (never behind the fill),
-            -- matching the real-frame themed branch + Dark mode. Keeps the preview
+            -- Matches the real-frame themed branch + Dark mode. Keeps the preview
             -- a 1:1 replica for reduced-fill-opacity setups.
-            f._bg:ClearAllPoints()
-            f._bg:SetPoint("TOPLEFT", f._health:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
-            f._bg:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+            AnchorPreviewBg()
             local bgA = (s.bgDarkness or 50) / 100
             local cc = s.bgClassColored and classToken and EllesmereUI.GetClassColor(classToken)
             if cc then
@@ -13800,7 +13977,11 @@ local function ApplyPreviewData(f, index)
             -- "Default Blizz Frames": seam spark + overshield spark (preview values are
             -- plain numbers, so overshield is a normal compare instead of isClamped).
             if modern then
-                if fw then
+                -- Vertical fill hides the two edge glows (see the live path).
+                if ns.RF_IsVerticalFill(s) and fw then
+                    if fw._edgeSpark then fw._edgeSpark:Hide() end
+                    if fw._bfSpark then fw._bfSpark:Hide() end
+                elseif fw then
                     local fmb = fw._modernBase
                     if fmb then fmb:SetAllPoints(fw:GetStatusBarTexture()) end
                     local previewOver = absorbAmt > (100 - (healthPct or 100))
@@ -13843,7 +14024,52 @@ local function ApplyPreviewData(f, index)
         local mc = f._absorbBar._missClip
         if cc and mc and f._health then
             local absorbMode = s.absorbEdgeMode or "overlay"
-            if absorbMode == "right" or absorbMode == "left" then
+            -- Vertical fill: same layout with the axis swapped (the fill's right
+            -- edge becomes its top edge). Mirrors the live vertical branch.
+            local pvAbVert = ns.RF_IsVerticalFill(s)
+            local pvAxisBars = { f._absorbBar, fw }
+            for i = 1, 2 do
+                local b = pvAxisBars[i]
+                if b then
+                    b:SetOrientation(pvAbVert and "VERTICAL" or "HORIZONTAL")
+                    ns.RF_ApplyFillRotation(b)
+                end
+            end
+            if pvAbVert then
+                local vfill = f._health:GetStatusBarTexture()
+                if absorbMode == "right" or absorbMode == "left" then
+                    cc:ClearAllPoints()
+                    cc:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                    cc:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+                    f._absorbBar:ClearAllPoints()
+                    if absorbMode == "left" then
+                        f._absorbBar:SetReverseFill(false)
+                        f._absorbBar:SetPoint("BOTTOMLEFT", f._health, "BOTTOMLEFT", 0, 0)
+                        f._absorbBar:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+                    else
+                        f._absorbBar:SetReverseFill(true)
+                        f._absorbBar:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                        f._absorbBar:SetPoint("TOPRIGHT", f._health, "TOPRIGHT", 0, 0)
+                    end
+                    if fw then fw:Hide() end
+                else
+                    cc:ClearAllPoints()
+                    cc:SetPoint("BOTTOMLEFT", f._health, "BOTTOMLEFT", 0, 0)
+                    cc:SetPoint("TOPRIGHT", vfill, "TOPRIGHT", 0, 0)
+                    mc:ClearAllPoints()
+                    mc:SetPoint("BOTTOMLEFT", vfill, "TOPLEFT", 0, -1)
+                    mc:SetPoint("TOPRIGHT", f._health, "TOPRIGHT", 0, 0)
+                    f._absorbBar:SetReverseFill(true)
+                    f._absorbBar:ClearAllPoints()
+                    f._absorbBar:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                    f._absorbBar:SetPoint("TOPRIGHT", f._health, "TOPRIGHT", 0, 0)
+                end
+                if fw then
+                    fw:ClearAllPoints()
+                    fw:SetPoint("BOTTOMLEFT", vfill, "TOPLEFT", 0, 0)
+                    fw:SetPoint("BOTTOMRIGHT", vfill, "TOPRIGHT", 0, 0)
+                end
+            elseif absorbMode == "right" or absorbMode == "left" then
                 cc:ClearAllPoints()
                 cc:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
                 cc:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
@@ -13871,6 +14097,14 @@ local function ApplyPreviewData(f, index)
                 f._absorbBar:ClearAllPoints()
                 f._absorbBar:SetPoint("TOPRIGHT", f._health, "TOPRIGHT", 0, 0)
                 f._absorbBar:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+            end
+            -- Restore the forward bar's horizontal anchors (the vertical branch
+            -- above re-points it, and these are otherwise only set at creation).
+            if not pvAbVert and fw then
+                local hfill = f._health:GetStatusBarTexture()
+                fw:ClearAllPoints()
+                fw:SetPoint("TOPLEFT", hfill, "TOPRIGHT", 0, 0)
+                fw:SetPoint("BOTTOMLEFT", hfill, "BOTTOMRIGHT", 0, 0)
             end
         end
     end
@@ -13920,30 +14154,62 @@ local function ApplyPreviewData(f, index)
         -- Heal absorb placement (independent of shield absorb; mirrors live).
         if f._health then
             local healMode = s.healAbsorbEdgeMode or "overlay"
-            if f._healClip then
-                f._healClip:ClearAllPoints()
-                if healMode == "right" or healMode == "left" then
-                    f._healClip:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
-                    f._healClip:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
-                else
-                    f._healClip:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
-                    f._healClip:SetPoint("BOTTOMRIGHT", f._health:GetStatusBarTexture(), "BOTTOMRIGHT", 0, 0)
+            -- Vertical fill: same layout, axis swapped (mirrors the live branch).
+            local pvHaVert = ns.RF_IsVerticalFill(s)
+            f._healAbsorbBar:SetOrientation(pvHaVert and "VERTICAL" or "HORIZONTAL")
+            ns.RF_ApplyFillRotation(f._healAbsorbBar)
+            if pvHaVert then
+                local vfill = f._health:GetStatusBarTexture()
+                if f._healClip then
+                    f._healClip:ClearAllPoints()
+                    if healMode == "right" or healMode == "left" then
+                        f._healClip:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                        f._healClip:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+                    else
+                        f._healClip:SetPoint("BOTTOMLEFT", f._health, "BOTTOMLEFT", 0, 0)
+                        f._healClip:SetPoint("TOPRIGHT", vfill, "TOPRIGHT", 0, 0)
+                    end
                 end
-            end
-            f._healAbsorbBar:ClearAllPoints()
-            if healMode == "right" then
-                f._healAbsorbBar:SetReverseFill(true)
-                f._healAbsorbBar:SetPoint("TOPRIGHT", f._health, "TOPRIGHT", 0, 0)
-                f._healAbsorbBar:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
-            elseif healMode == "left" then
-                f._healAbsorbBar:SetReverseFill(false)
-                f._healAbsorbBar:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
-                f._healAbsorbBar:SetPoint("BOTTOMLEFT", f._health, "BOTTOMLEFT", 0, 0)
+                f._healAbsorbBar:ClearAllPoints()
+                if healMode == "right" then
+                    f._healAbsorbBar:SetReverseFill(true)
+                    f._healAbsorbBar:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                    f._healAbsorbBar:SetPoint("TOPRIGHT", f._health, "TOPRIGHT", 0, 0)
+                elseif healMode == "left" then
+                    f._healAbsorbBar:SetReverseFill(false)
+                    f._healAbsorbBar:SetPoint("BOTTOMLEFT", f._health, "BOTTOMLEFT", 0, 0)
+                    f._healAbsorbBar:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+                else
+                    f._healAbsorbBar:SetReverseFill(true)
+                    f._healAbsorbBar:SetPoint("TOPLEFT", vfill, "TOPLEFT", 0, 0)
+                    f._healAbsorbBar:SetPoint("TOPRIGHT", vfill, "TOPRIGHT", 0, 0)
+                end
             else
-                local fill = f._health:GetStatusBarTexture()
-                f._healAbsorbBar:SetReverseFill(true)
-                f._healAbsorbBar:SetPoint("TOPRIGHT", fill, "TOPRIGHT", 0, 0)
-                f._healAbsorbBar:SetPoint("BOTTOMRIGHT", fill, "BOTTOMRIGHT", 0, 0)
+                if f._healClip then
+                    f._healClip:ClearAllPoints()
+                    if healMode == "right" or healMode == "left" then
+                        f._healClip:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                        f._healClip:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+                    else
+                        f._healClip:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                        f._healClip:SetPoint("BOTTOMRIGHT", f._health:GetStatusBarTexture(), "BOTTOMRIGHT", 0, 0)
+                    end
+                end
+                f._healAbsorbBar:ClearAllPoints()
+                if healMode == "right" then
+                    f._healAbsorbBar:SetReverseFill(true)
+                    f._healAbsorbBar:SetPoint("TOPRIGHT", f._health, "TOPRIGHT", 0, 0)
+                    f._healAbsorbBar:SetPoint("BOTTOMRIGHT", f._health, "BOTTOMRIGHT", 0, 0)
+                elseif healMode == "left" then
+                    f._healAbsorbBar:SetReverseFill(false)
+                    f._healAbsorbBar:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
+                    f._healAbsorbBar:SetPoint("BOTTOMLEFT", f._health, "BOTTOMLEFT", 0, 0)
+                else
+                    local fill = f._health:GetStatusBarTexture()
+                    f._healAbsorbBar:SetReverseFill(true)
+                    f._healAbsorbBar:SetPoint("TOPRIGHT", fill, "TOPRIGHT", 0, 0)
+                    f._healAbsorbBar:SetPoint("BOTTOMRIGHT", fill, "BOTTOMRIGHT", 0, 0)
+                end
             end
         end
     end
@@ -13960,6 +14226,25 @@ local function ApplyPreviewData(f, index)
             f._healPredBar:SetStatusBarColor(pc.r, pc.g, pc.b, pAlpha)
             f._healPredBar:SetWidth(w)
             f._healPredBar:SetHeight(healthH)
+            -- Grows from the HP edge into the missing health: the fill's right
+            -- edge normally, its top edge on a vertical bar. Only set at creation
+            -- otherwise, so both axes are re-applied here.
+            do
+                local pvPredVert = ns.RF_IsVerticalFill(s)
+                local pFill = f._health and f._health:GetStatusBarTexture()
+                f._healPredBar:SetOrientation(pvPredVert and "VERTICAL" or "HORIZONTAL")
+                ns.RF_ApplyFillRotation(f._healPredBar)
+                if pFill then
+                    f._healPredBar:ClearAllPoints()
+                    if pvPredVert then
+                        f._healPredBar:SetPoint("BOTTOMLEFT", pFill, "TOPLEFT", 0, 0)
+                        f._healPredBar:SetPoint("BOTTOMRIGHT", pFill, "TOPRIGHT", 0, 0)
+                    else
+                        f._healPredBar:SetPoint("TOPLEFT", pFill, "TOPRIGHT", 0, 0)
+                        f._healPredBar:SetPoint("BOTTOMLEFT", pFill, "BOTTOMRIGHT", 0, 0)
+                    end
+                end
+            end
             f._healPredBar:SetMinMaxValues(0, 100)
             f._healPredBar:SetValue(predAmt)
             f._healPredBar:Show()
@@ -13978,6 +14263,11 @@ local function ApplyPreviewData(f, index)
             or (not ns._testMode and not ns._indicatorsVisible and ns._absorbsPreviewVisible)
         if rmhShow and rmhAmt > 0 and rmhStyle ~= "none" then
             ns.ApplyMaxHealthStyle(f._reducedMaxHealthBar, rmhStyle, s)
+            do  -- eats the far end of the bar: the right edge, or the top when vertical
+                local pvRmhVert = ns.RF_IsVerticalFill(s)
+                f._reducedMaxHealthBar:SetOrientation(pvRmhVert and "VERTICAL" or "HORIZONTAL")
+                ns.RF_ApplyFillRotation(f._reducedMaxHealthBar)
+            end
             f._reducedMaxHealthBar:SetValue(rmhAmt)
             local rmhBg = f._reducedMaxHealthBg
             if rmhBg then

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -1875,9 +1875,38 @@ initFrame:SetScript("OnEvent", function(self)
         --   right   = pinned to the health bar's right edge, fills leftward
         --   left    = pinned to the health bar's left edge, fills rightward
         -- right/left are absolute (independent of reverse fill); overlay mirrors.
-        local function PositionPreviewAbsorb(bar, mode, isRev)
+        local function PositionPreviewAbsorb(bar, mode, isRev, isVert)
             if not bar then return end
             bar:ClearAllPoints()
+            bar:SetOrientation(isVert and "VERTICAL" or "HORIZONTAL")
+            ns.ApplyFillRotation(bar)
+            if isVert then
+                -- Vertical fill: same rules with the axis swapped. The edge modes
+                -- keep their key names -- "right" is the far edge of the fill axis
+                -- (the top here), "left" the near one (the bottom).
+                if mode == "right" then
+                    bar:SetReverseFill(true)
+                    bar:SetPoint("TOPLEFT",  health, "TOPLEFT",  0, 0)
+                    bar:SetPoint("TOPRIGHT", health, "TOPRIGHT", 0, 0)
+                elseif mode == "left" then
+                    bar:SetReverseFill(false)
+                    bar:SetPoint("BOTTOMLEFT",  health, "BOTTOMLEFT",  0, 0)
+                    bar:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+                elseif isRev then
+                    -- Reverse fill: missing health sits BELOW, so the shield grows
+                    -- down out of the current-HP edge (the health fill's bottom).
+                    bar:SetReverseFill(true)
+                    bar:SetPoint("TOPLEFT",  healthFill, "BOTTOMLEFT",  0, 0)
+                    bar:SetPoint("TOPRIGHT", healthFill, "BOTTOMRIGHT", 0, 0)
+                else
+                    -- Normal fill: missing health sits ABOVE, so the shield grows
+                    -- up out of the current-HP edge (the health fill's top).
+                    bar:SetReverseFill(false)
+                    bar:SetPoint("BOTTOMLEFT",  healthFill, "TOPLEFT",  0, 0)
+                    bar:SetPoint("BOTTOMRIGHT", healthFill, "TOPRIGHT", 0, 0)
+                end
+                return
+            end
             if mode == "right" then
                 bar:SetReverseFill(true)
                 bar:SetPoint("TOPRIGHT",    health, "TOPRIGHT",    0, 0)
@@ -1944,7 +1973,7 @@ initFrame:SetScript("OnEvent", function(self)
                 absFillTex:SetHorizTile(absTiled); absFillTex:SetVertTile(absTiled)
             end
             absorbBar:SetStatusBarColor(ac.r, ac.g, ac.b, alpha)
-            PositionPreviewAbsorb(absorbBar, settings.absorbEdgeMode or "overlay", settings.healthReverseFill)
+            PositionPreviewAbsorb(absorbBar, settings.absorbEdgeMode or "overlay", settings.healthReverseFill, settings.healthVerticalFill)
             PP.Width(absorbBar, frameW)
             PP.Height(absorbBar, healthH)
             absorbBar:SetMinMaxValues(0, 1)
@@ -1969,7 +1998,7 @@ initFrame:SetScript("OnEvent", function(self)
                 haFillTex:SetHorizTile(haTiled); haFillTex:SetVertTile(haTiled)
             end
             healAbsorbBar:SetStatusBarColor(hc.r, hc.g, hc.b, haAlpha)
-            PositionPreviewAbsorb(healAbsorbBar, settings.healAbsorbEdgeMode or "overlay", settings.healthReverseFill)
+            PositionPreviewAbsorb(healAbsorbBar, settings.healAbsorbEdgeMode or "overlay", settings.healthReverseFill, settings.healthVerticalFill)
             PP.Width(healAbsorbBar, frameW)
             PP.Height(healAbsorbBar, healthH)
             healAbsorbBar:SetMinMaxValues(0, 1)
@@ -2333,14 +2362,30 @@ initFrame:SetScript("OnEvent", function(self)
                 if portraitFrame then portraitFrame._anchored = false end
             end
             healthFill:ClearAllPoints()
-            if s.healthReverseFill then
-                healthFill:SetPoint("TOPRIGHT", health, "TOPRIGHT", 0, 0)
-                healthFill:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+            -- Vertical Fill swaps the preview's fill axis to match the live bar:
+            -- the fill grows up from the bottom, and Reverse Fill flips it to
+            -- grow down from the top. The two anchors always sit on the axis the
+            -- fill does NOT grow along, so the other dimension comes from the
+            -- explicit PP.Width / PP.Height below.
+            if s.healthVerticalFill then
+                if s.healthReverseFill then
+                    healthFill:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
+                    healthFill:SetPoint("TOPRIGHT", health, "TOPRIGHT", 0, 0)
+                else
+                    healthFill:SetPoint("BOTTOMLEFT", health, "BOTTOMLEFT", 0, 0)
+                    healthFill:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+                end
+                PP.Height(healthFill, math.floor(hh * (_previewHealthPct or 0.70) + 0.5))
             else
-                healthFill:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
-                healthFill:SetPoint("BOTTOMLEFT", health, "BOTTOMLEFT", 0, 0)
+                if s.healthReverseFill then
+                    healthFill:SetPoint("TOPRIGHT", health, "TOPRIGHT", 0, 0)
+                    healthFill:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+                else
+                    healthFill:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
+                    healthFill:SetPoint("BOTTOMLEFT", health, "BOTTOMLEFT", 0, 0)
+                end
+                PP.Width(healthFill, math.floor(fw * (_previewHealthPct or 0.70) + 0.5))
             end
-            PP.Width(healthFill, math.floor(fw * (_previewHealthPct or 0.70) + 0.5))
 
             -- Live-update dark mode colors
             do
@@ -2395,13 +2440,24 @@ initFrame:SetScript("OnEvent", function(self)
                 -- backdrop, not the bg color. Mirrors the live frame edge-anchor.
                 healthBgColor:ClearAllPoints()
                 do
-                    local hpW = math.floor(fw * (_previewHealthPct or 0.70) + 0.5)
-                    if s.healthReverseFill then
-                        healthBgColor:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
-                        healthBgColor:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", -hpW, 0)
+                    if s.healthVerticalFill then
+                        local hpH = math.floor(hh * (_previewHealthPct or 0.70) + 0.5)
+                        if s.healthReverseFill then
+                            healthBgColor:SetPoint("TOPLEFT", health, "TOPLEFT", 0, -hpH)
+                            healthBgColor:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+                        else
+                            healthBgColor:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
+                            healthBgColor:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, hpH)
+                        end
                     else
-                        healthBgColor:SetPoint("TOPLEFT", health, "TOPLEFT", hpW, 0)
-                        healthBgColor:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+                        local hpW = math.floor(fw * (_previewHealthPct or 0.70) + 0.5)
+                        if s.healthReverseFill then
+                            healthBgColor:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
+                            healthBgColor:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", -hpW, 0)
+                        else
+                            healthBgColor:SetPoint("TOPLEFT", health, "TOPLEFT", hpW, 0)
+                            healthBgColor:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+                        end
                     end
                 end
                 healthBgColor:SetColorTexture(uBgR, uBgG, uBgB, 1)
@@ -3022,7 +3078,7 @@ initFrame:SetScript("OnEvent", function(self)
                         _paFill:SetHorizTile(_paTiled); _paFill:SetVertTile(_paTiled)
                     end
                     absorbBar:SetStatusBarColor(_paC.r, _paC.g, _paC.b, _paA)
-                    PositionPreviewAbsorb(absorbBar, s.absorbEdgeMode or "overlay", s.healthReverseFill)
+                    PositionPreviewAbsorb(absorbBar, s.absorbEdgeMode or "overlay", s.healthReverseFill, s.healthVerticalFill)
                     absorbBar:SetWidth(fw)
                     absorbBar:SetHeight(hh)
                     absorbBar:Show()
@@ -3044,7 +3100,7 @@ initFrame:SetScript("OnEvent", function(self)
                         _haFill:SetHorizTile(_haTiled); _haFill:SetVertTile(_haTiled)
                     end
                     healAbsorbBar:SetStatusBarColor(_haC.r, _haC.g, _haC.b, _haA)
-                    PositionPreviewAbsorb(healAbsorbBar, s.healAbsorbEdgeMode or "overlay", s.healthReverseFill)
+                    PositionPreviewAbsorb(healAbsorbBar, s.healAbsorbEdgeMode or "overlay", s.healthReverseFill, s.healthVerticalFill)
                     healAbsorbBar:SetWidth(fw)
                     healAbsorbBar:SetHeight(hh)
                     healAbsorbBar:Show()
@@ -5764,6 +5820,15 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="toggle", label="Reverse Fill",
                       get=function() return SVal("healthReverseFill", false) end,
                       set=function(v) SSet("healthReverseFill", v); ReloadAndUpdate(); UpdatePreview() end },
+                    -- Vertical Fill swaps the bar's fill AXIS; Reverse Fill still
+                    -- flips the direction within it (bottom-to-top by default,
+                    -- top-to-bottom when reversed).
+                    { type="toggle", label="Vertical Fill",
+                      tooltip="Fill the health bar bottom-to-top instead of left-to-right. Reverse Fill flips it to top-to-bottom.",
+                      get=function() return SVal("healthVerticalFill", false) end,
+                      -- RefreshPage re-labels the Absorbs Placement dropdowns for
+                      -- the new axis (cog popups bake labels in on first build).
+                      set=function(v) SSet("healthVerticalFill", v); ReloadAndUpdate(); UpdatePreview(); EllesmereUI:RefreshPage() end },
                 },
             })
             MakeCogBtn(rgn, revCogShow)
@@ -11002,13 +11067,35 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline cog: absorb placement (overlay / right edge / left edge)
         do
             local rgn = absorbRow._leftRegion
+            -- Placement labels follow the FILL AXIS. The saved values stay right/left --
+            -- they have always meant the FAR / NEAR end of the fill -- but on a vertical
+            -- bar "From Left Edge" describes nothing, so the wording becomes top/bottom.
+            -- MUTATED IN PLACE, never rebuilt: RefreshPage's fast path does not rebuild
+            -- the page, and a cog popup is built once then cached, so a freshly-built
+            -- table would never reach the widget. The popup re-reads values[get()] on
+            -- every show, and _invalidateMenu makes an already-built menu rebuild its
+            -- entries from this same table on the next click.
+            local absorbEdgeLabels = { overlay = "Overlay" }
+            local absorbEdgeLabelsVert  -- last applied axis; nil until the first sync
+            -- Returns true only when the axis actually flipped, so the caller can
+            -- skip _invalidateMenu on unrelated refreshes (it nils the cached menu
+            -- and would break the wired click if one were open).
+            local function SyncAbsorbEdgeLabels()
+                local vert = (SValSupported("healthVerticalFill", false)) and true or false
+                if absorbEdgeLabelsVert == vert then return false end
+                absorbEdgeLabelsVert = vert
+                absorbEdgeLabels.right = vert and "From Top Edge"    or "From Right Edge"
+                absorbEdgeLabels.left  = vert and "From Bottom Edge" or "From Left Edge"
+                return true
+            end
+            SyncAbsorbEdgeLabels()
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Absorb Rendering",
                 rows = {
                     { type="dropdown", label="Placement",
-                      values = { overlay = "Overlay", right = "From Right Edge", left = "From Left Edge" },
+                      values = absorbEdgeLabels,
                       order = { "overlay", "right", "left" },
-                      get=function() return SValSupported("absorbEdgeMode", "overlay") end,
+                      get=function() SyncAbsorbEdgeLabels(); return SValSupported("absorbEdgeMode", "overlay") end,
                       set=function(v) SSetSupported("absorbEdgeMode", v) end },
                     { type="toggle", label="Show Overshield",
                       tooltip="Show the part of an absorb that exceeds your empty health and backfills over your current health. When off, absorbs only fill the empty part of the health bar.",
@@ -11029,6 +11116,17 @@ initFrame:SetScript("OnEvent", function(self)
                       end },
                 },
             })
+            -- Re-label on every page refresh (the Vertical Fill toggle fires one) and
+            -- drop any built menu so its entries rebuild with the new wording.
+            RegisterWidgetRefresh(function()
+                if not SyncAbsorbEdgeLabels() then return end
+                local pf = cogShow and cogShow._popupFrame
+                if pf and pf.GetChildren then
+                    for _, child in ipairs({ pf:GetChildren() }) do
+                        if child._invalidateMenu then child._invalidateMenu() end
+                    end
+                end
+            end)
             MakeCogBtn(rgn, cogShow)
         end
         -- Sync icon: Absorb Style + color swatch + cog settings across all frames
@@ -11147,19 +11245,52 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline cog: heal absorb placement (independent of shield absorb)
         do
             local rgn = healAbsorbRow._leftRegion
+            -- Placement labels follow the FILL AXIS. The saved values stay right/left --
+            -- they have always meant the FAR / NEAR end of the fill -- but on a vertical
+            -- bar "From Left Edge" describes nothing, so the wording becomes top/bottom.
+            -- MUTATED IN PLACE, never rebuilt: RefreshPage's fast path does not rebuild
+            -- the page, and a cog popup is built once then cached, so a freshly-built
+            -- table would never reach the widget. The popup re-reads values[get()] on
+            -- every show, and _invalidateMenu makes an already-built menu rebuild its
+            -- entries from this same table on the next click.
+            local healAbsorbEdgeLabels = { overlay = "Overlay" }
+            local healAbsorbEdgeLabelsVert  -- last applied axis; nil until the first sync
+            -- Returns true only when the axis actually flipped, so the caller can
+            -- skip _invalidateMenu on unrelated refreshes (it nils the cached menu
+            -- and would break the wired click if one were open).
+            local function SyncHealAbsorbEdgeLabels()
+                local vert = (SValSupported("healthVerticalFill", false)) and true or false
+                if healAbsorbEdgeLabelsVert == vert then return false end
+                healAbsorbEdgeLabelsVert = vert
+                healAbsorbEdgeLabels.right = vert and "From Top Edge"    or "From Right Edge"
+                healAbsorbEdgeLabels.left  = vert and "From Bottom Edge" or "From Left Edge"
+                return true
+            end
+            SyncHealAbsorbEdgeLabels()
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Heal Absorb Rendering",
                 rows = {
                     { type="dropdown", label="Placement",
-                      values = { overlay = "Overlay", right = "From Right Edge", left = "From Left Edge" },
+                      values = healAbsorbEdgeLabels,
                       order = { "overlay", "right", "left" },
-                      get=function() return SValSupported("healAbsorbEdgeMode", "overlay") end,
+                      get=function() SyncHealAbsorbEdgeLabels(); return SValSupported("healAbsorbEdgeMode", "overlay") end,
                       set=function(v) SSetSupported("healAbsorbEdgeMode", v) end },
                     { type="slider", label="Backing Opacity", min=0, max=100, step=1,
                       get=function() return SValSupported("healAbsorbBgOpacity", 15) end,
                       set=function(v) SSetSupported("healAbsorbBgOpacity", v) end },
                 },
             })
+            -- Re-label on every page refresh (the Vertical Fill toggle fires one) and
+            -- drop any built menu so its entries rebuild with the new wording.
+            RegisterWidgetRefresh(function()
+                if not SyncHealAbsorbEdgeLabels() then return end
+                local pf = cogShow and cogShow._popupFrame
+                if pf and pf.GetChildren then
+                    for _, child in ipairs({ pf:GetChildren() }) do
+                        if child._invalidateMenu then child._invalidateMenu() end
+                    end
+                end
+            end)
             MakeCogBtn(rgn, cogShow)
         end
         -- Sync icon: Heal Absorb Style + color swatch + cog settings across all frames
@@ -12570,6 +12701,17 @@ initFrame:SetScript("OnEvent", function(self)
                 RegisterWidgetRefresh(function() bgSwUpdate() end)
             end
         end
+
+        -- Vertical Fill: swaps the health bar's fill AXIS. Reverse Fill (above)
+        -- still flips the direction within it, so vertical + reverse fills
+        -- top-to-bottom. Its own row -- both mini and boss layouts already fill
+        -- both halves of the Reverse Fill row.
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Vertical Fill",
+              tooltip="Fill the health bar bottom-to-top instead of left-to-right. Reverse Fill flips it to top-to-bottom.",
+              getValue=function() return settingsTable.healthVerticalFill end,
+              setValue=function(v) settingsTable.healthVerticalFill = v; ReloadAndUpdate() end },
+            { type="spacer" });  y = y - h
 
         -- Row 3: Left Text + Right Text (with inline swatches + cogs)
         local textRow

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -461,6 +461,7 @@ local defaults = {
             leaderIndicatorX = 0,
             leaderIndicatorY = 0,
             healthReverseFill = false,
+            healthVerticalFill = false,
             smoothBars = false,
             powerReverseFill = false,
         },
@@ -645,6 +646,7 @@ local defaults = {
             leaderIndicatorX = 0,
             leaderIndicatorY = 0,
             healthReverseFill = false,
+            healthVerticalFill = false,
             smoothBars = false,
             powerReverseFill = false,
         },
@@ -697,6 +699,7 @@ local defaults = {
             playerCastbarWidth = 181,
             playerCastbarHeight = 14,
             healthReverseFill = false,
+            healthVerticalFill = false,
             smoothBars = false,
             powerReverseFill = false,
         },
@@ -729,6 +732,7 @@ local defaults = {
             highlightColor = { r = 1, g = 1, b = 1 },
             powerPosition = "none",
             healthReverseFill = false,
+            healthVerticalFill = false,
             smoothBars = false,
         },
         -- Focus Target: independent clone of Target of Target defaults.
@@ -764,6 +768,7 @@ local defaults = {
             highlightColor = { r = 1, g = 1, b = 1 },
             powerPosition = "none",
             healthReverseFill = false,
+            healthVerticalFill = false,
             smoothBars = false,
         },
         pet = {
@@ -795,6 +800,7 @@ local defaults = {
             highlightColor = { r = 1, g = 1, b = 1 },
             powerPosition = "none",
             healthReverseFill = false,
+            healthVerticalFill = false,
             smoothBars = false,
         },
         focus = {
@@ -961,6 +967,7 @@ local defaults = {
             raidMarkerX = 0,
             raidMarkerY = 0,
             healthReverseFill = false,
+            healthVerticalFill = false,
             smoothBars = false,
             powerReverseFill = false,
         },
@@ -1098,6 +1105,7 @@ local defaults = {
             raidMarkerY = 0,
             bossStackDirection = "down",
             healthReverseFill = false,
+            healthVerticalFill = false,
             smoothBars = false,
         },
         enabledFrames = {
@@ -1329,6 +1337,8 @@ local function ApplyHealthBarTexture(health, unitKey, texKeyOverride)
     health:SetStatusBarTexture(path)
     local hFill = health:GetStatusBarTexture()
     if hFill then UnsnapTex(hFill) end
+    -- The swap replaced the fill object; re-derive rotation for the bar's axis.
+    ns.ApplyFillRotation(health)
 
     -- Power bar: same texture. Walk up from health to find the oUF frame
     -- (health may be parented to a clip container, not the oUF frame directly).
@@ -1514,7 +1524,19 @@ local function AnchorHealthBg(health)
     local tex = health and health.GetStatusBarTexture and health:GetStatusBarTexture()
     if not bg or not tex then return end
     bg:ClearAllPoints()
-    if health.GetReverseFill and health:GetReverseFill() then
+    local reversed = health.GetReverseFill and health:GetReverseFill()
+    -- Vertical fill empties on the TOP (or the BOTTOM when reversed); read the
+    -- axis off the bar itself so this needs no settings lookup.
+    local vert = health.GetOrientation and health:GetOrientation() == "VERTICAL"
+    if vert then
+        if reversed then
+            bg:SetPoint("TOPLEFT", tex, "BOTTOMLEFT", 0, 0)
+            bg:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+        else
+            bg:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
+            bg:SetPoint("BOTTOMRIGHT", tex, "TOPRIGHT", 0, 0)
+        end
+    elseif reversed then
         bg:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
         bg:SetPoint("BOTTOMRIGHT", tex, "BOTTOMLEFT", 0, 0)
     else
@@ -3717,6 +3739,41 @@ end
 
 -- ShowFakeFrames / HideFakeFrames removed -- Unlock Mode handles all positioning
 
+-- Fill-texture rotation, DERIVED -- never set on its own, so it can never go
+-- stale against the bar's axis or a texture swap. Two texture families live on
+-- these bars and they want opposite treatment on a vertical bar:
+--
+--   stretch (shield.tga, striped3, blizzard, WHITE8X8, every health texture):
+--     one image scaled to the fill rect. Designed wide-and-short, so on a tall
+--     bar it must be ROTATED or it smears into a stretched mess.
+--   tiled (stripedReversed, the large* stripe sets, striped-maxhp, the modern
+--     absorb): repeats at native pixel size on BOTH axes, so it already reads
+--     correctly at any bar shape. Rotating it fights the tiling and is exactly
+--     what produced the stretched look -- leave these alone.
+--
+-- Tiling is read back off the live fill texture rather than passed in, so this
+-- stays correct no matter which style function last touched the bar.
+function ns.ApplyFillRotation(bar)
+    if not (bar and bar.SetRotatesTexture) then return end
+    local vert = bar.GetOrientation and bar:GetOrientation() == "VERTICAL"
+    local fill = bar.GetStatusBarTexture and bar:GetStatusBarTexture()
+    local tiled = fill and ((fill.GetHorizTile and fill:GetHorizTile())
+                         or (fill.GetVertTile and fill:GetVertTile()))
+    bar:SetRotatesTexture((vert and not tiled) and true or false)
+end
+
+-- Vertical health fill. SetOrientation drives the bar's fill AXIS; the existing
+-- healthReverseFill still flips the direction WITHIN that axis (horizontal:
+-- left-to-right / right-to-left, vertical: bottom-to-top / top-to-bottom).
+-- Exposed on ns so the options preview paints the same way.
+function ns.ApplyHealthOrientation(bar, settings)
+    if not bar then return end
+    local vert = (settings and settings.healthVerticalFill) and true or false
+    bar:SetOrientation(vert and "VERTICAL" or "HORIZONTAL")
+    ns.ApplyFillRotation(bar)
+    return vert
+end
+
 local function CreateHealthBar(frame, unit, height, xOffset, settings, rightInset)
     height = height or settings.healthHeight
     xOffset = xOffset or 0
@@ -3755,6 +3812,7 @@ local function CreateHealthBar(frame, unit, height, xOffset, settings, rightInse
     ApplyHealthBarTexture(health, UnitToSettingsKey(unit))
     ApplyHealthBarAlpha(health, UnitToSettingsKey(unit))
     health:SetReverseFill(settings.healthReverseFill and true or false)
+    ns.ApplyHealthOrientation(health, settings)
     ApplyDarkTheme(health)
 
     -- Smooth bar interpolation (opt-in; defaults off)
@@ -3833,6 +3891,9 @@ local function ApplyAbsorbStyle(absorbBar, style, settings)
         fill:SetVertTile(tiled)
         if mask then fill:AddMaskTexture(mask) end
     end
+    -- New fill object + new tiling state: re-derive rotation (stretch styles
+    -- rotate on a vertical bar, tiled ones must not).
+    ns.ApplyFillRotation(absorbBar)
     local fw = absorbBar._forward
     if fw then
         fw:SetStatusBarTexture(tex)
@@ -3844,6 +3905,7 @@ local function ApplyAbsorbStyle(absorbBar, style, settings)
             fwFill:SetVertTile(tiled)
             if mask then fwFill:AddMaskTexture(mask) end
         end
+        ns.ApplyFillRotation(fw)
     end
 end
 
@@ -3867,6 +3929,7 @@ local function ApplyHealAbsorbStyle(haBar, style, settings)
         fill:SetVertTile(tiled)
         if mask then fill:AddMaskTexture(mask) end
     end
+    ns.ApplyFillRotation(haBar)
 end
 
 -- Two-segment absorb rendering using dynamic clip-frame trickery, so it
@@ -3899,9 +3962,11 @@ end
 -- HealthPrediction.Override so oUF still owns event registration
 -- (UNIT_HEALTH, UNIT_ABSORB_AMOUNT_CHANGED, etc.) and enable/disable.
 
--- Re-anchor existing absorb bars for the current reverse fill state.
--- Called from the live-update path when the user toggles reverse fill.
-local function UpdateAbsorbBarReverseFill(frame, isReversed)
+-- Re-anchor existing absorb bars for the current fill state (reverse + axis).
+-- Called from the live-update path when the user toggles reverse or vertical
+-- fill. `settingsOverride` lets the creation path pass the settings table it
+-- already holds, for frames whose .unit is not resolvable yet.
+local function UpdateAbsorbBarReverseFill(frame, isReversed, settingsOverride)
     if not frame or not frame.HealthPrediction then return end
     local ab = frame.HealthPrediction.damageAbsorb
     if not ab then return end
@@ -3919,14 +3984,116 @@ local function UpdateAbsorbBarReverseFill(frame, isReversed)
     --   overlay = backfill into the filled health from the HP edge (default)
     --   right   = full bar, fill from the frame's right edge
     --   left    = full bar, fill from the frame's left edge
-    local s = GetSettingsForUnit(frame.unit)
+    local s = settingsOverride or GetSettingsForUnit(frame.unit)
     local absorbMode = (s and s.absorbEdgeMode) or "overlay"
     local healMode = (s and s.healAbsorbEdgeMode) or "overlay"
+
+    -- Vertical fill: the whole HP cluster rotates with the health bar. Every
+    -- anchor below is the horizontal layout with its axis swapped -- the health
+    -- fill's RIGHT edge (the "HP edge" the shields and heal absorb hang off)
+    -- becomes its TOP edge, and reverse fill flips it to the BOTTOM edge. The
+    -- edge modes keep their key names: "right" is the far edge of the fill axis
+    -- (top when vertical), "left" the near one (bottom when vertical).
+    local isVert = (s and s.healthVerticalFill) and true or false
+    ab._isVert = isVert
+    local ha = ab._healAbsorb
+    local healClip = ab._healClip
+    -- Indexed, not ipairs: ha can be nil and ipairs would stop at the hole.
+    local axisBars = { ab, fw, ha }
+    for i = 1, 3 do
+        local bar = axisBars[i]
+        if bar then
+            bar:SetOrientation(isVert and "VERTICAL" or "HORIZONTAL")
+            ns.ApplyFillRotation(bar)  -- derived: rotate stretch styles only
+        end
+    end
 
     curClip:ClearAllPoints()
     missClip:ClearAllPoints()
     ab:ClearAllPoints()
     fw:ClearAllPoints()
+
+    if isVert then
+        -- missClip + forward bar always use the overlay layout; in the edge
+        -- modes the full-bar backfill shows the whole absorb and the Override
+        -- hides fw.
+        if isReversed then
+            missClip:SetPoint("TOPLEFT",     hpTex, "BOTTOMLEFT",  0, 1)
+            missClip:SetPoint("BOTTOMRIGHT", hpBar, "BOTTOMRIGHT", 0, 0)
+            fw:SetReverseFill(true)
+            fw:SetPoint("TOPLEFT",  hpTex, "BOTTOMLEFT",  0, 0)
+            fw:SetPoint("TOPRIGHT", hpTex, "BOTTOMRIGHT", 0, 0)
+        else
+            missClip:SetPoint("BOTTOMLEFT", hpTex, "TOPLEFT",  0, -1)
+            missClip:SetPoint("TOPRIGHT",   hpBar, "TOPRIGHT", 0, 0)
+            fw:SetReverseFill(false)
+            fw:SetPoint("BOTTOMLEFT",  hpTex, "TOPLEFT",  0, 0)
+            fw:SetPoint("BOTTOMRIGHT", hpTex, "TOPRIGHT", 0, 0)
+        end
+
+        -- Shield absorb placement.
+        if absorbMode == "right" or absorbMode == "left" then
+            curClip:SetPoint("TOPLEFT",     hpBar, "TOPLEFT",     0, 0)
+            curClip:SetPoint("BOTTOMRIGHT", hpBar, "BOTTOMRIGHT", 0, 0)
+            if absorbMode == "left" then
+                ab:SetReverseFill(false)
+                ab:SetPoint("BOTTOMLEFT",  hpBar, "BOTTOMLEFT",  0, 0)
+                ab:SetPoint("BOTTOMRIGHT", hpBar, "BOTTOMRIGHT", 0, 0)
+            else
+                ab:SetReverseFill(true)
+                ab:SetPoint("TOPLEFT",  hpBar, "TOPLEFT",  0, 0)
+                ab:SetPoint("TOPRIGHT", hpBar, "TOPRIGHT", 0, 0)
+            end
+        elseif isReversed then
+            curClip:SetPoint("TOPLEFT",     hpBar, "TOPLEFT",       0, 0)
+            curClip:SetPoint("BOTTOMRIGHT", hpTex, "BOTTOMRIGHT",   0, 0)
+            ab:SetReverseFill(false)
+            ab:SetPoint("BOTTOMLEFT",  hpBar, "BOTTOMLEFT",  0, 0)
+            ab:SetPoint("BOTTOMRIGHT", hpBar, "BOTTOMRIGHT", 0, 0)
+        else
+            curClip:SetPoint("BOTTOMLEFT", hpBar, "BOTTOMLEFT", 0, 0)
+            curClip:SetPoint("TOPRIGHT",   hpTex, "TOPRIGHT",   0, 0)
+            ab:SetReverseFill(true)
+            ab:SetPoint("TOPLEFT",  hpBar, "TOPLEFT",  0, 0)
+            ab:SetPoint("TOPRIGHT", hpBar, "TOPRIGHT", 0, 0)
+        end
+
+        -- Heal absorb placement (own clip frame, same rules).
+        if healClip then
+            healClip:ClearAllPoints()
+            if healMode == "right" or healMode == "left" then
+                healClip:SetPoint("TOPLEFT",     hpBar, "TOPLEFT",     0, 0)
+                healClip:SetPoint("BOTTOMRIGHT", hpBar, "BOTTOMRIGHT", 0, 0)
+            elseif isReversed then
+                healClip:SetPoint("TOPLEFT",     hpBar, "TOPLEFT",     0, 0)
+                healClip:SetPoint("BOTTOMRIGHT", hpTex, "BOTTOMRIGHT", 0, 0)
+            else
+                healClip:SetPoint("BOTTOMLEFT", hpBar, "BOTTOMLEFT", 0, 0)
+                healClip:SetPoint("TOPRIGHT",   hpTex, "TOPRIGHT",   0, 0)
+            end
+        end
+        if ha then
+            ha:ClearAllPoints()
+            if healMode == "right" then
+                ha:SetReverseFill(true)
+                ha:SetPoint("TOPLEFT",  hpBar, "TOPLEFT",  0, 0)
+                ha:SetPoint("TOPRIGHT", hpBar, "TOPRIGHT", 0, 0)
+            elseif healMode == "left" then
+                ha:SetReverseFill(false)
+                ha:SetPoint("BOTTOMLEFT",  hpBar, "BOTTOMLEFT",  0, 0)
+                ha:SetPoint("BOTTOMRIGHT", hpBar, "BOTTOMRIGHT", 0, 0)
+            elseif isReversed then
+                ha:SetReverseFill(false)
+                ha:SetPoint("BOTTOMLEFT",  hpTex, "BOTTOMLEFT",  0, 0)
+                ha:SetPoint("BOTTOMRIGHT", hpTex, "BOTTOMRIGHT", 0, 0)
+            else
+                ha:SetReverseFill(true)
+                ha:SetPoint("TOPLEFT",  hpTex, "TOPLEFT",  0, 0)
+                ha:SetPoint("TOPRIGHT", hpTex, "TOPRIGHT", 0, 0)
+            end
+        end
+        return
+    end
 
     -- missClip + forward bar always use the overlay layout; in the edge modes
     -- the full-bar backfill shows the whole absorb and the Override hides fw.
@@ -3976,8 +4143,6 @@ local function UpdateAbsorbBarReverseFill(frame, isReversed)
     -- Heal absorb placement (independent of shield absorb). The heal absorb
     -- has its OWN clip frame (ab._healClip) so right/left span the full bar
     -- (filled + missing health) while overlay stays clipped to filled health.
-    local ha = ab._healAbsorb
-    local healClip = ab._healClip
     if healClip then
         healClip:ClearAllPoints()
         if healMode == "right" or healMode == "left" then
@@ -4417,8 +4582,13 @@ local function CreateAbsorbBar(frame, unit, settings)
 
             -- Re-anchor when the placement settings change. The key starts
             -- nil, so this also applies the saved placement on first update.
+            -- The fill AXIS is part of the placement now, so it belongs in the
+            -- key: the settings-apply path already re-anchors on a Vertical Fill
+            -- toggle, but including it here keeps this gate self-healing if the
+            -- axis ever changes by some route that path does not cover.
             local absorbMode = (s and s.absorbEdgeMode) or "overlay"
             local edgeKey = absorbMode .. ":" .. ((s and s.healAbsorbEdgeMode) or "overlay")
+                .. ":" .. tostring((s and s.healthVerticalFill) and true or false)
             if ab._lastEdgeKey ~= edgeKey then
                 ab._lastEdgeKey = edgeKey
                 UpdateAbsorbBarReverseFill(self, ab._isReversed)
@@ -4502,6 +4672,12 @@ local function CreateAbsorbBar(frame, unit, settings)
             end
         end,
     }
+
+    -- The anchors set above are the horizontal layout. Hand the whole cluster to
+    -- the shared re-anchor pass so a vertical-fill frame starts out correct
+    -- without waiting for the first settings apply. `settings` is passed through
+    -- because frame.unit is not resolvable this early on every frame.
+    UpdateAbsorbBarReverseFill(frame, isReversed, settings)
 
     return backfillBar
 end
@@ -7523,6 +7699,7 @@ local function StyleSimpleFrame(frame, unit)
     ApplyHealthBarTexture(health, unitKey, ns.ResolveHealthBarTextureKey(settings, donor))
     ApplyHealthBarAlpha(health, unitKey)
     health:SetReverseFill(settings.healthReverseFill and true or false)
+    ns.ApplyHealthOrientation(health, settings)
     ApplyDarkTheme(health)
 
     frame.Health = health
@@ -7768,6 +7945,7 @@ local function StylePetFrame(frame, unit)
     ApplyHealthBarTexture(health, unitKey, ns.ResolveHealthBarTextureKey(settings, donor))
     ApplyHealthBarAlpha(health, unitKey)
     health:SetReverseFill(settings.healthReverseFill and true or false)
+    ns.ApplyHealthOrientation(health, settings)
     ApplyDarkTheme(health)
 
     frame.Health = health
@@ -11156,8 +11334,9 @@ local function ReloadFrames()
                 ns.ApplyBossBorderState(frame)
             end
             frame.Health:SetReverseFill(settings.healthReverseFill and true or false)
-            ApplyDarkTheme(frame.Health)
-            UpdateAbsorbBarReverseFill(frame, settings.healthReverseFill and true or false)
+            ns.ApplyHealthOrientation(frame.Health, settings)
+            ApplyDarkTheme(frame.Health)  -- re-anchors health.bg for the new axis
+            UpdateAbsorbBarReverseFill(frame, settings.healthReverseFill and true or false, settings)
             -- Smooth bar interpolation (live toggle without /reload)
             if settings.smoothBars then
                 frame.Health.smoothing = Enum and Enum.StatusBarInterpolation


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?
u know what it does.

## How was it tested?

kulia tested. 8.7.2 retail

## Screenshots

<img width="157" height="97" alt="image" src="https://github.com/user-attachments/assets/71d463a3-9b65-4906-ba77-a62e2bf7240f" />
<img width="138" height="106" alt="image" src="https://github.com/user-attachments/assets/67039b11-ea06-4bff-a908-ea3665f56d09" />
<img width="142" height="57" alt="image" src="https://github.com/user-attachments/assets/6f26b83b-0d2a-4193-9c6e-34a04a79caf6" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [✔️ ] New settings default **OFF** (no behavior change without opt-in)
- [✔️ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [✔️ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [✔️ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [✔️ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
