### PR TITLE
Fix Player Aura Bars filtered bars rendering every buff when the engine identity gate is degraded

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -2150,6 +2150,7 @@ local function ApplyLiveConfig(isBuff)
             local _, spec = BuildContainerSpec(parent, cfg, grid)
             AK.RequestContainer(parent, "player", spec, function(newContainer)
                 buffsContainer = newContainer
+                WatchContainerVisibility(newContainer)
                 ApplyContainerAnchorAndGrowth(newContainer, parent, cfg, grid)
                 ShiftBuffsForEnchants(newContainer, parent, cfg, grid)
                 if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
@@ -4342,7 +4343,10 @@ function ns.PAB_SetEnabled(v)
     local s = PAB()
     if not s then return end
     s.enabled = v and true or nil
-    if v then CreateBars() end
+    if v then
+        CreateBars()
+        ns.PAB_ArmResyncEvents()
+    end
 end
 
 -- Engine re-parse recovery. An engine aura container re-parses its groups on a
@@ -4365,13 +4369,22 @@ local function ResyncContainers()
         resyncPending = false
         ApplyLiveConfig(true)
         ApplyLiveConfig(false)
+        -- Live containers only. A bar whose container request is still queued
+        -- (AK.RequestContainer self-defers in combat) has nothing to re-parse,
+        -- and reloading it would queue a SECOND request against the same parent
+        -- -- both build on PLAYER_REGEN_ENABLED and the loser stays shown with
+        -- its groups declared. It comes up with fresh config anyway.
         local cb = ns.PAB_CustomBuffBars()
         if cb then
-            for _, bar in ipairs(cb) do ns.PAB_ReloadCustomBuffBar(bar.id) end
+            for _, bar in ipairs(cb) do
+                if customBuffContainers[bar.id] then ns.PAB_ReloadCustomBuffBar(bar.id) end
+            end
         end
         local db2 = ns.PAB_CustomDebuffBars()
         if db2 then
-            for _, bar in ipairs(db2) do ns.PAB_ReloadCustomDebuffBar(bar.id) end
+            for _, bar in ipairs(db2) do
+                if customDebuffContainers[bar.id] then ns.PAB_ReloadCustomDebuffBar(bar.id) end
+            end
         end
     end)
 end
@@ -4397,22 +4410,25 @@ initFrame:SetScript("OnEvent", function(self, event)
     if event == "PLAYER_LOGIN" then
         self:UnregisterEvent("PLAYER_LOGIN")
         TryCreateBars()
-        -- Registered only for sessions where the feature runs at all; the
-        -- handler's container guard covers the module-disabled stand-down.
-        -- Vehicles are their own edge: the engine re-parses on the unit's
-        -- aura source swapping without anything of ours hiding, so the
-        -- visibility hook alone does not cover them. PLAYER_ENTERING_WORLD
-        -- covers the loading-screen edges (the login one lands before the
-        -- containers exist and is dropped by the guard; the bars' own
-        -- creation resync is what covers login).
-        if ns.PAB_Enabled() then
-            self:RegisterEvent("CINEMATIC_STOP")
-            self:RegisterEvent("PLAYER_ENTERING_WORLD")
-            self:RegisterUnitEvent("UNIT_ENTERED_VEHICLE", "player")
-            self:RegisterUnitEvent("UNIT_EXITED_VEHICLE", "player")
-        end
+        ns.PAB_ArmResyncEvents()
         return
     end
     ResyncContainers()
 end)
+
+-- Re-parse edges the visibility hook cannot see. Vehicles are their own: the
+-- engine re-parses on the unit's aura source swapping without anything of ours
+-- hiding. PLAYER_ENTERING_WORLD covers the loading-screen edges (the login one
+-- lands before the containers exist and is dropped by the guard -- the bars' own
+-- creation resync is what covers login). Armed only for sessions where the
+-- feature runs at all, and again from PAB_SetEnabled so a live enable is not
+-- left waiting for a reload; idempotent, RegisterEvent on an already-registered
+-- event is a no-op.
+function ns.PAB_ArmResyncEvents()
+    if not ns.PAB_Enabled() then return end
+    initFrame:RegisterEvent("CINEMATIC_STOP")
+    initFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+    initFrame:RegisterUnitEvent("UNIT_ENTERED_VEHICLE", "player")
+    initFrame:RegisterUnitEvent("UNIT_EXITED_VEHICLE", "player")
+end
 

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -4349,17 +4349,24 @@ function ns.PAB_SetEnabled(v)
     end
 end
 
