### PR TITLE
fix(unlockmode): Exit Without Saving now reverts a moved fallback anchor

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -9955,6 +9955,10 @@ local function SnapshotPositions()
                 refX = info.refX, refY = info.refY,
                 edgeOffX = info.edgeOffX, edgeOffY = info.edgeOffY,
                 refFor = info.refFor,
+                -- COPY, not a reference: _NudgeSelectedFallbackGhost mutates
+                -- fb.offsetX/offsetY in place, so a shared table would drag the
+                -- snapshot along with the edit and make the revert a no-op.
+                fallback = info.fallback and CopyTable(info.fallback) or nil,
             }
         end
     end
@@ -10271,18 +10275,14 @@ local function RevertPositions()
     -- 2) Restore anchor data before repositioning
     local anchorDB = GetAnchorDB()
     if anchorDB then
-        -- Fallback links live OUTSIDE the position transaction: setting or
-        -- adjusting one is an explicit action that survives a discard. The
-        -- snapshot never carried the field, so without this carry-over a
-        -- revert would silently destroy every fallback -- including ones
-        -- from previous sessions.
-        local liveFallbacks
-        for childKey, info in pairs(anchorDB) do
-            if info.fallback then
-                liveFallbacks = liveFallbacks or {}
-                liveFallbacks[childKey] = info.fallback
-            end
-        end
+        -- Fallbacks used to be carried over from the LIVE table here, because
+        -- the snapshot did not capture the field and a revert would otherwise
+        -- have destroyed every fallback including ones from earlier sessions.
+        -- The snapshot carries it now, which preserves those AND discards
+        -- edits made this session -- so the carry-over is gone. It was the
+        -- reason a fallback ghost dragged during a session kept its new
+        -- position after Exit Without Saving: the revert put the anchor back
+        -- and then re-attached the edited fallback on top of it.
         wipe(anchorDB)
         for childKey, info in pairs(snapshotAnchors) do
             anchorDB[childKey] = {
@@ -10291,15 +10291,11 @@ local function RevertPositions()
                 refX = info.refX, refY = info.refY,
                 edgeOffX = info.edgeOffX, edgeOffY = info.edgeOffY,
                 refFor = info.refFor,
+                -- Restored from the snapshot, so a fallback MOVED this session
+                -- reverts like every other position. Fresh copy so the next
+                -- session's nudges cannot reach back into the snapshot.
+                fallback = info.fallback and CopyTable(info.fallback) or nil,
             }
-        end
-        if liveFallbacks then
-            for childKey, fb in pairs(liveFallbacks) do
-                local entry = anchorDB[childKey]
-                -- Re-attach only where an anchor link still exists: a link
-                -- that reverted away takes its fallback with it.
-                if entry then entry.fallback = fb end
-            end
         end
     end
 


### PR DESCRIPTION
Reported by @grouch on 8.7.6: throw a fallback anchor far away to reach something underneath it, then Exit Without Saving, and it stays where it was thrown. This is ours, not an interaction with another addon.

## Cause

`RevertPositions` restored nine anchor fields from the snapshot and then deliberately re-attached the LIVE fallback on top.

That carry-over existed for a good reason: `SnapshotPositions` never captured `fallback`, so without it a revert would have destroyed every fallback, including ones set in earlier sessions. The side effect was that a fallback edited during the session also survived the discard, which is exactly the report. The anchor reverts, and then the edited fallback is put back over it.

## Fix

Snapshot `fallback` by copy, restore it from the snapshot by copy, and drop the carry-over it made redundant.

The copy is load-bearing. Fallbacks are positional, and `_NudgeSelectedFallbackGhost` does

```lua
fb.offsetX = (fb.offsetX or 0) + dx
fb.offsetY = (fb.offsetY or 0) + dy
```

so it mutates the table in place. A snapshot holding a reference would be dragged along by the edit and the revert would be a silent no-op. The restore copies for the same reason in the other direction, so the next session's nudges cannot reach back into the snapshot.

Pre-session fallbacks are still preserved, which is all the carry-over was protecting. Session edits now revert like every other position.

## Why dropping the carry-over is safe

Both the old carry-over and the new snapshot iterate `pairs(anchorDB)`, so coverage is identical rather than merely similar. Entries created during the session are dropped by both, since an entry with no snapshot is not recreated at all, which preserves the existing rule that a link reverting away takes its fallback with it. Pre-session fallbacks survive in both.

`fallback` only ever holds four scalars (`target`, `side`, `offsetX`, `offsetY`), with no frame references and no nesting, so `CopyTable` has nothing deep or cyclic to walk.

## One deliberate widening

Removing a fallback mid-session now reverts too. Previously that survived Exit Without Saving, because the carry-over simply had nothing to re-attach. It is now discarded like any other session edit, which is what Exit Without Saving is supposed to mean, but it is behaviour beyond the reported case and worth knowing about.

## Performance

`SnapshotPositions` has one caller, at unlock-mode entry. Not per frame, no timers, nothing added to any update loop. The change costs one four-field table copy per anchored element, once, when unlock mode opens. The same function already copies the whole `unlockAnchors`, `unlockWidthMatch`, `unlockHeightMatch`, and `phantomBounds` tables a few lines later, so this is a rounding error against work already being done, and `CopyTable` is the established idiom in this file.

Ghost visuals need no extra handling: `RevertPositions` already ends by hiding the fallback ghosts, and they recompute from `fb.offsetX/offsetY` whenever they are next shown.

## Notes

One file, net 16 insertions and 20 deletions, so it removes more than it adds. No new strings, no options changes, no saved-variable format changes.

Tested in game: a fallback anchor thrown during a session now returns to where it was on Exit Without Saving.

<img width="480" height="480" alt="Country Music Australia GIF by Dylan Yeandle" src="https://github.com/user-attachments/assets/3a5cc0da-2498-4c25-8500-b0acad340175" />

