### PR TITLE
feat(qol): hold Artisan payouts at shard cap

### DIFF
--- a/EllesmereUIQoL/EUI_QoL_Options.lua
+++ b/EllesmereUIQoL/EUI_QoL_Options.lua
@@ -2324,6 +2324,19 @@ initFrame:SetScript("OnEvent", function(self)
                           if not EllesmereUIDB then EllesmereUIDB = {} end
                           EllesmereUIDB.autoOpenContainersExcludeWarbound = v
                       end },
+                    { type="toggle", label="Hold Capped Artisan Payouts",
+                      tooltip="Keeps Artisan's Consortium Payouts closed while Shard of Dundun is at its maximum, then resumes automatic opening after you spend shards.",
+                      get=function()
+                          return EllesmereUIDB
+                              and EllesmereUIDB.autoOpenContainersHoldCappedArtisanPayouts == true
+                      end,
+                      set=function(v)
+                          if not EllesmereUIDB then EllesmereUIDB = {} end
+                          EllesmereUIDB.autoOpenContainersHoldCappedArtisanPayouts = v
+                          if EllesmereUI._applyAutoOpenContainers then
+                              EllesmereUI._applyAutoOpenContainers()
+                          end
+                      end },
                 },
             })
 
@@ -2435,6 +2448,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.autoUnwrapCollections = false
                 EllesmereUIDB.autoOpenContainers = false
                 EllesmereUIDB.autoOpenContainersExcludeWarbound = true
+                EllesmereUIDB.autoOpenContainersHoldCappedArtisanPayouts = false
                 EllesmereUIDB.autoRepairGuild = false
                 EllesmereUIDB.shifterEnabled = false
                 EllesmereUIDB.shifterPositions = nil

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -236,6 +236,18 @@ qolFrame:SetScript("OnEvent", function(self)
         local function IsEnabled()
             return EllesmereUIDB and EllesmereUIDB.autoOpenContainers == true
         end
+        -- This payout can award this capped currency; hold only the known pair.
+        local ARTISAN_PAYOUT_ITEM_ID = 246585
+        local SHARD_OF_DUNDUN_CURRENCY_ID = 3376
+        local function ShouldHoldCappedArtisanPayout(itemID)
+            if itemID ~= ARTISAN_PAYOUT_ITEM_ID
+                or not (EllesmereUIDB
+                    and EllesmereUIDB.autoOpenContainersHoldCappedArtisanPayouts == true) then
+                return false
+            end
+            return C_CurrencyInfo and C_CurrencyInfo.PlayerHasMaxQuantity
+                and C_CurrencyInfo.PlayerHasMaxQuantity(SHARD_OF_DUNDUN_CURRENCY_ID) or false
+        end
         -- A merchant being open turns UseContainerItem into a SELL (Blizzard
         -- routes "use item" to the vendor), so auto-open must pause while any
         -- merchant frame is shown -- otherwise freshly-bought containers get
@@ -362,6 +374,12 @@ qolFrame:SetScript("OnEvent", function(self)
                 -- linger in the bag) aren't opened over / re-opened while looting.
                 containerFrame:RegisterEvent("LOOT_OPENED")
                 containerFrame:RegisterEvent("LOOT_CLOSED")
+                if EllesmereUIDB.autoOpenContainersHoldCappedArtisanPayouts == true
+                    and C_CurrencyInfo and C_CurrencyInfo.PlayerHasMaxQuantity then
+                    containerFrame:RegisterEvent("CURRENCY_DISPLAY_UPDATE")
+                else
+                    containerFrame:UnregisterEvent("CURRENCY_DISPLAY_UPDATE")
+                end
                 -- Resume opens deferred while the player was casting. Without
                 -- these the deferral would stall until the next bag update.
                 containerFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
@@ -371,6 +389,8 @@ qolFrame:SetScript("OnEvent", function(self)
                     _scanBag = BACKPACK_CONTAINER
                     _scanSlot = 1
                     scanFrame:Show()
+                elseif RequestScan then
+                    RequestScan()
                 end
             else
                 containerFrame:UnregisterEvent("BAG_UPDATE_DELAYED")
@@ -382,6 +402,7 @@ qolFrame:SetScript("OnEvent", function(self)
                 end
                 containerFrame:UnregisterEvent("LOOT_OPENED")
                 containerFrame:UnregisterEvent("LOOT_CLOSED")
+                containerFrame:UnregisterEvent("CURRENCY_DISPLAY_UPDATE")
                 containerFrame:UnregisterEvent("UNIT_SPELLCAST_SUCCEEDED")
                 containerFrame:UnregisterEvent("UNIT_SPELLCAST_STOP")
                 containerFrame:UnregisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
@@ -501,7 +522,8 @@ qolFrame:SetScript("OnEvent", function(self)
                 -- (set synchronously below) or Blizzard's isLocked. Re-using a
                 -- container that's still resolving a previous open strands it.
                 if info and info.itemID and not info.isLocked and not _openInProgress[key] then
-                    if IsWarboundExcluded(item.bag, item.slot) then
+                    if IsWarboundExcluded(item.bag, item.slot)
+                        or ShouldHoldCappedArtisanPayout(info.itemID) then
                         return step(idx + 1)
                     end
                     if _openableCache[info.itemID] and not _failedItems[info.itemID] then
@@ -632,6 +654,12 @@ qolFrame:SetScript("OnEvent", function(self)
             end
             if event == "BAG_UPDATE_DELAYED" then
                 RequestScan()
+                return
+            end
+            if event == "CURRENCY_DISPLAY_UPDATE" then
+                if not ShouldHoldCappedArtisanPayout(ARTISAN_PAYOUT_ITEM_ID) then
+                    RequestScan()
+                end
                 return
             end
             if event == "UNIT_SPELLCAST_SUCCEEDED" or event == "UNIT_SPELLCAST_STOP"


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `Hold Capped Artisan Payouts` setting under Auto Open Containers.

When enabled, Artisan's Consortium Payouts (item 246585) stay closed while Shard of Dundun (currency 3376) is at its total maximum. Automatic opening resumes after shards are spent. All other containers keep the existing behavior.

The setting defaults off and targets only this known payout/currency pair.

## How was it tested?

- Lua 5.1 parse with luaparse 0.3.1.
- ASCII-only diff, `git diff --check`, and clean locale-key check.
- Retail: verified the setting appears under the existing Auto Open Containers gear menu, defaults off, applies live, registers `CURRENCY_DISPLAY_UPDATE` only while enabled, and unregisters it after restoring the setting.
- 12.1 PTR: repeated the default-off, live-apply, event-registration, and restore checks after a reload.
- Static proof: only item 246585 reaches the currency-cap query; no new frames, hooks, timers, loops, OnUpdate handlers, allocations, or client branches.

The exact capped-bag-slot hold could not be naturally exercised because neither test character simultaneously had a payout container and capped Shard of Dundun. The item/currency IDs and both client APIs were verified.

## Screenshots

Retail problem evidence: Shard of Dundun at its 8/8 total cap (left), with five Artisan's Consortium Payouts ready to open (right):

![Shard of Dundun capped at 8 of 8 and five Artisan payouts in the bag](https://raw.githubusercontent.com/0x963D/EllesmereUI/fa772ca864c8cff8936c76189fd91a4c8685a9aa/.github/pr-assets/1216-payout-guard.png)

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames (N/A: no Blizzard-frame mutation)
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
