### PR TITLE
CDM: resolve charge info the way Blizzard resolves it

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2676,6 +2676,14 @@ local function DecorateFrame(frame, barData)
                         end
                     end
                 end
+                -- Publish the tail decision for ReArmChargeRecharge. That runs from
+                -- the SetCooldown hooks, which fire for EVERY icon on every push,
+                -- so it must decide whether it cares without paying for a spell
+                -- lookup. This flag is exactly the state it needs -- a charge
+                -- recharge running underneath a GCD -- and it is already computed
+                -- here from clean bools. Blizzard's refresh calls SetSwipeColor
+                -- before CooldownFrame_Set, so it is fresh when the re-arm reads it.
+                fd._gcdChargeTailArmed = _gcdChargeTail ~= nil
                 -- Check per-spell settings
                 local ss2
                 if sid2 and bk2 then
@@ -3078,25 +3086,82 @@ local function DecorateFrame(frame, barData)
             -- SetUseAuraDisplayTime / SetCooldownFromDurationObject writes below.
             local function ReArmChargeRecharge()
                 if fd._isProcessingOverride then return end
-                if not fd._hideActiveOverriding then return end
-                local hasCharges = type(frame.HasVisualDataSource_Charges) == "function"
-                    and frame:HasVisualDataSource_Charges()
-                if not hasCharges then return end
+                -- Two field reads and nothing else. This runs from the SetCooldown
+                -- / SetCooldownFromDurationObject / SetUseAuraDisplayTime hooks, so
+                -- it fires for EVERY icon on EVERY cooldown push -- every GCD the
+                -- player triggers. Neither entry can be live without one of these
+                -- set, so bail before touching the frame or any API.
+                if not (fd._hideActiveOverriding or fd._gcdChargeTailArmed) then
+                    return
+                end
                 local fc2 = _ecmeFC[frame]
                 local sid2 = fc2 and fc2.spellID
                 if not sid2 or not C_Spell or not C_Spell.GetSpellCharges
                     or not C_Spell.GetSpellChargeDuration then
                     return
                 end
+                -- Hosted buff / custom buff frames are excluded here for the same
+                -- reason the SetSwipeColor and Clear hooks exclude them: their
+                -- cooldown widget is showing an AURA, and arming a spell recharge
+                -- over it would overwrite the duration they exist to display.
+                if fd._isBuffViewerFrame or frame._isCustomBuffFrame then return end
+                -- Split from the value: "false" and "the frame has no such method"
+                -- are different states, and entry B needs the first. Preset, racial,
+                -- custom-spell and trinket frames are ours rather than CooldownViewer
+                -- items and have no data source at all, which the sibling Clear hook
+                -- relies on as an exclusion -- treating that as "at zero charges"
+                -- would let them into a branch written for viewer items.
+                local isViewerItem = type(frame.HasVisualDataSource_Charges) == "function"
+                local hasCharges = isViewerItem and frame:HasVisualDataSource_Charges()
+                -- ENTRY A (original): the Hide-Active override window, where
+                -- Blizzard's aura pushes wipe the recharge we armed.
+                local entryA = (fd._hideActiveOverriding and hasCharges) or false
+                -- ENTRY B: the GCD has taken the icon over at the TAIL of a
+                -- recharge. Measured in game: once the remaining recharge falls
+                -- below one GCD length, Blizzard re-points the widget at the GCD
+                -- (SetCooldown fires, GetSpellCooldown().isOnGCD flips true), and
+                -- HasVisualDataSource_Charges is false throughout because the
+                -- player is at ZERO charges -- so entry A cannot fire. Suppress
+                -- GCD then does its job and alpha-0s that swipe, and the last
+                -- second of the recharge goes blank, snapping back only when the
+                -- charge lands. That is the reported "0 -> 1 breaks the cooldown
+                -- swipe", and hiding was never the right answer: the recharge is
+                -- still running and is what the player is watching. Re-arm the
+                -- real recharge so the swipe keeps showing the truth.
+                --
+                -- fd._gcdChargeTailArmed is the SetSwipeColor hook's own verdict on
+                -- that state, published one call earlier in the same refresh, so
+                -- this path re-derives nothing.
+                --
+                -- Suppress GCD is re-checked here rather than trusted from the
+                -- latch. Blizzard's expired branch skips SetSwipeColor entirely and
+                -- frames are pooled, so the latch can survive into a frame or a bar
+                -- it was not set for; requiring the setting again bounds a stale
+                -- latch to "re-arm a charge spell that is genuinely recharging",
+                -- which is the intended action anyway.
+                local entryB = false
+                if not entryA and isViewerItem and not hasCharges
+                   and fd._gcdChargeTailArmed == true then
+                    local bkB = fc2.barKey
+                    local bdB = bkB and barDataByKey and barDataByKey[bkB]
+                    entryB = (bdB and bdB.suppressGCD and true) or false
+                end
+                if not (entryA or entryB) then return end
                 local effID = sid2
                 if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
                     local ovr = C_SpellBook.FindSpellOverrideByID(sid2)
                     if ovr and ovr > 0 and ovr ~= sid2 then effID = ovr end
                 end
