### PR TITLE
Fix GCD bar showing on hard casts under Only Instant Casts

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -7843,9 +7843,21 @@ BuildGCDBar = function()
             end
         end
 
-        gcdBarFrame:SetScript("OnEvent", function(self, event, unit, _, spellID)
+        -- How each spell last behaved, keyed by spellID: "hard" once it has
+        -- ever opened a cast, channel or empower bar, "instant" once it has
+        -- finished with no cast bar at all. "hard" is sticky -- a proc (e.g.
+        -- Infusion of Light) makes one CAST instant, not the spell -- so a
+        -- procced cast simply falls back to the slower, always-correct
+        -- SUCCEEDED edge. Instant-only reads this to decide whether a press
+        -- may arm the bar; see the SPELL_UPDATE_COOLDOWN edge below.
+        local castKind = {}
+
+        gcdBarFrame:SetScript("OnEvent", function(self, event, unit, arg2, arg3, arg4)
             local gc = ERB.db.profile.gcdBar
             if not gc or not gc.enabled then return end
+            -- UNIT_SPELLCAST_SENT carries an extra target argument, so its
+            -- spellID sits one slot further along than the other cast events'.
+            local spellID = (event == "UNIT_SPELLCAST_SENT") and arg4 or arg3
 
             -- Press-parity edge (the action bar swipe lesson): the client
             -- PREDICTS the GCD and fires SPELL_UPDATE_COOLDOWN the moment
@@ -7858,19 +7870,35 @@ BuildGCDBar = function()
                 if self._gcdCapStamp == now then return end
                 self._gcdCapStamp = now
                 if gc.instantOnly then
-                    -- Hard casts also start a GCD, and cast info may not be
-                    -- readable yet on this exact frame -- check one later.
-                    C_Timer.After(0, function()
-                        if UnitCastingInfo("player") or UnitChannelInfo("player") then return end
-                        local gc2 = ERB.db.profile.gcdBar
-                        if gc2 and gc2.enabled then captureGCD(self, gc2, true) end
-                    end)
-                    return
+                    -- Hard casts and channels predict a GCD at the press too,
+                    -- and this edge IS the press: UNIT_SPELLCAST_START only
+                    -- lands a round trip later, so reading the cast one frame
+                    -- on read nothing at all on any real latency and the bar
+                    -- filled for every hard cast. Arm only when the spell just
+                    -- sent has already been seen finishing instantly; every
+                    -- other press waits for its own SUCCEEDED, which arrives
+                    -- classified. Unknown always means "wait", so the first
+                    -- cast of a spell is late rather than wrong.
+                    local sent = self._sentSpellID
+                    self._sentSpellID = nil   -- one press edge per send
+                    if not (sent and castKind[sent] == "instant"
+                        and (now - (self._sentAt or 0)) < 1) then return end
+                    -- An off-GCD press landing mid-cast must not open the bar
+                    -- on the hard cast's own GCD.
+                    if UnitCastingInfo("player") or UnitChannelInfo("player") then return end
                 end
                 captureGCD(self, gc, true)
                 return
             end
             if unit ~= "player" then return end
+
+            if event == "UNIT_SPELLCAST_SENT" then
+                -- Press-time bookkeeping for the edge above. Recording only --
+                -- this event never shows the bar.
+                self._sentSpellID = spellID
+                self._sentAt = GetTime()
+                return
+            end
 
             -- Stop events: clear the bar the moment the GCD is no longer active.
             if event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_INTERRUPTED"
@@ -7911,10 +7939,12 @@ BuildGCDBar = function()
                 -- (e.g. Swiftness Regrowth) will count as instant cast
                 if event ~= "UNIT_SPELLCAST_START" then
                     self._realCastSpellID = spellID
+                    if spellID then castKind[spellID] = "hard" end
                 else
                     local _, _, _, st, et = UnitCastingInfo("player")
                     if st and et and et > st then
                         self._realCastSpellID = spellID
+                        if spellID then castKind[spellID] = "hard" end
                     end
                 end
                 if gc.instantOnly then return end  -- instant-only: don't fill for hard casts
@@ -7932,8 +7962,16 @@ BuildGCDBar = function()
                 -- A channel's succeeded can fire before its channel_start.
                 -- Defer the capture one frame and skip it if channeling.
                 -- Avoids a 1-frame flash on channel start
+                local succeededID = spellID
                 C_Timer.After(0, function()
                     if UnitChannelInfo and UnitChannelInfo("player") then return end
+                    -- The option promises the bar stays down for the whole of
+                    -- a hard cast, so an off-GCD instant fired mid-cast must
+                    -- not open it on the cast's own GCD either.
+                    if UnitCastingInfo("player") then return end
+                    -- Got here with no cast bar of its own: this spell is an
+                    -- instant, so its next press may arm the bar directly.
+                    if succeededID and not castKind[succeededID] then castKind[succeededID] = "instant" end
                     local gc2 = ERB.db.profile.gcdBar
                     if gc2 and gc2.enabled then captureGCD(self, gc2) end
                 end)
@@ -7946,7 +7984,10 @@ BuildGCDBar = function()
     -- register the cast events that start a GCD. SPELL_UPDATE_COOLDOWN is
     -- the press-parity edge (client GCD prediction); the UNIT_SPELLCAST
     -- events carry the instant-only bookkeeping and the stop/clear edges.
+    -- SENT names the spell behind the press, which is the only thing the
+    -- press edge has to go on before the server answers.
     gcdBarFrame:RegisterEvent("SPELL_UPDATE_COOLDOWN")
+    gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_SENT", "player")
     gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
     gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_START", "player")
     gcdBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_FAILED", "player")


### PR DESCRIPTION
## What does this PR do?

Fixes a Resource Bars report from @Saijeh on v8.7.8: with **Only Instant Casts** ticked, the GCD bar still filled for hard casts and channels.

The `SPELL_UPDATE_COOLDOWN` press-parity edge fires on the client's GCD prediction, and that prediction happens at the **press** for hard casts and channels just as it does for instants. Instant-only tried to tell them apart by reading `UnitCastingInfo` one frame later, but `UNIT_SPELLCAST_START` only lands after the server ack -- a full round trip -- so on any real latency the read found nothing, the guard passed, and the bar filled for the whole GCD of every hard cast. Low-latency testing hides it.

The press is now classified rather than guessed at:

* `UNIT_SPELLCAST_SENT` names the spell behind each press (bookkeeping only -- it never shows the bar).
* A session table records how each spell last behaved: `"hard"` once it has opened a cast, channel or empower bar (sticky, because a proc such as Infusion of Light makes one *cast* instant rather than the spell), `"instant"` once it has finished with no cast bar at all.
* The press edge arms only for a fresh send whose spell is already known instant, and only when no cast or channel is running. Anything unknown waits for its own `UNIT_SPELLCAST_SUCCEEDED`, which arrives already classified.

Failure direction is now "late, never wrong": the first cast of a spell after a reload opens the bar one round trip in (the pre-8.7.7 behavior), and every press after that keeps press parity.

The succeeded edge also holds the bar down while a cast is running, so an off-GCD instant fired mid-cast cannot open it on the hard cast's own GCD -- which is what the option's tooltip already promises.

Behavior with the option off is unchanged.

## How was it tested?

Live retail 12.0.x, Holy Paladin (casts and instants), after `/reload`:

* Flash of Light and Holy Light -- bar stays down for the whole cast and the rest of the GCD, including the first cast after a reload.
* Holy Shock / Judgment / Crusader Strike -- bar shows; no perceptible delay on the first cast after a reload either.
* Infusion of Light proc making Flash of Light instant -- bar shows.
* Cast cancelled partway -- bar stays down, GCD refund paints the idle fill.
* Instant spam / queued casts -- bar re-arms each time, no drop-outs.
* Option unticked -- bar shows for everything again.
* Channeled spell -- bar stays down.

## Screenshots

N/A -- no visual change; the fix is which events open the bar.

## Checklist

- [x] New settings default **OFF** (no new settings; the existing `instantOnly` toggle already defaults off)
- [x] Zero cost while disabled: the events are registered only for an enabled GCD bar, as before
- [x] Cheap while enabled: event-driven, and a net reduction -- the removed path allocated a `C_Timer.After(0)` closure on every `SPELL_UPDATE_COOLDOWN`, which is chatty in combat. `UNIT_SPELLCAST_SENT` is unit-filtered to the player and its handler does two field writes; the classification table is bounded by the spells cast in a session.
- [x] No writes onto Blizzard-owned frames (all state lives on the addon's own GCD bar frame)
- [x] Tested in-game on live retail; no load errors
