### PR TITLE
Fixes the resource bar to randomly pop up even if deactivated

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -8578,6 +8578,12 @@ local function OnEvent(self, event, ...)
                 if newMax > 0 and newMax ~= cachedSecondary.max then
                     cachedSecondary.max = newMax
                     BuildBars()
+                    -- BuildBars re-shows the frames; re-apply conditional hides
+                    -- (same as the UNIT_MAXPOWER rebuild below). Without this a
+                    -- max-health change -- gearing up, an item upgrade, a stamina
+                    -- buff -- leaves bars that a visibility condition had hidden
+                    -- parked visible until the next visibility event.
+                    UpdateVisibility()
                 end
             end
             UpdateSecondaryResource()


### PR DESCRIPTION
## What does this PR do?

Ive got the resource bars deactived.
During certain actions (e.g. during item upgrades) this bar pops backup up empty.

## How was it tested?

Tested on 12.1 retail.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
