### PR TITLE
fix(unitframes): 2D portraits go blank after a loading screen

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2882,6 +2882,15 @@ local function PortraitOverride(self, event, evtUnit)
         -- stays the same; repaint once per zone so 3D portraits never come
         -- back blank.
         or event == "PLAYER_ENTERING_WORLD"
+        -- The repaint above runs mid-loading-screen, where SetPortraitTexture
+        -- has no portrait art to hand back yet and paints a blank one. The
+        -- client fires PORTRAITS_UPDATED once that art is ready, and it is the
+        -- only trigger that follows: the guid and the availability state both
+        -- come back unchanged, so without this the blank is what the gate
+        -- caches until the next reload. Blizzard's own player portrait (the
+        -- character micro button) re-runs SetPortraitTexture on the same event
+        -- for the same reason.
+        or event == "PORTRAITS_UPDATED"
     if hasStateChanged then
         if element:IsObjectType("PlayerModel") then
             if not isAvailable then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2873,6 +2873,7 @@ local function PortraitOverride(self, event, evtUnit)
     else
         changed = element.guid ~= guid
     end
+    local isModel = element:IsObjectType("PlayerModel")
     local hasStateChanged = changed
         or element.state ~= isAvailable
         or event == "UNIT_PORTRAIT_UPDATE"
@@ -2889,10 +2890,12 @@ local function PortraitOverride(self, event, evtUnit)
         -- come back unchanged, so without this the blank is what the gate
         -- caches until the next reload. Blizzard's own player portrait (the
         -- character micro button) re-runs SetPortraitTexture on the same event
-        -- for the same reason.
-        or event == "PORTRAITS_UPDATED"
+        -- for the same reason. 2D only: the event says portrait ART is ready,
+        -- which the model path does not read, and repainting it would mean a
+        -- ClearModel + SetUnit reload every time the client streams a batch.
+        or (event == "PORTRAITS_UPDATED" and not isModel)
     if hasStateChanged then
-        if element:IsObjectType("PlayerModel") then
+        if isModel then
             if not isAvailable then
                 element:SetCamDistanceScale(0.25)
                 element:SetPortraitZoom(0)
@@ -13400,6 +13403,35 @@ function InitializeFrames()
             if ct then
                 local classStyle = (uSettings and uSettings.classThemeStyle) or "modern"
                 ApplyClassIconTexture(backdrop._class, ct, classStyle)
+            end
+        end
+    end)
+
+    ---------------------------------------------------------------------------
+    --  Portrait art readiness for the OnUpdate-polled frames (Target of Target
+    --  / Focus Target). PORTRAITS_UPDATED is how the client says portrait art
+    --  finished loading, and PortraitOverride acts on it -- but the event is
+    --  never registered on these frames: once __eventless is set, the unit
+    --  frame library's RegisterEvent drops everything except
+    --  UNIT_PORTRAIT_UPDATE and UNIT_MODEL_CHANGED. PLAYER_ENTERING_WORLD
+    --  still reaches them (UpdateAllElements pushes it to every element), so
+    --  they take the mid-loading blank paint with nothing to heal it: the poll
+    --  just re-runs the same guid-gated Override. ForceUpdate is the trigger
+    --  that gate always honors. 2D only -- a PlayerModel does not read portrait
+    --  art, and repainting one costs a ClearModel + SetUnit reload.
+    ---------------------------------------------------------------------------
+    if not frames._portraitArtUpdater then
+        frames._portraitArtUpdater = CreateFrame("Frame")
+        frames._portraitArtUpdater:RegisterEvent("PORTRAITS_UPDATED")
+    end
+    frames._portraitArtUpdater:SetScript("OnEvent", function()
+        for _, frame in pairs(frames) do
+            if type(frame) == "table" and frame.__eventless and frame.IsElementEnabled then
+                local p = frame.Portrait
+                if p and p.ForceUpdate and not p:IsObjectType("PlayerModel")
+                    and frame:IsElementEnabled("Portrait") then
+                    p:ForceUpdate()
+                end
             end
         end
     end)


### PR DESCRIPTION
**Cause:** The portrait Override repaints on `PLAYER_ENTERING_WORLD` so 3D portraits do not return blank from a world transition, but for 2D that repaint lands mid-loading-screen, where `SetPortraitTexture` has no art yet and paints a blank. It then caches the guid and availability state, which both come back unchanged, so nothing repaints again and the blank survives until the next reload.

**Fix:** Treat `PORTRAITS_UPDATED` (the client's "portrait art is ready" event, which oUF already registers) as a state change, the same way Blizzard's character micro button re-runs `SetPortraitTexture` on it for the player's own portrait. Gated to the 2D texture path so 3D portraits are not reloaded on every fire. Target of Target and Focus Target are `__eventless`, so the library never registers the event on them; they get an addon-side watcher that `ForceUpdate`s their portraits.

**Test:** Verified in game. Player portrait, detached style + 2D mode, survives zone changes, instance entry and hearths; 3D portraits unchanged.

<img width="480" height="476" alt="Lock In Cat GIF" src="https://github.com/user-attachments/assets/e2d5b8e0-1e5a-4f8a-bc23-b89aab47444c" />
