### PR TITLE
CDM: keep the recharge visible when a GCD takes over its tail

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2676,6 +2676,14 @@ local function DecorateFrame(frame, barData)
                         end
                     end
                 end
+                -- Publish the tail decision for ReArmChargeRecharge. That runs from
+                -- the SetCooldown hooks, which fire for EVERY icon on every push,
+                -- so it must decide whether it cares without paying for a spell
+                -- lookup. This flag is exactly the state it needs -- a charge
+                -- recharge running underneath a GCD -- and it is already computed
+                -- here from clean bools. Blizzard's refresh calls SetSwipeColor
+                -- before CooldownFrame_Set, so it is fresh when the re-arm reads it.
+                fd._gcdChargeTailArmed = _gcdChargeTail ~= nil
                 -- Check per-spell settings
                 local ss2
                 if sid2 and bk2 then
@@ -3078,25 +3086,82 @@ local function DecorateFrame(frame, barData)
             -- SetUseAuraDisplayTime / SetCooldownFromDurationObject writes below.
             local function ReArmChargeRecharge()
                 if fd._isProcessingOverride then return end
-                if not fd._hideActiveOverriding then return end
-                local hasCharges = type(frame.HasVisualDataSource_Charges) == "function"
-                    and frame:HasVisualDataSource_Charges()
-                if not hasCharges then return end
+                -- Two field reads and nothing else. This runs from the SetCooldown
+                -- / SetCooldownFromDurationObject / SetUseAuraDisplayTime hooks, so
+                -- it fires for EVERY icon on EVERY cooldown push -- every GCD the
+                -- player triggers. Neither entry can be live without one of these
+                -- set, so bail before touching the frame or any API.
+                if not (fd._hideActiveOverriding or fd._gcdChargeTailArmed) then
+                    return
+                end
                 local fc2 = _ecmeFC[frame]
                 local sid2 = fc2 and fc2.spellID
                 if not sid2 or not C_Spell or not C_Spell.GetSpellCharges
                     or not C_Spell.GetSpellChargeDuration then
                     return
                 end
+                -- Hosted buff / custom buff frames are excluded here for the same
+                -- reason the SetSwipeColor and Clear hooks exclude them: their
+                -- cooldown widget is showing an AURA, and arming a spell recharge
+                -- over it would overwrite the duration they exist to display.
+                if fd._isBuffViewerFrame or frame._isCustomBuffFrame then return end
+                -- Split from the value: "false" and "the frame has no such method"
+                -- are different states, and entry B needs the first. Preset, racial,
+                -- custom-spell and trinket frames are ours rather than CooldownViewer
+                -- items and have no data source at all, which the sibling Clear hook
+                -- relies on as an exclusion -- treating that as "at zero charges"
+                -- would let them into a branch written for viewer items.
+                local isViewerItem = type(frame.HasVisualDataSource_Charges) == "function"
+                local hasCharges = isViewerItem and frame:HasVisualDataSource_Charges()
+                -- ENTRY A (original): the Hide-Active override window, where
+                -- Blizzard's aura pushes wipe the recharge we armed.
+                local entryA = (fd._hideActiveOverriding and hasCharges) or false
+                -- ENTRY B: the GCD has taken the icon over at the TAIL of a
+                -- recharge. Measured in game: once the remaining recharge falls
+                -- below one GCD length, Blizzard re-points the widget at the GCD
+                -- (SetCooldown fires, GetSpellCooldown().isOnGCD flips true), and
+                -- HasVisualDataSource_Charges is false throughout because the
+                -- player is at ZERO charges -- so entry A cannot fire. Suppress
+                -- GCD then does its job and alpha-0s that swipe, and the last
+                -- second of the recharge goes blank, snapping back only when the
+                -- charge lands. That is the reported "0 -> 1 breaks the cooldown
+                -- swipe", and hiding was never the right answer: the recharge is
+                -- still running and is what the player is watching. Re-arm the
+                -- real recharge so the swipe keeps showing the truth.
+                --
+                -- fd._gcdChargeTailArmed is the SetSwipeColor hook's own verdict on
+                -- that state, published one call earlier in the same refresh, so
+                -- this path re-derives nothing.
+                --
+                -- Suppress GCD is re-checked here rather than trusted from the
+                -- latch. Blizzard's expired branch skips SetSwipeColor entirely and
+                -- frames are pooled, so the latch can survive into a frame or a bar
+                -- it was not set for; requiring the setting again bounds a stale
+                -- latch to "re-arm a charge spell that is genuinely recharging",
+                -- which is the intended action anyway.
+                local entryB = false
+                if not entryA and isViewerItem and not hasCharges
+                   and fd._gcdChargeTailArmed == true then
+                    local bkB = fc2.barKey
+                    local bdB = bkB and barDataByKey and barDataByKey[bkB]
+                    entryB = (bdB and bdB.suppressGCD and true) or false
+                end
+                if not (entryA or entryB) then return end
                 local effID = sid2
                 if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
                     local ovr = C_SpellBook.FindSpellOverrideByID(sid2)
                     if ovr and ovr > 0 and ovr ~= sid2 then effID = ovr end
                 end
