### PR TITLE
fix(actionbars): don't touch the vehicle leave button during combat

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -10697,16 +10697,36 @@ do
         vehVis:RegisterEvent("PLAYER_ENTERING_WORLD")
         vehVis:RegisterEvent("PLAYER_REGEN_ENABLED")
         vehVis:SetScript("OnEvent", function(self, event, unit)
-            if event == "PLAYER_REGEN_ENABLED" then
-                local show = CanExitVehicle and CanExitVehicle()
-                btn:SetShown(show or false)
+            -- Only the UNIT_ events carry a unit; PLAYER_ENTERING_WORLD's first
+            -- arg is isInitialLogin, so testing it as a unit skipped the whole
+            -- pass on a fresh login.
+            if (event == "UNIT_ENTERED_VEHICLE" or event == "UNIT_EXITED_VEHICLE")
+                and unit ~= "player" then
                 return
             end
-            if unit and unit ~= "player" then return end
-            -- Protected instances (M+/raid) block SetShown during combat
-            if InCombatLockdown() and EllesmereUI.InProtectedInstance and EllesmereUI.InProtectedInstance() then return end
-            local show = CanExitVehicle and CanExitVehicle()
-            btn:SetShown(show or false)
+            if event ~= "PLAYER_REGEN_ENABLED" then
+                -- MainMenuBarVehicleLeaveButton is EditMode-managed, so SetShown
+                -- routes through the protected HideBase/ShowBase and is blocked
+                -- in ANY combat, not only inside a live keystone. This gate used
+                -- to AND InCombatLockdown with InProtectedInstance, which is
+                -- false in every normal dungeon AND goes false the instant a key
+                -- COMPLETES (it requires IsChallengeModeActive), so combat
+                -- vehicle events called straight through and tripped
+                -- ADDON_ACTION_BLOCKED -- field-reported from the end of a M+
+                -- run. Same rule the micro menu / bag bar site states above: the
+                -- restriction being worked around is "protected frame op blocked
+                -- in combat", so InCombatLockdown is the whole gate. Nothing is
+                -- lost by deferring: the protected call could not have succeeded
+                -- during combat either way, and the PLAYER_REGEN_ENABLED arm
+                -- re-applies the correct state the moment lockdown clears.
+                if InCombatLockdown() then return end
+            end
+            local show = (CanExitVehicle and CanExitVehicle()) or false
+            -- A redundant SetShown on a frame already in that state still trips
+            -- the block, so only issue the protected op on a real transition.
+            if btn:IsShown() ~= show then
+                btn:SetShown(show)
+            end
         end)
     end
 end


### PR DESCRIPTION
## Symptom

`ADDON_ACTION_BLOCKED: AddOn 'EllesmereUIActionBars' tried to call the protected function 'MainMenuBarVehicleLeaveButton:HideBase()'`, reported on 8.7.4 from the end of a Mythic+ run.

```
[C]: in function 'HideBase'
[Blizzard_EditMode/Shared/EditModeSystemTemplates.lua]:163
[tail call]: ?
[EllesmereUIActionBars/EllesmereUIActionBars.lua]:10709: in function <...:10699>
```

## Cause

`MainMenuBarVehicleLeaveButton` is EditMode-managed, so `SetShown` routes through the protected `HideBase`/`ShowBase` and is blocked in any combat. The vehicle visibility handler gated that call as:

```lua
if InCombatLockdown() and EllesmereUI.InProtectedInstance and EllesmereUI.InProtectedInstance() then return end
```

`InProtectedInstance()` requires `C_ChallengeMode.IsChallengeModeActive()` for a party instance, so it is false in every normal dungeon, and it goes false the instant a key completes even though combat can still be live. ANDing the two therefore narrowed a correct combat guard down to "only while a key is actively running", and a vehicle event landing in combat anywhere else called straight through into the protected op. That is the reported scenario exactly.

The module already documents the right rule at the micro menu and bag bar suppression site, and this handler simply never got the same treatment:

> `InCombatLockdown()` is the RIGHT gate here, not `InProtectedInstance()`: the restriction being worked around is "protected frame op blocked in combat". `InProtectedInstance()` reports true for a whole keystone run and exists for secret-value reads and Blizzard panel toggles.

## Fix

`InCombatLockdown()` alone is the gate. Nothing is lost by deferring, because the protected call could not have succeeded during combat either way, and the handler's existing `PLAYER_REGEN_ENABLED` arm re-applies the correct state the moment lockdown clears.

Two adjacent defects in the same handler, both from the same reading:

- A redundant `SetShown` on a frame already in that state still trips the block, so the protected call is now issued only on a real transition. This matches the same precedent, which documents the identical problem for the micro menu.
- `PLAYER_ENTERING_WORLD`'s first argument is `isInitialLogin`, not a unit, but the handler tested it with `if unit and unit ~= "player" then return end`. On a fresh login that argument is `true`, so the pass was skipped entirely. The unit test is now scoped to the two `UNIT_` events that actually carry one.

## Notes

- Line numbers were confirmed against the 8.7.4 tag rather than inferred: 10699 is the handler in the traceback, 10709 is the blocked `SetShown`, 10707 was the faulty gate.
- Swept for the same mistake elsewhere. This was the only place a protected-frame op was gated on `InProtectedInstance()`; the remaining callers are the secret-value reads it is meant for.
<img width="270" height="480" alt="Dog Puppy GIF by el" src="https://github.com/user-attachments/assets/4b493d49-62ea-497f-8dec-a480db4db78d" />