-                -- Only while a recharge is genuinely running. isActive is a clean
-                -- bool; currentCharges (secret) is never read.
+                -- Charge spell with a recharge genuinely running. maxCharges > 1 is
+                -- the charge-spell test every other carve-out in this file uses --
+                -- a 1-charge spell reports charge data too, and re-arming one that
+                -- Suppress GCD had just alpha-0'd would repaint it at full alpha in
+                -- the same refresh. Both fields are clean; the secret
+                -- currentCharges is never read.
                 local ci = C_Spell.GetSpellCharges(effID) or C_Spell.GetSpellCharges(sid2)
-                if not (ci and ci.isActive == true) then return end
+                if not (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true) then
+                    return
+                end
                 local durObj = C_Spell.GetSpellChargeDuration(effID)
                 if not durObj and effID ~= sid2 then
                     durObj = C_Spell.GetSpellChargeDuration(sid2)
@@ -3107,17 +3172,31 @@ local function DecorateFrame(frame, barData)
                     cd:SetUseAuraDisplayTime(false)
                 end
                 cd:SetCooldownFromDurationObject(durObj)
+                -- No-op on the entry-B path by construction: ApplyCdmChargeStyle
+                -- bails unless HasVisualDataSource_Charges is true, and entry B
+                -- requires it false. That is correct rather than an oversight --
+                -- Hide Swipe (Charges) and Hide Recharge Edge already do not apply
+                -- while the widget is off the charge source, so the tail now
+                -- matches the rest of the zero-charge window instead of differing
+                -- from it. Entry A still needs the call.
                 ApplyCdmChargeStyle(frame, cd)
                 -- We have just re-armed the REAL recharge, so whatever is now
                 -- displayed is the recharge -- never a GCD. Suppress-GCD's alpha-0
                 -- swipe (set while isOnGCD, e.g. right after pressing ANOTHER
-                -- ability) must not stick here or the recharge stays invisible
-                -- until the active state ends. Restore the normal black
-                -- hide-active swipe unconditionally; black where black is already
-                -- correct is a no-op for the Suppress-GCD-off case.
-                local bkSw = fc2 and fc2.barKey
-                local bdSw = bkSw and barDataByKey and barDataByKey[bkSw]
-                cd:SetSwipeColor(0, 0, 0, (bdSw and bdSw.swipeAlpha) or 0.7)
+                -- ability) must not stick here or the recharge stays invisible.
+                --
+                -- Black is only unconditionally right on the entry-A path, which by
+                -- definition runs inside the Hide-Active window. Entry B can reach
+                -- an icon whose active state paints a COLOURED swipe, and this write
+                -- sits under _isProcessingOverride so the SetSwipeColor hook cannot
+                -- put that colour back -- hence the active check. When the icon is
+                -- active, leaving the colour alone is correct: the next refresh
+                -- repaints it, and the geometry we just armed is what mattered.
+                local bkA = fc2.barKey
+                local bdA = bkA and barDataByKey and barDataByKey[bkA]
+                if entryA or not CdmFrameIsActive(frame) then
+                    cd:SetSwipeColor(0, 0, 0, (bdA and bdA.swipeAlpha) or 0.7)
+                end
                 fd._isProcessingOverride = false
             end
             if cd.SetCooldownFromDurationObject then

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -1207,6 +1207,44 @@ local function CdmFrameIsActive(frame)
     return false
 end
 
