### PR TITLE
feat(cooldown-manager): add text color customization for tracking bars

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -4981,6 +4981,81 @@ initFrame:SetScript("OnEvent", function(self)
             end
         end
 
+        local function AddTBBTextSwatch(row, region, prefix)
+            local ctrl = region._control
+            local function GetColor()
+                local bd = SelectedTBB()
+                if not bd then return 1, 1, 1, 0.9 end
+                local r = bd[prefix .. "TextR"]
+                local g = bd[prefix .. "TextG"]
+                local b = bd[prefix .. "TextB"]
+                local a = bd[prefix .. "TextA"]
+                if r == nil then r = 1 end
+                if g == nil then g = 1 end
+                if b == nil then b = 1 end
+                if a == nil then a = 0.9 end
+                return r, g, b, a
+            end
+            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
+                region, row:GetFrameLevel() + 3, GetColor,
+                function(r, g, b, a)
+                    local bd = SelectedTBB(); if not bd then return end
+                    bd[prefix .. "TextR"] = r
+                    bd[prefix .. "TextG"] = g
+                    bd[prefix .. "TextB"] = b
+                    bd[prefix .. "TextA"] = a
+                    RefreshTBB()
+                end,
+                true, 20)
+            PP.Point(swatch, "RIGHT", ctrl, "LEFT", -12, 0)
+            region._lastInline = swatch
+
+            local block = CreateFrame("Frame", nil, swatch)
+            block:SetAllPoints()
+            block:SetFrameLevel(swatch:GetFrameLevel() + 10)
+            block:EnableMouse(true)
+            block:SetScript("OnEnter", function()
+                local bd = SelectedTBB()
+                local tip
+                if prefix == "name" and bd and bd.verticalOrientation then
+                    tip = "Horizontal Orientation (name text is not shown on vertical bars)"
+                else
+                    local label = prefix == "timer" and "Duration Text"
+                        or (prefix == "stacks" and "Stacks Text" or "Name Text")
+                    tip = "This option requires a " .. label .. " position other than None"
+                end
+                EllesmereUI.ShowWidgetTooltip(swatch, EllesmereUI.DisabledTooltip(tip))
+            end)
+            block:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+            local function UpdateSwatchState()
+                local bd = SelectedTBB()
+                local position
+                if bd then
+                    position = bd[prefix .. "Position"]
+                    if not position then
+                        if prefix == "name" then
+                            position = (bd.showName ~= false) and "left" or "none"
+                        elseif prefix == "timer" then
+                            position = bd.showTimer and "right" or "none"
+                        else
+                            position = "center"
+                        end
+                    end
+                end
+                local enabled = position ~= nil and position ~= "none"
+                if prefix == "name" and bd and bd.verticalOrientation then enabled = false end
+                swatch:SetAlpha(enabled and 1 or 0.3)
+                if enabled then block:Hide() else block:Show() end
+            end
+
+            EllesmereUI.RegisterWidgetRefresh(function()
+                updateSwatch()
+                UpdateSwatchState()
+            end)
+            UpdateSwatchState()
+        end
+
         local nameRow
         nameRow, h = W:DualRow(parent, y,
             { type = "dropdown", text = "Name Text",
@@ -5017,6 +5092,8 @@ initFrame:SetScript("OnEvent", function(self)
                   RefreshTBB(); EllesmereUI:RefreshPage()
               end }
         );  y = y - h
+        AddTBBTextSwatch(nameRow, nameRow._leftRegion, "name")
+        AddTBBTextSwatch(nameRow, nameRow._rightRegion, "timer")
         -- Cog on Name Text: text size + x/y
         do
             local rgn = nameRow._leftRegion
@@ -5218,6 +5295,7 @@ initFrame:SetScript("OnEvent", function(self)
                   bd.reverseFill = v; RefreshTBB()
               end }
         );  y = y - h
+        AddTBBTextSwatch(stacksRow, stacksRow._leftRegion, "stacks")
         do
             local rgn = stacksRow._leftRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -77,6 +77,19 @@ local function SetFont(fs, size)
     fs:SetFont(GetFont(), size, GetOutline())
 end
 
+local function SetTBBTextColor(fs, cfg, prefix)
+    if not fs or not cfg then return end
+    local r = cfg[prefix .. "TextR"]
+    local g = cfg[prefix .. "TextG"]
+    local b = cfg[prefix .. "TextB"]
+    local a = cfg[prefix .. "TextA"]
+    if r == nil then r = 1 end
+    if g == nil then g = 1 end
+    if b == nil then b = 1 end
+    if a == nil then a = 0.9 end
+    fs:SetTextColor(r, g, b, a)
+end
+
 -------------------------------------------------------------------------------
 --  Pandemic state via Blizzard hooks
 -------------------------------------------------------------------------------
