### PR TITLE
CDM: fix Sacred Weapon / Holy Bulwark duration missing until you cast at login

### DIFF
--- a/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
+++ b/EllesmereUICooldownManager/EUI_CooldownManager_Options.lua
@@ -19911,6 +19911,11 @@ initFrame:SetScript("OnEvent", function(self)
                     _G._ECME_AceDB.sv._capturedOnce_CDM = nil
                 end
             end
+            -- Learned variant->base pairs are game data rather than settings,
+            -- but they sit on the SV root where StripDefaults and the profile
+            -- system never reach, so a pair learned wrong would survive every
+            -- other reset. This is the only path that clears them.
+            if ns.ResetVariantBaseStore then ns.ResetVariantBaseStore() end
             -- Wipe spell assignments for the current spec so the init
             -- snapshot re-populates from Blizzard's CDM. Spell data lives
             -- in EllesmereUIDB (per-profile store), not the AceDB profile, so

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -724,29 +724,57 @@ local _divertedVarBaseCD   = {}
 -- the live one. The claim is therefore missing from the very first build and
 -- the base falls through to whatever a repopulate assigned, until a cast
 -- transforms the slot and a later rebuild finally observes it. Persisting is
--- what lets a login start where the last session left off. The pairing is
--- static game data -- identical on every character and in every profile, and
--- it never changes -- so it belongs on the SV root beside _capturedOnce_CDM,
--- not in a profile. StripDefaults only walks keys present in DEFAULTS, so a
--- root key it does not know about survives logout untouched.
+-- what lets a login start where the last session left off.
+--
+-- SCOPED PER SPEC, and that is load-bearing. GetBaseSpell takes a `spec`
+-- argument documented as "overrides may vary by Spec", and we call it without
+-- one, so every answer describes the CURRENT spec only. The links are not
+-- always the tidy same-ability pair the armaments suggest, either: #842 saw
+-- GetBaseSpell tie SV Kill Command to a different ability entirely. Seeding one
+-- spec's answer into another would hand varMap a base that belongs to a
+-- different family there, and ResolveCDIDToBar consults varBaseMap BEFORE
+-- directMap[info.spellID], so a bogus pair would outrank that spell's own
+-- explicit assignment. Keying by spec confines every pair to the state it was
+-- measured in. Sharing across characters within one spec is fine: same spec,
+-- same links.
+--
+-- Lives on the SV root beside _capturedOnce_CDM rather than in a profile
+-- because it describes the game, not the user's settings. StripDefaults only
+-- walks keys present in DEFAULTS, so a root key it does not know about survives
+-- logout untouched -- which also means nothing else can ever clear it, hence
+-- ns.ResetVariantBaseStore below.
 local _variantBaseLearned = {}
-local _variantBaseLoaded = false
+local _variantBaseSpec = nil   -- spec key the live table was loaded for
 
 local function _variantBaseSV()
     local db = ECME and ECME.db
     return db and db.sv or nil
 end
 
--- Seeds the live table from the store. Idempotent, and reads WITHOUT creating:
--- a player who never assigns a transforming spell should not gain an empty
--- table in their SavedVariables. Leaves the flag clear when the db is not up
--- yet so a later rebuild retries.
+-- Seeds the live table for the current spec, and reloads it when the spec
+-- changes, since the previous spec's pairs do not describe the new one. Reads
+-- WITHOUT creating; only _learnVariantBase creates, so the table appears the
+-- first time a pair is actually observed. Bails without latching while the db
+-- or the spec is not up yet, so a later rebuild retries.
 local function _loadVariantBases()
-    if _variantBaseLoaded then return end
+    local specKey = ns.GetActiveSpecKey and ns.GetActiveSpecKey()
+    if not specKey then return end
+    if _variantBaseSpec == specKey then return end
     local sv = _variantBaseSV()
     if not sv then return end
-    _variantBaseLoaded = true
-    local store = sv._variantBase
+    wipe(_variantBaseLearned)
+    _variantBaseSpec = specKey
+    local root = sv._variantBase
+    if type(root) == "table" then
+        -- Pre-release test builds stored pairs flat, keyed by spellID, before
+        -- spec scoping existed. Those answers cannot be attributed to a spec so
+        -- they cannot be trusted; drop them rather than leave them orphaned.
+        -- Clearing existing fields during pairs() is defined behaviour in Lua.
+        for k in pairs(root) do
+            if type(k) ~= "string" then root[k] = nil end
+        end
+    end
+    local store = (type(root) == "table") and root[specKey] or nil
     if type(store) ~= "table" then return end
     for variant, base in pairs(store) do
         if type(variant) == "number" and type(base) == "number"
@@ -756,21 +784,39 @@ local function _loadVariantBases()
     end
 end
 
--- Record a pair in the live table and the store. Callers gate ids for secrecy
--- before calling: a secret must never index a table, let alone reach
--- SavedVariables. The unchanged-pair early-out keeps the resolve path, which
--- relearns the live pairing on every call, from touching the store per frame.
+-- Record a pair in the live table and the current spec's store. Callers gate
+-- ids for secrecy before calling: a secret must never index a table, let alone
+-- reach SavedVariables. The unchanged-pair early-out keeps the resolve path,
+-- which relearns the live pairing on every call, from touching the store per
+-- frame. Persists only once the spec is known, so a pair observed before that
+-- still routes this session without being filed under the wrong spec.
 local function _learnVariantBase(variant, base)
     if _variantBaseLearned[variant] == base then return end
     _variantBaseLearned[variant] = base
+    if not _variantBaseSpec then return end
     local sv = _variantBaseSV()
     if not sv then return end
-    local store = sv._variantBase
+    local root = sv._variantBase
+    if type(root) ~= "table" then
+        root = {}
+        sv._variantBase = root
+    end
+    local store = root[_variantBaseSpec]
     if type(store) ~= "table" then
         store = {}
-        sv._variantBase = store
+        root[_variantBaseSpec] = store
     end
     store[variant] = base
+end
+
+-- Reset hook for the CDM's own reset path. Without it a pair learned wrong is
+-- permanent: StripDefaults never walks this key and no profile operation
+-- touches it, so there would be no way back short of editing SavedVariables.
+function ns.ResetVariantBaseStore()
+    wipe(_variantBaseLearned)
+    _variantBaseSpec = nil
+    local sv = _variantBaseSV()
+    if sv then sv._variantBase = nil end
 end
 ns._divertedSpellsBuff = _divertedSpellsBuff
 ns._divertedSpellsCD   = _divertedSpellsCD

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -717,7 +717,61 @@ local _divertedVarBaseCD   = {}
 -- half the time -- and these transforms rebuild constantly. Learning it the
 -- moment it IS observable and keeping it is what makes the result stable, and
 -- keeping it is safe precisely because the relationship never changes.
+--
+-- Learning it in-session still leaves one hole, which is what the store below
+-- closes: a slot only ever names its base and the form live RIGHT NOW, so a
+-- fresh login can never witness the pair for an assigned variant that is not
+-- the live one. The claim is therefore missing from the very first build and
+-- the base falls through to whatever a repopulate assigned, until a cast
+-- transforms the slot and a later rebuild finally observes it. Persisting is
+-- what lets a login start where the last session left off. The pairing is
+-- static game data -- identical on every character and in every profile, and
+-- it never changes -- so it belongs on the SV root beside _capturedOnce_CDM,
+-- not in a profile. StripDefaults only walks keys present in DEFAULTS, so a
+-- root key it does not know about survives logout untouched.
 local _variantBaseLearned = {}
+local _variantBaseLoaded = false
+
+local function _variantBaseSV()
+    local db = ECME and ECME.db
+    return db and db.sv or nil
+end
+
+-- Seeds the live table from the store. Idempotent, and reads WITHOUT creating:
+-- a player who never assigns a transforming spell should not gain an empty
+-- table in their SavedVariables. Leaves the flag clear when the db is not up
+-- yet so a later rebuild retries.
+local function _loadVariantBases()
+    if _variantBaseLoaded then return end
+    local sv = _variantBaseSV()
+    if not sv then return end
+    _variantBaseLoaded = true
+    local store = sv._variantBase
+    if type(store) ~= "table" then return end
+    for variant, base in pairs(store) do
+        if type(variant) == "number" and type(base) == "number"
+           and base > 0 and base ~= variant then
+            _variantBaseLearned[variant] = base
+        end
+    end
+end
+
+-- Record a pair in the live table and the store. Callers gate ids for secrecy
+-- before calling: a secret must never index a table, let alone reach
+-- SavedVariables. The unchanged-pair early-out keeps the resolve path, which
+-- relearns the live pairing on every call, from touching the store per frame.
+local function _learnVariantBase(variant, base)
+    if _variantBaseLearned[variant] == base then return end
+    _variantBaseLearned[variant] = base
+    local sv = _variantBaseSV()
+    if not sv then return end
+    local store = sv._variantBase
+    if type(store) ~= "table" then
+        store = {}
+        sv._variantBase = store
+    end
+    store[variant] = base
+end
 ns._divertedSpellsBuff = _divertedSpellsBuff
 ns._divertedSpellsCD   = _divertedSpellsCD
 
@@ -770,6 +824,11 @@ function ns.RebuildSpellRouteMap()
     local p = ECME.db and ECME.db.profile
     if not p or not p.cdmBars then return end
 
+    -- Before any StoreDirect: the recall below is the only thing that can supply
+    -- a base for an assigned variant that is not the live form, and this is the
+    -- first build of the session.
+    _loadVariantBases()
+
     local SVV = ns.StoreVariantValue
     if not SVV then return end
 
@@ -794,7 +853,7 @@ function ns.RebuildSpellRouteMap()
             local ok, b = pcall(GetBase, sid)
             if ok and type(b) == "number" and b > 0 and b ~= sid then
                 base = b
-                _variantBaseLearned[sid] = b
+                _learnVariantBase(sid, b)
             end
         end
         base = base or _variantBaseLearned[sid]
@@ -978,7 +1037,7 @@ local function ResolveCDIDToBar(cdID, viewerDefaultBar)
     -- known from then on.
     if CdidIDReadable(info.spellID) and CdidIDReadable(info.overrideSpellID)
        and info.overrideSpellID ~= info.spellID then
-        _variantBaseLearned[info.overrideSpellID] = info.spellID
+        _learnVariantBase(info.overrideSpellID, info.spellID)
     end
 
     local routedBar = nil


### PR DESCRIPTION
**Cause:** the learned variant->base map was in-memory only, so it was empty at every login. A transforming slot only names its base and the form live *right now*, so the first `RebuildSpellRouteMap` of a session can never observe the pairing for an assigned variant that is not the live one. The claim was missing from the first build and the base fell through to whatever a repopulate had assigned, until a cast transformed the slot and a later rebuild finally saw it.

**Fix:** persist the pairs on the SV root (`_variantBase`) and seed them before the first `StoreDirect`, keyed by spec since `GetBaseSpell` answers per spec. Adds `ns.ResetVariantBaseStore`, called from the CDM reset, because nothing else reaches the SV root. There is no API route: `GetBaseSpell` on a non-live variant, `GetOverrideSpell` + `ignoreOverrideSpellID` on the base, and `GetOverrideSpell` on the variant were all measured and all refuse to name a form the client is not in.

**Test:** Holy paladin (Lightsmith). Three consecutive full logouts returned the same pairs, and post-login with no input Holy Bulwark renders its recharge countdown immediately. Also covers other override spells (Blessed Hammer, Avenging Crusader, Judgment variants). Note the per-spec scoping was added in review follow-up, after that in-game pass, so the spec-change reload path is not yet exercised live.

<img width="500" height="276" alt="sugar glider eating GIF" src="https://github.com/user-attachments/assets/ffa9df2c-bc94-4f37-a879-63b87d794501" />
