### PR TITLE
fix(aurabuff): hide the pet reminder while mounted

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3586,7 +3586,8 @@ local function Refresh()
                 petLabel = "Water Elemental"
                 if specID ~= 64 or not Known(31687) then suppress = true end
             end
-            if not suppress and not (UnitExists("pet") and not UnitIsDead("pet")) then
+            if not suppress and not IsMounted()
+               and not (UnitExists("pet") and not UnitIsDead("pet")) then
                 local e = AcquireEntry()
                 e.mode = "texture"
                 e.texture = petIcon


### PR DESCRIPTION
Mounting in the open world auto-dismisses the pet, so the "pet not summoned" reminder appeared for the whole ride and cleared itself on dismount when the pet returned. Skyriding already hid it, because the reminder pass suppresses everything while mounted and flying, which made the warning look inconsistent as well as wrong.

A pet cannot be summoned while mounted in any case, so the reminder is never actionable there. This matches the Pet on Passive reminder in the same block, which already skips while mounted for the same reason.

PLAYER_MOUNT_DISPLAY_CHANGED is already registered, so mounting and dismounting re-evaluate the reminder with no new events.

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [ ] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
