### PR TITLE
Quest Tracker: make the quest item hotkey work

### DIFF
--- a/EllesmereUIQuestTracker/EUI_QuestTracker_Options.lua
+++ b/EllesmereUIQuestTracker/EUI_QuestTracker_Options.lua
@@ -468,19 +468,50 @@ initFrame:SetScript("OnEvent", function(self)
             end)
             kbBtn:SetScript("OnKeyDown", function(self, key)
                 if not listening then self:SetPropagateKeyboardInput(true); return end
-                if key == "LSHIFT" or key == "RSHIFT" or key == "LCTRL" or key == "RCTRL"
-                   or key == "LALT" or key == "RALT" then
+                -- Blizzard's own test, which also covers LMETA/RMETA and
+                -- UNKNOWN. The hardcoded list missed the Windows/Command key,
+                -- so pressing it stored a modifier-only chord (or an empty
+                -- string) and closed the listener as if a key had been chosen.
+                local ignore
+                if IsKeyPressIgnoredForBinding then
+                    ignore = IsKeyPressIgnoredForBinding(key)
+                else
+                    ignore = (key == "LSHIFT" or key == "RSHIFT"
+                        or key == "LCTRL" or key == "RCTRL"
+                        or key == "LALT" or key == "RALT"
+                        or key == "LMETA" or key == "RMETA"
+                        or key == "UNKNOWN")
+                end
+                if ignore then
                     self:SetPropagateKeyboardInput(true); return
                 end
                 self:SetPropagateKeyboardInput(false)
                 if key == "ESCAPE" then
                     listening = false; self:EnableKeyboard(false); RefreshLabel(); return
                 end
-                local mods = ""
-                if IsShiftKeyDown() then mods = mods .. "SHIFT-" end
-                if IsControlKeyDown() then mods = mods .. "CTRL-" end
-                if IsAltKeyDown() then mods = mods .. "ALT-" end
-                local fullKey = mods .. key
+                -- Blizzard's canonical chord order is ALT-CTRL-SHIFT-KEY, and
+                -- CreateKeyChordStringUsingMetaKeyState is what produces it.
+                -- Hand-rolling the modifiers built SHIFT-CTRL-ALT-KEY, a chord
+                -- string the engine never generates, so any bind using more
+                -- than one modifier was stored in a form nothing could match.
+                -- Single-modifier binds happen to agree, which is why this
+                -- survived.
+                local fullKey
+                if CreateKeyChordStringUsingMetaKeyState then
+                    fullKey = CreateKeyChordStringUsingMetaKeyState(key)
+                else
+                    -- Mirror the helper's order exactly, META included.
+                    -- Dropping META would store CMD+F as plain "F" and then
+                    -- priority-override the bare key.
+                    local mods = ""
+                    if IsAltKeyDown() then mods = mods .. "ALT-" end
+                    if IsControlKeyDown() then mods = mods .. "CTRL-" end
+                    if IsShiftKeyDown() then mods = mods .. "SHIFT-" end
+                    if IsMetaKeyDown and IsMetaKeyDown() then
+                        mods = mods .. "META-"
+                    end
+                    fullKey = mods .. key
+                end
                 Set("questItemHotkey", fullKey)
                 if EQT.ApplyQuestItemHotkey then EQT.ApplyQuestItemHotkey() end
                 listening = false

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker.lua
@@ -157,6 +157,11 @@ _G._EQT_RefreshAll = function()
     if EQT.RestyleAll then EQT.RestyleAll() end
     if EQT.ApplyBackground then EQT.ApplyBackground() end
     if EQT.ApplyForceOnScreen then EQT.ApplyForceOnScreen() end
+    -- The hotkey is a per-profile setting backed by an override binding, so a
+    -- profile or spec swap has to re-point it. Without this the outgoing
+    -- profile's key stays overridden -- taken from whatever the player really
+    -- has bound there -- and the incoming profile's key is never laid down.
+    if EQT.ApplyQuestItemHotkey then EQT.ApplyQuestItemHotkey() end
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_QoL.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_QoL.lua
@@ -123,9 +123,21 @@ local function InstallAutoQuests()
 end
 
 -------------------------------------------------------------------------------
--- Quest-item hotkey. SecureActionButton bound to the player's current
--- quest item. Uses SecureHandlerAttributeTemplate so the binding flip is
--- performed entirely in the restricted environment (no taint).
+-- Quest-item hotkey. SecureActionButton (type="item") carrying the player's
+-- current quest item, reached by an OVERRIDE binding on the chosen key.
+--
+-- The button has to stay secure. Using an item is a protected action, and the
+-- dedicated quest API, UseQuestLogSpecialItem, is itself protected, so there
+-- is no insecure route to this: a plain button calling it is simply blocked.
+--
+-- The key used to travel through the GLOBAL binding table instead:
+-- SetBinding(key, "EUI_QUESTITEM") plus SaveBindings, with a restricted
+-- snippet reading GetBindingKey back out to build the click binding.
+-- EUI_QUESTITEM was never declared in a Bindings.xml, so no such binding
+-- command exists for the client to execute, and the round trip also took the
+-- key away from whatever the player had bound there and wrote that to their
+-- saved bindings. Override bindings avoid both: they execute a click on our
+-- button directly, and they never touch anything persistent.
 -------------------------------------------------------------------------------
 local function ScanForQuestItem()
     if not C_QuestLog then return nil end
@@ -151,27 +163,52 @@ local function ScanForQuestItem()
     return fallback
 end
 
+-- One-time repair for profiles that ran the SetBinding version below. That
+-- binding can never do anything, but it was written to the player's SAVED
+-- bindings, so it sits there holding a key hostage until something clears it.
+local _legacyCleared = false
+local function ClearLegacyQuestItemBinding()
+    if _legacyCleared or InCombatLockdown() then return end
+    if not (GetBindingKey and SetBinding) then return end
+    _legacyCleared = true
+    local k1, k2 = GetBindingKey("EUI_QUESTITEM")
+    if not (k1 or k2) then return end
+    if k1 then SetBinding(k1) end
+    if k2 then SetBinding(k2) end
+    local bindingSet = GetCurrentBindingSet and GetCurrentBindingSet()
+    if SaveBindings and bindingSet and bindingSet >= 1 and bindingSet <= 2 then
+        SaveBindings(bindingSet)
+    end
+end
+
 local function InstallQuestItemHotkey()
+    -- The button stays a SecureActionButton with type="item": quest items are
+    -- ordinary bag items as far as using them goes, and the dedicated
+    -- UseQuestLogSpecialItem API is PROTECTED, so a plain button calling it
+    -- would be blocked. What was broken was never the use, it was the key.
     local qItemBtn = CreateFrame("Button", "EUI_QuestItemHotkeyBtn", UIParent,
-        "SecureActionButtonTemplate, SecureHandlerAttributeTemplate")
+        "SecureActionButtonTemplate")
     qItemBtn:SetSize(32, 32)
     qItemBtn:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
     qItemBtn:SetAlpha(0)
     qItemBtn:EnableMouse(false)