@@ -241,10 +254,12 @@ local TBB_DEFAULT_BAR = {
     timerPosition = "right",
     timerSize = 11,
     timerX = 0, timerY = 0,
+    timerTextR = 1, timerTextG = 1, timerTextB = 1, timerTextA = 0.9,
     showName  = true,
     namePosition = "left",
     nameSize  = 11,
     nameX = 0, nameY = 0,
+    nameTextR = 1, nameTextG = 1, nameTextB = 1, nameTextA = 0.9,
     showSpark = true,
     iconDisplay = "none",
     iconSize    = 24,
@@ -253,6 +268,7 @@ local TBB_DEFAULT_BAR = {
     stacksPosition = "center",
     stacksSize     = 11,
     stacksX = 0, stacksY = 0,
+    stacksTextR = 1, stacksTextG = 1, stacksTextB = 1, stacksTextA = 0.9,
     stackThresholdEnabled = false,
     stackThreshold = 5,
     stackThresholdR = 0.8, stackThresholdG = 0.1, stackThresholdB = 0.1, stackThresholdA = 1,
@@ -1518,11 +1534,14 @@ local TBB_STYLE_KEYS = {
     "gradientEnabled", "gradientR", "gradientG", "gradientB", "gradientA", "gradientDir",
     "opacity", "hideWhenInactive", "onlyInCombat",
     "showTimer", "timerPosition", "timerSize", "timerX", "timerY",
+    "timerTextR", "timerTextG", "timerTextB", "timerTextA",
     "timerDecimals", "timerDecimalThreshold",
     "showName", "namePosition", "nameSize", "nameX", "nameY",
+    "nameTextR", "nameTextG", "nameTextB", "nameTextA",
     "showSpark",
     "iconDisplay", "iconSize", "iconX", "iconY", "iconBorderSize",
     "stacksPosition", "stacksSize", "stacksX", "stacksY",
+    "stacksTextR", "stacksTextG", "stacksTextB", "stacksTextA",
     "borderSize", "borderTexture", "borderR", "borderG", "borderB",
     "borderTextureOffset", "borderTextureOffsetY",
     "borderTextureShiftX", "borderTextureShiftY", "borderBehind",
@@ -2524,6 +2543,10 @@ local function ApplyTrackedBuffBarSettings(bar, cfg)
     -- Opacity
     bar._opacityTarget = cfg.opacity or 1.0
     if not bar._tbbReady then bar:SetAlpha(bar._opacityTarget) end
+
+    SetTBBTextColor(bar._timerText, cfg, "timer")
+    SetTBBTextColor(bar._nameText, cfg, "name")
+    SetTBBTextColor(bar._stacksText, cfg, "stacks")
 
     -- Timer text. Vertical bars honor the same position choices as horizontal
     -- ones: left/right sit OUTSIDE the (thin) bar, top/bottom sit above/below


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?
This PR adds the ability to customize the text colors of Name, Duration and Stacks on Tracking Bars. Previously, the text was always `#FFFFFF` with `0.9` opacity. This lets the user pick any color. Personally, I made this because the slightly lower opacity white text, next to other completely white text, looked off slightly off.

## How was it tested?

I've tested by using various colors. This is only static colors, so it's only applied during `ApplyTrackedBuffBarSettings`, where it persists. Color also applies correctly in the preview, and persists during reloads.

Also tested on PTR target dummies. 
**Note:** I do not seem to be able to get the "decimals" toggle to work on PTR, with or without the changes here. `GetBuildInfo()` reports version `120100`.

## Screenshots
Before:
<img width="320" height="56" alt="image" src="https://github.com/user-attachments/assets/55eab717-3c71-4340-8657-4a854ec99642" />


After:

https://github.com/user-attachments/assets/38fa4dc8-ed85-4c92-9c18-d5fbfacc6048

https://github.com/user-attachments/assets/ea011adb-3ed2-4c09-8110-44e80b5c16f1

<img width="325" height="57" alt="image" src="https://github.com/user-attachments/assets/70329bc8-24ee-429b-b922-905201aba37a" />
<img width="395" height="71" alt="image" src="https://github.com/user-attachments/assets/824694e9-8549-4245-8254-a8f960f84e68" />
<img width="835" height="96" alt="image" src="https://github.com/user-attachments/assets/5e23f4e7-d608-4830-a948-1fb34dd5a938" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
