### PR TITLE
fix(resourcebars): cast bar stayed white after an empowered cast

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -7508,10 +7508,25 @@ local function OnEmpowerStop(eventCastID)
             empowerColorB:SetRGBA(cb.gradientR or fR, cb.gradientG or fG, cb.gradientB or fB, cb.gradientA or fA)
             castBarFrame._gradTex:SetGradient(cb.gradientDir or "HORIZONTAL", empowerColorA, empowerColorB)
         elseif cb.gradientEnabled then
-            -- Gradient colors live in the SetGradient endpoints (with Fill
-            -- Opacity baked in); the vertex color must return to plain white
-            -- or the empower tint would keep coloring the gradient.
-            castBarFrame._bar:GetStatusBarTexture():SetVertexColor(1, 1, 1, 1)
+            -- Re-ISSUE the gradient, do not just neutralise the vertex color.
+            -- SetVertexColor REPLACES a texture's gradient rather than
+            -- multiplying it, so the per-stage empower tint above (which paints
+            -- this exact texture with SetVertexColor) already destroyed the
+            -- configured gradient. Whitening the vertex color therefore left a
+            -- plain WHITE fill, and nothing restored it: the gradient is issued
+            -- only where the bar is built, so every later cast in the session
+            -- stayed white until a config edit or reload rebuilt the bar. The
+            -- full-bar branch above already re-issues for the same reason.
+            -- Fill Opacity is baked into both endpoint alphas, matching the
+            -- build path.
+            local fillTex = castBarFrame._bar:GetStatusBarTexture()
+            local fillOp = (cb.fillOpacity or 100) / 100
+            fillTex:SetVertexColor(1, 1, 1, 1)
+            empowerColorA:SetRGBA(fR, fG, fB, fA * fillOp)
+            empowerColorB:SetRGBA(cb.gradientR or fR, cb.gradientG or fG,
+                cb.gradientB or fB, (cb.gradientA or fA) * fillOp)
+            fillTex:SetGradient(cb.gradientDir or "HORIZONTAL",
+                empowerColorA, empowerColorB)
         else
             local fillTex = castBarFrame._bar:GetStatusBarTexture()
             fillTex:SetVertexColor(fR, fG, fB, fA * ((cb.fillOpacity or 100) / 100))

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -7479,6 +7479,50 @@ local function OnChannelStop(eventCastID)
     ns.ShowIdleCastBar()
 end
 
+-- Undo the per-stage empower tint and put the configured fill back. Shared by
+-- OnEmpowerStop and OnCastStop: the 1s-overrun safety path routes a missed
+-- EMPOWER_STOP through OnCastStop, which clears _empowering, and OnEmpowerStop
+-- then early-returns on that very flag -- so without this call there the stage
+-- tint stayed painted for the rest of the session, the same stuck-fill symptom
+-- by a second route. On ns to respect the 200-local cap.
+ns.ResetEmpowerFillColor = function()
+    if not (castBarFrame and castBarFrame._empowerColorApplied) then return end
+    castBarFrame._empowerColorApplied = false
+    local cb = ERB.db.profile.castBar
+    local fR, fG, fB, fA = cb.fillR, cb.fillG, cb.fillB, 1
+    if cb.classColored then
+        local cc = CLASS_COLORS[cachedClass]
+        if cc then fR, fG, fB = cc[1], cc[2], cc[3] end
+    end
+    if castBarFrame._gradientFullBar and castBarFrame._gradTex then
+        empowerColorA:SetRGBA(fR, fG, fB, fA)
+        empowerColorB:SetRGBA(cb.gradientR or fR, cb.gradientG or fG, cb.gradientB or fB, cb.gradientA or fA)
+        castBarFrame._gradTex:SetGradient(cb.gradientDir or "HORIZONTAL", empowerColorA, empowerColorB)
+    elseif cb.gradientEnabled then
+        -- Re-ISSUE the gradient, do not just neutralise the vertex color.
+        -- SetVertexColor REPLACES a texture's gradient rather than
+        -- multiplying it, so the per-stage empower tint (which paints this
+        -- exact texture with SetVertexColor) already destroyed the configured
+        -- gradient. Whitening the vertex color therefore left a plain WHITE
+        -- fill, and nothing restored it: the gradient is issued only where the
+        -- bar is built, so every later cast in the session stayed white until a
+        -- config edit or reload rebuilt the bar. The full-bar branch above
+        -- already re-issues for the same reason. Fill Opacity is baked into
+        -- both endpoint alphas, matching the build path.
+        local fillTex = castBarFrame._bar:GetStatusBarTexture()
+        local fillOp = (cb.fillOpacity or 100) / 100
+        fillTex:SetVertexColor(1, 1, 1, 1)
+        empowerColorA:SetRGBA(fR, fG, fB, fA * fillOp)
+        empowerColorB:SetRGBA(cb.gradientR or fR, cb.gradientG or fG,
+            cb.gradientB or fB, (cb.gradientA or fA) * fillOp)
+        fillTex:SetGradient(cb.gradientDir or "HORIZONTAL",
+            empowerColorA, empowerColorB)
+    else
+        local fillTex = castBarFrame._bar:GetStatusBarTexture()
+        fillTex:SetVertexColor(fR, fG, fB, fA * ((cb.fillOpacity or 100) / 100))
+    end
+end
+
 -- Called for UNIT_SPELLCAST_EMPOWER_STOP.
 local function OnEmpowerStop(eventCastID)
     if not castBarFrame then return end
