### PR TITLE
fix(cdm): no tooltip or mouse capture on an invisible buff placeholder

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -4587,6 +4587,13 @@ local function GetOrCreatePlaceholderFrame(barKey, spellID, iconID, identKey)
             local bd2 = ffc and ffc.barKey and barDataByKey[ffc.barKey]
             if not bd2 or not bd2.showTooltip then return end
             if not self._phSpellID then return end
+            -- A placeholder that renders at alpha 0 has nothing under the
+            -- cursor to describe: "Keep Buffs in Same Place"
+            -- (bd2.hidePlaceholderIcon) and hosted "Visibility When Missing:
+            -- Hidden" (_missingHidden) both reserve the slot invisibly, so the
+            -- buff is NOT active and its tooltip must stay down. Same pair of
+            -- flags the three opacity passes test before forcing alpha 0.
+            if bd2.hidePlaceholderIcon or self._missingHidden then return end
             -- Honor the global "Show Tooltips" visibility mode (Blizzard Skin).
             if EllesmereUI and EllesmereUI._tooltipSuppressedByMode
                and EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -6530,6 +6530,17 @@ local function CollectAndReanchor()
                     -- Hidden frames are collected for data (assignedSpells)
                     -- but left visually untouched so we don't override
                     -- Blizzard's "hide when inactive" state machine.
+                    -- Our own (unprotected) placeholder frames own their mouse state
+                    -- here, at the point they are injected: a freshly pooled one is
+                    -- born mouse-enabled and may never see a visibility pass before
+                    -- the cursor reaches it. Same rule ApplyCDMTooltipState uses, plus
+                    -- the alpha-0 exclusion, so flipping "Keep Buffs in Same Place"
+                    -- back off restores capture on the next collect instead of latching.
+                    if frame._isPlaceholderFrame and frame.EnableMouseMotion then
+                        frame:EnableMouseMotion((barData.showTooltip
+                            and not (container and container._mouseTrack)
+                            and not ns.IsPlaceholderRenderHidden(frame, barData)) and true or false)
+                    end
                     if frame:IsShown() and not isFocusKickBar then
                         local barHidden = container and container._visHidden
                         local fcH = _ecmeFC[frame]
@@ -6540,10 +6551,7 @@ local function CollectAndReanchor()
                             -- via frame alpha 0. The same check is mirrored in the two
                             -- other per-icon opacity passes (_CDMApplyVisibility and
                             -- ApplyBarOpacity) so none of them paint over it.
-                            -- The off-by-default bar flag is tested FIRST so anyone not
-                            -- using this feature short-circuits straight to the original
-                            -- branch below (identical code, no added work).
-                            if barData.hidePlaceholderIcon and frame._isPlaceholderFrame then
+                            if ns.IsPlaceholderRenderHidden(frame, barData) then
                                 frame:SetAlpha(0)
                             else
                                 frame:SetAlpha(barHidden and 0 or ns.EffectiveBarAlpha(barData))

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -255,6 +255,22 @@ local function EffectiveBarAlpha(barData)
 end
 ns.EffectiveBarAlpha = EffectiveBarAlpha
 
+-- Placeholders rendered at alpha 0: "Keep Buffs in Same Place"
+-- (hidePlaceholderIcon) and a hosted "Visibility When Missing: Hidden" slot
+-- (_missingHidden) both keep the reserved layout slot but paint nothing. Alpha
+-- 0 stops the art, NOT hit-testing, so such a frame stays a live mouse target
+-- and must be excluded from every mouse pass too: it would answer tooltips for
+-- an inactive buff and swallow mouseover from whatever sits under the bar
+-- (Blizzard hides its own inactive items instead, so those slots hold no frame
+-- at all). Single predicate so the alpha passes and the mouse passes can never
+-- disagree. Off-by-default flags first: non-users stop at the first field.
+local function IsPlaceholderRenderHidden(icon, barData)
+    if not icon then return false end
+    return ((barData and barData.hidePlaceholderIcon) or icon._missingHidden)
+        and icon._isPlaceholderFrame and true or false
+end
+ns.IsPlaceholderRenderHidden = IsPlaceholderRenderHidden
+
 -- Vehicle/petbattle state proxy: created once in CDMFinishSetup; drives _CDMApplyVisibility so CDM bars hide while in vehicle UI.
 local _cdmVehicleProxy = nil
 local _cdmInVehicle    = false
