### PR TITLE
feat/fix: add standalone Weapon Enchants filter to the default Buffs

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -4547,6 +4547,26 @@ GetBarLabel = function(barKey)
 end
 EllesmereUI.GetBarLabel = GetBarLabel
 
+-- Re-read one already-built mover's name from its registered element. Movers are
+-- cached in `movers` for the session, and CreateMover captures the label into a
+-- plain local upvalue (`label`) that RefreshAnchoredIdle -- fired on every hover
+-- and every anchor-state change -- keeps re-painting verbatim. Setting
+-- mover._label's text directly is therefore not enough: the next hover reverts
+-- it. mover:UpdateLabel() (defined at the end of CreateMover, in the same
+-- closure as `label`) reassigns that upvalue and re-runs the same paint
+-- RefreshAnchoredIdle uses, so the change survives the next hover too.
+--
+-- No-op when the mover was never built, so callers may fire it unconditionally
+-- right after RegisterUnlockElements. Returns false in that case, or true plus
+-- the text it applied -- callers can ignore both; the return exists so the
+-- refresh can be driven (and diagnosed) straight from a /dump.
+function EllesmereUI.RefreshUnlockElementLabel(key)
+    local m = movers[key]
+    if not (m and m.UpdateLabel) then return false end
+    m:UpdateLabel()
+    return true, GetBarLabel(key)
+end
+
 -------------------------------------------------------------------------------
 --  Apply saved positions on login / reload
 -------------------------------------------------------------------------------
@@ -9813,6 +9833,19 @@ local function CreateMover(barKey)
             BuildCogMenu()
             ShowCogClickCatcher()
         end
+    end
+
+    -- Re-read this mover's name from its registered element. `label` above is
+    -- a plain local captured once at CreateMover time -- RefreshAnchoredIdle
+    -- (fired on every hover and anchor-state change, see ShowOverlayText /
+    -- RefreshAnchoredText) closes over that SAME local and keeps re-painting it
+    -- verbatim, so a caller that only did nameFS:SetText(...) directly would see
+    -- the very next hover silently revert the text. Reassigning the local here
+    -- (a plain Lua upvalue write, legal from any function sharing this closure)
+    -- is what makes the change stick.
+    function mover:UpdateLabel()
+        label = GetBarLabel(barKey)
+        RefreshAnchoredIdle()
     end
 
     movers[barKey] = mover

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -193,6 +193,50 @@ local function TruncateFilterName(name)
     return (name or ""):sub(1, 3) .. "..."
 end
 
+-- Both defined in EllesmereUIUnitFrames_PlayerAuraBars.lua next to the cfg they
+-- read, so this page and the unlock-mode mover label cannot drift apart. The
+-- module returns raw English keys; only the options page translates them.
+local function IsWeaponEnchantsOnly(cfg)
+    return ns.PAB_IsWeaponEnchantsOnly ~= nil
+        and ns.PAB_IsWeaponEnchantsOnly(cfg)
+end
+
+local function DefaultBuffBarName(cfg)
+    return L(ns.PAB_DefaultBuffsName and ns.PAB_DefaultBuffsName(cfg) or "Buffs")
+end
+
+-- Weapon-enchants-only is a fundamentally different shape of bar -- at most
+-- three cells (main hand / off hand / ranged, see EUI_UnitFrames_
+-- WeaponEnchants.lua's SLOTS, which matches Blizzard's own
+-- UpdateTemporaryEnchantmentBuffs) instead of a wrapping buff grid. Resize the
+-- grid to fit on the way in and restore it on the way out.
+--
+-- The user's own iconsPerRow/maxRows/maxTotal are stashed rather than assumed:
+-- restoring hardcoded defaults would silently eat a customized grid. Storing
+-- nil for an unset key is intentional -- the stash is then empty and restoring
+-- puts the keys back to nil, i.e. ComputeGrid's own 11/3/32 buff fallbacks.
+--
+-- Returns true when it actually crossed the boundary. Callers use that to pick
+-- a FORCE page rebuild: crossing rewrites the three grid sliders and the bar's
+-- name, and none of those are RegisterWidgetRefresh clients, so the usual
+-- lightweight refresh would leave them showing stale numbers.
+local function SyncWeaponEnchantsGrid(cfg)
+    if not cfg then return false end
+    if IsWeaponEnchantsOnly(cfg) then
+        if cfg.enchGridSaved then return false end
+        cfg.enchGridSaved = { iconsPerRow = cfg.iconsPerRow,
+            maxRows = cfg.maxRows, maxTotal = cfg.maxTotal }
+        cfg.iconsPerRow, cfg.maxRows, cfg.maxTotal = 3, 1, 3
+        return true
+    end
+    if not cfg.enchGridSaved then return false end
+    local saved = cfg.enchGridSaved
+    cfg.iconsPerRow, cfg.maxRows, cfg.maxTotal =
+        saved.iconsPerRow, saved.maxRows, saved.maxTotal
+    cfg.enchGridSaved = nil
+    return true
+end
+
 local function BuildBuffBarSubtitle(bar)
     local extraCount = bar.spells and #bar.spells or 0
 
