### PR TITLE
fix(unitframes): make Frame Strata per-frame for player/target/focus

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -4964,7 +4964,7 @@ initFrame:SetScript("OnEvent", function(self)
               getValue=function() return "_placeholder" end,
               setValue=function() end },
             { type="dropdown", text="Frame Strata",
-              tooltip="Controls the order that overlapping elements display in. Set higher to show above other elements. Applies to the selected frame only.",
+              tooltip="Controls the order that overlapping elements display in. Set higher to show above other elements.",
               values = ufStrataValues, order = ufStrataOrder,
               getValue=function() return SGet("frameStrata") or db.profile.frameStrata or "MEDIUM" end,
               setValue=function(v) SSet("frameStrata", v) end });  y = y - h
@@ -12504,6 +12504,26 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUI.RegisterWidgetRefresh(function() updHover(); updTarget(); UpdateHBSwatchVis() end)
                 UpdateHBSwatchVis()
             end
+        end
+
+        -- DISPLAY bottom row for boss: the mini frames carry their Strata
+        -- override in the Bar Texture row's right slot, which boss spends on
+        -- Hover Borders, so boss gets its own row here. Without it nothing in
+        -- the UI writes a boss strata at all -- the main frames' dropdown is
+        -- per-frame and the profile-wide value is only the fallback.
+        if unitKey == "boss" then
+            local bossStrataValues = EllesmereUI.FRAME_STRATA_LABELS
+            local bossStrataOrder = EllesmereUI.FRAME_STRATA_ORDER_BASE
+            _, h = W:DualRow(parent, y,
+                { type="dropdown", text="Strata",
+                  tooltip="Overrides the Frame Strata set in the main frames for this frame only. Controls the order that overlapping frames display in; set higher to show above other frames.",
+                  values = bossStrataValues, order = bossStrataOrder,
+                  getValue=function() return settingsTable.frameStrata or db.profile.frameStrata or "MEDIUM" end,
+                  setValue=function(v)
+                      settingsTable.frameStrata = v
+                      ReloadAndUpdate()
+                  end },
+                { type="label", text="" });  y = y - h
         end
 
         -- DISPLAY bottom row: per-frame Border Size override for ToT / Focus

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -4964,13 +4964,10 @@ initFrame:SetScript("OnEvent", function(self)
               getValue=function() return "_placeholder" end,
               setValue=function() end },
             { type="dropdown", text="Frame Strata",
-              tooltip="Controls the order that overlapping elements display in. Set higher to show above other elements.",
+              tooltip="Controls the order that overlapping elements display in. Set higher to show above other elements. Applies to the selected frame only.",
               values = ufStrataValues, order = ufStrataOrder,
-              getValue=function() return db.profile.frameStrata or "MEDIUM" end,
-              setValue=function(v)
-                  db.profile.frameStrata = v
-                  ReloadAndUpdate()
-              end });  y = y - h
+              getValue=function() return SGet("frameStrata") or db.profile.frameStrata or "MEDIUM" end,
+              setValue=function(v) SSet("frameStrata", v) end });  y = y - h
 
         -- Show Tooltip For checkbox-dropdown (left region)
         if not EllesmereUI._prebuilding then
