### PR TITLE
feat(unitframes): configurable weapon enchant placement (In Line / Above / Below)

### DIFF
--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -68,6 +68,11 @@ local FONT_OUTLINE_VALUES = {
     outline = "Outline", thick = "Thick Outline",
 }
 local FONT_OUTLINE_ORDER = { "default", "none", "outline", "thick" }
+-- Cross-axis side for the weapon-enchant line. "Above"/"Below" read naturally for the
+-- horizontal growth directions; under Up/Down growth the same two values mean the side
+-- before/after the columns, mirrored the same way.
+local ENCHANT_LINE_VALUES = { ABOVE = "Above", BELOW = "Below" }
+local ENCHANT_LINE_ORDER = { "ABOVE", "BELOW" }
 local GROW_DIR_VALUES = { LEFT = "Left", RIGHT = "Right", UP = "Up", DOWN = "Down" }
 local GROW_DIR_ORDER = { "LEFT", "RIGHT", "UP", "DOWN" }
 local ICON_WRAP_VALUES = { LEFT = "Left", RIGHT = "Right" }
@@ -758,7 +763,7 @@ end
 
 -- "Display": Border Size [swatch] | Spacing; Icons per Row (+Max Rows/Max
 -- Total/Row Spacing cog) | spacer.
-local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
+local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff, isDefaultBar)
     local W = EllesmereUI.Widgets
     local PP = EllesmereUI.PanelPP
     local _, hh = 0, 0
@@ -879,15 +884,44 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
     -- Buff bars only: debuffs are never player-cancelable, so the row would
     -- be a dead switch there.
     if isBuff then
-        _, hh = W:DualRow(frame, sy,
+        -- Weapon enchants render on the DEFAULT buffs bar only (it is the one
+        -- that publishes ns._weaponEnchPAB), so the placement control would be
+        -- a dead setting on a custom buff bar.
+        local enchantSlot = { type = "label", text = "" }
+        if isDefaultBar then
+            enchantSlot = {
+                type = "dropdown", text = "Weapon Enchant Line",
+                tooltip = "Which side of the bar oils, poisons and imbues sit on. They are not auras, so they get their own line rather than a grid cell -- putting them back in the grid is what used to push wrapped rows out of alignment. Use Below if the bar sits at the top of the screen, where an Above line has no room.",
+                values = ENCHANT_LINE_VALUES, order = ENCHANT_LINE_ORDER,
+                getValue = function() return string.upper(cfg.enchantLinePosition or "ABOVE") end,
+                setValue = function(v) cfg.enchantLinePosition = v; apply() end
+            }
+        end
+        local encRow
+        encRow, hh = W:DualRow(frame, sy,
             {
                 type = "toggle", text = "Right-Click to Cancel",
                 tooltip = "Right-clicking a buff icon cancels the buff. Turning this off makes the bar's icons click-through; tooltips still follow the Show Tooltips setting.",
                 getValue = function() return cfg.rightClickCancel ~= false end,
                 setValue = function(v) cfg.rightClickCancel = v; apply() end
             },
-            { type = "label", text = "" }
+            enchantSlot
         ); sy = sy - hh
+        if isDefaultBar then
+            local rgn = encRow._rightRegion
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Weapon Enchant Line",
+                rows = {
+                    { type = "slider", label = "Offset X", min = -200, max = 200, step = 1,
+                      get = function() return cfg.enchantLineOffsetX or 0 end,
+                      set = function(v) cfg.enchantLineOffsetX = v; apply() end },
+                    { type = "slider", label = "Offset Y", min = -200, max = 200, step = 1,
+                      get = function() return cfg.enchantLineOffsetY or 0 end,
+                      set = function(v) cfg.enchantLineOffsetY = v; apply() end },
+                },
+            })
+            ns._PAMakeCogBtn(rgn, cogShow)
+        end
     end
 
     return sy
@@ -1287,7 +1321,7 @@ local function BuildDefaultBarDetail(frame, fontPath, isBuff)
         sy = BuildAssignedDebuffsFields(body, fontPath, sy, cfg, ApplyBar)
     end
     sy = BuildCoreFields(body, fontPath, sy, cfg, ApplyBar, isBuff)
-    sy = BuildDisplayFields(body, fontPath, sy, cfg, ApplyBar, isBuff)
+    sy = BuildDisplayFields(body, fontPath, sy, cfg, ApplyBar, isBuff, true)
     if not isBuff then
         sy = BuildDispelColorFields(body, fontPath, sy, cfg, ApplyBar)
         sy = BuildFxEffects(body, sy, cfg, ApplyBar)

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -68,11 +68,12 @@ local FONT_OUTLINE_VALUES = {
     outline = "Outline", thick = "Thick Outline",
 }
 local FONT_OUTLINE_ORDER = { "default", "none", "outline", "thick" }
