### PR TITLE
AB: fix empowered spells losing Hold and Release on keybinds after a spec change

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -921,12 +921,61 @@ do
     -- (ExtraActionButton1 -- its spell-typed delve abilities have no action
     -- slot, so our own dispatch can't paint their cooldown; only Blizzard's
     -- native update, driven by this broadcaster, can).
-    local _vehNeed, _extraNeed, _broadcasterActive = false, false, false
+    -- A THIRD need, and a partial one: press-and-hold.
+    --
+    -- Empower keys ride the native command, so ACTIONBUTTON<n> resolves through
+    -- GetActionButtonForID to BLIZZARD's button, not ours -- which is why the
+    -- mouse was never affected. Those twins learn their pressAndHoldAction only
+    -- from Update() -> UpdatePressAndHoldAction, reached from the mixin OnEvent,
+    -- and the only thing that ever calls that OnEvent is this broadcaster. With
+    -- it dead the attribute is never initialised at all, so SecureTemplates
+    -- computes releasePressAndHoldAction = (not down) and (pressAndHoldAction or
+    -- CVar) and, with Press and Hold Casting off, key-up has nothing to release
+    -- the empower with. Broken since the empower keys became native, for every
+    -- login, not just after a spec change.
+    --
+    -- We cannot repair those buttons ourselves: writing any field or attribute
+    -- on them from here taints them, and their own later updates then fail
+    -- (blocked SetAttribute, and secret cooldown args rejected). Let Blizzard do
+    -- it in its own untainted execution instead, and buy the smallest possible
+    -- slice of the broadcaster to make that happen.
+    --
+    -- ACTIONBAR_SLOT_CHANGED ONLY, and that is the whole cost story. The event
+    -- the perf campaign profiled out is ACTIONBAR_UPDATE_COOLDOWN, which fires
+    -- ~11x/sec at total idle; this one fires only when a slot actually changes,
+    -- and Blizzard's own handler gates on "arg1 == 0 or arg1 == self.action" so
+    -- a single button does real work per event. Idle cost is zero.
+    local _vehNeed, _extraNeed, _phNeed = false, false, false
+    local _broadcasterMode = "off"
+    -- Class gate, and it exists purely for ORDERING. The survey that sets
+    -- _phNeed reads the action slots, and on a cold login those are still empty
+    -- when it first runs -- so it reports "no press-and-hold", we stay off, and
+    -- the ACTIONBAR_SLOT_CHANGED that arrives WITH the slot data is the one
+    -- event we needed and the one we are not listening for. The class is known
+    -- before any of that and cannot change mid-session, so it turns the listener
+    -- on early enough to catch the first fill. _phNeed remains the general
+    -- path: if press-and-hold ever reaches another class, the survey still
+    -- switches this on without touching this gate.
+    local _classPH
+    local function ClassMayPressHold()
+        if _classPH == nil then
+            local _, class = UnitClass("player")
+            if not class then return false end   -- too early; ask again later
+            _classPH = (class == "EVOKER")
+        end
+        return _classPH
+    end
     local function ApplyBroadcaster()
-        local want = _vehNeed or _extraNeed
-        if want == _broadcasterActive then return end
-        _broadcasterActive = want
-        if want then
+        local want = (_vehNeed or _extraNeed) and "full"
+            or ((_phNeed or ClassMayPressHold()) and "ph" or "off")
+        if want == _broadcasterMode then return end
+        _broadcasterMode = want
+        -- Always drop to a known state first: "full" and "ph" are different
+        -- registration sets, so switching between them directly would leave the
+        -- wider set's events behind.
+        if ActionBarButtonEventsFrame then ActionBarButtonEventsFrame:UnregisterAllEvents() end
+        if ActionBarActionEventsFrame then ActionBarActionEventsFrame:UnregisterAllEvents() end
+        if want == "full" then
             if ActionBarButtonEventsFrame then
                 for _, ev in ipairs(_abefEvents) do
                     ActionBarButtonEventsFrame:RegisterEvent(ev)
@@ -937,10 +986,46 @@ do
                     ActionBarActionEventsFrame:RegisterUnitEvent(ev, "player")
                 end
             end
