### PR TITLE
fix(unitframes/raidframes/cdm): recover filtered aura displays after a skipped movie

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -762,9 +762,20 @@ end
     -- re-parses on the way back, and no event marks that end -- STOP_MOVIE
     -- fires only for an ENGINE-stopped movie, never for the close dialog's
     -- skip or the QoL auto-skip, which both just hide the frame. OnHide is
-    -- the one point every end path shares.
+    -- the one point every end path shares. Deferred a tick, like the other
+    -- recovery lanes: a re-parse taken inside OnHide runs while the restore is
+    -- still landing (and bills to the Blizzard frame that owns the handler,
+    -- not to us) -- one tick later the gate has settled and the work is ours.
     if MovieFrame and MovieFrame.HookScript then
-        MovieFrame:HookScript("OnHide", ReparseArmed)
+        local moviePending = false
+        MovieFrame:HookScript("OnHide", function()
+            if moviePending or not C_Timer then return end
+            moviePending = true
+            C_Timer.After(0, function()
+                moviePending = false
+                ReparseArmed()
+            end)
+        end)
     end
     pew:SetScript("OnEvent", function(_, event)
         if event == "UNIT_FACTION" then

--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -750,13 +750,25 @@ end
     -- instead of the rule's, and no aura edge is guaranteed to follow the
     -- restore. Reparse armed built slots on that edge (typically one slot).
     pew:RegisterUnitEvent("UNIT_FACTION", "player")
+    local function ReparseArmed()
+        for _, st in pairs(FA121.byRule) do
+            if st.armed and st.built and st.container then
+                st.container:UpdateAllAuras()
+            end
+        end
+    end
+    -- Pre-rendered movies degrade the same slot a different way: MovieFrame
+    -- hides UIParent on show and re-shows it on hide, so the slot's container
+    -- re-parses on the way back, and no event marks that end -- STOP_MOVIE
+    -- fires only for an ENGINE-stopped movie, never for the close dialog's
+    -- skip or the QoL auto-skip, which both just hide the frame. OnHide is
+    -- the one point every end path shares.
+    if MovieFrame and MovieFrame.HookScript then
+        MovieFrame:HookScript("OnHide", ReparseArmed)
+    end
     pew:SetScript("OnEvent", function(_, event)
         if event == "UNIT_FACTION" then
-            for _, st in pairs(FA121.byRule) do
-                if st.armed and st.built and st.container then
-                    st.container:UpdateAllAuras()
-                end
-            end
+            ReparseArmed()
             return
         end
         FA121.Rescan()

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8602,6 +8602,24 @@ eventFrame:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
 -- Cinematic/cutscene end: Blizzard restores hidden frames, so re-hide ours
 eventFrame:RegisterEvent("CINEMATIC_STOP")
 eventFrame:RegisterEvent("STOP_MOVIE")
+-- STOP_MOVIE only fires when the ENGINE stops a movie. The close dialog's skip
+-- (ConfirmButton -> FinishMovie) and our own QoL auto-skip (MovieFrame:Hide())
+-- both end one without it, and the restore that follows the frame's OnHide
+-- puts the Blizzard CDM back on screen with nothing to re-hide it. OnHide is
+-- the point every end path shares; same re-hide as the event branch below.
+if MovieFrame and MovieFrame.HookScript then
+    MovieFrame:HookScript("OnHide", function()
+        local p = ECME.db and ECME.db.profile
+        if p and p.cdmBars and p.cdmBars.hideBlizzard then
+            C_Timer.After(0, function()
+                HideBlizzardCDM()
+                if p.cdmBars.useBlizzardBuffBars then
+                    RestoreBlizzardBuffFrame()
+                end
+            end)
+        end
+    end)
+end
 -- Equipment changes: trinket/weapon swaps update trinket frames and reanchor
 eventFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 -- Visibility option events: mounted, target, instance zone changes

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -3417,3 +3417,17 @@ assistWatch:SetScript("OnEvent", function(_, event)
     assistSweepPending = true
     C_Timer.After(0.25, AssistSweepDrain)
 end)
+-- Pre-rendered movies (MovieFrame) close the same gap from the other side: the
+-- frame hides UIParent on show and re-shows it on hide, so every container
+-- re-parses on the way back, and the only event for it (STOP_MOVIE) fires just
+-- for an ENGINE-stopped movie -- skipping via the close dialog and our QoL
+-- auto-skip both end the movie by hiding the frame instead. OnHide is the
+-- shared point. Deferred a tick: the sweep must read the gate after the
+-- restore has landed, not during it.
+if MovieFrame and MovieFrame.HookScript then
+    MovieFrame:HookScript("OnHide", function()
+        if assistSweepPending then return end
+        assistSweepPending = true
+        C_Timer.After(0, AssistSweepDrain)
+    end)
+end

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
@@ -1490,13 +1490,7 @@ end
 -- events that fire only on cinematics/faction flips/vehicle transitions.
 do
     local pending = false
-    local w = CreateFrame("Frame")
-    w:RegisterUnitEvent("UNIT_FACTION", "player")
-    w:RegisterEvent("CINEMATIC_STOP")
-    w:RegisterUnitEvent("UNIT_ENTERING_VEHICLE", "player")
-    w:RegisterUnitEvent("UNIT_ENTERED_VEHICLE", "player")
-    w:RegisterUnitEvent("UNIT_EXITED_VEHICLE", "player")
-    w:SetScript("OnEvent", function(_, event)
+    local function Recover()
         if pending then return end
         pending = true
         C_Timer.After(0, function()
@@ -1509,7 +1503,22 @@ do
             end
             RefreshUnit("player")
         end)
-    end)
+    end
+    local w = CreateFrame("Frame")
+    w:RegisterUnitEvent("UNIT_FACTION", "player")
+    w:RegisterEvent("CINEMATIC_STOP")
+    w:RegisterUnitEvent("UNIT_ENTERING_VEHICLE", "player")
+    w:RegisterUnitEvent("UNIT_ENTERED_VEHICLE", "player")
+    w:RegisterUnitEvent("UNIT_EXITED_VEHICLE", "player")
+    w:SetScript("OnEvent", Recover)
+    -- Pre-rendered movies hide UIParent and re-show it, so the containers take
+    -- the same hide/re-show re-parse a cancelled cinematic gives them -- but no
+    -- event marks the end: STOP_MOVIE fires only for an ENGINE-stopped movie,
+    -- not for the close dialog's ConfirmButton or our QoL auto-skip, both of
+    -- which just hide the frame. Hook the one point they share.
+    if MovieFrame and MovieFrame.HookScript then
+        MovieFrame:HookScript("OnHide", Recover)
+    end
 end
 
 -- The 12.1 ping-receiver strip workaround lived here until build 68914

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -4501,5 +4501,16 @@ function ns.PAB_ArmRecovery()
     -- Safety net only: an exit that never fires EXITED (teleport out of a
     -- vehicle). Zero work on ordinary loading screens.
     initFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+    -- Pre-rendered movies (MovieFrame) are the fourth trigger and the one
+    -- edge no event covers: MovieFrame hides UIParent on show and re-shows it
+    -- on hide, which puts every container through the same hide/re-show
+    -- re-parse as a cancelled cinematic, but STOP_MOVIE only fires when the
+    -- ENGINE stops playback. Skipping (close dialog -> ConfirmButton ->
+    -- FinishMovie) and our own QoL auto-skip (MovieFrame:Hide()) both end the
+    -- movie without it. OnHide is the one point every path passes through,
+    -- and it runs after UIParent is back up.
+    if MovieFrame and MovieFrame.HookScript then
+        MovieFrame:HookScript("OnHide", ReapplyAllAfterCinematic)
+    end
 end
 


### PR DESCRIPTION
Reported: PAB custom buff bars and raid/party custom buffs get replaced by the full buff set after a skipped cutscene.

**Cause:** `MovieFrame` hides `UIParent` on show and re-shows it on hide, so every aura container takes the same forced re-parse a cancelled cinematic gives it, and the engine's identity gate can leave the spell-ID filters off. `STOP_MOVIE` fires only when the *engine* stops playback: the close dialog's ConfirmButton and our own QoL auto-skip both end a movie without it, so no recovery lane saw the edge.

**Fix:** hook `MovieFrame`'s `OnHide`, the one point every end path shares, into the recovery each lane already has: PAB, UF player containers, RF assist sweep (deferred, no raid-wide reparse), the fake-active slot, and the hide-Blizzard re-hide (which also keyed off `STOP_MOVIE`).

**Test:** with a filtered custom buff bar configured, play a pre-rendered cutscene and skip it, both by hand and with QoL auto-skip on. Bars keep their filter, and the Blizzard cooldown manager stays hidden.
