### PR TITLE
Fix: Hide mail icon on minimap

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -3232,6 +3232,10 @@ local function SyncIndicatorVisibility()
                 hasMail = raw or false
             end
         end
+        local mp = EBS.db and EBS.db.profile.minimap
+        if mp and mp.hideMail then
+            hasMail = false
+        end
         _customIndicators.mail:SetShown(hasMail)
     end
     if _customIndicators.crafting then


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1518128984863281313

Mail received icon now correctly hides where it would still previously show even when toggled to not show.
