### PR TITLE
fix(actionbars): SHIFT+mouse-click [modifier:shift] macro support

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2077,13 +2077,20 @@ local function GetOrCreateButton(slot, parent, info, index, skipProtected)
         if not btn:GetAttribute("eabPickupWrap") and not InCombatLockdown() then
             btn:SetAttribute("eabPickupWrap", true)
             SecureHandlerWrapScript(btn, "OnClick", btn, [[
-                if down and IsModifiedClick("PICKUPACTION") and self:IsUnderMouse()
+                local flipped = false
+                if button ~= "Keybind" and IsModifiedClick("PICKUPACTION")
+                   and self:IsUnderMouse()
                    and self:GetAttribute("useOnKeyDown") ~= false then
+                    self:SetAttribute("eabPickupBackup", self:GetAttribute("useOnKeyDown") or true)
                     self:SetAttribute("useOnKeyDown", false)
-                    return nil, "restore"
+                    flipped = true
                 end
+                return nil, flipped and "flip" or "noop"
             ]], [[
-                self:SetAttribute("useOnKeyDown", true)
+                if self:GetAttribute("eabPickupBackup") ~= nil then
+                    self:SetAttribute("useOnKeyDown", self:GetAttribute("eabPickupBackup"))
+                    self:SetAttribute("eabPickupBackup", nil)
+                end
             ]])
         end
         if not skipProtected then


### PR DESCRIPTION

## How was it tested?

Tested in-game on live retail:

- SHIFT+mouse-click macro → [modifier:shift] fires ✅
- SHIFT+drag action → moves without miscast ✅
- SHIFT+keyboard bind → fires on press, no delay ✅
- CTRL/ALT+mouse-click → works ✅
- Normal click → works ✅
- No stuck useOnKeyDown across repeated clicks (#1165 not regressed) ✅

## Checklist
- N/A — no new settings
- N/A — no new feature, wraps existing button init
- N/A — no new events/timers
- N/A — no Blizzard frame writes
- Tested in-game, works on live retail