### PR TITLE
fix(cdm): never park a cooldown frame we failed to identify

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -7221,21 +7221,35 @@ local function CollectAndReanchor()
     end
     local buffViewer = _G["BuffIconCooldownViewer"]
     local barViewer  = _G["BuffBarCooldownViewer"]
-    -- Only protect unresolved frames while the retry budget below still has
-    -- passes left. Once it is spent, a frame that still will not resolve is no
-    -- longer plausibly transient (a stale pool entry with a dead cooldownID),
-    -- and parking it is right again -- otherwise it would sit at Blizzard's own
-    -- Edit Mode position forever, which is the "CDM looks scrambled" face of
-    -- this bug rather than the "CDM is empty" one.
+    -- Only protect NEVER-CLAIMED unresolved frames while the retry budget below
+    -- still has passes left. Once it is spent, a frame that has never been ours
+    -- and still will not resolve is no longer plausibly transient (a stale pool
+    -- entry with a dead cooldownID), and parking it is right again -- otherwise
+    -- it would sit at Blizzard's own Edit Mode position forever, which is the
+    -- "CDM looks scrambled" face of this bug rather than the "CDM is empty" one.
     local protectUnresolved = (ns._cdmUnresolvedRetries or 0) < 3
     for frame in pairs(allActiveFrames) do
         if usedFrames[frame] then
             -- Claimed: leave alone
-        elseif unresolvedFrames[frame] and protectUnresolved then
+        elseif unresolvedFrames[frame]
+               and (protectUnresolved
+                    or (_ecmeFC[frame] and _ecmeFC[frame].barKey)) then
             -- Unknown, not rejected: identification failed this pass, so we
             -- have no basis to park it. Leave it exactly as it is and let the
             -- re-collect scheduled at the end of this function claim it once
             -- the cooldown-viewer API answers again.
+            --
+            -- fc.barKey means we HAVE claimed this frame before, and that
+            -- exemption never expires. ScheduleTalentRebuild wipes resolvedSid
+            -- and cachedCdID but deliberately not barKey, so it survives the
+            -- exact rebuild that strips the resolve memos -- which is the zone
+            -- transition where the API answers nil for longer than any fixed
+            -- retry budget can cover. A frame that was on a bar a moment ago
+            -- and is momentarily unidentifiable is transient by definition, and
+            -- parking it is what turns a working CDM blank. Note this cannot
+            -- strand a genuinely retired frame: one whose spell was unassigned
+            -- or ghosted RESOLVES fine and simply routes nowhere, so it never
+            -- reaches this branch at all.
         elseif frame._isRacialFrame or frame._isTrinketFrame
                or frame._isPresetFrame or frame._isItemPresetFrame
                or frame._isCustomSpellFrame then

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -5509,6 +5509,10 @@ local _scratch_spellOrder = {}  -- CD/utility: spellID -> sort index
 local _scratch_activeFrames = {}
 local _scratch_usedFrames = {}
 local _scratch_cdFrames = {}    -- CD/utility: barKey -> {frame, frame, ...}
+-- CD/utility frames that routed to one of our bars but whose spell could not be
+-- resolved this pass (see the collect loop). "Unknown", NOT "rejected": the
+-- Phase 4 sweep must leave these alone rather than park them offscreen.
+local _scratch_unresolved = {}
 
 local function _sortByLayoutIndex(a, b)
     return (a.layoutIndex or 0) < (b.layoutIndex or 0)
@@ -5568,8 +5572,10 @@ local function CollectAndReanchor()
 
     wipe(_scratch_usedFrames)
     wipe(_scratch_activeFrames)
+    wipe(_scratch_unresolved)
     local allActiveFrames = _scratch_activeFrames
     local usedFrames = _scratch_usedFrames
