### PR TITLE
QoL: honour the cursor accent colour at login

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12480,7 +12480,23 @@ initFrame:SetScript("OnEvent", function(self, event)
         -- (per-profile euiAccent -> frozen global root -> theme color). When a
         -- profile has no per-profile accent this reproduces the legacy behavior
         -- exactly, so existing users see zero change.
-        ELLESMERE_GREEN.r, ELLESMERE_GREEN.g, ELLESMERE_GREEN.b = EllesmereUI.ResolveActiveAccent()
+        --
+        -- Routed through the live-apply path rather than assigning the three
+        -- fields directly: this handler is NOT the first PLAYER_LOGIN to run.
+        -- EllesmereUI_Lite.lua is TOC-ordered ahead of this file, so its
+        -- lifecycle frame registers first and every module's OnEnable has
+        -- already painted -- against the parse-time fallback, since a
+        -- per-profile accent cannot be resolved that early. A silent
+        -- assignment leaves anything that read the accent before now holding
+        -- the wrong colour for the entire session (field report: the QoL
+        -- cursor circle ignoring a white accent and drawing the default
+        -- green). Notifying repaints them.
+        local accentR, accentG, accentB = EllesmereUI.ResolveActiveAccent()
+        if EllesmereUI.ApplyAccentColorLive then
+            EllesmereUI.ApplyAccentColorLive(accentR, accentG, accentB)
+        else
+            ELLESMERE_GREEN.r, ELLESMERE_GREEN.g, ELLESMERE_GREEN.b = accentR, accentG, accentB
+        end
     end
 
     -- Spell ID / Item ID + Icon ID / Max Item Stack on Tooltip (developer option)

--- a/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
@@ -1277,8 +1277,33 @@ function ECL:OnEnable()
 
     Apply()
 
+    -- Repaint when the accent lands. Apply() above runs inside the module
+    -- lifecycle's PLAYER_LOGIN, which fires BEFORE the core resolves the
+    -- active profile's accent, so an accent-mode ring paints the parse-time
+    -- fallback and Apply() is never called again -- the colour stays wrong
+    -- for the whole session (field report: white accent, green cursor). The
+    -- GCD and cast rings escaped it only because their apply is deferred
+    -- half a second, past the core's resolution. Registering here also
+    -- covers a mid-session accent change, which nothing pushed to us before.
+    if EllesmereUI.RegAccent then
+        EllesmereUI.RegAccent({ type = "callback", fn = function()
+            local p = ECL.db and ECL.db.profile
+            if not p then return end
+            if p.useAccentColor then Apply() end
+            if p.gcd and p.gcd.useAccentColor then ApplyGCDCircle() end
+            if p.castCircle and p.castCircle.useAccentColor then ApplyCastCircle() end
+        end })
+    end
+
     -- Apply GCD / Cast circles (creates on demand only when enabled)
     C_Timer.After(0.5, function()
+        -- Re-apply the circle too. The RegAccent callback above is the real
+        -- fix, but it only lands if this module registered before the core
+        -- notified, which is frame event-dispatch ORDER -- an assumption, not
+        -- a guarantee. This runs well past the core's login resolution (it is
+        -- why the two rings below were always correct), so the colour is right
+        -- either way. Cheap: Apply() is a handful of setters.
+        Apply()
         ApplyGCDCircle()
         ApplyCastCircle()
         ApplyTrail()


### PR DESCRIPTION
## The bug

Reported on 8.7.6: setting the QoL cursor circle to **Accent Color** works immediately, but every login it looks like it reverted to **Custom Color**. The reporter's own workaround was to set the custom hex to their accent hex, which made it consistent.

## It is not a persistence bug

That workaround points straight at the saved data, so that got checked first, twice:

1. The real `DeepMergeDefaults` / `StripDefaults` / `DeepCopy` from `EllesmereUI_Lite.lua` were run over the actual cursor defaults in a standalone Lua interpreter, through a full logout to login round trip. `useAccentColor` survives. So does the awkward case where five separate `NewDB` calls share `EllesmereUIQoLDB` (QoL main, Cursor, BattleRes, MovementAlert, RaidTools all write the same folder slot at logout, last writer wins).
2. A reproduction on a live install, with the SavedVariables parsed afterwards: `useClassColor=false`, `useAccentColor=true`. The setting is on disk and correct.

The value saves, reloads, and is read correctly. The colour on screen is simply resolved before there is an accent to resolve.

## Root cause

`ELLESMERE_GREEN` is computed at file-parse time of `EllesmereUI.lua`, where only preset themes can be resolved (its own comment says so: class and custom themes are finished at `PLAYER_LOGIN`). The authoritative per-profile accent lands later, in that file's `PLAYER_LOGIN` handler, which mutates the table in place.

But that handler is not the first `PLAYER_LOGIN` to run. `EllesmereUI_Lite.lua` is TOC line 19 and `EllesmereUI.lua` is line 45, so Lite's lifecycle frame registers first and **every module's `OnEnable` runs before the accent is resolved**.

`ECL:OnEnable` calls `Apply()` synchronously. `ResolveColor` asks for `GetAccentColor()`, gets the parse-time fallback, and paints it. Nothing calls `Apply()` again, so the wrong colour stays for the whole session.

Two details made this hard to see from the report alone:

- **The fallback and the default share a value.** The cursor's default custom hex `0CD29D` is Ellesmere green, and so is the accent fallback. "It went green" reads as "reverted to the custom hex" but actually meant "the accent resolved to its default". The reporter with a white accent seeing green is the same event.
- **The GCD and cast rings were never affected**, despite identical colour code, because their apply sits in a `C_Timer.After(0.5)` block, which lands past the core's resolution. Same module, same `ResolveColor`, different timing, different outcome.

## The fix

Two halves, and neither works alone: the login path bypassed the notification, and the cursor was not registered to receive one.

- **Core:** the login resolution now goes through `ApplyAccentColorLive(...)` instead of assigning `ELLESMERE_GREEN.r/g/b` silently, so anything that read the accent earlier is told it changed. Guarded, with the original assignment as the fallback.
- **Cursor:** registers a `RegAccent({ type = "callback", ... })` using the existing public cross-addon registry, whose dispatcher already handles `type == "callback"`. It repaints only when a ring is actually in accent mode. This also fixes a mid-session accent change, which was never pushed to the cursor at all.
- **Order independence:** `Apply()` is also added to the existing deferred block. The callback is the real fix, but it only lands if the module registered before the core notified, and that is frame event-dispatch order, which is observed behaviour rather than a guarantee. The deferred call is correct either way.

## Scope and cost

Two files, +42/-1. No new events, no polling, no timers added, no secure or protected paths touched. The callback is a single registry entry that early-returns unless a ring is in accent mode, so a user who never picks accent pays a nil check at login and nothing else. The extra `UpdateAccentElements` pass at login walks a registry that is nearly empty at that point, since options widgets are built lazily.

Not a regression: the cursor accent option dates to 6.5.2 and the options file has not changed since 8.5.2. The 8.7.6 in the report is incidental.

## Known, deliberately not in this PR

Other cross-addon accent consumers read the same stale value during `OnEnable`: Chat (`innerBorderColorMode == "accent"`, `iconUseAccent`), DataBars (`ns.GetAccent`), Friends. They largely self-heal because they re-read on their own refresh paths, which is why the cursor was the one that got reported: it is the only one whose apply is never called again. The core half of this change makes them reachable the moment any of them wants to register, and auditing them is worth doing separately rather than widening a bug fix.

## Testing

Confirmed in game: with a white accent configured, the cursor is the accent colour immediately at login instead of the default green, and it now follows a live accent change.

<img width="386" height="480" alt="Dance Dancing GIF" src="https://github.com/user-attachments/assets/b481d52f-16e5-420c-a9d0-3810e1dad4bf" />

