### PR TITLE
chore(ci): improve github workflow security

### DIFF
--- a/.github/workflows/locale-check.yml
+++ b/.github/workflows/locale-check.yml
@@ -11,11 +11,16 @@ on:
       - 'Locales/_keys.txt'
       - '.tools/extract-locale-keys.sh'
 
+permissions:
+  contents: read
+
 jobs:
   locale-keys:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Regenerate the locale key list
         run: bash .tools/extract-locale-keys.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,22 @@ on:
     tags:
       - '**'
 
-env:
-  CF_API_KEY: ${{ secrets.CF_API_KEY }}
-  WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-  GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: BigWigsMods/packager@v2
+      - uses: BigWigsMods/packager@6d50adb6e8517eefef63f4afb16a6518166a6b28 # v2.5.1
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

_This PR does not touch the addon itself_

This PR improves the security around the github workflows according to [GitHub Security Guidance around workflows](https://docs.github.com/en/actions/reference/security/secure-use)

This could be improved further by adding a `CODEOWNERS` file that limits who can approve changes to these files as "in theory" someone with write access could do a lot of "damage" through workflows. But I would need to work with you all to make sure the right people/teams are in it.

## How was it tested?

Tested locally as much as I could using [act ](https://github.com/nektos/act) (ofc without creds for release)

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [N/A] New settings default **OFF** (no behavior change without opt-in)
- [N/A] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [N/A] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [N/A] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [N/A] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
