### PR TITLE
Fix party reload permanently writing overrides onto nil raid keys

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -11343,12 +11343,16 @@ ns.ReloadPartyFrames = function()
 
     -- Temp-swap: write party overrides onto db.profile so anchor closures
     -- (which captured db.profile) read party values. Only for keys whose
-    -- section is custom (unsynced).
-    local saved = {}
+    -- section is custom (unsynced). `swapped` records WHICH keys were swapped:
+    -- a key whose raid value is nil (no default, never set on raid) stores
+    -- nothing in `saved`, so restoring from `saved` alone would skip it and
+    -- leave the party value on the shared raid key permanently.
+    local saved, swapped = {}, {}
     for key, section in pairs(ns._PARTY_KEY_SECTION) do
         if ns._IsPartySectionCustom(section) then
             local pv = rawget(raw, "party_" .. key)
             if pv ~= nil then
+                swapped[#swapped + 1] = key
                 saved[key] = raw[key]
                 raw[key] = pv
             end
@@ -11504,9 +11508,10 @@ ns.ReloadPartyFrames = function()
         end
     end
 
-    -- Restore db.profile to raid values
-    for key, val in pairs(saved) do
-        raw[key] = val
+    -- Restore db.profile to raid values (via `swapped`, so a nil raid value
+    -- is written back as nil rather than skipped)
+    for _, key in ipairs(swapped) do
+        raw[key] = saved[key]
     end
 
     -- Re-layout header


### PR DESCRIPTION
Found during review of #1256. Silent, permanent overwrite of raid settings by party overrides, for the nine party-overridable keys that have no stored default.

## Cause

`ReloadPartyFrames` temp-swaps party overrides onto `db.profile` so the anchor closures that captured it read party values, then restores afterwards:

```lua
saved[key] = raw[key]   -- store the raid value
raw[key] = pv           -- swap in the party value
...
for key, val in pairs(saved) do raw[key] = val end   -- restore
```

In Lua, assigning `nil` into a table is a delete, not a store. A mapped key whose raid value is `nil` never enters `saved`, so the restore loop skips it and the party value stays on the shared raid key, then saves to disk. The reload runs on every party settings change, so one edit is enough.

Keys with a default are immune: `NewDB` merges defaults into the profile at load, so their raid value is never `nil` in memory. Nine mapped keys have no default: `tooltipMode`, `debuffIconZoom`, `defIconZoom`, `absorbBarPosition`, `dispelIconBorderSize`, `borderTextureOffset`, `borderTextureOffsetY`, `borderTextureShiftX`, `borderTextureShiftY`.

Repro on current main: unsync EXTRAS on the Party tab, set party Tooltip Mode to "never" on a profile that never changed the raid value, and raid frames stop showing tooltips, permanently.

## Change

Record the swapped keys in a presence list and restore by iterating it, so a `nil` raid value is written back as `nil` instead of being skipped. Keys with a raid value round-trip exactly as before; this is the only temp-swap site in the module.

No migration: the damage is a plain wrong value on a raid key, indistinguishable from a user choice after the fact. Users affected fix it by setting the raid value back once; it then sticks.

## Testing

`luac -p` passes. An offline round-trip test covers both cases: a defaulted key restores its raid value, a nil-valued key restores to `nil` (the old loop demonstrably leaves the party value behind).

Verified in game: with EXTRAS unsynced, party Tooltip Mode set to "never" no longer touches the raid value; the Frames tab reading and raid tooltips are unchanged, and both values survive a relog.

<img width="318" height="178" alt="Peace Out Goodbye GIF" src="https://github.com/user-attachments/assets/872b7fca-60f2-4795-beb2-a3f4a34ec570" />
