### PR TITLE
Fix: Failed to recognize "-" key input

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -10022,6 +10022,14 @@ do
         -- "CTRL-Q" → "Q"). IsKeyDown only accepts raw key names.
         local function BaseKey(binding)
             if not binding then return nil end
+            -- The hyphen/minus key is itself bound as the literal string "-"
+            -- (default ACTIONBUTTON11 keybind). A modifier combo ending in
+            -- the hyphen key (e.g. "SHIFT--") also ends in "-". In both
+            -- cases the trailing character IS the base key, so check for
+            -- that before stripping the "everything after the last '-'"
+            -- modifier prefix -- otherwise the pattern below finds no
+            -- non-hyphen run and returns nil.
+            if binding:sub(-1) == "-" then return "-" end
             return binding:match("[^%-]+$")
         end
         local function ShowPushedForSlot(slot)


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1535923335894925362

The fix: teach the helper a special rule: "if the key's name itself ends in a dash, that dash is the key — don't try to chop anything off, just say the answer is -." Now when someone presses the - key, the helper correctly says "the real key is -," and the glow stays on for as long as it's held, just like every other key.