@@ -272,7 +316,7 @@ end
 -- "Selected" plus the "Custom Spell ID" action -- no "Presets" group, there is
 -- nothing to browse. Used by BOTH the default Buffs bar and every custom buff bar
 -- (unified onto one model).
-local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply)
+local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply, isDefault)
     local W = EllesmereUI.Widgets
     local PP = EllesmereUI.PanelPP
     local _, hh = 0, 0
@@ -289,6 +333,13 @@ local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply)
     --                      its own, MUTUALLY EXCLUSIVE with All Buffs:
     --                      the catch-all narrowed to duration-carrying
     --                      buffs via candidateFilters.maxDuration)
+    --   [ ] Weapon Enchants (cfg.showWeaponEnchants, default-bar only --
+    --                      the enchant cells publish from the default
+    --                      Buffs bar alone. INDEPENDENT of the two modes
+    --                      above and of the real filters: oils/imbues are
+    --                      not auras, so they come from their own source
+    --                      rather than the catch-all group, and a mode
+    --                      flip must not clear it)
     --   ------------------ (isHeader divider)
     --   [ ] <real filters, alphabetical>
     --
@@ -319,6 +370,7 @@ local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply)
     ); sy = sy - hh
 
     local PAB_ALL_BUFFS_KEY, PAB_HAS_DURATION_KEY = "__allBuffs", "__hasDuration"
+    local PAB_WEAPON_ENCH_KEY = "__weaponEnchants"
 
     -- LEFT: Filters checkbox dropdown, "Edit Filters" pinned top action.
     do
@@ -360,8 +412,14 @@ local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply)
                   tooltip = "Show every buff. While this is on, checked filters below are hidden from the bar instead of added." },
                 { key = PAB_HAS_DURATION_KEY, label = "Has Duration",
                   tooltip = "Show every buff that has a duration (hides permanent buffs). While this is on, checked filters below are hidden instead of added." },
-                { isHeader = true, label = "" },
             }
+            -- Default Buffs bar only: the enchant cells publish from that bar
+            -- alone, so the row would be a dead switch on custom buff bars.
+            if isDefault then
+                items[#items + 1] = { key = PAB_WEAPON_ENCH_KEY, label = "Weapon Enchants",
+                  tooltip = "Show weapon oil and imbue icons at the front of this bar. They are weapon enchants rather than auras, so they show independently of the options above -- and the aura grid is shifted inward to make room for them, with every row shifting over by the same amount." }
+            end
+            items[#items + 1] = { isHeader = true, label = "" }
             for i = 1, #filters do
                 items[#items + 1] = { key = filters[i].id, label = filters[i].name }
             end
@@ -373,6 +431,7 @@ local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply)
             function(k)
                 if k == PAB_ALL_BUFFS_KEY then return AllBuffsOn() end
                 if k == PAB_HAS_DURATION_KEY then return cfg.hasDuration == true end
+                if k == PAB_WEAPON_ENCH_KEY then return cfg.showWeaponEnchants == true end
                 cfg.filters = cfg.filters or {}
                 return cfg.filters[k] == true
             end,
@@ -385,11 +444,15 @@ local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply)
                     -- are broad-content modes. Extra Spells stay untouched.
                     cfg.hasDuration = nil
                     cfg.filters = nil
+                    local gridChanged = SyncWeaponEnchantsGrid(cfg)
                     apply()
                     -- Non-force, same as every other row: the open menu
                     -- refreshes its own checks/locks in place, so a mode
-                    -- flip must not tear the page down under it.
-                    EllesmereUI:RefreshPage()
+                    -- flip must not tear the page down under it. The one
+                    -- exception is crossing the enchants-only boundary, which
+                    -- rewrites grid sliders and the bar name (see
+                    -- SyncWeaponEnchantsGrid).
+                    EllesmereUI:RefreshPage(gridChanged and true or nil)
                     return
                 end
                 if k == PAB_HAS_DURATION_KEY then
