### PR TITLE
fix(actionbars): make manual paging work while skyriding

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -1708,33 +1708,35 @@ local function HideBlizzardBars()
 
     -- Replace ActionBar_PageUp / ActionBar_PageDown with versions that
     -- read the current page from our state driver. The stock versions
-    -- call ChangeActionBarPage (a C function) which uses
-    -- GetActionBarPage() internally. Something in the stock pipeline
+    -- increment from GetActionBarPage(), and something in the stock pipeline
     -- resets the page back to 1 after each change because we disabled
-    -- MainMenuBar. Our replacements read state-page from the MainBar
-    -- frame and call SetActionBarPage directly.
-    ActionBar_PageUp = function()
-        local mainFrame = barFrames and barFrames["MainBar"]
-        local curPage
-        if mainFrame then
-            curPage = tonumber(mainFrame:GetAttribute("state-page")) or 1
-        else
-            curPage = EAB_VTABLE.GetActionBarPage()
-        end
+    -- MainMenuBar. Our replacements compute the target page themselves and
+    -- pass it to ChangeActionBarPage explicitly.
+    --
+    -- state-page is the RESOLVED page, so in a form, vehicle, override or
+    -- skyriding state it is 7-14 rather than a manual page. Cycling off that
+    -- value walked straight out of the 1-6 range: while skyriding (11), Next
+    -- Page always requested page 1 -- a no-op from manual page 1, so the key
+    -- looked dead -- and Previous Page called ChangeActionBarPage(10). Only
+    -- trust it inside the manual range; otherwise ask Blizzard for the page
+    -- the cycle actually moves, which is what ChangeActionBarPage writes.
+    local function CurrentManualPage()
         local maxPages = NUM_ACTIONBAR_PAGES or 6
+        local mainFrame = barFrames and barFrames["MainBar"]
+        local curPage = mainFrame and tonumber(mainFrame:GetAttribute("state-page"))
+        if not curPage or curPage < 1 or curPage > maxPages then
+            curPage = EAB_VTABLE.GetActionBarPage() or 1
+        end
+        return curPage, maxPages
+    end
+    ActionBar_PageUp = function()
+        local curPage, maxPages = CurrentManualPage()
         local newPage = curPage + 1
         if newPage > maxPages then newPage = 1 end
         ChangeActionBarPage(newPage)
     end
     ActionBar_PageDown = function()
-        local mainFrame = barFrames and barFrames["MainBar"]
-        local curPage
-        if mainFrame then
-            curPage = tonumber(mainFrame:GetAttribute("state-page")) or 1
-        else
-            curPage = EAB_VTABLE.GetActionBarPage()
-        end
-        local maxPages = NUM_ACTIONBAR_PAGES or 6
+        local curPage, maxPages = CurrentManualPage()
         local newPage = curPage - 1
         if newPage < 1 then newPage = maxPages end
         ChangeActionBarPage(newPage)
@@ -2206,12 +2208,19 @@ function EAB_VTABLE.BuildPagingConditions(barKey, pagingConfig, defaultPage)
             end
         end
     end
+    -- Manual pages come before the skyriding clause: the engine only consults
+    -- the bonus bar while Blizzard's page is 1 (ActionBarController_UpdateAll),
+    -- so [bonusbar:5] listed first pinned the bar to the skyriding page and
+    -- swallowed every manual page change until the player dismounted.
+    -- The form clauses above deliberately keep their old precedence -- a page
+    -- picked for a specific form in the dropdowns is an explicit request, and
+    -- this path is click-routed, so the icon and the key agree either way.
     if barKey == "MainBar" then
