### PR TITLE
Fix Blizzard-friendly nameplate hitboxes

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -3175,6 +3175,41 @@ function ns.RefreshStackingMotion()
     end
 end
 
+function ns.ApplyEnemyHitbox(plate)
+    if not plate then return end
+    local db = p or defaults
+    plate:SetSize(
+        GetHealthBarWidth() * ((db.hitboxScaleX or 100) / 100),
+        GetHealthBarHeight() * ((db.hitboxScaleY or 100) / 100))
+    local np = plate.nameplate
+    if np and np.CanChangeHitTestPoints and np.SetAllHitTestPoints
+       and np:CanChangeHitTestPoints() then
+        np:SetAllHitTestPoints(plate)
+    end
+end
+
+function ns.UpdateNamePlateSizeOwnership()
+    local euiOwnsFriendly = (p or defaults).showFriendlyPlayers ~= false
+    if euiOwnsFriendly and ns._blizzardNamePlateSize == nil and GetCVar then
+        ns._blizzardNamePlateSize = GetCVar("nameplateSize")
+    end
+    if NamePlateDriverFrame then
+        if euiOwnsFriendly then
+            NamePlateDriverFrame:UnregisterEvent("DISPLAY_SIZE_CHANGED")
+            NamePlateDriverFrame:UnregisterEvent("CVAR_UPDATE")
+        else
+            NamePlateDriverFrame:RegisterEvent("DISPLAY_SIZE_CHANGED")
+            NamePlateDriverFrame:RegisterEvent("CVAR_UPDATE")
+        end
+    end
+    if euiOwnsFriendly and SetCVar then
+        SetCVar("nameplateSize", 3)
+    elseif ns._blizzardNamePlateSize ~= nil and SetCVar then
+        SetCVar("nameplateSize", ns._blizzardNamePlateSize)
+        ns._blizzardNamePlateSize = nil
+    end
+end
+
 function ns.RefreshHitboxSize()
     if InCombatLockdown() then return end
     if not C_NamePlate or not C_NamePlate.SetNamePlateSize then return end
@@ -3194,8 +3229,8 @@ function ns.RefreshHitboxSize()
     else
         C_NamePlate.SetNamePlateSize(baseW * sx, newH)
     end
-    -- The frame grows from its CENTER, so a taller size enlarges the hitbox evenly above and
-    -- below the unit. -10000 insets let the hit rect fill the full (centered) frame.
+    -- Keep the native fallback clickable. EUI enemy plates replace this with
+    -- their per-frame hit-test points; Blizzard friendly plates keep it.
     if C_NamePlateManager and C_NamePlateManager.SetNamePlateHitTestInsets
        and Enum and Enum.NamePlateType then
         C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Enemy, -10000, -10000, -10000, -10000)
@@ -3205,13 +3240,14 @@ function ns.RefreshHitboxSize()
     -- centered, so the bar stays put and the hitbox stays centered on it.
     local yShift = GetHitboxYShift()
     for _, plate in pairs(ns.plates) do
+        ns.ApplyEnemyHitbox(plate)
         plate:ClearAllPoints()
         plate:SetPoint("CENTER", plate.nameplate, "CENTER", 0, yShift)
     end
 end
 
 -- Hitbox visualizer: translucent overlay matching each enemy nameplate's clickable bounds (the
--- frame sized by SetNamePlateSize), so the Hitbox Size sliders can be dialled in visually.
+-- EUI plate frame bound by SetAllHitTestPoints), so the Hitbox Size sliders can be dialled in visually.
 -- Runtime-only (resets on reload), created lazily so it costs nothing when off. On ns (cap).
 function ns._ApplyHitboxOverlay(plate)
     local np = plate and plate.nameplate
@@ -3239,7 +3275,7 @@ function ns._ApplyHitboxOverlay(plate)
         ov:SetParent(np)
         ov:SetFrameLevel(np:GetFrameLevel() + 10)
         ov:ClearAllPoints()
-        ov:SetAllPoints(np)
+        ov:SetAllPoints(plate)
         ov:Show()
     elseif plate.hitboxOverlay then
         plate.hitboxOverlay:Hide()
@@ -3512,7 +3548,6 @@ local function SetupAuraCVars()
             SetCVar("ShowClassColorInFriendlyNameplate", (db.classColorFriendly ~= false) and 1 or 0)
         end
         SetCVar("ShowClassColorInNameplate", 1)
