### PR TITLE
Add out-of-range nameplate opacity

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -347,6 +347,8 @@ local defaults = {
     enemyNameWrap = false,
     targetScale = 100,
     nonTargetKeepFocus = true,
+    outOfRangeAlpha = 50,
+    outOfRangeMode = "disabled",
     showAllDebuffs = false,
     rangeTextEnabled = false,  -- Distance to Target Text (range bucket on the target's nameplate)
     rangeTextSize = 11,
@@ -3261,6 +3263,7 @@ function ns.RefreshAllSettings()
         end
     end
     if ns.NT_RefreshSetting then ns.NT_RefreshSetting() end
+    if ns.RangeText_Apply then ns.RangeText_Apply() end
     if ns.ApplyClassPowerSetting then ns.ApplyClassPowerSetting() end
     -- Aura containers: fingerprint-guarded, near-free when no aura setting changed.
     if ns.NPC_ReloadAll then ns.NPC_ReloadAll() end
@@ -3269,11 +3272,13 @@ end
 -------------------------------------------------------------------------------
 --  Non-Target Opacity: while the player has a target, every skinned plate that is not the
 --  target, focus or player fades to nonTargetAlpha (0-100). 100 = OFF: every hook below
---  reduces to one numeric compare. Alpha rides the plate ROOT (our own frame, parented to the
---  Blizzard nameplate), so Blizzard's own occlusion fade still multiplies in.
+--  reduces to one numeric compare. Out-of-range alpha composes into the same root multiplier.
+--  Alpha rides the plate ROOT (our own frame, parented to the Blizzard nameplate), so
+--  Blizzard's own occlusion fade still multiplies in.
 -------------------------------------------------------------------------------
 ns._ntAlpha = 1   -- cached 0..1 from the profile; 1 = inert
 ns._ntKeepFocus = true   -- cached "Keep Focus Full Opacity" (default on)
+ns._oorAlpha = 1  -- cached out-of-range alpha; 1 = inert
 
 -- Applies the correct root alpha to ONE plate. Value-guarded via _ntCurAlpha so redundant
 -- SetAlpha calls are skipped and pooled frames reset cheaply (nil = never faded).
@@ -3288,6 +3293,7 @@ function ns.NT_Apply(plate)
        and not UnitIsUnit(unit, "player") then
         a = nt
     end
+    a = a * (plate._oorCurAlpha or 1)
     if (plate._ntCurAlpha or 1) ~= a then
         plate._ntCurAlpha = a
         plate:SetAlpha(a)
@@ -5779,6 +5785,7 @@ function NameplateFrame:ClearUnit()
         self:SetAlpha(1)
     end
     self._ntCurAlpha = nil
+    self._oorCurAlpha = nil
 
     if self.isCasting then
         self.isCasting = false
@@ -8139,13 +8146,14 @@ function npAddon:OnEnable()
 end
 
 -------------------------------------------------------------------------------
---  Distance to Target Text (EXTRAS): a range BUCKET on the target's nameplate -- "15+" =
+--  Nameplate range features: target distance text plus out-of-range plate alpha.
+--  Distance text is a range BUCKET on the target's nameplate -- "15+" =
 --  beyond the 15yd rung, inside the next longer one. The API exposes no exact enemy distance;
 --  the lower bound comes from the shared range engine's spell ladder (EllesmereUI_Range.lua),
---  active only while this is enabled. Anchoring: 5px left of whatever text occupies the Right
---  Text core slot, else just outside the health bar's right edge. Zero cost while disabled
---  (nothing created until first enabled); enabled, one OnUpdate driver ticks 5x/s. Secret range
---  results are skipped -- fail-open to no text, never an error.
+--  active only while either feature is enabled. Distance-text anchoring: 5px left of whatever
+--  text occupies the Right Text core slot, else just outside the health bar's right edge. Zero
+--  cost while both are disabled; enabled, one OnUpdate driver ticks 5x/s. Secret range results
+--  are skipped -- fail-open to no text or fade, never an error.
 -------------------------------------------------------------------------------
 do
     -- Single-table state: this file sits at Lua 5.1's 200-local cap, so the whole feature uses ONE chunk local (RT), everything else as table fields.
@@ -8228,6 +8236,28 @@ do
         end
     end
 
+    function RT.FadeTick()
+        local customCutoff = p and p.outOfRangeMode == "custom" and p.outOfRangeCustomRange
+        local cutoff = EllesmereUI.Range_GetAttackCutoff(customCutoff)
+        for _, plate in pairs(ns.plates) do
+            local beyond = plate.unit and EllesmereUI.Range_IsBeyondAttackRange(plate.unit, cutoff)
+            local alpha = beyond == true and ns._oorAlpha or 1
+            if (plate._oorCurAlpha or 1) ~= alpha then
+                plate._oorCurAlpha = alpha
+                ns.NT_Apply(plate)
+            end
+        end
+    end
+
+    function RT.ResetFade()
+        for _, plate in pairs(ns.plates) do
+            if plate._oorCurAlpha then
+                plate._oorCurAlpha = nil
+                ns.NT_Apply(plate)
+            end
+        end
+    end
+
     -- Options: re-apply font/color/anchor on the live attachment.
     ns.RangeText_Refresh = function()
         if RT.plate and RT.fs then
@@ -8237,7 +8267,13 @@ do
     end
 
     ns.RangeText_Apply = function()
-        if p and p.rangeTextEnabled then
+        local alpha = tonumber(p and p.outOfRangeAlpha) or defaults.outOfRangeAlpha
+        if alpha < 0 then alpha = 0 elseif alpha > 100 then alpha = 100 end
+        ns._oorAlpha = alpha / 100
+        local textEnabled = p and p.rangeTextEnabled
+        ns._oorFadeEnabled = ((p and p.outOfRangeMode) or defaults.outOfRangeMode) ~= "disabled" and ns._oorAlpha < 1
+        local fadeEnabled = ns._oorFadeEnabled
+        if textEnabled or fadeEnabled then
             if not RT.drv then
                 RT.drv = CreateFrame("Frame")
                 RT.drv:Hide()
@@ -8245,17 +8281,19 @@ do
                     RT.acc = RT.acc + dt
                     if RT.acc < 0.2 then return end
                     RT.acc = 0
-                    RT.Tick()
+                    if p and p.rangeTextEnabled then RT.Tick() end
+                    if ns._oorFadeEnabled then RT.FadeTick() end
                 end)
             end
             -- Ladder builds and invalidation live in the shared range engine.
-            EllesmereUI.Range_SetActive("npRangeText", true)
+            EllesmereUI.Range_SetActive("npRange", true)
             RT.drv:Show()
-        elseif RT.drv then
-            EllesmereUI.Range_SetActive("npRangeText", false)
-            RT.drv:Hide()
-            RT.Detach()
+        else
+            EllesmereUI.Range_SetActive("npRange", false)
+            if RT.drv then RT.drv:Hide() end
         end
+        if not textEnabled then RT.Detach() end
+        if not fadeEnabled then RT.ResetFade() end
     end
 
 end

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -3972,7 +3972,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUI:RefreshPage()
               end },
             { type="slider", text="Custom Range",
-              tooltip="Attack-range cutoff used by Out of Range Alpha. Five-yard steps match the available fallback range checks.",
+              tooltip="Attack-range cutoff used by Out of Range Opacity. Five-yard steps match the available fallback range checks.",
               min=5, max=50, step=5,
               disabled=function() return (DBVal("outOfRangeMode") or defaults.outOfRangeMode) ~= "custom" end,
               disabledTooltip="Range Check: Custom",
@@ -3984,7 +3984,7 @@ initFrame:SetScript("OnEvent", function(self)
                 if ns.RangeText_Apply then ns.RangeText_Apply() end
               end });  y = y - h
 
