### PR TITLE
Add centered Player Aura Bar growth

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -7103,22 +7103,22 @@ local function CreateMover(barKey)
                 isVert = v3
             end
         elseif barKey:sub(1, 4) == "PAB_" then
-            -- Player Aura Bars support vertical growth too (Up/Down) -- read the bar's
+            -- Player Aura Bars support vertical growth too -- read the bar's
             -- own current growDirection (same bridge the currentVal lookup below uses)
             -- to decide which pair of grow options this popup offers.
             local euf3 = EllesmereUI.Lite.GetAddon("EllesmereUIUnitFrames", true)
             local pabDir = (euf3 and euf3.GetGrowDirectionForBar and euf3:GetGrowDirectionForBar(barKey)) or "LEFT"
-            isVert = (pabDir == "UP" or pabDir == "DOWN")
+            isVert = (pabDir == "UP" or pabDir == "DOWN" or pabDir == "CENTER_VERTICAL")
         else
             local eab3 = EllesmereUI.Lite.GetAddon("EllesmereUIActionBars", true)
             local s3 = eab3 and eab3.db and eab3.db.profile and eab3.db.profile.bars and eab3.db.profile.bars[barKey]
             if s3 then isVert = (s3.orientation == "vertical") end
         end
-        -- Player Aura Bars: no "Grow Centered" -- AK's SetFlowLayoutGrowthDirection
-        -- (AnchorUtil.FlowDirection) is a strict Left/Right/Up/Down axis, it has
-        -- no centered concept, unlike CDM/ActionBars' own bar renderer.
         local growDirs = {}
