### PR TITLE
feat(bags): add a keybind for pinning the item under the cursor

### DIFF
--- a/EllesmereUIBags/Bindings.xml
+++ b/EllesmereUIBags/Bindings.xml
@@ -1,0 +1,5 @@
+<Bindings>
+	<Binding name="EUI_BAGS_PIN_ITEM" header="EUI_BAGS" category="EllesmereUI">
+		EUI_Bags:TogglePinUnderMouse()
+	</Binding>
+</Bindings>

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -1970,6 +1970,73 @@ _itemDragFrame:SetScript("OnUpdate", function(self)
 end)
 
 -------------------------------------------------------------------------------
+--  Pin / category-unassign toggle for a single bag slot. Both input paths land
+--  here (middle-click on the item button, and the "Pin/Unpin Item Under Cursor"
+--  keybind below) so the two can never drift apart.
+-------------------------------------------------------------------------------
+local function TogglePinForSlot(bagID, slotID)
+    if not bagID or not slotID or slotID == 0 then return end
+    local info = C_Container.GetContainerItemInfo(bagID, slotID)
+    if not info or not info.itemID then return end
+    -- If this item has a custom category assignment, the toggle unassigns it
+    local assignments = EllesmereUIDB and EllesmereUIDB.bagItemAssignments
+    if assignments and assignments[info.itemID] then
+        EUI_CategoryManager:UnassignItem(info.itemID)
+        if EUI_Bags.RefreshInventory then EUI_Bags:RefreshInventory() end
+        return
+    end
+    if not EllesmereUIDB then EllesmereUIDB = {} end
+    if not EllesmereUIDB.bagPinnedItems then EllesmereUIDB.bagPinnedItems = {} end
+    local pinned = EllesmereUIDB.bagPinnedItems
+    local itemLink = C_Container.GetContainerItemLink(bagID, slotID)
+    local isGear = IsGearItem(itemLink)
+    local cur = pinned[info.itemID] or 0
+    if isGear then
+        -- Gear: per-stack count toggle
+        if cur > 0 then
+            cur = cur - 1
+            pinned[info.itemID] = cur > 0 and cur or nil
+        else
+            pinned[info.itemID] = cur + 1
+        end
+    else
+        -- Non-gear: pin/unpin all stacks at once
+        if cur > 0 then
+            pinned[info.itemID] = nil
+        else
+            pinned[info.itemID] = 999
+        end
+    end
+    if EUI_Bags.RefreshInventory then EUI_Bags:RefreshInventory() end
+end
+
+-- Keybind entry point (Bindings.xml, auto-loaded from the addon root). Acts on
+-- whatever bag slot the cursor is over, so a mouse whose middle button is
+-- remapped to a keyboard chord -- or that has no middle button at all -- can
+-- still reach pinning. Unbound by default: nothing here runs until the user
+-- assigns a key, and middle-click is untouched.
+--
+-- The hovered button is matched by IDENTITY against the slot pool rather than
+-- by a marker field on the frame. Writing custom keys onto a
+-- ContainerFrameItemButtonTemplate button taints it and gets UseContainerItem()
+-- blocked as ADDON_ACTION_FORBIDDEN (see the PreClick note in GetOrCreateSlot).
+_G.BINDING_HEADER_EUI_BAGS = "EllesmereUI Bags"
+_G.BINDING_NAME_EUI_BAGS_PIN_ITEM = "Pin/Unpin Item Under Cursor"
+
+function EUI_Bags:TogglePinUnderMouse()
+    local foci = (GetMouseFoci and GetMouseFoci()) or (GetMouseFocus and { GetMouseFocus() })
+    if not foci then return end
+    for _, frame in ipairs(foci) do
+        for _, btn in pairs(itemSlots) do
+            if btn == frame then
+                TogglePinForSlot(btn:GetParent():GetID(), btn:GetID())
+                return
+            end
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
 --  Slot Factory (preserved with square icon fix)
 -------------------------------------------------------------------------------
 local function GetOrCreateSlot(idx)
@@ -2022,41 +2089,7 @@ local function GetOrCreateSlot(idx)
 
     btn:HookScript("OnMouseUp", function(self, button)
         if button ~= "MiddleButton" then return end
-        local bagID = self:GetParent():GetID()
-        local slotID = self:GetID()
-        if not bagID or not slotID or slotID == 0 then return end
-        local info = C_Container.GetContainerItemInfo(bagID, slotID)
-        if not info or not info.itemID then return end
-        -- If this item has a custom category assignment, middle-click unassigns it
-        local assignments = EllesmereUIDB and EllesmereUIDB.bagItemAssignments
-        if assignments and assignments[info.itemID] then
-            EUI_CategoryManager:UnassignItem(info.itemID)
-            if EUI_Bags.RefreshInventory then EUI_Bags:RefreshInventory() end
-            return
-        end
-        if not EllesmereUIDB then EllesmereUIDB = {} end
-        if not EllesmereUIDB.bagPinnedItems then EllesmereUIDB.bagPinnedItems = {} end
-        local pinned = EllesmereUIDB.bagPinnedItems
-        local itemLink = C_Container.GetContainerItemLink(bagID, slotID)
-        local isGear = IsGearItem(itemLink)
-        local cur = pinned[info.itemID] or 0
-        if isGear then
-            -- Gear: per-stack count toggle
-            if cur > 0 then
-                cur = cur - 1
-                pinned[info.itemID] = cur > 0 and cur or nil
-            else
-                pinned[info.itemID] = cur + 1
-            end
-        else
-            -- Non-gear: pin/unpin all stacks at once
-            if cur > 0 then
-                pinned[info.itemID] = nil
-            else
-                pinned[info.itemID] = 999
-            end
-        end
-        if EUI_Bags.RefreshInventory then EUI_Bags:RefreshInventory() end
+        TogglePinForSlot(self:GetParent():GetID(), self:GetID())
     end)
 
     -- Shift-click split hint: when the user shift-clicks an item while

--- a/EllesmereUIBags/EllesmereUIBags.toc
+++ b/EllesmereUIBags/EllesmereUIBags.toc
@@ -16,3 +16,8 @@ EUI_Bags_Options.lua
 EllesmereUIBags_Categories.lua
 EllesmereUIBags.lua
 EllesmereUIBags_Bank.lua
+
+# Note: Bindings.xml (the Pin/Unpin Item Under Cursor command) is intentionally
+# NOT listed here -- WoW auto-loads a file named Bindings.xml from the addon
+# root. Listing it would load it a second time through the UI-XML parser
+# ("Unrecognized XML: Binding").


### PR DESCRIPTION
**What:** pinning an item, and unassigning one from a custom category, was reachable only by middle-clicking it. A mouse whose middle button is remapped to a keyboard chord, or that has no middle button at all, could not reach the feature and had no workaround.

**Fix:** a `Bindings.xml` command, "Pin/Unpin Item Under Cursor", acting on the bag slot under the cursor. Unbound by default and middle-click is untouched, so nothing changes for anyone who did not ask for it; both paths now call one shared `TogglePinForSlot` helper so they cannot drift apart. The hovered button is matched by identity against the slot pool rather than by a marker field, since writing custom keys onto a `ContainerFrameItemButtonTemplate` button taints it and gets `UseContainerItem()` blocked.

**Test:** verified in game. `luac -p`, XML parse, diff-scoped style check and locale-key regeneration are all clean; no new locale keys, matching how Action Bars and Action Palette name their bindings.

**Note:** no `_WHATSNEW_PATCHES` entry, left for the release commit to own.
