### PR TITLE
Fix(PAB): right click cancel aura not working

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -1443,6 +1443,7 @@ local declared = { buffs = {}, debuffs = {} } -- buffs: only the "Show All Buffs
 local lastSize = { buffs = nil, debuffs = nil } -- {w=,h=} last-applied grid size, for CENTER-anchor compensation (see ApplyLiveConfig)
 local buffsSlotSig -- signature of the default Buffs bar's last-applied resolved spell list (ns.PAB_ResolveSpells), mirrors customBuffSig[barId] for the per-bar slots model
 local RegisterPABUnlock -- forward-declared; defined after CreateBars, called from it
+local SyncCancelCVar -- forward-declared; defined after RestyleBars, called from CreateBars/RestyleBars/ReloadCustomBuffBarImpl
 -- Last label the Buffs mover was registered under, so ApplyLiveConfig can
 -- re-register on a name change without doing it on every slider drag.
 local lastUnlockBuffLabel
@@ -1811,6 +1812,7 @@ local function CreateBars()
     end)
     RegisterPABUnlock()
     ReloadAllCustomBars()
+    SyncCancelCVar()
 end
 
 -- Unlock-mode registration, patterned on EllesmereUIDamageMeters.lua's
@@ -1897,8 +1899,60 @@ local function RestyleBars()
     AK.styles[STYLE_DEBUFFS] = BuildStyle(false, DefaultDebuffsCfg(s))
     AK.RestyleSoon(STYLE_BUFFS)
     AK.RestyleSoon(STYLE_DEBUFFS)
+    SyncCancelCVar()
 end
 ns.PAB_Restyle = RestyleBars
+
+-- CursorFreelookStartDelta is the fraction of the screen the cursor must move before a
+-- held mouse button counts as camera freelook instead of a click; Blizzard's own
+-- shipped default is 0.001 (verified against the client's cvar list, not assumed). At
+-- 0 -- the most aggressive setting, zero movement required -- ANY right-click on an
+-- aura icon is claimed for freelook before the release reaches our button, silently
+-- eating the "Right-Click to Cancel" click (field-reported 2026-08-12, twice
+-- independently). Players land on 0 via third-party "camera feel" addons/macros (a
+-- dedicated community addon, CursorDeltaFix, does exactly this:
+-- SetCVar("CursorFreelookStartDelta", 0)) or a manual /console tweak, not from
+-- anything EllesmereUI does.
+--
+-- Repair only, never a nudge above Blizzard's default: we only ever touch this CVar
+-- when it is caught sitting at the pathological 0, restoring it to Blizzard's own
+-- 0.001 -- never raised past that, and never touched at all if it's anywhere else
+-- (including a deliberately-tuned non-zero, non-default value). Conditional on some
+-- right-click-cancelable buff surface actually being live, so a player who never uses
+-- the feature never has this CVar touched by EllesmereUI at all.
+local CANCEL_CVAR = "CursorFreelookStartDelta"
+local CANCEL_CVAR_BROKEN = 0
+local CANCEL_CVAR_DEFAULT = "0.001"
+
+--- True while some right-click-cancelable player buff display is live: the default
+--- Buffs bar (rightClickCancel defaults ON), any enabled custom buff bar with its own
+--- toggle ON, or the classic Unit Frames player-buffs display (EUI_UnitFrames_
+--- AuraContainers.lua's cancelButtons is unconditional whenever unit=="player" and
+--- isBuff, gated only on the element being shown at all).
+local function AnyRightClickCancelActive(s)
+    if DefaultBuffsCfg(s).rightClickCancel ~= false then return true end
+    local customBuffBars = s.customBuffBars
+    if customBuffBars then
+        for i = 1, #customBuffBars do
+            local bar = customBuffBars[i]
+            if bar.enabled ~= false and bar.rightClickCancel ~= false then return true end
+        end
+    end
+    local db = ns.db
+    local playerCfg = db and db.profile and db.profile.player
+    if playerCfg and playerCfg.showBuffs ~= false then return true end
+    return false
+end
+
+function SyncCancelCVar()
+    local s = PAB()
+    if not s or s.enabled ~= true then return end
+    if not AnyRightClickCancelActive(s) then return end
+    if InCombatLockdown() then return end
+    if tonumber(GetCVar(CANCEL_CVAR)) == CANCEL_CVAR_BROKEN then
+        SetCVar(CANCEL_CVAR, CANCEL_CVAR_DEFAULT)
+    end
+end
 
 -- Public hook for the Options UI: live counterpart to RestyleBars for everything
 -- spec-level (class toggles, grid: iconsPerRow/maxRows/padding/maxBuffs-or-Debuffs,
@@ -2784,6 +2838,7 @@ local function ReloadCustomBuffBarImpl(barId)
     -- RestyleSoon re-runs ApplyStyleToRegions against every already-live button
     -- under that key.
     AK.RestyleSoon(styleKey)
+    SyncCancelCVar()
 
     local parent = customBuffParents[barId]
     if not parent then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -738,6 +738,21 @@ local function BuildStyle(isBuff, cfg)
         -- passes straight to the world. Hover is deliberately untouched:
         -- click and motion are separate mouse channels, so tooltips keep
         -- following Show Tooltips below either way.
+        -- UP phase, matching Blizzard's own AuraButtonMixin ("LeftButtonUp",
+        -- "RightButtonUp"). Known limitation, field-reported 2026-08-12: for some
+        -- players the right-button PRESS falls through to WorldFrame, which starts
+        -- camera mouselook and captures the mouse, so the matching ButtonUp ends the
+        -- mouselook instead of reaching the button and the buff survives. Blizzard's
+        -- legacy icons consume that press; the engine's intrinsic AuraButton denies
+        -- tainted (addon) code the input aspects that would do the same
+        -- (Blizzard_AuraButton.xml: ForbiddenAspect AlwaysPropagateInput /
+        -- ScriptedInput), and no API re-grants a denied aspect. "RightButtonDown"
+        -- works around it but was rejected deliberately: a right-click-drag starting
+        -- on an icon would then cancel that buff on press. Do not "fix" this by
+        -- registering BOTH phases either -- Blizzard's CanCancelAuraOnClick matches
+        -- any registered token, so OnClick fires twice and the engine may have
+        -- re-assigned this button's aura instance in between, cancelling a DIFFERENT
+        -- aura on the up edge.
         cancelButtons = (isBuff and cfg.rightClickCancel ~= false) and "RightButtonUp" or nil,
 
         hideDurationText = cfg.durationShow == false,

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -453,9 +453,41 @@ local function ApplyStyleToRegions(button, style)
     -- noTooltips). Running here also covers every Restyle, so a settings change cannot
     -- re-open either one. Same deferral as the neighbours above when the button is
     -- locked down while auras are secret.
