### PR TITLE
Fix Combat Text Font never applying for SharedMedia fonts

### DIFF
--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -1861,17 +1861,14 @@ initFrame:SetScript("OnEvent", function(self)
                 if v == "default" then
                     EllesmereUIDB.fctFont = nil
                     EllesmereUIDB.fctFontPath = nil
+                    EllesmereUIDB.fctFontPathFor = nil
                 else
                     EllesmereUIDB.fctFont = v
-                    -- Cache the resolved path (Name Font pattern). At next
-                    -- login the startup apply runs at OUR ADDON_LOADED, before
-                    -- an external SharedMedia pack has registered its fonts,
-                    -- so an smf: key cannot be resolved that early -- but the
-                    -- engine caches DAMAGE_TEXT_FONT in that window. Here the
-                    -- pack is loaded (its font is in this dropdown), so the
-                    -- path is known-good.
-                    local e = fctFontValues[v]
-                    EllesmereUIDB.fctFontPath = e and e.font or nil
+                    -- smf: keys cache their resolved path for the next login's
+                    -- early window; see ApplyCombatTextFont in Startup.
+                    local e = v:match("^smf:") and fctFontValues[v]
+                    EllesmereUIDB.fctFontPath = e and e.font
+                    EllesmereUIDB.fctFontPathFor = e and v
                 end
                 EllesmereUI:ShowConfirmPopup({
                     title   = "Logout Required",

--- a/EUI__General_Options.lua
+++ b/EUI__General_Options.lua
@@ -1860,8 +1860,18 @@ initFrame:SetScript("OnEvent", function(self)
                 if not EllesmereUIDB then EllesmereUIDB = {} end
                 if v == "default" then
                     EllesmereUIDB.fctFont = nil
+                    EllesmereUIDB.fctFontPath = nil
                 else
                     EllesmereUIDB.fctFont = v
+                    -- Cache the resolved path (Name Font pattern). At next
+                    -- login the startup apply runs at OUR ADDON_LOADED, before
+                    -- an external SharedMedia pack has registered its fonts,
+                    -- so an smf: key cannot be resolved that early -- but the
+                    -- engine caches DAMAGE_TEXT_FONT in that window. Here the
+                    -- pack is loaded (its font is in this dropdown), so the
+                    -- path is known-good.
+                    local e = fctFontValues[v]
+                    EllesmereUIDB.fctFontPath = e and e.font or nil
                 end
                 EllesmereUI:ShowConfirmPopup({
                     title   = "Logout Required",

--- a/EllesmereUI_Startup.lua
+++ b/EllesmereUI_Startup.lua
@@ -304,19 +304,42 @@ end
 -- CombatTextFont may not exist yet here, so we also hook ADDON_LOADED
 -- to catch it as soon as it becomes available.
 do
-    local function ApplyCombatTextFont()
-        local saved = EllesmereUIDB and EllesmereUIDB.fctFont
+    local function ApplyCombatTextFont(loginComplete)
+        local db = EllesmereUIDB
+        local saved = db and db.fctFont
         if not saved or type(saved) ~= "string" or saved == "" then return end
         -- Resolve "smf:" prefixed SharedMedia font keys to actual paths
         local fontPath = saved
         local smName = saved:match("^smf:(.+)")
         if smName then
             local LSM = LibStub and LibStub("LibSharedMedia-3.0", true)
-            local fetched = LSM and LSM:Fetch("font", smName)
-            -- If the SM addon is missing or hasn't loaded yet, skip entirely
-            -- so Blizzard's default combat text font stays intact.
-            if not fetched then return end
-            fontPath = fetched
+            -- noDefault: an unregistered key must yield nil here. Without it
+            -- Fetch silently substitutes the DEFAULT font (Friz Quadrata),
+            -- which then lands in DAMAGE_TEXT_FONT right as the engine caches
+            -- it -- external SM packs load after us, so at our ADDON_LOADED
+            -- their fonts are never registered yet.
+            local fetched = LSM and LSM:Fetch("font", smName, true)
+            local cached = db.fctFontPath
+            if fetched then
+                db.fctFontPath = fetched   -- keep the login cache current
+                fontPath = fetched
+            elseif loginComplete then
+                -- Every login addon has loaded and the font is still not
+                -- registered: the providing pack is gone. Drop the stale
+                -- cache so no later login points the engine at a missing
+                -- file, and leave Blizzard's default intact this session.
+                db.fctFontPath = nil
+                return
+            elseif type(cached) == "string" and cached ~= "" then
+                -- Early window (pack not loaded yet): use the path cached at
+                -- selection time. This is what makes an smf: font survive the
+                -- engine's login cache at all.
+                fontPath = cached
+            else
+                -- Pre-cache profile: nothing usable this early. The login-
+                -- complete pass above will populate the cache for next time.
+                return
+            end
         end
         _G.DAMAGE_TEXT_FONT = fontPath
         if _G.CombatTextFont then
@@ -341,14 +364,19 @@ do
             end
         end
 
-        ApplyCombatTextFont()
+        ApplyCombatTextFont(event == "PLAYER_LOGIN" or event == "PLAYER_ENTERING_WORLD")
         ApplyUnitNameFont()
 
         if event == "PLAYER_LOGIN" then
             self:UnregisterEvent("PLAYER_LOGIN")
         elseif event == "PLAYER_ENTERING_WORLD" then
             self:UnregisterEvent("PLAYER_ENTERING_WORLD")
-        elseif event == "ADDON_LOADED" then
+        elseif addonName == "Blizzard_CombatText" then
+            -- Only Blizzard_CombatText's load retires the ADDON_LOADED watch.
+            -- Our own addon always loads first, so unregistering on the first
+            -- match (the old behavior) meant the CombatTextFont object -- the
+            -- load-on-demand scrolling-text font -- was never restyled at its
+            -- actual load moment.
             self:UnregisterEvent("ADDON_LOADED")
         end
     end)

--- a/EllesmereUI_Startup.lua
+++ b/EllesmereUI_Startup.lua
@@ -216,16 +216,30 @@ end
 -- Reads EllesmereUIDB.fonts directly rather than going through GetFontsDB():
 -- that helper lazy-creates the table, and this can run at the ADDON_LOADED of
 -- Blizzard_CombatText, before our SavedVariables have been restored.
+
+-- Probe a font path before it reaches an engine global: SetFont returns a
+-- success boolean, so a cached path whose providing addon was uninstalled is
+-- detected instead of leaving the engine pointed at a missing file for the
+-- whole session (which kills floating text entirely).
+local probeFS
+local function ProbeFont(path)
+    if type(path) ~= "string" or path == "" then return false end
+    probeFS = probeFS or UIParent:CreateFontString()
+    local ok, success = pcall(probeFS.SetFont, probeFS, path, 12, "")
+    return ok and success == true
+end
+
 local function ApplyUnitNameFont()
     local fonts = EllesmereUIDB and EllesmereUIDB.fonts
     local name = fonts and fonts.unitNameFont
     if not name or name == "" then return end
     local path = fonts.unitNameFontPath
-    if (type(path) ~= "string" or path == "")
-       and EllesmereUI and EllesmereUI.ResolveFontName then
+    local ok = ProbeFont(path)
+    if not ok and EllesmereUI and EllesmereUI.ResolveFontName then
         path = EllesmereUI.ResolveFontName(name)
+        ok = ProbeFont(path)
     end
-    if type(path) == "string" and path ~= "" then
+    if ok then
         _G.UNIT_NAME_FONT = path
     end
 end
@@ -304,42 +318,30 @@ end
 -- CombatTextFont may not exist yet here, so we also hook ADDON_LOADED
 -- to catch it as soon as it becomes available.
 do
-    local function ApplyCombatTextFont(loginComplete)
+    -- smf: keys resolve via LSM when the providing pack has loaded, else via
+    -- the path cached at selection time (external packs load after us, so at
+    -- our ADDON_LOADED -- the window where the engine caches the global --
+    -- the name is never registered yet). noDefault on Fetch: without it an
+    -- unregistered name silently resolves to the DEFAULT font, not nil.
+    -- Every candidate is probed, so only a loadable path is ever applied or
+    -- kept in the cache.
+    local function ApplyCombatTextFont()
         local db = EllesmereUIDB
         local saved = db and db.fctFont
         if not saved or type(saved) ~= "string" or saved == "" then return end
-        -- Resolve "smf:" prefixed SharedMedia font keys to actual paths
         local fontPath = saved
         local smName = saved:match("^smf:(.+)")
         if smName then
             local LSM = LibStub and LibStub("LibSharedMedia-3.0", true)
-            -- noDefault: an unregistered key must yield nil here. Without it
-            -- Fetch silently substitutes the DEFAULT font (Friz Quadrata),
-            -- which then lands in DAMAGE_TEXT_FONT right as the engine caches
-            -- it -- external SM packs load after us, so at our ADDON_LOADED
-            -- their fonts are never registered yet.
             local fetched = LSM and LSM:Fetch("font", smName, true)
-            local cached = db.fctFontPath
-            if fetched then
-                db.fctFontPath = fetched   -- keep the login cache current
-                fontPath = fetched
-            elseif loginComplete then
-                -- Every login addon has loaded and the font is still not
-                -- registered: the providing pack is gone. Drop the stale
-                -- cache so no later login points the engine at a missing
-                -- file, and leave Blizzard's default intact this session.
-                db.fctFontPath = nil
-                return
-            elseif type(cached) == "string" and cached ~= "" then
-                -- Early window (pack not loaded yet): use the path cached at
-                -- selection time. This is what makes an smf: font survive the
-                -- engine's login cache at all.
-                fontPath = cached
-            else
-                -- Pre-cache profile: nothing usable this early. The login-
-                -- complete pass above will populate the cache for next time.
-                return
-            end
+            -- The cache only counts if it was written for the currently
+            -- saved key (fctFontPathFor pairs them).
+            local cached = (db.fctFontPathFor == saved) and db.fctFontPath or nil
+            fontPath = (ProbeFont(fetched) and fetched)
+                or (ProbeFont(cached) and cached) or nil
+            db.fctFontPath = fontPath
+            db.fctFontPathFor = fontPath and saved or nil
+            if not fontPath then return end
         end
         _G.DAMAGE_TEXT_FONT = fontPath
         if _G.CombatTextFont then
@@ -364,19 +366,21 @@ do
             end
         end
 
-        ApplyCombatTextFont(event == "PLAYER_LOGIN" or event == "PLAYER_ENTERING_WORLD")
+        ApplyCombatTextFont()
         ApplyUnitNameFont()
 
         if event == "PLAYER_LOGIN" then
             self:UnregisterEvent("PLAYER_LOGIN")
         elseif event == "PLAYER_ENTERING_WORLD" then
             self:UnregisterEvent("PLAYER_ENTERING_WORLD")
-        elseif addonName == "Blizzard_CombatText" then
-            -- Only Blizzard_CombatText's load retires the ADDON_LOADED watch.
-            -- Our own addon always loads first, so unregistering on the first
-            -- match (the old behavior) meant the CombatTextFont object -- the
-            -- load-on-demand scrolling-text font -- was never restyled at its
-            -- actual load moment.
+        elseif addonName == "Blizzard_CombatText"
+            or not (EllesmereUIDB and EllesmereUIDB.fctFont)
+            or (C_AddOns and C_AddOns.IsAddOnLoaded and C_AddOns.IsAddOnLoaded("Blizzard_CombatText")) then
+            -- The watch exists to restyle the load-on-demand CombatTextFont
+            -- object at its actual load (our own addon always fires first, so
+            -- retiring on the first match missed it). Retire it once that has
+            -- happened, or when it never can: feature unused (a mid-session
+            -- pick needs a relog anyway) or the addon already loaded.
             self:UnregisterEvent("ADDON_LOADED")
         end
     end)


### PR DESCRIPTION
Reported on 8.6.3: setting Combat Text Font to a SharedMedia font (e.g. "Numbers"), following the logout prompt, and logging back in shows the font selected in Global Settings, but the damage numbers never change. Bundled fonts work; only SharedMedia picks fail.

## Cause

Two defects stacked in `ApplyCombatTextFont` (EllesmereUI_Startup.lua).

**Load order.** A SharedMedia font is stored as `smf:<name>` and resolved at startup. The earliest apply with SavedVariables available is our own `ADDON_LOADED`, and external SharedMedia packs load after us, so at that moment the name is not registered yet. The engine caches `DAMAGE_TEXT_FONT` before the `PLAYER_LOGIN` re-apply (the feature's own "logout required" popup documents that cache), so the later correct write is invisible.

**Silent substitution.** `LSM:Fetch("font", name)` without its `noDefault` flag does not return nil for an unregistered name. It returns the *default* font, Friz Quadrata, the same face damage numbers already use. So the "skip if unavailable" guard never fired, and the engine cached "no change" every login.

Bundled fonts store a direct file path and skip resolution entirely, which is why they always worked.

## Change

Mirrors the Name Font pattern already in this codebase (`unitNameFontPath`):

- The dropdown's `setValue` also stores the resolved path (`EllesmereUIDB.fctFontPath`). At selection time the providing pack is necessarily loaded, since its font is in the dropdown.
- Startup applies the cached path in the early window, fetches with `noDefault` so a missing name can never silently become Friz, refreshes the cache once login completes, and clears it when the providing pack is gone, so no later login points the engine at a missing file.
- Profiles saved before this fix have no cache; their first login populates it and the font shows from the next login on. Re-selecting the font once applies it on the very next relog.

Also fixed in the same block: the `ADDON_LOADED` watch was unregistered on the first matching addon, which is always ours, so the load-on-demand `CombatTextFont` object (scrolling combat text) was never restyled at its actual load moment. Only `Blizzard_CombatText`'s load retires the watch now.

## Testing

`luac -p` passes on both files. The resolve logic was exercised offline across all five timing windows (bundled early, cached early, pre-fix profile early, login-complete refresh, pack removed), plus a demonstration that the old code fetched Friz Quadrata for an unregistered name.

Verified in game by the original reporter on a test build of this branch: SharedMedia font selected, logout to character select, damage numbers render in the chosen font on a training dummy. Bundled fonts and Blizzard Default unchanged.

<img width="500" height="375" alt="Family Guy Reaction GIF" src="https://github.com/user-attachments/assets/2a1e1785-5a68-403b-b7a0-475708951249" />



## Update after review

A multi-angle review of the first commit surfaced two real defects in its failure paths, both fixed in the second commit:

- **Pack uninstalled**: the early window applied the cached path blindly, leaving `DAMAGE_TEXT_FONT` pointed at a missing file for the whole session, which disables floating combat text entirely (worse than the original bug).
- **Destructive cache clear**: "not registered by PLAYER_LOGIN" was treated as "pack gone", so one login with the pack disabled (an alt, out-of-date after a patch) or a pack registering its fonts late wiped the account-wide cache and cost an extra default-font login after recovery.

The revision replaces the event-driven branching with a single invariant: every candidate path (LSM result or cache) is probed with `SetFont`, which returns a success boolean (per `SimpleFontStringAPIDocumentation`), before it reaches an engine global or stays cached. An uninstalled pack reverts to Blizzard default with the cache cleared; a disabled-but-on-disk pack keeps working, since font files load regardless of addon enable state. The cache also records which key produced it, so a desynced `fctFont` can never apply a stale path, and `ApplyUnitNameFont` gets the same probe (its `unitNameFontPath` rides profile export, where an import could carry a path the importer's machine does not have). The `ADDON_LOADED` watch now retires when the feature is unconfigured, keeping the unused-feature cost at zero.

All eight resolve scenarios (healthy, uninstalled, disabled, late-registering, key-mismatch, dead registration, pre-fix profile, bundled) pass an offline simulation of the new logic. The reporter-verified happy path is preserved by construction; a re-test of the pack-uninstalled path in game is welcome but the failure it guards against was never reachable in the verified flow.

