### PR TITLE
fix(questtracker): contain Blizzard quest icons within background

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
@@ -35,6 +35,12 @@ local function TopGapOffset()
     return 0
 end
 
+local function GetBGLeftOffset()
+    -- Blizzard quest icons extend 13px left of the tracker. Preserve the
+    -- existing 6px breathing room without widening icon-disabled layouts.
+    return EQT.Cfg("showQuestIcons") and -19 or -6
+end
+
 -- When "Hide All Objectives" is on, otf.Header/HeaderMenu is Hidden but
 -- Blizzard's topModulePadding still reserves its layout slot above the
 -- first module (the same "dead gap" this suite has run into before) --
@@ -276,9 +282,10 @@ local function EnsureBG()
     -- above) so it doesn't bleed above the content or leave a gap below it.
     -- Bottom edge extends past the last block (re-anchored dynamically below).
     local topOfs = TopGapOffset()
+    local leftOfs = GetBGLeftOffset()
     local anchorFrame, anchorPoint = GetBGTopAnchor()
     anchorFrame = anchorFrame or otf
-    _bgFrame:SetPoint("TOPLEFT", anchorFrame, anchorPoint .. "LEFT", -6, topOfs)
+    _bgFrame:SetPoint("TOPLEFT", anchorFrame, anchorPoint .. "LEFT", leftOfs, topOfs)
     -- Bottom is re-anchored dynamically in ResizeBGToContent(); this is
     -- only the fallback extent when no content has loaded yet (30px tall).
     _bgFrame:SetPoint("BOTTOMRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs - 30)
@@ -291,7 +298,7 @@ local function EnsureBG()
     -- directly to it so the line matches tracker width regardless of BG
     -- padding. Same snap pattern as PP.CreateBorder.
     local divider = _bgFrame:CreateTexture(nil, "OVERLAY")
-    divider:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  -6, topOfs)
+    divider:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
     divider:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT",  11, topOfs)
     _bgFrame._divider = divider
     return _bgFrame
@@ -438,26 +445,27 @@ local function ResizeBGToContent()
     bg._hideCheck = nil
     if not bg:IsShown() then bg:Show() end
     local topOfs = TopGapOffset()
+    local leftOfs = GetBGLeftOffset()
     local anchorFrame, anchorPoint = GetBGTopAnchor()
     anchorFrame = anchorFrame or otf
     local topY = (anchorPoint == "BOTTOM") and anchorFrame:GetBottom() or anchorFrame:GetTop()
     local lowestBottom = lowest:GetBottom()
     if bg._divider then
         bg._divider:ClearAllPoints()
-        bg._divider:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  -6, topOfs)
+        bg._divider:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
         bg._divider:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
     end
     if topY and lowestBottom then
         local h = topY + topOfs - lowestBottom + 15
         if h < 1 then h = 1 end
         bg:ClearAllPoints()
-        bg:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  -6, topOfs)
+        bg:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
         bg:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
         bg:SetHeight(h)
         bg._lastHeight = h
     elseif bg._lastHeight then
         bg:ClearAllPoints()
-        bg:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  -6, topOfs)
+        bg:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
         bg:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
         bg:SetHeight(bg._lastHeight)
     end


### PR DESCRIPTION
## What does this PR do?

Extends the addon-owned Quest Tracker background and divider far enough left to contain Blizzard's native quest icons when **Show Quest Icons** is enabled. Icon-disabled layouts keep the existing compact offset.

The right edge and tracker content alignment are unchanged. No Blizzard-owned frame or icon is modified.

Fixes #1197

## How was it tested?

- Retail 12.0.7.68974 on `Lillydan-Thunderhorn`: populated tracker with native icons, reload, and world map open/close.
- 12.1 PTR 12.1.0.69111 on `Lillydan-Anasterian`: matched baseline/patched A/B, native icons enabled and disabled, and repeated reloads.
- `taintLog 2`: zero Quest Tracker / Objective Tracker matches on both clients after the tested interactions.
- Lua 5.1 parse with `luac5.1 -p`, ASCII scan, and `git diff --check`.
- Static audit confirms every relevant background/divider `TOPLEFT` anchor uses the shared offset, with no new events, hooks, frames, timers, polling, or allocations.

Not exercised because the available characters did not have those states ready: an empty tracker, a newly completed quest transition, live combat, and a new supertrack transition.

## Screenshots

Matched 3440x1440 PTR captures at the same tracker position and UI scale:

| Before | After |
| --- | --- |
| ![Before: native icons protrude past the background](https://raw.githubusercontent.com/0x963D/EllesmereUI/c4f4cc6a10bb129de05063f33b4f6e54a2fd33b6/.github/pr-assets/1197-before.png) | ![After: native icons are contained with breathing room](https://raw.githubusercontent.com/0x963D/EllesmereUI/c4f4cc6a10bb129de05063f33b4f6e54a2fd33b6/.github/pr-assets/1197-after.png) |

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A; no new setting.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