-        -- Row 5: Execute Pulse Glow | Out of Range Alpha
+        -- Row 5: Execute Pulse Glow | Out of Range Opacity
         _, h = W:DualRow(parent, y,
             { type="toggle", text="Execute Pulse Glow",
               tooltip="Pulses a red glow on enemy nameplates below 30% health.",
@@ -3993,8 +3993,8 @@ initFrame:SetScript("OnEvent", function(self)
                 DB().lowHpGlow = v
                 ns.RefreshAllSettings()
               end },
-            { type="slider", text="Out of Range Alpha",
-              tooltip="Alpha used for enemy nameplates outside the selected attack range.",
+            { type="slider", text="Out of Range Opacity",
+              tooltip="Opacity used for enemy nameplates outside the selected attack range.",
               min=0, max=100, step=1,
               disabled=function() return (DBVal("outOfRangeMode") or defaults.outOfRangeMode) == "disabled" end,
               disabledTooltip="Range Check: Auto or Custom",

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -3706,7 +3706,7 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnLeave", function(self) UpdateCogAlpha() end)
         end
 
-        -- Row 4: Distance to Target Text -- range bucket ("15+") on the target's nameplate (see the runtime block at the end of the main file).
+        -- Row 4: Distance to Target Text
         local tfRangeOff = function() return DBVal("rangeTextEnabled") ~= true end
         local tfRangeRow
         tfRangeRow, h = W:DualRow(parent, y,
@@ -3956,7 +3956,35 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetAlpha(questObjOff() and 0.15 or 0.4)
         end
 
-        -- Row 4: Execute Pulse Glow | (blank)
+        -- Row 4: disabled, automatic class/spec cutoff, or profile-level custom cutoff.
+        _, h = W:DualRow(parent, y,
+            { type="dropdown", text="Range Check",
+              values={ disabled="Disabled", auto="Auto (Class/Spec)", custom="Custom" },
+              order={ "disabled", "auto", "custom" },
+              tooltip="Disabled runs no nameplate range checks. Auto uses your class and specialization's normal attack range. Custom uses the range selected beside this option.",
+              getValue=function() return DBVal("outOfRangeMode") or defaults.outOfRangeMode end,
+              setValue=function(v)
+                DB().outOfRangeMode = v
+                if v == "custom" and DB().outOfRangeCustomRange == nil then
+                    DB().outOfRangeCustomRange = EllesmereUI.Range_GetAttackCutoff()
+                end
+                if ns.RangeText_Apply then ns.RangeText_Apply() end
+                EllesmereUI:RefreshPage()
+              end },
+            { type="slider", text="Custom Range",
+              tooltip="Attack-range cutoff used by Out of Range Alpha. Five-yard steps match the available fallback range checks.",
+              min=5, max=50, step=5,
+              disabled=function() return (DBVal("outOfRangeMode") or defaults.outOfRangeMode) ~= "custom" end,
+              disabledTooltip="Range Check: Custom",
+              getValue=function()
+                  return DBVal("outOfRangeCustomRange") or EllesmereUI.Range_GetAttackCutoff()
+              end,
+              setValue=function(v)
+                DB().outOfRangeCustomRange = v
+                if ns.RangeText_Apply then ns.RangeText_Apply() end
+              end });  y = y - h
+
+        -- Row 5: Execute Pulse Glow | Out of Range Alpha
         _, h = W:DualRow(parent, y,
             { type="toggle", text="Execute Pulse Glow",
               tooltip="Pulses a red glow on enemy nameplates below 30% health.",
@@ -3965,7 +3993,16 @@ initFrame:SetScript("OnEvent", function(self)
                 DB().lowHpGlow = v
                 ns.RefreshAllSettings()
               end },
-            { type="label", text="" });  y = y - h
+            { type="slider", text="Out of Range Alpha",
+              tooltip="Alpha used for enemy nameplates outside the selected attack range.",
+              min=0, max=100, step=1,
+              disabled=function() return (DBVal("outOfRangeMode") or defaults.outOfRangeMode) == "disabled" end,
+              disabledTooltip="Range Check: Auto or Custom",
+              getValue=function() return DBVal("outOfRangeAlpha") or defaults.outOfRangeAlpha end,
+              setValue=function(v)
+                DB().outOfRangeAlpha = v
+                if ns.RangeText_Apply then ns.RangeText_Apply() end
+              end });  y = y - h
 
         return math.abs(y)
     end

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -2437,94 +2437,18 @@ do
     end
     EllesmereUI.GetCrosshairValue = CrosshairGet
 
-    local DRUID_MELEE_FORMS = { [1] = true, [2] = true }  -- Bear, Cat
-
-    local _, _chPlayerClass = UnitClass("player")
     local _crosshairCutoffRange = 5
 
     local function RefreshCrosshairCutoffRange()
-        local _, classFile = UnitClass("player")
-        local specIndex = GetSpecialization()
-        if not specIndex then
-            _crosshairCutoffRange = 5
-            return
-        end
-        
-        local specID = GetSpecializationInfo(specIndex)
-        if not specID then
-            _crosshairCutoffRange = 5
-            return
-        end
-        
-        if classFile == "DRUID" then
-            if specID == 102 or specID == 105 then -- Balance, Restoration
-                if IsPlayerSpell(197488) then -- Astral Influence
-                    _crosshairCutoffRange = 45
-                else
-                    _crosshairCutoffRange = 40
-                end
-            else
-                _crosshairCutoffRange = 5
-            end
-        elseif classFile == "DEMONHUNTER" then
-            if specIndex == 3 or (specID ~= 577 and specID ~= 581) then
-                _crosshairCutoffRange = 25 -- Devourer
-            else
-                _crosshairCutoffRange = 5
-            end
-        elseif classFile == "EVOKER" then
-            if specID == 1467 or specID == 1470 then -- Devastation, Augmentation
-                _crosshairCutoffRange = 25
-            elseif specID == 1468 then -- Preservation
-                _crosshairCutoffRange = 30
-            else
-                _crosshairCutoffRange = 25
-            end
-        elseif classFile == "HUNTER" then
-            if specID == 253 or specID == 254 then -- Beast Mastery, Marksmanship
-                _crosshairCutoffRange = 40
-            else
-                _crosshairCutoffRange = 5
-            end
-        elseif classFile == "PALADIN" then
-            if specID == 65 then -- Holy
-                -- Holy is a 40yd healer by default; opt into melee (5yd) via "Show Melee Range for Hpal".
-                if CrosshairGet("crosshairHpalMelee") then
-                    _crosshairCutoffRange = 5
-                else
-                    _crosshairCutoffRange = 40
-                end
-            else
-                _crosshairCutoffRange = 5
-            end
-        elseif classFile == "SHAMAN" then
-            if specID == 263 then -- Enhancement
-                _crosshairCutoffRange = 5
-            else
-                _crosshairCutoffRange = 40
-            end
-        elseif classFile == "MONK" then
-            if specID == 270 then -- Mistweaver
-                _crosshairCutoffRange = 40
-            else
-                _crosshairCutoffRange = 5
-            end
-        elseif classFile == "PRIEST" or classFile == "MAGE" or classFile == "WARLOCK" then
-            _crosshairCutoffRange = 40
-        else -- WARRIOR, ROGUE, DEATHKNIGHT
-            _crosshairCutoffRange = 5
-        end
-        -- Cutoff probe spells live in the shared range engine (EllesmereUI_Range.lua); rebuilt on spec/talent changes and whenever this cutoff moves.
+        _crosshairCutoffRange = EllesmereUI.Range_GetAttackCutoff(nil, CrosshairGet("crosshairHpalMelee"))
     end
     RefreshCrosshairCutoffRange()
     -- Exposed so the crosshair options toggle can re-resolve the cutoff live.
     EllesmereUI._RefreshCrosshairCutoffRange = RefreshCrosshairCutoffRange
 
     EllesmereUI._getCrosshairCutoffRange = function()
-        if _chPlayerClass == "DRUID" and DRUID_MELEE_FORMS[GetShapeshiftForm()] then
-            return 5
-        end
-        return _crosshairCutoffRange
+        return EllesmereUI.Range_GetAttackCutoff(nil, CrosshairGet("crosshairHpalMelee"))
+            or _crosshairCutoffRange
     end
 
     -- True only when there is an attackable, living target out of range.
@@ -2535,19 +2459,8 @@ do
         end
         local cutoff = EllesmereUI._getCrosshairCutoffRange()
 
-        -- PRIMARY: probe the player's top-range harmful spells (shared range
-        -- engine) -- exact, talented range extensions come free. A nil answer
-        -- (no probe could target right now) cascades to the item ladder below.
-        -- Melee cutoffs (5, incl. druid forms) skip straight to the ladder.
-        if cutoff > 5 then
-            local beyond = EllesmereUI.Range_BeyondCutoff("target", cutoff)
-            if beyond ~= nil then return beyond end
-        end
-
-        -- FALLBACK: shared item ladder, stopped at cutoff (rungs past it can't change the verdict). nil = nothing answered, out of range.
-        local minY, maxY = EllesmereUI.Range_ItemBracket("target", cutoff)
-        if minY == nil then return true end
-        return (maxY == nil) or (maxY > cutoff)
+        local beyond = EllesmereUI.Range_IsBeyondAttackRange("target", cutoff)
+        return beyond == nil or beyond
     end
 
     local function CreateCrosshair()

--- a/EllesmereUI_Range.lua
+++ b/EllesmereUI_Range.lua
@@ -1,8 +1,9 @@
 if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_ClientGate.lua)
 -------------------------------------------------------------------------------
 --  EllesmereUI_Range.lua
---  Shared range-check engine for the suite's three range consumers:
+--  Shared range-check engine for the suite's range consumers:
 --    - Nameplates "Distance to Target Text"  (spell-ladder lower bound)
+--    - Nameplates "Out of Range Alpha"       (class/spec cutoff probes)
 --    - QoL "Target Distance Text"            (item bracket or spell lower bound)
 --    - QoL crosshair out-of-range recolor    (cutoff probes + item fallback)
 --
@@ -78,6 +79,47 @@ local function ResetCaches()
     lbCache.has = false
     brCache.has = false
     RG.probeCutoff = nil
+end
+
+local DRUID_MELEE_FORMS = { [1] = true, [2] = true } -- Bear, Cat
+
+-- Attack range shared by range-aware UI. An explicit cutoff wins; otherwise
+-- class/spec decides. Holy Paladins can opt into melee range for the crosshair.
+function EllesmereUI.Range_GetAttackCutoff(customCutoff, holyPaladinMelee)
+    customCutoff = tonumber(customCutoff)
+    if customCutoff then
+        customCutoff = math.floor((customCutoff + 2.5) / 5) * 5
+        return math.max(5, math.min(50, customCutoff))
+    end
+
+    local _, classFile = UnitClass("player")
+    if classFile == "DRUID" and DRUID_MELEE_FORMS[GetShapeshiftForm()] then return 5 end
+
+    local specIndex = GetSpecialization()
+    local specID = specIndex and GetSpecializationInfo(specIndex)
+    if not specID then return 5 end
+
+    if classFile == "DRUID" then
+        if specID == 102 or specID == 105 then
+            return IsPlayerSpell(197488) and 45 or 40 -- Astral Influence
+        end
+        return 5
+    elseif classFile == "DEMONHUNTER" then
+        return (specID == 577 or specID == 581) and 5 or 25
+    elseif classFile == "EVOKER" then
+        return specID == 1468 and 30 or 25
+    elseif classFile == "HUNTER" then
+        return (specID == 253 or specID == 254) and 40 or 5
+    elseif classFile == "PALADIN" then
+        return specID == 65 and not holyPaladinMelee and 40 or 5
+    elseif classFile == "SHAMAN" then
+        return specID == 263 and 5 or 40
+    elseif classFile == "MONK" then
+        return specID == 270 and 40 or 5
+    elseif classFile == "PRIEST" or classFile == "MAGE" or classFile == "WARLOCK" then
+        return 40
+    end
+    return 5
 end
 
 local function BuildLadder()
@@ -290,6 +332,19 @@ function EllesmereUI.Range_BeyondCutoff(unit, cutoff)
         end
     end
     return nil
+end
+
+-- True/false when the unit can be classified against the supplied (or normal
+-- class/spec) attack range; nil when no spell or item probe answered.
+function EllesmereUI.Range_IsBeyondAttackRange(unit, cutoff)
+    cutoff = cutoff or EllesmereUI.Range_GetAttackCutoff()
+    if cutoff > 5 then
+        local beyond = EllesmereUI.Range_BeyondCutoff(unit, cutoff)
+        if beyond ~= nil then return beyond end
+    end
+    local minY, maxY = EllesmereUI.Range_ItemBracket(unit, cutoff)
+    if minY == nil then return nil end
+    return maxY == nil or maxY > cutoff
 end
 
 


### PR DESCRIPTION
- Add optional out-of-range opacity for enemy nameplates.
- Support automatic class/spec ranges or a custom 5-50 yard cutoff.
- Keep range checks fully disabled by default and share the existing range engine with QoL crosshair behavior.

Custom Range thresholds could maybe be extended to be user definable per spec.

<img width="919" height="308" alt="image" src="https://github.com/user-attachments/assets/61658c0c-b8df-4571-85a6-fdf1168edb16" />
