### PR TITLE
Feature: Auto Zoom Reset option to Minimap module

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -112,6 +112,8 @@ local defaults = {
             scrollZoom    = true,
             openMicroMenuOnMiddleClick = true,
             savedZoom     = 0,
+            -- Auto Zoom Reset: seconds of inactivity after a manual zoom change before snapping back to zoom level 0 (max distance). 0 = disabled (default).
+            zoomResetSeconds = 0,
             -- false = Zoom +/- Icons checked in Show Blizzard Elements (buttons hover-show). The old true default was inert on Midnight (targeted pre-Midnight global button names), so flipping it changed nobody's visual state.
             hideZoomButtons      = false,
             hideTrackingButton   = true,
@@ -1116,6 +1118,25 @@ local function SaveZoomLevel()
     local p = EBS.db and EBS.db.profile.minimap
     if not p then return end
     p.savedZoom = Minimap:GetZoom()
+end
+
+-- Auto Zoom Reset: (re)arms a one-shot timer on every manual zoom change (scroll wheel, zoom buttons) that snaps the map back to zoom level 0 (max distance) after zoomResetSeconds of inactivity. 0 = disabled.
+local zoomResetTimer
+local function RestartZoomResetTimer()
+    if zoomResetTimer then
+        zoomResetTimer:Cancel()
+        zoomResetTimer = nil
+    end
+    local p = EBS.db and EBS.db.profile.minimap
+    local secs = p and p.zoomResetSeconds or 0
+    if not secs or secs <= 0 then return end
+    zoomResetTimer = C_Timer.NewTimer(secs, function()
+        zoomResetTimer = nil
+        if Minimap:GetZoom() ~= 0 then
+            Minimap:SetZoom(0)
+            SaveZoomLevel()
+        end
+    end)
 end
 
 -- Global names of third-party buttons that REPLACE the expansion landing page button:
@@ -4061,6 +4082,7 @@ local function ApplyMinimap()
             end
             minimap:SetZoom(zoom)
             SaveZoomLevel()
+            RestartZoomResetTimer()
         end)
         -- Map-region hover reveal, entry-path-proof: the Minimap's motion focus follows
         -- its CIRCULAR hit region, so entering the square skin through a corner (or
@@ -4346,11 +4368,11 @@ local function ApplyMinimap()
     end
 
     if zoomIn and not GetFFD(zoomIn).zoomSaveHooked then
-        zoomIn:HookScript("OnClick", function() SaveZoomLevel() end)
+        zoomIn:HookScript("OnClick", function() SaveZoomLevel(); RestartZoomResetTimer() end)
         GetFFD(zoomIn).zoomSaveHooked = true
     end
     if zoomOut and not GetFFD(zoomOut).zoomSaveHooked then
-        zoomOut:HookScript("OnClick", function() SaveZoomLevel() end)
+        zoomOut:HookScript("OnClick", function() SaveZoomLevel(); RestartZoomResetTimer() end)
         GetFFD(zoomOut).zoomSaveHooked = true
     end
 
@@ -4879,6 +4901,11 @@ local function ApplyMinimap()
             minimap:SetZoom(saved)
         end
     end
+
+    -- Re-arm (or disarm) the Auto Zoom Reset timer on every apply, so
+    -- enabling it or changing the seconds slider in the options takes
+    -- effect immediately.
+    RestartZoomResetTimer()
 
     -- Position: only set on first activation; after that, unlock mode owns positioning.
     if not GetFFD(minimap).active then

--- a/EllesmereUIOptions/EUI_Minimap_Options.lua
+++ b/EllesmereUIOptions/EUI_Minimap_Options.lua
@@ -476,8 +476,38 @@ initFrame:SetScript("OnEvent", function(self)
                 RefreshMinimap()
                 EllesmereUI:RefreshPage()
               end },
-            { type="label", text="" }
+            { type="slider", text="Reset Zoom", min=0, max=15, step=1,
+              tooltip="Automatically zoom back out to maximum distance after this many seconds of no manual zoom change. 0 disables the reset.",
+              getValue=function() local m = MinimapDB(); return m and m.zoomResetSeconds or 0 end,
+              setValue=function(v)
+                local m = MinimapDB(); if not m then return end
+                m.zoomResetSeconds = v
+                RefreshMinimap()
+              end }
         );  y = y - h
+
+        -- "(seconds)" suffix next to the Reset Zoom slider (mirrors Damage
+        -- Meters' Refresh Rate suffix)
+        do
+            local rgn = fmRow._rightRegion
+            local suffix = rgn:CreateFontString(nil, "OVERLAY")
+            suffix:SetFont(EllesmereUI.EXPRESSWAY, 11, "")
+            suffix:SetTextColor(1, 1, 1, 0.35)
+            local rzLabel
+            for i = 1, rgn:GetNumRegions() do
+                local reg = select(i, rgn:GetRegions())
+                if reg and reg.GetText and EllesmereUI.EnKey(reg:GetText()) == "Reset Zoom" then
+                    rzLabel = reg
+                    break
+                end
+            end
+            if rzLabel then
+                suffix:SetPoint("LEFT", rzLabel, "RIGHT", 5, 0)
+            else
+                suffix:SetPoint("LEFT", rgn, "LEFT", 150, 0)
+            end
+            suffix:SetText(EllesmereUI.L("(seconds)"))
+        end
 
         -- "Reset" label next to the Free Move toggle (only visible when enabled)
         if not EllesmereUI._prebuilding then


### PR DESCRIPTION
## What does this PR do?

Adds an optional Auto Zoom Reset to the Minimap module. When enabled, the minimap automatically zooms back out to maximum distance (zoom level 0) after a configurable number of seconds without a manual zoom change (scroll wheel or the +/- buttons).

Configured via a single "Reset Zoom" slider (0-15 seconds) placed next to the existing "Free Move Buttons" toggle in the minimap options. 0 (the default) disables the feature entirely, matching current behavior.

## How was it tested?

Tested in-game on live retail: enabled the slider at various values (1-15s), zoomed in with the scroll wheel and with the +/- buttons, confirmed the map snaps back to max zoom-out after the configured delay and stays put while actively zooming. Confirmed the slider defaults to 0/disabled on a fresh profile and that existing zoom/scroll behavior is unchanged at 0.

Not tested on the 12.1 PTR client - the change touches only `Minimap:GetZoom()`/`SetZoom()`, which the module already calls elsewhere without an `IS_121` split, so no divergence is expected, but flagging per the "both clients" criterion.

## Screenshots

Not applicable - this is a single options-menu slider added next to an existing row, no layout/visual change beyond one new control.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -   `zoomResetSeconds = 0` by default, which disables the reset path entirely.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - `RestartZoomResetTimer()` reads the setting and returns immediately without creating a timer when the value is 0.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic,  no per-frame allocations) - **partially, flagging for review:** the feature is inherently a "reset after N seconds of inactivity", so it uses a single-shot `C_Timer.NewTimer`, cancelled and re-armed only on the actual zoom-change events (scroll wheel, +/- button clicks) - not a per-frame or polling timer. This mirrors the existing debounce-timer pattern already used elsewhere in this file (e.g. the hover-reveal watcher and the free-move-button save). No `OnUpdate`, no polling loop.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - only calls the existing `Minimap:GetZoom()`/`SetZoom()` API methods (already used elsewhere in this file for scroll-to-zoom), and hooks the zoom buttons via the existing `HookScript` pattern.
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client - live retail tested as above; PTR not tested, see note above.