### PR TITLE
CDM: repaint the Tracking Bars preview on Height, Width, Grow and Spacing

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -4660,6 +4660,8 @@ initFrame:SetScript("OnEvent", function(self)
                   setValue = function(v)
                       ns.TBBSetGroupGrow(gid, v)
                       ns.BuildTrackedBuffBars()
+                      -- Preview popout: RefreshPage() takes the fast path, repaint it here.
+                      RefreshTBBPopout()
                       EllesmereUI:RefreshPage()
                   end },
                 { type = "slider", pixel = true, text = "Bar Spacing", min = -2, max = 20, step = 1,
@@ -4667,6 +4669,8 @@ initFrame:SetScript("OnEvent", function(self)
                   setValue = function(v)
                       ns.TBBSetGroupSpacing(gid, v)
                       ns.BuildTrackedBuffBars()
+                      -- Preview popout: RefreshPage() takes the fast path, repaint it here.
+                      RefreshTBBPopout()
                       EllesmereUI:RefreshPage()
                   end }
             );  y = y - h
@@ -4830,6 +4834,12 @@ initFrame:SetScript("OnEvent", function(self)
                       end
                   end
                   ns.BuildTrackedBuffBars()
+                  -- BuildTrackedBuffBars() only rebuilds the LIVE bar pool; the
+                  -- preview wraps in the popout are separate frames. RefreshPage()
+                  -- takes the fast widget-refresh path here, so the page builder
+                  -- tail that repaints the popout never re-runs. Repaint it
+                  -- directly or the preview keeps the old geometry.
+                  RefreshTBBPopout()
                   EllesmereUI:RefreshPage()
               end },
             { type = "slider", text = "Width",
@@ -4848,6 +4858,8 @@ initFrame:SetScript("OnEvent", function(self)
                       end
                   end
                   ns.BuildTrackedBuffBars()
+                  -- Preview popout: RefreshPage() takes the fast path, repaint it here.
+                  RefreshTBBPopout()
                   EllesmereUI:RefreshPage()
               end }
         );  y = y - h


### PR DESCRIPTION
## What

Changing **Height**, **Width**, **Grow Direction** or **Bar Spacing** on the Tracking Bars page left the preview popout showing its old geometry. The live bars updated; the preview did not.

Reported against 8.7.7.

## Why it happened

Those four setters end in `ns.BuildTrackedBuffBars()` followed by `EllesmereUI:RefreshPage()`, and neither repaints the preview.

`ns.BuildTrackedBuffBars()` only rebuilds the live frame pool. The preview wraps are separate frames held in `_tbbPopoutBars`, so the live rebuild never touches them. Only `RefreshTBBPopout()` re-applies bar settings to those wraps and re-lays out the popout.

`RefreshPage(force)` then takes its fast widget-refresh path whenever `force` is falsy and the widget refresh list is non-empty, which it always is on this page since every generic slider and toggle self-registers a refresher. The fast path re-reads DB values into the existing widgets and returns, so the page builder never re-enters and its tail, which *does* call `RefreshTBBPopout()`, never runs.

## The fix

A direct `RefreshTBBPopout()` in each of the four setters, matching the group-mode builder tail's own idiom.

## Why only four

Every other setter on this page routes through the `RefreshTBB()` helper, whose debounced body already calls `RefreshTBBPopout()`. Vertical Orientation, Bar Texture, Reverse Fill, Smooth Bars, Bar Strata and the text options were never affected. The two group-membership setters call `RefreshPage(true)`, which skips the fast path and forces a full rebuild.

These four were the only ones calling raw `ns.BuildTrackedBuffBars()` and relying on a non-forced `RefreshPage()`.

## Deliberately unchanged

- The existing `BuildTrackedBuffBars()` calls stay: that is what keeps the live bars resizing during a slider drag.
- The `RefreshPage()` calls stay: that is what re-reads the paired slider and the Height/Width sync icon state.
- The debounced `RefreshTBB()` helper is **not** used here. Its 50ms timer would stall the live bars mid-drag and pull a full CDM apply into a per-drag-step path.

Cost when the page is closed is nil: `RefreshTBBPopout()` opens with the `TBBPreviewAllowed()` gate, and these setters can only fire while the page is open.

## Testing

Verified in game. Height, Width, Grow Direction and Bar Spacing all repaint the preview live, including during a continuous drag with no hitch in the live bars. Vertical Orientation, Bar Texture, Reverse Fill and Bar Strata re-checked for regressions.

<img width="245" height="203" alt="Baby Pug GIF" src="https://github.com/user-attachments/assets/8bfd2be6-beb2-4f87-aff8-3c3350c4e5fc" />
