### PR TITLE
UnitFrames: Fill Color modes with value-based health coloring

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Options.lua
@@ -1009,13 +1009,25 @@ initFrame:SetScript("OnEvent", function(self)
             -- Boss preview always renders as hostile-red since the real boss
             -- frame never class-colors (no player class).
             local cFill = settings.customFillColor
-            local isClassColored = settings.healthClassColored and unitKey ~= "boss"
-            if isClassColored then
+            local fillMode = ns.GetUnitHealthColorMode(settings)
+            -- The mini/pet frames have no mode dropdown and resolve "class" as
+            -- the fallback, so their class preview still follows the raw
+            -- healthClassColored key (pet defaults to the green fallback and
+            -- ToT/FoT to hostile red, matching their live frames).
+            local isSharedUnit = unitKey == "player" or unitKey == "target" or unitKey == "focus"
+            local isClassColored = fillMode == "class" and unitKey ~= "boss"
+                and (isSharedUnit or settings.healthClassColored)
+            if fillMode == "classic" or fillMode == "customDynamic" then
+                -- Value-based fill at the preview's fake health percent.
+                hR, hG, hB = ns.ResolveHealthByValueColor(
+                    fillMode == "classic" and ns.UF_CLASSIC_STOPS or settings,
+                    _previewHealthPct or 0.70)
+            elseif isClassColored then
                 local _, classToken = UnitClass("player")
                 local cc = RAID_CLASS_COLORS[classToken]
                 if cc then hR, hG, hB = cc.r, cc.g, cc.b
                 else hR, hG, hB = 37/255, 193/255, 29/255 end
-            elseif cFill then
+            elseif fillMode == "custom" and cFill then
                 hR, hG, hB = cFill.r, cFill.g, cFill.b
             elseif unitKey == "player" then
                 local _, classToken = UnitClass("player")
@@ -1077,7 +1089,7 @@ initFrame:SetScript("OnEvent", function(self)
         healthFill:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
         healthFill:SetPoint("BOTTOMLEFT", health, "BOTTOMLEFT", 0, 0)
         healthFill:SetWidth(math.floor(frameW * (_previewHealthPct or 0.70) + 0.5))
-        PV_FillColor(healthFill, nil, hR, hG, hB, (not isDarkTheme) and settings.gradientEnabled, settings.gradientColor, settings.gradientDir, hA)
+        PV_FillColor(healthFill, nil, hR, hG, hB, (not isDarkTheme) and settings.gradientEnabled and not ns.UF_IsCurveMode(settings), settings.gradientColor, settings.gradientDir, hA)
         healthFill:SetAlpha(hA)
         pf._healthFill = healthFill
         pf._hR, pf._hG, pf._hB, pf._hA = hR, hG, hB, hA
@@ -1436,7 +1448,7 @@ initFrame:SetScript("OnEvent", function(self)
             local texPath = (ns.healthBarTextures or {})[texKey]
 
             if texPath then
-                PV_FillColor(healthFill, texPath, hR, hG, hB, (not isDarkTheme) and settings.gradientEnabled, settings.gradientColor, settings.gradientDir, hA)
+                PV_FillColor(healthFill, texPath, hR, hG, hB, (not isDarkTheme) and settings.gradientEnabled and not ns.UF_IsCurveMode(settings), settings.gradientColor, settings.gradientDir, hA)
             end
             if pf._powerFill and powerH > 0 then
                 local txR, txG, txB
@@ -2385,13 +2397,24 @@ initFrame:SetScript("OnEvent", function(self)
                     -- Boss preview always renders as hostile-red since the real
                     -- boss frame never class-colors (no player class).
                     local cFill = s.customFillColor
-                    local isCC = s.healthClassColored and unitKey ~= "boss"
-                    if isCC then
+                    local uMode = ns.GetUnitHealthColorMode(s)
+                    -- Mini/pet frames resolve "class" as the fallback but keep
+                    -- following the raw healthClassColored key (see the static
+                    -- preview builder).
+                    local uShared = unitKey == "player" or unitKey == "target" or unitKey == "focus"
+                    local isCC = uMode == "class" and unitKey ~= "boss"
+                        and (uShared or s.healthClassColored)
+                    if uMode == "classic" or uMode == "customDynamic" then
+                        -- Value-based fill at the preview's fake health percent.
+                        uHR, uHG, uHB = ns.ResolveHealthByValueColor(
+                            uMode == "classic" and ns.UF_CLASSIC_STOPS or s,
+                            _previewHealthPct or 0.70)
+                    elseif isCC then
                         local _, ct = UnitClass("player")
                         local cc = RAID_CLASS_COLORS[ct]
                         if cc then uHR, uHG, uHB = cc.r, cc.g, cc.b
                         else uHR, uHG, uHB = 37/255, 193/255, 29/255 end
-                    elseif cFill then
+                    elseif uMode == "custom" and cFill then
                         uHR, uHG, uHB = cFill.r, cFill.g, cFill.b
                     elseif unitKey == "player" then
                         local _, ct = UnitClass("player")
@@ -2455,7 +2478,7 @@ initFrame:SetScript("OnEvent", function(self)
                     if healthFill then
                         local hGA = s.healthBarOpacity or 90
                         if hGA > 1.0 then hGA = hGA / 100 end
-                        PV_FillColor(healthFill, curTexPath, uHR, uHG, uHB, (not isDark) and s.gradientEnabled, s.gradientColor, s.gradientDir, hGA)
+                        PV_FillColor(healthFill, curTexPath, uHR, uHG, uHB, (not isDark) and s.gradientEnabled and not ns.UF_IsCurveMode(s), s.gradientColor, s.gradientDir, hGA)
                     end
                     if pf._powerFill then
                         local pvFR, pvFG, pvFB
@@ -5860,78 +5883,117 @@ initFrame:SetScript("OnEvent", function(self)
             })
         end
 
-        -- Row 2: Bar Color (multiSwatch) + Bar Background (slider + inline swatch)
+        -- Row 2: Fill Color (mode dropdown + inline swatches) + Bar Background
+        -- (slider + inline swatch). The dropdown mirrors the Raid Frames Fill
+        -- Color modes minus "dark" -- Dark Mode stays this module's master
+        -- toggle and overrides the whole row.
         local sharedHealthColorRow
         sharedHealthColorRow, h = W:DualRow(parent, y,
-            { type="multiSwatch", text="Fill Color",
-              swatches = {
-                { tooltip = "Gradient End Color", hasAlpha = false,
-                  disabled = function() return not SVal("gradientEnabled", false) end,
-                  disabledTooltip = function() return "Gradient" end,
-                  getValue = function()
-                      local c = SGet("gradientColor")
-                      if c then return c.r, c.g, c.b end
-                      return 0.20, 0.20, 0.80
-                  end,
-                  setValue = function(r, g, b)
-                      UNIT_DB_MAP[selectedUnit]().gradientColor = { r=r, g=g, b=b }
-                      ReloadAndUpdate(); UpdatePreview()
-                  end },
-                { tooltip = "Custom Colored Fill",
-                  hasAlpha = false,
-                  getValue = function()
-                      local c = SGet("customFillColor")
-                      if c then return c.r, c.g, c.b end
-                      return 37/255, 193/255, 29/255
-                  end,
-                  setValue = function(r, g, b)
-                      UNIT_DB_MAP[selectedUnit]().customFillColor = { r=r, g=g, b=b }
-                      ReloadAndUpdate(); UpdatePreview()
-                  end,
-                  onClick = function(self)
-                      if SVal("healthClassColored", true) then
-                          -- Seed the custom fill with the swatch's default the first
-                          -- time, so the bar shows it immediately. Without a stored
-                          -- customFillColor the runtime falls back to oUF's class/
-                          -- reaction color, so the bar looked unchanged until the
-                          -- color picker was dragged ("jump start"). Only seeds when
-                          -- unset, so it never clobbers an existing custom color.
-                          if SGet("customFillColor") == nil then
-                              UNIT_DB_MAP[selectedUnit]().customFillColor = { r = 37/255, g = 193/255, b = 29/255 }
-                          end
-                          SSet("healthClassColored", false)
-                          UpdatePreview()
-                          EllesmereUI:RefreshPage()
-                          return
-                      end
-                      if self._eabOrigClick then self._eabOrigClick(self) end
-                  end,
-                  refreshAlpha = function()
-                      return SVal("healthClassColored", true) and 0.3 or 1
-                  end },
-                { tooltip = "Class Colored Fill",
-                  hasAlpha = false,
-                  getValue = function()
-                      local _, ct = UnitClass("player")
-                      if ct and RAID_CLASS_COLORS[ct] then
-                          local cc = RAID_CLASS_COLORS[ct]
-                          return cc.r, cc.g, cc.b
-                      end
-                      return 1, 1, 1
-                  end,
-                  setValue = function() end,
-                  onClick = function()
-                      SSet("healthClassColored", true)
-                      UpdatePreview()
-                      EllesmereUI:RefreshPage()
-                  end,
-                  refreshAlpha = function()
-                      return SVal("healthClassColored", true) and 1 or 0.3
-                  end },
-              } },
+            { type="dropdown", text="Fill Color",
+              values={ ["class"]="Class Color", ["classic"]="Classic",
+                       ["custom"]="Custom Color", ["customDynamic"]="Custom Dynamic Colors" },
+              order={ "class", "classic", "custom", "customDynamic" },
+              tooltip="Custom Dynamic Colors: the health bar smoothly blends between three colors you pick -- one for full health (100%), one for half (50%), and one for empty (0%) -- shifting through them as the unit takes damage or is healed. Classic uses the standard green / yellow / red blend.",
+              getValue=function() return ns.GetUnitHealthColorMode(UNIT_DB_MAP[selectedUnit]()) end,
+              setValue=function(v)
+                  local d = UNIT_DB_MAP[selectedUnit]()
+                  d.healthColorMode = v
+                  -- Seed the custom fill with the swatch's default the first
+                  -- time, so the bar shows it immediately. Without a stored
+                  -- customFillColor the runtime falls back to the class/
+                  -- reaction color, so the bar looked unchanged until the
+                  -- color picker was dragged ("jump start"). Only seeds when
+                  -- unset, so it never clobbers an existing custom color.
+                  if v == "custom" and d.customFillColor == nil then
+                      d.customFillColor = { r = 37/255, g = 193/255, b = 29/255 }
+                  end
+                  ReloadAndUpdate(); UpdatePreview(); EllesmereUI:RefreshPage()
+              end },
             { type="slider", text="Bar Background", min=0, max=100, step=1,
               getValue=function() return SVal("customBgAlpha", 100) end,
               setValue=function(v) SSet("customBgAlpha", v); ReloadAndUpdate(); UpdatePreview() end });  y = y - h
+        -- Inline swatches on Fill Color (left region): a single custom-color
+        -- swatch (Custom Color mode) and the three Custom Dynamic Colors stop
+        -- swatches (100% / 50% / 0%). The sets share the same inline slot;
+        -- visibility follows the dropdown mode.
+        if not EllesmereUI._prebuilding then
+            local rgn = sharedHealthColorRow._leftRegion
+            local fillSw, fillSwUpdate = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5,
+                function()
+                    local c = SGet("customFillColor")
+                    if c then return c.r, c.g, c.b, 1 end
+                    return 37/255, 193/255, 29/255, 1
+                end,
+                function(r, g, b)
+                    UNIT_DB_MAP[selectedUnit]().customFillColor = { r=r, g=g, b=b }
+                    ReloadAndUpdate(); UpdatePreview()
+                end, false, 20)
+            fillSw:HookScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(fillSw, "Custom Colored Fill") end)
+            fillSw:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            PP.Point(fillSw, "RIGHT", rgn._control, "LEFT", -8, 0)
+            -- Blocking overlay: dim + non-clickable + tooltip unless Fill Color is Custom.
+            local fillSwBlock = CreateFrame("Frame", nil, fillSw)
+            fillSwBlock:SetAllPoints()
+            fillSwBlock:SetFrameLevel(fillSw:GetFrameLevel() + 10)
+            fillSwBlock:EnableMouse(true)
+            fillSwBlock:SetScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(fillSw, "Only available with Custom fill color") end)
+            fillSwBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+            -- Custom Dynamic Colors stop swatches, built right-to-left from the
+            -- dropdown control so the visual order reads 100% | 50% | 0%.
+            local dynDefs = {
+                { key = "dynamicColor100", def = { r = 0, g = 1, b = 0 }, tip = "Health bar color at full (100%) health" },
+                { key = "dynamicColor50",  def = { r = 1, g = 1, b = 0 }, tip = "Health bar color at half (50%) health" },
+                { key = "dynamicColor0",   def = { r = 1, g = 0, b = 0 }, tip = "Health bar color at empty (0%) health" },
+            }
+            local dynSwatches, dynUpdates = {}, {}
+            local prevAnchor = rgn._control
+            for i = #dynDefs, 1, -1 do
+                local dd = dynDefs[i]
+                local sw, swUpdate = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5,
+                    function()
+                        local c = SGet(dd.key) or dd.def
+                        return c.r, c.g, c.b, 1
+                    end,
+                    function(r, g, b)
+                        UNIT_DB_MAP[selectedUnit]()[dd.key] = { r=r, g=g, b=b }
+                        ReloadAndUpdate(); UpdatePreview()
+                    end, false, 18)
+                PP.Point(sw, "RIGHT", prevAnchor, "LEFT", (prevAnchor == rgn._control) and -8 or -6, 0)
+                sw:HookScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(sw, dd.tip) end)
+                sw:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                dynSwatches[i] = sw
+                dynUpdates[i] = swUpdate
+                prevAnchor = sw
+            end
+            -- Later inline widgets (the gradient cog) anchor left of the widest
+            -- set so they never overlap the stop swatches.
+            rgn._lastInline = prevAnchor
+
+            local function UpdateFillSwatchVis()
+                local mode = ns.GetUnitHealthColorMode(UNIT_DB_MAP[selectedUnit]())
+                local isDynamic = mode == "customDynamic"
+                -- Single custom swatch: active only in Custom mode; dimmed +
+                -- blocked in other modes, fully hidden in Dynamic mode so it
+                -- does not sit behind the stop swatches.
+                if isDynamic then
+                    fillSw:Hide(); fillSwBlock:Hide()
+                else
+                    fillSw:Show()
+                    if mode == "custom" then fillSw:SetAlpha(1); fillSwBlock:Hide()
+                    else fillSw:SetAlpha(0.3); fillSwBlock:Show() end
+                end
+                for _, sw in ipairs(dynSwatches) do
+                    if isDynamic then sw:Show() else sw:Hide() end
+                end
+            end
+            RegisterWidgetRefresh(function()
+                fillSwUpdate()
+                for _, u in ipairs(dynUpdates) do u() end
+                UpdateFillSwatchVis()
+            end)
+            UpdateFillSwatchVis()
+        end
         -- Inline color swatches on Bar Background (right region): a Custom + Class
         -- pair mirroring the Bar Color picker. Clicking either toggles bgClassColored;
         -- the inactive one dims to 0.3 (matches the fill swatch behavior).
