### PR TITLE
fix(bags): rebuild the category cache until the profile can be trusted

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags_Categories.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Categories.lua
@@ -52,6 +52,14 @@ local DEFAULT_CATEGORIES = {
 --  (renames, reorder, grouping). Saved state keyed by default name.
 -------------------------------------------------------------------------------
 function CategoryManager:InitCategories()
+    -- The category list is a DERIVATION of db.profile, cached in _categories
+    -- and read BACK by SaveState. In a standalone build every file executes
+    -- before the SavedVariables load, so an early build necessarily sees
+    -- defaults and BP()'s empty-table fallback hides that. Record whether this
+    -- build saw a trustworthy profile; GetCategories re-runs until one did.
+    -- Missing framework counts as NOT ready, so the answer can only improve.
+    local Lite = EllesmereUI and EllesmereUI.Lite
+    self._builtReady = (Lite and Lite.IsDBReady and Lite.IsDBReady()) or false
     -- User state: { [defaultName] = { rename, groupName, groupNameCustom } }
     local userState = BP().bagCategoryState or {}
     -- User order: list of default names in display order
@@ -216,6 +224,13 @@ end
 
 -- Save user state (renames, grouping) and order back to DB
 function CategoryManager:SaveState()
+    -- Never write a snapshot built before the SavedVariables merged. This is
+    -- the destructive half of the bug: the category list is cached and then
+    -- written straight back, so a cache built from the pre-SavedVariables
+    -- orphan profile does not merely display defaults, it stamps them over
+    -- the user's real categories on the very next save.
+    local Lite = EllesmereUI and EllesmereUI.Lite
+    if Lite and Lite.IsDBReady and not Lite.IsDBReady() then return end
     local cats = self._categories
     if not cats then return end
 
@@ -263,7 +278,13 @@ end
 --  Accessors
 -------------------------------------------------------------------------------
 function CategoryManager:GetCategories()
-    if not self._categories then
+    -- Rebuild not just when empty, but while the cached list was built before
+    -- the profile could be trusted. Pull, not push: a callback registered at
+    -- file scope would depend on the framework having loaded first, which is
+    -- the same ordering assumption that caused this bug -- and unverifiable in
+    -- the standalone TOC. By the time anything READS categories the framework
+    -- is certainly present.
+    if not self._categories or not self._builtReady then
         self:InitCategories()
     end
     return self._categories

--- a/EllesmereUI_Lite.lua
+++ b/EllesmereUI_Lite.lua
@@ -242,6 +242,19 @@ EUILite._dbRegistry = dbRegistry
 local IS_STANDALONE = type(ADDON_NAME) == "string" and ADDON_NAME:find("Standalone") ~= nil
 local _svLoaded = false   -- true once ADDON_NAME's SavedVariables are live
 local _preSVDBs = {}      -- dbs created before that, awaiting re-root
+--- True once db.profile can be trusted to be the real saved table.
+--
+-- A pre-SavedVariables db is built inside an orphan table and re-rooted in
+-- place at ADDON_LOADED (see _preSVDBs above), which silently invalidates
+-- anything a consumer CACHED from it. A cache that is only READ shows stale
+-- values; one written BACK to the profile destroys real saved data -- Bags'
+-- category list did exactly that. Consumers test this before trusting, or
+-- persisting, anything derived from db.profile.
+--
+-- Always true in the suite, where no db is ever created pre-SavedVariables.
+function EUILite.IsDBReady()
+    return (not IS_STANDALONE) or _svLoaded
+end
 
 --- Create or open a database backed by the central EllesmereUIDB store.
 -- Returns a db object with .profile pointing to the active profile table


### PR DESCRIPTION
## The report

Reported by @ercarp on 8.7.3: in the **standalone** bag addon, custom categories vanish on every `/reload` or relog. Simple settings like scale and columns are unaffected.

## Cause

The category list is a **derivation** of `db.profile`, not a view of it:

- `InitCategories()` builds it into `CategoryManager._categories`
- `GetCategories()` rebuilds only when that is nil
- `SaveState()` reads it back and writes it to the profile

So the cache is the source of truth for the next save. That is why categories die while sliders live: sliders read `db.profile` fresh every time, categories do not.

`EllesmereUI_Lite` already documents why only standalone is affected:

> a file-scope NewDB in the addon that OWNS the central store runs before WoW loads that addon's SavedVariables ... In the suite this can't happen (children's files execute long after the parent's SVs loaded), but in a STANDALONE build everything is one addon

The db is built inside an orphan table and re-rooted in place at `ADDON_LOADED`. **Nothing told consumers that had happened.** Bags caches a list derived from the orphan (defaults-only) profile, and the first `SaveState()` after any category action stamps that snapshot over the user's real data.

`BP()` falls back to an empty table, so the early build fails silently instead of erroring. That is why it presents as "categories were never saved" rather than "categories were overwritten".

## Fix

- **Lite** exposes `EUILite.IsDBReady()`: unconditionally true in the suite, true in standalone once the owning addon's SavedVariables are live.
- **`InitCategories`** records whether the build saw a trustworthy profile, and **`GetCategories` rebuilds until one did**.
- **`SaveState` refuses to write while the db is not ready**, so a future timing regression degrades to a no-op rather than data loss.

Inert in the suite by construction: `IsDBReady()` is unconditionally true there, so the rebuild condition is satisfied on the first build and the save guard never trips.

## Pull, not push

Worth flagging for review because I changed approach after self-review.

The first version registered a Lite callback from the categories file at file scope, to drop the cache when the db was re-rooted. That works in the suite, where Lite is guaranteed to load first. But **in a standalone build everything is one addon, and that ordering is precisely what I cannot verify** — it is the same assumption that caused the bug in the first place. If the categories file happened to load before the framework, the registration would silently no-op and the fix would do nothing, in the only packaging that needs it.

Reading readiness at `GetCategories()` time has no such dependency: by the time anything reads categories, the framework is certainly present. A missing framework counts as not-ready, so the answer can only improve.

## What I deliberately did not do

The reporter also proposed a fix: remove the file-scope `InitCategories()` and call it unconditionally from `EUI_Bags_Options.lua`'s `PLAYER_LOGIN`. His diagnosis was correct and is what put me on the right track, but I did not take that shape.

`GetCategories()` self-initialises, so removing the explicit call does not remove the hazard, it hands it to whichever caller touches categories first. And it would make the options file responsible for the category module's lifecycle, which is the same class of ordering assumption that caused the bug.

<img width="480" height="270" alt="Cat Tail GIF" src="https://github.com/user-attachments/assets/47abbbdb-8fe5-4d6e-92e2-d0edd225a83b" />
