### PR TITLE
Fix for plumbers minimap addon

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -1190,6 +1190,14 @@ local function SaveZoomLevel()
     p.savedZoom = Minimap:GetZoom()
 end
 
+-- Global names of third-party buttons that REPLACE the expansion landing page
+-- button. Such an addon hides Blizzard's button (typically unregistering its
+-- events first) and parents its own to the minimap in the same corner.
+-- Plumber's "Landing Button" is the reference case.
+local FOLIO_REPLACEMENT_BUTTONS = {
+    "PlumberLandingPageMinimapButton",
+}
+
 -- Blizzard structural frames that should NOT go into the flyout
 local flyoutBlacklist = {
     MinimapZoomIn    = true,
@@ -1200,6 +1208,18 @@ local flyoutBlacklist = {
     -- minimap surface instead of sweeping it into the addon-button flyout.
     ExpansionLandingPageMinimapButton = true,
 }
+
+-- A replacement landing button is a feature button, not a generic addon
+-- button: it belongs on the minimap surface for exactly the reason Blizzard's
+-- does. Sweeping one into the flyout also RE-CREATES the duplicate-button bug
+-- it is meant to prevent -- HideMinimapChild hides the replacement, our folio
+-- code then sees no replacement on screen and resurrects Blizzard's button via
+-- RefreshButton, and the replacing addon never hides it again because it still
+-- believes it did. Result: Blizzard's button back in the corner, the
+-- replacement buried in the flyout.
+for _, name in ipairs(FOLIO_REPLACEMENT_BUTTONS) do
+    flyoutBlacklist[name] = true
+end
 
 -- Persistently hide a minimap button via Show hook
 local addonButtonHooks = {}
@@ -3798,14 +3818,8 @@ end
 -- It is a plain (non-secure) Blizzard button, so SetParent/SetPoint are safe.
 local _omniumFolioHooked = false
 
--- Global names of third-party buttons that REPLACE the landing page button.
--- Such an addon hides Blizzard's button (typically unregistering its events
--- first) and draws its own in the same corner.
-local FOLIO_REPLACEMENT_BUTTONS = {
-    "PlumberLandingPageMinimapButton",
-}
-
--- True while a replacement button is on screen. Our RefreshButton nudge below
+-- True while a replacement button (FOLIO_REPLACEMENT_BUTTONS, declared with
+-- the flyout blacklist above) is on screen. Our RefreshButton nudge below
 -- would otherwise undo the replacement addon's hide -- RefreshButton re-Shows
 -- Blizzard's button, and the other addon never hides it again because it still
 -- believes it did -- so BOTH buttons end up visible until the user toggles the

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -3798,6 +3798,29 @@ end
 -- It is a plain (non-secure) Blizzard button, so SetParent/SetPoint are safe.
 local _omniumFolioHooked = false
 
+-- Global names of third-party buttons that REPLACE the landing page button.
+-- Such an addon hides Blizzard's button (typically unregistering its events
+-- first) and draws its own in the same corner.
+local FOLIO_REPLACEMENT_BUTTONS = {
+    "PlumberLandingPageMinimapButton",
+}
+
+-- True while a replacement button is on screen. Our RefreshButton nudge below
+-- would otherwise undo the replacement addon's hide -- RefreshButton re-Shows
+-- Blizzard's button, and the other addon never hides it again because it still
+-- believes it did -- so BOTH buttons end up visible until the user toggles the
+-- other addon's setting. When a replacement is visibly in charge, we keep our
+-- hands off Blizzard's button entirely; the replacement addon Shows it back
+-- itself (before hiding its own) if the user turns the replacement off, and
+-- our Show hook then re-applies our position/scale as usual.
+local function IsFolioReplacedByAddOn()
+    for _, name in ipairs(FOLIO_REPLACEMENT_BUTTONS) do
+        local b = _G[name]
+        if b and b:IsShown() then return true end
+    end
+    return false
+end
+
 -- Folio visibility mode with legacy fallback: pre-dropdown data carries the
 -- showOmniumFolio toggle (default ON; only false is ever stored).
 local function GetOmniumFolioMode(mp)
@@ -3934,7 +3957,7 @@ function EBS._HVRevealMapHover()
     if not mp.hideZoomButtons then
         raiseZoom()
     end
-    if GetOmniumFolioMode(mp) == "hover" then
+    if GetOmniumFolioMode(mp) == "hover" and not IsFolioReplacedByAddOn() then
         local b = _G.ExpansionLandingPageMinimapButton
         if b then
             PositionOmniumFolio(b)
@@ -3987,6 +4010,7 @@ local function ApplyOmniumFolio()
             -- Hide()/Show()s the button, and a raw IsMouseOver here could
             -- veto that Show at the exact edge for the same rounding reason.
             if mode == "never"
+               or IsFolioReplacedByAddOn()
                or (mode == "hover" and not (Minimap and EBS._HoverStillOver(Minimap))) then
                 self:Hide()
             else
@@ -4008,6 +4032,9 @@ local function ApplyOmniumFolio()
         btn:Hide()
         return
     end
+    -- A replacement landing button is on screen: leave Blizzard's alone rather
+    -- than resurrecting it next to the replacement (see IsFolioReplacedByAddOn).
+    if IsFolioReplacedByAddOn() then return end
     if mode == "hover" and not Minimap:IsMouseOver() then
         btn:Hide()
         return


### PR DESCRIPTION
## What does this PR do?

Fixes the minimap button of plumber to replace the omnium folio button.

If plumber hids the omnium folio button on the minimap - dont reactive the omnium folio button and hide plumber Extensible for more addons that do this kind of replacement

## How was it tested?

Tested on 12.0.7 retail
NOT tested on 12.1 PTR

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
