### PR TITLE
CDM: opt-in Fill Up for cooldown-tracking bars

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -5507,7 +5507,21 @@ initFrame:SetScript("OnEvent", function(self)
                   end
                   RefreshTBB()
               end },
-            { type = "label", text = "" });  y = y - h
+            { type = "toggle", text = "Fill Up",
+              tooltip = "Fills the bar as the cooldown recovers instead of draining it as the cooldown runs down.",
+              disabled = function()
+                  local bd = SelectedTBB()
+                  return not bd or bd.trackType ~= "cooldown"
+              end,
+              disabledTooltip = "This option requires a cooldown-tracking bar",
+              getValue = function()
+                  local bd = SelectedTBB(); return bd and bd.fillUp == true
+              end,
+              setValue = function(v)
+                  local bd = SelectedTBB(); if not bd then return end
+                  bd.fillUp = v and true or nil
+                  RefreshTBB()
+              end });  y = y - h
 
         -------------------------------------------------------------------
         --  DISPLAY

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -5288,12 +5288,7 @@ initFrame:SetScript("OnEvent", function(self)
                   EvictTBBTextConflicts(bd, "stacksPosition", v)
                   bd.stacksPosition = v; RefreshTBB(); EllesmereUI:RefreshPage()
               end },
-            { type = "toggle", text = "Reverse Fill",
-              getValue = function() local bd = SelectedTBB(); return bd and bd.reverseFill end,
-              setValue = function(v)
-                  local bd = SelectedTBB(); if not bd then return end
-                  bd.reverseFill = v; RefreshTBB()
-              end }
+            { type = "label", text = "" }
         );  y = y - h
         AddTBBTextSwatch(stacksRow, stacksRow._leftRegion, "stacks")
         do
@@ -5361,6 +5356,37 @@ initFrame:SetScript("OnEvent", function(self)
                 end,
             })
         end
+
+        -- Reverse Fill | Fill Up. Deliberately paired on one row: they are the
+        -- two options a user reaches for when the bar is not moving the way
+        -- they expect, and they do different things. Reverse Fill mirrors the
+        -- geometry, Fill Up flips the direction the value travels. Splitting
+        -- them across the page is what makes people try the wrong one.
+        local fillRow
+        fillRow, h = W:DualRow(parent, y,
+            { type = "toggle", text = "Reverse Fill",
+              tooltip = "Mirrors which end of the bar the fill is anchored to. It does not change the direction the bar travels: use Fill Up for that.",
+              getValue = function() local bd = SelectedTBB(); return bd and bd.reverseFill end,
+              setValue = function(v)
+                  local bd = SelectedTBB(); if not bd then return end
+                  bd.reverseFill = v; RefreshTBB()
+              end },
+            { type = "toggle", text = "Fill Up",
+              tooltip = "Fills the bar as the cooldown recovers instead of draining it as the cooldown runs down.",
+              disabled = function()
+                  local bd = SelectedTBB()
+                  return not bd or bd.trackType ~= "cooldown"
+              end,
+              disabledTooltip = "This option requires a cooldown-tracking bar",
+              getValue = function()
+                  local bd = SelectedTBB(); return bd and bd.fillUp == true
+              end,
+              setValue = function(v)
+                  local bd = SelectedTBB(); if not bd then return end
+                  bd.fillUp = v and true or nil
+                  RefreshTBB()
+              end }
+        );  y = y - h
 
         -- Charge Hash Lines | Smooth Bars. The number and orientation of hash
         -- separators are resolved automatically from the tracked spell's max
@@ -5507,21 +5533,7 @@ initFrame:SetScript("OnEvent", function(self)
                   end
                   RefreshTBB()
               end },
