### PR TITLE
fix: CDM repair stale-linked-spell icons instead of leaving them blank

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -1173,6 +1173,52 @@ local function CdmFrameIsActive(frame)
     return false
 end
 
+-- Blizzard resolves a cooldown item's spell through GetSpellID(), whose
+-- precedence is aura > linkedSpellID > overrideTooltip > override > base
+-- (CooldownViewerItemData.lua). When an aura ends without the item receiving the
+-- UNIT_AURA removal, cooldownInfo.linkedSpellID keeps pointing at the aura, so
+-- CheckCacheCooldownValuesFromSpellCooldown reads the cooldown from a spell that
+-- HAS none: start/dur come back 0, IsExpired() answers true, and
+-- RefreshSpellCooldownInfo takes its CooldownFrame_Clear branch on every refresh
+-- -- no swipe, no countdown text -- while RefreshIconDesaturation leaves the icon
+-- saturated. The ability is still on cooldown, so the icon reads as "never
+-- pressed" until a target switch (OnNewTarget clears the link), a re-cast of the
+-- base spell, or a cooldownID re-set. Blizzard's own repair for this,
+-- RefreshLinkedSpell, is only called from OnCooldownIDSet, never from RefreshData.
+--
+-- How the link outlives the aura: ClearAuraInstanceInfo() drops the instance but
+-- NOT the link, and the only path that drops both is OnUnitAuraRemovedEvent,
+-- which is dispatched through auraInstanceIDToItemFramesMap and is therefore
+-- missable. Any later RefreshData then clears the instance via RefreshAuraInstance
+-- and leaves the link standing.
+--
+-- Detected with nil-compares and never-secret bools ONLY. In instanced combat
+-- Cooldown:GetCooldownDuration answers a SECRET value, which is exactly why
+-- ReAssertRealCooldown's "widget reads ~0" proof fails closed there -- i.e. in
+-- the content where this is reported.
+--
+-- Field-captured 2026-08-10, Arcane Mage, live occurrence: base=321507 (Touch of
+-- the Magi) but the item resolved to 210824 (its debuff), linkedSpellID=210824,
+-- auraSpellID and auraInstanceID both nil, source "cooldown", drawSwipe true and
+-- swipe colour black -- i.e. the swipe was enabled and correctly coloured, only
+-- its geometry was gone. ToTM was the only icon on the bar carrying a link.
+--
+-- We repair OUR rendering only; Blizzard's item stays wrong, so its own alerts
+-- and isOnActualCooldown keep answering against the linked spell.
+--
+-- Ordered cheapest-first: linkedSpellID is nil for nearly every icon, so the
+-- common case costs two table lookups and no API call. Returns the STRUCTURAL
+-- verdict only; callers add their own "is on a real cooldown" test.
+local function CdmStaleLinkedSpell(frame)
+    local info = frame and frame.cooldownInfo
+    if info == nil or info.linkedSpellID == nil then return false end
+    -- An aura that is actually being displayed owns the widget; never fight it.
+    -- Covers the transient where UpdateLinkedSpell has set the link a moment
+    -- before RefreshAuraInstance attaches the matching instance.
+    if frame.auraInstanceID ~= nil or frame.wasSetFromAura then return false end
+    return true
+end
+
 -- Charge info for a CDM frame, resolved the way BLIZZARD resolves it.
 --
 -- We were resolving the charge spell with C_SpellBook.FindSpellOverrideByID and
@@ -2902,7 +2948,14 @@ local function DecorateFrame(frame, barData)
                 -- precede any truthiness/comparison (a secret errors on either);
                 -- a secret duration cannot prove "cleared", so fail closed (the
                 -- sigil failure moment reads a clean 0, so the fix still runs).
