### PR TITLE
Fix party ready check icon size and toggles ignoring party overrides

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -4575,7 +4575,7 @@ local function UpdateButton(button)
         local stc = s.statusTextColor or { r = 1, g = 1, b = 1 }
         if s.statusTextPosition == "none" then
             d.statusText:Hide()
-        elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
+        elseif s.showIncomingRez and UnitHasIncomingResurrection(unit) then
             -- Being resurrected: hide the status text so the incoming-rez icon (shown in the same
             -- spot by UpdateReadyCheck) isn't covered by the status text.
             d.statusText:Hide()
@@ -6075,11 +6075,16 @@ local function UpdateReadyCheck(button, unit)
     local tex = d.readyCheck
     if not tex then return end
 
-    local sz = PixelSnap(db.profile.readyCheckSize or 20)
+    -- Party/extra-aware settings source, same as every other indicator updater.
+    -- AnchorReadyCheck already resolves LIVE this way, so a raw db.profile read
+    -- here re-sized the shared texture back to the RAID value on every paint.
+    local s = d._isParty and ns._scaledPartyProxy or (d._isExtra and ns._scaledExtraProxy) or ns._scaledProfile
+
+    local sz = PixelSnap(s.readyCheckSize or 20)
     tex:SetSize(sz, sz)
 
     -- Ready check (priority)
-    if db.profile.showReadyCheck and readyCheckActive then
+    if s.showReadyCheck and readyCheckActive then
         local status = GetReadyCheckStatus(unit)
         if status == "ready" then
             tex:SetTexCoord(0, 1, 0, 1)
@@ -6100,7 +6105,7 @@ local function UpdateReadyCheck(button, unit)
     end
 
     -- Incoming summon
-    if db.profile.showSummonPending and unit and C_IncomingSummon.HasIncomingSummon(unit) then
+    if s.showSummonPending and unit and C_IncomingSummon.HasIncomingSummon(unit) then
         local sStatus = C_IncomingSummon.IncomingSummonStatus(unit)
         if sStatus == SUMMON_STATUS_PENDING then
             tex:SetAtlas("RaidFrame-Icon-SummonPending")
@@ -6120,7 +6125,7 @@ local function UpdateReadyCheck(button, unit)
     -- Incoming resurrection ("someone is casting a rez / rez waiting to be
     -- accepted"). Lowest priority; only meaningful on a dead unit. Lets healers
     -- see a body is already being picked up so they don't all rez the same one.
-    if db.profile.showIncomingRez and unit and UnitHasIncomingResurrection(unit) then
+    if s.showIncomingRez and unit and UnitHasIncomingResurrection(unit) then
         tex:SetTexCoord(0, 1, 0, 1)
         tex:SetTexture("Interface\\RaidFrame\\Raid-Icon-Rez")
         tex:Show()
@@ -6487,7 +6492,7 @@ ns._UpdateButtonHealth = function(button)
         local stc = s.statusTextColor or { r = 1, g = 1, b = 1 }
         if s.statusTextPosition == "none" then
             d.statusText:Hide()
-        elseif db.profile.showIncomingRez and UnitHasIncomingResurrection(unit) then
+        elseif s.showIncomingRez and UnitHasIncomingResurrection(unit) then
             -- Being resurrected: hide the status text so the incoming-rez icon isn't covered.
             d.statusText:Hide()
         elseif not UnitIsConnected(unit) then


### PR DESCRIPTION
Reported on 8.7.6: the Party Frames ready check Icon Size slider had no effect even at maximum.

## Cause

`UpdateReadyCheck` read `readyCheckSize`, `showReadyCheck`, `showSummonPending` and `showIncomingRez` straight from `db.profile`, while every sibling indicator updater resolves the party/extra-aware source:

```lua
local s = d._isParty and ns._scaledPartyProxy or (d._isExtra and ns._scaledExtraProxy) or ns._scaledProfile
```

That function re-sizes the shared ready/summon/rez texture on every call, and it runs from the full paint pass plus `READY_CHECK`, `INCOMING_SUMMON_CHANGED` and `INCOMING_RESURRECT_CHANGED` for party buttons as well. `ReloadPartyFrames` applied the correct party size and the next paint reset it to the raid value.

Ready check *position* was unaffected because `AnchorReadyCheck` already resolves its source live via `LiveS()`. One indicator reading two different settings sources is what made position work and size not.

Only reproduces when the party Indicators section is set to custom (unsynced), since that is when a `party_readyCheckSize` key exists. With the section synced both paths read the same key, which is why it went unnoticed.

## Change

- `UpdateReadyCheck` resolves the settings source through the same proxy chain as every other per-button updater, covering the size and the three visibility toggles.
- The two status-text incoming-rez gates now read that same source, so the DEAD text hides for the frame whose icon actually draws.

## Notes

No behaviour change for raid frames: `readyCheckSize` is not in `INDICATOR_SCALE_KEYS`, so the proxy returns exactly what `db.profile` returned. Party overrides only apply when `partySyncSections.indicators` is false and a `party_` key is set, so existing profiles are untouched.

No new events, no new frames, no secure-frame or combat-path changes.

## Testing

`luac -p` passes. Verified in game: with the party Indicators section set to custom, the party ready check icon now honours its own Icon Size through a full ready check, and raid frames are unchanged.

<img width="500" height="281" alt="Henry Cavill Batman GIF by mtv" src="https://github.com/user-attachments/assets/73681787-4b56-43de-b284-3e58569eed53" />

