### PR TITLE
fix(actionbars): restore mouse on slots un-parked by a combat page flip

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2630,13 +2630,73 @@ ns._eabEmpowerSnippet = [[
 -- re-checks (pass 3 of UpdateKeybinds, the combat-drop re-assert) correct
 -- any kept value as soon as identity is readable again.
 
+-- Un-park a slot that "Always Show Buttons" off left hidden. Parking writes
+-- four things (alpha 0, mouse off, statehidden, Hide) and un-parking must undo
+-- all four -- but EnableMouse on a protected button is combat-blocked, so
+-- SafeEnableMouse silently returns and the insecure pass can only restore the
+-- three unprotected ones. A form or page flip that fills the slot mid-combat
+-- therefore left the button VISIBLE (alpha is unprotected) yet deaf to hover
+-- and clicks, while keybinds -- which route through override bindings and need
+-- no mouse -- kept working (reported: druid stance change in combat).
+--
+-- The restore cannot come from the OnShow -> UpdateShown wrapper: that snippet
+-- gates on not IsShown(), and OnShow fires after the frame is already shown.
+-- It has to happen here, before the Show. Gated on the hidden->shown edge so a
+-- live on-cooldown alpha on an already-visible button is never stomped, and on
+-- eab-click so a reveal never makes a click-through bar clickable.
+ns._eabPageUnparkSnippet = [[
+if not self:IsShown() then
+    self:SetAlpha(1)
+    if (self:GetAttribute('eab-click') or 1) ~= 0 then
+        self:EnableMouse(true)
+    end
+end
+]]
+
 -- Build the _childupdate-eab-page snippet for a button at the given 1-based bar
--- index. On a page change: action = baseIndex + (page-1)*12, then re-check
--- hold-release. ALL install sites (SetupBar, RebuildBarPaging) call this so the
--- handler is byte-identical everywhere -- the page change rewrites the secure
--- "action" attribute (our buttons are ID=0, so actionpage is never consulted).
+-- index. On a page change: action = baseIndex + (page-1)*12, re-evaluate parked
+-- visibility, then re-check hold-release. ALL install sites (SetupBar,
+-- RebuildBarPaging) call this so the handler is byte-identical everywhere --
+-- the page change rewrites the secure "action" attribute (our buttons are
+-- ID=0, so actionpage is never consulted).
+--
+-- The visibility half is gated on eab-showempty EXISTING: it is stamped by
+-- ApplyAlwaysShowButtons out of combat, and a button that has never seen a
+-- stamp keeps the pre-existing behaviour (action only, visibility left to the
+-- controller's deferred UpdateShown) rather than guessing at a default.
+ns._eabPageVisSnippet = [[
+local showEmpty = self:GetAttribute('eab-showempty')
+if showEmpty then
+    local withinCutoff = self:GetAttribute('eab-withincutoff') ~= 0
+    local visible = withinCutoff
+    if visible and showEmpty == 0 then
+        visible = HasAction(slot)
+    end
+    -- A transient grid reveal outranks the empty-slot park, exactly as
+    -- UpdateShown does: a page flip during a combat spell drag must not
+    -- delete the drop targets under the cursor. Bits 2+ only -- bit 1 is
+    -- Blizzard's CVAR reason and is not a transient reveal. statehidden is
+    -- cleared only for a genuinely filled slot, so drag end still re-parks.
+    local grid = self:GetAttribute('showgrid') or 0
+    local transient = withinCutoff and (grid % 32) >= 2
+    if visible or transient then
+        if visible and self:GetAttribute('statehidden') then
+            self:SetAttribute('statehidden', nil)
+        end
+]] .. ns._eabPageUnparkSnippet .. [[
+        self:Show(true)
+    else
+        if not self:GetAttribute('statehidden') then
+            self:SetAttribute('statehidden', true)
+        end
+        self:Hide(true)
+    end
+end
+]]
+
 function ns._eabBuildPageChildSnippet(baseIndex)
-    return ("local page = tonumber(message) or 1; self:SetAttribute('action', %d + (page - 1) * 12)"):format(baseIndex) .. ns._eabEmpowerSnippet
+    return ("local page = tonumber(message) or 1; local slot = %d + (page - 1) * 12; self:SetAttribute('action', slot)\n"):format(baseIndex)
+        .. ns._eabPageVisSnippet .. ns._eabEmpowerSnippet
 end
 
 -------------------------------------------------------------------------------
@@ -8001,9 +8061,15 @@ function EAB:ApplyAlwaysShowButtons(barKey)
 
             -- Stamp the secure-side facts the restricted reveal needs
             -- (see the SetShowGrid snippet): this button is within the icon
-            -- cutoff, and whether a reveal may enable mouse clicks.
+            -- cutoff, whether empty slots are shown at all, and whether a
+            -- reveal may enable mouse clicks. eab-showempty is what lets the
+            -- paging snippet (ns._eabPageVisSnippet) re-evaluate a parked slot
+            -- during combat on every bar, not just MainBar -- without it a
+            -- custom-paged bar 2-10 leaves the slot statehidden for the whole
+            -- fight.
             if not InCombatLockdown() then
                 btn:SetAttributeNoHandler("eab-withincutoff", 1)
+                btn:SetAttributeNoHandler("eab-showempty", showEmpty and 1 or 0)
                 btn:SetAttributeNoHandler("eab-click", clickable and 1 or 0)
             end
             if not visible then
@@ -8052,6 +8118,7 @@ function EAB:ApplyAlwaysShowButtons(barKey)
                 -- Cutoff buttons are excluded from the secure drag reveal:
                 -- revealing them would paint slots the user configured away.
                 btn:SetAttributeNoHandler("eab-withincutoff", 0)
+                btn:SetAttributeNoHandler("eab-showempty", showEmpty and 1 or 0)
                 btn:SetAttributeNoHandler("statehidden", true)
                 btn:Hide()
             end
@@ -8118,24 +8185,37 @@ function EAB_VTABLE.MainBarPageSync.InstallButton(btn)
     local info = buttonToBar[btn]
     local baseIdx = info and info.index or 1
 
+    -- Only the slot arithmetic is interpolated. The body is concatenated raw:
+    -- it contains a modulo, and string.format eats a bare "%" as a broken
+    -- conversion spec.
     btn:SetAttributeNoHandler("_childupdate-eab-page", ([[
         local page = tonumber(message) or 1
         local slot = %d + (page - 1) * %d
         self:SetAttribute("action", slot)
-        local visible = self:GetAttribute("eab-withincutoff") ~= 0
+    ]]):format(baseIdx, NUM_ACTIONBAR_BUTTONS) .. [[
+        local withinCutoff = self:GetAttribute("eab-withincutoff") ~= 0
+        local visible = withinCutoff
 
         if visible and self:GetAttribute("eab-showempty") == 0 then
             visible = HasAction(slot)
         end
 
+        -- Transient grid reveal outranks the empty-slot park (see
+        -- ns._eabPageVisSnippet, which carries the same rule for bars 2-10):
+        -- a page flip during a combat spell drag must not delete the drop
+        -- targets. Bits 2+ only -- bit 1 is Blizzard's CVAR reason.
+        local grid = self:GetAttribute("showgrid") or 0
+        local transient = withinCutoff and (grid % 32) >= 2
+
         local hidden = self:GetAttribute("statehidden")
         local changed = false
 
-        if visible then
-            if hidden then
+        if visible or transient then
+            if visible and hidden then
                 self:SetAttribute("statehidden", nil)
                 changed = true
             end
+    ]] .. ns._eabPageUnparkSnippet .. [[
             self:Show(true)
         else
             if not hidden then
@@ -8149,7 +8229,7 @@ function EAB_VTABLE.MainBarPageSync.InstallButton(btn)
             local token = self:GetAttribute("eab-pagesync-token") or 0
             self:SetAttribute("eab-pagesync-token", token == 0 and 1 or 0)
         end
-    ]]):format(baseIdx, NUM_ACTIONBAR_BUTTONS))
+    ]])
 
     btn:SetAttributeNoHandler("_eabPageSyncInstalled", true)
 end