--- Cross-axis side for the weapon-enchant line. "Above"/"Below" read naturally for the
--- horizontal growth directions; under Up/Down growth the same two values mean the side
--- before/after the columns, mirrored the same way.
-local ENCHANT_LINE_VALUES = { ABOVE = "Above", BELOW = "Below" }
-local ENCHANT_LINE_ORDER = { "ABOVE", "BELOW" }
+-- Weapon-enchant placement. "In Line" = the default UI's model (first cells of the
+-- bar's top row). "Above"/"Below" = a dedicated line on the cross axis; they read
+-- naturally for the horizontal growth directions, and under Up/Down growth mean the
+-- side before/after the columns, mirrored the same way.
+local ENCHANT_LINE_VALUES = { INLINE = "In Line", ABOVE = "Above", BELOW = "Below" }
+local ENCHANT_LINE_ORDER = { "INLINE", "ABOVE", "BELOW" }
 local GROW_DIR_VALUES = { LEFT = "Left", RIGHT = "Right", UP = "Up", DOWN = "Down" }
 local GROW_DIR_ORDER = { "LEFT", "RIGHT", "UP", "DOWN" }
 local ICON_WRAP_VALUES = { LEFT = "Left", RIGHT = "Right" }
@@ -890,10 +891,10 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff, isDef
         local enchantSlot = { type = "label", text = "" }
         if isDefaultBar then
             enchantSlot = {
-                type = "dropdown", text = "Weapon Enchant Line",
-                tooltip = "Which side of the bar oils, poisons and imbues sit on. They are not auras, so they get their own line rather than a grid cell -- putting them back in the grid is what used to push wrapped rows out of alignment. Use Below if the bar sits at the top of the screen, where an Above line has no room.",
+                type = "dropdown", text = "Weapon Enchants",
+                tooltip = "Where oils, poisons and imbues sit. In Line matches the default UI: they take the first spots of the top row, which extends by one spot per enchant. Above and Below give them their own line so every row stays the same width; the cog offsets apply to those two. Avoid Above when the bar sits at the top of the screen.",
                 values = ENCHANT_LINE_VALUES, order = ENCHANT_LINE_ORDER,
-                getValue = function() return string.upper(cfg.enchantLinePosition or "ABOVE") end,
+                getValue = function() return string.upper(cfg.enchantLinePosition or "INLINE") end,
                 setValue = function(v) cfg.enchantLinePosition = v; apply() end
             }
         end