-        if barKey:sub(1, 4) ~= "PAB_" then
+        if barKey:sub(1, 4) == "PAB_" then
+            growDirs[#growDirs + 1] = { label = "Grow Centered Horizontal", val = "CENTER_HORIZONTAL" }
+            growDirs[#growDirs + 1] = { label = "Grow Centered Vertical", val = "CENTER_VERTICAL" }
+        else
             growDirs[#growDirs + 1] = { label = "Grow Centered", val = "CENTER" }
         end
         if isVert then

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -855,7 +855,7 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
             setValue = function(v) cfg.borderSize = v; apply() end
         },
         {
-            type = "slider", text = "Spacing", min = 0, max = 20, step = 1, trackWidth = 120,
+            type = "slider", text = "Spacing", min = -5, max = 20, step = 1, trackWidth = 120,
             getValue = function() return cfg.padding or 5 end,
             setValue = function(v) cfg.padding = v; apply() end
         }

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -68,8 +68,8 @@ local FONT_OUTLINE_VALUES = {
     outline = "Outline", thick = "Thick Outline",
 }
 local FONT_OUTLINE_ORDER = { "default", "none", "outline", "thick" }
-local GROW_DIR_VALUES = { LEFT = "Left", RIGHT = "Right", UP = "Up", DOWN = "Down" }
-local GROW_DIR_ORDER = { "LEFT", "RIGHT", "UP", "DOWN" }
+local GROW_DIR_VALUES = { LEFT = "Left", RIGHT = "Right", CENTER_HORIZONTAL = "Centered Horizontal", CENTER_VERTICAL = "Centered Vertical", UP = "Up", DOWN = "Down" }
+local GROW_DIR_ORDER = { "LEFT", "RIGHT", "CENTER_HORIZONTAL", "CENTER_VERTICAL", "UP", "DOWN" }
 local ICON_WRAP_VALUES = { LEFT = "Left", RIGHT = "Right" }
 local ICON_WRAP_ORDER = { "LEFT", "RIGHT" }
 

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
@@ -297,8 +297,10 @@ local function Paint()
                             if dir == "RIGHT" then dx = 1 elseif dir == "LEFT" then dx = -1
                             elseif dir == "UP" then dy = 1 elseif dir == "DOWN" then dy = -1 end
                             b:ClearAllPoints()
-                            b:SetPoint(rec.corner, rec.parent, rec.corner,
-                                dx * idx * cell, dy * idx * cell)
+                            local point = rec.point or rec.corner
+                            b:SetPoint(point, rec.parent, rec.relativePoint or rec.corner or point,
+                                (rec.x or 0) + dx * idx * cell,
+                                (rec.y or 0) + dy * idx * cell)
                             b._cell = idx
                             b._noTooltip = style.noTooltips == true
                         end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -509,8 +509,8 @@ local STYLE_DEBUFFS = "playerAuraBars_debuffs"
 -- lineSpacing/groupLineSpacing only, nil falls back to `padding`; elementSpacing/
 -- groupSpacing, icon-to-icon within a row, always stay tied to `padding`); maxTotal
 -- (overall icon cap); iconsPerRow (row width in columns); maxRows (row cap; with
--- iconsPerRow also bounds maxTotal, see ComputeGrid()); growDirection ("LEFT"/"RIGHT",
--- default LEFT, a TOPRIGHT anchor growing inward like Blizzard's own BuffFrame).
+-- iconsPerRow also bounds maxTotal, see ComputeGrid()); growDirection ("LEFT"/"RIGHT"/
+-- "CENTER_HORIZONTAL"/"CENTER_VERTICAL"/"UP"/"DOWN", default LEFT).
 -- Buff bars (default AND custom, one model): filters ([filterId]=true, shared PAB
 -- Filters registry); spells ({spellID,...}, direct/"Extra Spells"); showAllBuffs
 -- (default bar ONLY, custom buff bars never read it; defaults true, else an
@@ -944,6 +944,22 @@ local function EnsurePabSizedStyle(baseKey, size)
     return variantKey
 end
 
+local function BuildGroupLayout(cfg, gap, rowGap, size)
+    local PP = EllesmereUI.PP
+    rowGap = rowGap or gap
+    size = PP.Scale(size or cfg.iconSize or 32)
+    gap = PP.Scale(gap)
+    rowGap = PP.Scale(rowGap)
+    return {
+        elementWidth = size,
+        elementHeight = size,
+        elementSpacing = gap,
+        lineSpacing = rowGap,
+        groupSpacing = gap,
+        groupLineSpacing = rowGap,
+    }
+end
+
 local function ApplyGroupConfig(container, chain, declaredSet, styleKey, effectiveMax, gap, rowGap, cfg, extraCand)
     local sortMethod = ResolveSortMethod(cfg)
     local sortDirection = ResolveSortDirection(cfg)
@@ -954,28 +970,13 @@ local function ApplyGroupConfig(container, chain, declaredSet, styleKey, effecti
     -- distance is overridable independently of icon-to-icon spacing (cfg.rowSpacing in
     -- the Settings Schema comment). Container-level padding is a THIRD, unrelated
     -- concept: the OUTER edge inset, fixed at 0 elsewhere and never affected by either.
-    rowGap = rowGap or gap
-    -- Snap both to the physical pixel grid before the native engine's layout math
-    -- (SetAuraGroupLayout below): raw values can land the engine's OWN internal row
-    -- positioning a hair off a pixel boundary at a non-pixel-perfect UIParent scale,
-    -- which the border (independently pixel-perfect via GetEffectiveScale) then
-    -- visibly disagrees with by ~1px.
-    local PP = EllesmereUI.PP
-    gap = PP.Scale(gap)
-    rowGap = PP.Scale(rowGap)
-    local layout = {
-        elementSpacing = gap,
-        lineSpacing = rowGap,
-        groupSpacing = gap,
-        groupLineSpacing = rowGap,
-    }
-
     local active = {}
     for i = 1, #chain do
         local link = chain[i]
         -- Size override, debuffs only: cfg.fxList is nil for buffs, so szOv is always
         -- nil there.
         local szOv = PAB_FxSizeFor(cfg.fxList, link.key)
+        local layout = BuildGroupLayout(cfg, gap, rowGap, szOv)
         -- Token strings are declaration-fixed too, so the effective key embeds the
         -- link's token set: a changed negation shape (subtract flips, class-set edits)
         -- declares a fresh variant instead of leaving a stale filter on the old group.
@@ -1023,6 +1024,7 @@ local function ApplyGroupConfig(container, chain, declaredSet, styleKey, effecti
                 candidateFilters = candidateFilters,
                 sortMethod = sortMethod,
                 sortDirection = sortDirection,
+                layout = layout,
                 -- Icon Effects Per-Filter: stamps this button's category (matched
                 -- against fxList blocks by PAB_ApplyDmFx) and arms the glow/border
                 -- overlay inside the one legal creation window. style.applyExtra runs
@@ -1121,6 +1123,8 @@ local function ComputeGrid(isBuff, cfg)
     local iconSize = MaxIconSizeFor(isBuff, cfg)
     local pad = cfg.padding or 5
     local rowGap = cfg.rowSpacing or 12
+    local layoutPad = EllesmereUI.PP.Scale(pad)
+    local layoutRowGap = EllesmereUI.PP.Scale(rowGap)
     local cols = math.max(1, cfg.iconsPerRow or (isBuff and 11 or 8))
     local rows = math.max(1, cfg.maxRows or (isBuff and 3 or 2))
     local configuredMax = cfg.maxTotal or (isBuff and 32 or 16)
@@ -1130,9 +1134,9 @@ local function ComputeGrid(isBuff, cfg)
     -- `lineExtent` is the icons' own extent on the line axis (iconsPerRow
     -- icons of iconSize + gaps); `crossExtent` is the other axis (lines actually used).
     -- Horizontal growth: a "line" is a row, so lineExtent -> width. Vertical growth
-    -- (Up/Down): a "line" is a column, so lineExtent -> height -- see
+    -- modes: a "line" is a column, so lineExtent -> height -- see
     -- CornerFor/BuildContainerSpec for the matching growthH/growthV swap.
-    local lineExtent = cols * iconSize + (cols - 1) * pad
+    local lineExtent = cols * iconSize + (cols - 1) * layoutPad
     -- Wrap budget handed to the engine (AK.SetContainerRowWidth / layout.rowWidth),
     -- deliberately NOT lineExtent: the engine reserves a TRAILING elementSpacing
     -- after every element (not only between), so a full line needs
@@ -1140,9 +1144,9 @@ local function ComputeGrid(isBuff, cfg)
     -- still sizes the bar's own frame, so the drag box measures the icons, not
     -- the phantom trailing gap (the preview builder models the same and drops
     -- the trailing gap).
-    local rowWidth = lineExtent + pad
-    local crossExtent = usedRows * iconSize + (usedRows - 1) * rowGap
-    local vertical = (cfg.growDirection == "UP" or cfg.growDirection == "DOWN")
+    local rowWidth = math.max(iconSize, lineExtent + layoutPad)
+    local crossExtent = usedRows * iconSize + (usedRows - 1) * layoutRowGap
+    local vertical = (cfg.growDirection == "UP" or cfg.growDirection == "DOWN" or cfg.growDirection == "CENTER_VERTICAL")
     local width = vertical and crossExtent or lineExtent
     local height = vertical and lineExtent or crossExtent
     return {
@@ -1425,7 +1429,7 @@ local buffsParent, debuffsParent
 -- ApplyGroupConfig): reset only when a container is (re-)created, never on a live
 -- settings change.
 local declared = { buffs = {}, debuffs = {} } -- buffs: only the "Show All Buffs" catch-all key ("all"); debuffs: every class-token chain key
-local lastSize = { buffs = nil, debuffs = nil } -- {w=,h=} last-applied grid size, for CENTER-anchor compensation (see ApplyLiveConfig)
+local lastSize = { buffs = nil, debuffs = nil } -- {w=,h=} last-applied grid size, for fixed-edge compensation (see ApplyLiveConfig)
 local buffsSlotSig -- signature of the default Buffs bar's last-applied resolved spell list (ns.PAB_ResolveSpells), mirrors customBuffSig[barId] for the per-bar slots model
 local RegisterPABUnlock -- forward-declared; defined after CreateBars, called from it
 -- Last label the Buffs mover was registered under, so ApplyLiveConfig can
@@ -1434,10 +1438,28 @@ local lastUnlockBuffLabel
 local ReloadAllCustomBars -- forward-declared; defined after CreateBars (custom bars section), called from it
 local PAB_MaybeRefreshPreview -- forward-declared; assigned in the options-page preview section, called from every live-apply function so an open bar-detail preview box tracks slider drags without those functions knowing it exists
 
+local restrictedApplies = {}
+local restrictionHooked = false
+local function DeferRestrictedApply(key, fn)
+    AK = AK or (EllesmereUI and EllesmereUI.AuraKit)
+    if not (AK and AK.AurasRestricted and AK.AurasRestricted()) then return false end
+    restrictedApplies[key] = fn
+    if not restrictionHooked then
+        restrictionHooked = true
+        AK.OnRestrictionLift(function()
+            if not next(restrictedApplies) then return end
+            local pending = restrictedApplies
+            restrictedApplies = {}
+            for _, apply in pairs(pending) do apply() end
+        end)
+    end
+    return true
+end
+
 -- Grow direction. AK.ApplyContainerLayout only applies growth when BOTH growthH and
 -- growthV are set. Values are AnchorUtil.FlowDirection members, NOT strings
 -- (Blizzard_SharedXMLBase/AnchorUtil.lua: Left=-1, Right=1, Up=1, Down=-1); our
--- settings store "LEFT"/"RIGHT" strings, matching EUI_UnlockMode.lua's dropdown
+-- settings store uppercase direction strings, matching EUI_UnlockMode.lua's dropdown
 -- `val` convention.
 --
 -- CRITICAL: AnchorUtil.ApplyFlowLayout positions every element via
@@ -1460,10 +1482,11 @@ local PAB_MaybeRefreshPreview -- forward-declared; assigned in the options-page 
 local function ToGrowthH(dirStr, wrapStr)
     local FlowDir = AnchorUtil and AnchorUtil.FlowDirection
     if not FlowDir then return nil end
+    if dirStr == "CENTER_VERTICAL" then return FlowDir.Right end
     if dirStr == "UP" or dirStr == "DOWN" then
         return wrapStr == "RIGHT" and FlowDir.Right or FlowDir.Left
     end
-    return dirStr == "RIGHT" and FlowDir.Right or FlowDir.Left
+    return (dirStr == "RIGHT" or dirStr == "CENTER_HORIZONTAL") and FlowDir.Right or FlowDir.Left
 end
 local function ToGrowthV(dirStr)
     local FlowDir = AnchorUtil and AnchorUtil.FlowDirection
@@ -1476,12 +1499,13 @@ end
 -- growthH side), same rule horizontal or vertical (LEFT/RIGHT: growthV is always Down
 -- -> TOP component; growthH Right/Left -> LEFT/RIGHT component).
 local function CornerFor(dirStr, wrapStr)
+    if dirStr == "CENTER_VERTICAL" then return "TOP" end
     if dirStr == "UP" or dirStr == "DOWN" then
         local vSide = (dirStr == "UP") and "BOTTOM" or "TOP"
         local hSide = (wrapStr == "RIGHT") and "LEFT" or "RIGHT"
         return vSide .. hSide
     end
-    return dirStr == "RIGHT" and "TOPLEFT" or "TOPRIGHT"
+    return (dirStr == "RIGHT" or dirStr == "CENTER_HORIZONTAL") and "TOPLEFT" or "TOPRIGHT"
 end
 
 -- Shared by every container, default and custom alike: builds the AK.RequestContainer
@@ -1493,12 +1517,13 @@ end
 local function BuildContainerSpec(parent, cfg, grid)
     local dir = cfg.growDirection or "LEFT"
     local wrap = cfg.iconWrapDirection or "LEFT"
-    local vertical = (dir == "UP" or dir == "DOWN")
-    local corner = CornerFor(dir, wrap)
-    return corner, {
-        point = { corner, parent, corner, 0, 0 },
+    local vertical = (dir == "UP" or dir == "DOWN" or dir == "CENTER_VERTICAL")
+    local layoutAnchor = dir == "CENTER_HORIZONTAL" and "LEFT" or CornerFor(dir, wrap)
+    local containerAnchor = (dir == "CENTER_HORIZONTAL" or dir == "CENTER_VERTICAL") and "CENTER" or layoutAnchor
+    return containerAnchor, {
+        point = { containerAnchor, parent, containerAnchor, 0, 0 },
         layout = {
-            anchorPoint = corner,
+            anchorPoint = layoutAnchor,
             padding = { 0, 0, 0, 0 },
             rowWidth = grid.rowWidth,
             growthH = ToGrowthH(dir, wrap),
@@ -1513,10 +1538,10 @@ end
 -- the three cannot drift. The outer frame anchor is a plain SetPoint (not AK-managed),
 -- so it is live-settable like any other frame anchor.
 local function ApplyContainerAnchorAndGrowth(container, parent, cfg, grid)
-    local corner, spec, vertical = BuildContainerSpec(parent, cfg, grid)
+    local containerAnchor, spec, vertical = BuildContainerSpec(parent, cfg, grid)
     container:ClearAllPoints()
-    container:SetPoint(corner, parent, corner, 0, 0)
-    AK.SetContainerAnchor(container, corner)
+    container:SetPoint(containerAnchor, parent, containerAnchor, 0, 0)
+    AK.SetContainerAnchor(container, spec.layout.anchorPoint)
     AK.SetContainerAxis(container, vertical)
     if spec.layout.growthH then
         AK.SetContainerGrowth(container, spec.layout.growthH, spec.layout.growthV)
@@ -1601,21 +1626,52 @@ end
 -- leaves the anchor byte-identical. Full rows overflow the reserved grid by
 -- the shift while an oil is up -- accepted; the shift is transient.
 local function ShiftBuffsForEnchants(container, parent, cfg, grid)
-    local n = (ns._weaponEnchPAB and ns.WeaponEnchants_Count and ns.WeaponEnchants_Count()) or 0
-    if n == 0 then return end
-    local corner = BuildContainerSpec(parent, cfg, grid)
+    local n = (cfg.showWeaponEnchants == true and ns.WeaponEnchants_Count and ns.WeaponEnchants_Count()) or 0
+    local containerAnchor = BuildContainerSpec(parent, cfg, grid)
     local dir = cfg.growDirection or "LEFT"
+    local cell = EllesmereUI.PP.Scale(cfg.iconSize or 32) + EllesmereUI.PP.Scale(cfg.padding or 5)
+    container:ClearAllPoints()
+    if dir == "CENTER_HORIZONTAL" then
+        local span = n * cell
+        container:SetPoint("CENTER", parent, "CENTER", 0, 0)
+        if ns._weaponEnchPAB then
+            ns._weaponEnchPAB.parent = container
+            ns._weaponEnchPAB.corner = nil
+            ns._weaponEnchPAB.point = "LEFT"
+            ns._weaponEnchPAB.relativePoint = "LEFT"
+            ns._weaponEnchPAB.x = -span
+            ns._weaponEnchPAB.y = 0
+            ns._weaponEnchPAB.dir = "RIGHT"
+        end
+        return
+    end
+    if dir == "CENTER_VERTICAL" then
+        container:SetPoint("CENTER", parent, "CENTER", 0, 0)
+        if ns._weaponEnchPAB then
+            ns._weaponEnchPAB.parent = container
+            ns._weaponEnchPAB.corner = nil
+            ns._weaponEnchPAB.point = "BOTTOM"
+            ns._weaponEnchPAB.relativePoint = "TOP"
+            ns._weaponEnchPAB.x = 0
+            ns._weaponEnchPAB.y = math.max(0, n - 1) * cell + EllesmereUI.PP.Scale(cfg.padding or 5)
+            ns._weaponEnchPAB.dir = "DOWN"
+        end
+        return
+    end
+
     local dx, dy = 0, 0
     if dir == "RIGHT" then dx = 1 elseif dir == "LEFT" then dx = -1
     elseif dir == "UP" then dy = 1 elseif dir == "DOWN" then dy = -1 end
-    -- Both terms snapped, matching the engine's own cell stride exactly:
-    -- ApplyGroupConfig feeds it PP.Scale(padding) as elementSpacing and
-    -- BuildStyle PP.Scale(iconSize) as the element width. Leaving the gap raw
-    -- here drifts the reservation by PP.Scale(pad) - pad per cell at a
-    -- non-pixel-perfect UIParent scale.
-    local cell = EllesmereUI.PP.Scale(cfg.iconSize or 32) + EllesmereUI.PP.Scale(cfg.padding or 5)
-    container:ClearAllPoints()
-    container:SetPoint(corner, parent, corner, dx * n * cell, dy * n * cell)
+    container:SetPoint(containerAnchor, parent, containerAnchor, dx * n * cell, dy * n * cell)
+    if ns._weaponEnchPAB then
+        ns._weaponEnchPAB.parent = parent
+        ns._weaponEnchPAB.corner = containerAnchor
+        ns._weaponEnchPAB.point = nil
+        ns._weaponEnchPAB.relativePoint = nil
+        ns._weaponEnchPAB.x = nil
+        ns._weaponEnchPAB.y = nil
+        ns._weaponEnchPAB.dir = dir
+    end
 end
 
 -- Combat-path re-shift for enchant count changes: re-seating the CONTAINER
@@ -1629,20 +1685,7 @@ function ns.PAB_ReShiftEnchants()
     if not (AK and s and buffsContainer and buffsParent) then return end
     local cfg = DefaultBuffsCfg(s)
     local grid = ComputeGrid(true, cfg)
-    local corner = BuildContainerSpec(buffsParent, cfg, grid)
-    local n = (ns._weaponEnchPAB and ns.WeaponEnchants_Count and ns.WeaponEnchants_Count()) or 0
-    local dir = cfg.growDirection or "LEFT"
-    local dx, dy = 0, 0
-    if dir == "RIGHT" then dx = 1 elseif dir == "LEFT" then dx = -1
-    elseif dir == "UP" then dy = 1 elseif dir == "DOWN" then dy = -1 end
-    -- Both terms snapped, matching the engine's own cell stride exactly:
-    -- ApplyGroupConfig feeds it PP.Scale(padding) as elementSpacing and
-    -- BuildStyle PP.Scale(iconSize) as the element width. Leaving the gap raw
-    -- here drifts the reservation by PP.Scale(pad) - pad per cell at a
-    -- non-pixel-perfect UIParent scale.
-    local cell = EllesmereUI.PP.Scale(cfg.iconSize or 32) + EllesmereUI.PP.Scale(cfg.padding or 5)
-    buffsContainer:ClearAllPoints()
-    buffsContainer:SetPoint(corner, buffsParent, corner, dx * n * cell, dy * n * cell)
+    ShiftBuffsForEnchants(buffsContainer, buffsParent, cfg, grid)
 end
 
 local function CreateBars()
@@ -1734,7 +1777,9 @@ local function CreateBars()
     else
         ns._weaponEnchPAB = nil
     end
-    if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
+    if buffCfg.growDirection ~= "CENTER_HORIZONTAL" and buffCfg.growDirection ~= "CENTER_VERTICAL" and ns.WeaponEnchants_Layout then
+        ns.WeaponEnchants_Layout()
+    end
 
     -- Groups are declared additively right after creation (not via spec.groups) so
     -- the same ApplyGroupConfig path handles both initial creation and every later
@@ -1767,6 +1812,7 @@ local function CreateBars()
         buffsContainer = container
         AK.SetContainerAxis(container, buffVertical)
         ShiftBuffsForEnchants(container, buffsParent, buffCfg, buffGrid)
+        if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
         declared.buffs = {}
         ApplyGroupConfig(container, buffAllChain, declared.buffs, STYLE_BUFFS, buffGrid.effectiveMax, buffPad, buffGrid.rowGap, buffCfg, BuffCandidateExtras(buffCfg))
         if #buffSpells > 0 then
@@ -1780,10 +1826,7 @@ local function CreateBars()
                 candidateFilters = MergeCandidateFilters({ includeSpellIDs = includeMap }, BuffCandidateExtras(buffCfg)),
                 sortMethod = ResolveSortMethod(buffCfg),
                 sortDirection = ResolveSortDirection(buffCfg),
-            })
-            container:SetAuraGroupLayout("spells", {
-                elementSpacing = buffPad, lineSpacing = buffGrid.rowGap,
-                groupSpacing = buffPad, groupLineSpacing = buffGrid.rowGap,
+                layout = BuildGroupLayout(buffCfg, buffPad, buffGrid.rowGap),
             })
             declared.buffs.spells = true
         end
@@ -1893,6 +1936,8 @@ ns.PAB_Restyle = RestyleBars
 local function ApplyLiveConfig(isBuff)
     local s = PAB()
     if not (AK and s) then return end
+    if DeferRestrictedApply(isBuff and "default-buffs" or "default-debuffs",
+        function() ApplyLiveConfig(isBuff) end) then return end
     local container = isBuff and buffsContainer or debuffsContainer
     local parent = isBuff and buffsParent or debuffsParent
     if not container or not parent then return end
@@ -1902,15 +1947,14 @@ local function ApplyLiveConfig(isBuff)
     local sizeKey = isBuff and "buffs" or "debuffs"
     local prev = lastSize[sizeKey]
 
-    -- Compensate for CENTER-anchored saved positions: SetSize on a CENTER/CENTER point
-    -- grows/shrinks symmetrically, so any size change visibly shifts the icons. Shift
-    -- the saved position by half the delta so the CENTER point stays put. Uses OUR OWN
-    -- last-applied size (lastSize), not parent:GetWidth/GetHeight -- querying the live
-    -- frame is jitter-prone across rapid successive calls (slider drags), since its
-    -- rendered size may not yet reflect the previous call. Skipped when unchanged.
+    -- Edge-growing containers use a fixed parent corner, so move a CENTER-saved parent
+    -- by half the size delta to keep that corner fixed. Centered growth deliberately
+    -- skips this: the parent center is its fixed anchor. Uses lastSize rather than live
+    -- geometry so rapid slider updates cannot read a stale prior size.
     local posKey = BarPositionKey(isBuff)
     local pos = s[posKey]
-    if pos and pos.point == "CENTER" and prev and (prev.w ~= grid.width or prev.h ~= grid.height) then
+    if cfg.growDirection ~= "CENTER_HORIZONTAL" and cfg.growDirection ~= "CENTER_VERTICAL" and pos and pos.point == "CENTER"
+        and prev and (prev.w ~= grid.width or prev.h ~= grid.height) then
         pos.x = pos.x + (prev.w - grid.width) / 2
         pos.y = pos.y + (prev.h - grid.height) / 2
         -- Snap against the NEW grid.width/height (what parent:SetSize is about to
@@ -1974,6 +2018,7 @@ local function ApplyLiveConfig(isBuff)
                 buffsContainer = newContainer
                 AK.SetContainerAxis(newContainer, specVertical)
                 ShiftBuffsForEnchants(newContainer, parent, cfg, grid)
+                if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
                 declared.buffs = {}
                 ApplyGroupConfig(newContainer, allChain, declared.buffs, STYLE_BUFFS, grid.effectiveMax, pad, grid.rowGap, cfg, BuffCandidateExtras(cfg))
                 if #spells > 0 then
@@ -1987,10 +2032,7 @@ local function ApplyLiveConfig(isBuff)
                         candidateFilters = MergeCandidateFilters({ includeSpellIDs = includeMap }, BuffCandidateExtras(cfg)),
                         sortMethod = ResolveSortMethod(cfg),
                         sortDirection = ResolveSortDirection(cfg),
-                    })
-                    newContainer:SetAuraGroupLayout("spells", {
-                        elementSpacing = pad, lineSpacing = grid.rowGap,
-                        groupSpacing = pad, groupLineSpacing = grid.rowGap,
+                        layout = BuildGroupLayout(cfg, pad, grid.rowGap),
                     })
                     declared.buffs.spells = true
                 end
@@ -2005,10 +2047,7 @@ local function ApplyLiveConfig(isBuff)
             ApplyGroupConfig(container, allChain, declared.buffs, STYLE_BUFFS, grid.effectiveMax, pad, grid.rowGap, cfg, BuffCandidateExtras(cfg))
             if declared.buffs.spells then
                 container:SetAuraGroupMaxFrameCount("spells", grid.effectiveMax)
-                container:SetAuraGroupLayout("spells", {
-                    elementSpacing = pad, lineSpacing = grid.rowGap,
-                    groupSpacing = pad, groupLineSpacing = grid.rowGap,
-                })
+                container:SetAuraGroupLayout("spells", BuildGroupLayout(cfg, pad, grid.rowGap))
                 local liveIncludeMap = {}
                 for i = 1, #spells do liveIncludeMap[spells[i]] = true end
                 container:SetAuraGroupCandidateFilters("spells",
@@ -2748,6 +2787,8 @@ ns.PAB_RegisterCustomUnlock = RegisterPABCustomUnlock
 local function ReloadCustomBuffBarImpl(barId)
     AK = AK or (EllesmereUI and EllesmereUI.AuraKit)
     if not AK then return end
+    if DeferRestrictedApply("custom-buff-" .. barId,
+        function() ns.PAB_ReloadCustomBuffBar(barId) end) then return end
 
     local bar = ns.PAB_GetCustomBuffBar(barId)
     if not bar then
@@ -2806,10 +2847,7 @@ local function ReloadCustomBuffBarImpl(barId)
             if #spells > 0 then
                 local livePad = bar.padding or 5
                 container:SetAuraGroupMaxFrameCount("spells", grid.effectiveMax)
-                container:SetAuraGroupLayout("spells", {
-                    elementSpacing = livePad, lineSpacing = grid.rowGap,
-                    groupSpacing = livePad, groupLineSpacing = grid.rowGap,
-                })
+                container:SetAuraGroupLayout("spells", BuildGroupLayout(bar, livePad, grid.rowGap))
                 local liveIncludeMap = {}
                 for i = 1, #spells do liveIncludeMap[spells[i]] = true end
                 container:SetAuraGroupCandidateFilters("spells",
@@ -2846,10 +2884,7 @@ local function ReloadCustomBuffBarImpl(barId)
                 candidateFilters = MergeCandidateFilters({ includeSpellIDs = includeMap }, BuffCandidateExtras(bar)),
                 sortMethod = ResolveSortMethod(bar),
                 sortDirection = ResolveSortDirection(bar),
-            })
-            container:SetAuraGroupLayout("spells", {
-                elementSpacing = pad, lineSpacing = grid.rowGap,
-                groupSpacing = pad, groupLineSpacing = grid.rowGap,
+                layout = BuildGroupLayout(bar, pad, grid.rowGap),
             })
         end
     end)