-        else
-            if ActionBarButtonEventsFrame then ActionBarButtonEventsFrame:UnregisterAllEvents() end
-            if ActionBarActionEventsFrame then ActionBarActionEventsFrame:UnregisterAllEvents() end
+        elseif want == "ph" then
+            if ActionBarButtonEventsFrame then
+                ActionBarButtonEventsFrame:RegisterEvent("ACTIONBAR_SLOT_CHANGED")
+                -- PLAYER_ENTERING_WORLD as well, because SLOT_CHANGED alone
+                -- cannot seed a login. Blizzard gates that one on
+                -- "arg1 == 0 or arg1 == tonumber(self.action)", so a button only
+                -- re-checks when ITS slot is the one that changed -- and at login
+                -- a slot that never changes never fires, leaving that button
+                -- unset while its neighbours are fine. Measured: one empowered
+                -- slot read true at login and the other still false. The PEW
+                -- branch calls self:Update() with no gate at all, so every button
+                -- re-derives once per loading screen. Costs one pass per zone-in.
+                ActionBarButtonEventsFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+            end
         end
+    end
+    -- Driven from UpdateKeybinds, where the press-and-hold survey already runs,
+    -- so a character with no empowered spells never turns this on and pays
+    -- nothing at all.
+    -- No "unchanged value" early-out on purpose: the resolved mode also depends
+    -- on the class gate and on the vehicle/extra needs, so a survey reporting
+    -- the same _phNeed as last time can still need a different mode -- and at
+    -- load it reports false into an already-false _phNeed, which is exactly when
+    -- the class gate has to get its first look. ApplyBroadcaster early-outs on an
+    -- unchanged resolved mode, so calling it unconditionally costs nothing.
+    ns.SetBroadcasterPressHoldNeed = function(v)
+        _phNeed = v and true or false
+        ApplyBroadcaster()
+    end
+    -- For callers that unregister the broadcasters DIRECTLY rather than through
+    -- ApplyBroadcaster. The setup path has a "redundant kill, in case Blizzard
+    -- re-creates them" safety net that runs after we may already have
+    -- registered: it leaves the frames bare while _broadcasterMode still claims
+    -- "ph", and the mode check above then early-outs forever, so we never
+    -- register again. That is precisely how press-and-hold mode ended up
+    -- silently inert -- registered once at login, wiped moments later, and the
+    -- state machine none the wiser. Any direct wipe must come back through here.
+    ns.ResyncBroadcaster = function()
+        _broadcasterMode = "off"   -- the caller has just put the frames in that state
+        ApplyBroadcaster()
     end
     -- Recompute both needs from ground truth -- the actual visibility of the
     -- buttons that depend on the broadcaster -- and apply. We poll visibility on
@@ -1675,8 +1760,28 @@ end
 
 local function HideBlizzardBars()
     -- Fully hide all Blizzard action buttons. We create our own buttons
-    -- instead, so these are parented to a hidden frame and silenced.
+    -- instead, so these are silenced and hidden.
     -- Stance and Pet buttons are still reused, so only hide action buttons.
+    --
+    -- NOT reparented, and that is deliberate. The template sets
+    -- "useparent-actionpage" and then seeds self.action from UpdateAction() in
+    -- its OnLoad, so the button derives its slot from whichever frame is its
+    -- PARENT. Moving it to hiddenParent breaks that inheritance and freezes
+    -- self.action at whatever it resolved to at load -- and Blizzard's own
+    -- ACTIONBAR_SLOT_CHANGED handler gates on
+    -- "arg1 == 0 or arg1 == tonumber(self.action)", so a button with a stale
+    -- cached slot can never match the slot that actually changed and simply
+    -- stops updating. That is what left pressAndHoldAction unset on the
+    -- natively-routed twins and killed Hold and Release on empower KEYBINDS,
+    -- while mouse clicks (which go through our own buttons) were fine.
+    -- Measured in game: at login the twins read pressAndHoldAction=false, and
+    -- only ever flipped true for whichever buttons happened to match, which is
+    -- also why a spec change helped -- it fires arg1 == 0 and bypasses the gate.
+    --
+    -- Leaving them under their real bar costs no visibility: every stock bar is
+    -- in STOCK_BAR_DISPOSAL, which hides it and hooks OnShow to re-hide, so a
+    -- child of one is never drawn. statehidden and Hide still apply here; only
+    -- the reparent had to go.
     for _, info in ipairs(BAR_CONFIG) do
         if info.blizzBtnPrefix and not info.isStance and not info.isPetBar then
             for i = 1, info.count do