@@ -910,7 +911,10 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff, isDef
         if isDefaultBar then
             local rgn = encRow._rightRegion
             local _, cogShow = EllesmereUI.BuildCogPopup({
-                title = "Weapon Enchant Line",
+                title = "Weapon Enchants",
+                -- Above/Below only: In Line buttons sit in reserved grid cells,
+                -- where a free offset would detach them from the cells the
+                -- container shift is holding open (publisher zeroes them there).
                 rows = {
                     { type = "slider", label = "Offset X", min = -200, max = 200, step = 1,
                       get = function() return cfg.enchantLineOffsetX or 0 end,

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
@@ -9,15 +9,15 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 -- same reason (and may read secrets untainted; we cannot copy that path).
 --
 -- Integration model -- first-class citizens of BOTH displays:
---   * OWN LINE (PAB): the buttons sit on a dedicated line one icon + row gap
---     off the bar's fixed corner (rec.lineX/lineY), on the cross axis, so the
---     line reads as "before" the grid -- Blizzard's temp-enchants-first
---     ordering. They pack along the grow axis and share the grid's edge, and
---     the engine container never moves, so the grid stays a clean rectangle
---     at every count. The old model shifted the container inward by N cells,
---     which every wrapped row inherited (row 2+ inset from row 1, full rows
---     overflowing the reserved grid). The UF display keeps its own in-line
---     lead strip and is untouched by this.
+--   * PLACEMENT (PAB), per-bar three-way (rec.inline / rec.lineX/lineY):
+--     "In Line" (default, the default UI's model) packs the buttons into the
+--     bar's actual first cells -- the producer shifts its engine container
+--     inward by the active count to reserve them (ApplyEnchantShift), main
+--     hand adjacent to the run, Blizzard's temp-enchants-first ordering.
+--     "Above"/"Below" put them on a dedicated line one icon + row gap off
+--     the bar's fixed corner on the cross axis instead; the container never
+--     moves and every row keeps an identical width. The UF display keeps its
+--     own in-line lead strip and is untouched by any of this.
 --   * LIVE STYLE: buttons render from the display's own AK.styles table and
 --     speak both style dialects (PAB BuildStyle and the unit-frame
 --     BuildStyle: texCoord rect vs iconCrop/iconZoom, cdText* vs duration*,
@@ -53,8 +53,8 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 --
 -- Producer records (nil = display inactive/filtered), poked via
 -- ns.WeaponEnchants_Layout():
---   ns._weaponEnchPAB = { parent, corner, dir, lineCorner, lineX, lineY,
---                         lineGap, lineOffX, lineOffY, pad, styleKey,
+--   ns._weaponEnchPAB = { parent, corner, dir, inline, lineCorner, lineX,
+--                         lineY, lineGap, lineOffX, lineOffY, pad, styleKey,
 --                         canCancel }
 --   ns._weaponEnchUF  = { frame, ia, fp, x, y, gX, pad, styleKey }
 
@@ -321,13 +321,15 @@ local function Paint()
                         -- In combat positions are frozen: a button whose
                         -- last-packed cell is already taken by another enchant
                         -- goes alpha 0 instead of overlapping; the regen pass
-                        -- repacks everything. No "cell >= count" test: the
-                        -- enchant line is the enchants' own, so a stale cell
-                        -- can only leave a gap, never collide with the engine
-                        -- run -- hiding a still-active oil there would be a
+                        -- repacks everything. The "cell >= count" test applies
+                        -- ONLY in In Line mode, where a stale cell can land
+                        -- under the shifted engine run; on a dedicated
+                        -- Above/Below line a stale cell just leaves a gap, and
+                        -- hiding a still-active oil there would be a
                         -- disappearing icon for the rest of the fight.
                         local cellBad = combat and (b._cell == nil
-                            or usedCells[b._cell])
+                            or usedCells[b._cell]
+                            or (rec.inline and b._cell > n - 1))
                         if cellBad then
                             b:SetAlpha(0)
                         else
@@ -370,13 +372,16 @@ local function Paint()
     if anyShown then UpdateTexts() end
 end
 
--- Count changes re-anchor the displays. PAB has nothing to do in combat now
--- that its grid no longer shifts with the count: the container stays put, and
--- the SECURE trio's own geometry is lockdown-blocked anyway, so the regen pass
--- repacks the buttons. Out of combat the full pass runs (ApplyLiveConfig is the
--- combat-illegal one -- it would trip the anchor-poisoned parent:SetSize).
+-- Count changes re-anchor the displays. In combat PAB takes the minimal
+-- container-only re-seat (PAB_ReShiftEnchants -- plain SetPoint, combat-legal;
+-- a no-op offset unless the bar is in In Line mode), because the full
+-- ApplyLiveConfig is combat-illegal: the secure trio anchors into the bar
+-- frame's family, which blocks the bar's own SetSize in lockdown. The trio's
+-- own geometry is also lockdown-frozen, so the regen pass repacks the buttons.
 local function PokeProducers(combat)
-    if not combat then
+    if combat then
+        if ns.PAB_ReShiftEnchants then ns.PAB_ReShiftEnchants() end
+    else
         if ns.PAB_ApplyLiveConfig then ns.PAB_ApplyLiveConfig(true) end
     end
     if ns.UF_ReloadAllAuraContainers then ns.UF_ReloadAllAuraContainers() end

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
@@ -9,12 +9,15 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 -- same reason (and may read secrets untainted; we cannot copy that path).
 --
 -- Integration model -- first-class citizens of BOTH displays:
---   * IN-GRID CELLS: while N enchants are active, the display's engine
---     container is SHIFTED inward by N cells (the producers own that shift;
---     this file exposes ns.WeaponEnchants_Count and pokes them on change),
---     and the enchant buttons occupy the bar's actual first cells -- main
---     hand adjacent to the run, Blizzard's temp-enchants-first ordering.
---     No oils = zero shift = byte-identical layout.
+--   * OWN LINE (PAB): the buttons sit on a dedicated line one icon + row gap
+--     off the bar's fixed corner (rec.lineX/lineY), on the cross axis, so the
+--     line reads as "before" the grid -- Blizzard's temp-enchants-first
+--     ordering. They pack along the grow axis and share the grid's edge, and
+--     the engine container never moves, so the grid stays a clean rectangle
+--     at every count. The old model shifted the container inward by N cells,
+--     which every wrapped row inherited (row 2+ inset from row 1, full rows
+--     overflowing the reserved grid). The UF display keeps its own in-line
+--     lead strip and is untouched by this.
 --   * LIVE STYLE: buttons render from the display's own AK.styles table and
 --     speak both style dialects (PAB BuildStyle and the unit-frame
 --     BuildStyle: texCoord rect vs iconCrop/iconZoom, cdText* vs duration*,
@@ -50,7 +53,8 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 --
 -- Producer records (nil = display inactive/filtered), poked via
 -- ns.WeaponEnchants_Layout():
---   ns._weaponEnchPAB = { parent, corner, dir, pad, styleKey, canCancel }
+--   ns._weaponEnchPAB = { parent, corner, dir, lineX, lineY, lineGap, pad,
+--                         styleKey, canCancel }
 --   ns._weaponEnchUF  = { frame, ia, fp, x, y, gX, pad, styleKey }
 
 local _, ns = ...
@@ -261,7 +265,9 @@ local function Paint()
             -- any ancestor of them is combat-blocked); visibility rides
             -- button alpha exclusively. Out of combat: full geometry/style
             -- pass; in combat: alpha + content only. Cells pack active slots
-            -- with MAIN HAND adjacent to the engine run.
+            -- along the enchant line, MAIN HAND taking the innermost cell
+            -- (highest index, furthest along the grow direction) -- the order
+            -- the shifted-container model used, kept as-is here.
             local active = rec and style or nil
             local cellIndex = {}
             if active then
@@ -293,9 +299,16 @@ local function Paint()
                             local dx, dy = 0, 0
                             if dir == "RIGHT" then dx = 1 elseif dir == "LEFT" then dx = -1
                             elseif dir == "UP" then dy = 1 elseif dir == "DOWN" then dy = -1 end
+                            -- Cross-axis step onto the bar's dedicated enchant
+                            -- line (rec.lineX/lineY, one icon + the grid's row
+                            -- gap away from the corner). Buttons still pack
+                            -- along the grow axis, so the line shares the grid's
+                            -- edge and the container never has to move.
+                            local step = (style.width or 32) + (rec.lineGap or 0)
                             b:ClearAllPoints()
                             b:SetPoint(rec.corner, rec.parent, rec.corner,
-                                dx * idx * cell, dy * idx * cell)
+                                dx * idx * cell + (rec.lineX or 0) * step,
+                                dy * idx * cell + (rec.lineY or 0) * step)
                             b._cell = idx
                             b._noTooltip = style.noTooltips == true
                         end
@@ -304,11 +317,15 @@ local function Paint()
                     if info then
                         PaintContent(b, SLOTS[i], info)
                         -- In combat positions are frozen: a button whose
-                        -- last-packed cell now belongs to the shifted engine
-                        -- run (or to another enchant) goes alpha 0 instead
-                        -- of overlapping; the regen pass repacks everything.
+                        -- last-packed cell is already taken by another enchant
+                        -- goes alpha 0 instead of overlapping; the regen pass
+                        -- repacks everything. No "cell >= count" test: the
+                        -- enchant line is the enchants' own, so a stale cell
+                        -- can only leave a gap, never collide with the engine
+                        -- run -- hiding a still-active oil there would be a
+                        -- disappearing icon for the rest of the fight.
                         local cellBad = combat and (b._cell == nil
-                            or b._cell > n - 1 or usedCells[b._cell])
+                            or usedCells[b._cell])
                         if cellBad then
                             b:SetAlpha(0)
                         else
@@ -351,16 +368,13 @@ local function Paint()
     if anyShown then UpdateTexts() end
 end
 
--- Count changes re-anchor the displays (their containers shift inward by
--- the new count). Container re-seating is combat-legal and runs IMMEDIATELY
--- (the engine run repositions live); only the SECURE trio's geometry is
--- lockdown-blocked, so in combat PAB takes the minimal container-only path
--- (the full ApplyLiveConfig would trip the anchor-poisoned parent:SetSize)
--- and a regen pass repacks the buttons afterward.
+-- Count changes re-anchor the displays. PAB has nothing to do in combat now
+-- that its grid no longer shifts with the count: the container stays put, and
+-- the SECURE trio's own geometry is lockdown-blocked anyway, so the regen pass
+-- repacks the buttons. Out of combat the full pass runs (ApplyLiveConfig is the
+-- combat-illegal one -- it would trip the anchor-poisoned parent:SetSize).
 local function PokeProducers(combat)
-    if combat then
-        if ns.PAB_ReShiftEnchants then ns.PAB_ReShiftEnchants() end
-    else
+    if not combat then
         if ns.PAB_ApplyLiveConfig then ns.PAB_ApplyLiveConfig(true) end
     end
     if ns.UF_ReloadAllAuraContainers then ns.UF_ReloadAllAuraContainers() end

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
@@ -53,8 +53,9 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 --
 -- Producer records (nil = display inactive/filtered), poked via
 -- ns.WeaponEnchants_Layout():
---   ns._weaponEnchPAB = { parent, corner, dir, lineX, lineY, lineGap, pad,
---                         styleKey, canCancel }
+--   ns._weaponEnchPAB = { parent, corner, dir, lineCorner, lineX, lineY,
+--                         lineGap, lineOffX, lineOffY, pad, styleKey,
+--                         canCancel }
 --   ns._weaponEnchUF  = { frame, ia, fp, x, y, gX, pad, styleKey }
 
 local _, ns = ...
@@ -305,10 +306,11 @@ local function Paint()
                             -- along the grow axis, so the line shares the grid's
                             -- edge and the container never has to move.
                             local step = (style.width or 32) + (rec.lineGap or 0)
+                            local anchor = rec.lineCorner or rec.corner
                             b:ClearAllPoints()
-                            b:SetPoint(rec.corner, rec.parent, rec.corner,
-                                dx * idx * cell + (rec.lineX or 0) * step,
-                                dy * idx * cell + (rec.lineY or 0) * step)
+                            b:SetPoint(anchor, rec.parent, anchor,
+                                dx * idx * cell + (rec.lineX or 0) * step + (rec.lineOffX or 0),
+                                dy * idx * cell + (rec.lineY or 0) * step + (rec.lineOffY or 0))
                             b._cell = idx
                             b._noTooltip = style.noTooltips == true
                         end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -1514,45 +1514,24 @@ local function HideBlizzardPlayerAuras()
     end
 end
 
--- Shifts the default Buffs container inward by the active weapon-enchant
--- count (see EUI_UnitFrames_WeaponEnchants.lua): the enchant buttons occupy
--- the bar's first cells and the engine run starts after them -- Blizzard's
--- temp-enchants-first ordering. Zero enchants (or a filtered-out record)
--- leaves the anchor byte-identical. Full rows overflow the reserved grid by
--- the shift while an oil is up -- accepted; the shift is transient.
-local function ShiftBuffsForEnchants(container, parent, cfg, grid)
-    local n = (ns._weaponEnchPAB and ns.WeaponEnchants_Count and ns.WeaponEnchants_Count()) or 0
-    if n == 0 then return end
-    local corner = BuildContainerSpec(parent, cfg, grid)
+-- Weapon-enchant lead cells used to be carved out of the grid by SHIFTING the whole
+-- Buffs container inward by the active count. Every wrapped row inherits a container
+-- shift, so row 2+ ended up inset from row 1's edge whenever an oil was up and the
+-- buffs wrapped, and a full row overflowed the reserved grid by the shift. The
+-- enchants now sit on their OWN line just outside the grid instead, so the container
+-- never moves and the grid stays a clean rectangle at every enchant count.
+--
+-- Returns the unit direction from the grid's fixed corner to that line, i.e. the cross
+-- axis, pointing AWAY from where the flow's lines extend. Horizontal growth wraps
+-- downward always (ToGrowthV), so the line goes UP; vertical growth wraps along
+-- iconWrapDirection, so the line goes against it. The enchant buttons still pack along
+-- the GROW axis from the corner, keeping main-hand-adjacent order and the grid's edge.
+local function EnchantLineOffset(cfg)
     local dir = cfg.growDirection or "LEFT"
-    local dx, dy = 0, 0
-    if dir == "RIGHT" then dx = 1 elseif dir == "LEFT" then dx = -1
-    elseif dir == "UP" then dy = 1 elseif dir == "DOWN" then dy = -1 end
-    local cell = EllesmereUI.PP.Scale(cfg.iconSize or 32) + (cfg.padding or 5)
-    container:ClearAllPoints()
-    container:SetPoint(corner, parent, corner, dx * n * cell, dy * n * cell)
-end
-
--- Combat-path re-shift for enchant count changes: re-seating the CONTAINER
--- is combat-legal (plain SetPoint, same class as the merged-debuff ride),
--- but the full ApplyLiveConfig is not -- the secure enchant trio anchors
--- into the bar frame's family, which blocks the bar's own SetSize in
--- lockdown. Recomputes the live grid and re-seats ONLY the container,
--- INCLUDING the shift-to-zero reset when the last oil expires.
-function ns.PAB_ReShiftEnchants()
-    local s = PAB()
-    if not (AK and s and buffsContainer and buffsParent) then return end
-    local cfg = DefaultBuffsCfg(s)
-    local grid = ComputeGrid(true, cfg)
-    local corner = BuildContainerSpec(buffsParent, cfg, grid)
-    local n = (ns._weaponEnchPAB and ns.WeaponEnchants_Count and ns.WeaponEnchants_Count()) or 0
-    local dir = cfg.growDirection or "LEFT"
-    local dx, dy = 0, 0
-    if dir == "RIGHT" then dx = 1 elseif dir == "LEFT" then dx = -1
-    elseif dir == "UP" then dy = 1 elseif dir == "DOWN" then dy = -1 end
-    local cell = EllesmereUI.PP.Scale(cfg.iconSize or 32) + (cfg.padding or 5)
-    buffsContainer:ClearAllPoints()
-    buffsContainer:SetPoint(corner, buffsParent, corner, dx * n * cell, dy * n * cell)
+    if dir == "UP" or dir == "DOWN" then
+        return ((cfg.iconWrapDirection or "LEFT") == "RIGHT") and -1 or 1, 0
+    end
+    return 0, 1
 end
 
 local function CreateBars()
@@ -1632,8 +1611,10 @@ local function CreateBars()
     -- Duration on -- the same gate as the catch-all group). They render with
     -- the bar's live style, so every customization follows automatically.
     if buffCfg.showAllBuffs ~= false or buffCfg.hasDuration == true then
+        local lineX, lineY = EnchantLineOffset(buffCfg)
         ns._weaponEnchPAB = { parent = buffsParent, corner = buffCorner,
             dir = buffCfg.growDirection or "LEFT",
+            lineX = lineX, lineY = lineY, lineGap = buffGrid.rowGap,
             pad = buffPad, styleKey = STYLE_BUFFS, canCancel = true }
     else
         ns._weaponEnchPAB = nil
@@ -1670,7 +1651,6 @@ local function CreateBars()
     AK.RequestContainer(buffsParent, "player", buffSpec, function(container)
         buffsContainer = container
         AK.SetContainerAxis(container, buffVertical)
-        ShiftBuffsForEnchants(container, buffsParent, buffCfg, buffGrid)
         declared.buffs = {}
         ApplyGroupConfig(container, buffAllChain, declared.buffs, STYLE_BUFFS, buffGrid.effectiveMax, buffPad, buffGrid.rowGap, buffCfg, BuffCandidateExtras(buffCfg))
         if #buffSpells > 0 then
@@ -1821,18 +1801,18 @@ local function ApplyLiveConfig(isBuff)
     ApplyContainerAnchorAndGrowth(container, parent, cfg, grid)
 
     if isBuff then
-        -- Keep the weapon-enchant cells riding the bar's live geometry and
-        -- filter state (same broad-content gate as the catch-all group),
-        -- then shift the engine run inward past them.
+        -- Keep the weapon-enchant line riding the bar's live geometry and
+        -- filter state (same broad-content gate as the catch-all group).
         if cfg.showAllBuffs ~= false or cfg.hasDuration == true then
             local liveCorner = BuildContainerSpec(parent, cfg, grid)
+            local lineX, lineY = EnchantLineOffset(cfg)
             ns._weaponEnchPAB = { parent = parent, corner = liveCorner,
                 dir = cfg.growDirection or "LEFT",
+                lineX = lineX, lineY = lineY, lineGap = grid.rowGap,
                 pad = pad, styleKey = STYLE_BUFFS, canCancel = true }
         else
             ns._weaponEnchPAB = nil
         end
-        ShiftBuffsForEnchants(container, parent, cfg, grid)
         if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
     end
 
@@ -1852,7 +1832,6 @@ local function ApplyLiveConfig(isBuff)
             AK.RequestContainer(parent, "player", spec, function(newContainer)
                 buffsContainer = newContainer
                 AK.SetContainerAxis(newContainer, specVertical)
-                ShiftBuffsForEnchants(newContainer, parent, cfg, grid)
                 declared.buffs = {}
                 ApplyGroupConfig(newContainer, allChain, declared.buffs, STYLE_BUFFS, grid.effectiveMax, pad, grid.rowGap, cfg, BuffCandidateExtras(cfg))
                 if #spells > 0 then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -1514,25 +1514,22 @@ local function HideBlizzardPlayerAuras()
     end
 end
 
--- Weapon-enchant lead cells used to be carved out of the grid by SHIFTING the whole
--- Buffs container inward by the active count. Every wrapped row inherits a container
--- shift, so row 2+ ended up inset from row 1's edge whenever an oil was up and the
--- buffs wrapped, and a full row overflowed the reserved grid by the shift. The
--- enchants now sit on their OWN line just outside the grid instead, so the container
--- never moves and the grid stays a clean rectangle at every enchant count.
---
--- Returns (anchorCorner, unitX, unitY) for that line: the cross axis, one step off the
--- grid. "Above" leaves from the flow's own fixed corner, away from where its lines
--- extend (horizontal growth always wraps downward per ToGrowthV, so that is UP;
--- vertical growth wraps along iconWrapDirection, so it is against that). "Below" leaves
--- from the MIRRORED corner instead -- stepping down from a TOP corner would land on row
--- 1, so the far edge of the reserved grid is the only anchor that clears it. Buttons
--- still pack along the GROW axis, so either way the line shares the grid's edge.
---
--- Position is a per-bar setting because there is no placement that always fits: a bar
--- parked at the top of the screen pushes an "above" line off-screen entirely (field
--- report: only the duration text stayed visible), while "below" sits against the
--- RESERVED row count, so it floats away from the icons when fewer rows are in use.
+-- Weapon-enchant placement, a per-bar three-way ("In Line"/"Above"/"Below") because no
+-- single placement fits everyone:
+--   * In Line (default; the default UI's model and this bar's original one): the
+--     buttons take the bar's first cells and the container shifts inward to reserve
+--     them. Field history: this briefly LOOKED like it misaligned wrapped rows, but
+--     that was the ComputeGrid trailing-gap off-by-one (fixed separately) stacking on
+--     top of the honest one-cell top-row overhang.
+--   * Above/Below: a dedicated line on the cross axis, one step off the grid -- every
+--     row identical width. "Above" leaves from the flow's own fixed corner, away from
+--     where its lines extend (horizontal growth always wraps downward per ToGrowthV,
+--     so that is UP; vertical growth wraps along iconWrapDirection, so it is against
+--     that). "Below" leaves from the MIRRORED corner -- stepping down from a TOP
+--     corner would land on row 1. Neither is a safe default: a bar parked at the top
+--     of the screen pushes an "above" line off-screen entirely (field report: only the
+--     duration text stayed visible), and "below" sits against the RESERVED row count,
+--     floating away from the icons when fewer rows are in use.
 local function MirrorCornerV(corner)
     if string.find(corner, "^TOP") then return (string.gsub(corner, "^TOP", "BOTTOM")) end
     if string.find(corner, "^BOTTOM") then return (string.gsub(corner, "^BOTTOM", "TOP")) end
@@ -1543,9 +1540,18 @@ local function MirrorCornerH(corner)
     if string.find(corner, "RIGHT$") then return (string.gsub(corner, "RIGHT$", "LEFT")) end
     return corner
 end
+-- Returns (anchorCorner, unitX, unitY, inline). "In Line" (the default -- it is the
+-- default UI's placement and the model this bar always had) puts the buttons IN the
+-- bar's first cells: unit vector zero, and ApplyEnchantShift below reserves the cells
+-- by shifting the engine container inward. The one visual departure from the default
+-- UI is that wrapped rows do not tuck under the enchant cells -- the engine has ONE
+-- wrap width per container, so row 1 cannot hold fewer buffs than row 2; the top row
+-- extends by one cell per active enchant instead.
 local function EnchantLineSpec(cfg, corner)
+    local pos = string.upper(cfg.enchantLinePosition or "INLINE")
+    if pos ~= "ABOVE" and pos ~= "BELOW" then return corner, 0, 0, true end
     local dir = cfg.growDirection or "LEFT"
-    local below = (string.upper(cfg.enchantLinePosition or "ABOVE") == "BELOW")
+    local below = (pos == "BELOW")
     if dir == "UP" or dir == "DOWN" then
         local away = ((cfg.iconWrapDirection or "LEFT") == "RIGHT") and -1 or 1
         if below then return MirrorCornerH(corner), -away, 0 end
@@ -1553,6 +1559,34 @@ local function EnchantLineSpec(cfg, corner)
     end
     if below then return MirrorCornerV(corner), 0, -1 end
     return corner, 0, 1
+end
+
+-- In Line's cell reservation: seat the engine container one cell inward per active
+-- enchant so the buttons occupy the bar's true first cells, Blizzard's
+-- temp-enchants-first ordering. ALWAYS re-seats (n = 0 -> offset 0), so an
+-- Above/Below flip or the last oil expiring resets the shift rather than
+-- leaving a stale one. Plain SetPoint on the container -- combat-legal, which
+-- is why ns.PAB_ReShiftEnchants below is safe as the in-combat poke (the full
+-- ApplyLiveConfig is not: the secure enchant trio anchors into the bar frame's
+-- family, which blocks the bar's own SetSize in lockdown).
+local function ApplyEnchantShift(container, parent, cfg, grid)
+    local rec = ns._weaponEnchPAB
+    local n = (rec and rec.inline and ns.WeaponEnchants_Count and ns.WeaponEnchants_Count()) or 0
+    local corner = BuildContainerSpec(parent, cfg, grid)
+    local dir = cfg.growDirection or "LEFT"
+    local dx, dy = 0, 0
+    if dir == "RIGHT" then dx = 1 elseif dir == "LEFT" then dx = -1
+    elseif dir == "UP" then dy = 1 elseif dir == "DOWN" then dy = -1 end
+    local cell = EllesmereUI.PP.Scale(cfg.iconSize or 32) + (cfg.padding or 5)
+    container:ClearAllPoints()
+    container:SetPoint(corner, parent, corner, dx * n * cell, dy * n * cell)
+end
+
+function ns.PAB_ReShiftEnchants()
+    local s = PAB()
+    if not (AK and s and buffsContainer and buffsParent) then return end
+    local cfg = DefaultBuffsCfg(s)
+    ApplyEnchantShift(buffsContainer, buffsParent, cfg, ComputeGrid(true, cfg))
 end
 
 local function CreateBars()
@@ -1632,13 +1666,13 @@ local function CreateBars()
     -- Duration on -- the same gate as the catch-all group). They render with
     -- the bar's live style, so every customization follows automatically.
     if buffCfg.showAllBuffs ~= false or buffCfg.hasDuration == true then
-        local lineCorner, lineX, lineY = EnchantLineSpec(buffCfg, buffCorner)
+        local lineCorner, lineX, lineY, inline = EnchantLineSpec(buffCfg, buffCorner)
         ns._weaponEnchPAB = { parent = buffsParent, corner = buffCorner,
-            dir = buffCfg.growDirection or "LEFT",
+            dir = buffCfg.growDirection or "LEFT", inline = inline,
             lineCorner = lineCorner, lineX = lineX, lineY = lineY,
             lineGap = buffGrid.rowGap,
-            lineOffX = buffCfg.enchantLineOffsetX or 0,
-            lineOffY = buffCfg.enchantLineOffsetY or 0,
+            lineOffX = (not inline and (buffCfg.enchantLineOffsetX or 0)) or 0,
+            lineOffY = (not inline and (buffCfg.enchantLineOffsetY or 0)) or 0,
             pad = buffPad, styleKey = STYLE_BUFFS, canCancel = true }
     else
         ns._weaponEnchPAB = nil
@@ -1675,6 +1709,7 @@ local function CreateBars()
     AK.RequestContainer(buffsParent, "player", buffSpec, function(container)
         buffsContainer = container
         AK.SetContainerAxis(container, buffVertical)
+        ApplyEnchantShift(container, buffsParent, buffCfg, buffGrid)
         declared.buffs = {}
         ApplyGroupConfig(container, buffAllChain, declared.buffs, STYLE_BUFFS, buffGrid.effectiveMax, buffPad, buffGrid.rowGap, buffCfg, BuffCandidateExtras(buffCfg))
         if #buffSpells > 0 then
@@ -1829,17 +1864,18 @@ local function ApplyLiveConfig(isBuff)
         -- filter state (same broad-content gate as the catch-all group).
         if cfg.showAllBuffs ~= false or cfg.hasDuration == true then
             local liveCorner = BuildContainerSpec(parent, cfg, grid)
-            local lineCorner, lineX, lineY = EnchantLineSpec(cfg, liveCorner)
+            local lineCorner, lineX, lineY, inline = EnchantLineSpec(cfg, liveCorner)
             ns._weaponEnchPAB = { parent = parent, corner = liveCorner,
-                dir = cfg.growDirection or "LEFT",
+                dir = cfg.growDirection or "LEFT", inline = inline,
                 lineCorner = lineCorner, lineX = lineX, lineY = lineY,
                 lineGap = grid.rowGap,
-                lineOffX = cfg.enchantLineOffsetX or 0,
-                lineOffY = cfg.enchantLineOffsetY or 0,
+                lineOffX = (not inline and (cfg.enchantLineOffsetX or 0)) or 0,
+                lineOffY = (not inline and (cfg.enchantLineOffsetY or 0)) or 0,
                 pad = pad, styleKey = STYLE_BUFFS, canCancel = true }
         else
             ns._weaponEnchPAB = nil
         end
+        ApplyEnchantShift(container, parent, cfg, grid)
         if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
     end
 
@@ -1859,6 +1895,7 @@ local function ApplyLiveConfig(isBuff)
             AK.RequestContainer(parent, "player", spec, function(newContainer)
                 buffsContainer = newContainer
                 AK.SetContainerAxis(newContainer, specVertical)
+                ApplyEnchantShift(newContainer, parent, cfg, grid)
                 declared.buffs = {}
                 ApplyGroupConfig(newContainer, allChain, declared.buffs, STYLE_BUFFS, grid.effectiveMax, pad, grid.rowGap, cfg, BuffCandidateExtras(cfg))
                 if #spells > 0 then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -1521,17 +1521,38 @@ end
 -- enchants now sit on their OWN line just outside the grid instead, so the container
 -- never moves and the grid stays a clean rectangle at every enchant count.
 --
--- Returns the unit direction from the grid's fixed corner to that line, i.e. the cross
--- axis, pointing AWAY from where the flow's lines extend. Horizontal growth wraps
--- downward always (ToGrowthV), so the line goes UP; vertical growth wraps along
--- iconWrapDirection, so the line goes against it. The enchant buttons still pack along
--- the GROW axis from the corner, keeping main-hand-adjacent order and the grid's edge.
-local function EnchantLineOffset(cfg)
+-- Returns (anchorCorner, unitX, unitY) for that line: the cross axis, one step off the
+-- grid. "Above" leaves from the flow's own fixed corner, away from where its lines
+-- extend (horizontal growth always wraps downward per ToGrowthV, so that is UP;
+-- vertical growth wraps along iconWrapDirection, so it is against that). "Below" leaves
+-- from the MIRRORED corner instead -- stepping down from a TOP corner would land on row
+-- 1, so the far edge of the reserved grid is the only anchor that clears it. Buttons
+-- still pack along the GROW axis, so either way the line shares the grid's edge.
+--
+-- Position is a per-bar setting because there is no placement that always fits: a bar
+-- parked at the top of the screen pushes an "above" line off-screen entirely (field
+-- report: only the duration text stayed visible), while "below" sits against the
+-- RESERVED row count, so it floats away from the icons when fewer rows are in use.
+local function MirrorCornerV(corner)
+    if string.find(corner, "^TOP") then return (string.gsub(corner, "^TOP", "BOTTOM")) end
+    if string.find(corner, "^BOTTOM") then return (string.gsub(corner, "^BOTTOM", "TOP")) end
+    return corner
+end
+local function MirrorCornerH(corner)
+    if string.find(corner, "LEFT$") then return (string.gsub(corner, "LEFT$", "RIGHT")) end
+    if string.find(corner, "RIGHT$") then return (string.gsub(corner, "RIGHT$", "LEFT")) end
+    return corner
+end
+local function EnchantLineSpec(cfg, corner)
     local dir = cfg.growDirection or "LEFT"
+    local below = (string.upper(cfg.enchantLinePosition or "ABOVE") == "BELOW")
     if dir == "UP" or dir == "DOWN" then
-        return ((cfg.iconWrapDirection or "LEFT") == "RIGHT") and -1 or 1, 0
+        local away = ((cfg.iconWrapDirection or "LEFT") == "RIGHT") and -1 or 1
+        if below then return MirrorCornerH(corner), -away, 0 end
+        return corner, away, 0
     end
-    return 0, 1
+    if below then return MirrorCornerV(corner), 0, -1 end
+    return corner, 0, 1
 end
 
 local function CreateBars()
@@ -1611,10 +1632,13 @@ local function CreateBars()
     -- Duration on -- the same gate as the catch-all group). They render with
     -- the bar's live style, so every customization follows automatically.
     if buffCfg.showAllBuffs ~= false or buffCfg.hasDuration == true then
-        local lineX, lineY = EnchantLineOffset(buffCfg)
+        local lineCorner, lineX, lineY = EnchantLineSpec(buffCfg, buffCorner)
         ns._weaponEnchPAB = { parent = buffsParent, corner = buffCorner,
             dir = buffCfg.growDirection or "LEFT",
-            lineX = lineX, lineY = lineY, lineGap = buffGrid.rowGap,
+            lineCorner = lineCorner, lineX = lineX, lineY = lineY,
+            lineGap = buffGrid.rowGap,
+            lineOffX = buffCfg.enchantLineOffsetX or 0,
+            lineOffY = buffCfg.enchantLineOffsetY or 0,
             pad = buffPad, styleKey = STYLE_BUFFS, canCancel = true }
     else
         ns._weaponEnchPAB = nil
@@ -1805,10 +1829,13 @@ local function ApplyLiveConfig(isBuff)
         -- filter state (same broad-content gate as the catch-all group).
         if cfg.showAllBuffs ~= false or cfg.hasDuration == true then
             local liveCorner = BuildContainerSpec(parent, cfg, grid)
-            local lineX, lineY = EnchantLineOffset(cfg)
+            local lineCorner, lineX, lineY = EnchantLineSpec(cfg, liveCorner)
             ns._weaponEnchPAB = { parent = parent, corner = liveCorner,
                 dir = cfg.growDirection or "LEFT",
-                lineX = lineX, lineY = lineY, lineGap = grid.rowGap,
+                lineCorner = lineCorner, lineX = lineX, lineY = lineY,
+                lineGap = grid.rowGap,
+                lineOffX = cfg.enchantLineOffsetX or 0,
+                lineOffY = cfg.enchantLineOffsetY or 0,
                 pad = pad, styleKey = STYLE_BUFFS, canCancel = true }
         else
             ns._weaponEnchPAB = nil


### PR DESCRIPTION
**Cause:** Weapon enchants always occupied the bar's first cells via a container shift. That placement is fine (it is the default UI's model), but it briefly looked broken because the ComputeGrid trailing-gap off-by-one (#1335) stacked on top of it, and there was no way to move the enchants for users who wanted uniform rows.

**Fix:** Per-bar three-way placement on the default Buffs bar. In Line (default) keeps the original model: first cells of the top row, container shift restored, in-combat cell-collision hide restored for this mode only. Above/Below put them on a dedicated cross-axis line with Offset X/Y in the cog (offsets are zeroed In Line, where the buttons sit in reserved cells). Below anchors from the vertically mirrored corner. The shift always re-seats, so mode flips and the last oil expiring reset it cleanly.

**Test:** Default (In Line): apply an oil, enchants take the top row's first spots and buff rows share an edge (needs #1335). Switch to Above/Below, confirm the dedicated line and working offsets, then flip back and confirm the shift resets. Drop an enchant mid-combat: its icon hides rather than overlapping the run, and regen repacks.