### PR TITLE
Fix warrior sweeping strike changes in 12.1

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4464,8 +4464,10 @@ do
         end
     end
 
+    -- Since 12.1, this is hard coded in game to be 18 stacks.
+    -- Using sweeping stick at 18 will not exceed 18.
     local function MaxStacks()
-        return improvedKnown and IMPROVED_MAX or BASE_MAX
+        return 18
     end
 
     -- Broad Strokes generators (only count with the talent known)
@@ -4489,6 +4491,7 @@ do
         [202168]  = 1,  -- Impending Victory
         [1715]    = 1,  -- Hamstring
         [1269383] = 1,  -- Heroic Strike (replaces Slam via Master of Warfare)
+        [772]     = 1,  -- Rend (in 12.1, this is now a single target ability)
         [436358]  = 2,  -- Demolish: the channel sweeps twice (damage IDs
                         -- 440884/440886) -- confirmed in-game, 2 per cast
     }
@@ -4586,7 +4589,9 @@ do
 
         if spellID == SWEEP
            or (CS_GENERATORS[spellID] and broadKnown) then
-            stacks = MaxStacks()
+            if spellID == SWEEP then stacks = stacks + 12 
+            elseif CS_GENERATORS[spellID] and broadKnown then stacks = stacks + 6 end
+            stacks = math.min(stacks, MaxStacks())
             expiresAt = GetTime() + DURATION
             cdmSeenActive, cdmInactiveSince = false, nil
             dbg("activated:", stacks, "stacks (cast", spellID .. ")")

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4412,8 +4412,7 @@ end
 -- the primary target -- that Slam sweeps and consumes a charge.
 do
     local stacks, expiresAt = 0, nil
-    local BASE_MAX     = 12
-    local IMPROVED_MAX = 18
+    local BASE_MAX = 18
     local DURATION = 30
     local SWEEP    = 260708
     local IMPROVED = 383155   -- Improved Sweeping Strikes: 12 -> 18 charges
@@ -4467,7 +4466,7 @@ do
     -- Since 12.1, this is hard coded in game to be 18 stacks.
     -- Using sweeping stick at 18 will not exceed 18.
     local function MaxStacks()
-        return 18
+        return BASE_MAX
     end
 
     -- Broad Strokes generators (only count with the talent known)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

## Bug:
Warrior Sweeping Strike Class Resource Bar Not working as intended in 12.1.
- When using Rend, the bar doesnt decrease.
- When using Sweeping Strike, the stack is not added, but rather replaced.
- When using Colossus Smash, the stack is not added, but rather replaced.

## Why is this happening:
There are some logic changes in the new patch.
 - "Broad Stroke"talent now adds 6 stacks instead of setting it to 12.
 - Sweeping Strike now adds 12 stacks instead of setting to 12.
 - Rend is now a single target spell that consumes Sweeping Strike charges.

## Expected behavior:
- The resource bar might need to have a new UI state to represent 12+ stacks.
- The bar is correctly reflecting the current charges of sweeping strike buff,

## How was it tested?

Tested in game by editing the same code in my local file. See screenshots.

## Screenshots
### Before:
<img width="377" height="191" alt="image" src="https://github.com/user-attachments/assets/64cb8be5-8d83-4bf3-afe4-880d9977ef3e" />

### After:
<img width="382" height="201" alt="image" src="https://github.com/user-attachments/assets/10f3bc05-ccae-42df-9b33-07e107091e14" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