-    qItemBtn:RegisterForClicks("LeftButtonUp")
+    -- BOTH phases, and this is load-bearing rather than defensive.
+    -- SecureActionButton_OnClick runs the action only when the click phase
+    -- matches the player's "cast on key down" preference:
+    --     useOnKeyDown = SecureActionButton_ShouldUseOnKeyDown(self)
+    --                    -- attribute, else the ActionButtonUseKeyDown CVar
+    --     clickAction  = (down and useOnKeyDown)
+    --                    or (not down and not useOnKeyDown)
+    -- Registered for up only, OnClick can never fire with down == true, so
+    -- for anyone playing with cast-on-key-down the test is false every time
+    -- and the action is silently discarded. The binding is created, the
+    -- attributes are right, the click is delivered, and nothing happens --
+    -- which is exactly how this presented. Register both and let the secure
+    -- handler pick the phase; it fires the action for precisely one of them.
+    qItemBtn:RegisterForClicks("AnyDown", "AnyUp")
 
     local function InitSecureAttributes()
         qItemBtn:SetAttribute("type", "item")
-        qItemBtn:SetAttribute("_onattributechanged", [[
-            if name == 'item' then
-                self:ClearBindings()
-                if value then
-                    local key1, key2 = GetBindingKey('EUI_QUESTITEM')
-                    if key1 then self:SetBindingClick(false, key1, self, 'LeftButton') end
-                    if key2 then self:SetBindingClick(false, key2, self, 'LeftButton') end
-                end
-            end
-        ]])
     end
     if InCombatLockdown() then
         local initFrame = CreateFrame("Frame")
