### PR TITLE
fix(widgets): disabled-widget tooltips ignored the locale catalog

### DIFF
--- a/EllesmereUI_Widgets.lua
+++ b/EllesmereUI_Widgets.lua
@@ -460,7 +460,12 @@ end
 -- state: "enabled" (default) or "disabled" -- controls the trailing verb so negative
 -- requirements ("disabled because X must be OFF") read "...to be disabled".
 local function DisabledTooltip(requirement, state)
-    if type(requirement) == "string" and requirement:find("^This option") then return requirement end
+    -- Already a whole sentence: skip the wrapper, but still translate it. The
+    -- catalog keys the whole sentence, so L() resolves it (and is identity on
+    -- English or when the key is missing).
+    if type(requirement) == "string" and requirement:find("^This option") then
+        return EllesmereUI.L(requirement)
+    end
     local verb = (state == "disabled") and "disabled" or "enabled"
     -- Compose via a positional template so the wrapper sentence, the requirement
     -- noun, and the verb each localize independently (word order is translator
@@ -480,7 +485,8 @@ local function ResolveDisabledTip(cfg)
     if tt == nil then return nil end
     local raw = cfg.rawTooltip
     if type(raw) == "function" then raw = raw() end
-    if raw then return tt end
+    -- rawTooltip skips the wrapper sentence, not the translation.
+    if raw then return EllesmereUI.L(tt) end
     return DisabledTooltip(tt, cfg.requireState)
 end
 


### PR DESCRIPTION
### Problem

Disabled-widget tooltips that are written as a whole sentence always render in
English, on every non-English client, even though the sentence is already
translated in the locale files. Short-noun tooltips ("Show Text", "Max Stacks")
are unaffected and translate correctly today, which is why this went unnoticed.

Repro: on a zhTW client, open Unit Frames and set Portrait Mode to None. The
disabled Art Style dropdown's tooltip reads "Portrait Mode is set to None" in
English, while `L["Portrait Mode is set to None"]` has been sitting in
`Locales/zhTW.lua` unused.

### Cause

Two independent early returns hand the caller's string back without ever
calling `L()`:

- `DisabledTooltip()` sniffs for `^This option` and returns the requirement
  verbatim. The intent is to skip the "This option requires X to be enabled"
  wrapper for strings that are already full sentences, but it skips the
  translation along with the wrapper. The `L()` call on the line below is
  never reached for these.
- `ResolveDisabledTip()` does the same for `cfg.rawTooltip`, which exists for
  exactly the same reason and has exactly the same side effect.

Both are "skip the template" switches that were also, unintentionally, "skip
the catalog" switches.

### Fix

Return `L(requirement)` / `L(tt)` instead of the raw string. `L()` is identity
when no catalog is active, when the key is missing, and for non-strings, so
English is unchanged and any locale without the key still falls back to English.

This deliberately does not touch the `^This option` sniff itself. Narrowing or
removing the sniff would change which sentences get wrapped, which is a
behavior change; translating what is already being returned is not.

### Notes

The affected sentences are already translated, so this lights up existing
locale data rather than needing new strings. In zhTW that is 44 keys: 15
reached through the `^This option` path and 29 through `rawTooltip`, all of
which are already in `Locales/zhTW.lua` and are simply not being read. deDE,
frFR, koKR, ruRU and zhCN benefit the same way for the keys they cover.

One case stays English by design: `EllesmereUI.MatchGuard()` in
`EUI_UnlockMode.lua` composes its tooltip at runtime from a bar name
(`axis .. " matched to " .. name .. "."`), so it can never match a catalog key.
`L()` returns it unchanged, exactly as today. Fixing that one needs the
sentence rebuilt as an `Lf()` template and is left out of this PR.

Pre-existing non-ASCII characters elsewhere in `EllesmereUI_Widgets.lua` (lines
6855-6862, 7466) were left alone to keep the diff minimal.

### Testing

In-game, on live, zhTW client. Unit Frames -> Portrait covers both code paths
from one dropdown:

- Portrait Mode = None -> hover the disabled Art Style dropdown
  (the `rawTooltip` path) -> now reads 頭像模式設為無, was English
- Portrait Mode = Attached -> hover the disabled position cog
  (the `^This option` path) -> now reads 此選項需要將頭像模式設為「分離」。,
  was English
- Short-noun tooltips on the same pages still wrap and translate as before,
  confirming the untouched third path is unaffected

Not verified by me: the 12.1 PTR client, and the enUS no-catalog path. The
enUS path is `L()`'s first guard (`if not cat then return s end`), so it
returns the identical string, but I have not loaded an enUS client to confirm
it by eye.

### Checklist

- [x] N/A - no new settings
- [x] N/A - no new code paths while disabled; this is two existing returns
- [x] Event-driven; one extra table lookup on tooltip hover only
- [x] N/A - no Blizzard frames touched
- [ ] Tested in-game on live retail (zhTW); 12.1 PTR client not tested