### PR DESCRIPTION
## What does this PR do?

Fixes the bug reported by @Growlyr: with **Always Show Buttons** off, changing
stance in combat left every bar 1 button that was empty when combat started
visible but dead -- no tooltip on hover, nothing on click -- while its keybind
still worked. Leaving combat repaired it.

An empty slot is parked with four writes: alpha 0, mouse off, `statehidden`,
`Hide`. Un-parking has to undo all four, but `EnableMouse` on a protected
button is combat-blocked while `SetAlpha` is not, so a form or page change
mid-combat undid three of them:

| write | undone in combat by |
|---|---|
| `statehidden` + `Hide` | the secure page-sync snippet, recomputing `HasAction(slot)` |
| `SetAlpha(0)` | the insecure pass, via `ACTIONBAR_PAGE_CHANGED` |
| mouse off | nobody |

Keybinds kept working because they route through override bindings and need no
mouse, which is what made this read as a hit-rect or tooltip bug.

The restore cannot come from the `OnShow` -> `UpdateShown` wrapper: that snippet
gates on `not self:IsShown()`, and `OnShow` fires after the frame is already
shown. It now happens inside the restricted environment, before the `Show`, on
the hidden->shown edge, honouring `eab-click` so a click-through bar is never
made clickable. `HANDLE:SetAlpha` and `HANDLE:EnableMouse` both exist there
(`Blizzard_RestrictedAddOnEnvironment/RestrictedFrames.lua`).