@@ -398,8 +461,24 @@ local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply)
                     -- own); mode flips clear the filter selection, same as All Buffs.
                     if v then cfg.showAllBuffs = false end
                     cfg.filters = nil
+                    local gridChanged = SyncWeaponEnchantsGrid(cfg)
                     apply()
-                    EllesmereUI:RefreshPage()
+                    EllesmereUI:RefreshPage(gridChanged and true or nil)
+                    return
+                end
+                if k == PAB_WEAPON_ENCH_KEY then
+                    -- Its own content source (oils/imbues are not auras), so it
+                    -- neither clears nor is cleared by the two modes above and
+                    -- never touches cfg.filters -- which is also why the mode
+                    -- rows' `cfg.filters = nil` resets leave it standing.
+                    cfg.showWeaponEnchants = v and true or nil
+                    SyncWeaponEnchantsGrid(cfg)
+                    apply()
+                    -- Force: entering/leaving enchants-only rewrites the grid
+                    -- sliders (Icons per Row / Max Rows / Max Total) and the
+                    -- bar's name, none of which are RegisterWidgetRefresh
+                    -- clients -- a lightweight pass would leave them stale.
+                    EllesmereUI:RefreshPage(true)
                     return
                 end
                 cfg.filters = cfg.filters or {}
@@ -761,7 +840,7 @@ end
 
 -- "Display": Border Size [swatch] | Spacing; Icons per Row (+Max Rows/Max
 -- Total/Row Spacing cog) | spacer.
-local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff, isDefault)
+local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
     local W = EllesmereUI.Widgets
     local PP = EllesmereUI.PanelPP
     local _, hh = 0, 0
@@ -880,9 +959,10 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff, isDef
     end
 
     -- Buff bars only: debuffs are never player-cancelable, so the row would
-    -- be a dead switch there. Show Weapon Enchants is default-bar only: the
-    -- enchant cells publish from the default Buffs bar alone, so the toggle
-    -- would be dead on custom buff bars.
+    -- be a dead switch there. (Weapon enchants used to share this row as a
+    -- second toggle; they are a content source rather than a display tweak,
+    -- so they now live as the "Weapon Enchants" pinned row in the Filters
+    -- dropdown -- see BuildAssignedBuffsFields.)
     if isBuff then
         _, hh = W:DualRow(frame, sy,
             {
@@ -891,12 +971,7 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff, isDef
                 getValue = function() return cfg.rightClickCancel ~= false end,
                 setValue = function(v) cfg.rightClickCancel = v; apply() end
             },
-            isDefault and {
-                type = "toggle", text = "Show Weapon Enchants",
-                tooltip = "Show weapon oil and imbue icons at the front of this bar. They are weapon enchants rather than auras, so the aura grid is shifted inward to make room for them -- with multiple rows showing, every row shifts over by the same amount.",
-                getValue = function() return cfg.showWeaponEnchants == true end,
-                setValue = function(v) cfg.showWeaponEnchants = v and true or nil; apply() end
-            } or { type = "label", text = "" }
+            { type = "label", text = "" }
         ); sy = sy - hh
     end
 
@@ -1288,16 +1363,17 @@ local function BuildDefaultBarDetail(frame, fontPath, isBuff)
     end
     local body = WrapCompensatedBody(frame, scrollTop)
     local sy = 0