+    local unresolvedFrames = _scratch_unresolved
 
     -- Always Show Buffs: hide every placeholder up front; the routing path below
     -- re-shows only the placeholders it injects this pass, so stale ones (buff
@@ -5850,6 +5856,18 @@ local function CollectAndReanchor()
                                     fc.barKey = barKey
                                     fc.spellID = baseSID or displaySID
                                     fc.isHostedBuff = nil
+                                else
+                                    -- Routed to one of our bars, but the spell
+                                    -- would not resolve: GetCooldownViewerCooldownInfo
+                                    -- returns nil for a cooldownID while Blizzard is
+                                    -- mid-rebuild (zone-in, PvP talents activating,
+                                    -- a spec swap that just wiped the resolve memos).
+                                    -- This frame is OURS and merely unidentified, so
+                                    -- Phase 4 must not treat it like a deliberately
+                                    -- unrouted one and park it at -10000 -- that is
+                                    -- what empties the bars until a reload, since
+                                    -- nothing re-collects afterwards.
+                                    unresolvedFrames[frame] = true
                                 end
                             end
                         end
@@ -7203,9 +7221,21 @@ local function CollectAndReanchor()
     end
     local buffViewer = _G["BuffIconCooldownViewer"]
     local barViewer  = _G["BuffBarCooldownViewer"]
+    -- Only protect unresolved frames while the retry budget below still has
+    -- passes left. Once it is spent, a frame that still will not resolve is no
+    -- longer plausibly transient (a stale pool entry with a dead cooldownID),
+    -- and parking it is right again -- otherwise it would sit at Blizzard's own
+    -- Edit Mode position forever, which is the "CDM looks scrambled" face of
+    -- this bug rather than the "CDM is empty" one.
+    local protectUnresolved = (ns._cdmUnresolvedRetries or 0) < 3
     for frame in pairs(allActiveFrames) do
         if usedFrames[frame] then
             -- Claimed: leave alone
+        elseif unresolvedFrames[frame] and protectUnresolved then
+            -- Unknown, not rejected: identification failed this pass, so we
+            -- have no basis to park it. Leave it exactly as it is and let the
+            -- re-collect scheduled at the end of this function claim it once
+            -- the cooldown-viewer API answers again.
         elseif frame._isRacialFrame or frame._isTrinketFrame
                or frame._isPresetFrame or frame._isItemPresetFrame
                or frame._isCustomSpellFrame then
@@ -7419,6 +7449,29 @@ local function CollectAndReanchor()
         local pv = EllesmereUI._contentHeaderPreview
         if pv and pv.Update then pv:Update() end
     end
+    -- Frames we could not identify this pass were skipped by the Phase 4 sweep
+    -- and are still sitting wherever Blizzard left them. Re-collect shortly so
+    -- they claim as soon as the cooldown-viewer API answers again -- this is
+    -- what makes the recovery timing-independent instead of racing a fixed
+    -- delay against the loading screen. Bounded and self-resetting: a clean
+    -- pass restores the budget, and an id that never resolves falls back to the
+    -- park path above once the budget is spent, so this can never spin.
+    if next(unresolvedFrames) then
+        local tries = ns._cdmUnresolvedRetries or 0
+        if tries < 3 and not ns._cdmUnresolvedPending then
+            ns._cdmUnresolvedRetries = tries + 1
+            ns._cdmUnresolvedPending = true
+            -- Backoff 0.5s / 1.5s / 2.5s: covers a loading-screen settle
+            -- without a poll, since each retry is one queued reanchor.
+            C_Timer.After(0.5 + tries, function()
+                ns._cdmUnresolvedPending = nil
+                if ns.QueueReanchor then ns.QueueReanchor() end
+            end)
+        end
+    elseif ns._cdmUnresolvedRetries then
+        ns._cdmUnresolvedRetries = 0
+    end
+
     -- Claims just settled: retire the proc-alert child map so the next alert
     -- rebuilds it against the fresh claim set.
     if ns._cdmClaimGen then ns._cdmClaimGen = ns._cdmClaimGen + 1 end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -9711,3 +9711,82 @@ SlashCmdList.ECME = function(msg)
 end
 
 
+
+-------------------------------------------------------------------------------
+--  /cdmwhy -- one-shot claim diagnostic
+--
+--  Exists because "the CDM is empty" has three completely different causes and
+--  a screenshot cannot tell them apart:
+--    * Blizzard's pools are empty      -> nothing for us to claim; our problem
+--                                         is that the viewer never repopulated
+--    * frames exist but are PARKED     -> we claimed nothing and swept them to
+--                                         -10000 (the unclaimed-frame cleanup)
+--    * frames exist and are CLAIMED    -> the bars are fine and something else
+--                                         (visibility, alpha) is hiding them
+--  Read-only and zero cost until typed.
+-------------------------------------------------------------------------------
+SLASH_CDMWHY1 = "/cdmwhy"
+SlashCmdList.CDMWHY = function()
+    local function say(fmt, ...)
+        print("|cff0cd29fCDM|r " .. string.format(fmt, ...))
+    end
+    local _, instType = IsInInstance()
+    say("zone=%s  wasPvP=%s  retries=%s  pending=%s",
+        tostring(instType), tostring(ns._cdmWasInPvP),
+        tostring(ns._cdmUnresolvedRetries), tostring(ns._cdmUnresolvedPending))
+
+    local totActive, totClaimed, totParked, totUnres = 0, 0, 0, 0
+    for _, vname in ipairs(_cdmViewerNames) do
+        local vf = _G[vname]
+        local active, claimed, parked, unres = 0, 0, 0, 0
+        if vf and vf.itemFramePool and vf.itemFramePool.EnumerateActive then
+            for ch in vf.itemFramePool:EnumerateActive() do
+                active = active + 1
+                local fc = _ecmeFC[ch]
+                if fc and fc.barKey then claimed = claimed + 1 end
+                -- Parked = swept offscreen by the unclaimed-frame cleanup.
+                local l = ch.GetLeft and ch:GetLeft()
+                if l and l < -9000 then parked = parked + 1 end
+                -- Live resolve probe: this is the exact call whose nil return
+                -- is what makes a frame unidentifiable mid-rebuild.
+                local cdID = ch.cooldownID or (ch.cooldownInfo and ch.cooldownInfo.cooldownID)
+                if cdID and C_CooldownViewer and C_CooldownViewer.GetCooldownViewerCooldownInfo then
+                    if not C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID) then
+                        unres = unres + 1
+                    end
+                elseif not cdID then
+                    unres = unres + 1
+                end
+            end
+        end
+        say("%s active=%d claimed=%d parked=%d unresolvable=%d",
+            vname, active, claimed, parked, unres)
+        totActive, totClaimed = totActive + active, totClaimed + claimed
+        totParked, totUnres = totParked + parked, totUnres + unres
+    end
+    say("TOTAL active=%d claimed=%d parked=%d unresolvable=%d",
+        totActive, totClaimed, totParked, totUnres)
+
+    local p = ECME.db and ECME.db.profile
+    if p and p.cdmBars and p.cdmBars.bars then
+        for _, bd in ipairs(p.cdmBars.bars) do
+            if bd.enabled then
+                local icons = cdmBarIcons[bd.key]
+                local f = cdmBarFrames[bd.key]
+                say("bar %-14s icons=%d alpha=%s hidden=%s",
+                    bd.key, icons and #icons or 0,
+                    f and string.format("%.2f", f:GetAlpha()) or "nil",
+                    tostring(f and f._visHidden))
+            end
+        end
+    end
+    if totActive == 0 then
+        say("VERDICT: Blizzard's pools are EMPTY -- the viewer never repopulated.")
+    elseif totParked >= totActive - 1 then
+        say("VERDICT: frames exist but are PARKED -- the claim pass failed.")
+    elseif totClaimed > 0 and totUnres == 0 then
+        say("VERDICT: frames are CLAIMED -- look at bar alpha/visibility above.")
+    else
+        say("VERDICT: mixed; send the whole dump.")
+    end
+end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8151,10 +8151,21 @@ function ns.FullCDMRebuild(reason)
                         chfc.isChargeSpell = nil
                         chfc.maxCharges = nil
                         chfc.sortOrder = nil