-                -- Only while a recharge is genuinely running. isActive is a clean
-                -- bool; currentCharges (secret) is never read.
+                -- Charge spell with a recharge genuinely running. maxCharges > 1 is
+                -- the charge-spell test every other carve-out in this file uses --
+                -- a 1-charge spell reports charge data too, and re-arming one that
+                -- Suppress GCD had just alpha-0'd would repaint it at full alpha in
+                -- the same refresh. Both fields are clean; the secret
+                -- currentCharges is never read.
                 local ci = C_Spell.GetSpellCharges(effID) or C_Spell.GetSpellCharges(sid2)
-                if not (ci and ci.isActive == true) then return end
+                if not (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true) then
+                    return
+                end
                 local durObj = C_Spell.GetSpellChargeDuration(effID)
                 if not durObj and effID ~= sid2 then
                     durObj = C_Spell.GetSpellChargeDuration(sid2)
@@ -3107,17 +3172,31 @@ local function DecorateFrame(frame, barData)
                     cd:SetUseAuraDisplayTime(false)
                 end
                 cd:SetCooldownFromDurationObject(durObj)
+                -- No-op on the entry-B path by construction: ApplyCdmChargeStyle
+                -- bails unless HasVisualDataSource_Charges is true, and entry B
+                -- requires it false. That is correct rather than an oversight --
+                -- Hide Swipe (Charges) and Hide Recharge Edge already do not apply
+                -- while the widget is off the charge source, so the tail now
+                -- matches the rest of the zero-charge window instead of differing
+                -- from it. Entry A still needs the call.
                 ApplyCdmChargeStyle(frame, cd)
                 -- We have just re-armed the REAL recharge, so whatever is now
                 -- displayed is the recharge -- never a GCD. Suppress-GCD's alpha-0
                 -- swipe (set while isOnGCD, e.g. right after pressing ANOTHER
-                -- ability) must not stick here or the recharge stays invisible
-                -- until the active state ends. Restore the normal black
-                -- hide-active swipe unconditionally; black where black is already
-                -- correct is a no-op for the Suppress-GCD-off case.
-                local bkSw = fc2 and fc2.barKey
-                local bdSw = bkSw and barDataByKey and barDataByKey[bkSw]
-                cd:SetSwipeColor(0, 0, 0, (bdSw and bdSw.swipeAlpha) or 0.7)
+                -- ability) must not stick here or the recharge stays invisible.
+                --
+                -- Black is only unconditionally right on the entry-A path, which by
+                -- definition runs inside the Hide-Active window. Entry B can reach
+                -- an icon whose active state paints a COLOURED swipe, and this write
+                -- sits under _isProcessingOverride so the SetSwipeColor hook cannot
+                -- put that colour back -- hence the active check. When the icon is
+                -- active, leaving the colour alone is correct: the next refresh
+                -- repaints it, and the geometry we just armed is what mattered.
+                local bkA = fc2.barKey
+                local bdA = bkA and barDataByKey and barDataByKey[bkA]
+                if entryA or not CdmFrameIsActive(frame) then
+                    cd:SetSwipeColor(0, 0, 0, (bdA and bdA.swipeAlpha) or 0.7)
+                end
                 fd._isProcessingOverride = false
             end
             if cd.SetCooldownFromDurationObject then

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -1430,6 +1430,30 @@ function ns.RescanChargeCdTextFlag()
     end)
 end
 
+-- Charge style gate: set ns._cdmAnyChargeStyle once if any saved spell (any spec)
+-- has Hide Swipe (Charges) or Hide Recharge Edge enabled. Same monotonic,
+-- scanned-once contract as RescanChargeCdTextFlag.
+--
+-- This flag is the one charge gate that had no priming pass: it was set only from
+-- inside the SetSwipeColor hook, i.e. not until the first cooldown re-push after
+-- login, which is already after the rebuild has run RefreshCDMIconAppearance. So
+-- the rebuild's ReapplyChargeStyle was skipped, and ApplyCdmChargeStyle itself
+-- gates its whole Hide Swipe / Hide Recharge Edge block on the flag -- meaning a
+-- charge spell already recharging at login kept its swipe until something pushed
+-- its cooldown again. Priming here closes that window; the reactive hooks then
+-- carry it as before.
+function ns.RescanChargeStyleFlag()
+    if ns._cdmAnyChargeStyle or ns._chargeStyleFlagScanned then return end
+    if not EllesmereUIDB then return end
+    ns._chargeStyleFlagScanned = true
+    ns.ForEachSavedSettingsBlock(function(ss)
+        if ss.chargeHideSwipe or ss.hideRechargeEdge then
+            ns._cdmAnyChargeStyle = true
+            return true
+        end
+    end)
+end
+
 -- Custom Item gate: set ns._cdmAnyCustomItem once if any saved bar (any spec)
 -- tracks a custom item (an assignedSpells entry <= -100). The buff-bar injection
 -- pass is then skipped entirely for anyone who never adds one -- 0 cost when off.
