### PR TITLE
Clamp negative power values to zero

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -4159,6 +4159,18 @@ local function UpdatePrimaryBar()
     local cur = UnitPower("player", cachedPrimary)
     local mx = UnitPowerMax("player", cachedPrimary)
     if not mx or mx <= 0 then return end
+	-- Some custom power types (e.g. Devourer Fury) can transiently report a
+    -- negative value from the server between spend and the next power sync.
+    -- The StatusBar widget itself clamps the *fill* to [0, mx] automatically,
+    -- but nothing was clamping the raw number handed to the text formatters
+    -- below, so "smart"/"curpp"/"both" text could show a negative number
+    -- while the bar visually read empty. Floor it once here, and use the
+    -- clamped value everywhere after this point (fill + text) so both stay
+    -- consistent. issecretvalue()'d numbers can't be compared, so skip the
+    -- floor for those (SetValue's own clamp still protects the fill).
+    if not (issecretvalue and issecretvalue(cur)) and cur < 0 then
+        cur = 0
+    end
 
     primaryBar:SetMinMaxValues(0, mx)
 


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1536398420514840727

The Fury bar in the addon could occasionally show a negative number as text (like "-15 Fury") even though the bar itself looked empty.

Why: the code that draws the bar and the code that draws the text both start from the same raw number. The bar automatically refuses to draw below empty, but nobody told the text to do the same — so if the game ever reported Fury dipping below zero for a split second, the bar just looked empty while the text printed the raw negative number.

Fix: before using that number for anything, round any negative value up to 0. Now bar and text always agree.

Scope: this wasn't a Devourer-only bug — it's in the one shared function that draws the primary resource bar for every class. Devourer was just the spec most likely to actually trigger it, since its Fury math is custom rather than running through Blizzard's own always-clamped power system.