### PR TITLE
Damage Meters: key the spec icon memo on the spec, not the class

### DIFF
--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -3373,13 +3373,17 @@ local function CreateDMWindow(winIdx)
             bar.fill:SetAlpha(c.barFillAlpha or 1)
             SetDMFont(bar.pos, leftFS); SetDMFont(bar.label, leftFS); SetDMFont(bar.amount, rightFS)
             bar.label:SetWidth(math.max(20, (frame:GetWidth() or 200) * 0.60))
-            W._stickyClassCache = nil  -- force icon/color rebuild
+            W._stickyClassCache = nil; W._stickySpecCache = nil  -- force icon/color rebuild
         end
         bar.row:Show()
-        -- Icon + color: only when class changes
+        -- Icon + color: only when the icon's own inputs change (see the row
+        -- loop below -- the sticky bar is re-pointed at whatever source holds
+        -- the player's rank, so it needs the same spec-aware memo).
         local classFile = src.classFilename
-        if classFile ~= W._stickyClassCache then
+        local specIcon = src.specIconID
+        if classFile ~= W._stickyClassCache or specIcon ~= W._stickySpecCache then
             W._stickyClassCache = classFile
+            W._stickySpecCache = specIcon
             local iconOffset = showIcon and ResolveIcon(src, bar.classIcon, barH) or 0
             if not showIcon then bar.classIcon:Hide() end
             if bar._iconBorderFrame then bar._iconBorderFrame:SetShown(bar.classIcon:IsShown()) end
@@ -3523,15 +3527,25 @@ local function CreateDMWindow(winIdx)
                             bar.pos:SetText(RANK_STRINGS[i] or (i .. "."))
                         end
                         -- Invalidate icon + color caches so they rebuild
-                        bar._cachedClass = nil; bar._cachedColorClass = nil
+                        bar._cachedClass = nil; bar._cachedSpecIcon = nil; bar._cachedColorClass = nil
                     end
 
                     -- Per-tick content: only for visible bars
                     if i >= visFirst and i <= visLast then
-                        -- Icon: only when class changes
+                        -- Icon: only when the icon's own inputs change. The memo
+                        -- must include the SPEC, not just the class: bars are
+                        -- recycled by rank, so a rank swap between two players
+                        -- of the same class but different specs left classFile
+                        -- unchanged, the rebuild was skipped, and the row kept
+                        -- the previous player's spec icon. Field report: an
+                        -- Affliction and a Demonology Warlock trading 2nd and
+                        -- 3rd place showed two Afflictions, and it got rarer as
+                        -- the DPS gap grew, because the swaps did.
                         local classFile = src.classFilename
-                        if classFile ~= bar._cachedClass then
+                        local specIcon = src.specIconID
+                        if classFile ~= bar._cachedClass or specIcon ~= bar._cachedSpecIcon then
                             bar._cachedClass = classFile
+                            bar._cachedSpecIcon = specIcon
                             local iconOffset = showIcon and ResolveIcon(src, bar.classIcon, barH) or 0
                             if not showIcon then bar.classIcon:Hide() end
                             if bar._iconBorderFrame then bar._iconBorderFrame:SetShown(bar.classIcon:IsShown()) end
@@ -4397,7 +4411,7 @@ end
 -- keyed only on classFile, which does not change when the palette is edited).
 ns.RefreshColors = function()
     for _, w in ipairs(_windows) do
-        w._stickyClassCache = nil
+        w._stickyClassCache = nil; w._stickySpecCache = nil
         w._barCacheKey = nil
         if w.rowPool then
             for _, bar in ipairs(w.rowPool) do bar._cachedColorClass = nil end


### PR DESCRIPTION
## The bug

Reported under Damage Meters: with players of the same class but different specs in the raid, the spec icons swap between them during a fight. An Affliction and a Demonology Warlock would show as two Afflictions, or two Demonologies, or with the icons on the wrong players. It looked random.

The reporter's follow-up is what makes it not random:

> this issue seems to happen more often when the two players are close in DPS, for example one is 2nd and the other 3rd, and their ranks keep swapping throughout the fight. When the DPS gap is larger, the issue is much less likely to occur.

That says the fault tracks **row order**, not player identity. Bars are recycled by rank, so a symptom that correlates with two players trading places is a per-row cache surviving the row being re-pointed at someone else.

## Root cause

The icon rebuild was gated on the class:

```lua
local classFile = src.classFilename
if classFile ~= bar._cachedClass then
    bar._cachedClass = classFile
    local iconOffset = showIcon and ResolveIcon(src, bar.classIcon, barH) or 0
    ...
```

but `ResolveIcon` draws from `src.specIconID` when the icon style is `spec`, which is the default. Two players of the same class share a `classFilename`, so when they swapped places the memo was satisfied, the rebuild was skipped, and the recycled row kept the previous player's spec icon.

This is why the report describes two Afflictions rather than a Warlock icon on a Mage: a wrong **class** was never possible, only a wrong **spec** within the same class. It also explains the DPS gap correlation with no extra machinery, since a bigger gap means fewer rank swaps means fewer chances to go stale.

## The fix

The memo now carries `specIconID` alongside the class, so it invalidates exactly when the drawn icon can change. A memo key has to cover every input the memoized work reads, and this one was keyed on a strictly coarser field than the value it guarded.

Applied at both sites:

- the recycled row loop, and
- the sticky player row, which is re-pointed at whichever source holds the player's current rank and carried the identical gate.

Both invalidation points (the settings-change path and `ns.RefreshColors`) now clear the spec memo as well, so a stale value cannot outlive a future change to the class arm.

## Cost

None added per tick. A row whose class and spec are both unchanged still skips the rebuild exactly as before, and rows with no spec icon compare nil to nil. `specIconID` is a plain number rather than a secret value, which the surrounding code already relies on.

The tooltip breakdown path sets its icon unconditionally on every render, so it never had this bug and is untouched.

## Scope

One file, +21/-7, all of it inside the two icon memos. No new events, no timers, no polling, no API calls added.

## Testing

Confirmed in game. Each row's icon now follows the player instead of sticking with the row when ranks swap.

<img width="320" height="180" alt="Computer Working GIF" src="https://github.com/user-attachments/assets/063fc7e1-464a-43fb-99a8-b2af69c44132" />

