### PR TITLE
FEATURE: Damage Meters: add Delve and PvP hide options

### DIFF
--- a/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIDamageMeters/EUI_DamageMeters_Options.lua
@@ -1618,6 +1618,8 @@ initFrame:SetScript("OnEvent", function(self)
         local SH_ICON_VIS_ITEMS = {
             { key = "iconHideInDungeon",      label = "Hide in Dungeons" },
             { key = "iconHideInRaid",         label = "Hide in Raids" },
+            { key = "iconHideInDelve",        label = "Hide in Delves" },
+            { key = "iconHideInPvP",          label = "Hide in PvP" },
             { key = "iconHideOutOfInstance",   label = "Hide out of Instances" },
         }
         local iconVisRow
@@ -1734,6 +1736,8 @@ initFrame:SetScript("OnEvent", function(self)
         local SH_BAR_VIS_ITEMS = {
             { key = "barHideInDungeon",      label = "Hide in Dungeons" },
             { key = "barHideInRaid",         label = "Hide in Raids" },
+            { key = "barHideInDelve",        label = "Hide in Delves" },
+            { key = "barHideInPvP",          label = "Hide in PvP" },
             { key = "barHideOutOfInstance",   label = "Hide out of Instances" },
         }
         local barVisRow

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -2668,6 +2668,14 @@ local function CreateDMWindow(winIdx)
                 wdb.hideInRaid = not wdb.hideInRaid
                 for _, w in ipairs(_windows) do w.UpdateVisibility() end
             end },
+            { text = L("Hide in Delves"), isActive = wdb.hideInDelve, onClick = function()
+                wdb.hideInDelve = not wdb.hideInDelve
+                for _, w in ipairs(_windows) do w.UpdateVisibility() end
+            end },
+            { text = L("Hide in PvP"), isActive = wdb.hideInPvP, onClick = function()
+                wdb.hideInPvP = not wdb.hideInPvP
+                for _, w in ipairs(_windows) do w.UpdateVisibility() end
+            end },
             { text = L("Hide out of Instances"), isActive = wdb.hideOutOfInstance, onClick = function()
                 wdb.hideOutOfInstance = not wdb.hideOutOfInstance
                 for _, w in ipairs(_windows) do w.UpdateVisibility() end
@@ -4459,6 +4467,8 @@ local function CreateDMWindow(winIdx)
         local _, iType = IsInInstance()
         if wdb.hideInDungeon and iType == "party" then frame:Hide(); return end
         if wdb.hideInRaid and iType == "raid" then frame:Hide(); return end
+        if wdb.hideInDelve and C_PartyInfo and C_PartyInfo.IsDelveInProgress and C_PartyInfo.IsDelveInProgress() then frame:Hide(); return end
+        if wdb.hideInPvP and (iType == "pvp" or iType == "arena") then frame:Hide(); return end
         if wdb.hideOutOfInstance and (iType == "none" or iType == nil) then frame:Hide(); return end
         if vis == "mouseover" then frame:Hide()
         else frame:SetAlpha(1); frame:EnableMouse(true); frame:Show() end

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters_SpellHistory.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters_SpellHistory.lua
@@ -56,9 +56,13 @@ local SH_DEFAULTS = {
     bgR = 0, bgG = 0, bgB = 0, bgAlpha = 0.25,
     iconHideInDungeon    = false,
     iconHideInRaid       = false,
+    iconHideInDelve      = false,
+    iconHideInPvP        = false,
     iconHideOutOfInstance = false,
     barHideInDungeon     = false,
     barHideInRaid        = false,
+    barHideInDelve       = false,
+    barHideInPvP         = false,
     barHideOutOfInstance = false,
 }
 
@@ -442,12 +446,14 @@ end
 -------------------------------------------------------------------------------
 --  Instance visibility check
 -------------------------------------------------------------------------------
-local function ShouldHide(hideInDungeon, hideInRaid, hideOutOfInstance)
+local function ShouldHide(hideInDungeon, hideInRaid, hideInDelve, hideInPvP, hideOutOfInstance)
     -- Always visible while options panel is open
     if ns._optionsOpen then return false end
     local _, iType = IsInInstance()
     if hideInDungeon and iType == "party" then return true end
     if hideInRaid and iType == "raid" then return true end
+    if hideInDelve and C_PartyInfo and C_PartyInfo.IsDelveInProgress and C_PartyInfo.IsDelveInProgress() then return true end
+    if hideInPvP and (iType == "pvp" or iType == "arena") then return true end
     if hideOutOfInstance and (iType == "none" or iType == nil) then return true end
     return false
 end
@@ -690,7 +696,7 @@ end
 
 BuildIconStrip = function()
     local sh = DB()
-    if not sh.iconEnabled or ShouldHide(sh.iconHideInDungeon, sh.iconHideInRaid, sh.iconHideOutOfInstance) then
+    if not sh.iconEnabled or ShouldHide(sh.iconHideInDungeon, sh.iconHideInRaid, sh.iconHideInDelve, sh.iconHideInPvP, sh.iconHideOutOfInstance) then
         if _iconStrip then _iconStrip:Hide() end
         StopFadeClock()
         return
@@ -967,7 +973,7 @@ local MIN_W, MIN_H = 150, 80
 local function BuildBarWindow()
     local sh = DB()
     local dmCfg = ns.EDM.DB()
-    if not sh.barEnabled or ShouldHide(sh.barHideInDungeon, sh.barHideInRaid, sh.barHideOutOfInstance) then
+    if not sh.barEnabled or ShouldHide(sh.barHideInDungeon, sh.barHideInRaid, sh.barHideInDelve, sh.barHideInPvP, sh.barHideOutOfInstance) then
         if _barWin then _barWin:Hide() end
         return
     end


### PR DESCRIPTION
## What does this PR do?

Adds opt-in **Hide in Delves** and **Hide in PvP** visibility options wherever Damage Meters already offers Hide in Dungeons, Hide in Raids, and Hide out of Instances:

- Individual Damage Meter window menu
- Spell History Icon History
- Spell History Bar History

PvP covers battlegrounds and arenas. Delves use the existing guarded `C_PartyInfo.IsDelveInProgress()` pattern.

All new settings default OFF. No events, hooks, frames, polling, or timers were added.

## How was it tested?

In-game test checklist completed:

- Default-off behavior remains unchanged.
- Individual meter, Icon History, and Bar History options all display the two new choices.
- Hide in Delves works during an active Delve.
- Hide in PvP works in battlegrounds and arenas.
- Existing Dungeon, Raid, and out-of-instance rules still work.
- `/reload` preserves settings and refreshes visibility correctly.
- No load errors observed on live retail, NOT tested on 12.1 PTR.

## Screenshots

Before/after comparisons:

1. Individual Damage Meter window visibility menu

Before 
<img width="214" height="272" alt="Screenshot 2026-08-02 064008" src="https://github.com/user-attachments/assets/092767c3-76f2-41f0-b717-da5177ad093f" />

After
<img width="209" height="315" alt="Screenshot 2026-08-02 063812" src="https://github.com/user-attachments/assets/c95ae83f-fdbb-4eda-b0be-94c758f258ab" />

2. Spell History Icon History visibility options

Before
<img width="937" height="305" alt="Screenshot 2026-08-02 064032" src="https://github.com/user-attachments/assets/2ac5c2e7-fb98-44ea-a870-33963ba715aa" />

After
<img width="930" height="308" alt="Screenshot 2026-08-02 063857" src="https://github.com/user-attachments/assets/42ea46a7-0918-4811-9fa6-84d586ccdc74" />

3. Spell History Bar History visibility options

Before
<img width="956" height="321" alt="Screenshot 2026-08-02 064045" src="https://github.com/user-attachments/assets/2ba316dd-b45b-43ab-b95f-7607bf1fd023" />

After
<img width="935" height="314" alt="Screenshot 2026-08-02 063911" src="https://github.com/user-attachments/assets/18f38d2a-49ef-49a5-b95e-9f8329e43b22" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames; no hooks added
- [x] Tested in-game on live retail, NOT tested on 12.1 PTR