-            { type = "toggle", text = "Fill Up",
-              tooltip = "Fills the bar as the cooldown recovers instead of draining it as the cooldown runs down.",
-              disabled = function()
-                  local bd = SelectedTBB()
-                  return not bd or bd.trackType ~= "cooldown"
-              end,
-              disabledTooltip = "This option requires a cooldown-tracking bar",
-              getValue = function()
-                  local bd = SelectedTBB(); return bd and bd.fillUp == true
-              end,
-              setValue = function(v)
-                  local bd = SelectedTBB(); if not bd then return end
-                  bd.fillUp = v and true or nil
-                  RefreshTBB()
-              end });  y = y - h
+            { type = "label", text = "" });  y = y - h
 
         -------------------------------------------------------------------
         --  DISPLAY

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -5362,8 +5362,10 @@ initFrame:SetScript("OnEvent", function(self)
         -- they expect, and they do different things. Reverse Fill mirrors the
         -- geometry, Fill Up flips the direction the value travels. Splitting
         -- them across the page is what makes people try the wrong one.
-        local fillRow
-        fillRow, h = W:DualRow(parent, y,
+        -- Named distinctly: `fillRow` is already taken further down by the
+        -- Fill Color row, which preview click-nav targets by reference.
+        local fillDirRow
+        fillDirRow, h = W:DualRow(parent, y,
             { type = "toggle", text = "Reverse Fill",
               tooltip = "Mirrors which end of the bar the fill is anchored to. It does not change the direction the bar travels: use Fill Up for that.",
               getValue = function() local bd = SelectedTBB(); return bd and bd.reverseFill end,
@@ -5375,9 +5377,20 @@ initFrame:SetScript("OnEvent", function(self)
               tooltip = "Fills the bar as the cooldown recovers instead of draining it as the cooldown runs down.",
               disabled = function()
                   local bd = SelectedTBB()
+                  -- Charge Hash Lines drives its own recovery bar, which
+                  -- already fills upward, so fillUp cannot do anything there.
+                  -- Leaving the toggle live would promise behaviour it has no
+                  -- way to deliver.
                   return not bd or bd.trackType ~= "cooldown"
+                      or bd.chargeHashLines == true
               end,
-              disabledTooltip = "This option requires a cooldown-tracking bar",
+              disabledTooltip = function()
+                  local bd = SelectedTBB()
+                  if not bd or bd.trackType ~= "cooldown" then
+                      return "This option requires a cooldown-tracking bar"
+                  end
+                  return "Charge Hash Lines already fills as charges recover"
+              end,
               getValue = function()
                   local bd = SelectedTBB(); return bd and bd.fillUp == true
               end,

--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -5380,10 +5380,18 @@ initFrame:SetScript("OnEvent", function(self)
                   -- Charge Hash Lines drives its own recovery bar, which
                   -- already fills upward, so fillUp cannot do anything there.
                   -- Leaving the toggle live would promise behaviour it has no
-                  -- way to deliver.
+                  -- way to deliver. Test the same way the Charge Hash Lines
+                  -- toggle does: the stored flag alone is not enough, because
+                  -- chargeHashLines rides in TBB_STYLE_KEYS and a style copy
+                  -- or preset can set it on a single-charge spell, where the
+                  -- hash fill never actually runs.
                   return not bd or bd.trackType ~= "cooldown"
-                      or bd.chargeHashLines == true
+                      or (bd.chargeHashLines == true
+                          and SelectedTBBSupportsChargeHash())
               end,
+              -- rawTooltip: these are whole sentences. Without it they get
+              -- wrapped into "This option requires <text> to be enabled".
+              rawTooltip = true,
               disabledTooltip = function()
                   local bd = SelectedTBB()
                   if not bd or bd.trackType ~= "cooldown" then

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -239,6 +239,7 @@ local TBB_DEFAULT_BAR = {
     width     = 270,
     verticalOrientation = false,
     reverseFill = false,
+    fillUp = false,          -- cooldown bars only: fill as the cooldown recovers
     chargeHashLines = false,
     chargeHashLineWidth = 2,
     chargeHashLineR = 0, chargeHashLineG = 0,
@@ -1525,7 +1526,7 @@ end
 --  and stackThresholds too: a copied style must not carry threshold numbers.
 -------------------------------------------------------------------------------
 local TBB_STYLE_KEYS = {
-    "height", "width", "verticalOrientation", "reverseFill",
+    "height", "width", "verticalOrientation", "reverseFill", "fillUp",
     "chargeHashLines", "chargeHashLineWidth",
     "chargeHashLineR", "chargeHashLineG", "chargeHashLineB", "chargeHashLineA",
     "texture", "strata",
@@ -4523,11 +4524,19 @@ local function _UpdateCooldownBar(bar, cfg)
             -- the visible clipped texture and spark were updated above.
         elseif durObj and sb.SetTimerDuration and timerDir then
             _restoreTBBNormalFill(bar, cfg)
-            -- Engine-driven drain: the duration handle tracks CDR and
+            -- Engine-driven fill: the duration handle tracks CDR and
             -- resets live, no numbers ever read. The bar timer is re-set
-            -- only when a fresh handle was fetched (event/revalidate) or
-            -- the bar just appeared -- the engine animates in between.
-            if bar._cdNeedSet or not wasShown then
+            -- only when a fresh handle was fetched (event/revalidate), the
+            -- bar just appeared, or the requested direction changed -- the
+            -- engine animates in between. Fill Up asks the engine for
+            -- ElapsedTime instead of RemainingTime, the same constant the
+            -- charge-hash recovery bar uses. The direction term matters
+            -- because toggling the option restyles a LIVE bar in place: with
+            -- only the fetch/show terms the engine would keep animating the
+            -- old direction until the next handle fetch.
+            local wantDir = cfg.fillUp and timerDir.ElapsedTime
+                or timerDir.RemainingTime
+            if bar._cdNeedSet or not wasShown or bar._cdFillDir ~= wantDir then
                 sb:SetMinMaxValues(0, 1)
                 local interpE = Enum.StatusBarInterpolation
                 local interp
@@ -4538,33 +4547,43 @@ local function _UpdateCooldownBar(bar, cfg)
                         interp = interpE.None
                     end
                 end
-                sb:SetTimerDuration(durObj, interp, timerDir.RemainingTime)
+                sb:SetTimerDuration(durObj, interp, wantDir)
                 if not wasShown and sb.SetToTargetValue then
                     -- Snap on first show: avoids the empty-to-full sweep-in.
                     sb:SetToTargetValue()
                 end
                 bar._cdNeedSet = nil
+                bar._cdFillDir = wantDir
             end
             if cfg.showSpark and bar._spark then bar._spark:Show() end
         elseif remaining then
             _restoreTBBNormalFill(bar, cfg)
             sb:SetMinMaxValues(0, duration)
+            -- Both operands are clean numbers on this branch, and a
+            -- non-positive remaining was normalised away above, so Fill Up
+            -- can simply mirror the fraction in Lua.
+            local fillVal = cfg.fillUp and (duration - remaining) or remaining
             -- Smooth fill is baseline (see UpdateLustBar note).
             local smooth = _smoothCooldowns and wasShown and Enum
                 and Enum.StatusBarInterpolation
                 and Enum.StatusBarInterpolation.ExponentialEaseOut
             if smooth then
-                sb:SetValue(remaining, smooth)
+                sb:SetValue(fillVal, smooth)
             else
-                sb:SetValue(remaining)
+                sb:SetValue(fillVal)
             end
+            -- Plain SetValue cancels the running bar timer, so the cached
+            -- engine direction is stale the moment this branch runs.
+            bar._cdFillDir = nil
             if cfg.showSpark and bar._spark then bar._spark:Show() end
         else
             _restoreTBBNormalFill(bar, cfg)
-            -- Ready (kept on screen) or unreadable fail-open: full bar.
-            -- Plain SetValue also cancels any running bar timer.
+            -- Ready (kept on screen) or unreadable fail-open: full bar in
+            -- either direction. Plain SetValue also cancels any running bar
+            -- timer.
             sb:SetMinMaxValues(0, 1)
             sb:SetValue(1)
+            bar._cdFillDir = nil
             if bar._spark then bar._spark:Hide() end
         end
     end

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -4299,13 +4299,18 @@ end
 
 -------------------------------------------------------------------------------
 --  Cooldown-tracking bar (cfg.trackType == "cooldown"): the stock fill drains
---  with the spell's remaining cooldown. Charge Hash Lines instead fill through
---  one section per recovered charge while the timer remains the NEXT charge's
---  remaining cooldown. Stacks text = current charges. Ready (off cooldown /
---  GCD-only / at max charges / spell unknown) counts as INACTIVE for
---  hideWhenInactive; a shown-but-ready bar renders full with no timer.
+--  with the spell's remaining cooldown. cfg.fillUp inverts that, filling as
+--  the cooldown recovers -- it changes only WHICH WAY the value travels, and
+--  every fill source below honours it. Reverse Fill is a different thing
+--  entirely and composes with it: that mirrors the bar's geometry and never
+--  touches the value. Charge Hash Lines instead fill through one section per
+--  recovered charge while the timer remains the NEXT charge's remaining
+--  cooldown, and already fill upward by construction, so fillUp is a no-op
+--  there. Stacks text = current charges. Ready (off cooldown / GCD-only / at
+--  max charges / spell unknown) counts as INACTIVE for hideWhenInactive; a
+--  shown-but-ready bar renders full with no timer, in either direction.
 --
---  FILL SOURCE ORDER:
+--  FILL SOURCE ORDER (each honours cfg.fillUp):
 --  1. Engine duration handle (C_Spell.GetSpellCooldownDuration /
 --     GetSpellChargeDuration + StatusBar:SetTimerDuration): the ENGINE
 --     animates the drain and tracks CDR / resets live, secret-proof by
@@ -4548,8 +4553,16 @@ local function _UpdateCooldownBar(bar, cfg)
                     end
                 end
                 sb:SetTimerDuration(durObj, interp, wantDir)
-                if not wasShown and sb.SetToTargetValue then
-                    -- Snap on first show: avoids the empty-to-full sweep-in.
+                -- Snap whenever the bar was not already animating THIS
+                -- direction. First show is the original case (the
+                -- empty-to-full sweep-in). The direction term adds two more:
+                -- arriving from the ready state, which parks the bar full and
+                -- clears _cdFillDir, and a mid-cooldown toggle. Both leave the
+                -- bar sitting at the opposite end, and with smooth cooldowns
+                -- on, easing from there plays a visible backwards sweep at the
+                -- exact moment the spell was cast.
+                if (not wasShown or bar._cdFillDir ~= wantDir)
+                    and sb.SetToTargetValue then
                     sb:SetToTargetValue()
                 end
                 bar._cdNeedSet = nil


### PR DESCRIPTION
## What

Adds an opt-in **Fill Up** toggle to Tracking Bars. A cooldown-tracking bar normally starts full and drains as the cooldown runs down; with Fill Up it starts empty and fills as the cooldown recovers.

Off by default, so nothing changes for anyone who doesn't switch it on.

## Why

Reported as a bug: enabling Reverse Fill didn't make the bar fill upward. That behaviour is correct. `SetReverseFill` relocates the end the fill texture is anchored to and never touches the value channel, so the bar still drains however it's set. The real gap was that no fill-direction option existed at all.

Reverse Fill also had no tooltip, which is most of why it got mistaken for one. Both options now have tooltips and sit on the same row, since they're the pair people reach for when the bar isn't moving as expected. Having them ~220 lines apart in the options is what made people try the wrong one.

## How

The engine already supports both directions, and the module already used the other one: charge hash lines pass `Enum.StatusBarTimerDirection.ElapsedTime`. Fill Up asks for that same constant instead of `RemainingTime`, so the engine still owns the animation and no cooldown numbers are read in Lua.

Every fill source honours it:

- **Engine duration handle** — `ElapsedTime` instead of `RemainingTime`.
- **Clean API numbers** — mirrors the fraction.
- **Ready / fail-open** — full bar either way, unchanged.

Two details worth calling out for review:

1. The engine re-arm gate gained a direction term (`bar._cdFillDir`). Without it, toggling the option restyles a live bar in place and the engine keeps animating the old direction until the next handle fetch.
2. The bar now snaps rather than eases whenever it wasn't already animating the requested direction. Arriving from the ready state (which parks the bar full) or toggling mid-cooldown otherwise plays a visible backwards sweep at the moment you cast, with smooth cooldowns on.

## Scope

Cooldown-tracking bars only. Greys out for buff bars, and for cooldown bars under Charge Hash Lines, whose recovery bar already fills upward.

Buff-tracking bars are deliberately excluded. That path mirrors Blizzard's bar rather than driving its own timer, and inverting a mirror needs arithmetic on values that are secret in combat. Any fail-open there makes the bar grow in the open world and drain in a fight. Doing it properly means driving buff bars from an aura duration object so the engine can invert them, which is a change to the main buff render path and belongs in its own PR.

## Testing

Verified in game on cooldown bars. Worth using a long cooldown (2 min+): with smooth easing on, a short one looks near-identical in both directions.

- Fill Up off: unchanged, starts full and drains.
- Fill Up on: starts empty, fills as the cooldown recovers.
- Toggled mid-cooldown, both directions: flips in place rather than waiting for the next cast.
- Timer text counts down in both modes.
- Reverse Fill x Fill Up, all four combinations.
- Charge Hash Lines on: Fill Up greys out.

`luac -p` clean on both files.