--- Engine re-parse recovery. An engine aura container re-parses its groups on a
--- hide/re-show, and a re-parse that lands while the teardown's filter state is
--- still degraded renders the FULL buff set on a FILTERED bar -- with no aura
--- event following, the wrong content sticks until a reload. First seen on an
--- addon-cancelled cinematic (CINEMATIC_STOP), then reported for the login world
--- fade, entering a vehicle, and an unlock-mode round trip: every one of those is
--- the same edge, since the parent chain up to UIParent belongs to whoever hides
--- it, not to us. The one lever Lua holds over engine-owned content is config:
--- re-run the group config for every live container (candidate filters are the
--- live-changeable channel, so re-setting them forces a fresh parse), one tick
--- after the edge so the teardown has finished. Coalesced; all rare edges.
+-- Identity-gate recovery: why a FILTERED bar can render every buff.
+--
+-- Blizzard_AuraContainer/Blizzard_AuraContainerUtil.lua (12.1) gates the
+-- spell-ID candidate filters behind CanApplyIdentityCandidateFilters, and
+-- DoesAuraPassCandidateFilters SKIPS includeSpellIDs/excludeSpellIDs entirely
+-- when that gate says no -- the aura then passes on the filter string alone.
+-- For a helpful group the gate is `isHelpful and not UnitCanAssist("player",
+-- unit)`, so any moment the player is not assistable to itself (unit flags not
+-- streamed yet at login, control handed to a vehicle) parses the whole helpful
+-- set into a bar that asked for four spells. Membership is cached per aura
+-- instance, so with no aura event following the wrong content sticks until a
+-- reload. Same engine gate the Raid Frames containers guard against with
+-- ApplyAssistGate, one unit over.
+--
+-- The lever is config: SetAuraGroupCandidateFilters runs UpdateAllAuras, which
+-- marks FullAuraRebuild and re-evaluates every aura's membership, so re-running
+-- the group config for every live container re-parses with the gate settled.
+-- One tick after the edge, coalesced; all rare edges.
 local resyncPending = false
 local function ResyncContainers()
     if resyncPending then return end
@@ -4389,9 +4396,12 @@ local function ResyncContainers()
     end)
 end
 
--- Every container gets its own visibility watch, so a hide/re-show recovers no
--- matter who caused it (a fullscreen panel taking UIParent down, the login world
--- fade, unlock mode). Hooked, never SetScript: these are engine frames and the
+-- Every container gets its own visibility watch, whoever hides it (a fullscreen
+-- panel taking UIParent down, the login world fade, unlock mode). The container
+-- already re-parses itself on show (AuraContainerPrivateMixin:OnShow_Intrinsic
+-- calls UpdateAllAuras) -- that is the point: that parse runs INSIDE the show,
+-- while the identity gate above can still be reading the old state, so ours has
+-- to land a tick later. Hooked, never SetScript: these are engine frames and the
 -- engine owns their handlers. Weak-keyed registry rather than a field on the
 -- frame -- an AuraContainer is aspect-restricted while tainted, so nothing of
 -- ours is stored on it (the grow-direction registry above does the same). The
@@ -4416,18 +4426,22 @@ initFrame:SetScript("OnEvent", function(self, event)
     ResyncContainers()
 end)
 
