### PR TITLE
Fix empowered spells reverting to Press-and-Tap after a loading screen

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2682,12 +2682,22 @@ local function CreateBarFrame(info)
 
     barFrames[key] = frame
 
-    -- Empower re-check: when addon code sets "eab-empower-trigger", dispatch
+    -- Empower re-check: when addon code sets "state-eabempower", dispatch
     -- ChildUpdate to re-evaluate pressAndHoldAction on all child buttons.
-    frame:SetAttributeNoHandler("_onattributechanged", [[
-        if name == "eab-empower-trigger" then
-            self:ChildUpdate("eab-empower", "")
-        end
+    --
+    -- This MUST be an _onstate- handler on a state- attribute. These bar
+    -- frames are SecureHandlerStateTemplate, whose
+    -- SecureHandler_StateOnAttributeChanged only matches "^state%-(.+)" and
+    -- dispatches to "_onstate-<id>". It has no _onattributechanged path at
+    -- all -- that belongs to SecureHandlerAttributeTemplate (which is what
+    -- OverrideController above correctly uses). The original trigger was an
+    -- _onattributechanged snippet keyed on a plain "eab-empower-trigger"
+    -- attribute, so setting it fired NOTHING: the re-check has never once run
+    -- through this path since it was written. Every empower repair outside a
+    -- page change silently did nothing, which is why an empowered spell that
+    -- lost pressAndHoldAction stayed lost.
+    frame:SetAttributeNoHandler("_onstate-eabempower", [[
+        self:ChildUpdate("eab-empower", "")
     ]])
 
     -- Install a secure visibility handler so we can show/hide the frame
@@ -2916,8 +2926,8 @@ local function SetupBar(info, skipProtected)
                     btn:SetAttributeNoHandler("_childupdate-eab-page", ns._eabBuildPageChildSnippet(i))
                 end
                 -- Empower re-check on slot change (spec swap, drag, etc.)
-                -- The bar header's _onattributechanged dispatches ChildUpdate
-                -- when addon code sets "eab-empower-trigger" on slot change.
+                -- The bar header's _onstate-eabempower dispatches ChildUpdate
+                -- when addon code sets "state-eabempower".
                 if not btn:GetAttribute("_childupdate-eab-empower") then
                     btn:SetAttributeNoHandler("_childupdate-eab-empower", ns._eabEmpowerSnippet)
                 end
@@ -3440,21 +3450,14 @@ do
     local _empowerReroutePending = false
 
     -- Empower keybind reroute, shared by the immediate and the deferred path.
-    -- UpdateKeybinds returns false when the routing signature is unchanged
-    -- (mouseover-conditional macro storms re-fire ACTIONBAR_SLOT_CHANGED on
-    -- every flip without changing any binding or empower state). Skip the
-    -- secure re-trigger in that case: rebuilding bindings and running the
-    -- ChildUpdate snippet on every bar every frame is what tanked FPS while
-    -- hovering across nameplates.
+    -- The secure re-trigger that re-evaluates pressAndHoldAction now lives in
+    -- UpdateKeybinds itself (pass 3), so it can never be omitted by a caller;
+    -- it is still skipped when the routing signature is unchanged, which is
+    -- what keeps mouseover-conditional macro storms (ACTIONBAR_SLOT_CHANGED on
+    -- every flip) from rebuilding bindings and running the ChildUpdate snippet
+    -- on every bar every frame.
     local function _EmpowerReroute()
-        if _G._EAB_UpdateKeybinds and _G._EAB_UpdateKeybinds() then
-            for _, info in ipairs(BAR_CONFIG) do
-                local frame = barFrames[info.key]
-                if frame then
-                    frame:SetAttribute("eab-empower-trigger", GetTime())
-                end
-            end
-        end
+        if _G._EAB_UpdateKeybinds then _G._EAB_UpdateKeybinds() end
     end
 
     -- Deferral shell for that reroute. ACTIONBAR_SLOT_CHANGED fires freely IN
@@ -10630,6 +10633,35 @@ local function UpdateKeybinds()
                     end
                 end
             end
+        end
+    end
+    -- Pass 3: re-evaluate pressAndHoldAction/typerelease on every button.
+    -- Routing the key is only HALF of hold-and-release -- a CLICK-routed key
+    -- still behaves as Press-and-Tap unless the button also carries those
+    -- attrs. The only writers are this re-check and _childupdate-eab-page, and
+    -- that page handler is installed on MainBar and custom-paged bars alone.
+    --
+    -- Meanwhile Blizzard writes the attribute too, and gets the last word on
+    -- every loading screen: BUTTON_EVENT_LISTS.action registers
+    -- PLAYER_ENTERING_WORLD per button, the template wires OnEvent to the
+    -- mixin, and its PEW branch calls Update() -> UpdatePressAndHoldAction().
+    -- Zoning into an instance is where that lands wrong, and because the page
+    -- state does not change across the loading screen (page 1 -> page 1)
+    -- nothing re-ran our snippet afterwards, so an empowered spell sat on
+    -- pressAndHoldAction=false -- Press-and-Tap behaviour -- for the rest of
+    -- the session.
+    --
+    -- The re-check also used to be fired from the ACTIONBAR_SLOT_CHANGED
+    -- reroute only, so every other caller (load time, UPDATE_BINDINGS, the
+    -- combat re-arm above, the housing restore, and the post-loading-screen
+    -- restore) rebuilt the routing and left the attrs stale. Firing it here
+    -- covers all of them. SetAttribute on a secure header is protected, but
+    -- the combat bail at the top of this function guarantees we only reach
+    -- here out of combat.
+    for _, info in ipairs(BAR_CONFIG) do
+        local frame = barFrames[info.key]
+        if frame then
+            frame:SetAttribute("state-eabempower", GetTime())
         end
     end
     return true

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2547,10 +2547,24 @@ ns.LayoutPagingFrame = LayoutPagingFrame
 
 -- Secure snippet appended to each button's _childupdate-eab-page handler (and
 -- reused as the _childupdate-eab-empower handler): after the action attr changes
--- on a page swap, re-evaluate pressAndHoldAction/typerelease for empowered /
--- hold-release spells. IsPressHoldReleaseSpell and GetActionInfo are available
--- in the restricted environment even though they are gone from _G.
+-- on a page swap, re-evaluate pressAndHoldAction for empowered / hold-release
+-- spells. IsPressHoldReleaseSpell and GetActionInfo are available in the
+-- restricted environment even though they are gone from _G (GetActionInfo as a
+-- scrubbing wrapper, RestrictedEnvironment.lua).
 -- Stored on ns (not a file local) to stay clear of Lua's 200-local chunk cap.
+--
+-- Writes pressAndHoldAction ONLY, exactly like Blizzard's own
+-- UpdatePressAndHoldAction. It must NOT touch typerelease: Blizzard sets that
+-- to "actionrelease" once in the button mixin's OnLoad and never clears it,
+-- and SecureTemplates reads it on EVERY key release when the
+-- ActionButtonUseKeyHeldSpell CVar is on, not just for empowered spells
+-- (releasePressAndHoldAction = (not down) and (pressAndHoldAction or CVar)).
+-- Clearing it on non-empower buttons would leave those users' key-up path with
+-- no action type at all. The old version did clear it, which was harmless only
+-- because this snippet never actually ran outside a page change -- the
+-- re-check trigger was wired to an _onattributechanged handler that
+-- SecureHandlerStateTemplate does not implement. Fixing the trigger made this
+-- snippet live addon-wide, so the clear had to go with it.
 ns._eabEmpowerSnippet = [[
     local slot = self:GetAttribute('action')
     if slot and IsPressHoldReleaseSpell then
@@ -2563,12 +2577,8 @@ ns._eabEmpowerSnippet = [[
         end
         if spellID and IsPressHoldReleaseSpell(spellID) then
             self:SetAttribute('pressAndHoldAction', true)
-            self:SetAttribute('typerelease', 'actionrelease')
         else
             self:SetAttribute('pressAndHoldAction', false)
-            if self:GetAttribute('typerelease') then
-                self:SetAttribute('typerelease', nil)
-            end
         end
     end
 ]]
@@ -10635,10 +10645,10 @@ local function UpdateKeybinds()
             end
         end
     end
-    -- Pass 3: re-evaluate pressAndHoldAction/typerelease on every button.
+    -- Pass 3: re-evaluate pressAndHoldAction on every button.
     -- Routing the key is only HALF of hold-and-release -- a CLICK-routed key
-    -- still behaves as Press-and-Tap unless the button also carries those
-    -- attrs. The only writers are this re-check and _childupdate-eab-page, and
+    -- still behaves as Press-and-Tap unless the button also carries that
+    -- attr. The only writers are this re-check and _childupdate-eab-page, and
     -- that page handler is installed on MainBar and custom-paged bars alone.
     --
     -- Meanwhile Blizzard writes the attribute too, and gets the last word on


### PR DESCRIPTION
## Problem

Empowered spells silently revert to Press-and-Tap behaviour, most reliably after zoning into a dungeon, and stay that way for the rest of the session. The Empowered Spell Input setting itself is untouched; the CVar is not involved.

Hold-and-release needs two things: the key routed through our button, and `pressAndHoldAction` set on that button. Only the first was maintained reliably. The mechanism meant to maintain the second was inert.

## Root cause

The empower re-check was wired as an `_onattributechanged` snippet keyed on a plain `eab-empower-trigger` attribute, set on the bar header frames. Those frames are `SecureHandlerStateTemplate`, whose script is `SecureHandler_StateOnAttributeChanged`: it matches `"^state%-(.+)"` and dispatches to `_onstate-<id>`, and has no `_onattributechanged` path at all. That belongs to `SecureHandlerAttributeTemplate`, which is what `OverrideController` correctly uses.

So setting the attribute fired nothing, and had fired nothing since the mechanism was written. The re-check only ever ran as the tail of `_childupdate-eab-page`, which is installed on MainBar and custom-paged bars alone, so it ran on page changes and nowhere else.

Blizzard writes the same attribute and gets the last word on every loading screen. `BUTTON_EVENT_LISTS.action` registers `PLAYER_ENTERING_WORLD` per button, the template wires `OnEvent` to their mixin, and its PEW branch runs `Update()` -> `UpdatePressAndHoldAction()`. Zoning into an instance lands that write as false. The page state does not change across a loading screen, so nothing re-ran our snippet, and the spell sat on `pressAndHoldAction = false` for the rest of the session.

## Changes

**1. Make the re-check trigger fire.** The handler is now `_onstate-eabempower`, driven by a `state-eabempower` attribute, which the state template does dispatch.

**2. Fire it from every keybind rebuild.** The trigger moves out of the `ACTIONBAR_SLOT_CHANGED` reroute into `UpdateKeybinds`' success path, so no caller can omit it. Load time, `UPDATE_BINDINGS`, the combat re-arm, the housing restore and the post-loading-screen restore all rebuilt the routing and left the attribute stale. Zoning needs that last one specifically, because no slot changes across a loading screen and nothing else would fire the re-check.

The signature short-circuit is unchanged, so mouseover-conditional macro storms still do not rebuild every bar every frame. The protected `SetAttribute` is unreachable in combat because `UpdateKeybinds` bails at the top.

**3. Stop the snippet clearing `typerelease`.** Separate commit, and a prerequisite for shipping the first two. Blizzard sets `typerelease` to `"actionrelease"` once in the button mixin's `OnLoad` and never clears it, and `SecureTemplates` reads it on every key release when the `ActionButtonUseKeyHeldSpell` CVar is on, not only for empowered spells:

```lua
releasePressAndHoldAction = (not down) and (pressAndHoldAction or GetCVarBool("ActionButtonUseKeyHeldSpell"))
```

Clearing it on non-empower buttons would leave those users' key-up path with no action type and nothing to perform. This was harmless only while the snippet never ran outside a page change; fixing the trigger makes it live addon-wide, so the clear has to go with it. Their own `UpdatePressAndHoldAction` writes `pressAndHoldAction` and nothing else, and this now matches.

## Testing

Diagnosed and verified in game on an Evoker with a temporary probe that dumped both layers per button. The probe is not part of this PR.

- Before: Fire Breath and Upheaval read `pressAndHold=false` in a dungeon, out of combat and in combat, while their keybinds were correct `CLICK` routes the whole time. Firing the old trigger by hand reported success and moved nothing, which is what identified the dead handler.
- After: both hold `pressAndHold=true` through the zone-in and in combat.

The `typerelease` regression was caught the moment the trigger started working, when a flyout button that had always reported `typerelease=actionrelease` came back `nil`.

## Risk

Confined to the empower re-check path. No new secure frames, no new event registrations, and no change to the binding routing itself. The one behavioural widening is intended: the snippet now actually runs on keybind rebuilds, which is the fix.