@@ -2869,6 +2904,8 @@ end
 local function ReloadCustomDebuffBarImpl(barId)
     AK = AK or (EllesmereUI and EllesmereUI.AuraKit)
     if not AK then return end
+    if DeferRestrictedApply("custom-debuff-" .. barId,
+        function() ns.PAB_ReloadCustomDebuffBar(barId) end) then return end
 
     local bar = ns.PAB_GetCustomDebuffBar(barId)
     if not bar then
@@ -3678,7 +3715,8 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
     -- box/divider while doing it.
     local growDir = cfg.growDirection or "LEFT"
     local wrapDir = cfg.iconWrapDirection or "LEFT"
-    local vertical = (growDir == "UP" or growDir == "DOWN")
+    local centeredVertical = growDir == "CENTER_VERTICAL"
+    local vertical = (growDir == "UP" or growDir == "DOWN" or centeredVertical)
     local corner = CornerFor(growDir, wrapDir)
     local pad = cfg.padding or 5
     local rowGap = cfg.rowSpacing or 12
@@ -3801,12 +3839,15 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
             -- btn's own anchor point is `corner` (matching growDirection/
             -- iconWrapDirection), placed at an offset from the box's CENTER -- see the
             -- block-centering comment above `local rows = ...`. Vertical growth
