### PR TITLE
CDM/AB: charge count hides itself when a charge lands

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -86,23 +86,26 @@ ns._EABZeroCountAlpha = function(fd, fs, v, action)
         local mc = ci and ci.maxCharges
         if mc ~= nil and not (issecretvalue and issecretvalue(mc)) and mc > 1 then
             local cc = ci.currentCharges
-            if cc == nil then
-                -- Struct field is non-nilable by contract; belt anyway so a
-                -- missing read can never strand a hidden count.
+            -- issecretvalue FIRST, and type() rather than == nil for the missing
+            -- case. The count is secret whenever cooldowns are restricted, and
+            -- comparing a secret to nil is the operation our own secret rules
+            -- forbid -- so ordering the nil "belt" ahead of the guard made the
+            -- belt the hazard, and a throw strands the count HIDDEN rather than
+            -- protecting it. Same defect and same fix as the CDM counterpart in
+            -- EllesmereUICdmHooks (EvalZeroChargeTextFrame).
+            if issecretvalue and issecretvalue(cc) then
+                fd._zeroCountAlpha = nil
+                fs:SetAlpha(cc)
+            elseif type(cc) ~= "number" then
                 if fd._zeroCountAlpha ~= 1 then
                     fd._zeroCountAlpha = 1
                     fs:SetAlpha(1)
                 end
             else
-                if issecretvalue and issecretvalue(cc) then
-                    fd._zeroCountAlpha = nil
-                    fs:SetAlpha(cc)
-                else
-                    a = cc > 1 and 1 or cc
-                    if fd._zeroCountAlpha ~= a then
-                        fd._zeroCountAlpha = a
-                        fs:SetAlpha(a)
-                    end
+                a = cc > 1 and 1 or cc
+                if fd._zeroCountAlpha ~= a then
+                    fd._zeroCountAlpha = a
+                    fs:SetAlpha(a)
                 end
             end
             return

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -1880,11 +1880,21 @@ local function EvalZeroChargeTextFrame(frame, fd)
     -- write, no comparison, correct for every charge wiring (see the block
     -- header). Secret count (instanced combat): same write, memo dirtied.
     local cc = ci.currentCharges
-    if cc == nil then
-        ZctSetAlpha(fd, fs, 1)
-    elseif issecretvalue and issecretvalue(cc) then
+    -- issecretvalue FIRST, and type() rather than == nil for the missing case.
+    -- currentCharges is secret whenever cooldowns are restricted (combat,
+    -- encounter, challenge mode, PvP match), and comparing a secret to nil is
+    -- the exact operation this addon's own secret rules forbid. Ordering the
+    -- nil "belt" ahead of the guard made the belt the hazard: a throw here
+    -- aborts the eval with the alpha still 0, so the counter stays HIDDEN until
+    -- the next SPELL_UPDATE_CHARGES -- which for a charge spell that just
+    -- refilled is a whole recharge away. That is the reported "0 -> 1 hides the
+    -- stack count temporarily". The throw also kills the pairs() loop in the
+    -- event handler, so every other watched icon stops updating with it.
+    if issecretvalue and issecretvalue(cc) then
         fd._zctAlpha = nil
         fs:SetAlpha(cc)
+    elseif type(cc) ~= "number" then
+        ZctSetAlpha(fd, fs, 1)
     else
         ZctSetAlpha(fd, fs, cc > 1 and 1 or cc)
     end


### PR DESCRIPTION
## Charge count hides itself when a charge lands

Reported by @Jesir as the second half of the 0 -> 1 charge report (the first half
is #1275): the stack count hides temporarily when a charge comes back.

### Cause

"Hide Text at 0 Stacks" sets the counter's alpha to `currentCharges` and lets the
engine clamp it, so the count renders itself with no comparison at all. But the
missing-value belt was ordered ahead of the secret guard:

```lua
local cc = ci.currentCharges
if cc == nil then                                 -- compares a SECRET
elseif issecretvalue and issecretvalue(cc) then   -- guard runs too late
```

`currentCharges` is secret whenever cooldowns are restricted -- combat, encounter,
challenge mode or PvP match -- and comparing a secret to nil is exactly the
operation our own secret rules forbid.

So the belt written to stop a missing read stranding a hidden count is itself what
strands it. The eval throws with the alpha still 0, the counter stays HIDDEN, and
nothing rewrites it until the next `SPELL_UPDATE_CHARGES` -- which, for a spell
that has just refilled a charge, is a whole recharge away. That is the
"temporarily" in the report.

The throw also aborts the `pairs()` loop in the shared event handler, so every
other watched icon stops updating for that event too.

### Fix

`issecretvalue` first, then `type()` for the missing case, never `==`.

Both copies are fixed, because the defect is duplicated:

- `EvalZeroChargeTextFrame` in `EllesmereUICdmHooks.lua` (Cooldown Manager)
- the identical alpha trick on action charge counts in `EllesmereUIActionBars.lua`

`EllesmereUICdmBuffBars` already gets this right -- `_tbbCleanNum` checks
`issecretvalue` before `type` -- which is what makes these two the outliers rather
than the convention.

### Testing

- Verified in game: charge spell with Hide Text at 0 Stacks enabled, spent to zero
  in combat; the counter now reappears the moment the charge lands instead of
  staying hidden until the following recharge.
- No behaviour change for a plain (non-secret) count: same alpha, same memo, same
  writes, same early-outs.
- No new strings, no saved-variable changes, no API surface change.

<img width="480" height="480" alt="Lisa Smash GIF" src="https://github.com/user-attachments/assets/2f148ef6-d362-47f5-8e76-3215a22d3f42" />