@@ -7784,6 +7808,7 @@ BuildAllCDMBars = function()
     EnsureFocusKickBar()
     ns.RescanMaxStacksGlowFlag()  -- set the Max Stacks Glow gate (once) before refresh
     ns.RescanChargeCdTextFlag()   -- set the Hide CD Text (Charges) gate (once) before refresh
+    ns.RescanChargeStyleFlag()    -- set the Hide Swipe (Charges) gate (once) before refresh
     ns.RescanBuffSoundFlag()      -- set the Audio on Buff Gain/Loss gate (once) before refresh
     ns.RescanCdReadySoundFlag()   -- set the Audio Effect on CD Ready gate (once) before refresh
     ns.RescanCustomItemFlag()     -- set the custom-item buff-injection gate (once)


### PR DESCRIPTION
## Cooldown Manager: charge spell 0 -> 1 breaks the cooldown swipe

Reported by @Jesir (8.7.7, Ret Paladin / Judgment): with Suppress GCD and Hide
Active State on, a charge spell going 0 -> 1 often breaks the cooldown swipe.
Repro: press something in the second before the recharge completes.

### Cause

Once the remaining recharge falls below one GCD length, Blizzard re-points the
cooldown widget at the GCD -- `SetCooldown` fires and `GetSpellCooldown().isOnGCD`
flips true, because the GCD now outlasts the recharge. Suppress GCD then does
exactly what it is meant to and alpha-0s that swipe. The last second of the
recharge goes blank, and the swipe snaps back only when the charge lands.

Hiding was never right here: the recharge is still running and is what the player
is watching. It is only invisible because the widget was pointed elsewhere.

`ReArmChargeRecharge` already exists to restore a wiped recharge, but both its
gates are false in this window -- `fd._hideActiveOverriding` is only set during
the Hide-Active override, and `HasVisualDataSource_Charges` is false for the whole
zero-charge stretch (Blizzard sets it only when `cooldownStartTime > 0` AND
`currentCharges > 0`, so it is false at zero charges and at max). The repair path
could never fire.

### Fix

Entry condition B re-arms the real recharge for exactly that case: a charge spell
with a recharge running, the swipe hook having just identified a GCD over that
recharge, and the charge data source off. Ordering works in our favour --
Blizzard's refresh calls `SetSwipeColor` before `CooldownFrame_Set`, so the
`SetCooldown` hook lands last and the re-armed recharge wins over the alpha-0 the
swipe hook just wrote.

Gated on the bar's own Suppress GCD. With it off the GCD sweep is something the
user has chosen to see; with it on, showing the real recharge is strictly closer
to what the setting promises.

Second commit is independent: `ns._cdmAnyChargeStyle` was the one charge gate with
no `Rescan*Flag` priming pass, so a charge spell already recharging at login kept
the swipe the user had asked to hide until its next cooldown push.

### Evidence

Measured in game out of combat, so every value is plain (Arcane Orb, 2 charges,
`gcd=1.18`):

```
rem=1.18  onGCD=false            curve threshold crossed
rem=0.97  onGCD=true   outA=0.00 GCD takes over, swipe blanked
rem=0.93..0.03          outA=0.00 stays blank for the rest of the recharge
rem=20.00 chgSrc=true  outA=0.70 charge lands, swipe returns
```

Control: the same recharge with nothing pressed keeps `onGCD=false` to zero and
the swipe stays visible -- which is why the report says "often". `GCDTailAlpha`
itself is correct and untouched; probing the curve every sample showed it
returning 0 exactly at its own threshold.

### Testing

- Verified in game: the re-arm fires on the takeover and the swipe now counts
  down through the final second instead of blanking.
- Priming fix verified by instrumenting the flag on both sides of the new call at
  the login rebuild: `before=nil after=true`.
- Zero cost when unused: the re-arm bails on field reads before any API call, and
  the priming scan is monotonic and runs once.
- No new strings, no saved-variable changes, no secure/protected calls. The secret
  `currentCharges` is never read; only `maxCharges` / `isActive` / `isOnGCD`,
  which are NeverSecret or clean bools.
- Hosted buff / custom buff frames are excluded, matching the sibling hooks, so a
  spell recharge is never armed over an aura duration.

### Not addressed

- The same report's "hides the stack count temporarily" -- that is the separate
  Hide Text at 0 Stacks path and wants its own look.
- A separate mismatch found while instrumenting: for override spells the charge
  read resolves to the override (Shimmer) while Blizzard's item tracks the base
  (Blink), so `chargeRecharging` can read false while Blizzard reports a charge
  recharge. Noted, not touched here.
