### PR TITLE
fix(unitframes): honour a class power style changed outside the options panel

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -11983,11 +11983,6 @@ function InitializeFrames()
         if not bar or not frames.player then return end
         bar:ClearAllPoints()
         local style = db.profile.player.classPowerStyle or "none"
-        -- Seed the built-style marker from the init build too, not just from
-        -- _toggleClassPower. Without this the first reload of a session sees a
-        -- nil marker, assumes a change, and pays a pointless teardown/rebuild
-        -- for users who have no override at all.
-        frames._classPowerBuiltStyle = style
         local position = db.profile.player.classPowerPosition or "top"
         local offsetX = db.profile.player.classPowerBarX or 0
         local offsetY = db.profile.player.classPowerBarY or 0
@@ -12183,6 +12178,16 @@ function InitializeFrames()
         end)
     end
 
+    -- Seed the built-style marker from the init build, so the first reload of a
+    -- session does not see a nil marker, assume a change, and pay a pointless
+    -- teardown for users with no override at all. It belongs HERE and not in
+    -- PositionClassPowerBar: that is a repositioning function, and
+    -- ReassertClassPower calls it from Blizzard's SetParent/Hide hooks with no
+    -- rebuild behind it. Stamping the current profile style there would claim a
+    -- style is built when it is not, which suppresses the very rebuild the
+    -- reload pass exists to trigger. Guarded on frames.player to match
+    -- _toggleClassPower, which returns before stamping when there is no frame.
+    if frames.player then frames._classPowerBuiltStyle = classPowerStyle end
     if classPowerStyle ~= "none" and frames.player then
         if classPowerStyle == "blizzard" then
             if savedClassPowerBar then
@@ -13535,6 +13540,31 @@ function SetupOptionsPanel()
     local reloadPending = false
     local reloadThrottle = CreateFrame("Frame")
     reloadThrottle:Hide()
+    -- Realise a classPowerStyle that changed through a path which never calls
+    -- _toggleClassPower (a Spec Override applying at login, a profile switch, an
+    -- import). Gated on an actual change because the toggle is a full teardown
+    -- and rebuild; running it every reload would thrash the bar.
+    local cpRegen = CreateFrame("Frame")
+    local function RealiseClassPowerStyle()
+        if not frames._toggleClassPower then return end
+        local wantCP = db.profile.player.classPowerStyle or "none"
+        if wantCP == frames._classPowerBuiltStyle then return end
+        -- Not in combat: the toggle reparents and hides Blizzard's class power
+        -- frame and re-anchors the health bar. ReloadFrames() early-returns in
+        -- lockdown for the same reason, but this runs from the throttle body
+        -- AFTER that return, so it needs its own guard (the same shape as the
+        -- UpdateFrameVisibility note above) plus a re-run, since nothing else
+        -- re-arms the pass once combat ends.
+        if InCombatLockdown() then
+            cpRegen:RegisterEvent("PLAYER_REGEN_ENABLED")
+            return
+        end
+        frames._toggleClassPower(wantCP)
+    end
+    cpRegen:SetScript("OnEvent", function(self)
+        self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+        RealiseClassPowerStyle()
+    end)
     reloadThrottle:SetScript("OnUpdate", function(self)
         self:Hide()
         reloadPending = false
@@ -13567,18 +13597,10 @@ function SetupOptionsPanel()
         -- Class power: _toggleClassPower is the ONLY thing that honours a
         -- classPowerStyle change, and it had exactly two callers -- the options
         -- dropdown and the PLAYER_SPECIALIZATION_CHANGED watcher. Any other
-        -- path that changes the style left the live bar stale: a Spec Override
-        -- applying at login, a profile switch, an import. That is why the
+        -- path that changes the style left the live bar stale. That is why the
         -- reported workaround was to switch spec away and back, which is the
         -- one event that does call it.
-        -- Gated on an actual change because the toggle is a full teardown and
-        -- rebuild; running it every reload would thrash the bar.
-        if frames._toggleClassPower then
-            local wantCP = db.profile.player.classPowerStyle or "none"
-            if wantCP ~= frames._classPowerBuiltStyle then
-                frames._toggleClassPower(wantCP)
-            end
-        end
+        RealiseClassPowerStyle()
     end)
     ns.ReloadFrames = function()
         if not reloadPending then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -11983,6 +11983,11 @@ function InitializeFrames()
         if not bar or not frames.player then return end
         bar:ClearAllPoints()
         local style = db.profile.player.classPowerStyle or "none"
+        -- Seed the built-style marker from the init build too, not just from
+        -- _toggleClassPower. Without this the first reload of a session sees a
+        -- nil marker, assumes a change, and pays a pointless teardown/rebuild
+        -- for users who have no override at all.
+        frames._classPowerBuiltStyle = style
         local position = db.profile.player.classPowerPosition or "top"
         local offsetX = db.profile.player.classPowerBarX or 0
         local offsetY = db.profile.player.classPowerBarY or 0