-                if cd.GetCooldownDuration then
+                --
+                -- SECOND PROOF, needed because the fail-closed above is permanent in
+                -- instanced combat (the duration reads secret there, so this function
+                -- could never act -- see CdmStaleLinkedSpell). A stale linked spell
+                -- means Blizzard clears this widget on EVERY refresh, so there is
+                -- nothing to fight and no duration read is required to know it.
+                local staleLink = CdmStaleLinkedSpell(frame)
+                if not staleLink and cd.GetCooldownDuration then
                     local ok, curDur = pcall(cd.GetCooldownDuration, cd)
                     if not ok then return end
                     if issecretvalue and issecretvalue(curDur) then return end
@@ -2914,6 +2967,27 @@ local function DecorateFrame(frame, barData)
                 fd._isProcessingOverride = true
                 if cd.SetUseAuraDisplayTime then cd:SetUseAuraDisplayTime(false) end
                 cd:SetCooldownFromDurationObject(durObj)
+                if staleLink then
+                    -- Blizzard's expired branch never calls SetSwipeColor, so the
+                    -- widget still carries whatever colour was painted last. For an
+                    -- aura-tracking icon that is the ACTIVE colour from the aura
+                    -- window, and it then renders over the cooldown we just armed --
+                    -- field-seen as "the swipe was still yellow". Repaint the resting
+                    -- cooldown colour, the same black the SetSwipeColor hook's
+                    -- not-active branch uses (the per-spell Cooldown Swipe Color only
+                    -- applies to buff-viewer frames, which never reach here).
+                    -- This also releases a Suppress-GCD alpha-0 that can be stuck for
+                    -- the same reason -- what we just armed is a real cooldown, never
+                    -- a GCD. Mirrors ReArmChargeRecharge, which repaints for exactly
+                    -- this reason on the charge path.
+                    -- Gated to the stale case on purpose: the placement-sigil case
+                    -- reaches here with a colour Blizzard has kept current, so it is
+                    -- left alone. Bar data is resolved LIVE rather than from the
+                    -- decorate-time closure, since pooled frames decorate once.
+                    local bkS = fc2.barKey
+                    local bdS = bkS and barDataByKey and barDataByKey[bkS]
+                    cd:SetSwipeColor(0, 0, 0, (bdS and bdS.swipeAlpha) or 0.7)
+                end
                 -- Only geometry was wiped (Blizzard's clear leaves draw-swipe on),
                 -- so re-arming the duration restores the swipe. Deliberately NOT
                 -- forcing SetDrawSwipe(true): under the override guard that would
@@ -3148,7 +3222,15 @@ local function DecorateFrame(frame, barData)
             fd._desatOverrideHooked = true
             local function onDesatChange()
                 if fd._isProcessingOverride then return end
-                if not fd._hideActiveOverriding then return end
+                -- Two owners of this path now. The Hide-Active override is the
+                -- original one. The second is the stale-linked-spell state, where
+                -- Blizzard re-clears the widget AND re-saturates the icon on every
+                -- refresh -- so the repair has to ride the same per-tick driver to
+                -- survive, and the body below already does exactly the right thing
+                -- for it: it re-arms the cooldown from OUR spell id and then sets
+                -- the desaturation from that same id's real cooldown state.
+                -- Cheap-first: the flag is one lookup, the helper two more.
+                if not (fd._hideActiveOverriding or CdmStaleLinkedSpell(frame)) then return end
                 fd._isProcessingOverride = true
                 local cdw = fd.cooldown
                 local fc2 = _ecmeFC[frame]


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1536157914031718531

## What does this PR do?

Fixes a Cooldown Manager bug where an aura-tracking icon (e.g. Touch of the Magi, Execution Sentence) can go completely blank while the ability is on a long cooldown — no swipe, no countdown text, and not desaturated, as if it had never been pressed. Root cause is in Blizzard's own CooldownViewer, not in EllesmereUI:

`GetSpellID()` prefers `cooldownInfo.linkedSpellID` over the base spell. If an aura's `UNIT_AURA` removal fails to reach the item — e.g. because a refresh lands inside the removal race and clears the aura instance a moment early, or the aura sits on a unit that is no longer the target — the link outlives the aura. Blizzard then reads the cooldown from the linked (aura) spell instead of the ability, gets `start=0`/`dur=0`, and treats the item as expired for the rest of the real cooldown. `ReAssertRealCooldown`'s existing "widget reads ~0" repair can't catch this in instanced content, because the widget duration itself is a secret value there — exactly where the bug is reported from.

This adds a second, secret-safe detector for the stale-link state (link set, no aura instance, aura not currently displayed — nil-compares and never-secret bools only, never a spell-id comparison) and repairs both the swipe geometry/colour and the icon's saturation from it. Blizzard's own state is left untouched; only our rendering is corrected.

Filed upstream as a Blizzard bug report, since the underlying issue is not ours to fully fix. Their PTR branch already adds the equivalent repair to `CooldownViewerBuffItemMixin`, but not to the cooldown-item mixin this addon hooks — the source diff is unchanged there otherwise.

## How was it tested?

Live retail. Reproduced and confirmed on two separate accounts using a throwaway diagnostic addon that reads only Blizzard's own item fields (`cooldownInfo.linkedSpellID`, `auraInstanceID`, `C_Spell.GetSpellCooldown`) — never written by EllesmereUI anywhere in the tree, confirmed by grep before attributing the state to Blizzard.

Field capture with real ids: `base=321507` (Touch of the Magi) resolving to `210824` (its debuff) via `linkedSpellID`, aura instance and aura spell both nil, swipe enabled with a stale colour, icon not desaturated. A second capture on another account caught the state entered right after a target switch that produced two `PLAYER_TARGET_CHANGED` events and no `UNIT_TARGET` — the only event the viewer's own target-change recovery listens for.

After the fix: swipe colour and geometry both confirmed correct in-game across multiple occurrences (14 repair passes observed in one capture, matching Blizzard's refresh rate for the state). Desaturation was confirmed visually correct after removing a debug probe that had been writing to the same icon texture and could otherwise have masked the result.

Regression-tested in-game against the unaffected paths this hook also serves: normal aura display runs its full duration before handing off to the cooldown swipe; Hide Active State unaffected; charge-spell recharge swipe and charge count unaffected; resumes correctly after `/reload`; Suppress GCD unaffected.

Rebased onto current `main` (v8.8.3) to pick up the unrelated cooldown-edge work landed on this file since branching; the same functional diff applies cleanly, `luac5.1 -p` and the style check both pass against the new base.

PTR: checked by diffing this addon's hooked functions against the current PTR branch of `Blizzard_CooldownViewer` (source comparison, not an in-game PTR client — I don't have PTR access). Every function this fix reads or is built around (`GetSpellID`, `IsExpired`, `RefreshSpellCooldownInfo`, `RefreshIconDesaturation`, `ClearAuraInstanceInfo`) is unchanged there, so the fix should behave identically on PTR.

## Screenshots

Not applicable — the fix restores existing visuals (swipe, countdown, desaturation) to their normal appearance; there is no new visual to show.

## Checklist

- [x] N/A — this is a bug fix, not a new setting; there is no opt-in
- [x] Zero cost while unaffected: no new events, no polling, no timer, no new hooks. The added check runs inside two existing hooks (`SetDesaturated`'s post-hook and `ReAssertRealCooldown`) and costs two table reads for every icon that isn't in the stale state
- [x] Cheap while active: only runs the extra work while an icon is actually in the stale-linked-spell state, driven by Blizzard's own existing refresh cadence — no polling
- [x] No writes onto Blizzard-owned frames: only calls `Cooldown:SetSwipeColor` and `Texture:SetDesaturated`, both already called by the existing hooks this extends; reads `cooldownInfo`, `auraInstanceID`, `wasSetFromAura`
- [x] Tested in-game on live retail (see above); PTR checked by source diff only, not an in-game PTR client