### PR TITLE
OnEnter hook in action bars

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -2045,6 +2045,14 @@ local function GetOrCreateButton(slot, parent, info, index, skipProtected)
                 if EAB._RefreshCooldownVisuals then
                     EAB._RefreshCooldownVisuals(self)
                 end
+                -- Same Blizzard hover repaint also resets HotKey's text color
+                -- to white (see ReapplyHotkeyColors above); OnEnter never fed
+                -- the event-driven reassert, so a custom color reverted on
+                -- every hover until the next unrelated ACTIONBAR_* event.
+                -- Queue instead of reapplying inline: coalesces with any
+                -- burst already pending and costs nothing when the bar is on
+                -- the default white (see ReapplyHotkeyColors' early-out).
+                EAB:QueueHotkeyColorReassert()
             end)
         end
         -- Physical-press GCD paint: keybinds arrive as clicks too


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1536385435809349635

Keybind numbers were turning white every time you hovered over a button because the game itself resets that text color whenever you mouse over an action bar slot. We already had a system to fix that color back to green, but it only ran when certain background events happened — not specifically when you hovered. So the green would only come back once one of those other events happened to fire, which is why moving your mouse to a different frame seemed to "fix" it (it was really just coincidental timing).

The fix tells the addon: also re-apply the green color right when you hover over a button. Now the color gets fixed immediately instead of waiting for an unrelated event, so it should hold steady on hover.