### PR TITLE
fix(damagemeters): cancel a staggered window build that a rebuild supersedes

### DIFF
--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -418,6 +418,14 @@ local _inEncounter = false       -- true between ENCOUNTER_START and ENCOUNTER_E
 local _playerGUID
 local _windows = {}  -- array of active window tables
 ns._windows = _windows
+
+-- Bumped whenever a build of the windows starts or _EDM_Apply() supersedes one. The
+-- login build is staggered across frames, so a rebuild arriving while it is still in
+-- flight would otherwise let the pending steps assign _windows[i] over entries the
+-- rebuild had just created -- abandoning those frames while they stay parented and
+-- visible. A staggered step checks this before doing any work and drops out if a newer
+-- build has taken over.
+local _buildGen = 0
 ns._DM_TYPE_NAMES = DM_TYPE_NAMES
 
 -------------------------------------------------------------------------------
@@ -5242,7 +5250,12 @@ initFrame:SetScript("OnEvent", function(self)
     cfg.windowCount = winCount
     for i = winCount + 1, MAX_WINDOWS do cfg.windows[i] = nil end
     local winIdx = 0
+    _buildGen = _buildGen + 1
+    local myBuildGen = _buildGen
     local function CreateNextWindow()
+        -- A rebuild has superseded this staggered build; carrying on would overwrite the
+        -- windows it created and leave those frames orphaned but visible.
+        if myBuildGen ~= _buildGen then return end
         winIdx = winIdx + 1
         if winIdx > winCount then
             -- All windows exist: register them with the core unlock mode system
@@ -5263,6 +5276,9 @@ initFrame:SetScript("OnEvent", function(self)
 
     -- Profile swap rebuild: tear down all windows and recreate from new profile
     _G._EDM_Apply = function()
+        -- Supersede any staggered build still in flight, so its remaining steps do not
+        -- assign over the windows created below and orphan them
+        _buildGen = _buildGen + 1
         -- Destroy existing windows (frame cleanup only, don't touch DB)
         for i = #_windows, 1, -1 do
             local w = _windows[i]
@@ -5299,10 +5315,15 @@ initFrame:SetScript("OnEvent", function(self)
         ns.RegisterDMUnlock()
         -- Recreate standalone timer if enabled
         if c.standaloneTimer then CreateSATimer() end
+        -- Pre-create tooltip frame so first hover doesn't pay creation cost. This and the
+        -- ticker below are the staggered build's closing steps, repeated here because
+        -- this rebuild may have superseded that build before it reached them.
+        EnsureTooltipFrame()
         -- Update tooltip scale
         if _ttFrame then
             local sc = (c.hoverTooltipScale or 100) / 100
             _ttFrame:SetScale(sc)
         end
+        if _inCombat and not _sharedTicker then StartSharedTicker() end
     end
 end)


### PR DESCRIPTION
DISCLAIMER: AI was used to create this PR (Claude Fable 5 Max)

## What does this PR do?

Fixes duplicate damage meter windows that appear after login and show up as
frozen "ghost" meters at combat start.

The login build creates windows one per frame: `CreateNextWindow` re-arms itself
through `C_Timer.After(0)`. `_EDM_Apply()` does the opposite, tearing everything
down and rebuilding synchronously. When an apply lands while the login build is
still in flight, the two overlap: the staggered build's remaining steps assign
`_windows[i]` over the entries the rebuild has just created. Those window tables
are dropped from `_windows`, but their frames stay parented and shown. The user
is left with a second meter that never updates, which becomes obvious at combat
start when the live windows begin refreshing and the orphan sits there frozen.

This does not need a third-party addon to trigger. `EllesmereUI_Profiles.lua` and
`EllesmereUI_SpecOverrides.lua` both call `_EDM_Apply()` directly, so a profile
apply or a spec override arriving during login is enough.

The fix is a build generation counter. `CreateNextWindow` captures the generation
when its build starts and drops out if a newer one has taken over; `_EDM_Apply`
bumps the counter before tearing down, superseding any build still running.
Because a superseded build can now be cut off before reaching its closing steps,
`_EDM_Apply` performs them itself: `EnsureTooltipFrame()` and the in-combat
ticker restart, which the staggered build otherwise does after its last window.

Nothing changes when the two never overlap, which is the normal login.

## How this was discovered

It surfaced as duplicate meters while running NaowhUI's EllesmereUI profile
addon, so the first assumption was that it belonged downstream: NaowhUI writes
profile keys during login and each write triggered a meter rebuild, which is
exactly the apply-lands-mid-build case. I worked around it on that side by
deferring the rebuild.

NaowhUI then shipped its own guard in 1.0.6 (`NaowhUI.RefreshDamageMeter()` in
`NaowhUI_Core.lua`), better than the workaround: it debounces the writes so one
toggle drives a single rebuild, and it polls for the last window's globally named
frame instead of guessing a delay, capped at about 5s.

The duplicates still came back at combat start, which is what pointed at
EllesmereUI. A downstream guard can only cover its own trigger; `_EDM_Apply()` is
called directly from `EllesmereUI_Profiles.lua` and `EllesmereUI_SpecOverrides.lua`
with no equivalent protection, so the race stays reachable from inside
EllesmereUI regardless of what any addon does. Hence this fix here rather than
there.

Worth reading if you want a second account of the same race: the comment above
`RefreshDamageMeter` in `NaowhUI_Core.lua` (~line 311) describes it
independently, including a consequence I had not traced. They report that the
stranded window's close button removes the *live* window's saved slot, so the
window is, in their words, "gone for good on the next reload". If that holds,
this is a data-loss bug and not only a cosmetic one.

Two notes for anyone reproducing or writing similar guards:

- The `EllesmereUIDMFrame1..5` globals are not a reliable guide to which windows
  are live. `CreateFrame` with an existing name does not rebind the global, so
  after the first build those globals stay non-nil even for frames that have been
  torn down, while the live windows exist only in the private `_windows` table.
  Diagnostics keyed off the globals will report the wrong frames, and a readiness
  probe keyed off them can read "built" while a build is still in flight. With
  the generation counter in place, downstream addons should not need such a probe
  at all.
- Several plausible-looking fixes are dead ends: calling `_EDM_Apply()` from its
  own hook, tracking orphans by reference (it cannot see frames leaked before its
  own baseline), or hiding/reparenting frames found through those globals, which
  tears down the working meters instead.

## How was it tested?

Live retail, `Interface: 120001`.

- Reproduced first: duplicate window present after `/reload`, and a frozen ghost
  meter reappearing at combat start.
- With the change: repeated `/reload` cycles, profile switches and spec-override
  swaps, entering and leaving combat each time. No duplicate windows, and
  `#_windows` matches `windowCount` after each apply.
- Tooltip on first hover and the in-combat refresh ticker both still come up when
  a rebuild supersedes the login build (the two closing steps moved into
  `_EDM_Apply`).
- Carried across 8.7.4 through 8.7.7 in daily play, with NaowhUI's own profile
  addon installed and actively rebuilding the meter.

<!-- TODO before opening: 12.1 PTR load check has NOT been done. Either run the
     client once and confirm no load errors, or say so plainly here and leave
     that checklist box unticked. -->

## Screenshots

<!-- TODO: optional but helpful. A before shot of the duplicate/ghost meter at
     combat start would make the report concrete. Delete this section if you do
     not attach one. -->

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new settings; bug fix only
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A, nothing added to disable
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - one integer compare per staggered build step; the counter is written only when a build starts or is superseded
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A, touches only EllesmereUI's own window tables
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
      <!-- TODO: live retail yes; PTR not yet checked. Tick once verified. -->