### PR TITLE
fix(raidframes): restore the Icon Effects per-slot gate, dropping a stray dbg global

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_DebuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_DebuffManager.lua
@@ -834,16 +834,17 @@ local function FxApply(button, dd, style)
     local fx = style.fx
     if not (refs and fx) then return end
 
-    -- Per-filter gating: an effect tile declares one slot per EVER-checked category (add-only engine); currently-
-    -- unchecked slots render nothing. Both paths pcall-wrapped with error RECORDED, since the restyler swallows applier errors silently -- dbg.err is how we see them.
-    local ok, err
-    if not dbg.gate then
-        ok, err = pcall(FxHideAll, dd)
+    -- Per-filter gating: an effect tile declares one slot per EVER-checked category
+    -- (add-only engine -- a slot cannot be un-declared), so a slot whose category is
+    -- currently UNCHECKED must render nothing. dd.dmCat is stamped at slot creation
+    -- and fx.filters is the live checked set, so the two together are the gate.
+    -- Both paths stay pcall-wrapped: this runs inside the engine's CreateFrameBatch,
+    -- where an uncaught error aborts the whole batch and the slot never appears.
+    if dd and fx.filters and fx.filters[dd.dmCat] then
+        pcall(FxApplyInner, button, dd, refs, fx)
     else
-        ok, err = pcall(FxApplyInner, button, dd, refs, fx)
+        pcall(FxHideAll, dd)
     end
-    dbg.ok = ok
-    dbg.err = (not ok) and tostring(err) or nil
 end
 
 -- Icon-tile flow anchoring: corner-pinned chain, CENTER growth centers the


### PR DESCRIPTION
**Cause:** `FxApply` gated on `dbg.gate` and wrote `dbg.ok`/`dbg.err` -- leftover instrumentation whose backing table never shipped, so `dbg` was a nil global. The index sits OUTSIDE the pcalls, so it threw before either path could run, and since the applier runs inside the engine's `CreateFrameBatch` the throw aborted slot creation. Icon Effects tiles on raid frames rendered nothing and errored on every attempt (`attempt to index global 'dbg'`, DebuffManager.lua:840).

**Fix:** Restore the gate the surrounding code documents twice: `fx.filters` is "the applier's per-slot gate" (a live reference to the tile's checked-filter set, DebuffManager.lua:974) and each slot is stamped `d2.dmCat = catKey` "(applier filter gate)" at creation (:1116). A tile declares one slot per EVER-checked category and slots cannot be un-declared, so a slot whose category is currently unchecked must render nothing. Both paths stay pcall-wrapped for batch safety; the debug recording is gone. Swept the suite for other stray `dbg` references -- the only two remaining are backed by locals declared directly above them.

**Test:** Add a Debuff Manager Icon Effects tile, claim a category, and confirm the effect renders on matching debuffs with no Lua error. Uncheck that category and confirm the slot renders nothing rather than keeping a stale effect. Check both `square` and `bar` tile kinds.