@@ -180,7 +217,6 @@ local function InstallQuestItemHotkey()
             f:UnregisterAllEvents()
             InitSecureAttributes()
             if EQT.ApplyQuestItemHotkey then EQT.ApplyQuestItemHotkey() end
-            if EQT.UpdateQuestItemAttribute then EQT.UpdateQuestItemAttribute() end
         end)
     else
         InitSecureAttributes()
@@ -188,64 +224,83 @@ local function InstallQuestItemHotkey()
 
     EQT.qItemBtn = qItemBtn
 
-    local _applyingQuestItemHotkey = false
-    local function ApplyQuestItemHotkey()
+    -- The key the override is currently laid down on, or nil for "none".
+    -- _bindingDirty is tracked SEPARATELY and deliberately: nil has to mean
+    -- "bound to nothing", not "state unknown". Folding the two together meant
+    -- that after an external invalidation, losing the quest item compared
+    -- nil == nil, skipped ClearOverrideBindings, and left a priority override
+    -- sitting on a button with no item -- eating the key for good, which is
+    -- the exact failure the want/_boundKey check exists to avoid.
+    local _boundKey = nil
+    local _bindingDirty = true
+    -- Our own binding writes raise UPDATE_BINDINGS. Re-applying from inside
+    -- that event is a self-feeding loop, and a plain "did anything change"
+    -- test cannot break it because the invalidation arrives after the write.
+    -- Ignore the event for a short window after we write instead; a genuine
+    -- external clear inside that window is picked up by the next quest event
+    -- or by PLAYER_REGEN_ENABLED.
+    local _selfWriteUntil = 0
+
+    local function ApplyBinding()
+        -- Binding writes are combat-restricted; PLAYER_REGEN_ENABLED replays.
         if InCombatLockdown() then return end
-        if _applyingQuestItemHotkey then return end
-        _applyingQuestItemHotkey = true
-
-        local ok, err = pcall(function()
-            local key = Cfg("questItemHotkey")
-            local old1, old2 = GetBindingKey("EUI_QUESTITEM")
-            local hasOld = old1 or old2
-            local hasNew = key and key ~= ""
-            if not hasOld and not hasNew then return end
-
-            local changed = false
-            if hasOld then
-                if old1 and old1 ~= key then SetBinding(old1); changed = true end
-                if old2 and old2 ~= key then SetBinding(old2); changed = true end
-            end
-            if hasNew then
-                local alreadyBound = (old1 == key or old2 == key)
-                if not alreadyBound then
-                    SetBinding(key, "EUI_QUESTITEM")
-                    changed = true
-                end
-            end
-            if changed then
-                local bindingSet = GetCurrentBindingSet()
-                if bindingSet and bindingSet >= 1 and bindingSet <= 2 then
-                    SaveBindings(bindingSet)
-                end
-            end
-
-            local cur = qItemBtn:GetAttribute("item")
-            qItemBtn:SetAttribute("item", nil)
-            qItemBtn:SetAttribute("item", cur)
-        end)
-
-        _applyingQuestItemHotkey = false
-        if not ok and err then geterrorhandler()(err) end
+        local key = Cfg("questItemHotkey")
+        if key == "" then key = nil end
+        -- Bind only while a quest item actually exists. An override outranks
+        -- the player's own binding for that key, so holding it while there is
+        -- nothing to use would silently eat the key.
+        local want = (key and qItemBtn:GetAttribute("item")) and key or nil
+        if not _bindingDirty and want == _boundKey then return end
+        _bindingDirty = false
+        _selfWriteUntil = GetTime() + 0.5
+        if ClearOverrideBindings then ClearOverrideBindings(qItemBtn) end
+        if want and SetOverrideBindingClick then
+            SetOverrideBindingClick(qItemBtn, true, want,
+                "EUI_QuestItemHotkeyBtn", "LeftButton")
+        end
+        _boundKey = want
     end
-    EQT.ApplyQuestItemHotkey = ApplyQuestItemHotkey
-
-    _G["BINDING_NAME_EUI_QUESTITEM"] = "Use Quest Item"
 
     local cachedName = nil
     local dirty = true
 
     local function UpdateQuestItemAttribute()
         if InCombatLockdown() then return end