Two related fixes ride along:

- **Bars 2-10 had the same defect in a worse form.** Their paging snippet only
  rewrote the `action` attribute, so a parked slot stayed `statehidden` for the
  whole fight -- invisible rather than merely dead. They now share the
  visibility half, fed by an `eab-showempty` stamp on every bar instead of
  MainBar alone, and gated on that stamp existing so an unstamped button keeps
  its previous behaviour.
- **A transient grid reveal now outranks the empty-slot park** in both snippets,
  matching `UpdateShown`. Without it, swapping forms during a combat spell drag
  would delete the drop targets under the cursor.

## How was it tested?

Live retail, druid, bar 1 with Always Show Buttons off and form paging on.

1. Reported case -- nostance with only slot 1 filled, cat form with slot 2
   filled, enter combat in nostance, shift to cat. Slot 2 draws, tooltips, and
   casts on click. **Pass**
2. Inverse -- combat entered in cat: all cat buttons work; shifting to nostance
   hides the now-empty slot; shifting back restores it. **Pass**
3. Always Show Buttons **on**: unchanged in every stance. **Pass**
4. Click-through bar: the revealed slot stays click-through. **Pass**
5. Icon cutoff (3 of 12): the trimmed slots stay hidden across the form change.
   **Pass**
6. Combat drag: picked a spell up, swapped forms mid-drag, dropped it on the new
   form's bar -- it landed and was removed from the original. **Pass**
7. Bars 2-10 with custom paging: no issues. **Pass**
8. Click-through **and** mouseover together: the bar reveals on hover in both
   forms and stays unclickable, which is what click-through means. Hover
   detection lives on the bar frame's motion-only mouse, so it is unaffected by
   the button-level restore. **Pass**

## Screenshots

N/A -- no visual change; the buttons already drew correctly, they just did not
take mouse input.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; this restores the documented behaviour of an existing one
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations). Out of combat, one extra attribute write per button per apply pass. In combat, two attribute reads and an `IsShown` per button **per page flip**, with writes only on the hidden->shown edge. No new `OnUpdate`, no new event registrations, no allocations in combat.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
