### PR TITLE
fix(raid frames): let an aura show duration text with no cooldown swipe

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -4166,8 +4166,13 @@ function ns.BM_BuildPage(pageName, parent, yOffset)
             end
 
             local durRow = SettingsRow(
+                -- NOT gated on Hide Icons, unlike Opacity and Border above. Those
+                -- describe the icon art and are meaningless without it; the swipe is a
+                -- separate layer that keeps drawing over a hidden icon, so hiding the
+                -- icon is exactly when a user needs to reach this. Locking it there left
+                -- the text-only setup -- hidden icon, duration text, no swipe -- with no
+                -- way to turn the swipe off at all.
                 { type="toggle", text="Duration Swipe",
-                  disabled=IconHidden, disabledTooltip="Hide Icons",
                   getValue=function() return ind.showDuration ~= false end,
                   setValue=function(v) ind.showDuration = v; ReloadAndUpdate() end },
                 { type="toggle", text="Duration Text",

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -209,7 +209,23 @@ local function ApplyStyleToRegions(button, style)
         d.cooldown:SetReverse(style.cooldownReverse ~= false)
         d.cooldown:SetDrawEdge(style.cooldownDrawEdge == true)
         d.cooldown:SetHideCountdownNumbers(true) -- duration text comes from the binding, not the swipe
-        d.cooldown:SetShown(style.hideSwipe ~= true)
+        -- Hidden-swipe gate. SetShown alone does not stick: the engine calls
+        -- Cooldown:SetCooldown on this frame whenever the slot's aura data
+        -- refreshes, and that native API implicitly re-Shows the frame.
+        -- Withholding the frame from SetDurationCooldown does not work either --
+        -- that registration is the button's DURATION SOURCE, so a button without
+        -- one loses its duration TEXT along with the swipe.
+        -- SetDrawSwipe is the knob that means what we want: keep the cooldown
+        -- registered and running, draw no swipe from it. It is a CooldownStyle
+        -- aspect rather than visibility, so an aura refresh has no reason to
+        -- clear it, and it is annotated AllowedWhenTainted so our own call is
+        -- legal in the contexts where this matters.
+        local hideSwipe = style.hideSwipe == true
+        d.cooldown:SetShown(not hideSwipe)
+        if d.akHideSwipe ~= hideSwipe then
+            d.akHideSwipe = hideSwipe
+            if d.cooldown.SetDrawSwipe then d.cooldown:SetDrawSwipe(not hideSwipe) end
+        end
     end
 
     -- Modules with their own text pipeline (fonts, anchors, outline rules) set
@@ -662,15 +678,7 @@ function AK.MakeInitializer(styleKey, extra)
         ApplyStyleToRegions(button, style)
 
         button:SetIcon(d.icon)
-        -- Registering the cooldown hands OWNERSHIP to the engine, which then draws and
-        -- re-shows the swipe on its own schedule. ApplyStyleToRegions' SetShown(false)
-        -- above runs before this line and does not survive it, so a hidden swipe has to
-        -- be hidden by never handing the widget over -- inside the creation window,
-        -- because touching an engine-owned region afterwards is forbidden-object access
-        -- (the same lesson EllesmereUICdmFakeActive.lua records at its own binding).
-        -- Duration TEXT is unaffected: it comes from SetDurationTextSafe below, not from
-        -- the swipe, which is what makes the text-only setup possible at all.
-        button:SetDurationCooldown(style.hideSwipe ~= true and d.cooldown or nil)
+        button:SetDurationCooldown(d.cooldown)
         button:SetApplicationCount(d.stack, {})
 
         local durationOpts = AK.BuildDurationTextOpts(

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -662,7 +662,15 @@ function AK.MakeInitializer(styleKey, extra)
         ApplyStyleToRegions(button, style)
 
         button:SetIcon(d.icon)
-        button:SetDurationCooldown(d.cooldown)
+        -- Registering the cooldown hands OWNERSHIP to the engine, which then draws and
+        -- re-shows the swipe on its own schedule. ApplyStyleToRegions' SetShown(false)
+        -- above runs before this line and does not survive it, so a hidden swipe has to
+        -- be hidden by never handing the widget over -- inside the creation window,
+        -- because touching an engine-owned region afterwards is forbidden-object access
+        -- (the same lesson EllesmereUICdmFakeActive.lua records at its own binding).
+        -- Duration TEXT is unaffected: it comes from SetDurationTextSafe below, not from
+        -- the swipe, which is what makes the text-only setup possible at all.
+        button:SetDurationCooldown(style.hideSwipe ~= true and d.cooldown or nil)
         button:SetApplicationCount(d.stack, {})
 
         local durationOpts = AK.BuildDurationTextOpts(


### PR DESCRIPTION
### Cause
Two things blocked the text-only aura setup on Party/Raid frames.

`Cooldown:SetShown(false)` does not stick on an aura button: the engine calls `SetCooldown` on that frame whenever the slot's data refreshes, and the native call implicitly re-Shows it. So `hideSwipe` was written and then overruled, from both Hide Icons and Duration Swipe.

On top of that, Duration Swipe was greyed out whenever Hide Icons was on, so the one control that could have helped was unreachable in exactly the configuration that needed it.

### Fix
Use `SetDrawSwipe`, a CooldownStyle aspect the engine has no reason to clear on refresh (and `AllowedWhenTainted`, so the call is legal in restricted content). The cooldown stays registered via `SetDurationCooldown` because that registration is the button's duration SOURCE -- withholding it removes the duration text along with the swipe. Ungate the toggle; Opacity and Border keep their gating, since those describe icon art.

### Test
Verified in game on party frames: hidden icon with duration text, stacks and no swipe, and the swipe returns when re-enabled.

<img width="480" height="480" alt="Greatest Of All Time Goat GIF by Nutrena Feed" src="https://github.com/user-attachments/assets/824bdf7b-1ecc-456e-b95c-b23c3fb4891b" />