@@ -5046,6 +5043,44 @@ initFrame:SetScript("OnEvent", function(self)
             if strataRgn then
                 MakeCogBtn(strataRgn, cogShow)
             end
+        end
+
+        -- Sync icon: Frame Strata (right region) -- pushes this unit's strata to
+        -- the other main frames. Each frame keeps its own value; unset frames
+        -- fall back to the profile-wide default.
+        if not EllesmereUI._prebuilding then
+            local rgn = tipStrataRow._rightRegion
+            local function CurStrata(key)
+                return UNIT_DB_MAP[key]().frameStrata or db.profile.frameStrata or "MEDIUM"
+            end
+            local function ApplyStrataTo(keys)
+                local strata = CurStrata(selectedUnit)
+                for _, key in ipairs(keys) do
+                    if key ~= selectedUnit then
+                        UNIT_DB_MAP[key]().frameStrata = strata
+                    end
+                end
+                ReloadAndUpdate(); EllesmereUI:RefreshPage()
+            end
+            EllesmereUI.BuildSyncIcon({
+                region  = rgn,
+                tooltip = "Apply Frame Strata to all Frames",
+                onClick = function() ApplyStrataTo(GROUP_UNIT_ORDER) end,
+                isSynced = function()
+                    local cur = CurStrata(selectedUnit)
+                    for _, key in ipairs(GROUP_UNIT_ORDER) do
+                        if CurStrata(key) ~= cur then return false end
+                    end
+                    return true
+                end,
+                flashTargets = function() return { rgn } end,
+                multiApply = {
+                    elementKeys   = GROUP_UNIT_ORDER,
+                    elementLabels = SHORT_LABELS,
+                    getCurrentKey = function() return selectedUnit end,
+                    onApply       = function(checkedKeys) ApplyStrataTo(checkedKeys) end,
+                },
+            })
         end
 
         -- Show Decimal on Health Text (global): one decimal on health value

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -9213,9 +9213,13 @@ local function ReloadFrames()
         if type(frame) == "table" and frame.SetFrameStrata then
             -- Any unit with its own settings table can override the global
             -- strata; nil (the default) means "follow the global value".
+            -- GetSettingsForUnit maps boss1..boss5 onto the shared boss table
+            -- and falls back to the player's settings, which is what the
+            -- non-unit entries in `frames` (the class power bar above all)
+            -- should ride with anyway.
             local strata = ufStrata
-            local us = profile[unitKey]
-            if type(us) == "table" and us.frameStrata then strata = us.frameStrata end
+            local us = GetSettingsForUnit(unitKey)
+            if us and us.frameStrata then strata = us.frameStrata end
             frame:SetFrameStrata(strata)
             -- Re-apply or reset custom strata for detached bars
             if frame.BottomTextBar and frame.BottomTextBar._isDetached then
@@ -12820,10 +12824,12 @@ function InitializeFrames()
     for unitKey, frame in pairs(frames) do
         if type(frame) == "table" and frame.SetFrameStrata then
             -- Any unit with its own settings table can override the global
-            -- strata; nil (the default) means "follow the global value".
+            -- strata; nil (the default) means "follow the global value". See
+            -- the matching comment in the other frameStrata-apply pass for why
+            -- this resolves through GetSettingsForUnit.
             local strata = ufStrata
-            local us = db.profile[unitKey]
-            if type(us) == "table" and us.frameStrata then strata = us.frameStrata end
+            local us = GetSettingsForUnit(unitKey)
+            if us and us.frameStrata then strata = us.frameStrata end
             frame:SetFrameStrata(strata)
             if frame.BottomTextBar and frame.BottomTextBar._isDetached then
                 if db.profile.enableCustomBarStratas then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -9211,12 +9211,11 @@ local function ReloadFrames()
     local ufStrata = profile.frameStrata or "MEDIUM"
     for unitKey, frame in pairs(frames) do
         if type(frame) == "table" and frame.SetFrameStrata then
-            -- Mini frames (ToT / Focus Target / Pet) can override the global strata.
+            -- Any unit with its own settings table can override the global
+            -- strata; nil (the default) means "follow the global value".
             local strata = ufStrata
-            if unitKey == "targettarget" or unitKey == "focustarget" or unitKey == "pet" then
-                local us = profile[unitKey]
-                if us and us.frameStrata then strata = us.frameStrata end
-            end
+            local us = profile[unitKey]
+            if type(us) == "table" and us.frameStrata then strata = us.frameStrata end
             frame:SetFrameStrata(strata)
             -- Re-apply or reset custom strata for detached bars
             if frame.BottomTextBar and frame.BottomTextBar._isDetached then
@@ -12820,12 +12819,11 @@ function InitializeFrames()
     local ufStrata = db.profile.frameStrata or "MEDIUM"
     for unitKey, frame in pairs(frames) do
         if type(frame) == "table" and frame.SetFrameStrata then
-            -- Mini frames (ToT / Focus Target / Pet) can override the global strata.
+            -- Any unit with its own settings table can override the global
+            -- strata; nil (the default) means "follow the global value".
             local strata = ufStrata
-            if unitKey == "targettarget" or unitKey == "focustarget" or unitKey == "pet" then
-                local us = db.profile[unitKey]
-                if us and us.frameStrata then strata = us.frameStrata end
-            end
+            local us = db.profile[unitKey]
+            if type(us) == "table" and us.frameStrata then strata = us.frameStrata end
             frame:SetFrameStrata(strata)
             if frame.BottomTextBar and frame.BottomTextBar._isDetached then
                 if db.profile.enableCustomBarStratas then


### PR DESCRIPTION
**Cause:** Main Frame Settings is a per-unit page (every control reads/writes the selected unit's table), but the Frame Strata dropdown read and wrote the single profile-wide `frameStrata`. Setting it on Player moved Target and Focus with it.

**Fix:** The dropdown now writes the selected unit's `frameStrata`, falling back to the profile-wide value when unset, so existing profiles behave exactly as before. Both runtime apply passes resolve through `GetSettingsForUnit`, which also reaches boss1..boss5 (a raw `profile[unitKey]` never did) and keeps the class power bar on the player frame's strata. Added the usual Apply to All / Multiple sync icon, plus a Strata dropdown on the Boss page since the main frames' control no longer sets a value boss could follow.

**Test:** Set Frame Strata to HIGH on Player, confirm Target and Focus still read MEDIUM and the frames stack accordingly; Apply to All pushes one value to the three; Boss Frames > DISPLAY > Strata moves the boss frames; ToT/Focus Target/Pet overrides unchanged.

<img width="400" height="400" alt="chip GIF" src="https://github.com/user-attachments/assets/9477f604-e71a-45e5-9cce-f6b75994bdeb" />