-        SetCVar("nameplateSize", 3)
         SetCVar("nameplateShowAll", 1)
         SetCVar("nameplateMinScale", 1)
         SetCVar("nameplateOverlapH", 1)
@@ -3548,11 +3583,11 @@ local function SetupAuraCVars()
     local function ApplyNamePlateClickArea()
         ns.RefreshHitboxSize()
     end
+    ns.UpdateNamePlateSizeOwnership()
     ApplyNamePlateClickArea()
-    -- Prevent Blizzard resetting EUI-owned nameplate sizes on display changes (jitter).
+    -- EUI suppresses Blizzard size refreshes only while it owns friendly plates.
+    -- Otherwise Blizzard's size slider owns the native frame used by friendlies.
     if NamePlateDriverFrame then
-        NamePlateDriverFrame:UnregisterEvent("DISPLAY_SIZE_CHANGED")
-        NamePlateDriverFrame:UnregisterEvent("CVAR_UPDATE")
         hooksecurefunc(NamePlateDriverFrame, "UpdateNamePlateOptions", ApplyNamePlateClickArea)
         -- Suppress Blizzard class resource bar setup on our nameplates
         if NamePlateDriverFrame.SetupClassNameplateBars then
@@ -5670,6 +5705,7 @@ function NameplateFrame:SetUnit(unit, nameplate)
         self:ApplyAppearance()
         self._appearanceGen = ns._npAppearanceGen
     end
+    ns.ApplyEnemyHitbox(self)
     HideBlizzardFrame(nameplate, unit)
     self:RegisterUnitEvent("UNIT_HEALTH", unit)
     self:RegisterUnitEvent("UNIT_ABSORB_AMOUNT_CHANGED", unit)
@@ -5769,6 +5805,14 @@ function NameplateFrame:SetUnit(unit, nameplate)
 end
 function NameplateFrame:ClearUnit()
     self:UnregisterAllEvents()
+
+    local np = self.nameplate
+    if np and np.CanChangeHitTestPoints and np.SetAllHitTestPoints and np.UnitFrame
+       and np:CanChangeHitTestPoints() then
+        -- Restore Blizzard's own frame before
+        -- Blizzard recycles this enemy nameplate for a friendly unit.
+        np:SetAllHitTestPoints(np.UnitFrame)
+    end
 
     -- Non-Target Opacity: released pool frames always go back at full
     -- alpha (nil _ntCurAlpha = never faded, keeps this a no-op).

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -3184,7 +3184,16 @@ function ns.RefreshHitboxSize()
     local baseW = GetHealthBarWidth()
     local baseH = GetHealthBarHeight()
     local newH  = baseH * sy
-    C_NamePlate.SetNamePlateSize(baseW * sx, newH)
+    -- Native nameplate geometry is global. Restore Blizzard's size while Blizzard owns
+    -- friendly plates so protected friendly visuals keep a matching hit target.
+    if db.showFriendlyPlayers == false and NamePlateDriverFrame
+       and NamePlateDriverFrame.GetNamePlateScale and NamePlateDriverFrame.UpdateNamePlateSize then
+        local scale = NamePlateDriverFrame:GetNamePlateScale()
+        NamePlateDriverFrame:UpdateNamePlateSize(
+            GetCVarNumberOrDefault(NamePlateConstants.STYLE_CVAR), scale)
+    else
+        C_NamePlate.SetNamePlateSize(baseW * sx, newH)
+    end
     -- The frame grows from its CENTER, so a taller size enlarges the hitbox evenly above and
     -- below the unit. -10000 insets let the hit rect fill the full (centered) frame.
     if C_NamePlateManager and C_NamePlateManager.SetNamePlateHitTestInsets
@@ -3537,22 +3546,10 @@ local function SetupAuraCVars()
     -- Apply stacking state via the Midnight bitfield CVar.
     ns.RefreshStackingMotion()
     local function ApplyNamePlateClickArea()
-        if InCombatLockdown() then return end
-        local db = p or defaults
-        local sx = (db.hitboxScaleX or 100) / 100
-        local sy = (db.hitboxScaleY or 100) / 100
-        local baseH = GetHealthBarHeight()
-        local newH  = baseH * sy
-        if C_NamePlate and C_NamePlate.SetNamePlateSize then
-            C_NamePlate.SetNamePlateSize(GetHealthBarWidth() * sx, newH)
-        end
-        if C_NamePlateManager and C_NamePlateManager.SetNamePlateHitTestInsets and Enum and Enum.NamePlateType then
-            C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Enemy, -10000, -10000, -10000, -10000)
-            C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Friendly, -10000, -10000, -10000, -10000)
-        end
+        ns.RefreshHitboxSize()
     end
     ApplyNamePlateClickArea()