@@ -7495,43 +7539,8 @@ local function OnEmpowerStop(eventCastID)
     castBarFrame._numStages = 0
 
     -- Reset empower stage coloring if it was applied
-    if castBarFrame._empowerColorApplied then
-        castBarFrame._empowerColorApplied = false
-        local cb = ERB.db.profile.castBar
-        local fR, fG, fB, fA = cb.fillR, cb.fillG, cb.fillB, 1
-        if cb.classColored then
-            local cc = CLASS_COLORS[cachedClass]
-            if cc then fR, fG, fB = cc[1], cc[2], cc[3] end
-        end
-        if castBarFrame._gradientFullBar and castBarFrame._gradTex then
-            empowerColorA:SetRGBA(fR, fG, fB, fA)
-            empowerColorB:SetRGBA(cb.gradientR or fR, cb.gradientG or fG, cb.gradientB or fB, cb.gradientA or fA)
-            castBarFrame._gradTex:SetGradient(cb.gradientDir or "HORIZONTAL", empowerColorA, empowerColorB)
-        elseif cb.gradientEnabled then
-            -- Re-ISSUE the gradient, do not just neutralise the vertex color.
-            -- SetVertexColor REPLACES a texture's gradient rather than
-            -- multiplying it, so the per-stage empower tint above (which paints
-            -- this exact texture with SetVertexColor) already destroyed the
-            -- configured gradient. Whitening the vertex color therefore left a
-            -- plain WHITE fill, and nothing restored it: the gradient is issued
-            -- only where the bar is built, so every later cast in the session
-            -- stayed white until a config edit or reload rebuilt the bar. The
-            -- full-bar branch above already re-issues for the same reason.
-            -- Fill Opacity is baked into both endpoint alphas, matching the
-            -- build path.
-            local fillTex = castBarFrame._bar:GetStatusBarTexture()
-            local fillOp = (cb.fillOpacity or 100) / 100
-            fillTex:SetVertexColor(1, 1, 1, 1)
-            empowerColorA:SetRGBA(fR, fG, fB, fA * fillOp)
-            empowerColorB:SetRGBA(cb.gradientR or fR, cb.gradientG or fG,
-                cb.gradientB or fB, (cb.gradientA or fA) * fillOp)
-            fillTex:SetGradient(cb.gradientDir or "HORIZONTAL",
-                empowerColorA, empowerColorB)
-        else
-            local fillTex = castBarFrame._bar:GetStatusBarTexture()
-            fillTex:SetVertexColor(fR, fG, fB, fA * ((cb.fillOpacity or 100) / 100))
-        end
-    end
+    ns.ResetEmpowerFillColor()
+
     cachedStageThresholds = nil
 
     ns.ShowIdleCastBar()
@@ -7543,6 +7552,10 @@ OnCastStop = function()
     castBarFrame._channeling = false
     castBarFrame._empowering = false
     castBarFrame._castID = nil
+    -- The overrun safety path forces a stop here on a missed EMPOWER_STOP, and
+    -- clearing _empowering above is exactly what makes OnEmpowerStop early-return
+    -- later, so this is the only chance to undo the stage tint.
+    ns.ResetEmpowerFillColor()
     -- Pip textures, channel ticks and the latency overlay are all cleared by
     -- the idle pass below.
     ns.ShowIdleCastBar()


### PR DESCRIPTION
**Cause:** `SetVertexColor` REPLACES a texture's gradient rather than multiplying it. The per-stage empower tint paints the fill with `SetVertexColor`, so the configured gradient was already gone by the time the cast ended, and the reset only whitened the vertex color -- on the belief that gradient endpoints and vertex color are independent channels. That left a plain white fill, and nothing restored it: the cast bar's gradient is issued only where the bar is built, so every later cast in the session stayed white until a config edit or reload rebuilt it. Only with the gradient option on; the flat path re-applies its real colour on the same reset and was always fine.

**Fix:** Re-issue the gradient on reset, with Fill Opacity baked into both endpoint alphas to match the build path. The full-bar empower branch beside it already did exactly this, for the same reason.

**Test:** Verified in game on Evoker with a custom cast bar colour and the gradient option on: empower, then normal casts keep the gradient.