+-- Charge info for a CDM frame, resolved the way BLIZZARD resolves it.
+--
+-- We were resolving the charge spell with C_SpellBook.FindSpellOverrideByID and
+-- Blizzard resolves it from the CooldownViewer's OWN override record --
+-- CooldownViewerItemDataMixin:GetSpellChargeInfo reads
+-- `info.overrideSpellID or info.spellID`, deliberately, "to ensure that charges
+-- work correctly for cooldown items that are actively cast, apply auras, and
+-- have charges". Those are two different sources and they disagree in the field:
+-- captured on a Mage, base Blink 1953 with FindSpellOverrideByID resolving to
+-- Shimmer 212653, our read returned isActive=false (no recharge) while Blizzard's
+-- own HasVisualDataSource_Charges was true (a recharge running with charges in
+-- hand) on the very same frame in the very same call.
+--
+-- That disagreement is not cosmetic: chargeRecharging false is what lets the
+-- Suppress GCD block alpha-0 a swipe, so with Suppress GCD on, an override
+-- spell's recharge swipe gets blanked for the whole GCD every time another
+-- ability is pressed -- the exact failure the charge carve-out exists to
+-- prevent. Asking Blizzard removes the whole class rather than special-casing
+-- Shimmer.
+--
+-- Falls back to the old resolution for frames without the accessor (preset,
+-- custom-spell and item frames are ours, not CooldownViewer items), so those
+-- keep exactly today's behaviour.
+local function CdmChargeInfoFor(frame, sid)
+    if frame and type(frame.GetSpellChargeInfo) == "function" then
+        local ci = frame:GetSpellChargeInfo()
+        if ci then return ci end
+    end
+    if not (sid and C_Spell and C_Spell.GetSpellCharges) then return nil end
+    local effID = sid
+    if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
+        local ovr = C_SpellBook.FindSpellOverrideByID(sid)
+        if ovr and ovr > 0 and ovr ~= sid then effID = ovr end
+    end
+    return C_Spell.GetSpellCharges(effID) or C_Spell.GetSpellCharges(sid)
+end
+ns.CdmChargeInfoFor = CdmChargeInfoFor
+
 -- Apply charge cooldown style. Returns true for charge spells (caller then skips
 -- its own swipe forcing). BASELINE edge is drawn for every charge spell; the
 -- swipe is hidden only when the per-spell Hide Swipe toggle is set (resolved
@@ -2648,9 +2686,13 @@ local function DecorateFrame(frame, barData)
                         local ovr = C_SpellBook.FindSpellOverrideByID(sid2)
                         if ovr and ovr > 0 and ovr ~= sid2 then effID2 = ovr end
                     end
+                    -- Resolved through Blizzard's own accessor: see CdmChargeInfoFor.
+                    -- This value decides whether the swipe may be alpha-0'd, and a
+                    -- wrong "not recharging" here blanks a live recharge for a whole
+                    -- GCD on every override spell.
                     local chargeRecharging = false
-                    if C_Spell.GetSpellCharges then
-                        local ci = C_Spell.GetSpellCharges(effID2) or C_Spell.GetSpellCharges(sid2)
+                    do
+                        local ci = CdmChargeInfoFor(frame, sid2)
                         chargeRecharging = (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true) or false
                     end
                     -- The GCD read must use the override too: a transform's real
@@ -2739,8 +2781,8 @@ local function DecorateFrame(frame, barData)
                         local ovrID = C_SpellBook.FindSpellOverrideByID(sid2)
                         if ovrID and ovrID > 0 and ovrID ~= sid2 then
                             local chargeRecharging = false
-                            if C_Spell.GetSpellCharges then
-                                local ci = C_Spell.GetSpellCharges(ovrID) or C_Spell.GetSpellCharges(sid2)
+                            do
+                                local ci = CdmChargeInfoFor(frame, sid2)
                                 chargeRecharging = (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true) or false
                             end
                             local oc = C_Spell.GetSpellCooldown(ovrID)
@@ -3055,8 +3097,8 @@ local function DecorateFrame(frame, barData)
                 -- ONLY inside our Hide-Active override so non-override charge spells
                 -- keep Blizzard's native display untouched. Secret-safe: GetSpellCharges
                 -- .isActive is a clean bool; currentCharges is never read.
-                local chargeActive = fd._hideActiveOverriding and C_Spell.GetSpellCharges
-                    and (C_Spell.GetSpellCharges(effID) or C_Spell.GetSpellCharges(sid2) or {}).isActive == true
+                local chargeActive = fd._hideActiveOverriding
+                    and (CdmChargeInfoFor(frame, sid2) or {}).isActive == true
                 if not (cdActive or chargeActive) then return end
                 -- Re-derive the charge recharge duration. The duration object is
                 -- opaque and fed straight to the widget, never inspected, so it is
@@ -3158,7 +3200,7 @@ local function DecorateFrame(frame, barData)
                 -- Suppress GCD had just alpha-0'd would repaint it at full alpha in
                 -- the same refresh. Both fields are clean; the secret
                 -- currentCharges is never read.
-                local ci = C_Spell.GetSpellCharges(effID) or C_Spell.GetSpellCharges(sid2)
+                local ci = CdmChargeInfoFor(frame, sid2)
                 if not (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true) then
                     return
                 end
@@ -4847,8 +4889,11 @@ local function ApplyPresetGCDSwipe(f, sid, cdInfo, barKey)
             -- showing its RECHARGE, never a GCD, and alpha-0'ing that would
             -- blank the recharge for a whole GCD every time another ability is
             -- pressed. Read it from the stable charge data (maxCharges +
-            -- isActive), never the secret currentCharges.
-            local ci = C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(sid)
+            -- isActive), never the secret currentCharges. Resolved through
+            -- CdmChargeInfoFor so this copy cannot drift from the hook's answer;
+            -- preset frames are ours rather than CooldownViewer items, so it
+            -- falls back to the spellbook resolution for them.
+            local ci = CdmChargeInfoFor(f, sid)
             hide = not (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true)
         end
     end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -1430,6 +1430,30 @@ function ns.RescanChargeCdTextFlag()
     end)
 end
 
