### PR TITLE
fix(cdm): show keybinds for spells on Action Bars 9 and 10

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7538,6 +7538,14 @@ local _barBindingDefs = {
     { prefix = "MULTIACTIONBAR5BUTTON", startSlot = 145 },  -- bar 6
     { prefix = "MULTIACTIONBAR6BUTTON", startSlot = 157 },  -- bar 7
     { prefix = "MULTIACTIONBAR7BUTTON", startSlot = 169 },  -- bar 8
+    -- EUI bars 9/10 have no native binding command: their keys are routed
+    -- through the button with SetOverrideBindingClick against the custom
+    -- commands declared in the Action Bars module's Bindings.xml. Because that
+    -- route always reads the button's live "action" attr, resolve the slot from
+    -- the button when it exists and only fall back to the base page slot when
+    -- the Action Bars module is not loaded.
+    { prefix = "EUI_BAR9_BUTTON",       startSlot = 13,  eabButton = true },  -- bar 9  (action page 2)
+    { prefix = "EUI_BAR10_BUTTON",      startSlot = 109, eabButton = true },  -- bar 10 (action page 10)
     { prefix = "ACTIONBUTTON",          startSlot = 1   },  -- bar 1 (last = lowest priority)
 }
 
@@ -7605,6 +7613,10 @@ local function RebuildKeybindCache()
                         end
                     end
                     slot = i + (pg - 1) * 12
+                elseif def.eabButton then
+                    local btn = _G["EABButton" .. slot]
+                    local live = btn and tonumber(btn:GetAttribute("action"))
+                    if live then slot = live end
                 end
                 local slotType, id, subType = GetActionInfo(slot)
                 local spellID


### PR DESCRIPTION
Reported by @expor on 8.7.5: with "show keybinds" enabled in the Cooldown Manager, keys displayed for every ability except the ones placed on Action Bar 9. Toggling the CDM option, and toggling keybinds on Bar 9 itself, changed nothing.

## Cause

`RebuildKeybindCache` enumerates the action bars by binding-command prefix, and listed only the eight bars WoW gives a native command to:

```
ACTIONBUTTONn, MULTIACTIONBAR1BUTTONn ... MULTIACTIONBAR7BUTTONn
```

Bars 9 and 10 have no native binding command. Their keys come from the `EUI_BAR9_BUTTONn` / `EUI_BAR10_BUTTONn` commands declared in the Action Bars module's `Bindings.xml`, routed through the button with `SetOverrideBindingClick`. Those slots were therefore never scanned, no cache entry was ever produced for them, and the icon had nothing to display. That also explains why neither toggle had any effect: the lookup was not reaching those slots at all.

The bar count in `BAR_CONFIG` (10) and the prefix count in this consumer (8) had simply drifted apart with nothing tying them together.

## Fix

Add both prefixes to the scan, positioned ahead of `ACTIONBUTTON` so the more specific bar wins over bar 1, matching how bars 2 through 8 are already ordered.

| bar | command | slots | action page |
|---|---|---|---|
| 9 | `EUI_BAR9_BUTTONn` | 13-24 | 2 |
| 10 | `EUI_BAR10_BUTTONn` | 109-120 | 10 |

One wrinkle beyond the slot ranges: because these two bars have no native command, their keys are always click routed, so a keypress fires against the button's live `action` attribute rather than a fixed slot. The new entries resolve their slot from `EABButton<slot>` when that button exists, so a custom paged Bar 9 or Bar 10 reads the slot the key actually casts. They fall back to the base page slot when the Action Bars module is not loaded, which is the same fallback shape the main bar branch already uses for its page lookup.

## Notes

Read only, plus text writes on our own frames, so it stays safe on the existing debounced in-combat path. No new events, no new strings, no options changes.

Confirmed in game on the reporter's case: keys now show for abilities on Bar 9.

The press mirror hook in `EllesmereUICdmHooks.lua` has the same eight bar blind spot, but it rides Blizzard's `MultiActionButtonDown`, which Bar 9 and Bar 10 buttons never call. Different feature and a different fix, so it is untouched here.

<img width="400" height="300" alt="funny cat GIF" src="https://github.com/user-attachments/assets/64392dfc-dc06-4ecf-8126-9b4d51cd6008" />