+        -- The gate belongs HERE, on the scan, not only on the quest-event
+        -- branch that used to carry it. PLAYER_REGEN_ENABLED reaches this
+        -- through the force entry point, so with the gate further out every
+        -- combat drop paid a full quest-log walk -- the allocation peak the
+        -- coalescer below exists to avoid -- for players who never set a
+        -- hotkey. ApplyBinding still runs either way, so unbinding still
+        -- clears.
+        if not Cfg("questItemHotkey") then return end
         if not dirty then return end
         dirty = false
         local found = ScanForQuestItem()
         if found ~= cachedName then
             cachedName = found
             qItemBtn:SetAttribute("item", found)
+            -- Gaining or losing the item flips whether the key should be bound
+            -- at all, so the binding has to follow the scan.
+            ApplyBinding()
         end
     end
     EQT.UpdateQuestItemAttribute = UpdateQuestItemAttribute
+
+    -- Options entry point. It must force a rescan, not just re-apply: the
+    -- event-driven scan is skipped entirely while no hotkey is configured, so
+    -- the very first bind would otherwise apply against a stale item.
+    local function ApplyQuestItemHotkey()
+        if InCombatLockdown() then return end
+        dirty = true
+        -- Force the binding too, not just the scan. Without this the entry
+        -- point cannot re-lay an override something else wiped: the state
+        -- would compare equal and take the early-out.
+        _bindingDirty = true
+        UpdateQuestItemAttribute()
+        ApplyBinding()
+    end
+    EQT.ApplyQuestItemHotkey = ApplyQuestItemHotkey
 
     -- Loot-storm coalescer (memory pass 2026-08-03): QUEST_LOG_UPDATE fires
     -- in bursts on loot/objective progress, and each fire paid a full quest
@@ -267,23 +322,40 @@ local function InstallQuestItemHotkey()
     qItemFrame:RegisterEvent("QUEST_TURNED_IN")
     qItemFrame:RegisterEvent("UPDATE_BINDINGS")
     qItemFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