-    -- Prevent Blizzard resetting nameplate sizes on display changes (jitter).
+    -- Prevent Blizzard resetting EUI-owned nameplate sizes on display changes (jitter).
     if NamePlateDriverFrame then
         NamePlateDriverFrame:UnregisterEvent("DISPLAY_SIZE_CHANGED")
         NamePlateDriverFrame:UnregisterEvent("CVAR_UPDATE")

--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -35,6 +35,20 @@ local _cachedFriendlyTargetPlate = nil
 
 local FRIENDLY_PLATE_Y_OFFSET = -18
 
+local function ApplyFriendlyHitbox(plate, restoreBlizzard)
+    local np = plate and plate.nameplate
+    if not (np and np.CanChangeHitTestPoints and np:CanChangeHitTestPoints()) then return end
+    if restoreBlizzard then
+        if np.SetAllHitTestPoints and np.UnitFrame then
+            np:SetAllHitTestPoints(np.UnitFrame)
+        end
+    elseif FP() and FP().friendlyClickThrough == true then
+        if np.ClearAllHitTestPoints then np:ClearAllHitTestPoints() end
+    elseif np.SetAllHitTestPoints then
+        np:SetAllHitTestPoints(plate.health)
+    end
+end
+
 local function IsInFollowerDungeon()
     if C_LFGInfo and C_LFGInfo.IsInLFGFollowerDungeon and C_LFGInfo.IsInLFGFollowerDungeon() then
         return true
@@ -1098,6 +1112,7 @@ function FriendlyFrame:SetUnit(unit, nameplate)
     self:Show()
 
     self.health:SetSize(GetFriendlyHealthBarWidth(), GetFriendlyHealthBarHeight())
+    ApplyFriendlyHitbox(self)
 
     -- Suppress Blizzard UF via reparenting (immediate, no OnUpdate needed)
     SuppressBlizzardUF(unit, nameplate)
@@ -1151,6 +1166,7 @@ function FriendlyFrame:ClearUnit()
     end
     -- Restore Blizzard UF before clearing our reference
     if self.unit then RestoreBlizzardUF(self.unit) end
+    ApplyFriendlyHitbox(self, true)
     self.unit = nil
     self.nameplate = nil
     self.glow:Hide()
@@ -1527,6 +1543,9 @@ local function ApplyFriendlyClickThrough()
     clickThroughRetry:UnregisterEvent("PLAYER_REGEN_ENABLED")
     local inset = on and CLICK_THROUGH_INSET or 0
     C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Friendly, inset, inset, inset, inset)
+    for _, plate in pairs(friendlyPlates) do
+        ApplyFriendlyHitbox(plate)
+    end
     clickThroughApplied = on
 end
 ns.UpdateFriendlyClickThrough = ApplyFriendlyClickThrough

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -2353,6 +2353,7 @@ initFrame:SetScript("OnEvent", function(self)
                     end
                 end
                 if ns.UpdateFriendlyNameplateSystem then ns.UpdateFriendlyNameplateSystem() end
+                ns.RefreshHitboxSize()
                 -- Re-assert stacking after friendly CVar changes (Blizzard can reset the stacking bitfield as a side effect).
                 ns.RefreshStackingMotion()
                 EllesmereUI:RefreshPage()

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -2353,6 +2353,7 @@ initFrame:SetScript("OnEvent", function(self)
                     end
                 end
                 if ns.UpdateFriendlyNameplateSystem then ns.UpdateFriendlyNameplateSystem() end
+                if ns.UpdateNamePlateSizeOwnership then ns.UpdateNamePlateSizeOwnership() end
                 ns.RefreshHitboxSize()
                 -- Re-assert stacking after friendly CVar changes (Blizzard can reset the stacking bitfield as a side effect).
                 ns.RefreshStackingMotion()


### PR DESCRIPTION
- Restore Blizzard native plate geometry when EUI relinquishes friendly player nameplates.
- Explore per-nameplate hit-test ownership for EUI enemy and friendly plates, plus runtime size ownership handoff.
- WIP: sizing and mouseover behavior still require in-game investigation.