### PR TITLE
fix(chat): scroll-to-bottom chevron only worked on the first tab

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -4270,12 +4270,19 @@ local function SkinChatFrame(cf)
         if settingsBtn then HookIconTooltip(settingsBtn, "Settings") end
         HookIconTooltip(scrollBtn, "Scroll to Bottom")
 
-        -- Scroll to bottom
+        -- Scroll to bottom. One sidebar serves the whole docked panel, so the
+        -- target has to be resolved at click time: docked windows other than the
+        -- selected one are Hide()n by FCFDock_UpdateTabs, and scrolling a hidden
+        -- ChatFrame1 from the Guild or Loot tab does nothing the user can see.
+        -- Same lookup the Copy icon uses (ReadActiveChatText), and ScrollToBottom
+        -- is the call Blizzard's own jump-to-bottom button makes, so the restyled
+        -- ScrollBar follows through the message frame's display-refreshed callback
+        -- instead of being driven directly.
         scrollBtn:SetScript("OnClick", function()
-            local cf1 = ChatFrame1
-            if cf1 and cf1.ScrollBar and cf1.ScrollBar.SetScrollPercentage then
-                cf1.ScrollBar:SetScrollPercentage(1)
-            end
+            local selected = GENERAL_CHAT_DOCK and FCFDock_GetSelectedWindow
+                and FCFDock_GetSelectedWindow(GENERAL_CHAT_DOCK)
+            local cf = selected or ChatFrame1
+            if cf and cf.ScrollToBottom then cf:ScrollToBottom() end
         end)
 
         -- Copy chat history from the active tab (reads directly from the frame)

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -4281,8 +4281,8 @@ local function SkinChatFrame(cf)
         scrollBtn:SetScript("OnClick", function()
             local selected = GENERAL_CHAT_DOCK and FCFDock_GetSelectedWindow
                 and FCFDock_GetSelectedWindow(GENERAL_CHAT_DOCK)
-            local cf = selected or ChatFrame1
-            if cf and cf.ScrollToBottom then cf:ScrollToBottom() end
+            local target = selected or ChatFrame1
+            if target and target.ScrollToBottom then target:ScrollToBottom() end
         end)
 
         -- Copy chat history from the active tab (reads directly from the frame)


### PR DESCRIPTION
Reported by @Boomshakalek on 8.7.7. The sidebar scroll-to-bottom chevron works on the first tab only.

**Cause:** the chevron's `OnClick` hardcoded `ChatFrame1`, and Blizzard hides every docked window except the selected one. From any other tab the click was scrolling a hidden frame.

**Fix:** resolve the target at click time with `FCFDock_GetSelectedWindow`, already the idiom in five other places in this file, and call `ScrollToBottom` (what Blizzard's own button calls) instead of driving the scrollbar directly.

**Taint:** ChatFrames are `<ScrollingMessageFrame>` intrinsics whose `secureMixin` covers `ScrollToBottom`, so the field writes stay secure. Verified in game with `issecurevariable`: true on the new path, false on the old `ScrollBar:SetScrollPercentage` one.

**Left alone, both pre-existing:** the suppressed native per-frame button is deliberate (`FCF_UpdateScrollbarAnchors` anchors the ScrollBar to it), and undocked windows fall back to ChatFrame1.

**Test:** leave tab 1 scrolled up, switch to Combat Log, scroll up, click the chevron. It jumps to bottom and tab 1 keeps its position.

<img width="480" height="480" alt="Tom And Jerry Cat GIF" src="https://github.com/user-attachments/assets/41cb0100-0dbc-47ca-9e4b-6be724dea29b" />
