### PR TITLE
fix(performance): Properly set graphicsSpellDensity to 0 when optimizing performance

### DIFF
--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -1186,7 +1186,7 @@ initFrame:SetScript("OnEvent", function(self)
             { "graphicsComputeEffects",     "0" },
             { "graphicsOutlineMode",        "0" },
             { "graphicsTextureResolution",  "2" },
-            { "graphicsSpellDensity",       "1" },
+            { "graphicsSpellDensity",       "0" },
             { "graphicsProjectedTextures",  "1" },
             { "graphicsViewDistance",        "1" },
             { "graphicsEnvironmentDetail",  "1" },


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

The FPS & Graphics optimization says it's supposed to be setting Spell Density to "Essential" but the code currently sets it to "Reduced"

I'm not sure if this was always a bug or if blizzard changed some indexes, but `"0"` is `Essential` and `"1"` is `Reduced`.

This corrects the logic to match the described intent when a user presses the button to optimize game performance.

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
Tested in retail 12.0.7. Confirming that the video settings showed the correct value and the value from `/run print(GetCVar("graphicsSpellDensity"))` changed properly.

## Screenshots

N/A

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
