### PR TITLE
fix(cdm): FocusKick cast sound goes silent and never re-arms

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -17716,6 +17716,24 @@ initFrame:SetScript("OnEvent", function(self)
                     spellValues["__none"] = "(no spells on bar)"
                     spellOrder[#spellOrder + 1] = "__none"
                 end
+                -- The stored selection can outlive its spell: removing the kick
+                -- from the bar empties assignedSpells while
+                -- focusKickInterruptSpellID keeps pointing at it. With no label
+                -- for that key the dropdown falls back to rendering the key
+                -- itself, so the row displayed a bare spell id (field report:
+                -- "47528"). Give it a NAME but deliberately do NOT add it to
+                -- spellOrder -- it must not appear as a selectable option on a
+                -- bar that no longer holds it.
+                local selSid = BD and BD() and BD().focusKickInterruptSpellID
+                if selSid then
+                    local selKey = tostring(selSid)
+                    if not spellValues[selKey] then
+                        local selInfo = C_Spell and C_Spell.GetSpellInfo
+                            and C_Spell.GetSpellInfo(selSid)
+                        spellValues[selKey] = (selInfo and selInfo.name)
+                            or ("Spell " .. selKey)
+                    end
+                end
             end
             RebuildSpellOptions()
 

--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -358,6 +358,14 @@ function ns.AddSpellToBar(barKey, spellID)
     end
     local frame = cdmBarFrames[barKey]
     if frame then frame._blizzCache = nil; frame._prevVisibleCount = nil end
+    -- FocusKick arms its proxies on bar CONTENT, and nothing re-runs that when
+    -- the content changes here: adding the interrupt to an empty kick bar left
+    -- the cast sound unarmed until an unrelated rebuild (a spec change or a
+    -- loading screen) happened to run it. Field-reported as "added the spell,
+    -- still no sound; took a portal and it started working".
+    if barKey == ns.FOCUSKICK_BAR_KEY and ns.RefreshFocusKickProxies then
+        ns.RefreshFocusKickProxies("spell-added")
+    end
     return true
 end
 
@@ -415,6 +423,12 @@ function ns.RemoveSpellFromBar(barKey, spellID)
     end
     local frame = cdmBarFrames[barKey]
     if frame then frame._blizzCache = nil; frame._prevVisibleCount = nil end
+    -- Same reason as AddSpellToBar: emptying the kick bar must re-evaluate the
+    -- proxies. The cast sound survives an empty bar when an explicit interrupt
+    -- spell is set, so this is a re-evaluation, not an unconditional teardown.
+    if barKey == ns.FOCUSKICK_BAR_KEY and ns.RefreshFocusKickProxies then
+        ns.RefreshFocusKickProxies("spell-removed")
+    end
     return removed
 end
 

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7076,6 +7076,15 @@ function ns.RefreshFocusKickProxies()
             end
         end
     end
+    local soundWanted = false
+    if bd and bd.enabled ~= false then
+        local sk = bd.focusCastSoundKey
+        if sk and sk ~= "none" then
+            local sid = bd.focusKickInterruptSpellID
+            soundWanted = (type(sid) == "number" and sid > 0) or hasContent
+        end
+    end
+
     if not hasContent and not storeReady then
         -- Spell store unresolved: hold the current state rather than tearing
         -- down something that may still be correct, and COME BACK. Arming is
@@ -7085,6 +7094,10 @@ function ns.RefreshFocusKickProxies()
         -- fully populated bar. Field-confirmed: spells=1(1 pos) alongside
         -- sound=NOT CREATED, cured only by a spec change (which reruns
         -- BuildAllCDMBars). One pending retry at a time, self-cancelling.
+        -- An explicit interrupt spell id lives on the bar data, not in the
+        -- spell store, so the sound can arm right now even though the store is
+        -- still unresolved. Only the bar-content dependent parts have to wait.
+        if soundWanted then EnsureFocusCastProxy() end
         if not ns._fkRearmPending then
             ns._fkRearmPending = true
             C_Timer.After(2, function()
@@ -7094,12 +7107,20 @@ function ns.RefreshFocusKickProxies()
         end
         return
     end
+    -- The cast SOUND has a weaker requirement than the rest of the FocusKick
+    -- family. Its handler needs exactly two things: a configured sound, and an
+    -- interrupt spell id to run the "is my kick ready" check against. The bar's
+    -- assigned spells are only the FALLBACK source for that id -- an explicit
+    -- focusKickInterruptSpellID satisfies it on its own. Gating the sound on
+    -- hasContent therefore made a legitimate setup impossible: wanting the
+    -- focus-cast sound WITHOUT the kick icon sitting on the focus bar. The
+    -- icon-bearing parts of the family (anchor proxy, reminders) keep the
+    -- original bar-content gate.
     if hasContent then
         EnsureFocusKickProxy()
         ApplyFocusKickAnchor()
         EnsureFocusReminderProxy()
         RefreshFocusReminders()
-        EnsureFocusCastProxy()
     else
         if _focusKickProxy then
             _focusKickProxy:UnregisterAllEvents()
@@ -7110,9 +7131,12 @@ function ns.RefreshFocusKickProxies()
             _focusReminderProxy:UnregisterAllEvents()
             HideAllFocusReminders()
         end
-        if _focusCastProxy then
-            _focusCastProxy:UnregisterAllEvents()
-        end
+    end
+
+    if soundWanted then
+        EnsureFocusCastProxy()
+    elseif _focusCastProxy then
+        _focusCastProxy:UnregisterAllEvents()
     end
 end
 

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7078,7 +7078,20 @@ function ns.RefreshFocusKickProxies()
     end
     if not hasContent and not storeReady then
         -- Spell store unresolved: hold the current state rather than tearing
-        -- down something that may still be correct.
+        -- down something that may still be correct, and COME BACK. Arming is
+        -- otherwise a one-shot -- its only callers are setup and the tail of
+        -- BuildAllCDMBars -- so a login or zone where the spec key has not
+        -- resolved yet leaves the proxy unbuilt for the whole session, with a
+        -- fully populated bar. Field-confirmed: spells=1(1 pos) alongside
+        -- sound=NOT CREATED, cured only by a spec change (which reruns
+        -- BuildAllCDMBars). One pending retry at a time, self-cancelling.
+        if not ns._fkRearmPending then
+            ns._fkRearmPending = true
+            C_Timer.After(2, function()
+                ns._fkRearmPending = nil
+                if ns.RefreshFocusKickProxies then ns.RefreshFocusKickProxies() end
+            end)
+        end
         return
     end
     if hasContent then
@@ -9006,6 +9019,22 @@ function ECME:CDMFinishSetup()
     -- FocusKick family (anchor proxy + plate watcher, reminder text, cast
     -- sound): demand-gated -- an EMPTY kick bar installs nothing at all.
     ns.RefreshFocusKickProxies()
+    -- ...and again after every loading screen. Demand-gating makes arming a
+    -- one-shot, so any pass that runs before the spell store resolves leaves
+    -- the cast-sound proxy unbuilt until something unrelated rebuilds the bars
+    -- (a spec change, or opening the options). That is the reported "sound
+    -- stops working after I port" and it never recovers on its own. The
+    -- refresh is cheap and idempotent: it early-returns when the bar is empty
+    -- and re-registers the same events when it is not.
+    do
+        local fkRearm = CreateFrame("Frame")
+        fkRearm:RegisterEvent("PLAYER_ENTERING_WORLD")
+        fkRearm:SetScript("OnEvent", function()
+            C_Timer.After(2, function()
+                if ns.RefreshFocusKickProxies then ns.RefreshFocusKickProxies() end
+            end)
+        end)
+    end
     -- SharedMedia sounds feed the options dropdowns; append regardless.
     if EllesmereUI.AppendSharedMediaSounds then
         EllesmereUI.AppendSharedMediaSounds(

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7062,7 +7062,7 @@ function ns.RefreshFocusKickProxies()
     -- sound dying after a port or a zone change and only coming back when
     -- something else rebuilt the bars. When the store is not ready we now
     -- leave the proxy exactly as it is; the next rebuild arms it properly.
-    local storeReady = true
+    local storeReady, soundWanted = true, false
     if bd and bd.enabled ~= false then
         local sd = ns.GetBarSpellData and ns.GetBarSpellData(FOCUSKICK_BAR_KEY)
         if not sd then storeReady = false end
@@ -7075,13 +7075,17 @@ function ns.RefreshFocusKickProxies()
                 end
             end
         end
-    end
-    local soundWanted = false
-    if bd and bd.enabled ~= false then
+        -- The cast SOUND has a weaker requirement than the rest of the family.
+        -- Its handler needs a configured sound and an interrupt spell id to run
+        -- the "is my kick ready" check against; the bar's assigned spells are
+        -- only the FALLBACK source for that id, so an explicit
+        -- focusKickInterruptSpellID satisfies it alone. Gating the sound on
+        -- hasContent made a legitimate setup impossible: the focus-cast sound
+        -- WITHOUT the kick icon on the focus bar.
         local sk = bd.focusCastSoundKey
         if sk and sk ~= "none" then
-            local sid = bd.focusKickInterruptSpellID
-            soundWanted = (type(sid) == "number" and sid > 0) or hasContent
+            local pick = bd.focusKickInterruptSpellID
+            soundWanted = (type(pick) == "number" and pick > 0) or hasContent
         end
     end
 
@@ -7093,11 +7097,13 @@ function ns.RefreshFocusKickProxies()
         -- resolved yet leaves the proxy unbuilt for the whole session, with a
         -- fully populated bar. Field-confirmed: spells=1(1 pos) alongside
         -- sound=NOT CREATED, cured only by a spec change (which reruns
-        -- BuildAllCDMBars). One pending retry at a time, self-cancelling.
+        -- BuildAllCDMBars).
+        --
         -- An explicit interrupt spell id lives on the bar data, not in the
         -- spell store, so the sound can arm right now even though the store is
         -- still unresolved. Only the bar-content dependent parts have to wait.
         if soundWanted then EnsureFocusCastProxy() end
+        -- One pending retry at a time, self-cancelling.
         if not ns._fkRearmPending then
             ns._fkRearmPending = true
             C_Timer.After(2, function()
@@ -7107,15 +7113,7 @@ function ns.RefreshFocusKickProxies()
         end
         return
     end
-    -- The cast SOUND has a weaker requirement than the rest of the FocusKick
-    -- family. Its handler needs exactly two things: a configured sound, and an
-    -- interrupt spell id to run the "is my kick ready" check against. The bar's
-    -- assigned spells are only the FALLBACK source for that id -- an explicit
-    -- focusKickInterruptSpellID satisfies it on its own. Gating the sound on
-    -- hasContent therefore made a legitimate setup impossible: wanting the
-    -- focus-cast sound WITHOUT the kick icon sitting on the focus bar. The
-    -- icon-bearing parts of the family (anchor proxy, reminders) keep the
-    -- original bar-content gate.
+    -- Icon-bearing parts of the family keep the original bar-content gate.
     if hasContent then
         EnsureFocusKickProxy()
         ApplyFocusKickAnchor()

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7054,8 +7054,18 @@ ns.EnsureFocusReminderProxy = EnsureFocusReminderProxy
 function ns.RefreshFocusKickProxies()
     local bd = barDataByKey and barDataByKey[FOCUSKICK_BAR_KEY]
     local hasContent = false
+    -- "No spell data available" is NOT the same as "the bar is empty".
+    -- GetBarSpellData returns nil while the active spec key is unresolved
+    -- (not specKey or specKey == "0"), which is exactly the state during a
+    -- loading screen. Treating that as empty ran the teardown below and
+    -- UNREGISTERED a perfectly good proxy, which is the field report of the
+    -- sound dying after a port or a zone change and only coming back when
+    -- something else rebuilt the bars. When the store is not ready we now
+    -- leave the proxy exactly as it is; the next rebuild arms it properly.
+    local storeReady = true
     if bd and bd.enabled ~= false then
         local sd = ns.GetBarSpellData and ns.GetBarSpellData(FOCUSKICK_BAR_KEY)
+        if not sd then storeReady = false end
         local spells = sd and sd.assignedSpells
         if spells then
             for _, sid in ipairs(spells) do
@@ -7065,6 +7075,11 @@ function ns.RefreshFocusKickProxies()
                 end
             end
         end
+    end
+    if not hasContent and not storeReady then
+        -- Spell store unresolved: hold the current state rather than tearing
+        -- down something that may still be correct.
+        return
     end
     if hasContent then
         EnsureFocusKickProxy()

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6615,7 +6615,20 @@ ns.FOCUSKICK_SOUND_ORDER = FOCUSKICK_SOUND_ORDER
 -- token follows focus changes automatically.
 local _focusCastProxy
 local function RefreshFocusCastProxyUnit()
-    if not _focusCastProxy then return end
+    if not _focusCastProxy then
+        -- The proxy does not exist yet, so there is no unit to re-point. That
+        -- happens whenever the bar had no assigned spell the last time the
+        -- arming ran: RefreshFocusKickProxies only builds the proxy on its
+        -- hasContent branch, and its ONLY two callers are setup and the tail of
+        -- BuildAllCDMBars. Adding a spell in the options writes assignedSpells
+        -- without re-arming anything, so the sound stayed dead with the bar
+        -- fully populated -- field-confirmed by the probe reporting
+        -- spells=1(1 pos) alongside sound=NOT CREATED at the same instant.
+        -- Returning here was what made the state unrecoverable without a
+        -- rebuild; run the full refresh so this path can create it.
+        if ns.RefreshFocusKickProxies then ns.RefreshFocusKickProxies() end
+        return
+    end
     local unit = GetFocusKickUnit()
     _focusCastProxy:UnregisterAllEvents()
     _focusCastProxy:RegisterUnitEvent("UNIT_SPELLCAST_START", unit)


### PR DESCRIPTION
## Symptom

The FocusKick cast sound went silent at random. It came back if the options panel was touched, and reset again after porting or a loading screen. Reported on 8.7.4.

## Cause

Arming is demand-gated: `RefreshFocusKickProxies` builds the cast-sound proxy only on its `hasContent` branch, and it had exactly two callers, `CDMFinishSetup` and the tail of `BuildAllCDMBars`. That makes arming effectively a one-shot, with nothing to re-check when the inputs change afterwards.

Three separate routes into the bad state came out of that, each confirmed with a diagnostic build on the reporter's client:

1. **Unresolved spell store read as "empty bar".** `GetBarSpellData` returns nil while the active spec key is unresolved, which is exactly the state during a loading screen. That nil was indistinguishable from an empty bar, so the else branch ran and unregistered a working proxy. Nothing re-armed afterwards. This is the "sound stops after I port" report.
2. **No re-arm when content appears.** The probe caught `spells=1(1 pos)` and `sound=NOT CREATED` at the same instant: a fully populated bar with no proxy. `AddSpellToBar` and `RemoveSpellFromBar` are the chokepoints for `assignedSpells` and neither re-evaluated the proxies. The reporter's own words: "added the spell, still no sound; took a portal and it started working".
3. **The one user-reachable path could not recover.** `RefreshFocusCastProxyUnit` is what the options page calls, and it opened with `if not _focusCastProxy then return end` — so the only route a user could reach by hand was also the only one incapable of creating the proxy.

## Changes

- A nil spell store is treated as *unknown* rather than *empty*: the refresh leaves the proxy alone and schedules one bounded retry.
- `PLAYER_ENTERING_WORLD` schedules a deferred refresh, so a login or zone cannot leave the proxy permanently unbuilt.
- `AddSpellToBar` / `RemoveSpellFromBar` re-evaluate the proxies when the focuskick bar's content changes. Guarded on the focuskick key, so every other bar is unaffected, including the ghost-bar removal `AddSpellToBar` performs internally.
- `RefreshFocusCastProxyUnit` runs the full refresh instead of returning when the proxy is absent.

## Behaviour change, requested

The cast sound no longer requires the interrupt to be sitting on the FocusKick bar.

The handler never needed it: it requires a configured sound and an interrupt spell id to run its "is my kick ready" cooldown check against, and the bar's assigned spells are only the *fallback* source for that id. An explicit `focusKickInterruptSpellID` satisfies it alone. Arming was gated on `hasContent` regardless, so the runtime handler and the gate that installs it disagreed about what the feature needs, and taking the kick off the bar killed a sound that had everything required to keep working.

The cast sound now arms on its own condition. The icon-bearing parts of the family, the anchor proxy and the reminders, keep the original bar-content gate and are unchanged.

Who this affects, given `focusCastSoundKey` defaults to `"none"` and `focusKickInterruptSpellID` defaults to nil and is only ever written by the options dropdown:

- never configured a Focus Cast Sound: no change, the gate requires a sound
- sound set but no explicit interrupt picked: no change, the condition reduces to `hasContent`
- sound set **and** an explicit interrupt picked, bar empty: previously silent, now plays

The last group had to deliberately configure both, so the sound is almost certainly what they wanted. The one edge worth naming: anyone who silenced the sound by emptying the bar rather than setting the sound to None will hear it again. Setting Focus Cast Sound to None is the intended control.

Note that this makes `focusKickInterruptSpellID` load-bearing after the spell leaves the bar. It is deliberately not cleared on removal.

## Also

The Interrupt Spell dropdown rendered a bare spell id (`47528`) once its spell left the bar, because the label map is built only from spells currently on it. The stored selection now gets a resolved name, but is deliberately not added to the menu order, so it displays correctly without appearing as a selectable option on a bar that no longer holds it.

## Testing

Verified in game by the reporter across the full sequence: log in with the bar empty, add the spell and the sound works immediately with no portal or spec change, remove the spell and it keeps working, zone and it survives, log back in with the bar still empty and it still works.

Diagnostics used to find this were kept on a separate branch and are not in this diff.

<img width="480" height="360" alt="Link Smash GIF" src="https://github.com/user-attachments/assets/742f6e3a-98bc-4a89-8f56-ee9700ef9e4d" />

