### PR TITLE
fix(unitframes): stop reading the cast tint's alpha back, it can be secret

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1355,6 +1355,15 @@ end
 -- tint. Fully inert at 100: nothing is touched unless previously applied
 -- (_fillOpApplied). Value-blind (relational anchors + plain alphas only),
 -- so secret cast states render identically.
+-- castbar._castTintOn mirrors "the last alpha we wrote to castTintLayer was
+-- above zero". It exists because castTintLayer:GetAlpha() cannot be trusted to
+-- return a plain number: this castbar also drives _shieldedTint's alpha from
+-- the SECRET notInterruptible flag (SetAlphaFromBoolean), and once secrecy is
+-- in a castbar's render state an alpha read comes back secret. Comparing that
+-- inside our own (tainted) execution throws "attempt to compare a secret number
+-- value", which aborts the whole styling pass mid-way and leaves the cast bar
+-- unanchored at screen centre. We write every one of these alphas ourselves, so
+-- owning the state costs one boolean and removes the comparison entirely.
 ns.ApplyCastFillOpacity = function(castbar, settings)
     local op = (settings and settings.castFillOpacity) or 100
     local bgHost = castbar:GetParent()
@@ -1367,9 +1376,9 @@ ns.ApplyCastFillOpacity = function(castbar, settings)
                 bgTex:ClearAllPoints()
                 bgTex:SetAllPoints(bgHost)
             end
-            -- Mid-cast restore: the tint's alpha is its active/idle state, so
-            -- only lift it back to full when it is currently active.
-            if castbar.castTintLayer and castbar.castTintLayer:GetAlpha() > 0 then
+            -- Mid-cast restore: the tint's active/idle state comes from our own
+            -- flag, never from reading the widget back (see _castTintOn).
+            if castbar.castTintLayer and castbar._castTintOn then
                 castbar.castTintLayer:SetAlpha(1)
             end
         end
@@ -1389,7 +1398,7 @@ ns.ApplyCastFillOpacity = function(castbar, settings)
         end
     end
     -- Mid-cast application: retune the tint if it is currently active.
-    if castbar.castTintLayer and castbar.castTintLayer:GetAlpha() > 0 then
+    if castbar.castTintLayer and castbar._castTintOn then
         castbar.castTintLayer:SetAlpha(op / 100)
     end
 end
@@ -5792,6 +5801,7 @@ local function CreateCastBar(frame, unit, settings)
     castTintLayer:SetVertexColor(c.r, c.g, c.b)
     castTintLayer:SetAlpha(0)
     castbar.castTintLayer = castTintLayer
+    castbar._castTintOn = nil
 
     local shieldedTint = castbar:CreateTexture(nil, "ARTWORK", nil, 2)
     shieldedTint:SetPoint("TOPLEFT", castbar:GetStatusBarTexture(), "TOPLEFT")
@@ -5810,6 +5820,7 @@ local function CreateCastBar(frame, unit, settings)
             -- _fillOp is nil unless Fill Opacity is below 100 (see
             -- ns.ApplyCastFillOpacity), so the default path is unchanged.
             self.castTintLayer:SetAlpha(self._fillOp or 1)
+            self._castTintOn = true
             ApplyUnitFrameCastColor(self)
         end
     end
@@ -13867,7 +13878,10 @@ function SetupOptionsPanel()
         local castbar = frame.Castbar
         local castbarBg = castbar and castbar:GetParent()
         if castbar then
-            if castbar.castTintLayer then castbar.castTintLayer:SetAlpha(0) end
+            if castbar.castTintLayer then
+                castbar.castTintLayer:SetAlpha(0)
+                castbar._castTintOn = nil
+            end
             castbar:Hide()
         end
         if castbarBg then castbarBg:Hide() end
@@ -13905,6 +13919,7 @@ function SetupOptionsPanel()
         -- Active-cast tint -- same path a real cast uses.
         if castbar.castTintLayer then
             castbar.castTintLayer:SetAlpha(castbar._fillOp or 1)
+            castbar._castTintOn = true
             ApplyUnitFrameCastColor(castbar)
         end
         castbarBg:Show()


### PR DESCRIPTION
## The report

Reported by @Zoon on 8.7.5. Two symptoms that turned out to be one bug:

- The target's cast bar detaches and sits in the centre of the screen.
- 50x `attempt to compare a secret number value (execution tainted by 'EllesmereUIUnitFrames')` at `ApplyCastFillOpacity`.

His repro is the part that decodes it: no error at login, but it appears after flying to a **field boss**, killing it, and taking a return stone back. Changing the cast bar's background transparency also triggers it.

## Cause

`ApplyCastFillOpacity` describes itself as value-blind in its own header comment, then does the one value-dependent thing in the function:

```lua
if castbar.castTintLayer and castbar.castTintLayer:GetAlpha() > 0 then
```

That read cannot be trusted to return a plain number. **A safe secret sink is not a safe secret source.** The same castbar drives `_shieldedTint`'s alpha from the secret `notInterruptible` flag via `SetAlphaFromBoolean`, which is the sanctioned way to consume a secret. But it puts secrecy into that castbar's render state, and the alpha then reads back secret. Comparing it inside our own tainted execution throws.

That is exactly why the field boss matters. `notInterruptible` is secret for any non-player unit, so the boss's cast is what seeds it. Before that the tint has never been active, the alpha is still a plain `0`, and `0 > 0` is harmless. Afterwards, every styling pass throws, which is why it surfaces on the next thing that re-runs one: a transparency change, or zoning back to a city.

## Why the cast bar also detaches

Same bug, not a second one. The throw is at line 10202 of the per-unit styling pass. The cast bar background's anchoring lives at 10975 **in that same pass**:

```lua
castbarBg:ClearAllPoints()
castbarBg:SetPoint("TOP", frame, "BOTTOM", settings.castbarOffsetX or 0, settings.castbarOffsetY or 0)
```

Aborting at 10202 means that never runs, so `castbarBg` keeps its creation-time anchor instead of the configured one.

## Fix

Own the state instead of interrogating the widget. `castbar._castTintOn` mirrors "the last alpha we wrote was above zero", is set at all four write sites, and the comparison is deleted. We write every one of those alphas ourselves, so this removes the hazard rather than trying to reason about when the read happens to be safe.

Behaviour is identical to the old readback, including the case where the flag stays true after a cast ends, which is what `GetAlpha()` reported before.

## Notes for review

- `_castTintOn` is written on `castbar`, which is `CreateFrame("StatusBar", nil, castbarBg)`, one of ours. No field is written to a Blizzard frame, so the fix cannot itself introduce the class of problem it repairs. The name also matches the castbar's existing `_fillOp` / `_fillOpApplied` / `_durSide` fields.
- Verified against v8.7.5 with `git show v8.7.5:` rather than trusting line numbers across versions: the failing line is byte-identical to current.
- No `GetAlpha()` comparisons remain in the module.
- `luac -p` clean.

## Testing

Confirmed in game by the reporter on a build cut from this branch: the errors are gone and the cast bar stays attached across his original repro.

<img width="500" height="273" alt="Safe For Work Cat GIF" src="https://github.com/user-attachments/assets/c6d5fa15-a32d-4022-9fdb-12335f120e0a" />