@@ -12208,6 +12213,10 @@ function InitializeFrames()
         -- default frame (or hidden), there is no EUI frame to attach it to.
         if not frames.player then return end
         style = style or db.profile.player.classPowerStyle or "none"
+        -- What is actually BUILT right now. Read by the reload pass below to
+        -- notice a style that changed through a path which never calls this
+        -- function (see the reload hook).
+        frames._classPowerBuiltStyle = style
         -- Keep showClassPowerBar in sync with style
         db.profile.player.showClassPowerBar = (style ~= "none")
         db.profile.player.classPowerStyle = style
@@ -13555,6 +13564,21 @@ function SetupOptionsPanel()
         -- Player private auras re-register with fresh geometry (one boolean
         -- check + return when disabled).
         if ns.PlayerPA_Apply then ns.PlayerPA_Apply() end
+        -- Class power: _toggleClassPower is the ONLY thing that honours a
+        -- classPowerStyle change, and it had exactly two callers -- the options
+        -- dropdown and the PLAYER_SPECIALIZATION_CHANGED watcher. Any other
+        -- path that changes the style left the live bar stale: a Spec Override
+        -- applying at login, a profile switch, an import. That is why the
+        -- reported workaround was to switch spec away and back, which is the
+        -- one event that does call it.
+        -- Gated on an actual change because the toggle is a full teardown and
+        -- rebuild; running it every reload would thrash the bar.
+        if frames._toggleClassPower then
+            local wantCP = db.profile.player.classPowerStyle or "none"
+            if wantCP ~= frames._classPowerBuiltStyle then
+                frames._toggleClassPower(wantCP)
+            end
+        end
     end)
     ns.ReloadFrames = function()
         if not reloadPending then


### PR DESCRIPTION
Reported by @n0ObiX_ on 8.7.5: a Spec Override setting Enable Class Resource to None for Arms does not apply on login. Switching to another spec and back makes it work.

## Cause

`frames._toggleClassPower` is the only thing that honours a `classPowerStyle` change. It tears the bar down, rebuilds it, and re-anchors the health bar. It had exactly two callers: the options dropdown, and the `PLAYER_SPECIALIZATION_CHANGED` watcher.

So a style changed through any other path left the live bar stale. Spec Overrides applying at login is one such path; so are a profile switch and an import. The reported workaround is the diagnosis, since switching spec away and back is the one event that does call it. The watcher deliberately does nothing on `PLAYER_ENTERING_WORLD` beyond setting its init flag, so login was never covered.

## Fix

Realise the style on any reload instead, gated on the built style actually differing, because the toggle is a full teardown and running it on every reload would thrash the bar.

`frames._classPowerBuiltStyle` records what is currently built. It is written in exactly two places, both real build sites: the init build, and the toggle itself. The init one matters so the first reload of a session does not see a nil marker, assume a change, and pay a pointless rebuild for users with no override at all.

The spec-change watcher is unaffected. It calls the toggle itself, which updates the marker, so the reload it queues finds them equal and no-ops.

## Two things the self-review caught after the first in-game pass

Both are in the second commit, and neither was visible to a passing test of the reported case.

The marker was originally seeded inside `PositionClassPowerBar`. That is a repositioning function, not a build, and `ReassertClassPower` calls it from Blizzard's `SetParent` and `Hide` hooks on form and spec changes with no rebuild behind it. It therefore stamped the current profile style onto a bar still built as something else, which makes the reload pass see no change and skip the rebuild: the reported bug, back again. It only bites while the Blizzard style is live, since `_blizzCPActive` gates the reassert. A marker that records what is built has to be written where the build happens, so it moved to the init build block, guarded on `frames.player` to match the toggle.

The call also had no combat gate. `ReloadFrames()` early-returns in lockdown, but this runs from the throttle body after that return, so that guard does not cover it, which is the same trap the `UpdateFrameVisibility` note a few lines up already documents. Unguarded it would reparent and hide Blizzard's class power frame and re-anchor the health bar mid-fight; `ReassertClassPower` guards `Show()` on that same frame the same way. Skipping alone was not enough either, because nothing re-arms the pass once combat ends, so it defers to `PLAYER_REGEN_ENABLED` and re-runs.

## Performance

Steady state is a table lookup, a db read, and a string compare per reload pass, then an early return. The teardown only runs on an actual change.

No polling is added. The deferral frame has no `OnUpdate` and registers `PLAYER_REGEN_ENABLED` only while a change is pending in combat, unregistering as soon as it fires. Neither `_toggleClassPower` nor `ResizeFrameForClassPower` re-arms the reload pass, so there is no loop, and the marker would make a second pass a no-op even if something did.

Net it is marginally cheaper than before the review, since the marker write moved off `PositionClassPowerBar`, which runs on every Blizzard reparent, onto a build path that runs once.

## Notes

One file. No new strings, no options changes, no saved-variable changes.

Tested in game: the reported Spec Override case now applies at login, and re-tested after the review changes.

<img width="480" height="480" alt="cat GIF by The Videobook" src="https://github.com/user-attachments/assets/f532d0d4-d728-47a6-96c9-a477c9129f0e" />