+                        -- NOT chfc.barKey: CollectAndReanchor reads it as
+                        -- "we have claimed this frame before" and refuses to
+                        -- park it while identification is transiently failing.
+                        -- Clearing it here would hand the next pass a frame it
+                        -- cannot identify AND cannot vouch for.
                     end
                 end
             end
         end
+        -- A memo wipe is the START of a fresh transient-failure window, so
+        -- hand the reanchor below a full retry budget instead of whatever an
+        -- earlier transition left behind. Matters for cooldowns that are new
+        -- to the spec being swapped TO: those have no barKey to vouch for
+        -- them, so the budget is all they have.
+        ns._cdmUnresolvedRetries = 0
         -- Cancel the reanchor BuildAllCDMBars queued -- we run our own
         -- direct one immediately below. Without this, the queued reanchor
         -- would fire ~200ms later and run the entire reanchor pipeline
@@ -9446,6 +9457,7 @@ local function ScheduleTalentRebuild()
                 end
             end
         end
+        ns._cdmUnresolvedRetries = 0  -- fresh window; see FullCDMRebuild
         -- Rebuild keybind cache (talent swap may change action slot contents)
         UpdateCDMKeybinds()
         -- Invalidate TBB frame cache + spell caches, then reanchor so


### PR DESCRIPTION
## The report