-    if not EQT._eventFrames then EQT._eventFrames = {} end
-    if not EQT._eventRegistrations then EQT._eventRegistrations = {} end
-    local idx = #EQT._eventFrames + 1
-    EQT._eventFrames[idx] = qItemFrame
-    EQT._eventRegistrations[idx] = {"QUEST_LOG_UPDATE", "QUEST_ACCEPTED", "QUEST_REMOVED", "QUEST_TURNED_IN", "UPDATE_BINDINGS", "PLAYER_REGEN_ENABLED"}
+    -- Deliberately NOT enrolled in EQT._eventFrames, so the raid/arena/M+
+    -- suspension leaves it alone. That suspension exists to stop skin and
+    -- layout work while the tracker is hidden; this frame does neither, it
+    -- owns a keybind.
+    --
+    -- Enrolling it was actively harmful. The dominant suspension trigger is
+    -- ENCOUNTER_START, which fires IN COMBAT, and binding writes are
+    -- combat-restricted -- so the override could not be cleared on the way in,
+    -- and unregistering PLAYER_REGEN_ENABLED removed the one event that could
+    -- have cleared it on the way out. The result was a priority override
+    -- parked on the player's key for the whole encounter, pointing at a
+    -- button whose item attribute was frozen where the scan stopped.
+    --
+    -- The scan it drives is already gated on a hotkey being configured and
+    -- coalesced to one pass per burst, so leaving it registered costs nothing
+    -- for anyone who has not set a key.
     qItemFrame:SetScript("OnEvent", function(_, event)
         if InCombatLockdown() then return end
         if event == "PLAYER_REGEN_ENABLED" then
+            -- Also the recovery path for a /reload taken in combat, where the
+            -- init timer bailed before it could run.
+            ClearLegacyQuestItemBinding()
             ApplyQuestItemHotkey()
-            dirty = true
-            UpdateQuestItemAttribute()
             return
         end
         if event == "UPDATE_BINDINGS" then
-            local cur = qItemBtn:GetAttribute("item")
-            qItemBtn:SetAttribute("item", nil)
-            qItemBtn:SetAttribute("item", cur)
+            -- Ours, echoing back: ignore, or we re-enter forever.
+            if GetTime() < _selfWriteUntil then return end
+            -- Someone else rewrote the binding table. LoadBindings, which the
+            -- settings panel runs on cancel and on a binding-set switch,
+            -- clears every override, so waiting for the tracked item to change
+            -- before re-applying could leave the hotkey dead indefinitely.
+            _bindingDirty = true
+            ApplyBinding()
             return
         end
         if not Cfg("questItemHotkey") then return end
@@ -296,8 +368,8 @@ local function InstallQuestItemHotkey()
 
     C_Timer.After(1.5, function()
         if InCombatLockdown() then return end
+        ClearLegacyQuestItemBinding()
         ApplyQuestItemHotkey()
-        UpdateQuestItemAttribute()
     end)
 end
 


### PR DESCRIPTION
## What

Assigning a Quest Item Hotkey did nothing when pressed. Reported against 8.4.5, still present on current.

Three independent bugs, each fatal on its own, which is why fixing any one of them looked like no progress.

## 1. The binding could never execute

The key was routed through the global binding table:

```lua
SetBinding(key, "EUI_QUESTITEM")   -- + SaveBindings
-- ...then a restricted snippet read GetBindingKey('EUI_QUESTITEM') back out
```

**`EUI_QUESTITEM` is declared in no `Bindings.xml` anywhere in the suite.** No such binding command exists for the client to run, so the key press had nothing to execute.

The round trip also permanently took the key away from whatever the player had bound to it, and wrote that to their **saved** bindings.

Now an override binding on the chosen key, pointing at a click on our button. Overrides execute the click directly and never touch saved bindings.

## 2. Multi-modifier binds were stored in an unmatchable form

The capture hand-rolled `SHIFT-CTRL-ALT-KEY`. The client's canonical order is `ALT-CTRL-SHIFT-KEY`, so any bind with more than one modifier was stored as a chord the engine never produces. Single-modifier binds agree either way, which is how it survived.

Now uses `CreateKeyChordStringUsingMetaKeyState`, the same helper Blizzard's capture uses, plus `IsKeyPressIgnoredForBinding` to filter meta keys. The hardcoded filter missed `LMETA`/`RMETA`, so pressing the Windows key stored a modifier-only chord and closed the listener as though a key had been chosen.

## 3. The click was delivered, then discarded

`SecureActionButton_OnClick` runs the action only when the click phase matches the player's cast-on-key-down preference:

```lua
useOnKeyDown = SecureActionButton_ShouldUseOnKeyDown(self)  -- attribute, else ActionButtonUseKeyDown
clickAction  = (down and useOnKeyDown) or (not down and not useOnKeyDown)
```

The button registered for up clicks only, so `OnClick` could never fire with `down == true`. For anyone playing with cast-on-key-down that test is false on every press and the action is skipped silently. Registering both phases lets the secure handler pick; exactly one satisfies the test, so the item is used once per press.

This is why the symptom was so opaque: the configured key, the attributes and the override binding all read correct, and `/use <item>` worked by hand.

## Not changed

The button stays a `SecureActionButton` with `type="item"`. Using an item is protected, and the dedicated `UseQuestLogSpecialItem` API is protected too, so there is no insecure route to this action.

## Notes for review

- The binding is laid down only while a quest item exists. An override outranks the player's own binding for that key, so holding it with nothing to use would silently eat the key.
- "Bound to nothing" and "state unknown" are tracked separately. Folding them together meant that after an external invalidation, losing the quest item compared `nil == nil`, skipped the clear, and stranded the override.
- Binding writes raise `UPDATE_BINDINGS`, so ours are ignored for a short window afterwards. Re-applying from that event without the window never terminates. The event is still handled, because `LoadBindings` (settings cancel, binding-set switch) clears every override.
- The event frame is deliberately **not** enrolled in the tracker's raid/arena/M+ event suspension. That suspension is for skin and layout work; this frame owns a keybind. Enrolling it was harmful: `ENCOUNTER_START` fires in combat where binding writes are illegal, so the override could not be cleared going in, and unregistering the frame removed the `PLAYER_REGEN_ENABLED` that would have cleared it coming out.
- Profiles that ran the old version get a one-time cleanup of the dead `EUI_QUESTITEM` binding, on login and again after combat so a `/reload` taken in combat still recovers it.

## Testing

Verified in game by a tester who originally reported it not working, including with cast-on-key-down enabled, on numpad and letter keys, and with multi-modifier chords.

<img width="225" height="325" alt="Animation Wow GIF by ethan clarke" src="https://github.com/user-attachments/assets/79549d89-7b6c-4698-a159-a2bf68ce1a0c" />
