### PR TITLE
fix(actionbars): let a pickup-modifier click cast on release

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2067,32 +2067,51 @@ local function GetOrCreateButton(slot, parent, info, index, skipProtected)
             end)
         end
         -- When the pickup modifier is held (shift-click to move abilities),
-        -- temporarily disable useOnKeyDown so the action doesn't fire on
-        -- mouse down; the drag then consumes the action instead of a cast.
+        -- clear useOnKeyDown for the duration of that mouse click so the
+        -- action doesn't fire on mouse down: a drag then consumes the action
+        -- instead of casting, and a click without a drag casts on RELEASE.
+        -- This matches Blizzard's default buttons, which force useOnKeyDown
+        -- off for hardware mouse clicks (SecureTemplates.lua) and so act on
+        -- the up edge.
         -- MOUSE-ONLY via IsUnderMouse (rect test): keybinds ALSO arrive as
         -- OnClick (SetOverrideBindingClick dispatch for all bars), and a
-        -- modified KEYBIND press must cast normally. The old wrap flipped
-        -- useOnKeyDown=false for those too -- and the flip STUCK, because a
-        -- wrap's post-body only executes when the pre-body returns a message
-        -- (SecureHandlers.lua) and this pre returned none. Every button
-        -- pressed with the pickup modifier down was left casting on key
-        -- RELEASE until an out-of-combat rebuild rewrote the attribute:
-        -- issue #1165's delayed presses and late GCD swipes that begin mid
-        -- combat and persist for the rest of it. The pre now returns a
-        -- message exactly when it flips, and the post restores right after
-        -- the down-click handler, so nothing can stay flipped across clicks
-        -- -- the up-click of a mouse pickup then simply does not cast
-        -- (useOnKeyDown is back to true, and up-clicks never fire in
-        -- key-down mode), which is the intended pickup behavior.
+        -- modified KEYBIND press must cast on its configured edge.
+        -- The flip must SURVIVE to the up edge. The first version of this
+        -- wrap flipped for keybinds too and never restored, because a wrap's
+        -- post-body only executes when the pre-body returns a message
+        -- (SecureHandlers.lua) and that pre returned none -- issue #1165's
+        -- delayed presses and late GCD swipes. The next version restored
+        -- immediately after the DOWN click's handler, which broke the other
+        -- direction: the down edge was suppressed and the up edge never
+        -- fired (up-clicks are dead in key-down mode), so a shift-click cast
+        -- on neither edge. The pre now returns the message on the UP click,
+        -- so the restore lands after the release has cast.
+        -- The flip is tracked by its own attribute rather than inferred from
+        -- useOnKeyDown, because useOnKeyDown=false is also a legitimate user
+        -- setting (press-and-hold casting, ActionButtonUseKeyDown): the flag
+        -- keeps us from ever forcing those users' attribute back to true.
+        -- If the click ended in a drag, no up-click arrives and the flip is
+        -- left stale; the next down click clears it before the native
+        -- handler runs, so that press still acts on its configured edge.
         if not btn:GetAttribute("eabPickupWrap") and not InCombatLockdown() then
             btn:SetAttribute("eabPickupWrap", true)
             SecureHandlerWrapScript(btn, "OnClick", btn, [[
-                if down and IsModifiedClick("PICKUPACTION") and self:IsUnderMouse()
-                   and self:GetAttribute("useOnKeyDown") ~= false then
-                    self:SetAttribute("useOnKeyDown", false)
+                local flipped = self:GetAttribute("eabPickupFlipped")
+                if down then
+                    if IsModifiedClick("PICKUPACTION") and self:IsUnderMouse() then
+                        if self:GetAttribute("useOnKeyDown") ~= false then
+                            self:SetAttribute("eabPickupFlipped", true)
+                            self:SetAttribute("useOnKeyDown", false)
+                        end
+                    elseif flipped then
+                        self:SetAttribute("eabPickupFlipped", false)
+                        self:SetAttribute("useOnKeyDown", true)
+                    end
+                elseif flipped then
                     return nil, "restore"
                 end
             ]], [[
+                self:SetAttribute("eabPickupFlipped", false)
                 self:SetAttribute("useOnKeyDown", true)
             ]])
         end


### PR DESCRIPTION
## Problem

Since v8.7.5, Shift+Left-Click on an action button did nothing, which broke `[mod:shift]` macro branches. Reported twice against v8.7.7 (mount macros switching on `[nomod]`/`[mod:shift]`). Ctrl and Alt clicks were unaffected because only Shift is the PICKUPACTION modifier.

## Cause

The pickup wrap on each action button flips `useOnKeyDown` off on a modified mouse press, so the press does not cast before a drag can pick the action up. The v8.7.5 stuck-attribute fix (#1165) restored the attribute immediately after the DOWN click's handler. That left a Shift+click casting on **neither** edge: the down edge was suppressed by the flip, and the up edge arrived back in key-down mode, where up-clicks never fire.

## Fix

Match the default UI. Blizzard ignores the down edge of a modified click and casts on the **release** — `ActionBarActionButtonMixin:OnClick` passes `isSecureAction=true`/`isKeyPress=false`, which forces `useOnKeyDown` off for hardware mouse clicks in `SecureActionButton_OnClick`. The wrap now keeps the flip alive through the up edge so the release casts, then restores in the post-body after the up-click handler runs.

- The flip is tracked in its own `eabPickupFlipped` attribute, so a user-set `useOnKeyDown=false` (press-and-hold casting) is never mistaken for our flip and never forced back to true.
- A drag consumes the up edge and leaves the flip stale; the next down click clears it before the native handler runs, so that press still casts on its configured edge. Keybind presses (which arrive as OnClick but fail the `IsUnderMouse` rect test) heal a stale flip the same way.

All logic changes are inside the existing secure snippet bodies; the wrap installation and its out-of-combat guard are unchanged, so there is no new taint surface.

## Testing

Confirmed in-game:
- Shift+click on a `[nomod]X; Y` mount macro summons Y (casts on release, matching the default UI), in and out of combat.
- Plain click, Ctrl+click, Alt+click, and keybinds behave as before.
- Shift+drag still picks the ability up without casting; the next click and keypress on that slot cast normally on the configured edge.