### PR TITLE
Fix: Double nameplates

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -9241,13 +9241,20 @@ CreatePendingWatcher = function(unit, nameplate)
         self:UnregisterAllEvents()
         pendingWatchers[u] = nil
         pendingUnits[u] = nil
+        local currentPlate = C_NamePlate.GetNamePlateForUnit(u)
+        -- Name-only friendly NPCs are suppressed via a nameplate-keyed name
+        -- overlay, not the friendlyPlates[] pool the calls below clean up.
+        -- Tear it down here or the old friendly name text is left rendering
+        -- on top of the new enemy plate/bar.
+        if ns.RemoveFriendlyNPCOverlayForUnit then
+            ns.RemoveFriendlyNPCOverlayForUnit(u, currentPlate)
+        end
         -- Remove friendly plate WITHOUT restoring Blizzard UF (we'll suppress it as enemy)
         if ns.RemoveFriendlyPlateNoRestore then
             ns.RemoveFriendlyPlateNoRestore(u)
         elseif ns.RemoveFriendlyPlate then
             ns.RemoveFriendlyPlate(u)
         end
-        local currentPlate = C_NamePlate.GetNamePlateForUnit(u)
         if currentPlate then
             local plate = frameCache:Acquire()
             if not plate._mixedIn then

--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -815,6 +815,22 @@ local function RestoreNPCNameplate(nameplate, unit)
     end
 end
 
+-- Name-only friendly NPCs never touch friendlyPlates[] -- they're suppressed
+-- purely via SuppressNPCNameplate/npcOverlays, keyed by nameplate rather than
+-- unit. RemoveFriendlyPlate/RemoveFriendlyPlateNoRestore only clean up the
+-- full-plate pool, so when such an NPC is promoted to an enemy plate (e.g.
+-- becomes attackable) the orphaned name overlay is left rendering on top of
+-- the new enemy bar. Called from the friendly->enemy promotion watcher
+-- BEFORE the enemy plate spawns; leaves the Blizzard UF alpha'd/reparented
+-- as-is (mirrors RemoveFriendlyPlateNoRestore) since HideBlizzardFrame takes
+-- over suppression independently in the enemy plate's SetUnit.
+function ns.RemoveFriendlyNPCOverlayForUnit(unit, nameplate)
+    nameplate = nameplate or (unit and C_NamePlate.GetNamePlateForUnit(unit))
+    if not nameplate or not nameOnlyNPCSuppressed[nameplate] then return end
+    nameOnlyNPCSuppressed[nameplate] = nil
+    HideNPCOverlay(nameplate)
+end
+
 -------------------------------------------------------------------------------
 --  NamePlateDriverFrame hooks — suppress Blizzard UFs at the earliest moment
 --  These fire synchronously inside Blizzard's nameplate creation, BEFORE


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1527856782351925338

After NPC transition from Friendly/Neutral -> Enemy both sets of nameplates would be kept.
Now correctly hides original nameplate overlay after transition.