### PR TITLE
fix(bags): stop the options builder erroring during the search pre-build

### DIFF
--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -250,7 +250,13 @@ initFrame:SetScript("OnEvent", function(self)
             ); y = y - h
 
             -- Inline cog (RESIZE) on Show BoE / Warbound Text: text size
-            do
+            -- Skipped during the hidden search pre-build: that pass swaps the
+            -- widget factory for the frameless absorber, so DualRow returns a
+            -- plain table and CreateFrame/SetPoint against its regions throw.
+            -- Nothing is lost from the index -- cog popup rows are not search
+            -- entries, and the host rows were already registered by DualRow.
+            -- Same for every region-chrome block below.
+            if not EllesmereUI._prebuilding then
                 local _, btCogShow = EllesmereUI.BuildCogPopup({
                     title = "BoE / Warbound Text Options",
                     rows = {
@@ -321,7 +327,7 @@ initFrame:SetScript("OnEvent", function(self)
 
             -- Inline cog on Show Item Level (right region): Show Gear Track Rank
             -- (gated by Show Item Level; the rank only renders when ilvl is shown).
-            do
+            if not EllesmereUI._prebuilding then
                 local _, ilCogShow = EllesmereUI.BuildCogPopup({
                     title = "Item Level Options",
                     rows = {
@@ -376,7 +382,7 @@ initFrame:SetScript("OnEvent", function(self)
             ); y = y - h
 
             -- Enabled Categories dropdown (left side)
-            do
+            if not EllesmereUI._prebuilding then
                 local catItems = {}
                 if _G.EUI_CategoryManager then
                     local cats = _G.EUI_CategoryManager:GetCategories()
@@ -417,7 +423,7 @@ initFrame:SetScript("OnEvent", function(self)
             end
 
             -- Enabled Currencies dropdown (right side)
-            do
+            if not EllesmereUI._prebuilding then
                 local currencyItems = {}
                 if C_CurrencyInfo and C_CurrencyInfo.GetCurrencyListSize then
                     -- Expand all collapsed headers so we can see every currency,
@@ -553,7 +559,7 @@ initFrame:SetScript("OnEvent", function(self)
             ); y = y - h
 
             -- Inline cog for Show Sort Icon: "Sort to Bottom"
-            do
+            if not EllesmereUI._prebuilding then
                 local _, sortCogShow = EllesmereUI.BuildCogPopup({
                     title = "Sort Options",
                     rows = {
@@ -639,7 +645,7 @@ initFrame:SetScript("OnEvent", function(self)
             ); y = y - h
 
             -- Inline cog for Show Pinned Items: "Show in OneBag"
-            do
+            if not EllesmereUI._prebuilding then
                 local _, pinCogShow = EllesmereUI.BuildCogPopup({
                     title = "Pinned Items Options",
                     rows = {
@@ -687,7 +693,7 @@ initFrame:SetScript("OnEvent", function(self)
             end
 
             -- Inline cog for Show Recent Items: "Show in OneBag"
-            do
+            if not EllesmereUI._prebuilding then
                 local _, recentCogShow = EllesmereUI.BuildCogPopup({
                     title = "Recent Items Options",
                     rows = {


### PR DESCRIPTION
## Bug

Reported by @Arassu and @Rekiam (Discord, v8.7.6): a red "[Bags Options ERROR] ...EUI_Bags_Options.lua:268: Wrong object type for function" prints in chat once per login. No other visible breakage.

## Cause

The frameless global-search index pass that shipped in 8.7.6 runs every options page builder once (at login / first search) with the widget factory swapped to the absorber stubs, which return plain tables instead of frames. The Bags builder's region-chrome blocks feed those tables straight into real APIs: `CreateFrame("Button", nil, bindRow._rightRegion)` throws "Wrong object type for function" on the first inline cog.

Bags is the only module whose buildPage wraps itself in its own pcall with an unconditional chat print, which is why users see the error while other modules fail silently. The error is not harmless either: the pcall aborts the builder at the first cog block, so every setting below it on the Bags page is missing from the global search index until the page is opened live.

## Fix

Guard all seven region-chrome blocks (five inline cogs, plus the Enabled Categories and Enabled Currencies dropdowns) with the established `EllesmereUI._prebuilding` check that GlobalSearch documents as the builder contract and that CooldownManager, DamageMeters, DataBars, QoL, ResourceBars and RaidFrames options already use.

Nothing drops out of the search index: cog popup rows and dropdown items were never search entries (only the real widget factory calls `IndexSlotForSearch`), and the host rows are registered by `DualRow` itself. Skipping the currency block during the pre-build also stops the login pass from transiently expanding and collapsing the player's currency-list headers.

## Verification

Could not be tested in-game this round, so it went through a deeper static review instead: search-index parity, Spec Overrides capture, page-cache behaviour, block scoping and layout math were each verified against the widget factory and GlobalSearch sources; the guard form and comment style match the existing sites. The change is pure build-time gating of chrome that only matters on a visible page, and the guarded blocks register nothing.

Heads-up beyond this PR's scope: the same unguarded pattern exists in the buildPage paths of several other modules (Unit Frames' MakeCogBtn alone drives ~81 cog sites; Nameplates, Raid Frames, Minimap, Chat, Blizzard Skin and others have the same shape). Those fail silently and truncate their pages' search index the same way. Happy to sweep those as a follow-up if wanted.

No new options, saved variables, events, or OnUpdate; zero cost when the pre-build is not running.

<img width="330" height="427" alt="Excited American Horror Story GIF" src="https://github.com/user-attachments/assets/f2aeb4b3-fd31-43f5-8c0d-2e69bb97bcf2" />

