### PR TITLE
Individual pips border

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -484,6 +484,23 @@ initFrame:SetScript("OnEvent", function(self)
                     UnsnapTex(pip._fill)
 
                     if pip._border then pip._border:SetShown(false) end
+
+                    if sp.borderOnPips then
+                        if not pip._borderFrame then
+                            local bf = CreateFrame("Frame", nil, pip)
+                            bf:SetAllPoints(pip)
+                            pip._borderFrame = bf
+                        end
+                        pip._borderFrame:SetFrameLevel(sp.borderBehind and math.max(0, pip:GetFrameLevel() - 1) or (pip:GetFrameLevel() + 2))
+                        EllesmereUI.ApplyBorderStyle(pip._borderFrame, sp.borderSize or 1,
+                            sp.borderR or 0, sp.borderG or 0, sp.borderB or 0, sp.borderA or 1,
+                            sp.borderTexture or "solid", sp.borderTextureOffset, sp.borderTextureOffsetY,
+                            sp.borderTextureShiftX, sp.borderTextureShiftY)
+                        pip._borderFrame:Show()
+                    else
+                        if pip._borderFrame then pip._borderFrame:Hide() end
+                    end
+
                     local active = i <= filledCount
                     if active and useThresh then
                         if _pvPartialOnly and i < _pvThreshCount then
@@ -584,10 +601,16 @@ initFrame:SetScript("OnEvent", function(self)
                 pc._barBorderFrame = bf
             end
             pc._barBorderFrame:SetFrameLevel(sp.borderBehind and math.max(0, pc:GetFrameLevel() - 1) or (pc:GetFrameLevel() + 2))
-            EllesmereUI.ApplyBorderStyle(pc._barBorderFrame, sp.borderSize or 1,
-                sp.borderR or 0, sp.borderG or 0, sp.borderB or 0, sp.borderA or 1,
-                sp.borderTexture or "solid", sp.borderTextureOffset, sp.borderTextureOffsetY,
-                sp.borderTextureShiftX, sp.borderTextureShiftY)
+            
+            if sp.borderOnPips and cf ~= "DEATHKNIGHT" and not isBar then
+                pc._barBorderFrame:Hide()
+            else
+                EllesmereUI.ApplyBorderStyle(pc._barBorderFrame, sp.borderSize or 1,
+                    sp.borderR or 0, sp.borderG or 0, sp.borderB or 0, sp.borderA or 1,
+                    sp.borderTexture or "solid", sp.borderTextureOffset, sp.borderTextureOffsetY,
+                    sp.borderTextureShiftX, sp.borderTextureShiftY)
+                pc._barBorderFrame:Show()
+            end
 
             -- Full-bar background (for pips only bar-type uses _barBg)
             if not isBar then

--- a/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_Options.lua
@@ -4987,6 +4987,39 @@ initFrame:SetScript("OnEvent", function(self)
                 })
             end
                 end
+            
+            -- Toggle pip border on/off
+                if not EllesmereUI._prebuilding then
+                    local rgn = classBsRow._leftRegion
+                    local lastInline = rgn._lastInline or rgn._control
+                    local _, cogShow = EllesmereUI.BuildCogPopup({
+                        title = "Pip Border",
+                        rows = {
+                            { type = "toggle", label = "Border on individual pips",
+                            tooltip = "Draws a border around each pip instead of the bar as a whole.",
+                              get = function() local c = cfg(); return c and c.borderOnPips end,
+                              set = function(v)
+                                  local c = cfg(); if not c then return end
+                                  c.borderOnPips = v; RebuildClass(); EllesmereUI:RefreshPage()
+                              end },
+                        },
+                    })
+
+                    local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.COGS_ICON)
+                    cogBtn:Show()
+
+                    local function UpdateCogVis()
+                        local c = cfg()
+                        local tex = c and c.borderTexture or "solid"
+                        if tex == "solid" then 
+                            PP.Point(cogBtn, "RIGHT", rgn._control, "LEFT", -8, 0)
+                        else
+                            PP.Point(cogBtn, "RIGHT", lastInline, "LEFT", -8, 0)
+                        end
+                    end
+                    EllesmereUI.RegisterWidgetRefresh(UpdateCogVis)
+                    UpdateCogVis()
+                end
         end
 
         -- Row: Bar Spacing (slider + opt-in gap-color toggle/swatch) | Empty Bar Overlay (opacity slider + inline color swatch)

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1,4 +1,4 @@
--------------------------------------------------------------------------------
+﻿-------------------------------------------------------------------------------
 --  EllesmereUIResourceBars.lua
 --  Custom class resource, health, and mana bar display
 --  Features: Health bar, primary resource bar (mana/rage/energy/etc),
@@ -3725,7 +3725,15 @@ local function BuildBars()
                 pip["_barAnim_x1"] = x1 - x0
                 pip["_barAnim_ph"] = pipH
                 ApplyPipPos()
-                pips[i]:ApplyBorder(0, 0, 0, 0, 0)
+
+                if sp.borderOnPips then
+                    pips[i]:ApplyBorder(sp.borderSize, sp.borderR, sp.borderG, sp.borderB, sp.borderA,
+                        sp.borderTexture, sp.borderTextureOffset, sp.borderTextureOffsetY,
+                        sp.borderTextureShiftX, sp.borderTextureShiftY, "resourcebars", sp.borderSize)
+                else
+                    pips[i]:ApplyBorder(0, 0, 0, 0, 0)
+                end
+
                 pips[i]:ApplyTexture(g.barTexture or "none")
                 pips[i]._bg:SetColorTexture(ERB.PipBgColor(sp))
                 -- Fill Opacity: stamp the per-pip factor (consumed by SetActive
@@ -3766,9 +3774,14 @@ local function BuildBars()
             local pl = secondaryFrame:GetFrameLevel()
             secondaryFrame._barBorder._frame:SetFrameLevel(sp.borderBehind and math.max(0, pl - 1) or (pl + 5))
         end
-        secondaryFrame._barBorder:ApplyStyle(sp.borderSize, sp.borderR, sp.borderG, sp.borderB, sp.borderA,
-            sp.borderTexture, sp.borderTextureOffset, sp.borderTextureOffsetY,
-            sp.borderTextureShiftX, sp.borderTextureShiftY, "resourcebars", sp.borderSize)
+
+        if sp.borderOnPips and cachedSecondary.type ~= "runes" and not isBarType then
+            secondaryFrame._barBorder:ApplyStyle(0,0,0,0,0)
+        else
+            secondaryFrame._barBorder:ApplyStyle(sp.borderSize, sp.borderR, sp.borderG, sp.borderB, sp.borderA,
+                sp.borderTexture, sp.borderTextureOffset, sp.borderTextureOffsetY,
+                sp.borderTextureShiftX, sp.borderTextureShiftY, "resourcebars", sp.borderSize)
+        end
 
         -- Full-bar background (behind all pips) -- this is what shows through
         -- the pip spacing/gaps. In dark theme the inactive pips are opaque gray


### PR DESCRIPTION
## What does this PR do?

Add the option to toggle between full bar border or individual pips border. With recent additions to the resource bar options, this let users have completly individual pip bars visually.

## How was it tested?

Tested on ptr, on rogue only. The setting is not active as dk and single bar resource specs. Also tested the option preview.

## Screenshots

Setting toggled on:
<img width="955" height="521" alt="image" src="https://github.com/user-attachments/assets/828a5dc8-bdf5-4641-8a49-3e53c8a5549b" />
And off
<img width="985" height="480" alt="image" src="https://github.com/user-attachments/assets/fa4626af-f9c6-4d90-9025-b5f394c2cc04" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