-    sy = BuildBarTitle(body, fontPath, isBuff and L("Buffs") or L("Debuffs"),
+    sy = BuildBarTitle(body, fontPath,
+        isBuff and DefaultBuffBarName(cfg) or L("Debuffs"),
         L("Built-in bar. Cannot be deleted"), sy)
 
     if isBuff then
-        sy = BuildAssignedBuffsFields(body, fontPath, sy, cfg, ApplyBar)
+        sy = BuildAssignedBuffsFields(body, fontPath, sy, cfg, ApplyBar, true)
     else
         sy = BuildAssignedDebuffsFields(body, fontPath, sy, cfg, ApplyBar)
     end
     sy = BuildCoreFields(body, fontPath, sy, cfg, ApplyBar, isBuff)
-    sy = BuildDisplayFields(body, fontPath, sy, cfg, ApplyBar, isBuff, true)
+    sy = BuildDisplayFields(body, fontPath, sy, cfg, ApplyBar, isBuff)
     if not isBuff then
         sy = BuildDispelColorFields(body, fontPath, sy, cfg, ApplyBar)
         sy = BuildFxEffects(body, sy, cfg, ApplyBar)
@@ -2395,9 +2471,14 @@ function ns.PABMP_BuildPage(pageName, parent, yOffset)
         hdr:SetTextColor(0.6, 0.6, 0.6)
         tileY = tileY - 35
 
+        -- Name follows the bar's content (see DefaultBuffBarName). Static, not
+        -- a refresh client: every toggle that can change it forces a full page
+        -- rebuild, which re-runs this.
+        local sPAB = ns.db and ns.db.profile and ns.db.profile.playerAuraBars
         tileY = tileY - BuildTile(sidebarChild, tileY, {
             width = sidebarW, fontPath = fontPath,
-            title = L("Buffs"),
+            title = DefaultBuffBarName(sPAB and ns.PAB_DefaultBuffsCfg
+                and ns.PAB_DefaultBuffsCfg(sPAB) or nil),
             subtitle = L("Default"),
             selected = (pabSel and pabSel.kind == "buff" and pabSel.id == "default"),
             showToggle = false,

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -1168,6 +1168,31 @@ end
 ns.PAB_DefaultBuffsCfg = DefaultBuffsCfg
 ns.PAB_DefaultDebuffsCfg = DefaultDebuffsCfg
 
+-- True while the default Buffs bar shows NOTHING but weapon enchants: the
+-- opt-in is on and neither broad-content mode admits generic buffs. Filters /
+-- Extra Spells are deliberately NOT considered -- they resolve to a finite
+-- add-set that comes and goes as the user edits it, and letting that flip the
+-- bar's name and grid underneath them would be unpredictable.
+function ns.PAB_IsWeaponEnchantsOnly(cfg)
+    return cfg ~= nil and cfg.showWeaponEnchants == true
+        and cfg.showAllBuffs == false and cfg.hasDuration ~= true
+end
+
+-- Default Buffs bar display name, following what the bar actually shows.
+-- Weapon enchants are a content source of their own, so they rename the bar
+-- outright when nothing else is on and append to it otherwise; Has Duration
+-- counts as a broad buff mode here, the bar still leads with generic buffs.
+--
+-- Returns the RAW English key: unlock mode stores element labels untranslated
+-- (EUI_UnlockMode.lua's GetBarLabel hands back elem.label verbatim), and the
+-- options page wraps the result in L() itself. Defined here, next to the cfg
+-- it reads, so the options page and the unlock element cannot drift apart.
+function ns.PAB_DefaultBuffsName(cfg)
+    if not (cfg and cfg.showWeaponEnchants == true) then return "Buffs" end
+    if ns.PAB_IsWeaponEnchantsOnly(cfg) then return "Weapon Enchants" end
+    return "Buffs & Weapon Enchants"
+end
+
 -- One-time seed of the default Buffs/Debuffs bars' position/size/grid from Blizzard's
 -- EditMode Buff/Debuff frame setup, so a first-time PAB user doesn't lose an
 -- already-customized Blizzard layout. Guarded by s.pabEditModeSeeded, deliberately NOT
@@ -1403,6 +1428,9 @@ local declared = { buffs = {}, debuffs = {} } -- buffs: only the "Show All Buffs
 local lastSize = { buffs = nil, debuffs = nil } -- {w=,h=} last-applied grid size, for CENTER-anchor compensation (see ApplyLiveConfig)
 local buffsSlotSig -- signature of the default Buffs bar's last-applied resolved spell list (ns.PAB_ResolveSpells), mirrors customBuffSig[barId] for the per-bar slots model
 local RegisterPABUnlock -- forward-declared; defined after CreateBars, called from it
+-- Last label the Buffs mover was registered under, so ApplyLiveConfig can
+-- re-register on a name change without doing it on every slider drag.
+local lastUnlockBuffLabel
 local ReloadAllCustomBars -- forward-declared; defined after CreateBars (custom bars section), called from it
 local PAB_MaybeRefreshPreview -- forward-declared; assigned in the options-page preview section, called from every live-apply function so an open bar-detail preview box tracks slider drags without those functions knowing it exists
 
@@ -1679,14 +1707,14 @@ local function CreateBars()
     local _, debuffSpec, debuffVertical = BuildContainerSpec(debuffsParent, debuffCfg, debuffGrid)
 
     -- Weapon enchant lead icons (oils/imbues are not auras; see
-    -- EUI_UnitFrames_WeaponEnchants.lua): opt-in (showWeaponEnchants,
-    -- default off -- the cell shift offsets the aura grid), and published
-    -- only while the bar's broad-content mode admits generic duration buffs
-    -- (All Buffs or Has Duration on -- the same gate as the catch-all
-    -- group). They render with the bar's live style, so every customization
-    -- follows automatically.
-    if buffCfg.showWeaponEnchants == true
-        and (buffCfg.showAllBuffs ~= false or buffCfg.hasDuration == true) then
+    -- EUI_UnitFrames_WeaponEnchants.lua): opt-in (showWeaponEnchants, default
+    -- off -- the cell shift offsets the aura grid), exposed as the "Weapon
+    -- Enchants" pinned row in the bar's Filters dropdown. A content source of
+    -- its own, NOT gated on the broad-content modes: enchants are not auras
+    -- and never come from the catch-all group, so checking the row alone
+    -- shows just the enchant cells. They render with the bar's live style, so
+    -- every customization follows automatically.
+    if buffCfg.showWeaponEnchants == true then
         ns._weaponEnchPAB = { parent = buffsParent, corner = buffCorner,
             dir = buffCfg.growDirection or "LEFT",
             pad = buffPad, styleKey = STYLE_BUFFS, canCancel = true }
@@ -1807,11 +1835,26 @@ function RegisterPABUnlock()
         })
     end
 
+    -- Buffs mover carries the bar's content-derived name (see
+    -- ns.PAB_DefaultBuffsName), so an enchants-only bar reads "Weapon Enchants"
+    -- in unlock mode instead of "Buffs". Baked in at registration --
+    -- EUI_UnlockMode.lua's GetBarLabel returns the stored string -- which is why
+    -- ApplyLiveConfig re-registers when the name changes.
+    local s = PAB()
+    local buffLabel = ns.PAB_DefaultBuffsName(s and DefaultBuffsCfg(s) or nil)
+    lastUnlockBuffLabel = buffLabel
+
     local elements = {
-        MakeBarElement("PAB_Buffs", "Buffs", 700, true, function() return buffsParent end),
+        MakeBarElement("PAB_Buffs", buffLabel, 700, true, function() return buffsParent end),
         MakeBarElement("PAB_Debuffs", "Debuffs", 701, false, function() return debuffsParent end),
     }
     EllesmereUI:RegisterUnlockElements(elements, "EllesmereUIUnitFrames")