-    if not style.cancelButtons and button.SetMouseClickEnabled then
-        if not pcall(button.SetMouseClickEnabled, button, false)
-            and d.styleKey and AK.AurasRestricted() then
+    -- The click channel is symmetric, unlike the click-off-only pass this used to be.
+    -- A style that GAINS cancelButtons later only reaches its already-created buttons
+    -- through Restyle (PAB's per-bar "Right-Click to Cancel" toggled off and back on, a
+    -- profile switch into a profile that has it on), and nothing undid the earlier
+    -- SetMouseClickEnabled(false) -- the bar stayed click-through until the next
+    -- /reload, with the right-click landing on the container below the icon. Field
+    -- report 2026-08-12: player buffs that cannot be right-click cancelled, /fstack
+    -- showing no button above the AuraContainer. SetCancelAuraButtons is re-asserted in
+    -- the same breath: it ran at button creation only, so the re-enabled toggle also
+    -- needed its click token registered again (Blizzard's own
+    -- AuraButtonSharedMixin:SetCancelAuraButtons -> RegisterForClicks). Change-guarded
+    -- by stamps, both deferred to the restriction lift like the neighbours above.
+    if style.cancelButtons then
+        if d.akClickOff and button.SetMouseClickEnabled then
+            if pcall(button.SetMouseClickEnabled, button, true) then
+                d.akClickOff = nil
+            elseif d.styleKey and AK.AurasRestricted() then
+                deferredRestyles[d.styleKey] = true
+            end
+        end
+        if d.akCancel ~= style.cancelButtons and button.SetCancelAuraButtons then
+            if pcall(button.SetCancelAuraButtons, button, style.cancelButtons) then
+                d.akCancel = style.cancelButtons
+            elseif d.styleKey and AK.AurasRestricted() then
+                deferredRestyles[d.styleKey] = true
+            end
+        end
+    elseif button.SetMouseClickEnabled then
+        -- Re-asserted every pass (not stamp-guarded): configuring tooltip behaviour on
+        -- an engine button turns its mouse back on, which silently re-opened the
+        -- nameplate click-eater. The stamp only records that WE own the off state, for
+        -- the re-arm above.
+        if pcall(button.SetMouseClickEnabled, button, false) then
+            d.akClickOff = true
+        elseif d.styleKey and AK.AurasRestricted() then
             deferredRestyles[d.styleKey] = true
         end
     end
@@ -641,8 +673,12 @@ function AK.MakeInitializer(styleKey, extra)
         -- restyles; duration opts otherwise land only here at creation).
         d.durationFmtS = style.durationShowSeconds and true or false
 