--- Re-parse edges the visibility hook cannot see. Vehicles are their own: the
--- engine re-parses on the unit's aura source swapping without anything of ours
--- hiding. PLAYER_ENTERING_WORLD covers the loading-screen edges (the login one
--- lands before the containers exist and is dropped by the guard -- the bars' own
--- creation resync is what covers login). Armed only for sessions where the
--- feature runs at all, and again from PAB_SetEnabled so a live enable is not
--- left waiting for a reload; idempotent, RegisterEvent on an already-registered
--- event is a no-op.
+-- Identity-gate edges no visibility change announces. Control transfer is the
+-- direct one -- UnitCanAssist("player", "player") is what the gate reads, and
+-- PLAYER_CONTROL_LOST/GAINED bracket every handover (vehicles, taxis, mind
+-- control); the vehicle pair stays for seat changes that swap the aura source
+-- without a control edge. PLAYER_ENTERING_WORLD covers loading screens (the
+-- login one lands before the containers exist and is dropped by the guard --
+-- the bars' own creation resync is what covers login). Armed only for sessions
+-- where the feature runs at all, and again from PAB_SetEnabled so a live enable
+-- is not left waiting for a reload; idempotent, RegisterEvent on an
+-- already-registered event is a no-op.
 function ns.PAB_ArmResyncEvents()
     if not ns.PAB_Enabled() then return end
     initFrame:RegisterEvent("CINEMATIC_STOP")
     initFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+    initFrame:RegisterEvent("PLAYER_CONTROL_LOST")
+    initFrame:RegisterEvent("PLAYER_CONTROL_GAINED")
     initFrame:RegisterUnitEvent("UNIT_ENTERED_VEHICLE", "player")
     initFrame:RegisterUnitEvent("UNIT_EXITED_VEHICLE", "player")
 end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -1474,6 +1474,7 @@ local SyncCancelCVar -- forward-declared; defined after RestyleBars, called from
 -- re-register on a name change without doing it on every slider drag.
 local lastUnlockBuffLabel
 local ReloadAllCustomBars -- forward-declared; defined after CreateBars (custom bars section), called from it
+local WatchContainerVisibility -- forward-declared; defined in the Lifecycle section (engine re-parse recovery), called from every container-creation callback
 local PAB_MaybeRefreshPreview -- forward-declared; assigned in the options-page preview section, called from every live-apply function so an open bar-detail preview box tracks slider drags without those functions knowing it exists
 
 local restrictedApplies = {}
@@ -1884,6 +1885,7 @@ local function CreateBars()
     buffsSlotSig = table.concat(buffSpells, ",")
     AK.RequestContainer(buffsParent, "player", buffSpec, function(container)
         buffsContainer = container
+        WatchContainerVisibility(container)
         ApplyContainerAnchorAndGrowth(container, buffsParent, buffCfg, buffGrid)
         ShiftBuffsForEnchants(container, buffsParent, buffCfg, buffGrid)
         if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
@@ -1907,6 +1909,7 @@ local function CreateBars()
     end)
     AK.RequestContainer(debuffsParent, "player", debuffSpec, function(container)
         debuffsContainer = container
+        WatchContainerVisibility(container)
         ApplyContainerAnchorAndGrowth(container, debuffsParent, debuffCfg, debuffGrid)
         declared.debuffs = {}
         ApplyGroupConfig(container, debuffChain, declared.debuffs, STYLE_DEBUFFS, debuffGrid.effectiveMax, debuffPad, debuffGrid.rowGap, debuffCfg)
@@ -3008,6 +3011,7 @@ local function ReloadCustomBuffBarImpl(barId)
     local pad = bar.padding or 5
     AK.RequestContainer(parent, "player", spec, function(container)
         customBuffContainers[barId] = container
+        WatchContainerVisibility(container)
         ApplyContainerAnchorAndGrowth(container, parent, bar, grid)
         customBuffSig[barId] = sig
         customBuffDeclared[barId] = {}
@@ -3093,6 +3097,7 @@ local function ReloadCustomDebuffBarImpl(barId)
     if not customDebuffContainers[barId] then
         AK.RequestContainer(parent, "player", spec, function(container)
             customDebuffContainers[barId] = container
+            WatchContainerVisibility(container)
             ApplyContainerAnchorAndGrowth(container, parent, bar, grid)
             customDebuffDeclared[barId] = {}
             ApplyGroupConfig(container, chain, customDebuffDeclared[barId], styleKey, grid.effectiveMax, pad, grid.rowGap, bar)
@@ -4340,21 +4345,24 @@ function ns.PAB_SetEnabled(v)
     if v then CreateBars() end
 end
 
--- Cinematic recovery. An addon-cancelled cinematic (CINEMATIC_STOP) puts the
--- engine aura containers through a hide/re-show whose re-parse can land while
--- the teardown's filter state is still degraded -- filtered bars then render
--- the FULL buff set, and with no aura event following, the wrong content
--- sticks. The one lever Lua holds over engine-owned content is config: re-run
--- the group config for every live container (candidate filters are the
+-- Engine re-parse recovery. An engine aura container re-parses its groups on a
+-- hide/re-show, and a re-parse that lands while the teardown's filter state is
+-- still degraded renders the FULL buff set on a FILTERED bar -- with no aura
+-- event following, the wrong content sticks until a reload. First seen on an
+-- addon-cancelled cinematic (CINEMATIC_STOP), then reported for the login world
+-- fade, entering a vehicle, and an unlock-mode round trip: every one of those is
+-- the same edge, since the parent chain up to UIParent belongs to whoever hides
+-- it, not to us. The one lever Lua holds over engine-owned content is config:
+-- re-run the group config for every live container (candidate filters are the
 -- live-changeable channel, so re-setting them forces a fresh parse), one tick
--- after the event so the teardown has finished. Coalesced; rare event.
-local cineFixPending = false
-local function ReapplyAllAfterCinematic()
-    if cineFixPending then return end
+-- after the edge so the teardown has finished. Coalesced; all rare edges.
+local resyncPending = false
+local function ResyncContainers()
+    if resyncPending then return end
     if not (buffsContainer or debuffsContainer) then return end
-    cineFixPending = true
+    resyncPending = true
     C_Timer.After(0, function()
-        cineFixPending = false
+        resyncPending = false
         ApplyLiveConfig(true)
         ApplyLiveConfig(false)
         local cb = ns.PAB_CustomBuffBars()
@@ -4368,6 +4376,21 @@ local function ReapplyAllAfterCinematic()
     end)
 end
 
+-- Every container gets its own visibility watch, so a hide/re-show recovers no
+-- matter who caused it (a fullscreen panel taking UIParent down, the login world
+-- fade, unlock mode). Hooked, never SetScript: these are engine frames and the
+-- engine owns their handlers. Weak-keyed registry rather than a field on the
+-- frame -- an AuraContainer is aspect-restricted while tainted, so nothing of
+-- ours is stored on it (the grow-direction registry above does the same). The
+-- creation-time OnShow fires before the hook is installed, hence the resync here.
+local shownHooked = setmetatable({}, { __mode = "k" })
+function WatchContainerVisibility(container)
+    if not container or shownHooked[container] then return end
+    shownHooked[container] = true
+    container:HookScript("OnShow", ResyncContainers)
+    ResyncContainers()
+end
+
 local initFrame = CreateFrame("Frame")
 initFrame:RegisterEvent("PLAYER_LOGIN")
 initFrame:SetScript("OnEvent", function(self, event)
@@ -4376,11 +4399,20 @@ initFrame:SetScript("OnEvent", function(self, event)
         TryCreateBars()
         -- Registered only for sessions where the feature runs at all; the
         -- handler's container guard covers the module-disabled stand-down.
+        -- Vehicles are their own edge: the engine re-parses on the unit's
+        -- aura source swapping without anything of ours hiding, so the
+        -- visibility hook alone does not cover them. PLAYER_ENTERING_WORLD
+        -- covers the loading-screen edges (the login one lands before the
+        -- containers exist and is dropped by the guard; the bars' own
+        -- creation resync is what covers login).
         if ns.PAB_Enabled() then
             self:RegisterEvent("CINEMATIC_STOP")
+            self:RegisterEvent("PLAYER_ENTERING_WORLD")
+            self:RegisterUnitEvent("UNIT_ENTERED_VEHICLE", "player")
+            self:RegisterUnitEvent("UNIT_EXITED_VEHICLE", "player")
         end
         return
     end
-    ReapplyAllAfterCinematic()
+    ResyncContainers()
 end)
 


### PR DESCRIPTION
Reported: External Defensives (Externals filter) shows unrelated buffs at login until a /reload, after entering a vehicle, and after an unlock-mode round trip.

**Cause:** Blizzard_AuraContainerUtil.DoesAuraPassCandidateFilters only applies includeSpellIDs/excludeSpellIDs when CanApplyIdentityCandidateFilters passes, and for a helpful group that gate is `isHelpful and not UnitCanAssist("player", unit)`. Any moment the player is not assistable to itself (unit flags not streamed at login, control handed to a vehicle) parses the whole helpful set into a bar that asked for four spells, and group membership is cached per aura instance, so it sticks until a reload.

**Fix:** re-run the group config for every live container after those edges. SetAuraGroupCandidateFilters calls UpdateAllAuras, which marks FullAuraRebuild and re-evaluates membership with the gate settled. Edges: hooked container OnShow, container creation (login), PLAYER_ENTERING_WORLD, PLAYER_CONTROL_LOST/GAINED and vehicle enter/exit. Coalesced one-tick pass, no polling; the cinematic handler this replaces did the same thing for one edge.

**Test:** logged in on a druid, mounted and took a vehicle, entered and exited unlock mode: the Externals bar keeps only its filtered buffs.