### PR TITLE
Fix buff listed in two Cooldown Manager buff groups at once

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -1042,6 +1042,15 @@ end
 --- Enumerate default-buffs-bar entries (viewer pool + this bar's customs/items),
 --- minus spells diverted to other buff-family or hosted CD/utility bars.
 function ns.CollectDefaultBuffTrackEntries()
+    -- Variant-aware (base/override family), not a plain sid set: a claimed
+    -- buff's stored id and the id this same viewer slot enumerates as later
+    -- can legitimately differ (a talent-override swap, or a fresh clean-cache
+    -- forcing GetCanonicalSpellIDForFrame down its cooldownInfo fallback --
+    -- see the comment there). An exact-number set misses that drift and the
+    -- claimed buff reappears here as a phantom duplicate of the other bar's
+    -- entry. StoreVariantValue/ResolveVariantValue are the same mechanism
+    -- RebuildSpellRouteMap and ns.GetCDMSpellsForBar already use to answer
+    -- "is this the same buff" everywhere else in this file.
     local diverted = {}
     local divertedCd = {}  -- cooldownID-level diversions (collided-buff slots)
     local p = ECME and ECME.db and ECME.db.profile
@@ -1052,7 +1061,9 @@ function ns.CollectDefaultBuffTrackEntries()
                 if otherBd.barType == "buffs" or otherBd.barType == "custom_buff" then
                     if otherSd and otherSd.assignedSpells then
                         for _, sid in ipairs(otherSd.assignedSpells) do
-                            if type(sid) == "number" and sid > 0 then diverted[sid] = true end
+                            if type(sid) == "number" and sid > 0 then
+                                StoreVariantValue(diverted, sid, true, false)
+                            end
                         end
                     end
                     local otherClaims = otherSd and ns.CollectCdClaimSet(otherSd)
@@ -1061,7 +1072,9 @@ function ns.CollectDefaultBuffTrackEntries()
                     end
                 elseif otherSd and otherSd.hostedBuffSpellIDs then
                     for sid in pairs(otherSd.hostedBuffSpellIDs) do
-                        if type(sid) == "number" and sid > 0 then diverted[sid] = true end
+                        if type(sid) == "number" and sid > 0 then
+                            StoreVariantValue(diverted, sid, true, false)
+                        end
                     end
                 end
             end
@@ -1077,7 +1090,7 @@ function ns.CollectDefaultBuffTrackEntries()
         -- (Diabolist Demonic Art vs Diabolic Ritual). Keying on sid here would
         -- re-merge what EnumerateCDMViewerSpells now keeps separate.
         local key = BuffDisplayStableKey(e.sid, e.cdID)
-        if e.sid and not diverted[e.sid]
+        if e.sid and not ResolveVariantValue(diverted, e.sid)
            and not (e.cdID and divertedCd[e.cdID])
            and key and not seen[key] then
             seen[key] = true


### PR DESCRIPTION
## What does this PR do?

Fixes a buff appearing in **two** Cooldown Manager buff groups at once in the options editor, where it can only be removed from one of them.

Reported symptom: a tracked buff (e.g. Ice Cold) claimed by a custom buff group also shows up in the default buff group's icon strip. Right-clicking the phantom copy offers only "Delete Spell" (which opens Blizzard's CDM, since the default group can't un-track a Blizzard buff), and deleting it there removes the buff from every EUI group rather than the one intended.

### Root cause

`ns.CollectDefaultBuffTrackEntries` builds the default buff group's list from the live BuffIcon viewer pool minus the buffs claimed by other buff-family/hosted bars. That exclusion set was keyed by **exact spellID**, compared against `assignedSpells` as stored at add time.

A viewer slot's enumerated spellID is not guaranteed to equal the stored one. `GetCanonicalSpellIDForFrame` resolves in order `GetSpellID()` -> `GetAuraSpellID()` -> per-cooldownID clean cache -> `cooldownInfo.spellID`/`overrideSpellID`, so a talent-override swap, or a fresh clean cache while the aura is active (forcing the `cooldownInfo` fallback), can yield a different-but-equivalent id. The exact-match exclusion then misses and the claimed buff is re-listed on the default group.

Confirmed on a live Mage: buff viewer slot `161380` reports `GetSpellID() = 44544` while `cooldownInfo.spellID`/`overrideSpellID` both report `112965`. `C_Spell.GetSpellName` resolves both to "Fingers of Frost". The same slot, two different ids, no talent change required.

The runtime router (`RebuildSpellRouteMap` / `ResolveCDIDToBar`) already handles this correctly via variant-family matching, which is why the bars themselves render fine and the defect appears to be options-only.

### Fix

Build the exclusion set with `StoreVariantValue` and test it with `ResolveVariantValue`, the same base/override variant-family matching `RebuildSpellRouteMap` and `ns.GetCDMSpellsForBar` already use elsewhere in this file. The options list now agrees with runtime routing instead of maintaining a second, weaker notion of buff identity.

Not changed (both are working as designed, and were only reachable here because of the phantom listing):

- The default buff group offers "Delete Spell" -> Blizzard CDM rather than a direct remove. Blizzard owns tracked-buff visibility; the default group is a mirror of whatever the viewer pool exposes minus other groups' claims.
- Untracking a buff in Blizzard's CDM removes it from all EUI groups. It destroys the viewer frame every group routes, so there is nothing left to render anywhere.

## How was it tested?

Live retail, Mage.

- Reproduced the double-listing before the fix using the id-split slot above, verified it no longer occurs after.
- Verified ordinary buffs with no id drift still appear in exactly one group (no regression in the normal exclusion path).
- Verified right-click on a claiming group still offers "Remove Spell" and removes from that group only.

Diagnostic used to establish the id split, for anyone reproducing:

```
/run for f in BuffIconCooldownViewer.itemFramePool:EnumerateActive()do local i=f.cooldownInfo print(f.cooldownID,f.GetSpellID and f:GetSpellID(),i and i.spellID,i and i.overrideSpellID)end
```

## Screenshots

N/A -- no visual change. The fix removes an entry that should never have been listed.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; this is a correctness fix to an existing list
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A, no new feature; no new events/hooks/frames
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- cold path (options page enumeration only), no runtime/per-frame impact
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, reads only from our own config tables
- [x] Tested in-game, works on live retail. Not exercised on the 12.1 PTR client; the change is a pure Lua table-lookup swap using helpers already present in this file, with no API surface that differs between clients.

<img width="295" height="222" alt="Shocked Baby GIF" src="https://github.com/user-attachments/assets/24bea5f8-5bbc-488f-93da-ffac0fcbf5b5" />

