### PR TITLE
fix(actionbars): the cast kick must re-open the rate gates it re-arms the wave for

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -3805,6 +3805,22 @@ do
             -- Cost: only in that racy interleaving, one extra push
             -- of the wave that was owed to the cast anyway.
             ns._cdCastWave = true
+            -- ...and re-open the two rate gates for the same reason. The cast
+            -- branch zeroes both, but a cooldown event in the cast's OWN frame
+            -- consumes that opening and re-arms them (storm cap to +0.15s, slow
+            -- tier to +0.5s) off state read inside the transient window. The
+            -- kick would then be capped out of the walk entirely, and the slow
+            -- tier -- every utility spell, item and macro, i.e. most of the bar
+            -- -- would keep whatever that transient push painted until its gate
+            -- expired, or until the ~1/sec heartbeat if no event landed at the
+            -- gate. Measured before this: swipe start a mean 231-304ms late
+            -- over two captures, a fifth to a third of them past 500ms, tail
+            -- reaching 616ms; after, 85ms mean with nothing past 208ms and the
+            -- 500ms+ band empty. Reopening is
+            -- self-limiting: the kick is once per cast (pending guard), and
+            -- when the wave was NOT stolen these are already 0.
+            ns._cdWalkNext = 0
+            ns._cdSlowNext = 0
             local d2 = ns._cdDispatcher
             local h2 = d2 and d2:GetScript("OnEvent")
             if h2 then h2(d2, "ACTIONBAR_UPDATE_COOLDOWN") end


### PR DESCRIPTION
## Symptom

Cooldown swipes started visibly late on 8.7.4, and worse while spamming a keybind. Reported with video, and the delay was put at "0.5s or more".

## Cause

The cooldown walk runs in two cadence tiers: `fast` is the curated Essential rotation kit, and `slow` is every other spell plus items and macros, riding a 0.5s gate.

A cast is meant to bypass both gates. `UNIT_SPELLCAST_SUCCEEDED` zeroes `_cdWalkNext` and `_cdSlowNext`, then schedules `_cdCastKick` as the guaranteed post-cascade pass. But a cooldown event arriving in the cast's own frame consumes that opening: it runs a pass on state read inside the cooldown API's transient-disagreement window, and in doing so re-arms the storm cap to +0.15s and the slow tier to +0.5s.

The kick already re-armed `_cdCastWave` to survive exactly that theft. It did not re-arm the gates. So the corrective pass the kick exists to perform was capped out of the walk entirely, and the slow tier kept whatever the transient push painted until its gate expired, or until the ~1/sec heartbeat when no event landed on the gate.

## Fix

Two lines in `_cdCastKick`, reopening both gates alongside the wave it already re-arms, for the same documented reason.

It is self-limiting: the kick runs once per cast behind its existing pending guard, and when the wave was not stolen both values are already 0, so the common path is unchanged.

## Measurement

Found and verified with a repaint-latency harness that times the gap between the engine reporting a button as on cooldown and the button actually being painted. Three captures on the reporter's machine, roughly 8-11k frames each:

| | before (run 1) | before (run 2) | after |
|---|---|---|---|
| mean | 304ms | 231ms | 85ms |
| max | 616ms | 578ms | 208ms |
| 500ms-1s | 74 | 50 | 0 |
| 200-500ms | 60 | 65 | 16 |

The entire half-second-plus tail is gone, which is the slow-tier gate disappearing.

What named the cause was the shape of the distribution rather than the mean: both pre-fix captures showed an identical 51 sub-frame paints, a fixed subset always prompt while the rest were always late, which is a tier split and not a throttle. The worst offender in every capture was a utility spell, i.e. slow tier.

## Notes

- The residual 85ms mean is the 0.15s storm cap plus its 0.02s trailing flush, and is by design. Lowering that cap trades CPU (it was already brought from 0.5s to 0.15s in #1087), so it is left alone here.
- The harness itself is not part of this PR.