-            -- (Up/Down) swaps which step drives X vs Y: the within-line step (icons
+            -- swaps which step drives X vs Y: the within-line step (icons
             -- stacking inside one column) becomes Y, the across-lines step (columns
             -- wrapping sideways) becomes X -- mirrors the corner/growthH/growthV swap
             -- in CornerFor/BuildContainerSpec used by the real (non-preview) bars.
             local btnX, btnY
-            if vertical then
+            if centeredVertical then
+                btnY = halfPrimary - withinLineStep - slotSize[i] / 2
+                btnX = -halfCross + acrossLinesStep + slotSize[i] / 2
+            elseif vertical then
                 btnY = growUp and (-halfPrimary + withinLineStep) or (halfPrimary - withinLineStep)
                 btnX = wrapRight and (-halfCross + acrossLinesStep) or (halfCross - acrossLinesStep)
             else
@@ -3814,7 +3855,7 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
                 btnY = halfCross - acrossLinesStep
             end
             btn:ClearAllPoints()
-            btn:SetPoint(corner, box, "CENTER", btnX, btnY)
+            btn:SetPoint(centeredVertical and "CENTER" or corner, box, "CENTER", btnX, btnY)
             btn:SetSize(slotSize[i], slotSize[i])
 
             local slot = slots[i]

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -566,6 +566,12 @@ local OPPOSITE_POINT = {
     CENTER = "CENTER",
 }
 
+local function SetTexturePixelSnap(texture, enabled)
+    if not (texture and texture.SetSnapToPixelGrid) then return end
+    texture:SetSnapToPixelGrid(enabled)
+    texture:SetTexelSnappingBias(0)
+end
+
 -- Secondary text-styling pass: AK calls style.applyExtra as (button, d, style), where
 -- d.duration/d.stack are the FontStrings AK's own initializer creates. Adds what AK has
 -- no native field for: duration/stack text color and independent stack-text show/hide
@@ -669,6 +675,26 @@ local function PAB_ApplyExtraText(button, d, style)
     if style.fxList or d.pabFxGlow or d.pabFxBdr then
         PAB_ApplyDmFx(button, d, style)
     end
+
+    -- Centered runs can have an odd content width/height, whose CENTER anchor is a
+    -- half pixel. Let textures use Blizzard's normal pixel snapping so
+    -- icon art cannot bleed over PP's one-pixel border. Edge-growing bars keep EUI's
+    -- usual unsnapped rendering.
+    d.pabCenteredSnap = style.centeredGrowth == true
+    if d.icon and not d.pabIconSnapHooked then
+        d.pabIconSnapHooked = true
+        hooksecurefunc(d.icon, "SetTexture", function(texture)
+            if d.pabCenteredSnap then SetTexturePixelSnap(texture, true) end
+        end)
+    end
+    SetTexturePixelSnap(d.icon, d.pabCenteredSnap)
+    local border = d.borderHost and EllesmereUI.PP.GetBorders(d.borderHost)
+    if border then
+        SetTexturePixelSnap(border._top, d.pabCenteredSnap)
+        SetTexturePixelSnap(border._bottom, d.pabCenteredSnap)
+        SetTexturePixelSnap(border._left, d.pabCenteredSnap)
+        SetTexturePixelSnap(border._right, d.pabCenteredSnap)
+    end
 end
 
 -- Icon-text outline flag for duration/stack text. Default follows the house icon-text
@@ -715,6 +741,7 @@ local function BuildStyle(isBuff, cfg)
     local style = {
         width = iconSize,
         height = iconSize,
+        centeredGrowth = cfg.growDirection == "CENTER_HORIZONTAL" or cfg.growDirection == "CENTER_VERTICAL",
         iconCrop = true,
         iconZoom = iconZoom or 0.055,
 
@@ -1137,14 +1164,9 @@ local function ComputeGrid(isBuff, cfg)
     -- modes: a "line" is a column, so lineExtent -> height -- see
     -- CornerFor/BuildContainerSpec for the matching growthH/growthV swap.
     local lineExtent = cols * iconSize + (cols - 1) * layoutPad
-    -- Wrap budget handed to the engine (AK.SetContainerRowWidth / layout.rowWidth),
-    -- deliberately NOT lineExtent: the engine reserves a TRAILING elementSpacing
-    -- after every element (not only between), so a full line needs
-    -- cols * (icon + spacing) or the last icon of every row wraps. lineExtent
-    -- still sizes the bar's own frame, so the drag box measures the icons, not
-    -- the phantom trailing gap (the preview builder models the same and drops
-    -- the trailing gap).
-    local rowWidth = math.max(iconSize, lineExtent + layoutPad)
+    -- Maximum line size covers the configured icon limit and only the gaps between
+    -- them. Adding a trailing gap makes negative spacing wrap the final icon early.
+    local rowWidth = math.max(iconSize, lineExtent)
     local crossExtent = usedRows * iconSize + (usedRows - 1) * layoutRowGap
     local vertical = (cfg.growDirection == "UP" or cfg.growDirection == "DOWN" or cfg.growDirection == "CENTER_VERTICAL")
     local width = vertical and crossExtent or lineExtent
@@ -1532,6 +1554,8 @@ local function BuildContainerSpec(parent, cfg, grid)
     }, vertical
 end
 
+local containerDirections = setmetatable({}, { __mode = "k" })
+
 -- Re-applies container anchor/axis/growth/padding/rowWidth for an already-created
 -- container against `parent`'s current grid. Shared by ApplyLiveConfig and the
 -- existing-container branches of ReloadCustomBuffBarImpl/ReloadCustomDebuffBarImpl so
@@ -1539,7 +1563,14 @@ end
 -- so it is live-settable like any other frame anchor.
 local function ApplyContainerAnchorAndGrowth(container, parent, cfg, grid)
     local containerAnchor, spec, vertical = BuildContainerSpec(parent, cfg, grid)
+    local direction = cfg.growDirection or "LEFT"
+    local directionChanged = containerDirections[container] and containerDirections[container] ~= direction
+    containerDirections[container] = direction
+    if directionChanged then container:Hide() end
+
+    local size = EllesmereUI.PP.Scale(cfg.iconSize or 32)
     container:ClearAllPoints()
+    container:SetSize(size, size)
     container:SetPoint(containerAnchor, parent, containerAnchor, 0, 0)
     AK.SetContainerAnchor(container, spec.layout.anchorPoint)
     AK.SetContainerAxis(container, vertical)
@@ -1548,6 +1579,12 @@ local function ApplyContainerAnchorAndGrowth(container, parent, cfg, grid)
     end
     AK.SetContainerPadding(container, 0, 0, 0, 0)
     AK.SetContainerRowWidth(container, grid.rowWidth)
+
+    if directionChanged then
+        container:SetUnit("player")
+        container:UpdateAllAuras()
+        container:Show()
+    end
 end
 
 -- Default anchor when no saved position exists yet. Independent per bar (bars must be
@@ -1756,8 +1793,8 @@ local function CreateBars()
     local buffPad = buffCfg.padding or 5
     local debuffPad = debuffCfg.padding or 5
 
-    local buffCorner, buffSpec, buffVertical = BuildContainerSpec(buffsParent, buffCfg, buffGrid)
-    local _, debuffSpec, debuffVertical = BuildContainerSpec(debuffsParent, debuffCfg, debuffGrid)
+    local buffCorner, buffSpec = BuildContainerSpec(buffsParent, buffCfg, buffGrid)
+    local _, debuffSpec = BuildContainerSpec(debuffsParent, debuffCfg, debuffGrid)
 
     -- Weapon enchant lead icons (oils/imbues are not auras; see
     -- EUI_UnitFrames_WeaponEnchants.lua): opt-in (showWeaponEnchants, default
@@ -1810,7 +1847,7 @@ local function CreateBars()
     buffsSlotSig = table.concat(buffSpells, ",")
     AK.RequestContainer(buffsParent, "player", buffSpec, function(container)
         buffsContainer = container
-        AK.SetContainerAxis(container, buffVertical)
+        ApplyContainerAnchorAndGrowth(container, buffsParent, buffCfg, buffGrid)
         ShiftBuffsForEnchants(container, buffsParent, buffCfg, buffGrid)
         if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
         declared.buffs = {}
@@ -1833,7 +1870,7 @@ local function CreateBars()
     end)
     AK.RequestContainer(debuffsParent, "player", debuffSpec, function(container)
         debuffsContainer = container
-        AK.SetContainerAxis(container, debuffVertical)
+        ApplyContainerAnchorAndGrowth(container, debuffsParent, debuffCfg, debuffGrid)
         declared.debuffs = {}
         ApplyGroupConfig(container, debuffChain, declared.debuffs, STYLE_DEBUFFS, debuffGrid.effectiveMax, debuffPad, debuffGrid.rowGap, debuffCfg)
     end)
@@ -2013,10 +2050,10 @@ local function ApplyLiveConfig(isBuff)
             -- harmless overhead. A group's candidateFilters is fixed at declaration, so a
             -- spell-list change requires this release+rebuild.
             RetireContainer(container, declared.buffs)
-            local _, spec, specVertical = BuildContainerSpec(parent, cfg, grid)
+            local _, spec = BuildContainerSpec(parent, cfg, grid)
             AK.RequestContainer(parent, "player", spec, function(newContainer)
                 buffsContainer = newContainer
-                AK.SetContainerAxis(newContainer, specVertical)
+                ApplyContainerAnchorAndGrowth(newContainer, parent, cfg, grid)
                 ShiftBuffsForEnchants(newContainer, parent, cfg, grid)
                 if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
                 declared.buffs = {}
@@ -2865,11 +2902,11 @@ local function ReloadCustomBuffBarImpl(barId)
         customBuffContainers[barId] = nil
     end
 
-    local _, spec, specVertical = BuildContainerSpec(parent, bar, grid)
+    local _, spec = BuildContainerSpec(parent, bar, grid)
     local pad = bar.padding or 5
     AK.RequestContainer(parent, "player", spec, function(container)
         customBuffContainers[barId] = container
-        AK.SetContainerAxis(container, specVertical)
+        ApplyContainerAnchorAndGrowth(container, parent, bar, grid)
         customBuffSig[barId] = sig
         customBuffDeclared[barId] = {}
         ApplyGroupConfig(container, allChain, customBuffDeclared[barId], styleKey, grid.effectiveMax, pad, grid.rowGap, bar, BuffCandidateExtras(bar))
@@ -2947,13 +2984,13 @@ local function ReloadCustomDebuffBarImpl(barId)
     parent:SetSize(grid.width, grid.height)
 
     local chain = BuildChain("HARMFUL", function(class) return ClassEnabled(class, false, bar) or (PAB_FxSafeToForce(class) and PAB_FxWantsCategory(bar.fxList, class.key)) end, bar.showAllDebuffs ~= false, DebuffSubtractFn(bar))
-    local _, spec, vertical = BuildContainerSpec(parent, bar, grid)
+    local _, spec = BuildContainerSpec(parent, bar, grid)
     local pad = bar.padding or 5
 
     if not customDebuffContainers[barId] then
         AK.RequestContainer(parent, "player", spec, function(container)
             customDebuffContainers[barId] = container
-            AK.SetContainerAxis(container, vertical)
+            ApplyContainerAnchorAndGrowth(container, parent, bar, grid)
             customDebuffDeclared[barId] = {}
             ApplyGroupConfig(container, chain, customDebuffDeclared[barId], styleKey, grid.effectiveMax, pad, grid.rowGap, bar)
         end)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -1619,12 +1619,28 @@ local function SnapBarPos(frame, point, relPoint, x, y)
     return PP.SnapForES(x, es), PP.SnapForES(y, es)
 end
 
+-- Centered growth needs a position whose meaning does not change with the mover's
+-- configured grid size. Rebase any edge-anchored saved position to CENTER/CENTER at
+-- the frame's current visual center before resizing it.
+local function RebaseBarPositionToCenter(frame, pos)
+    if pos and pos.point == "CENTER" and (pos.relPoint or pos.point) == "CENTER" then return pos end
+    local cx, cy = frame:GetCenter()
+    local ux, uy = UIParent:GetCenter()
+    if not (cx and cy and ux and uy) then return pos end
+    local x, y = cx - ux, cy - uy
+    local sx, sy = SnapBarPos(frame, "CENTER", "CENTER", x, y)
+    frame:ClearAllPoints()
+    frame:SetPoint("CENTER", UIParent, "CENTER", sx, sy)
+    return { point = "CENTER", relPoint = "CENTER", x = x, y = y }
+end
+
 -- Applies the saved position (if any) or the default to the given parent frame.
 -- Shared between initial creation and the unlock-mode applyPos callback so the two
 -- never drift into different SetPoint logic.
 local function ApplyBarPosition(parent, isBuff)
     local s = PAB()
-    local pos = s and s[BarPositionKey(isBuff)]
+    local posKey = BarPositionKey(isBuff)
+    local pos = s and s[posKey]
     local def = isBuff and DEFAULT_POS.buffs or DEFAULT_POS.debuffs
     parent:ClearAllPoints()
     if pos and pos.point then
@@ -1633,6 +1649,10 @@ local function ApplyBarPosition(parent, isBuff)
     else
         local x, y = SnapBarPos(parent, def.point, def.relPoint, def.x, def.y)
         parent:SetPoint(def.point, UIParent, def.relPoint, x, y)
+    end
+    local cfg = s and (isBuff and DefaultBuffsCfg(s) or DefaultDebuffsCfg(s))
+    if cfg and (cfg.growDirection == "CENTER_HORIZONTAL" or cfg.growDirection == "CENTER_VERTICAL") then
+        s[posKey] = RebaseBarPositionToCenter(parent, pos)
     end
 end
 
@@ -1670,7 +1690,7 @@ local function ShiftBuffsForEnchants(container, parent, cfg, grid)
     container:ClearAllPoints()
     if dir == "CENTER_HORIZONTAL" then
         local span = n * cell
-        container:SetPoint("CENTER", parent, "CENTER", 0, 0)
+        container:SetPoint("CENTER", parent, "CENTER", span / 2, 0)
         if ns._weaponEnchPAB then
             ns._weaponEnchPAB.parent = container
             ns._weaponEnchPAB.corner = nil
@@ -1683,7 +1703,8 @@ local function ShiftBuffsForEnchants(container, parent, cfg, grid)
         return
     end
     if dir == "CENTER_VERTICAL" then
-        container:SetPoint("CENTER", parent, "CENTER", 0, 0)
+        local span = n * cell
+        container:SetPoint("CENTER", parent, "CENTER", 0, -span / 2)
         if ns._weaponEnchPAB then
             ns._weaponEnchPAB.parent = container
             ns._weaponEnchPAB.corner = nil
@@ -1990,6 +2011,10 @@ local function ApplyLiveConfig(isBuff)
     -- geometry so rapid slider updates cannot read a stale prior size.
     local posKey = BarPositionKey(isBuff)
     local pos = s[posKey]
+    if cfg.growDirection == "CENTER_HORIZONTAL" or cfg.growDirection == "CENTER_VERTICAL" then
+        pos = RebaseBarPositionToCenter(parent, pos)
+        s[posKey] = pos
+    end
     if cfg.growDirection ~= "CENTER_HORIZONTAL" and cfg.growDirection ~= "CENTER_VERTICAL" and pos and pos.point == "CENTER"
         and prev and (prev.w ~= grid.width or prev.h ~= grid.height) then
         pos.x = pos.x + (prev.w - grid.width) / 2
@@ -2136,10 +2161,12 @@ function ns.PAB_SetGrowDirection(barKey, dir)
     if not s then return end
     if barKey == "PAB_Buffs" then
         DefaultBuffsCfg(s).growDirection = dir
+        RestyleBars()
         ApplyLiveConfig(true)
         return
     elseif barKey == "PAB_Debuffs" then
         DefaultDebuffsCfg(s).growDirection = dir
+        RestyleBars()
         ApplyLiveConfig(false)
         return
     end
@@ -2706,6 +2733,10 @@ local function ApplyCustomBarPosition(parent, bar, barId)
     parent:ClearAllPoints()
     local x, y = SnapBarPos(parent, pos.point, pos.relPoint or pos.point, pos.x, pos.y)
     parent:SetPoint(pos.point, UIParent, pos.relPoint or pos.point, x, y)
+    if bar.growDirection == "CENTER_HORIZONTAL" or bar.growDirection == "CENTER_VERTICAL" then
+        local centeredPos = RebaseBarPositionToCenter(parent, pos)
+        if bar.pos or centeredPos ~= pos then bar.pos = centeredPos end
+    end
 end
 
 local function CustomBuffSpellSignature(spells)
@@ -2848,16 +2879,17 @@ local function ReloadCustomBuffBarImpl(barId)
     -- under that key.
     AK.RestyleSoon(styleKey)
 
+    local grid = ComputeGrid(true, bar)
     local parent = customBuffParents[barId]
     if not parent then
         parent = CreateFrame("Frame", "EllesmereUIPlayerAuraBars_CustomBuff" .. barId, UIParent)
         customBuffParents[barId] = parent
+        parent:SetSize(grid.width, grid.height)
     end
     ApplyCustomBarPosition(parent, bar, barId)
     parent:SetShown(bar.enabled ~= false)
     if bar.enabled == false then return end
 
-    local grid = ComputeGrid(true, bar)
     parent:SetSize(grid.width, grid.height)
 
     local spells = ns.PAB_ResolveSpells(bar)
@@ -2971,16 +3003,17 @@ local function ReloadCustomDebuffBarImpl(barId)
     -- Required for the same reason as ReloadCustomBuffBarImpl above.
     AK.RestyleSoon(styleKey)
 
+    local grid = ComputeGrid(false, bar)
     local parent = customDebuffParents[barId]
     if not parent then
         parent = CreateFrame("Frame", "EllesmereUIPlayerAuraBars_CustomDebuff" .. barId, UIParent)
         customDebuffParents[barId] = parent
+        parent:SetSize(grid.width, grid.height)
     end
     ApplyCustomBarPosition(parent, bar, barId)
     parent:SetShown(bar.enabled ~= false)
     if bar.enabled == false then return end
 
-    local grid = ComputeGrid(false, bar)
     parent:SetSize(grid.width, grid.height)
 
     local chain = BuildChain("HARMFUL", function(class) return ClassEnabled(class, false, bar) or (PAB_FxSafeToForce(class) and PAB_FxWantsCategory(bar.fxList, class.key)) end, bar.showAllDebuffs ~= false, DebuffSubtractFn(bar))

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -867,6 +867,9 @@ function AK.CreateContainerShell(parent, spec)
     -- Combat creation is legal since 68914 (PTR-7 notes; /euit3 field PASS
     -- 2026-07-23). The old in-combat zombie soft-fail -- and the OOC assert
     -- that guarded against it -- are gone.
+    if not C_AddOns.IsAddOnLoaded("Blizzard_AuraContainer") then
+        C_AddOns.LoadAddOn("Blizzard_AuraContainer")
+    end
     local container = CreateFrame("AuraContainer", nil, parent, "CustomAuraContainerTemplate")
 
     -- Anchor and a provisional size up front: the engine drains its parse and
@@ -1125,9 +1128,8 @@ end
 ------------------------------------------------------------------------------
 -- Restriction probe
 --
--- There is no official "are auras secret" query. This is a best-effort helper
--- for the surviving spellID-lookup paths that want to know whether silent
--- absence semantics are in effect. Never treat it as a data source.
+-- Prefer Blizzard's official secrecy query; retain the aura-data probe as a fallback
+-- for builds where that API is unavailable. Never treat either as a data source.
 --
 -- Cached per frame time: while restricted, the probe THROWS (and catches) a
 -- real Lua error, and error construction is the expensive part -- callers
@@ -1145,6 +1147,10 @@ end
 local restrictedStamp = -1
 function AK.AurasRestricted()
     local now = GetTime()
+    if C_Secrets and C_Secrets.ShouldAurasBeSecret and C_Secrets.ShouldAurasBeSecret() then
+        restrictedStamp = now
+        return true
+    end
     if now == restrictedStamp then return true end
     if pcall(C_UnitAuras.GetAuraDataByIndex, "player", 1, "HELPFUL") then
         return false


### PR DESCRIPTION
## Summary
- add centered horizontal and vertical growth modes for Player Aura Bars
- configure AuraContainer element dimensions and centered reflow, including negative spacing
- keep previews, weapon enchants, and borders centered and pixel-aligned across live direction changes
- load Blizzard_AuraContainer through AuraKit and defer restricted-aura reconfiguration with C_Secrets

## Implementation notes
- centered layout logic remains in Player Aura Bars; AuraKit only provides required container setup and secret-aura handling

<img width="355" height="251" alt="image" src="https://github.com/user-attachments/assets/d9d4e783-e110-4690-81fe-8a857bb74b63" />
