### PR TITLE
CDM: fix hosted buffs resolving per-spell settings from the CD store, and their threshold rows locking after a bar apply

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -10248,6 +10248,14 @@ initFrame:SetScript("OnEvent", function(self)
                                 -- opens on hover (Exclude / Include / Apply to Bar), never by
                                 -- re-selecting the value. A bar-applied "+ " toggle counts too.
                                 local function itemIsBarApplied()
+                                    -- A hosted buff never chains to the bar tiers (its
+                                    -- effective read passes nil for the bar/spec tiers,
+                                    -- and the runtime resolver strips them too), so a
+                                    -- bar-wide apply can never drive it. Reporting
+                                    -- "bar applied" here would dead-lock its toggle
+                                    -- rows: the OnClick bails on bar-applied items and
+                                    -- hosted rows have no Apply strip to escape through.
+                                    if hostedBuffNoApply then return false end
                                     if not (applyKeys and AB.KeysBarApplied(applyKeys)) then return false end
                                     if isChargeToggle or isActiveBorder or isFnToggle then return true end
                                     local barTier = ns.GetBarTierSettings and ns.GetBarTierSettings(sd, barKey)
@@ -10467,7 +10475,11 @@ initFrame:SetScript("OnEvent", function(self)
                                     --    is the break-out for a bar-applied-ON toggle.)
                                     -- Once the spell owns a value it reports editable and
                                     -- writes straight through (the excluded state).
-                                    if AB.KeysBarApplied(applyKeys) and not AB.SpellHasOwn(applyKeys) then
+                                    -- canApply: hosted-buff rows (and rows with no apply
+                                    -- write) never enter the break-out flow -- it flashes
+                                    -- an Apply strip those rows suppress -- they just
+                                    -- write their own value below.
+                                    if canApply and AB.KeysBarApplied(applyKeys) and not AB.SpellHasOwn(applyKeys) then
                                         if not (isChargeToggle or isActiveBorder or isFnToggle) then
                                             local cv = getVal()
                                             if (cv == item.val) or (cv == nil and item.val == nil) then

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -309,10 +309,22 @@ local function ResolveSpellSettingsUncached(frame, sid2, sd2, barKey)
     -- must keep the normal CD-family resolution. A buff frame only reaches a
     -- non-buff bar through an explicit host, so the frame identity is exact.
     -- Cheap: sd2.hostedBuffSpellIDs is nil on bars with no host.
+    -- All four signals are frame-scoped, and FC.isHostedBuff / viewerFrame are
+    -- readable BEFORE the frame is decorated (the claim pass stamps the first;
+    -- the second is the Blizzard field DecorateFrame later reads). Testing only
+    -- the decoration stamps made a pre-decoration resolve report "not hosted",
+    -- and the miss is SILENT: the family store below falls back to
+    -- spellSettingsCD and applies a CD-era entry under the same id to the buff.
+    -- Only bites ids where the aura and spell id coincide (Agony 980, Unstable
+    -- Affliction 1259790), which is why one hosted DoT of three looked correct.
     local hostedFrame = false
     if frame and bk and sd2 and sd2.hostedBuffSpellIDs then
         local fdH = ns._hookFrameData and ns._hookFrameData[frame]
-        if (fdH and fdH._isBuffViewerFrame) or frame._isPlaceholderFrame then
+        if (fc0 and fc0.isHostedBuff)
+           or (fdH and fdH._isBuffViewerFrame)
+           or frame._isPlaceholderFrame
+           or frame.viewerFrame == _G.BuffIconCooldownViewer
+           or frame.viewerFrame == _G.BuffBarCooldownViewer then
             local bdH = ns.barDataByKey and ns.barDataByKey[bk]
             if bdH and bdH.barType ~= "buffs" and bdH.barType ~= "custom_buff" then
                 hostedFrame = true

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -5876,16 +5876,31 @@ local function RefreshCDMIconAppearance(barKey)
                 -- A hosted buff (buff frame on a CD/util bar) uses the BUFF baseline
                 -- (fill-up), not the cd baseline, so "Reverse" flips the same way it
                 -- would on a real buffs bar.
-                local rfBuff = (barData.barType == "buffs" or barKey == "buffs"
-                    or barData.barType == "custom_buff" or (fd and fd._isBuffViewerFrame)) or false
-                local rfReverse = rfBuff
                 local rfFc = _ecmeFC[icon]
+                -- "Fills like a buff" has to agree with the claim loops in
+                -- EllesmereUICdmHooks (DecorateFrame's isBuff, the CD claim pass's
+                -- wantRev): a hosted buff and its placeholder fill UP even though
+                -- they render on a CD/util bar. Omitting those two kept a hosted
+                -- buff on the cd baseline here, and because this pass writes the
+                -- widget directly it also has to stamp fd._revKind below -- the
+                -- claim-pass repairs are gated on that memo, so an unstamped write
+                -- left the memo and the widget disagreeing and the repair was
+                -- skipped for the rest of the session.
+                local rfBuff = (barData.barType == "buffs" or barKey == "buffs"
+                    or barData.barType == "custom_buff"
+                    or (rfFc and rfFc.isHostedBuff)
+                    or (fd and fd._isBuffViewerFrame)
+                    or icon._isPlaceholderFrame) and true or false
+                local rfReverse = rfBuff
                 local rfSid = rfFc and rfFc.spellID
                 if rfSid then
                     -- Regular per-spell setting (per-bar spellSettings).
                     local rev
                     if ns.ResolveSpellSettings then
-                        local rfSs = ns.ResolveSpellSettings(icon, rfSid, ns.GetBarSpellData(barKey))
+                        -- Pass barKey explicitly: the resolver picks the FAMILY
+                        -- store from the bar identity, and leaving it to be
+                        -- inferred resolves a hosted buff against the CD store.
+                        local rfSs = ns.ResolveSpellSettings(icon, rfSid, ns.GetBarSpellData(barKey), barKey)
                         rev = rfSs and rfSs.reverseSwipe
                     end
                     -- Preset / custom cd-utility spell setting (profile customActiveStates;
@@ -5897,6 +5912,9 @@ local function RefreshCDMIconAppearance(barKey)
                     if rev then rfReverse = not rfBuff end
                 end
                 cd:SetReverse(rfReverse)
+                -- Keep the kind memo equal to what is RENDERED, so the
+                -- kind-gated re-asserts in the claim loops stay sound.
+                if fd then fd._revKind = rfReverse end
             end
             -- Per-spell Hide CD Swipe: removes the cooldown swipe entirely for
             -- cd/utility spells (non-charge -- charge spells use "Hide Swipe (Charges)").


### PR DESCRIPTION
## The bug

Reported by @Nokram (Affliction Warlock, 8.7.7): with Agony, Corruption and Unstable Affliction added as buffs on a cooldown row, Agony and Unstable Affliction always swipe the wrong way while Corruption is correct, regardless of whether Reverse Swipe is toggled on or off for them. A talent swap fixes the two until the next `/reload`.

## Cause

A buff hosted on a CD/utility bar decided whether it was "hosted" using only DecorateFrame's stamps (`_isBuffViewerFrame` / `_isPlaceholderFrame`). Those exist only after the frame has been decorated, so any resolve running before that reported "not hosted".

The miss is silent. `ResolveSpellSettingsUncached` then falls back to the `spellSettingsCD` family store and applies a CD-era entry stored under the same id to the buff.

The options page writes a hosted buff's settings to `spellSettingsBuff`, so the toggle the user flips is not the value being applied. That is why Reverse Swipe appeared to do nothing.

It only bites ids where the aura id and the spell id coincide, which is exactly the reported 2-of-3 split. From the reporter's SavedVariables:

| Spell | Hosted as | CD store entry | Collides |
|---|---|---|---|
| Agony | `980` | `980`, `reverseSwipe = true` | yes |
| Unstable Affliction | `1259790` | `1259790`, `reverseSwipe = true` | yes |
| Corruption | `146739` (aura) | `172` (spell) | no |

His `spellSettingsBuff` entries for all three exist but are empty, confirming the writes and the reads were going to different stores.

## Changes

**`EllesmereUICdmHooks.lua`, `ResolveSpellSettingsUncached`**

Detect the hosted kind from signals that exist before decoration: `FC.isHostedBuff` (stamped by the claim pass) and Blizzard's own `viewerFrame` field. All signals stay frame-scoped, so a cooldown icon of the same spellID on the same bar still resolves CD-family settings, preserving the original intent of the frame-based test.

Fixing detection at the source rather than adding decoration state to the resolver memo: the memo is keyed on `resGen` plus ids plus bar, so widening the key would only cache the wrong answer more reliably.

**`EllesmereUICooldownManager.lua`, `RefreshCDMIconAppearance`**

- `rfBuff` omitted `FC.isHostedBuff` and `_isPlaceholderFrame`, leaving a hosted buff on the cd swipe baseline. It now agrees with `DecorateFrame`'s `isBuff` and the CD claim pass's `wantRev`.
- The pass wrote the cooldown widget without stamping `fd._revKind`, which the claim-pass re-asserts are gated on. Memo and widget could disagree, and the repair was then skipped for the rest of the session.
- `barKey` is now passed explicitly, so the resolver takes the family store from a stated bar identity instead of inferring it.

## Risk

The whole per-spell Reverse Swipe block stays behind the existing `ns._cdmAnyReverseSwipe` session gate, so it remains zero cost for anyone who has never enabled the toggle. No new events, no OnUpdate, no secure-frame or Blizzard-frame writes: `_revKind` lives on the addon's own external frame-data table.

Existing profiles with an orphaned `spellSettingsCD` entry for an id that is now a hosted buff will stop having that stale value applied. The entry is not deleted. Happy to add a migration that moves such entries into `spellSettingsBuff` if you would prefer the setting be carried over rather than dropped.

<img width="480" height="272" alt="No Way Smh GIF by MOODMAN" src="https://github.com/user-attachments/assets/8d451c99-ed48-48f5-9cc2-33eb1278ffb1" />



---

## Second commit: hosted-buff threshold rows dead-locked by a bar-wide apply

Found while the reporter was testing the fix above. Pre-existing on 8.7.8, not caused by the first commit (that commit touches no options code, and the gate below is byte-identical on `main`). It surfaced only because the fix above makes per-spell buff settings work, so users now get far enough to hit it.

**Repro:** clear all threshold settings, apply Threshold Text to one hosted DoT (works), then from a non-buff spell use Apply to Bar / All Specs. The remaining hosted DoTs' Threshold Color and Threshold Decimals rows stop responding to clicks entirely.

**Cause:** `itemIsBarApplied()` is name-keyed and bar-scoped, so once the bar tier holds a threshold key `AB.KeysBarApplied` answers true for every spell on the bar. The three Threshold Text rows carry `toggleGet`, so they classify as fn-toggles and short-circuit to "bar applied", and the default OnClick returns early on those. Normal spells manage that state through the hover Apply strip, but hosted rows set `hostedBuffNoApply`, which suppresses both the arrow and the strip, so there is no way out.

The gate is wrong rather than merely inconvenient: a hosted buff's effective read passes nil for the bar tiers, the apply sweep and cas stamping skip it, and the runtime resolver strips the tier and reads the buff family store. A bar apply cannot drive a hosted buff through any path, so reporting "bar applied" claims an override that can never be delivered.

**Fix:** report hosted rows as never bar-applied, so their clicks fall through to the normal per-spell write, and gate the bar-driven break-out branch on `canApply` so a hosted row cannot enter logic that flashes a strip it never shows. Arrow and strip stay suppressed as before, and normal spells are unaffected since `hostedBuffNoApply` is false for them. This unlocks every hosted-buff row, not just the threshold ones.

Unchanged by design: a bar-wide apply still does not push settings onto hosted buffs, so they are configured per-spell.

Verified in game by the reporter, including the precondition that the bar apply actually landed (the applied row on the non-buff spell shows the unclickable arrow).