-        if not noSky then
-            parts[#parts + 1] = "[bonusbar:5] 11"
-        end
         for i = 2, NUM_AB_PAGES do
             parts[#parts + 1] = "[bar:" .. i .. "] " .. i
+        end
+        if not noSky then
+            parts[#parts + 1] = "[bonusbar:5] 11"
         end
     end
     -- Target conditions come after bonusbar/bar so dragonriding and manual
@@ -2230,8 +2239,10 @@ end
 
 -------------------------------------------------------------------------------
 --  Paging State Conditions (class-specific, hardcoded fallback)
---  Used when no custom paging is configured. Produces the exact same
---  conditional string as the original implementation for zero impact.
+--  Used when no custom paging is configured. Clause order mirrors the engine's
+--  own resolution (see ActionBarController_UpdateAll): vehicle/override/possess
+--  ignore the page, then the manual page, then the bonusbar states, which the
+--  engine only consults while the page is 1.
 --  Format: "[condition] pageNumber; ..."
 -------------------------------------------------------------------------------
 local function GetClassPagingConditions()
@@ -2246,11 +2257,6 @@ local function GetClassPagingConditions()
     end
     if EAB_VTABLE.GetVehicleBarIndex then
         conditions = conditions .. "[vehicleui][possessbar] " .. EAB_VTABLE.GetVehicleBarIndex() .. "; "
-    end
-
-    -- Dragonriding (all classes)
-    if not noSky then
-        conditions = conditions .. "[bonusbar:5] 11; "
     end
 
     -- Manual page switching (pages 2-6)
@@ -2275,6 +2281,14 @@ local function GetClassPagingConditions()
         elseif class == "ROGUE" then
             conditions = conditions .. "[bonusbar:1] 7; "
         end
+    end
+
+    -- Dragonriding (all classes). Also page 1 only: skyriding is bonusbar 5, and
+    -- the engine only reads the bonus bar while the page is 1, so listing this
+    -- ahead of [bar:N] would freeze the bar on the skyriding page and make every
+    -- manual page unreachable until you dismount.
+    if not noSky then
+        conditions = conditions .. "[bonusbar:5] 11; "
     end
 
     -- Default: page 1

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7598,10 +7598,13 @@ local function RebuildKeybindCache()
                     local pg = mbf and tonumber(mbf:GetAttribute("actionpage"))
                     if not pg then
                         local bonus = GetBonusBarOffset and GetBonusBarOffset() or 0
-                        if bonus > 0 then
+                        local page = (GetActionBarPage and GetActionBarPage()) or 1
+                        -- The bonus bar only wins on page 1; a manual page beats
+                        -- the form/skyriding swap, same as the engine.
+                        if bonus > 0 and page == 1 then
                             pg = 6 + bonus
                         else
-                            pg = (GetActionBarPage and GetActionBarPage()) or 1
+                            pg = page
                         end
                     end
                     slot = i + (pg - 1) * 12


### PR DESCRIPTION
## Bug

Reported by @Anmity (Discord, v8.7.4): while dragonriding, paging Action Bar 1 to page 2/3 changes the page number but the bar keeps showing the skyriding abilities, so pages 2/3 are unusable until dismounting. Static flying mounts are unaffected.

## Cause

Two independent defects, both hit while skyriding:

1. **The MainBar paging state driver emitted `[bonusbar:5] 11` ahead of the `[bar:N]` clauses.** First match wins, so mounting pinned the bar to the skyriding page and every manual page change was swallowed. Blizzard only consults the bonus bar while the action bar page is 1 (`ActionBarController_UpdateAll`), and MainBar keybinds are native `ACTIONBUTTONn` commands that resolve the same way, so on page 2 while skyriding the button showed a skyriding ability but the keypress fired the page 2 slot.

2. **`ActionBar_PageUp`/`PageDown` (our replacements, backing the Next/Previous Action Bar Page keybinds) cycled off the bar's `state-page` attribute as if it were the manual page.** But `state-page` is the resolved page: 11 while skyriding, 7-10 in a form, 12/14 in a vehicle. Cycling off 11 walked out of the 1-6 range, so Next Page always requested page 1 (a no-op from manual page 1, leaving the key looking dead) and Previous Page called `ChangeActionBarPage(10)`. This is why the reporter saw the page number move (the on-screen arrows use a `[bar:N]` macro, which reads the manual page by construction) while the bound keys did nothing.

## Fix

- Move `[bonusbar:5] 11` after the `[bar:N]` loop in both the hardcoded fallback (`GetClassPagingConditions`) and the custom-paging builder (`BuildPagingConditions`), matching the engine's resolution order. Form paging keeps its existing precedence in the custom-paging builder, so configured form pages (e.g. Cat Form -> Bar 7) behave exactly as before.
- `ActionBar_PageUp`/`PageDown` now trust `state-page` only inside the manual 1-6 range and otherwise fall back to `GetActionBarPage()`, which is what `ChangeActionBarPage` writes. Also fixes Next Page doing nothing in cat form.
- Same bonusbar-beats-page inversion fixed in the CDM keybind cache fallback (only runs with the Action Bars module disabled).

## Behaviour note

Parking on page 2 and then mounting no longer swaps to the skyriding bar, because a manual page now beats the skyriding swap. This matches the default UI exactly, and "Disable Skyriding Paging" already exists for anyone who wants to stay off the skyriding bar entirely.

## Testing

Tested in-game: page keys and paging arrows both work while skyriding (bar shows and fires pages 2/3), page 1 while skyriding still shows the skyriding bar, dismounting on page 2 stays on page 2, and Druid form paging is unchanged with and without custom paging configured.

No new options, saved variables, events, or OnUpdate; changes are reordered state driver strings and insecure-Lua page math only.