@@ -4678,7 +4694,10 @@ local function ApplyCDMTooltipState(barKey)
             for i = 1, #icons do
                 local ic = icons[i]
                 if ic and ic.EnableMouseMotion then
-                    ic:EnableMouseMotion(wantHover)
+                    -- Invisible placeholders are excluded even with tooltips on: an
+                    -- alpha-0 slot has no art to hover, so capturing here would only
+                    -- take mouseover away from whatever the bar sits over.
+                    ic:EnableMouseMotion(wantHover and not IsPlaceholderRenderHidden(ic, bd))
                 end
             end
         end
@@ -6660,20 +6679,19 @@ _CDMApplyVisibility = function()
                     for ii = 1, #icons do
                         local ic = icons[ii]
                         if ic then
+                            local phHidden = IsPlaceholderRenderHidden(ic, barData)
                             -- EnableMouse/EnableMouseMotion are protected on Blizzard CDM frames; skip during combat to avoid ADDON_ACTION_BLOCKED when dismounting mid-combat.
                             if not icCombat2 then
                                 ic:EnableMouse(false)
                                 -- Same mouseover-stealing rule as the container above: icons may only
                                 -- capture mouse motion when this bar's tooltips are on, and never on cursor-tracked bars (those must stay fully click-AND-motion-through).
+                                -- An invisible placeholder never captures: there is nothing drawn to hover.
                                 if ic.EnableMouseMotion then
-                                    ic:EnableMouseMotion((barData.showTooltip and not frame._mouseTrack) and true or false)
+                                    ic:EnableMouseMotion((barData.showTooltip and not frame._mouseTrack and not phHidden) and true or false)
                                 end
                             end
                             local icfc = _ecmeFC[ic]
-                            -- Off-by-default flags tested first: non-users short-circuit straight to the
-                            -- original branch (identical code, no added work). _missingHidden = hosted
-                            -- "Visibility When Missing: Hidden" placeholder (slot reserved, rendered invisible).
-                            if (barData.hidePlaceholderIcon or ic._missingHidden) and ic._isPlaceholderFrame then
+                            if phHidden then
                                 -- Hide Icon: an Always-Show placeholder keeps its reserved layout slot but stays fully invisible (icon, border, bg).
                                 ic:SetAlpha(0)
                             elseif not (icfc and (icfc._cdStateHidden or icfc._missingActiveHidden)) then
@@ -6742,9 +6760,7 @@ local function ApplyBarOpacity(barKey)
             local ic = icons[i]
             if ic then
                 local icfc = _ecmeFC[ic]
-                -- Off-by-default flags tested first: non-users short-circuit straight to the original
-                -- branch (identical code, no added work). _missingHidden = hosted "Visibility When Missing: Hidden" placeholder (slot reserved, rendered invisible).
-                if (barData.hidePlaceholderIcon or ic._missingHidden) and ic._isPlaceholderFrame then
+                if IsPlaceholderRenderHidden(ic, barData) then
                     -- Hide Icon: an Always-Show placeholder keeps its reserved
                     -- layout slot but stays fully invisible (icon, border, bg).
                     ic:SetAlpha(0)


### PR DESCRIPTION
**Cause:** "Keep Buffs in Same Place" reserves each tracked buff's slot with a placeholder rendered at alpha 0. Alpha 0 stops the art, not hit-testing, so the invisible slot still answered its OnEnter with the spell tooltip while the buff was inactive, and still took mouseover from whatever sat under the bar (raid frame hover, [@mouseover] casts). Blizzard hides its own inactive items, so those slots normally hold no frame at all.

**Fix:** One predicate, `IsPlaceholderRenderHidden`, now drives the three opacity passes and both mouse passes, so an alpha-0 placeholder shows no tooltip and captures no motion. The collect pass owns mouse state for these frames at the point they are injected, so turning the option back off restores capture on the next collect instead of latching it off. Only our own unprotected frames are touched, never a Blizzard viewer icon.

**Test:** Buff bar with Keep Buffs in Same Place and Show Tooltip on Hover both on. Hovering an inactive slot shows nothing and passes mouseover through to raid frames underneath; active buffs tooltip as before. Toggling the option off restores normal icons and tooltips with no reload. Clean in combat, no ADDON_ACTION_BLOCKED. Hosted "Visibility When Missing: Hidden" slots get the same treatment.

<img width="300" height="225" alt="bat orgasm GIF" src="https://github.com/user-attachments/assets/7ff4a91f-897f-4ab8-add9-35b6b0596393" />
