### PR TITLE
fix(raidframes): describe what hiding Non-Player Auras actually does

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
@@ -891,8 +891,15 @@ local function BuildBaseDetailDM(frame, fontPath)
             { key = DM_ALL_KEY, label = "All Debuffs",
               tooltip = "Show every debuff. While this is on, checked filters below are hidden from the grid instead of added." },
             { isHeader = true, label = "" },
+            -- The examples this used to lead with (Sated, Forbearance) sold the
+            -- category as small noise, but it is EVERY debuff no player applied --
+            -- which in dungeon and raid content is nearly all of them. Checking it
+            -- while All Debuffs is on therefore empties the frames, and that read as
+            -- a broken filter rather than as the subtract working. Sated is also
+            -- already excluded by its own default, so it was never a reason to
+            -- check this.
             { key = "nonplayer", label = "Non-Player Auras",
-              tooltip = "Debuffs not caused by any player or player pet, like Sated and Forbearance." },
+              tooltip = "Debuffs not caused by a player or player pet, which in dungeons and raids is nearly every debuff you take. While All Debuffs is on, checking this hides almost everything. Sated is already hidden by default without it." },
             { key = "priority", label = "Important",
               tooltip = "Debuffs Blizzard flags as priority for raid frames." },
             { key = "cc", label = "Crowd Control",


### PR DESCRIPTION
**Cause:** Not a filtering bug. `BuildRecords` is correct in both directions: Non-Player Auras adds via `isFromPlayerOrPlayerPet = false`, and subtracts by inverting to `isFromPlayerOrPlayerPet = true` on the all-record. The tooltip was the defect. Leading with "like Sated and Forbearance" sold the category as small noise, when it is every debuff no player applied, i.e. nearly all of them in dungeon and raid content. Checking it while All Debuffs is on therefore empties the frames correctly, which reads as a broken filter rather than as the subtract working. Sated is also already excluded by its own `hideLustDebuff` default, so it was never a reason to check this category.

**Fix:** Rewrite the tooltip to state the real scope and the All Debuffs interaction, and note that Sated needs no action. No behaviour change.

**Test:** Reported from M+ (@Shikoba, 8.8.2): All Debuffs on plus Non-Player Auras checked showed no debuffs, while All Debuffs alone worked. Confirm the same setup still shows nothing (correct), that the tooltip now says so up front, and that unchecking Non-Player Auras restores the full set.