### PR TITLE
Bags: track currencies per character instead of per profile

### DIFF
--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -472,20 +472,28 @@ initFrame:SetScript("OnEvent", function(self)
                     local cbDD, cbDDRefresh = EllesmereUI.BuildVisOptsCBDropdown(
                         rightRgn, 210, rightRgn:GetFrameLevel() + 2,
                         currencyItems,
+                        -- Tracked currencies are per character (the module owns
+                        -- the accessor and its first-use seeding; see
+                        -- CurrencyOrder in EllesmereUIBags.lua). Reading
+                        -- db.profile.currencyOrder here would edit the legacy
+                        -- shared table that nothing renders any more.
                         function(cID)
-                            local co = db.profile.currencyOrder
+                            local co = EllesmereUI._BagsCurrencyOrder
+                                and EllesmereUI._BagsCurrencyOrder()
                             return co and co[cID] and true or false
                         end,
                         function(cID, v)
-                            if not db.profile.currencyOrder then db.profile.currencyOrder = {} end
+                            local co = EllesmereUI._BagsCurrencyOrder
+                                and EllesmereUI._BagsCurrencyOrder()
+                            if not co then return end
                             if v then
                                 local maxOrder = 0
-                                for _, ord in pairs(db.profile.currencyOrder) do
+                                for _, ord in pairs(co) do
                                     if type(ord) == "number" and ord > maxOrder then maxOrder = ord end
                                 end
-                                db.profile.currencyOrder[cID] = maxOrder + 1
+                                co[cID] = maxOrder + 1
                             else
-                                db.profile.currencyOrder[cID] = nil
+                                co[cID] = nil
                             end
                             if _G.EUI_Bags and _G.EUI_Bags.RefreshInventory then
                                 C_Timer.After(0.1, function()

--- a/EllesmereUIBags/EUI_Bags_Options.lua
+++ b/EllesmereUIBags/EUI_Bags_Options.lua
@@ -835,6 +835,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.bagItemAssignments = nil
                 EllesmereUIDB.characterGold = nil
                 EllesmereUIDB.warbandGold = nil
+                EllesmereUIDB.bagCurrencyByChar = nil
             end
             EllesmereUI:InvalidatePageCache()
         end,

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -83,6 +83,52 @@ local EUI = EllesmereUI
 local _emptyP = {}
 local function BP() return (EUI._bagsDB and EUI._bagsDB.profile) or _emptyP end
 
+-- Tracked currencies are PER CHARACTER, unlike every other bag setting.
+--
+-- They used to live in one profile-level `currencyOrder` table, which meant
+-- ticking a currency on one character put it in every character's bag. Worse,
+-- the input feeding that table is Blizzard's own currency tab, which IS
+-- per-character (see the TokenFrame.OnTokenWatchChanged sync below): a
+-- per-character source writing a shared store can only ever bleed. Reported by
+-- a user wanting one currency on their main and another on the alt that farms
+-- it, which the shared table made impossible.
+--
+-- Storage stays inside the Bags profile, keyed by character, so it still rides
+-- the existing profile plumbing (defaults merge, logout strip, export). A
+-- profile exported to someone else simply carries keys their characters do not
+-- match, and they seed fresh.
+local function BagsCharKey()
+    return (UnitName("player") or "?") .. " - " .. (GetRealmName() or "?")
+end
+
+-- The per-character order table, seeded on this character's first use.
+-- Returns nil only when the DB is not up yet (callers already handle that).
+local function CurrencyOrder()
+    local p = BP()
+    if p == _emptyP then return nil end
+    local byChar = p.currencyOrderByChar
+    if type(byChar) ~= "table" then byChar = {}; p.currencyOrderByChar = byChar end
+    local key = BagsCharKey()
+    local t = byChar[key]
+    if type(t) ~= "table" then
+        t = {}
+        -- Seed from the legacy shared table so an upgrading user keeps exactly
+        -- what they had. The legacy table is deliberately NOT deleted: every
+        -- character seeds from it once, so a character that has not logged in
+        -- since the upgrade still inherits the old setup rather than an empty
+        -- bag footer. Nothing writes to it any more, so the seed is stable.
+        local legacy = p.currencyOrder
+        if type(legacy) == "table" then
+            for cID, order in pairs(legacy) do
+                if type(order) == "number" then t[cID] = order end
+            end
+        end
+        byChar[key] = t
+    end
+    return t
+end
+EUI._BagsCurrencyOrder = CurrencyOrder
+
 -- Resolve the default bag-type view ("all" | "onebag" | "multibag"). Reads the
 -- new bagDefaultBagType key, falling back to the legacy bagDefaultOneBag boolean
 -- so existing users keep their OneBag default. (Cross-version profile imports are
@@ -1667,7 +1713,7 @@ local function UpdateCurrencyDisplays(footerWidth)
 
     -- Build tracked list from internal order table (decoupled from Blizzard)
     local tracked = {}
-    local orderDB = BP().currencyOrder
+    local orderDB = CurrencyOrder()
     if orderDB and C_CurrencyInfo and C_CurrencyInfo.GetCurrencyInfo then
         for cID, order in pairs(orderDB) do
             if type(order) == "number" then
@@ -6656,14 +6702,16 @@ local function StartAddon()
         end
     end
 
-    -- Seed currencyOrder from Blizzard's tracked currencies on first load
+    -- Seed this character's tracked currencies from Blizzard's on first load
     if EllesmereUIDB and C_CurrencyInfo and C_CurrencyInfo.GetBackpackCurrencyInfo then
-        if not BP().currencyOrder then BP().currencyOrder = {} end
-        local co = BP().currencyOrder
-        -- Only seed if our table is empty (first install or fresh profile)
+        -- Only seed when this character's table is empty: first install, a
+        -- fresh profile, or a character whose legacy seed was empty too.
+        local co = CurrencyOrder()
         local hasAny = false
-        for _ in pairs(co) do hasAny = true; break end
-        if not hasAny then
+        if co then
+            for _ in pairs(co) do hasAny = true; break end
+        end
+        if co and not hasAny then
             local order = 0
             for i = 1, 20 do
                 local info = C_CurrencyInfo.GetBackpackCurrencyInfo(i)
@@ -6695,8 +6743,8 @@ local function StartAddon()
     if EventRegistry and EventRegistry.RegisterCallback then
         EventRegistry:RegisterCallback("TokenFrame.OnTokenWatchChanged", function()
             if not EllesmereUIDB then return end
-            if not BP().currencyOrder then BP().currencyOrder = {} end
-            local co = BP().currencyOrder
+            local co = CurrencyOrder()
+            if not co then return end
             local blizzSet = ReadBlizzSet()
             -- Add newly checked currencies
             for cID in pairs(blizzSet) do

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -93,31 +93,43 @@ local function BP() return (EUI._bagsDB and EUI._bagsDB.profile) or _emptyP end
 -- a user wanting one currency on their main and another on the alt that farms
 -- it, which the shared table made impossible.
 --
--- Storage stays inside the Bags profile, keyed by character, so it still rides
--- the existing profile plumbing (defaults merge, logout strip, export). A
--- profile exported to someone else simply carries keys their characters do not
--- match, and they seed fresh.
+-- Stored at the EllesmereUIDB ROOT, not in the bag profile, which is where the
+-- module already keeps its other per-character data (characterGold,
+-- bagPinnedItems, bagItemAssignments). Profile data is the wrong home for it in
+-- two ways: ApplyProfileData wipes db.profile wholesale before copying an
+-- imported snapshot, so importing any shared profile would erase every
+-- character's currencies, and profile exports would ship a roster of the
+-- author's character names, realms and per-alt currency lists to whoever
+-- imported it -- the leak PRIVATE_ADDON_KEYS exists to plug.
+local _bagsCharKey  -- session-constant; UpdateCurrencyDisplays is a render path
 local function BagsCharKey()
-    return (UnitName("player") or "?") .. " - " .. (GetRealmName() or "?")
+    if not _bagsCharKey then
+        local n, r = UnitName("player"), GetRealmName()
+        if not n or not r then return nil end  -- too early; do not cache a stub
+        _bagsCharKey = n .. " - " .. r
+    end
+    return _bagsCharKey
 end
 
 -- The per-character order table, seeded on this character's first use.
--- Returns nil only when the DB is not up yet (callers already handle that).
+-- Returns nil only when the DB or the player identity is not up yet (callers
+-- already handle that).
 local function CurrencyOrder()
-    local p = BP()
-    if p == _emptyP then return nil end
-    local byChar = p.currencyOrderByChar
-    if type(byChar) ~= "table" then byChar = {}; p.currencyOrderByChar = byChar end
+    if not EllesmereUIDB then return nil end
     local key = BagsCharKey()
+    if not key then return nil end
+    local byChar = EllesmereUIDB.bagCurrencyByChar
+    if type(byChar) ~= "table" then byChar = {}; EllesmereUIDB.bagCurrencyByChar = byChar end
     local t = byChar[key]
     if type(t) ~= "table" then
         t = {}
         -- Seed from the legacy shared table so an upgrading user keeps exactly
         -- what they had. The legacy table is deliberately NOT deleted: every
-        -- character seeds from it once, so a character that has not logged in
-        -- since the upgrade still inherits the old setup rather than an empty
-        -- bag footer. Nothing writes to it any more, so the seed is stable.
-        local legacy = p.currencyOrder
+        -- character seeds from it once, at ITS first login after the upgrade,
+        -- so a character that has not logged in yet still inherits the old
+        -- setup instead of an empty footer. Nothing writes to it any more, so
+        -- the seed stays stable. A per-character migration is never a one-shot.
+        local legacy = BP().currencyOrder
         if type(legacy) == "table" then
             for cID, order in pairs(legacy) do
                 if type(order) == "number" then t[cID] = order end


### PR DESCRIPTION
## The bug

Reported by a user who wanted one currency tracked on their main and a different one on the alt that farms it: the bag's currency display was identical on every character. Unticking everything and re-picking, from either the EUI dropdown or Blizzard's own currency tab, always ended with every character showing the same set.

## Root cause

The bag footer does not render Blizzard's tracked currencies. It renders the module's own `currencyOrder` table (the code comment says "decoupled from Blizzard"), and that table lives in the bag **profile**, so every character on the profile shares it.

The input feeding it is not shared. A `TokenFrame.OnTokenWatchChanged` callback syncs Blizzard's currency tab, which **is** per-character, into that one profile-level table. A per-character source writing a shared store can only ever bleed: ticking a currency on one character wrote it into everyone's bag.

That also explains the half of the report that sounded impossible, that Blizzard's own per-character tracking looked broken. EUI never writes that tab, and there is no `SetCurrencyBackpack`-family call anywhere in the module, only reads. What the user saw was the bag ignoring their per-character selection and showing the shared list instead.

## The fix

Tracked currencies move to `EllesmereUIDB.bagCurrencyByChar`, keyed by name and realm.

**Storage is at the DB root, not in the profile.** The module already keeps its other per-character data there (`characterGold`, `bagPinnedItems`, `bagItemAssignments`), and it is cleared alongside them by the options page's per-character reset. Profile storage would have been wrong twice over:

- `ApplyProfileData` wipes `db.profile` wholesale before copying an imported snapshot, so importing any shared profile would have erased every character's currencies and substituted the exporter's.
- Profile exports would have shipped a roster of the author's character names, realms and per-alt currency lists to whoever imported it. That is exactly the leak `PRIVATE_ADDON_KEYS` exists to plug for the DataBars gold ledger and the QoL upgrade calculator.

Root storage also removes a failure mode the profile version had: a spec-driven profile switch (`RepointAllDBs`, no reload) could hand a character a freshly created empty table mid-session with nothing to seed it, blanking the footer for the rest of the session. Root data does not move with profiles, so first use happens once per character, ever.

**Each character seeds once from the legacy shared table**, so an upgrading user keeps exactly what they had and only diverges as they change things. The legacy table is deliberately left in place rather than deleted or migrated away: a per-character migration is not a one-shot, it runs once per character at that character's first login, so the seed source has to survive indefinitely. A character that has not logged in since the update still needs it, or it would open with an empty footer. Nothing writes to it any more, so the seed stays stable. Fresh installs are unchanged and still seed from Blizzard's tracked set.

**One accessor owns the location and the seeding.** The options dropdown goes through `EllesmereUI._BagsCurrencyOrder` rather than reaching for `db.profile.currencyOrder`, so there is a single definition of where this data lives. Because the TOC loads the options file before the module, that call is a runtime namespace lookup rather than a local captured at load time.

The character key is resolved once and cached. It is session-constant and was being rebuilt, two API calls plus a string allocation, on a render path driven by `CURRENCY_DISPLAY_UPDATE`. It refuses to cache before `UnitName` and `GetRealmName` both answer, so an early call returns nil rather than pinning a stub key for the session.

## Scope

Two files, +70/−14. No new events, no timers, no API calls added. `bagCurrencyByChar` is deliberately absent from `BAGS_DEFAULTS`: `StripDefaults` and `DeepMergeDefaults` only walk keys present in the defaults table, so the per-character data is never stripped or masked.

## Testing

Confirmed in game: currencies ticked on one character no longer follow to another, existing setups carry over untouched on upgrade, and Blizzard's currency tab now drives only the character it belongs to.

<img width="258" height="258" alt="South Park Animation GIF" src="https://github.com/user-attachments/assets/8204b21e-7bfb-41ae-babb-3a1fd2be6cb0" />

