### PR TITLE
Fix hero-talent spell icons reverting to their base spell on zone change

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -3306,7 +3306,20 @@ function EAB_VTABLE.ForceButtonRefresh(btn, action)
     if not action then return end
     local icon = btn.icon or btn.Icon
     if icon then
-        icon:SetTexture(GetActionTexture(action))
+        -- Stamp the icon texture-delta memo with what we actually paint.
+        -- ns._cdIconHeal skips its repaint when the memo equals the live
+        -- texture, so the memo is only safe while it matches what is ON the
+        -- icon. This path paints whatever GetActionTexture reports RIGHT NOW,
+        -- and a spell override can resolve late (zone in/out on a hero talent:
+        -- Black Arrow briefly reports as Kill Shot). Painting the base texture
+        -- here while the memo still held the override's left the two
+        -- disagreeing, and the SPELL_UPDATE_ICON heal that follows -- the one
+        -- whose whole job is repainting an override change -- then compared
+        -- equal and skipped, stranding the base icon until something else
+        -- repainted the slot.
+        local tex = GetActionTexture(action)
+        icon:SetTexture(tex)
+        EFD(btn).lastIconTex = tex
         -- The mixin's Update() HIDES the icon region for empty slots and only
         -- re-Shows it in its filled branch. A slot that was empty before this
         -- content change still has a hidden icon region, so painting the new
@@ -4065,11 +4078,17 @@ do
         -- Shared per-button icon heal (texture-delta memo). The texture
         -- fileID is the override's visible fingerprint (never secret, per
         -- the API docs), so only buttons whose texture actually changed pay
-        -- the mixin path. The memo is write-behind everywhere else on
-        -- purpose: paths that paint the icon without stamping it
-        -- (ForceButtonRefresh, the infrequent walk's UpdateAction) always
-        -- paint the CURRENT texture, so a stale memo can only cause one
-        -- redundant repaint here -- never a wrong skip. Used by the full
+        -- the mixin path. INVARIANT: the memo must equal what is ON the icon,
+        -- so every path that paints the ACTION's texture stamps it too
+        -- (ForceButtonRefresh). This was previously write-behind, reasoning
+        -- that unstamped painters "always paint the CURRENT texture, so a
+        -- stale memo can only cause one redundant repaint -- never a wrong
+        -- skip"; that holds only while CURRENT means the texture the memo
+        -- already holds, and an override resolving late (zone in/out on a
+        -- hero talent) breaks it in exactly the direction that does cause a
+        -- wrong skip. The assist painters are the deliberate exception --
+        -- they paint the SUGGESTED spell's texture, not the action's, and
+        -- stamping that would make this heal clobber them. Used by the full
         -- walk below and by the payload-targeted SPELL_UPDATE_ICON fast
         -- path in the dispatcher prologue; ns-hosted (200-local cap).
         ns._cdIconHeal = function(btn)


### PR DESCRIPTION
## What does this PR do?

Fixes hero-talent spell icons reverting to their base spell's icon when you enter or leave an instance.

Reported symptom: on a Dark Ranger, Black Arrow renders as Kill Shot after zoning; same for Rider of the Apocalypse's Death Charge showing as Death's Advance. Pressing the button sometimes repaints it, usually not. Confirmed not to occur on Blizzard's action bars, and the Cooldown Manager is unaffected.

### Root cause

`ns._cdIconHeal` skips its repaint when a per-button texture memo equals the live texture:

```lua
local tex = GetActionTexture(action)
local fd = EFD(btn)
if fd.lastIconTex ~= tex then
    fd.lastIconTex = tex
    ...paint...
end
```

`fd.lastIconTex` was written in exactly one place in the codebase: inside `_cdIconHeal` itself. Every other painter left it alone. The comment documented that as deliberate, reasoning that unstamped painters "always paint the CURRENT texture, so a stale memo can only cause one redundant repaint here -- never a wrong skip".

That reasoning holds only while CURRENT means the texture the memo already holds. A spell override resolves late across a zone change, so `GetActionTexture` briefly reports the BASE spell, and `ForceButtonRefresh` paints it without stamping. The memo and the icon then disagree, in the one direction that does cause a wrong skip:

1. Hero talent live: `_cdIconHeal` stamps the memo with Black Arrow's texture. Icon correct.
2. Zone change, override not yet resolved: `ForceButtonRefresh` paints Kill Shot's texture, memo untouched. Icon and memo now diverge.
3. Override resolves, `SPELL_UPDATE_ICON` fires `_cdIconHeal`, which computes Black Arrow's texture, finds it equal to the stale memo, and skips.

So the event whose entire purpose is repainting an override change is the one the stale memo disables. The icon stays wrong until some other path repaints that slot, which is why pressing the button occasionally cleared it.

This also explains the reporter's other observations: Blizzard's bars have no such memo and simply repaint, the Cooldown Manager is a separate module, and only override spells are affected because an override is the only thing that changes a slot's texture without changing the slot, which is the memo's entire premise.

### Fix

`ForceButtonRefresh` now stamps the memo with the texture it paints, restoring the invariant that the memo matches what is actually on the icon. `GetActionTexture` was already being called there, so it is hoisted into a local rather than called twice: no new API call, and no new handling of the texture value beyond the assignment `_cdIconHeal` already performed.

The two assisted-combat painters are deliberately left unstamped, and the comment now says so. They paint the SUGGESTED spell's texture rather than the action's, so stamping that would make `_cdIconHeal` see a mismatch and repaint with the action texture, clobbering the One Button Assist icon. A blanket "stamp every painter" change would regress OBA.

I also rewrote the `_cdIconHeal` comment, since it asserted the old write-behind reasoning as fact and would invite someone to remove the stamp as redundant.

### One thing left alone, flagging for you

The file contradicts itself on whether the action texture can be secret. The `_cdIconHeal` comment builds the memo on "the texture fileID is ... never secret, per the API docs", while `ForceButtonRefresh` says to gate on `HasAction` and never on "the texture value, which can be secret". Both cannot be right, and the memo's design rests on the first.

This PR does not depend on which is correct and changes nothing about secret handling, deliberately: if that note is there on purpose, it should be your call rather than an assumption from me. If the second comment is the accurate one, the `~=` comparison inside `_cdIconHeal` has a separate issue that predates this bug and is worth a look on its own.

## How was it tested?

Live retail. Reproduced the stale icon across instance enter/leave on an overriding hero-talent spell, applied the branch, and confirmed the icon now stays correct in both directions.

For anyone verifying, this scan reports any button whose painted texture has drifted from what its slot reports (silence means all icons match; run it outside an instance, since the texture can come back secret inside):

```
/run for s=1,180 do local b=_G["EABButton"..s] local i=b and (b.icon or b.Icon) local a=b and b:GetAttribute("action") local y=a and GetActionTexture(a) if i and y and i:GetTexture()~=y then print("MISMATCH",s) end end
```

## Screenshots

N/A, no visual design change. The fix stops an icon from rendering the wrong spell's art.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; correctness fix to an existing paint path
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A, no new feature; no new events, hooks or frames
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- one table field write per `ForceButtonRefresh` call, no new API call (the existing `GetActionTexture` is hoisted to a local), no allocation
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- the buttons are EUI's own `EABButton` frames and the memo lives in EUI's own `ns._eabFD` side table
- [x] Tested in-game, works on live retail. Not exercised on the 12.1 PTR client; the change is a local hoist plus one field assignment on an existing path, with no API surface that differs between clients.
<img width="270" height="174" alt="Scared Baby GIF" src="https://github.com/user-attachments/assets/46303c85-fdc3-4731-9111-8bf4d6dca75e" />

