### PR TITLE
Drop chat chrome from DIALOG to MEDIUM strata

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -74,8 +74,13 @@ local BISECT_TEX_SHIFT_OFF = false      -- 8: CLEARED (this cycle) -- textures
 local _tabHostClip
 local function GetTabHostClip()
     if _tabHostClip then return _tabHostClip end
+    -- MEDIUM, not DIALOG: the chrome only has to beat the chat tabs and dock
+    -- (ChatTabTemplate / DockManagerTemplate are both LOW), and DIALOG kept the
+    -- 1px tab underline on top of MEDIUM Blizzard panels that Raise() over the
+    -- UI, such as the maximized world map. Do NOT drop this to LOW -- that
+    -- washes out the active-tab underline. Levels carry all of the ordering.
     local clip = CreateFrame("Frame", nil, UIParent)
-    clip:SetFrameStrata("DIALOG")
+    clip:SetFrameStrata("MEDIUM")
     clip:EnableMouse(false)
     clip:SetClipsChildren(true)
     local gdm = _G.GeneralDockManager
@@ -643,11 +648,11 @@ function ECHAT.ApplyExtendedBackground()
         -- fill covers its inward half and only the outward half frames the
         -- panel.
         local showBehind = cfg.panelBorderBehind == true
-        border:SetFrameStrata(showBehind and "BACKGROUND" or "DIALOG")
+        border:SetFrameStrata(showBehind and "BACKGROUND" or "MEDIUM")
         -- Solid borders use a child at host + 1, while textured borders render
         -- directly at host level. In behind mode both stay at 0, under the
-        -- extended strip (level 1) and the chat bg. Cap below 100: the options
-        -- window sits at DIALOG level 100 and must draw over the chat border.
+        -- extended strip (level 1) and the chat bg. Cap below 100: the per-tab
+        -- border hosts sit at level 100 and must draw over the chat border.
         local borderLevel = showBehind and 0 or max(96, min(98, cf1:GetFrameLevel() + 20))
         border:SetFrameLevel(borderLevel)
 
@@ -694,7 +699,7 @@ function ECHAT.ApplyExtendedBackground()
                     sbBorder:ClearAllPoints()
                     sbBorder:SetPoint("TOPLEFT", sb, "TOPLEFT", 0, sbTop)
                     sbBorder:SetPoint("BOTTOMRIGHT", sb, "BOTTOMRIGHT", 0, 0)
-                    sbBorder:SetFrameStrata(showBehind and "BACKGROUND" or "DIALOG")
+                    sbBorder:SetFrameStrata(showBehind and "BACKGROUND" or "MEDIUM")
                     sbBorder:SetFrameLevel(borderLevel)
                     EllesmereUI.ApplyBorderStyle(sbBorder, sizes[thicknessKey] or 1,
                         color.r, color.g, color.b, alpha, cfg.panelBorderTexture or "solid",
@@ -3076,8 +3081,8 @@ function ECHAT.ApplyTabBorders()
             if host:GetParent() ~= wantedParent then
                 host:SetParent(wantedParent)
             end
-            host:SetFrameStrata("DIALOG")
-            -- Constant level: hosts render on our clip at DIALOG strata,
+            host:SetFrameStrata("MEDIUM")
+            -- Constant level: hosts render on our clip at MEDIUM strata,
             -- so a tab-derived level is meaningless -- and tab:GetFrameLevel
             -- was an un-exonerated tab getter in this (dirty-tested) pass.
             local level = 100
@@ -3153,7 +3158,7 @@ function ECHAT.ApplyTabSeparators()
         end
         if not ns._tabPanelSepHost then
             local host = CreateFrame("Frame", nil, clip)
-            host:SetFrameStrata("DIALOG")
+            host:SetFrameStrata("MEDIUM")
             host:SetFrameLevel(90)
             host:EnableMouse(false)
             host:SetHeight((PP and PP.mult) or 1)
@@ -3239,7 +3244,7 @@ local function SkinTab(cf)
 
     local separatorHost = CreateFrame("Frame", nil, hostParent)
     separatorHost:Hide()
-    separatorHost:SetFrameStrata("DIALOG")
+    separatorHost:SetFrameStrata("MEDIUM")
     separatorHost:SetFrameLevel(90)
     separatorHost:EnableMouse(false)
     local onePx = (PP and PP.mult) or 1
@@ -3264,7 +3269,7 @@ local function SkinTab(cf)
 
     local underlineHost = CreateFrame("Frame", nil, hostParent)
     underlineHost:Hide()
-    underlineHost:SetFrameStrata("DIALOG")
+    underlineHost:SetFrameStrata("MEDIUM")
     underlineHost:SetFrameLevel(95)
     underlineHost:EnableMouse(false)
     local activeUnderline = underlineHost:CreateTexture(nil, "OVERLAY", nil, 7)


### PR DESCRIPTION
### Problem

The chat tab host clip, the per-tab border/separator/underline hosts and the chat panel border were all pinned to `DIALOG`. Anything at `DIALOG` renders above `MEDIUM`, so this chrome drew on top of Blizzard panels that `Raise()` over the UI — most visibly the 1px active-tab underline sitting on top of the **maximized world map**.

### Fix

Moved that cluster to `MEDIUM`. It still clears everything it has to cover:

- `ChatTabTemplate` and `DockManagerTemplate` are both `LOW` (`FloatingChatFrame.xml:278`, `:135`)
- the chat frame itself is `LOW` at level 5
- these hosts sit at levels 90–100

**No frame level changed.** The existing interleave is preserved exactly:

| frame | level |
| --- | --- |
| per-tab border host | 100 |
| chat panel border / sidebar border | 96–98 |
| active-tab underline host | 95 |
| tab separator hosts | 90 |

Popups that legitimately need to float (the tab flyout, the URL copy popup, the confirm dialogs) are untouched and stay at `DIALOG`/`FULLSCREEN_DIALOG`.

### Note for future readers

`LOW` was tried first and washes out the active-tab underline. There is a comment at the clip recording that so it does not get retried.

### Testing

Verified in-game: the active-tab underline renders at full brightness as before, and the chat chrome now correctly draws behind the maximized world map. `luac -p` clean.