### PR TITLE
fix(visibility): dragonriding options ignore flight forms

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12286,8 +12286,13 @@ function EllesmereUI.IsPlayerMountedLike()
     return false
 end
 
+-- canGlide is already scoped to being on a glide-capable mount or form, so it
+-- needs no mount-shaped prefilter. IsPlayerMountedLike used to gate this and
+-- hard-returns false off DRUID, which silently excluded the non-druid flight
+-- forms (Dracthyr Soar, Haranir) from "Hide when Dragonriding". Deliberately
+-- no IsFlying() term: unlike the show/hide visibility MODES, this option fires
+-- on the ground too, as soon as the skyriding bar is available.
 function EllesmereUI.IsPlayerSkyriding()
-    if not (EllesmereUI.IsPlayerMountedLike and EllesmereUI.IsPlayerMountedLike()) then return false end
     if C_PlayerInfo and C_PlayerInfo.GetGlidingInfo then
         local _, canGlide = C_PlayerInfo.GetGlidingInfo()
         return canGlide == true
@@ -12370,8 +12375,8 @@ function EllesmereUI.CheckVisibilityMode(mode, state)
         return (EllesmereUI.IsAirborneSkyriding and EllesmereUI.IsAirborneSkyriding()) or false
     end
     if mode == "show_not_dragonriding" then
-        -- Exact inverse of show_dragonriding: show whenever NOT airborne on
-        -- a glide-capable (skyriding) mount.
+        -- Exact inverse of show_dragonriding: show whenever NOT airborne and
+        -- glide-capable (skyriding mounts and flight forms alike).
         return not (EllesmereUI.IsAirborneSkyriding and EllesmereUI.IsAirborneSkyriding())
     end
     -- "always" and "mouseover" both return true (mouseover handled separately)

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12364,8 +12364,9 @@ function EllesmereUI.CheckVisibilityMode(mode, state)
     if mode == "in_party" then return state.inParty end
     if mode == "solo" then return not state.inRaid and not state.inParty end
     if mode == "show_dragonriding" then
-        -- Approximates the secure-macro [advflyable,flying] driver: show only while airborne on
-        -- a glide-capable (skyriding) mount. The shared predicate lives in EllesmereUI_Visibility.lua and is also used by the multi-select visibility engine.
+        -- Mirrors the secure-macro [advflyable,flying] driver: show only while airborne and
+        -- glide-capable (skyriding mounts and flight forms alike). The shared predicate lives in
+        -- EllesmereUI_Visibility.lua and is also used by the multi-select visibility engine.
         return (EllesmereUI.IsAirborneSkyriding and EllesmereUI.IsAirborneSkyriding()) or false
     end
     if mode == "show_not_dragonriding" then

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -291,17 +291,21 @@ for _, k in ipairs(VIS_REPRESENTATIVE_ORDER) do VIS_COMBINABLE_KEYS[k] = true en
 EUI.VIS_COMBINABLE_KEYS = VIS_COMBINABLE_KEYS
 
 -- Airborne skyriding predicate shared by CheckVisibilityMode's dragonriding
--- branches and the multi-select engine. Approximates the secure driver's
--- [advflyable,flying]; the additional IsMounted() requirement is a
--- deliberate, documented drift (Druid Flight Form matches the secure driver
--- but not this predicate).
+-- branches and the multi-select engine. Mirrors the secure driver's
+-- [advflyable,flying]: glide capability plus airborne, and nothing else.
+-- An IsMounted() term used to sit here, which made every non-secure module
+-- disagree with the secure Action Bars driver in a flight form (Druid and
+-- Haranir flight forms are shapeshifts, not mounts, so IsMounted() is false
+-- while [advflyable] still matches).
 function EUI.IsAirborneSkyriding()
-    if not (IsMounted and IsMounted() and IsFlying and IsFlying()) then return false end
+    if not (IsFlying and IsFlying()) then return false end
     if C_PlayerInfo and C_PlayerInfo.GetGlidingInfo then
         local _, canGlide = C_PlayerInfo.GetGlidingInfo()
         return canGlide == true
     end
-    return true
+    -- No capability API to consult: keep the old mounted heuristic rather
+    -- than count ordinary (non-skyriding) flight as dragonriding.
+    return (IsMounted and IsMounted()) and true or false
 end
 
 local function VisRepresentative(modes)


### PR DESCRIPTION
**Cause:** the non-secure dragonriding checks were gated on mount-shaped tests. `IsAirborneSkyriding` required `IsMounted()`, and `IsPlayerSkyriding` required `IsPlayerMountedLike()` (which hard-returns false off DRUID). Flight forms are shapeshifts, not mounts, so both failed while the secure Action Bars driver `[advflyable,flying]` handled them natively.

**Effect:** "When Not Dragonriding" never hid CDM, Unit Frames or Resource Bars in any flight form. "Hide when Dragonriding" never fired in Dracthyr Soar or Haranir form (Druid passed via form ID 27).

**Fix:** both now key off `canGlide`, which is capability-scoped, matching the secure driver. `IsAirborneSkyriding` keeps its `IsFlying()` term; `IsPlayerSkyriding` deliberately has none, since that option is meant to fire on the ground once the skyriding bar appears. The mounted heuristic survives only as the fallback for a client without `C_PlayerInfo.GetGlidingInfo`.

**Test:** verified in game on Druid Flight Form and Haranir flight form, across skyriding mounts, ordinary flying mounts and unmounted, for both the visibility mode and the checkbox.
