### PR TITLE
Fix: rendering issues on the custom Dragonriding HUD

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
@@ -398,7 +398,17 @@ local function CreateSpeedBar(parent)
     f.bg = CreateSolidTexture(f, "BACKGROUND", 0)
     f.bg:SetAllPoints(f)
     f.tick = CreateSolidTexture(f, "OVERLAY", 5)
-    f.text = f:CreateFontString(nil, "OVERLAY")
+    -- The pip stacks/icon nest their bar textures one parent level deeper
+    -- than the speed bar itself (stackFrame -> pip, wsIcon -> tex/cd), and
+    -- frame level always outranks draw layer across frames. A plain OVERLAY
+    -- fontstring parented directly to f would render behind that nested
+    -- content, so give the text its own frame raised well above every level
+    -- used anywhere in this HUD (same pattern as CreateWhirlingSurgeIcon's
+    -- textFrame).
+    f.textFrame = CreateFrame("Frame", nil, f)
+    f.textFrame:SetAllPoints(f)
+    f.textFrame:SetFrameLevel(f:GetFrameLevel() + 10)
+    f.text = f.textFrame:CreateFontString(nil, "OVERLAY")
     return f
 end
 

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
@@ -339,6 +339,16 @@ local function EnsureBorder(frame)
     borderedFrames[#borderedFrames + 1] = frame
 end
 
+local function ApplyBorderEdges(frame, hideL, hideR, hideT, hideB)
+    local PP = EllesmereUI and EllesmereUI.PP
+    local edges = PP and PP.GetBorders and PP.GetBorders(frame)
+    if not edges then return end
+    edges._hideLeft = hideL or nil
+    edges._hideRight = hideR or nil
+    edges._hideTop = hideT or nil
+    edges._hideBottom = hideB or nil
+end
+
 local function ApplyBordersAll()
     local PP = EllesmereUI and EllesmereUI.PP
     if not PP then return end
@@ -351,6 +361,31 @@ local function ApplyBordersAll()
             PP.ShowBorder(f)
         else
             PP.HideBorder(f)
+        end
+    end
+
+    if thick > 0 then
+        -- At Element Spacing / Stack Spacing = 0 the touching frames each
+        -- draw their own full border, so the shared seam gets two
+        -- independently pixel-snapped lines instead of one. Suppress the
+        -- edge on one side of every seam so only a single line remains.
+        local gapTouch = p.gap == 0
+        local stackTouch = p.stackSpacing == 0
+        -- The icon spans the full column height (speed bar + both pip rows),
+        -- so its left edge also touches each row's LAST pip, not just the
+        -- speed bar, whenever Element Spacing is 0.
+        ApplyBorderEdges(speedBar, false, gapTouch, gapTouch, false)
+        for i = 1, SKYRIDING_PIPS do
+            local hideR = (stackTouch and i < SKYRIDING_PIPS) or (gapTouch and i == SKYRIDING_PIPS)
+            ApplyBorderEdges(stackFrame.pips[i], false, hideR, false, false)
+        end
+        for i = 1, SECONDWIND_PIPS do
+            local hideR = (stackTouch and i < SECONDWIND_PIPS) or (gapTouch and i == SECONDWIND_PIPS)
+            ApplyBorderEdges(swFrame.pips[i], false, hideR, false, gapTouch)
+        end
+        -- Re-snap so the updated hide flags take effect immediately.
+        for _, f in ipairs(borderedFrames) do
+            PP.SetBorderSize(f, thick)
         end
     end
 end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
@@ -458,11 +458,19 @@ local function LayoutPips(frame, pipCount, width, height, spacing)
     -- degenerate case so pips stay visible, just not perfectly pixel-snapped.
     if widthAvail < px then px = 1 end
     local totalUnits = floor(widthAvail / px + 1e-6)
-    local unitsPer = floor(totalUnits / pipCount)
-    local remUnits = totalUnits - unitsPer * pipCount
+    -- Cumulative boundary = floor(totalUnits * i / pipCount), not a fixed
+    -- remainder lumped onto the first N pips. The two pip rows (6 and 3
+    -- charges) share the same widthAvail and pipCount is an exact multiple
+    -- between them, so this formula lands every 2nd Skyward Ascent divider
+    -- on the exact same physical pixel as a Second Wind divider -- a
+    -- per-row remainder would drift the two rows' dividers by up to 1px
+    -- relative to each other even though they should align.
     local x = 0
+    local prevBoundary = 0
     for i = 1, pipCount do
-        local thisW = (unitsPer + (i <= remUnits and 1 or 0)) * px
+        local boundary = floor(totalUnits * i / pipCount + 1e-6)
+        local thisW = (boundary - prevBoundary) * px
+        prevBoundary = boundary
         local pip = frame.pips[i]
         pip:ClearAllPoints()
         pip:SetPoint("TOPLEFT", frame, "TOPLEFT", x, 0)


### PR DESCRIPTION
## What does this PR do?

Fixes two rendering issues on the custom Dragonriding/Skyriding HUD (Skyward Ascent charges, Second Wind charges, speed bar, Whirling Surge icon):

1. **Double border at 0 spacing.** Each bordered piece (speed bar, every individual charge pip, the icon) drew its own independent 4-side border, so a touching seam between two elements with **Element Spacing** and/or **Stack Spacing** set to 0 rendered as two overlapping, independently pixel-snapped lines instead of one. Fixed by suppressing the border edge on one side of each touching seam (speed bar ↔ pip stack, pip stack ↔ second wind stack, speed bar/last pip ↔ icon, and pip-to-pip within a row) using the border container's existing `_hideLeft`/`_hideRight`/`_hideTop`/`_hideBottom` edge-suppression flags (already used elsewhere, e.g. Unit Frames power bar borders) — no changes to the shared border rendering code itself.

2. **Misaligned pip dividers between the two charge rows.** `LayoutPips` distributed leftover pixels onto the first N pips independently per row, so the Skyward Ascent row (6 pips) and Second Wind row (3 pips) could drift up to 1px apart at dividers that should line up exactly, since one pip count is an integer multiple of the other. Fixed by computing each pip's boundary as `floor(totalUnits * i / pipCount)` instead of a fixed per-row remainder, which makes every 2nd Skyward Ascent divider land on the exact same physical pixel as the corresponding Second Wind divider.

3. Speed text rendered behind the pip stacks/icon. The pip stacks and Whirling Surge icon nest their bar textures one parent level deeper than the speed bar (stackFrame → pip, wsIcon → tex/cd), and frame level always outranks draw layer across frames, so the speed bar's plain OVERLAY fontstring rendered behind them. Fixed by giving the speed text its own frame raised well above every level used in this HUD — the same pattern already used by CreateWhirlingSurgeIcon's textFrame.

## How was it tested?

Tested in-game on retail: enabled the HUD border, set Element Spacing and Stack Spacing to 0, confirmed every seam (between pips, pip stack/speed bar, speed bar/icon) renders a single border line. Confirmed the two charge rows' pip dividers now line up pixel-for-pixel at every shared boundary instead of being off by 1px. Also checked non-zero spacing still renders full borders around each element as before, and that pip widths still sum correctly to the bar width. Confirmed the speed percentage text now renders above the pip stacks and icon instead of behind them.

## Screenshots

**Before:**
<img width="458" height="41" alt="grafik" src="https://github.com/user-attachments/assets/8dab3faa-c019-475c-a1f5-7dbde1734f3d" />

**After:**
<img width="458" height="41" alt="grafik" src="https://github.com/user-attachments/assets/49fb6d29-78b9-462e-a9c6-b63da67dccf2" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) — N/A, no new settings added
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built — border edge-suppression logic only runs when the border is enabled (`borderThickness > 0`), same gate as before; the pip-layout fix is the same cost as the code it replaces
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) — both fixes run only inside `Redraw()`/`Rebuild()` on settings/profile changes, not on `OnUpdate`
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames — N/A, this HUD is fully custom-built by EllesmereUI, not a skin of a Blizzard frame
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
