### PR TITLE
fix(resourcebars): respect Border Size/Color on the Ebon Might power bar

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_EbonMight121.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_EbonMight121.lua
@@ -228,5 +228,16 @@ function ns.EMB121_Sync(bar, pp, pc)
     S.proxy:Show()
     -- One container-level set lifts the whole engine subtree above the
     -- (empty) legacy fill.
-    S.container:SetFrameLevel(bar:GetFrameLevel() + 1)
+    local lvl = bar:GetFrameLevel() + 1
+    S.container:SetFrameLevel(lvl)
+    -- ...which also lifts it above the bar's border strips (bar+2), so the
+    -- fill -- a slot-button child two levels down, edge to edge over the whole
+    -- rect -- paints over them: Border Size/Color silently did nothing while
+    -- the power type was Ebon Might. Push the border back on top, clearing the
+    -- engine fill with a level of margin (the subtree is denied to us
+    -- afterward, so its exact levels can't be read back). The countdown text
+    -- sits at fill+5, still above the border, as on the legacy path.
+    if bar.RaiseBorderAbove then
+        bar:RaiseBorderAbove(lvl + 3, pp and pp.borderBehind)
+    end
 end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1790,6 +1790,24 @@ local function CreateStatusBar(parent, name, w, h, borderSize, borderR, borderG,
         self._border:ApplyStyle(sz, r, g, b, a, textureKey, texOffset, texOffsetY, shiftX, shiftY, addonKey, sizeKey)
     end
 
+    -- Lift the border above an overlay that draws inside the bar's rect. The
+    -- default level (+1 over the bar, strips +1 over that) only clears the
+    -- legacy fill; the 12.1 Ebon Might engine slot renders its own StatusBar
+    -- deeper in the tree, so it paints over the strips and Border Size/Color
+    -- look like they do nothing. "Show Behind" is honored -- that border is
+    -- meant to sit under the fill. Idempotent: safe to re-assert every update.
+    function bar:RaiseBorderAbove(coverLevel, behind)
+        local bf = self._border and self._border._frame
+        if not bf then return end
+        local lvl = behind and math.max(0, self:GetFrameLevel() - 1) or (coverLevel + 1)
+        bf:SetFrameLevel(lvl)
+        -- Re-assert on the PP strip container too: it was levelled off the
+        -- border frame at creation, and the textured-border backdrop tracks
+        -- the border frame's level directly.
+        local edges = PP and PP.GetBorders and PP.GetBorders(bf)
+        if edges then edges:SetFrameLevel(lvl + 1) end
+    end
+
     -- Text overlay (above all bar borders)
     local textFrame = CreateFrame("Frame", nil, bar)
     textFrame:SetAllPoints(bar)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->
Fixes the border for Ebon Might. It was being drawn behind the power bar. This fix lifts it up by one frame level so the border is shown again.

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
12.1.0

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
Previous:
<img width="199" height="443" alt="image" src="https://github.com/user-attachments/assets/61fdfafd-741e-4324-90ee-8e3486d26721" />

Current:
<img width="118" height="382" alt="image" src="https://github.com/user-attachments/assets/fc8000cc-e124-4393-b3de-faf71c87c390" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
