### PR TITLE
fix(cdm): mirror presses from click-routed keybinds

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2039,8 +2039,17 @@ local function GetOrCreateButton(slot, parent, info, index, skipProtected)
         -- and HookScript stacks.
         if not EFD(btn).cdClickHooked then
             EFD(btn).cdClickHooked = true
-            btn:HookScript("PostClick", function(self)
+            btn:HookScript("PostClick", function(self, _, down)
                 if ns._EABPressPush then ns._EABPressPush(self) end
+                -- Publish the press for other EUI modules (the CDM press
+                -- mirror). Same reason this hook exists at all: a click-routed
+                -- keybind never reaches ActionButtonDown/MultiActionButtonDown,
+                -- so a subscriber watching those native commands cannot see
+                -- Bars 9/10, empower spells, or any custom-paged bar. Global
+                -- rather than ns because the subscriber is a separate addon,
+                -- matching _EAB_UpdateKeybinds. Nil when that module is off.
+                local onPress = _G._EUI_OnActionButtonPress
+                if onPress then onPress(self, down) end
             end)
         end
         -- When the pickup modifier is held (shift-click to move abilities),

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2039,6 +2039,14 @@ local function GetOrCreateButton(slot, parent, info, index, skipProtected)
         -- and HookScript stacks.
         if not EFD(btn).cdClickHooked then
             EFD(btn).cdClickHooked = true
+            -- The binding command this button answers to, captured once. It is
+            -- a property of the BUTTON, not of the slot it currently shows, so
+            -- it stays correct across every page swap. A subscriber deriving it
+            -- from the live action slot instead would be ambiguous exactly
+            -- where it matters: Bar 9 is action page 2, so its slots collide
+            -- with MainBar's whenever MainBar is paged there.
+            local pressBindCmd = BINDING_MAP[info.key]
+            pressBindCmd = pressBindCmd and (pressBindCmd .. index) or nil
             btn:HookScript("PostClick", function(self, _, down)
                 if ns._EABPressPush then ns._EABPressPush(self) end
                 -- Publish the press for other EUI modules (the CDM press
@@ -2049,7 +2057,7 @@ local function GetOrCreateButton(slot, parent, info, index, skipProtected)
                 -- rather than ns because the subscriber is a separate addon,
                 -- matching _EAB_UpdateKeybinds. Nil when that module is off.
                 local onPress = _G._EUI_OnActionButtonPress
-                if onPress then onPress(self, down) end
+                if onPress then onPress(self, down, pressBindCmd) end
             end)
         end
         -- When the pickup modifier is held (shift-click to move abilities),

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -8978,6 +8978,49 @@ do
     end
 
     ---------------------------------------------------------------------------
+    --  Click-routed keybinds.
+    --  ActionButtonDown/MultiActionButtonDown below only fire for bars that
+    --  own a NATIVE binding command. EllesmereUI's action bars route a key
+    --  through the button with SetOverrideBindingClick whenever the native
+    --  command cannot resolve what the button actually shows: Bars 9 and 10
+    --  (no native command exists at all), every empower spell, and any bar
+    --  with user-configured or opted-out paging. Those presses never reach the
+    --  native handlers, so the mirror never saw them.
+    --
+    --  The action bars module already hooks PostClick on every button for its
+    --  own press-time GCD paint and publishes the press to us there, which is
+    --  the safe place to sit: PostClick runs after Blizzard's click handler has
+    --  finished, so this stays downstream of the protected calls that
+    --  OnActionButtonClick makes (UseContainerItem/SpellTargetItem on the
+    --  spell-targets-item path). Same taint posture as the native hooks below,
+    --  which likewise run after TryUseActionButton has fully returned.
+    ---------------------------------------------------------------------------
+    _G._EUI_OnActionButtonPress = function(btn, down)
+        -- Paint at the physical press, not the release: buttons register for
+        -- both edges, and in key-up mode the key is already gone by the up
+        -- click, which the IsKeyDown gate below would then read as a mouse
+        -- click.
+        if not down or not btn or not _anyPressMirror then return end
+        -- tonumber, not the raw attr: SetAttribute preserves whatever type was
+        -- written, and the slot map is keyed numerically, so a string "13"
+        -- would miss every lookup without erroring.
+        local slot = tonumber(btn.action or (btn.GetAttribute and btn:GetAttribute("action")))
+        if not slot then return end
+        local map = ns.CDMSlotBinding
+        local bindCmd = map and map[slot]
+        if not bindCmd then return end
+        -- Keyboard only, matching the native path. A click-routed keybind and a
+        -- mouse click are indistinguishable by this point (Blizzard's own note
+        -- in SecureTemplates: an addon's key press and mouse click look the
+        -- same), so use the binding itself as the discriminator. On the down
+        -- edge a real keypress always still has the key held.
+        local k1, k2 = GetBindingKey(bindCmd)
+        local b1, b2 = BaseKey(k1), BaseKey(k2)
+        if not ((b1 and IsKeyDown(b1)) or (b2 and IsKeyDown(b2))) then return end
+        OnPress(btn, bindCmd)
+    end
+
+    ---------------------------------------------------------------------------
     --  Hook the action-button key-down path (fires on press, even on cooldown)
     ---------------------------------------------------------------------------
     local MULTIBAR_BINDING = {

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -8995,28 +8995,23 @@ do
     --  spell-targets-item path). Same taint posture as the native hooks below,
     --  which likewise run after TryUseActionButton has fully returned.
     ---------------------------------------------------------------------------
-    _G._EUI_OnActionButtonPress = function(btn, down)
+    _G._EUI_OnActionButtonPress = function(btn, down, bindCmd)
         -- Paint at the physical press, not the release: buttons register for
         -- both edges, and in key-up mode the key is already gone by the up
-        -- click, which the IsKeyDown gate below would then read as a mouse
-        -- click.
-        if not down or not btn or not _anyPressMirror then return end
-        -- tonumber, not the raw attr: SetAttribute preserves whatever type was
-        -- written, and the slot map is keyed numerically, so a string "13"
-        -- would miss every lookup without erroring.
-        local slot = tonumber(btn.action or (btn.GetAttribute and btn:GetAttribute("action")))
-        if not slot then return end
-        local map = ns.CDMSlotBinding
-        local bindCmd = map and map[slot]
-        if not bindCmd then return end
-        -- Keyboard only, matching the native path. A click-routed keybind and a
-        -- mouse click are indistinguishable by this point (Blizzard's own note
-        -- in SecureTemplates: an addon's key press and mouse click look the
-        -- same), so use the binding itself as the discriminator. On the down
-        -- edge a real keypress always still has the key held.
+        -- click, which the held-key test below would then misread.
+        if not down or not btn or not bindCmd or not _anyPressMirror then return end
+        -- Keyboard only, matching the native path. By PostClick a click-routed
+        -- keybind and a real mouse click are indistinguishable (Blizzard says
+        -- as much in SecureActionButton_OnClick), so this needs two tests, not
+        -- one. A held binding key proves keyboard, but cannot: mouse WHEEL
+        -- binds are never IsKeyDown, and gating on that alone would silently
+        -- drop every wheel-bound button, which the native path still mirrors.
+        -- The cursor-rect test covers those. Together they only miss a wheel
+        -- bind pressed while the cursor happens to rest on its own button.
         local k1, k2 = GetBindingKey(bindCmd)
         local b1, b2 = BaseKey(k1), BaseKey(k2)
-        if not ((b1 and IsKeyDown(b1)) or (b2 and IsKeyDown(b2))) then return end
+        local keyHeld = (b1 and IsKeyDown(b1)) or (b2 and IsKeyDown(b2))
+        if not keyHeld and btn.IsUnderMouse and btn:IsUnderMouse() then return end
         OnPress(btn, bindCmd)
     end
 

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -241,7 +241,6 @@ local StartNativeGlow, StopNativeGlow
 -- Keybind cache: built once out-of-combat, looked up per tick
 local _cdmKeybindCache       = {}   -- [spellID] -> formatted key string
 local _cdmKeybindFromMacro   = {}   -- [key] -> true if the cached bind came from a macro
-local _cdmSlotBinding        = {}   -- [actionSlot] -> binding command name (press mirror)
 local _keybindCacheReady     = false  -- true after first successful build
 local _keybindDebounceTimer  = nil   -- cancellable timer for debounced keybind updates
 
@@ -7582,7 +7581,6 @@ end
 local function RebuildKeybindCache()
     wipe(_cdmKeybindCache)
     wipe(_cdmKeybindFromMacro)
-    wipe(_cdmSlotBinding)
     for _, def in ipairs(_barBindingDefs) do
         for i = 1, 12 do
             local bindName = def.prefix .. i
@@ -7608,13 +7606,6 @@ local function RebuildKeybindCache()
                     end
                     slot = i + (pg - 1) * 12
                 end
-                -- Reverse map for the press mirror, which starts from a button
-                -- (so a slot) and needs the binding back to poll IsKeyDown for
-                -- the release. Built here rather than separately so it shares
-                -- this loop's page resolution and priority order and cannot
-                -- drift from the keybind cache. First writer wins, same as
-                -- _SetKeybind: the more specific bar is listed first.
-                if _cdmSlotBinding[slot] == nil then _cdmSlotBinding[slot] = bindName end
                 local slotType, id, subType = GetActionInfo(slot)
                 local spellID
                 local fromMacro = false
@@ -7750,8 +7741,6 @@ ns.UpdateCDMKeybinds = UpdateCDMKeybinds
 -- Expose apply-only for the tick loop (new spellID assigned to an icon mid-session)
 ns.ApplyCachedKeybinds = ApplyCachedKeybinds
 ns.CDMKeybindCache = _cdmKeybindCache
--- [actionSlot] -> binding command, for the press mirror in EllesmereUICdmHooks
-ns.CDMSlotBinding = _cdmSlotBinding
 
 BuildAllCDMBars = function()
     ns._spellOrderDirty = true  -- force spell order cache rebuild

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -241,6 +241,7 @@ local StartNativeGlow, StopNativeGlow
 -- Keybind cache: built once out-of-combat, looked up per tick
 local _cdmKeybindCache       = {}   -- [spellID] -> formatted key string
 local _cdmKeybindFromMacro   = {}   -- [key] -> true if the cached bind came from a macro
+local _cdmSlotBinding        = {}   -- [actionSlot] -> binding command name (press mirror)
 local _keybindCacheReady     = false  -- true after first successful build
 local _keybindDebounceTimer  = nil   -- cancellable timer for debounced keybind updates
 
@@ -7581,6 +7582,7 @@ end
 local function RebuildKeybindCache()
     wipe(_cdmKeybindCache)
     wipe(_cdmKeybindFromMacro)
+    wipe(_cdmSlotBinding)
     for _, def in ipairs(_barBindingDefs) do
         for i = 1, 12 do
             local bindName = def.prefix .. i
@@ -7606,6 +7608,13 @@ local function RebuildKeybindCache()
                     end
                     slot = i + (pg - 1) * 12
                 end
+                -- Reverse map for the press mirror, which starts from a button
+                -- (so a slot) and needs the binding back to poll IsKeyDown for
+                -- the release. Built here rather than separately so it shares
+                -- this loop's page resolution and priority order and cannot
+                -- drift from the keybind cache. First writer wins, same as
+                -- _SetKeybind: the more specific bar is listed first.
+                if _cdmSlotBinding[slot] == nil then _cdmSlotBinding[slot] = bindName end
                 local slotType, id, subType = GetActionInfo(slot)
                 local spellID
                 local fromMacro = false
@@ -7741,6 +7750,8 @@ ns.UpdateCDMKeybinds = UpdateCDMKeybinds
 -- Expose apply-only for the tick loop (new spellID assigned to an icon mid-session)
 ns.ApplyCachedKeybinds = ApplyCachedKeybinds
 ns.CDMKeybindCache = _cdmKeybindCache
+-- [actionSlot] -> binding command, for the press mirror in EllesmereUICdmHooks
+ns.CDMSlotBinding = _cdmSlotBinding
 
 BuildAllCDMBars = function()
     ns._spellOrderDirty = true  -- force spell order cache rebuild


### PR DESCRIPTION
The CDM press mirror hangs off `ActionButtonDown` and `MultiActionButtonDown`, which are the *native* binding commands. Any key the action bars route through the button with `SetOverrideBindingClick` never reaches them, so the mirror never saw the press.

Per the `useClick` decision in `EllesmereUIActionBars.lua`, that is not just Bars 9 and 10, which have no native command at all:

- Bars 9 and 10, always (`info.customPage ~= nil`)
- every empower spell, on any bar
- any bar with user-configured paging
- MainBar when form or skyriding paging is opted out

So an empowered spell sitting on bar 1 had the same missing press flash, with no extra bar involved. Found while fixing the Bar 9 keybind report in #1230, not separately reported.

## Why not hook UseAction

The tempting fix is `hooksecurefunc("UseAction", ...)`, which catches every route at once: `SECURE_ACTIONS.action` calls the global from Lua at `SecureTemplates.lua:349`.

It is not safe here. `OnActionButtonClick` keeps going after that handler returns and calls protected `C_Container.UseContainerItem`, `UseInventoryItem`, and `SpellTargetItem` on the spell-targets-item path, which is what runs when you apply an oil, enchant, or poison. A hook on `UseAction` sits upstream of those. The two existing native hooks are safe precisely because `ActionButtonDown` calls `TryUseActionButton`, which completes that whole protected block before the post-hook runs.

## What it does instead

The action bars module already hooks `PostClick` on every button for its own press-time GCD paint, added for this exact reason ("keybinds arrive as clicks too"). `PostClick` runs after Blizzard's click handler has fully returned, so it keeps the same taint posture the native hooks already have. The bars module publishes the press through a global, matching `_EAB_UpdateKeybinds`, so it costs one nil check when the CDM module is off.

The binding command is captured at hook-install time from `BINDING_MAP[info.key] .. index`. It is a property of the button rather than of the slot the button currently shows, so it stays correct across every page swap. Deriving it from the live action slot instead would be ambiguous exactly where it matters, since Bar 9 is action page 2 and its slots collide with MainBar's whenever MainBar is paged there.

## Keeping the existing semantics

Two gates, so nothing changes for anyone not on a click-routed key.

It acts on the down edge only, because buttons register for both edges and the key is already released by the up click in key-up mode.

It requires evidence the press was from the keyboard, because by `PostClick` a click-routed keypress and a real mouse click are indistinguishable, as `SecureActionButton_OnClick`'s own comment says. That needs two tests rather than one: a held binding key proves keyboard, but `IsKeyDown` is never true for mousewheel binds, and gating on it alone would silently drop every wheel-bound button that the native path still mirrors. The cursor-rect test covers those. Together they only miss a wheel bind pressed while the cursor happens to rest on that same button.

## Notes

Two files, 56 lines. Read-only plus Show/Hide on our own overlay textures. No new events, no new strings, no options changes, no saved-variable changes. Zero cost when the mirror is off, which is an O(1) early-out on an already-cached flag.

Independent of #1230 despite being found alongside it: no shared files.

Tested in game: a bar 2 key flashes exactly once (native-routed presses do not reach `PostClick`, since `TryUseActionButton` calls `SecureActionButton_OnClick` as a plain Lua call rather than a widget click), Bars 9 and 10 now mirror, and empower spells now mirror where they previously did not.