-        if style.cancelButtons then
+        -- Creation-time guarantee, stamp-guarded: ApplyStyleToRegions above already
+        -- wires the click token on this pass, so this only fires if that call was
+        -- denied (secret-value lockdown), leaving the deferred restyle to repair it.
+        if style.cancelButtons and d.akCancel ~= style.cancelButtons then
             button:SetCancelAuraButtons(style.cancelButtons)
+            d.akCancel = style.cancelButtons
         end
 
         GetStyleSet(styleKey)[button] = true


### PR DESCRIPTION
## What does this PR do?

Fixes player buffs on the Player Aura Bars (and classic Unit Frames player buffs) sometimes staying un-cancelable via right-click, in two independent parts.

**Click channel repair (AuraKit).** AuraKit's `ApplyStyleToRegions` only ever turned the click channel OFF (for styles without `cancelButtons`, the nameplate click-eater guard), and `SetCancelAuraButtons` ran once at button creation only. A style that GAINED `cancelButtons` on already-created buttons therefore never got them back: toggling a Player Aura Bar's per-bar "Right-Click to Cancel" off and on again, or switching into a profile that has it on, left that bar's buffs permanently un-cancelable until the next `/reload`. The click channel is symmetric now -- clicks are re-enabled for buttons AuraKit itself turned off (`d.akClickOff` stamp) and the cancel token is re-applied change-guarded (`d.akCancel` stamp), both `pcall`-wrapped with the same `deferredRestyles` fallback the tooltip/motion passes next to them already use. Covers both consumers of the cancel style, Player Aura Bars and the Unit Frames player buffs.

**CursorFreelookStartDelta repair (Player Aura Bars).** A second, independent trigger for the same symptom, confirmed by two separate field reports: the client CVar `CursorFreelookStartDelta` controls how far the cursor must move before a held mouse button counts as camera freelook instead of a click. At `0` (zero movement required), any right-click on an aura icon is claimed for freelook before the release reaches the button -- the click is real, the button just never sees it. Blizzard's own shipped default is `0.001`, not `0`; players land on `0` via third-party "camera feel" addons/macros (a dedicated community addon, CursorDeltaFix, does exactly this: `SetCVar("CursorFreelookStartDelta", 0)`) or a manual console tweak, never from anything EllesmereUI does.

`SyncCancelCVar()` repairs this, it does not nudge it: the CVar is only ever touched when caught sitting at the pathological `0`, restored to Blizzard's own `0.001` -- never raised past that, and never touched at all if it sits anywhere else, including a deliberately-tuned non-zero value. It only runs while some right-click-cancelable buff surface is actually live (the default Buffs bar, an enabled custom buff bar, or the classic Unit Frames player-buffs display), so a player who never uses the feature never has this CVar touched at all. Hooked into the three points that already own PAB's live style state: `CreateBars` (login), `RestyleBars` (default-bar settings changes), and `ReloadCustomBuffBarImpl` (custom-bar creation/changes).

A deliberately rejected alternative for the same symptom: switching the cancel click token from `"RightButtonUp"` to `"RightButtonDown"` also works around a related but separate WorldFrame-mouselook interaction, but was NOT taken -- a right-click-drag starting on an aura icon would then cancel that buff on press. The token stays `"RightButtonUp"`, matching Blizzard's own `AuraButtonMixin`.

## How was it tested?

Static analysis and `luac5.1 -p` on both changed files. Blizzard behaviour was verified against the shipped source rather than from memory: `AuraButtonSharedMixin:SetCancelAuraButtons` (string token, `RegisterForClicks`), `AuraButtonPrivateMixin:OnClick_Intrinsic` / `CanCancelAuraOnClick` (plain OnClick, matches any registered token), the `ForbiddenAspects` block on the intrinsic `AuraButton`, and `CursorFreelookStartDelta`'s Blizzard-shipped default (`0.001`, cross-checked against the client's canonical cvar list).

## Screenshots

N/A -- no visual change.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; the AuraKit fix makes an existing toggle work live instead of after `/reload`, and the CVar repair only ever touches players already sitting at the broken `0` value while using a feature that needs the click
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- `SyncCancelCVar` short-circuits immediately if PAB is disabled or no cancel-capable surface is live; the click-channel stamps add zero extra button calls on a steady-state restyle pass
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- both fixes only run on existing settings-apply/login hooks, never per-frame
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- the click-channel state lives in AuraKit's existing weak-keyed side table (`bd`); the CVar repair calls only the public `GetCVar`/`SetCVar` API, no frame writes
- [x] Tested in-game, works on live retail