Porting into a battleground left the Cooldown Manager holding one or two icons, out of combat, with no Lua errors, and only a `/reload` brought it back. A second reporter saw the same thing on the way *out* of a battleground, and after swapping spec during a battleground load.

## Cause

`CollectAndReanchor`'s Phase 4 sweep names two states and handles two, but three arrive. Its own comment says it:

```lua
-- CD/utility frame: unclaimed (unrouted or ghost-bar routed).
```

Everything not in `usedFrames` is alpha-zeroed **and parked at -10000**. A frame that merely failed to *resolve* lands in that same bucket.

Resolution fails whenever `C_CooldownViewer.GetCooldownViewerCooldownInfo` returns nil for a cooldownID, which is exactly what Blizzard does mid-rebuild: a zone-in, PvP talents activating or deactivating, or a spec swap. At the collect site the failure had no `else` at all, so the frame was silently dropped, never entered `usedFrames`, and got parked.

The survivors are the frames whose `fc` memo was still valid (`fc.resolvedSid and fc.cachedCdID == cdID`) and so never re-resolved. That is why it presents as "everything gone except an icon or two".

The same root has a second face: a frame that misses the sweep sits at Blizzard's own Edit Mode position instead, which is the centre-screen scramble over the action bars that one reporter caught on video.

## Fix

**Record resolve failures separately and skip them in the sweep.** Unknown is not rejected, and there is no basis to park what could not be identified. A bounded 0.5 / 1.5 / 2.5s backoff re-collects so the frames claim as soon as the API answers, which makes recovery timing-independent rather than racing a fixed delay against the loading screen.

**A frame we have claimed before never parks on a failed resolve.** `fc.barKey` records that we claimed it, and neither memo-wipe path (`ScheduleTalentRebuild` nor `FullCDMRebuild`'s `isFullWipe`) clears it, so it survives the very rebuild that strips identification. A frame that was on a bar moments ago and is briefly unidentifiable is transient by definition. This is what covers the zone-*out* case, where a loading-screen settle can outlast any fixed budget.

This cannot strand a retired frame: one whose spell was unassigned or ghosted still resolves and simply routes nowhere, so it never enters the unresolved set and takes the normal park path.

**The budget refills at every memo wipe**, since a wipe is by definition the start of a fresh window of transient failures. That matters for cooldowns new to the spec being swapped *to*, which have no `barKey` to vouch for them.

Once the budget is spent, a never-claimed frame that still will not resolve is no longer plausibly transient and parks as before, so a stale pool entry cannot sit on screen forever. Any clean pass restores the budget.

## `/cdmwhy`

The last commit adds a read-only diagnostic, in the same spirit as `/eablag` and `/cdmbb`. "The CDM is empty" has three causes a screenshot cannot separate: Blizzard's pools are empty, the frames are parked, or they are claimed and something else hides them. Only the middle one is what this PR addresses, and three rounds of this bug were reasoned without being able to tell them apart. `/cdmwhy` dumps per-viewer active/claimed/parked counts, probes the resolve call live, lists each bar's icon count and alpha, and prints a verdict. Zero cost until typed, and easy to drop from this PR if you would rather it landed separately.

## Notes

- No new chunk-level locals; both files are near Lua 5.1's 200-local cap. The retry state lives on `ns`, the frame set on the existing `_scratch_*` pattern.
- The wipe site in `FullCDMRebuild` now carries a comment explaining why `barKey` is deliberately absent from the list, since that omission is load-bearing and would otherwise read like an oversight.
- `luac -p` clean.

## Testing

Confirmed in game: battleground entry, exit, and a spec swap during a battleground load, with no breakage.

<img width="344" height="272" alt="Bunny Cute Animals GIF" src="https://github.com/user-attachments/assets/9286a203-e4f9-4f62-9760-44782e1a33ef" />
