### PR TITLE
fix(cdm): a hand-added potion rank tracks only that rank

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -4833,6 +4833,23 @@ end
 -- Options toggle: force every pot frame to re-resolve on the next pass.
 ns._BumpPotResolveGen = PotSwap.Bump
 
+-- True when this frame IS the preset rather than one specific variant of it.
+-- The picker only ever stores -(preset.itemID), so a frame sitting on an ALT id
+-- can only have come from the user typing that exact item id into Custom Item
+-- ID -- they asked for that rank, not for the family.
+-- Frames still carry _presetData either way: the preset icon and the keybind
+-- fallback (which deliberately answers across ranks) want it. Only the
+-- family-wide reads below are primary-only -- summing the family's bag counts
+-- made a hand-added rank-2 pot report its rank-1 siblings as its own count,
+-- point _itemCdSource at a sibling's cooldown and, with Hide Items if Missing
+-- on, stay on the bar while the user owned none of it. Two such entries then
+-- showed the same count off the same art (ranks share an icon), which reads as
+-- one pot tracked twice. Mirrors PotSwap.Ensure's own primary check.
+local function IsPresetFamilyFrame(f)
+    local pd = f and f._presetData
+    return (pd and pd.altItemIDs and f._presetItemID == pd.itemID) and true or false
+end
+
 -- Guard: after ENCOUNTER_END clears item-preset caches, subsequent events
 -- fire before Blizzard has finished resetting potion CDs. Without this guard
 -- the update loop re-caches stale cooldown data from C_Item.GetItemCooldown.
@@ -5190,7 +5207,7 @@ local function ProcessPresetCooldowns()
                     f._countArm = false
                     total = C_Item.GetItemCount(f._presetItemID, false, true) or 0
                     local owned = total > 0 and f._presetItemID or nil
-                    if total == 0 and f._presetData and f._presetData.altItemIDs then
+                    if total == 0 and IsPresetFamilyFrame(f) then
                         for _, altID in ipairs(f._presetData.altItemIDs) do
                             local c = C_Item.GetItemCount(altID, false, true) or 0
                             total = total + c
@@ -5271,7 +5288,7 @@ local function CheckItemPresenceForHide()
                     total = f._displayCount or 0
                 else
                     total = C_Item.GetItemCount(f._presetItemID, false, true) or 0
-                    if total == 0 and f._presetData and f._presetData.altItemIDs then
+                    if total == 0 and IsPresetFamilyFrame(f) then
                         for _, altID in ipairs(f._presetData.altItemIDs) do
                             total = total + (C_Item.GetItemCount(altID, false, true) or 0)
                         end
@@ -6152,7 +6169,7 @@ local function CollectAndReanchor()
                                         total = f._displayCount or 0
                                     else
                                         total = C_Item.GetItemCount(itemID, false, true) or 0
-                                        if total == 0 and f._presetData and f._presetData.altItemIDs then
+                                        if total == 0 and IsPresetFamilyFrame(f) then
                                             for _, altID in ipairs(f._presetData.altItemIDs) do
                                                 total = total + (C_Item.GetItemCount(altID, false, true) or 0)
                                             end
@@ -6705,7 +6722,7 @@ local function CollectAndReanchor()
                                         total = f._displayCount or 0
                                     else
                                         total = C_Item.GetItemCount(itemID, false, true) or 0
-                                        if total == 0 and f._presetData and f._presetData.altItemIDs then
+                                        if total == 0 and IsPresetFamilyFrame(f) then
                                             for _, altID in ipairs(f._presetData.altItemIDs) do
                                                 total = total + (C_Item.GetItemCount(altID, false, true) or 0)
                                             end


### PR DESCRIPTION
**Cause:** Item frames match their id against every preset *including* the presets' `altItemIDs`, then read the whole family wherever a count is needed. The picker only ever stores `-(preset.itemID)`, so a frame on an alt id can only have come from Custom Item ID -- the user asked for one rank and got the family: the bag count summed its siblings, `_itemCdSource` followed a sibling's cooldown, and Hide Items if Missing read the siblings as presence and kept the entry on the bar with none owned. Add rank 1 and rank 2 as custom items and both report the rank you happen to own, off the same art.

**Fix:** Gate the family-wide reads on the frame actually being the preset, mirroring the primary check `PotSwap.Ensure` already makes. Picker-added presets are unchanged, and `_presetData` still hangs on every frame: the preset icon and the keybind fallback answer across ranks on purpose.

**Test:** Verified in game. With no rank 2 in bags and several rank 1, both added via Custom Item ID and Hide Items if Missing on: the rank 2 entry now hides and the rank 1 entry counts only rank 1. Picker-added potion presets still resolve across ranks.

<img width="480" height="360" alt="Studying Locked In GIF" src="https://github.com/user-attachments/assets/22d5164d-0688-4f36-accf-555c1cea0439" />