@@ -1684,7 +1789,6 @@ local function HideBlizzardBars()
                 if btn then
                     btn:UnregisterAllEvents()
                     btn:SetAttributeNoHandler("statehidden", true)
-                    btn:SetParent(hiddenParent)
                     btn:Hide()
                 end
             end
@@ -11458,6 +11562,12 @@ local function UpdateKeybinds()
     -- combat-drop attr re-assert knows whether any press-and-hold slot
     -- exists at all -- non-empower classes never pay for it.
     _bindState.hasPH = anyPH
+    -- Same survey drives the broadcaster's press-and-hold need: Blizzard's twin
+    -- buttons are what a natively-routed empower key actually drives, and only
+    -- the broadcaster can keep their pressAndHoldAction current (we cannot write
+    -- it ourselves without tainting them). Costs nothing for a character with no
+    -- press-and-hold slots, which is every class but one.
+    if ns.SetBroadcasterPressHoldNeed then ns.SetBroadcasterPressHoldNeed(anyPH) end
     if not changed then return false end
     _bindState.sigValid = true
     -- Pass 2: apply. Reads the routing decisions computed above.
@@ -14091,6 +14201,11 @@ function EAB:FinishSetup()
         -- Redundant kill here as safety net in case Blizzard re-creates them.
         if _G.ActionBarButtonEventsFrame then _G.ActionBarButtonEventsFrame:UnregisterAllEvents() end
         if _G.ActionBarActionEventsFrame then _G.ActionBarActionEventsFrame:UnregisterAllEvents() end
+        -- ...then hand control back to the mode machine. This safety net runs
+        -- after the press-and-hold mode may already have registered, so without
+        -- the resync it silently wipes that registration and the mode check
+        -- believes it is still active, leaving empower keybinds unfixable.
+        if ns.ResyncBroadcaster then ns.ResyncBroadcaster() end
     end)
 
     -- Hook Show on stock bars so they can never re-appear regardless


### PR DESCRIPTION
**Cause:** empower keys ride the native command, so they drive Blizzard's action buttons, not ours (mouse clicks were never affected). We freeze those buttons two ways: `SetParent(hiddenParent)` breaks `useparent-actionpage`, so `self.action` goes stale and Blizzard's `ACTIONBAR_SLOT_CHANGED` gate (`arg1 == 0 or arg1 == tonumber(self.action)`) can never match; and `ActionBarButtonEventsFrame`, the only caller of their `OnEvent`, is killed at load. `pressAndHoldAction` therefore keeps the login spec's answer forever, which is why the login spec always worked and only the other specs' own empowered spell bugged.

**Fix:** stop reparenting those buttons, and give the broadcaster a third ref-counted need that registers `ACTIONBAR_SLOT_CHANGED` + `PLAYER_ENTERING_WORLD` only, for characters that can have press-and-hold spells. Both events are already in the vehicle set, so this is a strict subset of a mode the addon already runs.

**On dropping the reparent,** since it is the line most likely to look risky: it was also doing hiding work, and it is safe to remove because every stock bar is already in `STOCK_BAR_DISPOSAL`, hidden with an `OnShow` re-hide, so a child of one is never drawn. `statehidden` and `Hide` still apply to the buttons themselves. It also removes a taint write, and that is deliberate: we now write nothing to Blizzard's buttons at all. Writing to them taints them, and their own later updates then fail, `ADDON_ACTION_BLOCKED` on `SetAttribute` and `SetCooldown` rejecting secret args. An earlier version of this fix did exactly that and had to be abandoned. Verified in game: no stray Blizzard buttons in any spec, mounted, or in a vehicle.

**Test:** Evoker, all three specs, Press and Hold Casting off. Empowered keybinds hold-and-release correctly after every spec swap, confirmed by dumping `pressAndHoldAction` per slot. Profiler clean on a nameplate sweep, no stray buttons, BugSack clean.

**Perf:** the registered event fires only when a slot actually changes, unlike `ACTIONBAR_UPDATE_COOLDOWN` which fires ~11x/sec at idle and was the one the button silencing was aimed at. Blizzard's handler gates it to a single button per event, and no class but Evoker ever turns it on, so non-Evokers are byte-identical to today.

<img width="245" height="230" alt="game of thrones dance GIF" src="https://github.com/user-attachments/assets/27c614a6-80ca-4712-b37b-eb96f61d3769" />

