### PR TITLE
Fix: spec override labels drop the first character of localized class names

### DIFF
--- a/EllesmereUI_SpecOverrides.lua
+++ b/EllesmereUI_SpecOverrides.lua
@@ -160,7 +160,13 @@ end
 local function SpecName(specID)
     local _, name, _, _, _, _, className = GetSpecializationInfoByID(specID)
     if name and className then
-        return name .. " - " .. className:sub(1, 1):upper() .. className:sub(2):lower()
+        -- Title-case is byte-based; only safe on ASCII class names. Localized
+        -- clients (koKR and friends) return multibyte names -- mangling the
+        -- first byte drops the first character, so leave those untouched.
+        if className:find("^%a") then
+            className = className:sub(1, 1):upper() .. className:sub(2):lower()
+        end
+        return name .. " - " .. className
     end
     return name or ("Spec " .. tostring(specID))
 end


### PR DESCRIPTION
## What does this PR do?

`SpecName()` title-cases the class name with `sub(1, 1):upper()`, which is byte-based.
On localized clients class names are multibyte, so uppercasing the first byte mangles the first character 
-- a koKR client renders "조화 - 드루이드" (Balance - Druid) as "조화 - 루이드", dropping the first letter of the class name entirely.

The fix applies title-casing only when the name starts with an ASCII letter (`className:find("^%a")`); localized names are already correctly cased by the game and pass through untouched.

| | Before | After |
|---|---|---|
| enUS | Balance - Druid | Balance - Druid (unchanged) |
| koKR | 조화 - 루이드 | 조화 - 드루이드 |

### Notes

- One file, +7/-1; no new locale keys, no settings
- `%a` matches ASCII letters only in WoW's Lua, so every multibyte first
  character takes the pass-through branch

## How was it tested?

On a koKR 12.1 PTR client the spec override labels now show the full class name (조화 - 드루이드);
on an English client the string path is byte-identical to before by construction
(ASCII names still title-case through the same expression).

## Checklist

- [ ] New settings default **OFF** -- N/A (bug fix, no settings)
- [ ] Zero cost while disabled -- N/A
- [x] Cheap while enabled -- one `find` per label build
- [x] No writes onto Blizzard-owned frames -- N/A (string handling only)
- [x] Tested in-game, works on the 12.1 PTR with a koKR client; English path unchanged by construction