@@ -6046,9 +6108,14 @@ initFrame:SetScript("OnEvent", function(self)
                 local gEn = src.gradientEnabled or false
                 local gDir = src.gradientDir or "HORIZONTAL"
                 local gc = src.gradientColor
+                local mode = ns.GetUnitHealthColorMode(src)
+                local d100 = src.dynamicColor100
+                local d50 = src.dynamicColor50
+                local d0 = src.dynamicColor0
                 for _, key in ipairs(keys) do
                     if key ~= selectedUnit then
                         local d = UNIT_DB_MAP[key]()
+                        d.healthColorMode = mode
                         d.healthClassColored = cc
                         if fc then d.customFillColor = { r=fc.r, g=fc.g, b=fc.b }
                         else d.customFillColor = nil end
@@ -6056,6 +6123,12 @@ initFrame:SetScript("OnEvent", function(self)
                         d.gradientDir = gDir
                         if gc then d.gradientColor = { r=gc.r, g=gc.g, b=gc.b }
                         else d.gradientColor = nil end
+                        if d100 then d.dynamicColor100 = { r=d100.r, g=d100.g, b=d100.b }
+                        else d.dynamicColor100 = nil end
+                        if d50 then d.dynamicColor50 = { r=d50.r, g=d50.g, b=d50.b }
+                        else d.dynamicColor50 = nil end
+                        if d0 then d.dynamicColor0 = { r=d0.r, g=d0.g, b=d0.b }
+                        else d.dynamicColor0 = nil end
                     end
                 end
                 ReloadAndUpdate(); EllesmereUI:RefreshPage()
@@ -6073,11 +6146,14 @@ initFrame:SetScript("OnEvent", function(self)
                     end
                     for _, key in ipairs(GROUP_UNIT_ORDER) do
                         local d = UNIT_DB_MAP[key]()
-                        if (d.healthClassColored or false) ~= (src.healthClassColored or false) then return false end
+                        if ns.GetUnitHealthColorMode(d) ~= ns.GetUnitHealthColorMode(src) then return false end
                         if not colEq(d.customFillColor, src.customFillColor) then return false end
                         if (d.gradientEnabled or false) ~= (src.gradientEnabled or false) then return false end
                         if not colEq(d.gradientColor, src.gradientColor) then return false end
                         if (d.gradientDir or "HORIZONTAL") ~= (src.gradientDir or "HORIZONTAL") then return false end
+                        if not colEq(d.dynamicColor100, src.dynamicColor100) then return false end
+                        if not colEq(d.dynamicColor50, src.dynamicColor50) then return false end
+                        if not colEq(d.dynamicColor0, src.dynamicColor0) then return false end
                     end
                     return true
                 end,
@@ -6095,14 +6171,41 @@ initFrame:SetScript("OnEvent", function(self)
             local rgn = sharedHealthColorRow._leftRegion
             local _, gradCogShow = EllesmereUI.BuildCogPopup({
                 title = "Gradient Settings",
+                -- The gradient config belongs to the Bar Color slot; capturing
+                -- through the hosting region keeps gradientColor in the same
+                -- capture group it had when it lived on the old swatch row.
+                captureRegion = rgn,
                 rows = {
                     { type="toggle", label="Enable Gradient",
+                      disabled=function() return ns.UF_IsCurveMode(UNIT_DB_MAP[selectedUnit]()) end,
+                      disabledTooltip="This option is not available with a value-based Fill Color (Classic or Custom Dynamic Colors)",
                       get=function() return SVal("gradientEnabled", false) end,
                       set=function(v) SSet("gradientEnabled", v); ReloadAndUpdate(); UpdatePreview(); EllesmereUI:RefreshPage() end },
                     { type="dropdown", label="Gradient Direction",
                       values={ HORIZONTAL="Horizontal", VERTICAL="Vertical" }, order={ "HORIZONTAL", "VERTICAL" },
+                      disabled=function() return ns.UF_IsCurveMode(UNIT_DB_MAP[selectedUnit]()) end,
+                      disabledTooltip="This option is not available with a value-based Fill Color (Classic or Custom Dynamic Colors)",
                       get=function() return SVal("gradientDir", "HORIZONTAL") end,
                       set=function(v) SSet("gradientDir", v); ReloadAndUpdate(); UpdatePreview(); EllesmereUI:RefreshPage() end },
+                    { type="colorpicker", label="Gradient End Color", hasAlpha=false,
+                      disabled=function()
+                          return ns.UF_IsCurveMode(UNIT_DB_MAP[selectedUnit]()) or not SVal("gradientEnabled", false)
+                      end,
+                      disabledTooltip=function()
+                          if ns.UF_IsCurveMode(UNIT_DB_MAP[selectedUnit]()) then
+                              return "This option is not available with a value-based Fill Color (Classic or Custom Dynamic Colors)"
+                          end
+                          return "Gradient"
+                      end,
+                      get=function()
+                          local c = SGet("gradientColor")
+                          if c then return c.r, c.g, c.b end
+                          return 0.20, 0.20, 0.80
+                      end,
+                      set=function(r, g, b)
+                          UNIT_DB_MAP[selectedUnit]().gradientColor = { r=r, g=g, b=b }
+                          ReloadAndUpdate(); UpdatePreview()
+                      end },
                 },
             })
             MakeCogBtn(rgn, gradCogShow)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1419,8 +1419,10 @@ local function ApplyHealthBarAlpha(health, unitKey)
     local fillA = opacity / 100
     local fillTex = health:GetStatusBarTexture()
     -- When a gradient is active the opacity is baked into the gradient endpoints,
-    -- so the texture region alpha must stay 1 to avoid double-dimming.
-    if fillTex then fillTex:SetAlpha((s and s.gradientEnabled) and 1 or fillA) end
+    -- so the texture region alpha must stay 1 to avoid double-dimming. The
+    -- value-based fill modes suppress the gradient (PostUpdateColor skips it),
+    -- so the region alpha must carry the opacity again.
+    if fillTex then fillTex:SetAlpha((s and s.gradientEnabled and not ns.UF_IsCurveMode(s)) and 1 or fillA) end
     if health.bg then health.bg:SetAlpha((s and (s.customBgAlpha or 100) or 100) / 100) end
 end
 
@@ -1589,6 +1591,93 @@ local function UF_SecretSafeHealthColor(self, event, unit)
     end
 end
 
+-- Health By Value: the fill color follows current health through three
+-- user-chosen gradient stops (full / half / empty). Live frames feed a
+-- C_CurveUtil color curve to UnitHealthPercent so the percent itself is never
+-- read (it can be a secret value); only the resulting color reaches
+-- SetStatusBarColor. One curve is cached per unit key and rebuilt only when a
+-- stop color changes. Wrapped in a do-block so the cache state does not
+-- consume main-chunk local slots.
+do
+    local DEF100 = { r = 0, g = 1, b = 0 }
+    local DEF50  = { r = 1, g = 1, b = 0 }
+    local DEF0   = { r = 1, g = 0, b = 0 }
+    local curves = {}
+    function ns.GetHealthByValueCurve(unitKey, s)
+        local c0   = s.dynamicColor0   or DEF0
+        local c50  = s.dynamicColor50  or DEF50
+        local c100 = s.dynamicColor100 or DEF100
+        local e = curves[unitKey]
+        if not (e
+            and e.r0   == c0.r   and e.g0   == c0.g   and e.b0   == c0.b
+            and e.r50  == c50.r  and e.g50  == c50.g  and e.b50  == c50.b
+            and e.r100 == c100.r and e.g100 == c100.g and e.b100 == c100.b) then
+            local curve = C_CurveUtil.CreateColorCurve()
+            curve:SetType(Enum.LuaCurveType.Linear)
+            curve:AddPoint(0,   CreateColor(c0.r,   c0.g,   c0.b,   1))
+            curve:AddPoint(0.5, CreateColor(c50.r,  c50.g,  c50.b,  1))
+            curve:AddPoint(1,   CreateColor(c100.r, c100.g, c100.b, 1))
+            e = { curve = curve,
+                  r0 = c0.r,     g0 = c0.g,     b0 = c0.b,
+                  r50 = c50.r,   g50 = c50.g,   b50 = c50.b,
+                  r100 = c100.r, g100 = c100.g, b100 = c100.b }
+            curves[unitKey] = e
+        end
+        return e.curve
+    end
+
+    -- Clean-number interpolation matching the curve above, for the options
+    -- preview where the health percent is a known fake value (0-1).
+    function ns.ResolveHealthByValueColor(s, pct01)
+        local c0   = s.dynamicColor0   or DEF0
+        local c50  = s.dynamicColor50  or DEF50
+        local c100 = s.dynamicColor100 or DEF100
+        if pct01 >= 0.5 then
+            local t = (pct01 - 0.5) * 2
+            return c50.r + (c100.r - c50.r) * t,
+                   c50.g + (c100.g - c50.g) * t,
+                   c50.b + (c100.b - c50.b) * t
+        end
+        local t = pct01 * 2
+        return c0.r + (c50.r - c0.r) * t,
+               c0.g + (c50.g - c0.g) * t,
+               c0.b + (c50.b - c0.b) * t
+    end
+
+    -- "classic" is the value-based fill with nothing customized: an empty
+    -- stops table falls through to the green / yellow / red defaults above.
+    local CLASSIC_STOPS = {}
+    ns.UF_CLASSIC_STOPS = CLASSIC_STOPS
+
+    -- Effective fill-color mode for a unit's settings table:
+    -- "class" | "classic" | "custom" | "customDynamic". An explicit
+    -- healthColorMode wins; profiles that predate the dropdown derive the mode
+    -- from the legacy keys (Health By Value toggle, class/custom swatch state).
+    function ns.GetUnitHealthColorMode(s)
+        if not s then return "class" end
+        local m = s.healthColorMode
+        if m then return m end
+        if s.healthByValue then return "customDynamic" end
+        if s.healthClassColored then return "class" end
+        if s.customFillColor then return "custom" end
+        return "class"
+    end
+
+    -- The two value-based modes paint through a curve and suppress the
+    -- gradient path (their RGB can be secret values).
+    function ns.UF_IsCurveMode(s)
+        local m = ns.GetUnitHealthColorMode(s)
+        return m == "classic" or m == "customDynamic"
+    end
+
+    function ns.GetUnitHealthModeCurve(mode, unitKey, s)
+        if mode == "classic" then
+            return ns.GetHealthByValueCurve("__classic", CLASSIC_STOPS)
+        end
+        return ns.GetHealthByValueCurve(unitKey, s)
+    end
+end
+
 local function ApplyDarkTheme(health)
     if not health then return end
     -- TEMPORARY (see UF_SecretSafeHealthColor above). Idempotent: this
@@ -1652,15 +1741,29 @@ local function ApplyDarkTheme(health)
         end
         local customFill = unitSettings and unitSettings.customFillColor
         local customBg   = unitSettings and unitSettings.customBgColor
-        if customFill then
-            -- Custom fill overrides class coloring; skip if class color is enabled
-            if not (unitSettings and unitSettings.healthClassColored) then
-                health.colorClass = false
-                health.colorReaction = false
-                health.colorTapped = false
-                health.colorDisconnected = false
-                health:SetStatusBarColor(customFill.r, customFill.g, customFill.b)
+        local colorMode = ns.GetUnitHealthColorMode(unitSettings)
+        local curveMode = colorMode == "classic" or colorMode == "customDynamic"
+        if curveMode then
+            -- Value-based fill overrides class/reaction coloring; the live
+            -- color re-applies on every health update in PostUpdateColor.
+            health.colorClass = false
+            health.colorReaction = false
+            health.colorTapped = false
+            health.colorDisconnected = false
+            local u = health.__owner and health.__owner.unit
+            if u and UnitExists(u) then
+                local col = UnitHealthPercent(u, true, ns.GetUnitHealthModeCurve(colorMode, unitKey, unitSettings))
+                if col and col.GetRGB then
+                    health:SetStatusBarColor(col:GetRGB())
+                end
             end
+        elseif colorMode == "custom" and customFill then
+            -- Custom fill overrides class coloring
+            health.colorClass = false
+            health.colorReaction = false
+            health.colorTapped = false
+            health.colorDisconnected = false
+            health:SetStatusBarColor(customFill.r, customFill.g, customFill.b)
         end
         -- Tint bg to 20% of the class/reaction color, or use custom bg color.
         -- Alpha is NOT re-applied -- SetStatusBarColor(r,g,b) preserves
@@ -1672,31 +1775,48 @@ local function ApplyDarkTheme(health)
             local cBg   = uSettings and uSettings.customBgColor
             local classColored = uSettings and uSettings.healthClassColored
             local bgClassColored = uSettings and uSettings.bgClassColored
-            -- Resolve base fill color (custom, or oUF's class/reaction color), then apply
-            -- gradient additively when enabled; otherwise the existing flat behavior.
-            local bR, bG, bB
-            if cFill and not classColored then
-                bR, bG, bB = cFill.r, cFill.g, cFill.b
-            elseif classColored and uKey == "pet" then
-                local _, ct = UnitClass("player")
-                local cc = ct and not issecretvalue(ct) and EllesmereUI.GetClassColor(ct)
-                if cc then bR, bG, bB = cc.r, cc.g, cc.b end
-            elseif color and color.GetRGB then
-                bR, bG, bB = color:GetRGB()
-            end
-            if uSettings and uSettings.gradientEnabled and bR then
-                local gc = uSettings.gradientColor
-                -- A gradient overrides the texture's region alpha, so Bar Opacity
-                -- is baked into the gradient endpoint alphas instead of SetAlpha.
-                local ga = uSettings.healthBarOpacity or 90
-                if ga > 1.0 then ga = ga / 100 end
-                ApplyBarGradient(self:GetStatusBarTexture(), uSettings.gradientDir or "HORIZONTAL",
-                    bR, bG, bB, ga,
-                    gc and gc.r or 0.20, gc and gc.g or 0.20, gc and gc.b or 0.80, ga)
-            elseif classColored and uKey == "pet" and bR then
-                self:SetStatusBarColor(bR, bG, bB)
-            elseif cFill and not classColored then
-                self:SetStatusBarColor(cFill.r, cFill.g, cFill.b)
+            local pMode = ns.GetUnitHealthColorMode(uSettings)
+            if pMode == "classic" or pMode == "customDynamic" then
+                -- Value-based fill: evaluate the stop curve at the unit's
+                -- current health. The color components can be secret, so they
+                -- go straight into SetStatusBarColor (documented
+                -- AllowedWhenTainted) and never feed the gradient path, which
+                -- would truthiness-test them.
+                local u = unit or (self.__owner and self.__owner.unit)
+                if u and UnitExists(u) then
+                    local col = UnitHealthPercent(u, true, ns.GetUnitHealthModeCurve(pMode, uKey, uSettings))
+                    if col and col.GetRGB then
+                        self:SetStatusBarColor(col:GetRGB())
+                    end
+                end
+            else
+                -- eui-style: allow thirdparty (vendored oUF is this module's own framework)
+                -- Resolve base fill color (custom, or oUF's class/reaction color), then apply
+                -- gradient additively when enabled; otherwise the existing flat behavior.
+                local bR, bG, bB
+                if pMode == "custom" and cFill then
+                    bR, bG, bB = cFill.r, cFill.g, cFill.b
+                elseif classColored and uKey == "pet" then
+                    local _, ct = UnitClass("player")
+                    local cc = ct and not issecretvalue(ct) and EllesmereUI.GetClassColor(ct)
+                    if cc then bR, bG, bB = cc.r, cc.g, cc.b end
+                elseif color and color.GetRGB then
+                    bR, bG, bB = color:GetRGB()
+                end
+                if uSettings and uSettings.gradientEnabled and bR then
+                    local gc = uSettings.gradientColor
+                    -- A gradient overrides the texture's region alpha, so Bar Opacity
+                    -- is baked into the gradient endpoint alphas instead of SetAlpha.
+                    local ga = uSettings.healthBarOpacity or 90
+                    if ga > 1.0 then ga = ga / 100 end
+                    ApplyBarGradient(self:GetStatusBarTexture(), uSettings.gradientDir or "HORIZONTAL",
+                        bR, bG, bB, ga,
+                        gc and gc.r or 0.20, gc and gc.g or 0.20, gc and gc.b or 0.80, ga)
+                elseif classColored and uKey == "pet" and bR then
+                    self:SetStatusBarColor(bR, bG, bB)
+                elseif pMode == "custom" and cFill then
+                    self:SetStatusBarColor(cFill.r, cFill.g, cFill.b)
+                end
             end
             if self.bg then
                 -- Keep bg covering only the empty (missing-health) portion as
@@ -1719,7 +1839,7 @@ local function ApplyDarkTheme(health)
                     self.bg:SetColorTexture(bgClassR, bgClassG, bgClassB, 1)
                 elseif cBg then
                     self.bg:SetColorTexture(cBg.r, cBg.g, cBg.b, 1)
-                elseif cFill and not classColored then
+                elseif pMode == "custom" and cFill then
                     self.bg:SetColorTexture(cFill.r * 0.2, cFill.g * 0.2, cFill.b * 0.2, 1)
                 elseif color and color.GetRGB then
                     local r, g, b = color:GetRGB()
@@ -1753,7 +1873,7 @@ local function ApplyDarkTheme(health)
                 health.bg:SetColorTexture(bgClassR, bgClassG, bgClassB, 1)
             elseif customBg then
                 health.bg:SetColorTexture(customBg.r, customBg.g, customBg.b, 1)
-            elseif customFill then
+            elseif colorMode == "custom" and customFill then
                 health.bg:SetColorTexture(customFill.r * 0.2, customFill.g * 0.2, customFill.b * 0.2, 1)
             else
                 -- No custom colors set -- use default dark bg (#111)


### PR DESCRIPTION
## What does this PR do?

Adds health-by-value coloring to the player, target, and focus unit frames, as requested in the "health-by-value coloring for player/target unitframes" feature request.

The class/custom fill swatches on the Main Frames health section become a **Fill Color** dropdown with the same modes as the Raid Frames:

- **Class Color** -- unchanged current behavior (default)
- **Classic** -- the bar blends green / yellow / red with current health
- **Custom Color** -- one flat custom color (unchanged behavior, now an explicit mode)
- **Custom Dynamic Colors** -- the bar blends between three user-chosen stops (100% / 50% / 0%), shown as inline swatches next to the dropdown. Picking a dark 100% stop gives the requested dark-at-full style.

Dark Mode stays the module-wide master and overrides the row, exactly as it overrode the old swatches. The gradient applies only in the Class / Custom modes; the Gradient End Color picker moves into the gradient cog, and the cog rows disable in the value-based modes. The Bar Color sync icon copies the mode and the three stops.

Profiles that predate the dropdown resolve their mode from the legacy keys (`healthClassColored`, `customFillColor`), so existing setups load with identical colors and the dropdown shows the matching mode.

**Secret-value safety:** the two value-based modes feed a cached `C_CurveUtil` color curve to `UnitHealthPercent`, the same mechanism the Raid Frames Custom Dynamic Colors use. Lua never reads the health percent; the possibly-secret RGB goes only into `SetStatusBarColor` and never enters the gradient path or any comparison.

## How was it tested?

Live retail 12.0.7 (68974), in dungeon content (trash pulls and bosses):

- Custom Dynamic Colors on the target frame with dark/yellow/red stops: the color tracks damage in combat, including while health is a secret value.
- Mode switches between Class, Custom, and Custom Dynamic mid-session; options previews follow the dropdown.
- CPU profiled with `C_AddOnProfiler` recordings through the same boss in Custom Dynamic and Class modes: 0.075 vs 0.080 ms/frame in combat for the whole module -- within the same-session run spread, no measurable cost from the curve path.

Not yet run on the 12.1 PTR client.

## Screenshots

(To be added.)

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- the resolved default mode is Class Color, the current behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- the default path adds two table reads per color update, nothing else
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- the curve modes run only on health events; `UnitHealthPercent` returns one small ColorMixin per event, replacing the class-color lookup on the same path
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- no Blizzard frames touched
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client -- tested on live retail; PTR run still pending