+-- Charge style gate: set ns._cdmAnyChargeStyle once if any saved spell (any spec)
+-- has Hide Swipe (Charges) or Hide Recharge Edge enabled. Same monotonic,
+-- scanned-once contract as RescanChargeCdTextFlag.
+--
+-- This flag is the one charge gate that had no priming pass: it was set only from
+-- inside the SetSwipeColor hook, i.e. not until the first cooldown re-push after
+-- login, which is already after the rebuild has run RefreshCDMIconAppearance. So
+-- the rebuild's ReapplyChargeStyle was skipped, and ApplyCdmChargeStyle itself
+-- gates its whole Hide Swipe / Hide Recharge Edge block on the flag -- meaning a
+-- charge spell already recharging at login kept its swipe until something pushed
+-- its cooldown again. Priming here closes that window; the reactive hooks then
+-- carry it as before.
+function ns.RescanChargeStyleFlag()
+    if ns._cdmAnyChargeStyle or ns._chargeStyleFlagScanned then return end
+    if not EllesmereUIDB then return end
+    ns._chargeStyleFlagScanned = true
+    ns.ForEachSavedSettingsBlock(function(ss)
+        if ss.chargeHideSwipe or ss.hideRechargeEdge then
+            ns._cdmAnyChargeStyle = true
+            return true
+        end
+    end)
+end
+
 -- Custom Item gate: set ns._cdmAnyCustomItem once if any saved bar (any spec)
 -- tracks a custom item (an assignedSpells entry <= -100). The buff-bar injection
 -- pass is then skipped entirely for anyone who never adds one -- 0 cost when off.