+    -- Registration alone only updates the element table; a mover already built
+    -- this session keeps the label CreateMover baked into its FontString. No-op
+    -- before the first unlock session, so it is safe on the CreateBars path too.
+    if EllesmereUI.RefreshUnlockElementLabel then
+        EllesmereUI.RefreshUnlockElementLabel("PAB_Buffs")
+    end
 end
 
 -- Public hook for the Options UI: rebuild both style tables and re-decorate every
@@ -1877,10 +1920,9 @@ local function ApplyLiveConfig(isBuff)
 
     if isBuff then
         -- Keep the weapon-enchant cells riding the bar's live geometry and
-        -- filter state (opt-in + the same broad-content gate as the
-        -- catch-all group), then shift the engine run inward past them.
-        if cfg.showWeaponEnchants == true
-            and (cfg.showAllBuffs ~= false or cfg.hasDuration == true) then
+        -- filter state (opt-in only -- an independent content source, see the
+        -- publish in CreateBars), then shift the engine run inward past them.
+        if cfg.showWeaponEnchants == true then
             local liveCorner = BuildContainerSpec(parent, cfg, grid)
             ns._weaponEnchPAB = { parent = parent, corner = liveCorner,
                 dir = cfg.growDirection or "LEFT",
@@ -1890,6 +1932,15 @@ local function ApplyLiveConfig(isBuff)
         end
         ShiftBuffsForEnchants(container, parent, cfg, grid)
         if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
+
+        -- Unlock mode bakes the mover's label at registration, so a Filters
+        -- change would leave the old name on it until the next CreateBars.
+        -- Re-register only when the name actually changed -- this function runs
+        -- on every slider drag.
+        local label = ns.PAB_DefaultBuffsName(cfg)
+        if label ~= lastUnlockBuffLabel and RegisterPABUnlock then
+            RegisterPABUnlock()
+        end
     end
 
     if isBuff then
@@ -3057,6 +3108,55 @@ local function PreviewSpellIcon(spellID)
     return icon
 end
 
+-- Weapon-enchant preview cells, leading the bar exactly like the live ones
+-- (EUI_UnitFrames_WeaponEnchants.lua publishes them ahead of the engine run).
+-- Main hand + off hand only: those are the two slots reachable in current
+-- retail content, even though both that module's SLOTS and Blizzard's
+-- UpdateTemporaryEnchantmentBuffs still poll a third (ranged) -- so a bar sized
+-- for three enchants shows one placeholder cell of genuine spare capacity here,
+-- which is what the live bar would do too.
+--
+-- Paints the player's OWN equipped weapon icons rather than an invented sample:
+-- that is literally what the live buttons draw (PaintContent ->
+-- GetInventoryItemTexture), so the preview matches the real thing instead of
+-- approximating it. 134400 is the codebase's standard unknown-icon fallback,
+-- used when a slot is empty.
+local PREVIEW_ENCHANT_SLOTS = { INVSLOT_MAINHAND or 16, INVSLOT_OFFHAND or 17 }
+
+-- Only slots actually holding a weapon get a cell. With a two-hander (or any
+-- empty off hand) there is no second weapon to enchant, and drawing the
+-- unknown-icon question mark there would advertise a cell the player can never
+-- fill. An unarmed character still gets the single main-hand cell, so ticking
+-- the option always previews as something rather than silently nothing.
+local function PreviewEnchantSlots()
+    local out = {}
+    for i = 1, #PREVIEW_ENCHANT_SLOTS do
+        local slot = PREVIEW_ENCHANT_SLOTS[i]
+        if GetInventoryItemTexture("player", slot) then out[#out + 1] = slot end
+    end
+    if #out == 0 then out[1] = PREVIEW_ENCHANT_SLOTS[1] end
+    return out
+end
+
+-- Empty-slot art per weapon slot, for a character with nothing equipped:
+-- Blizzard's own character-pane silhouette reads as "a weapon goes here", where
+-- the generic unknown-icon question mark reads as "something is broken".
+-- C_PaperDollInfo.GetInventorySlotInfo(slotName) -> id, textureName, checkRelic
+-- (verified against Blizzard_UIPanels_Game/PaperDollFrame.lua, which uses the
+-- same namespaced call).
+local PREVIEW_ENCHANT_SLOT_NAMES = { [INVSLOT_MAINHAND or 16] = "MainHandSlot",
+    [INVSLOT_OFFHAND or 17] = "SecondaryHandSlot" }
+local function PreviewEnchantIcon(slot)
+    local tex = GetInventoryItemTexture("player", slot)
+    if tex then return tex end
+    local name = PREVIEW_ENCHANT_SLOT_NAMES[slot]
+    if name and C_PaperDollInfo and C_PaperDollInfo.GetInventorySlotInfo then
+        local _, slotTex = C_PaperDollInfo.GetInventorySlotInfo(name)
+        if slotTex then return slotTex end
+    end
+    return 134400
+end
+
 -- Same memoization for the preview's "Name" sort simulation below.
 local previewNameCache = {}
 local function PreviewSpellName(spellID)
@@ -3389,19 +3489,46 @@ local function BuildPreviewSlots(isBuff, cfg, list, listLen, count)
     -- surviving first `count` per sort, so changing sort would swap WHICH spells
     -- appear, not just their order. Truncate to `count` on the stable, sort-
     -- independent mixed order FIRST, then sort that fixed selection for display.
+    -- Weapon enchants take the LEADING cells and are never sorted into the aura
+    -- content: they are not auras. They are also ADDITIVE, not a slice of the
+    -- bar's capacity -- the live container keeps its full maxFrameCount and is
+    -- shifted past them wholesale (ShiftBuffsForEnchants), so an enchant never
+    -- costs an aura its slot.
+    local numEnch, enchSlots = 0, nil
+    if isBuff and cfg.showWeaponEnchants == true then
+        enchSlots = PreviewEnchantSlots()
+        numEnch = #enchSlots
+    end
+    -- The two modes are genuinely different shapes and the preview mirrors both:
+    --   * alongside auras -- the container keeps its full maxFrameCount and is
+    --     shifted past the enchants wholesale, so they cost no aura its slot and
+    --     the first row overflows the reserved grid by the shift.
+    --   * enchants-only -- the grid was auto-sized FOR the enchants
+    --     (SyncWeaponEnchantsGrid) and the container holds no groups, so the
+    --     cells sit INSIDE that reserved width. The leftover cells stay as
+    --     placeholders on purpose: they are what explains where the bar's width
+    --     comes from, and dropping them made the 3-wide frame look arbitrary.
+    local avail = count
+    if isBuff and ns.PAB_IsWeaponEnchantsOnly(cfg) then
+        avail = math.max(0, count - numEnch)
+    end
+
     local mixed = isBuff and DedupeByIcon(BuildMixedRealSpells(cfg)) or nil
     local extraIDs
     if mixed then
-        local numSelected = math.min(#mixed, count)
+        local numSelected = math.min(#mixed, avail)
         local selected = {}
         for i = 1, numSelected do selected[i] = mixed[i] end
         extraIDs = SortPreviewList(selected, isBuff, cfg)
     end
     local numExtra = extraIDs and #extraIDs or 0
-    local numFiller = count - numExtra
+    local numFiller = avail - numExtra
     local slots = {}
+    for i = 1, numEnch do
+        slots[i] = { kind = "enchant", slot = enchSlots[i] }
+    end
     for i = 1, numExtra do
-        slots[i] = { kind = "extra", spellID = extraIDs[i] }
+        slots[numEnch + i] = { kind = "extra", spellID = extraIDs[i] }
     end
     if numFiller > 0 then
         if hasFiller then
@@ -3446,15 +3573,15 @@ local function BuildPreviewSlots(isBuff, cfg, list, listLen, count)
             fillerSelected = SortPreviewList(fillerSelected, isBuff, cfg)
             for i = 1, numFiller do
                 local e = fillerSelected[i]
-                slots[numExtra + i] = e and { kind = "fake", entry = e } or { kind = "placeholder" }
+                slots[numEnch + numExtra + i] = e and { kind = "fake", entry = e } or { kind = "placeholder" }
             end
         else
             for i = 1, numFiller do
-                slots[numExtra + i] = { kind = "placeholder" }
+                slots[numEnch + numExtra + i] = { kind = "placeholder" }
             end
         end
     end
-    return slots
+    return slots, numEnch
 end
 
 -- Icon Effects Per-Filter preview: applies a matched fx block's Glow/Border to a
@@ -3551,7 +3678,11 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
     -- selects the fixed filler slice from this stable, shuffled-once order FIRST, sorts after.
     local list = (pool and #pool > 0 and pool) or (isBuff and PREVIEW_BUFF_SPELLS or PREVIEW_DEBUFF_SPELLS)
     local listLen = #list
-    local slots = BuildPreviewSlots(isBuff, cfg, list, listLen, count)
+    local slots, numEnch = BuildPreviewSlots(isBuff, cfg, list, listLen, count)
+    -- Enchants are additive leading cells, so the rendered total exceeds the
+    -- bar's aura capacity by however many are showing.
+    local total = #slots
+    local auraCount = total - numEnch
 
     -- Icon Effects Per-Filter preview (debuffs only): deliberately NOT tied to the
     -- bar's own active Base Filters/Show All Debuffs state -- requiring a matching
@@ -3583,7 +3714,7 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
         end
     end
 
-    local rows = math.max(1, math.ceil(count / cols))
+    local rows = math.max(1, math.ceil(auraCount / cols))
 
     -- Real per-icon flow packing: each slot's OWN actual render size (its fx Size
     -- override, or the bar's base iconSize) drives its own footprint directly, so
@@ -3591,7 +3722,7 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
     -- neighbors get pushed out -- true flow-layout behavior rather than a uniform
     -- worst-case cell grid (which left too much gap around every normal icon).
     local slotSize = {}
-    for i = 1, count do
+    for i = 1, total do
         local e = fxBySlot and fxBySlot[i]
         local sz = e and tonumber(e.size)
         slotSize[i] = (sz and sz > 0) and sz or iconSize
@@ -3599,10 +3730,24 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
 
     local rowWidth, rowHeight, colOffset, rowYOffset = {}, {}, {}, {}
     do
+        -- Weapon enchants lead row 0 at the bar's own corner, and the aura block
+        -- starts past them on EVERY row -- ShiftBuffsForEnchants moves the whole
+        -- container, not just its first line, so lower rows stay indented by the
+        -- same amount and the first row overflows the reserved grid by the
+        -- shift. That asymmetry is the real bar's behavior; packing enchants as
+        -- plain leading members of one uniform flow would wrap row 2 back to the
+        -- bar's edge and misrepresent it.
+        local enchShift = 0
+        for k = 1, numEnch do
+            colOffset[k] = enchShift
+            enchShift = enchShift + slotSize[k] + pad
+            rowHeight[0] = math.max(rowHeight[0] or 0, slotSize[k])
+        end
+
         local runningX, runningY = {}, 0
-        for r = 0, rows - 1 do runningX[r] = 0 end
-        for i = 1, count do
-            local r = math.floor((i - 1) / cols)
+        for r = 0, rows - 1 do runningX[r] = enchShift end
+        for i = numEnch + 1, total do
+            local r = math.floor((i - numEnch - 1) / cols)
             colOffset[i] = runningX[r]
             runningX[r] = runningX[r] + slotSize[i] + pad
             rowHeight[r] = math.max(rowHeight[r] or 0, slotSize[i])
@@ -3625,15 +3770,18 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
     local growUp = (growDir == "UP")
     local wrapRight = (wrapDir == "RIGHT")
 
-    for i = 1, math.max(count, #icons) do
-        if i <= count then
+    for i = 1, math.max(total, #icons) do
+        if i <= total then
             local btn = icons[i]
             if not btn then
                 btn = CreatePreviewIcon(box)
                 icons[i] = btn
             end
 
-            local row = math.floor((i - 1) / cols)
+            -- Enchant cells all live on row 0; aura slots index into their own
+            -- block, which starts after them (see the packing block above).
+            local row = (i <= numEnch) and 0
+                or math.floor((i - numEnch - 1) / cols)
             local withinLineStep = colOffset[i]
             local acrossLinesStep = rowYOffset[row]
             -- btn's own anchor point is `corner` (matching growDirection/
@@ -3675,18 +3823,23 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
                 btn.placeholder:Hide()
                 btn.textHost:Show()
 
-                local spellID
-                if slot.kind == "extra" then
-                    -- Real Extra Spell: always its own actual icon, never folded into
-                    -- the fake cycling pool.
-                    spellID = slot.spellID
-                else -- "fake"
-                    local entry = slot.entry
-                    spellID = isBuff and entry or entry.id
-                    dispel = (not isBuff) and entry.dispel or nil
+                if slot.kind == "enchant" then
+                    -- Weapon enchant: an ITEM texture, not a spell icon -- the
+                    -- live buttons paint the equipped weapon the same way.
+                    btn.icon:SetTexture(PreviewEnchantIcon(slot.slot))
+                else
+                    local spellID
+                    if slot.kind == "extra" then
+                        -- Real Extra Spell: always its own actual icon, never folded into
+                        -- the fake cycling pool.
+                        spellID = slot.spellID
+                    else -- "fake"
+                        local entry = slot.entry
+                        spellID = isBuff and entry or entry.id
+                        dispel = (not isBuff) and entry.dispel or nil
+                    end
+                    btn.icon:SetTexture(PreviewSpellIcon(spellID))
                 end
-
-                btn.icon:SetTexture(PreviewSpellIcon(spellID))
                 local z = style.iconZoom or 0.055
                 btn.icon:SetTexCoord(z, 1 - z, z, 1 - z)
             end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds a standalone "Weapon Enchants" filter to the default Buffs bar's Filters dropdown, pinned right below "Has Duration". Checking it alone now shows just the weapon oil/imbue cells with no other content required — previously the toggle lived in the DISPLAY section and only worked while All Buffs or Has Duration was also on. The setting is default-bar-only since the enchant cells publish from that bar alone.

The default Buffs bar renames itself to match what it actually shows: "Weapon Enchants" when that's the only thing on, "Buffs & Weapon Enchants" when combined with a broad-content mode, "Buffs" otherwise. This applies in both the options sidebar/detail title and the unlock-mode mover label.

While showing weapon enchants only, the bar's grid auto-sizes to 3 icons per row / 1 max row / 3 max total (matching the three inventory slots Blizzard's own BuffFrame polls for temporary enchantments) and restores whatever the user had configured before entering that mode on the way back out.

The preview box now mirrors the live bar's actual behavior instead of treating enchants as ordinary leading aura icons: enchant cells lead row 0 at the bar's own corner, the aura content starts indented past them on every row (matching how the live container is shifted as a whole, not just its first line), and the enchants-only preview still shows the full 3-wide reserved grid with empty placeholder cells so the bar's width doesn't look arbitrary. Empty weapon slots preview with Blizzard's own empty-slot silhouette art instead of the generic unknown-icon question mark.

Also fixes an existing bug found while building this: renaming the default Buffs bar via Filters changes never reached the unlock-mode mover, because its label text is cached in a FontString that a hover-triggered refresh (`RefreshAnchoredIdle`) kept re-painting from a stale value captured once when the mover was first built. Added `mover:UpdateLabel()` to `EUI_UnlockMode.lua` so a re-registered element's label survives the next hover, and exposed `EllesmereUI.RefreshUnlockElementLabel(key)` for callers to trigger it.

## How was it tested?

Tested in-game on live retail. Verified: the Filters row appears only on the default Buffs bar, not on custom buff bars; checking only Weapon Enchants shows just the enchant cells with no auras; the bar renames correctly in both the sidebar and an open unlock-mode session, including after a mouse hover over the mover; grid values save and restore correctly across mode switches, including when the user had customized them beforehand; the preview matches the live bar's enchant-then-aura layout and row indentation; empty weapon slots show the silhouette placeholder instead of a question mark.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
