### PR TITLE
fix(quickdraw): classify toys dragged from the Toy Box as kind=toy

### DIFF
--- a/EllesmereUIQuickdraw/EllesmereUIQuickdraw.lua
+++ b/EllesmereUIQuickdraw/EllesmereUIQuickdraw.lua
@@ -406,6 +406,15 @@ local function MigrateNames(p)
         -- carries none, so the copy is simply dropped.
         for _, slot in pairs(palette.slots or {}) do
             if slot.kind == "palette" then slot.name = nil end
+            -- Toys dragged in from the Collections/Toy Box frame before
+            -- SlotFromCursor reclassified them landed here as kind="item",
+            -- which runs SlotUsability through C_Item.IsUsableItem -- always
+            -- "unusable" for a toy -- instead of the toy path, which leaves
+            -- them untinted. Same fix, applied to what was already saved.
+            if slot.kind == "item" and type(slot.id) == "number"
+               and PlayerHasToy(slot.id) then
+                slot.kind = "toy"
+            end
         end
     end
 end
@@ -1747,6 +1756,11 @@ local function SlotFromCursor()
     elseif cursorType == "item" then
         local itemID = tonumber(a)
         if not itemID then return nil end
+        -- The Toy Box frame hands back cursorType "item", not "toy", so
+        -- reclassify here to match what the search picker already stores.
+        if PlayerHasToy(itemID) then
+            return { kind = "toy", id = itemID }
+        end
         return { kind = "item", id = itemID }
 
     elseif cursorType == "macro" then


### PR DESCRIPTION
## What does this PR do?

Blizzard's Collections/Toy Box frame hands GetCursorInfo() back with cursorType "item" instead of "toy" for dragged toys. SlotFromCursor stored these as kind="item", which runs SlotUsability through C_Item.IsUsableItem -- always "unusable" for a toy -- causing the icon to stay dimmed even though it is usable. Entries created via the "change action" search picker were unaffected since it always builds toy entries with kind="toy" directly.

Reclassify at cursor-read time via PlayerHasToy(), and extend the existing per-profile migration pass to fix already-saved entries too.

## How was it tested?

In-game, dragging and dropping a toy from the collections window into the quickdraw action menu.

If you do this on the live version, you´ll have an "item" entry:
<img width="259" height="185" alt="image" src="https://github.com/user-attachments/assets/6ab22217-786a-483f-9fb8-ae96df598d35" />
and it will be dimmed(compare to the other entry that is a kind="toy" version):
<img width="326" height="341" alt="image" src="https://github.com/user-attachments/assets/69d41dce-50d5-4bbb-8615-4988cead057c" />

After my change, this will now properly be a "toy", so it won't be dimmed (and broken entries are migrated properly as well, though not sure if there might be a side effect for doing this migration).

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [N/A] New settings default **OFF** (no behavior change without opt-in)
- [N/A] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [N/A] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [N/A] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [X] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
