### PR TITLE
fix(actionbars): only reveal empty slots when the drag can actually pick up

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -12923,7 +12923,12 @@ function EAB:FinishSetup()
         if locked == nil and C_CVar and C_CVar.GetCVarBool then
             locked = C_CVar.GetCVarBool("lockActionBars") and true or false
         end
-        ActionButtonController:SetAttribute("eab-barslocked", locked and 1 or 0)
+        local v = locked and 1 or 0
+        -- Guarded: SetAttribute re-runs the controller's _onattributechanged
+        -- snippet, and CVAR_UPDATE is a firehose at login.
+        if ActionButtonController:GetAttribute("eab-barslocked") ~= v then
+            ActionButtonController:SetAttribute("eab-barslocked", v)
+        end
     end
 
     -- 12.1: registering events on a frame stamps it with the EventRegistrations
@@ -12931,7 +12936,7 @@ function EAB:FinishSetup()
     -- any aspect. The controller wraps buttons and executes snippets, so its
     -- events must live on a plain sidecar listener, never on the controller.
     EAB._abcEvents = ns.TakeShell()
-    EAB._abcEvents:SetScript("OnEvent", function(_, event)
+    EAB._abcEvents:SetScript("OnEvent", function(_, event, arg1)
         if event == "ACTIONBAR_SHOWGRID" then
             -- Cancel any pending restore (swap case: drop + immediate pickup)
             _gridRestorePending = false
@@ -12979,8 +12984,11 @@ function EAB:FinishSetup()
                 end
             end
         elseif event == "CVAR_UPDATE" then
-            -- Lock toggled in Blizzard's settings: re-sync so the drag wrapper
-            -- stops (or starts) revealing on a plain left-drag immediately.
+            -- Name-filtered: CVAR_UPDATE fires for every cvar, dozens of times
+            -- at login. Only the lock matters to the drag wrapper.
+            if arg1 == "lockActionBars" then ns.EABSyncBarsLocked() end
+        elseif event == "PLAYER_REGEN_ENABLED" then
+            -- A lock toggled during combat deferred; pick it up on regen.
             ns.EABSyncBarsLocked()
         elseif event == "PLAYER_ENTERING_WORLD" or event == "SPELLS_CHANGED" then
             ns.EABSyncBarsLocked()
@@ -13010,6 +13018,7 @@ function EAB:FinishSetup()
     EAB._abcEvents:RegisterEvent("PLAYER_ENTERING_WORLD")
     EAB._abcEvents:RegisterEvent("SPELLS_CHANGED")
     EAB._abcEvents:RegisterEvent("CVAR_UPDATE")
+    EAB._abcEvents:RegisterEvent("PLAYER_REGEN_ENABLED")
     -- Seed before the first drag: PLAYER_ENTERING_WORLD may already be past.
     ns.EABSyncBarsLocked()
 

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -1271,8 +1271,19 @@ local function RegisterButtonWithController(btn)
     -- MainActionBar event chain staying secure end to end). The pre-wrap
     -- returns nothing, so the native drag proceeds untouched; the matching
     -- grid-off arrives via the monitor or, failing that, the regen apply.
+    -- OnDragStart fires on the GESTURE, not on a successful pickup. Blizzard's
+    -- own handler no-ops when the bars are locked and the PICKUPACTION modifier
+    -- is not held, so an unconditional reveal here lit every empty slot on a
+    -- plain left-drag over a locked bar -- and since no pickup happened, no
+    -- ACTIONBAR_HIDEGRID ever arrived to turn it back off. It then sat there
+    -- until some unrelated repaint cleared it (reported: "goes away in 5-15
+    -- seconds, or when I use the spell"). Mirror Blizzard's own condition so
+    -- the reveal only fires when the drag will actually pick the action up.
+    -- IsModifiedClick is whitelisted in the restricted environment.
     ActionButtonController:WrapScript(btn, "OnDragStart", [[
-        control:RunAttribute("SetShowGrid", true, 2)
+        if control:GetAttribute("eab-barslocked") ~= 1 or IsModifiedClick("PICKUPACTION") then
+            control:RunAttribute("SetShowGrid", true, 2)
+        end
     ]])
 
     -- Per-button showgrid: toggle the flag bit and update visibility.
@@ -12897,6 +12908,24 @@ function EAB:FinishSetup()
         end
         wipe(_gridSurfacedBars)
     end
+    -- Mirror Blizzard's lockActionBars setting onto the controller so the
+    -- secure OnDragStart wrapper can tell a real pickup from a dead gesture
+    -- (see the wrapper in RegisterButtonWithController). Attribute, not a
+    -- chunk local: this file is at Lua 5.1's 200-local cap, and the snippet
+    -- can only read attributes anyway.
+    ns.EABSyncBarsLocked = function()
+        if InCombatLockdown() then ns._eabApplyDeferred = true return end
+        local locked
+        if Settings and Settings.GetValue then
+            local ok, v = pcall(Settings.GetValue, "lockActionBars")
+            if ok then locked = v and true or false end
+        end
+        if locked == nil and C_CVar and C_CVar.GetCVarBool then
+            locked = C_CVar.GetCVarBool("lockActionBars") and true or false
+        end
+        ActionButtonController:SetAttribute("eab-barslocked", locked and 1 or 0)
+    end
+
     -- 12.1: registering events on a frame stamps it with the EventRegistrations
     -- forbidden aspect, and the restricted environment refuses frames carrying
     -- any aspect. The controller wraps buttons and executes snippets, so its
@@ -12949,7 +12978,12 @@ function EAB:FinishSetup()
                     C_Timer_After(0, RestoreGridSurfacedBars)
                 end
             end
+        elseif event == "CVAR_UPDATE" then
+            -- Lock toggled in Blizzard's settings: re-sync so the drag wrapper
+            -- stops (or starts) revealing on a plain left-drag immediately.
+            ns.EABSyncBarsLocked()
         elseif event == "PLAYER_ENTERING_WORLD" or event == "SPELLS_CHANGED" then
+            ns.EABSyncBarsLocked()
             -- Spec/talent swaps refill slots: retire the filled-slot fast
             -- lists (see the dispatcher's repaint walks) AND the curated-set
             -- memo (talents change what the viewer curates).
@@ -12975,6 +13009,9 @@ function EAB:FinishSetup()
     EAB._abcEvents:RegisterEvent("PET_BAR_HIDEGRID")
     EAB._abcEvents:RegisterEvent("PLAYER_ENTERING_WORLD")
     EAB._abcEvents:RegisterEvent("SPELLS_CHANGED")
+    EAB._abcEvents:RegisterEvent("CVAR_UPDATE")
+    -- Seed before the first drag: PLAYER_ENTERING_WORLD may already be past.
+    ns.EABSyncBarsLocked()
 
     -- Reset showgrid state at login (covers waiting for the game to apply
     -- the always-show-buttons state to the main bar).

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -1270,7 +1270,9 @@ local function RegisterButtonWithController(btn)
     -- ActionButton1 showgrid monitor (which depends on Blizzard's retained
     -- MainActionBar event chain staying secure end to end). The pre-wrap
     -- returns nothing, so the native drag proceeds untouched; the matching
-    -- grid-off arrives via the monitor or, failing that, the regen apply.
+    -- grid-off arrives via the monitor or, failing that, the regen apply --
+    -- but only when a pickup actually happens, which is what the guard below
+    -- is for.
     -- OnDragStart fires on the GESTURE, not on a successful pickup. Blizzard's
     -- own handler no-ops when the bars are locked and the PICKUPACTION modifier
     -- is not held, so an unconditional reveal here lit every empty slot on a
@@ -12914,11 +12916,16 @@ function EAB:FinishSetup()
     -- chunk local: this file is at Lua 5.1's 200-local cap, and the snippet
     -- can only read attributes anyway.
     ns.EABSyncBarsLocked = function()
-        if InCombatLockdown() then ns._eabApplyDeferred = true return end
+        -- No _eabApplyDeferred here, unlike the widget-writing guards: nothing
+        -- else needs re-applying, and PLAYER_REGEN_ENABLED re-syncs this.
+        if InCombatLockdown() then return end
         local locked
         if Settings and Settings.GetValue then
             local ok, v = pcall(Settings.GetValue, "lockActionBars")
-            if ok then locked = v and true or false end
+            -- v ~= nil, not just ok: this seeds during FinishSetup, which can
+            -- run before the setting is registered. Accepting nil as "false"
+            -- would skip the CVar fallback and seed a LOCKED bar as unlocked.
+            if ok and v ~= nil then locked = v and true or false end
         end
         if locked == nil and C_CVar and C_CVar.GetCVarBool then
             locked = C_CVar.GetCVarBool("lockActionBars") and true or false
@@ -12991,7 +12998,7 @@ function EAB:FinishSetup()
             -- A lock toggled during combat deferred; pick it up on regen.
             ns.EABSyncBarsLocked()
         elseif event == "PLAYER_ENTERING_WORLD" or event == "SPELLS_CHANGED" then
-            ns.EABSyncBarsLocked()
+            if event == "PLAYER_ENTERING_WORLD" then ns.EABSyncBarsLocked() end
             -- Spec/talent swaps refill slots: retire the filled-slot fast
             -- lists (see the dispatcher's repaint walks) AND the curated-set
             -- memo (talents change what the viewer curates).


### PR DESCRIPTION
## The report

Reported by @WildKab on 8.7.6, a follow-on to the empty-slot fix in that release. With action bars **locked**, left-click-dragging a spell lights up the empty-slot boxes on every bar, and they stay there for 5-15 seconds, or until the spell is used, or until it is actually moved with shift.

## Cause

The combat-drag belt wraps `OnDragStart` on every button and set the transient grid bit unconditionally:

```lua
ActionButtonController:WrapScript(btn, "OnDragStart", [[
    control:RunAttribute("SetShowGrid", true, 2)
]])
```

`OnDragStart` fires on the **gesture**, not on a successful pickup. Blizzard's own `ActionBarActionButtonMixin:OnDragStart` checks `Settings.GetValue("lockActionBars")` and `IsModifiedClick("PICKUPACTION")` and no-ops when the bars are locked without the modifier.

So a plain left-drag over a locked bar turned the grid on with no pickup behind it. With no pickup there is no `ACTIONBAR_HIDEGRID`, so the wrapper's assumption that "the matching grid-off arrives via the monitor or, failing that, the regen apply" never came true on this path.

That accounts for all three ways the reporter saw it clear:

- **Shift-drag** is a real pickup, so it produces a real SHOWGRID/HIDEGRID pair.
- **Using the spell** forces a repaint.
- **5-15 seconds** is however long until some unrelated grid event lands.

This is not a regression of the 8.7.6 fix. That one was about the showgrid reason bitmask, where bit 1 is Blizzard's own CVAR reason so the transient test had to become `>= 2` rather than `> 0`. Same subsystem, different cause.

## Fix

Mirror Blizzard's own condition inside the snippet, so the reveal only fires when the drag will actually pick the action up.

`IsModifiedClick` is available in the restricted environment: it is in `DIRECT_MACRO_CONDITIONAL_NAMES`, copied into `RESTRICTED_FUNCTIONS_SCOPE` at `Blizzard_RestrictedAddOnEnvironment/RestrictedEnvironment.lua:97`, and `SecureHandlers.lua` ships in that same addon.

The lock setting cannot be read in there, so it rides in as an `eab-barslocked` attribute on the controller, synced at setup, on `PLAYER_ENTERING_WORLD`, and on `CVAR_UPDATE` (name-filtered) and `PLAYER_REGEN_ENABLED` for a lock toggled during combat.

**Fails open.** An unseeded or stale attribute reads as "not locked" and you get the previous unconditional reveal, so the combat-drag fix cannot regress into being worse than today.

## Notes for review

- Third commit is a self-review pass. It fixes a real seed-path defect: `Settings.GetValue` returning nil was accepted as "not locked" because only the pcall status was checked, and the seed runs inside `FinishSetup`, which can execute before that setting is registered.
- The write to the controller attribute is guarded on change, since `SetAttribute` re-runs the controller's `_onattributechanged` snippet. That snippet only acts on `name == "flush"`, so the new attribute is otherwise inert there.
- No new chunk-level locals; this file is at Lua 5.1's 200-local cap.
- `luac -p` clean.

<img width="392" height="498" alt="Cracking Up Lol GIF by MOODMAN" src="https://github.com/user-attachments/assets/0b42c095-9fdf-4b67-98fd-65847a279048" />
