### PR TITLE
fix(damagemeters): stop a mid-resize position re-apply yanking the window

### DIFF
--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -374,6 +374,14 @@ end
 --   legacy format: { x = left, y = top } -- TOPLEFT offset from UIParent's
 --                  BOTTOMLEFT, written by header drags outside unlock mode
 ns.ApplyWinPosition = function(frame, wdb, idx)
+    -- The resize grip owns the frame's anchor while a drag is in flight. Even
+    -- with the format converted above, re-anchoring mid-resize would fight the
+    -- grip's live SetPoint for a frame; leave it alone until the drag ends.
+    -- ns._windows, not the _windows local: that local is declared BELOW this
+    -- function, so referencing it here would read a nil global and the guard
+    -- would silently never fire.
+    local W = ns._windows and ns._windows[idx]
+    if W and W.resizing then return end
     local pos = wdb.position
     frame:ClearAllPoints()
     if pos and pos.point then
@@ -3173,7 +3181,22 @@ local function CreateDMWindow(winIdx)
         if button ~= "LeftButton" or W.windowLocked then return end
         if EUI.InProtectedInstance and EUI.InProtectedInstance() then return end
         local left, top = frame:GetLeft(), frame:GetTop()
-        if left and top then frame:ClearAllPoints(); frame:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", left, top) end
+        if left and top then
+            frame:ClearAllPoints(); frame:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", left, top)
+            -- Convert the STORED position to match the pin immediately, not
+            -- just on mouse-up. wdb.position is point-format whenever unlock
+            -- mode saved it (an imported profile is all point-format), and
+            -- ApplyWinPosition re-applies that as SetPoint(pos.point, ...) --
+            -- a different anchor from the TOPLEFT pin above. Any re-apply that
+            -- lands mid-drag therefore yanks the frame back to its old anchor,
+            -- which is the resize "glitch": random, because it depends on
+            -- whether a refresh happens while the mouse is down. A window whose
+            -- position is already legacy format never showed it, since that
+            -- re-applies to the same corner the pin uses.
+            if wdb.position and wdb.position.point then
+                wdb.position = { x = left, y = top }
+            end
+        end
         resizeAnchorLeft = left; resizeAnchorTop = top
         local cx, cy = GetCursorPosition(); local es = frame:GetEffectiveScale()
         resizeStartX = cx/es; resizeStartY = cy/es; resizeStartW = frame:GetWidth(); resizeStartH = frame:GetHeight()


### PR DESCRIPTION
## The report

Reported by @Kulia on 8.7.5: damage meter windows glitch while being resized, but not on a preset profile.

Reproduced locally after importing a third-party profile: all four windows glitch, at random, and **deleting and recreating a window fixes it permanently**. That last detail is what cracked it.

## Cause

Two systems anchor the frame during an unlock-mode resize.

The grip pins it to a corner:

```lua
frame:ClearAllPoints()
frame:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", left, top)
```

Meanwhile `wdb.position` still holds whatever format was saved, and `ApplyWinPosition` re-applies point-format as `SetPoint(pos.point, ...)` — a **different anchor**. Any position re-apply landing mid-drag yanks the frame back to its old anchor. Random, because it depends on whether a refresh fires while the mouse is down.

That also explains the two things that made this look like bad saved data:

- Unlock mode's `savePos` writes point format, so an **imported profile is entirely point-format**.
- A freshly created window has no position, or a legacy `{x, y}` one, and legacy re-applies to `TOPLEFT`/`BOTTOMLEFT` — the same corner the grip pins. A re-apply is then a no-op, which is why recreating a window cures it for good.

The existing code already knew the formats disagree. Its comment says so:

> Resize pins the TOPLEFT corner, so a point-based position saved by unlock mode (e.g. CENTER-anchored) no longer describes this spot. Re-save in TOPLEFT drag format to match the pinned corner exactly.

It just reconciled them on mouse-up, leaving the entire drag unprotected.

## Fix

- Convert the stored position to match the pin at resize **start** as well as at the end, so any re-apply during the drag agrees with the grip.
- `ApplyWinPosition` no-ops while that window is resizing, so the grip owns the anchor for the duration.

## Notes for review

- The guard reads `ns._windows`, not the `_windows` local. That local is declared *below* `ApplyWinPosition`, so the obvious spelling would have read a nil global and the guard would have silently never fired. Caught while building; the comment records it so it is not "tidied" back later.
- A click-with-no-drag now converts point to legacy at start. The old code already did that conversion unconditionally on mouse-up, so behaviour is unchanged.
- Known limitation, accepted deliberately: the guard drops a position re-apply rather than deferring it. A profile switch occurring while the resize grip is physically held would skip that window's reposition. `wdb` would be a stale table reference across a profile switch anyway, so a flush would need more machinery than the edge case warrants.

## Testing

Confirmed in game on the reproducing profile: repeated drag-resizes on all four windows, no jumping. Sizes persist across `/reload`, and dragging a window by its header still places it correctly (both paths write `wdb.position`).

<img width="390" height="477" alt="animation cat GIF" src="https://github.com/user-attachments/assets/cf79e1fd-51af-4d67-87fb-dab117ec132b" />
