### PR TITLE
DataBars: anchor the loadout flyout to the hovered spec row

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -3144,6 +3144,7 @@ ns.BlockFactories.spec = function(blockCfg, slot, content, barCtx)
         EVOKER      = { "evoker-dev", "evoker-pres", "evoker-aug" },
     }
     local POPUP_FONT_SIZE = 12
+    local POPUP_PAD = 8
 
     local specCache, numSpecs = {}, 0
     local currentSpecIdx, currentLootSpecID = nil, 0
@@ -3236,7 +3237,7 @@ ns.BlockFactories.spec = function(blockCfg, slot, content, barCtx)
         local ar, ag, ab = ns.GetAccent()
         local fontSize = POPUP_FONT_SIZE
         local iconSz = fontSize + 2
-        local PAD, LINE = 8, 18
+        local PAD, LINE = POPUP_PAD, 18
 
         -- Title is optional: a nil/empty title (the loadout subnav) renders
         -- a plain list with even PAD margins on all four sides.
@@ -3432,7 +3433,7 @@ ns.BlockFactories.spec = function(blockCfg, slot, content, barCtx)
             subnavPool._popup:Hide()
         end
     end
-    local function OpenLoadoutSubnav()
+    local function OpenLoadoutSubnav(rowBtn)
         if subnavPool and subnavPool._popup and subnavPool._popup:IsShown() then return end
         if not (C_ClassTalents and C_ClassTalents.GetConfigIDsBySpecID
                 and C_Traits and C_Traits.GetConfigInfo) then return end
@@ -3457,16 +3458,27 @@ ns.BlockFactories.spec = function(blockCfg, slot, content, barCtx)
             C_ClassTalents.UpdateLastSelectedSavedConfigID(specId, e.configID)
             inst:Refresh()
         end, true)
-        -- Flyout anchoring: flush against the spec popup's edge; flips to
-        -- the left side when the screen runs out (clamped either way).
+        -- Flyout anchoring: flush against the spec popup's edge, with its
+        -- FIRST entry level with the row the cursor is on, so a straight
+        -- rightward move lands inside the list. Anchoring to the popup with
+        -- a row-derived offset, rather than to the row button itself, keeps
+        -- the anchor between two long-lived frames: the rows are POOLED and
+        -- ResetPooledFrame clears their points on release, which _wbOnHide
+        -- does BEFORE it closes this flyout. Vertical overflow is left to
+        -- SetClampedToScreen (already set), so the flyout only bumps when it
+        -- would leave the screen.
         local main = specPool and specPool._popup
         if pop and main then
+            local mainTop = main:GetTop()
+            local rowTop  = rowBtn and rowBtn.GetTop and rowBtn:GetTop()
+            local dy = 0
+            if mainTop and rowTop then dy = POPUP_PAD - (mainTop - rowTop) end
             pop:ClearAllPoints()
             local right = main:GetRight() or 0
             if right + (pop:GetWidth() or 0) > UIParent:GetWidth() then
-                pop:SetPoint("TOPRIGHT", main, "TOPLEFT", 0, 0)
+                pop:SetPoint("TOPRIGHT", main, "TOPLEFT", 0, dy)
             else
-                pop:SetPoint("TOPLEFT", main, "TOPRIGHT", 0, 0)
+                pop:SetPoint("TOPLEFT", main, "TOPRIGHT", 0, dy)
             end
         end
     end


### PR DESCRIPTION
**Cause:** `OpenLoadoutSubnav` declared no parameter, so the row button `BuildPopup` passes to `entry.onHover(btn)` was discarded and the flyout was anchored to the spec popup's top corner with a hardcoded y offset of 0.

**Effect:** the active spec row sits `34 + 21*(i-1)` below the popup top while the flyout is only `21N + 13` tall, so any active spec on row 3+ with a short loadout list leaves a vertical dead band with no continuous cursor path into the flyout (Druid Restoration with 2 loadouts: 42px).

**Fix:** `OpenLoadoutSubnav(rowBtn)` derives `dy = PAD - (popupTop - rowTop)` so the first entry lands level with the hovered row. The anchor stays on the popup, not the row, because the rows are pooled and their points are cleared on release before the flyout closes. A nil rect degrades to the previous behaviour, and vertical overflow is still left to the existing `SetClampedToScreen`.

**Test:** Druid in Restoration with 2 loadouts, verified the flyout lines up with the row and is reachable by a straight rightward move; also checked 1 and 3 loadouts, spec row 1, the screen-edge clamp cases, and that the Ctrl+Click loadout list and loot spec popup are unchanged.