@@ -7784,6 +7808,7 @@ BuildAllCDMBars = function()
     EnsureFocusKickBar()
     ns.RescanMaxStacksGlowFlag()  -- set the Max Stacks Glow gate (once) before refresh
     ns.RescanChargeCdTextFlag()   -- set the Hide CD Text (Charges) gate (once) before refresh
+    ns.RescanChargeStyleFlag()    -- set the Hide Swipe (Charges) gate (once) before refresh
     ns.RescanBuffSoundFlag()      -- set the Audio on Buff Gain/Loss gate (once) before refresh
     ns.RescanCdReadySoundFlag()   -- set the Audio Effect on CD Ready gate (once) before refresh
     ns.RescanCustomItemFlag()     -- set the custom-item buff-injection gate (once)


### PR DESCRIPTION
## Resolve charge info the way Blizzard resolves it

> Stacked on #1275 -- it edits the same function, so this PR shows that commit too
> until #1275 merges, after which it reduces to the single commit here.

### Cause

Found while instrumenting @Jesir's swipe report. One captured line, covering a
single frame in a single call, had our charge read saying `isActive = false` (no
recharge running) while Blizzard's own `HasVisualDataSource_Charges` on that same
frame said true (a recharge running with charges in hand). Both cannot be right.

They are reading different spells. We resolve the charge spell with
`C_SpellBook.FindSpellOverrideByID`; Blizzard resolves it from the CooldownViewer's
own override record -- `CooldownViewerItemDataMixin:GetSpellChargeInfo` reads
`info.overrideSpellID or info.spellID`, and its comment says that is deliberate,
"to ensure that charges work correctly for cooldown items that are actively cast,
apply auras, and have charges". For base Blink 1953 the spellbook resolves to
Shimmer 212653 and the two records disagree.

This is not cosmetic. `chargeRecharging == false` is exactly what permits the
Suppress GCD block to alpha-0 a swipe, so with Suppress GCD enabled an override
spell's live recharge swipe is blanked for the whole GCD every time another
ability is pressed -- the precise failure the charge carve-out was written to
prevent, reintroduced through the back door by resolving the spell differently.

### Fix

`CdmChargeInfoFor(frame, sid)` asks Blizzard's accessor when the frame has it,
which every CooldownViewer item does, and falls back to the previous spellbook
resolution otherwise. Preset, custom-spell and item frames are ours rather than
CooldownViewer items, so they keep exactly today's behaviour.

When the question is "is the swipe Blizzard is currently drawing a recharge or a
GCD?", the authoritative answer is Blizzard's own -- the same call that decides
the visual data source. Re-deriving it from a parallel API is how the two answers
drifted apart.

Applied to every site whose answer can BLANK a swipe, so the copies cannot drift
again:

- both `chargeRecharging` carve-outs in the SetSwipeColor hook
- `ReAssertRealCooldown`'s charge probe
- `ReArmChargeRecharge`
- the `ApplyPresetGCDSwipe` copy

### Deliberately not converted

The display-side reads -- Hide CD Text (Charges), Hide Text at 0 Stacks, Max
Stacks Glow, Audio on CD Ready. They share the same resolution and would show the
same disagreement, but they only decide what a counter or a timer reads rather
than whether a swipe is erased, and converting them is a larger mechanical change
than the evidence here justifies. Worth doing as its own pass.

### Testing

- Verified in game: Mage with Shimmer on a Suppress GCD bar; the recharge swipe no
  longer blanks while pressing other abilities.
- Falls back to the previous behaviour for every frame without the accessor, so
  preset/custom/item frames are unaffected.
- Secret-safe: only `maxCharges` and `isActive` are read, both NeverSecret per
  `SpellChargeInfo`. The secret `currentCharges` is never touched.
- No new strings, no saved-variable changes.
