### PR TITLE
feat(cdm): accept 'all' in Ticks at Stacks

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -2021,11 +2021,22 @@ local function GetTBBMaxCharges(cfg)
 end
 ns.GetTBBMaxCharges = GetTBBMaxCharges
 
-local function ParseTickValues(str)
+-- "all" (any case, anywhere in the list) puts a tick between every stack: N
+-- stacks give N-1 interior divisions, the same convention as the charge hash
+-- lines below. Numbers listed alongside it are redundant and ignored.
+local function ParseTickValues(str, maxStacks)
     if not str or str == "" then return nil end
     local vals = {}
     for s in str:gmatch("[^,]+") do
-        local n = tonumber(s:match("^%s*(.-)%s*$"))
+        local tok = s:match("^%s*(.-)%s*$")
+        if tok:lower() == "all" then
+            local m = maxStacks and math.floor(maxStacks) or 0
+            if m < 2 then return nil end
+            local out = {}
+            for i = 1, m - 1 do out[i] = i end
+            return out
+        end
+        local n = tonumber(tok)
         if n and n > 0 then vals[#vals + 1] = n end
     end
     return #vals > 0 and vals or nil
@@ -2033,7 +2044,7 @@ end
 
 local function ApplyTBBTickMarks(sb, cfg, tickCache, isVert, tickParent)
     local maxStacks = cfg.stackThresholdMax or 10
-    local vals = ParseTickValues(cfg.stackThresholdTicks)
+    local vals = ParseTickValues(cfg.stackThresholdTicks, maxStacks)
     if tickCache then
         for i = 1, #tickCache do tickCache[i]:Hide() end
     end

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -5804,7 +5804,8 @@ initFrame:SetScript("OnEvent", function(self)
                   local bd = SelectedTBB(); if not bd then return end
                   bd.stackThresholdMaxEnabled = v; RefreshTBB(); EllesmereUI:RefreshPage()
               end },
-            { type = "label", text = "Ticks at Stacks" }
+            { type = "label", text = "Ticks at Stacks",
+              tooltip = "Comma separated stack counts to put a tick mark at. Type all to mark every stack." }
         );  y = y - h
         -- Inline slider on Enable Max Stacks toggle (same as inline swatch positioning)
         do


### PR DESCRIPTION
## What does this PR do?

Cooldown Manager -> Tracking Bars -> "Ticks at Stacks" now accepts the keyword
`all` in addition to a comma-separated list. Typing `all` puts a tick at every
stack, so a bar with Max Stacks 10 no longer needs `1,2,3,4,5,6,7,8,9` typed out
by hand and retyped every time the Max Stacks slider moves.

## How was it tested?

<!-- TODO: fill in your client build and what you did in game -->

Retail live, 12.1. Enabled Max Stacks on a stack-tracking bar, entered `all`,
confirmed evenly spaced ticks in both the options preview and on the live bar,
and confirmed the tick count follows the Max Stacks slider without retyping.

## Screenshots

<img width="326" height="68" alt="image" src="https://github.com/user-attachments/assets/b24e34a9-b857-4b3b-a4b3-ca331a99474d" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - no new
      setting; the existing field defaults to `""` and only behaves differently
      once a user types the keyword
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing
      work, no frames built - the expansion runs only when the token is present
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no
      per-frame allocations) - `ApplyTBBTickMarks` runs from the skin/apply pass
      and the `_ticksDirty` one-shot consumers, never OnUpdate; the loop is
      bounded by the Max Stacks slider cap of 100, and tick textures come from
      the existing per-bar cache
- [x] No writes onto Blizzard-owned frames (weak-table pattern used);
      `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -
      N/A, pure Lua string/number handling on addon-owned frames; no game API touched
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client