### PR TITLE
Use health bar border size for cast bars

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -5533,7 +5533,8 @@ local function CreateCastBar(frame, unit, settings)
     -- fill texture) so the OVERLAY border sits above the ARTWORK fill.
     -- Drawing on castbarBg would put the border behind the fill because
     -- castbar is a child of castbarBg and draws above it.
-    PP.CreateBorder(castbar, 0, 0, 0, 1, 1, "OVERLAY", 0)
+    -- Border size is inherited from the frame.
+    PP.CreateBorder(castbar, 0, 0, 0, 1, settings.borderSize or 0, "OVERLAY", 0)
 
 
     -- Three-zone cast bar text layout matching nameplates:


### PR DESCRIPTION
Use health bar border size for cast bars

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?
Makes unit-frame cast bars use the configured health-bar border size instead of a hard-coded value.

The existing default of 1 is retained when no border size is configured.

## How was it tested?
Tested on my local branch with the stable version of the game ( _retail )

## Screenshots
<img width="1576" height="419" alt="image" src="https://github.com/user-attachments/assets/cc94ec1c-d0e1-4140-9176-48c9e6a6f017" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
**Hard to make it OFF by default since its just inheritance ( which in my opinion should work like that from the begining.**
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
