### PR TITLE
fix(chat): editbox reserving top space when not needed

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -298,7 +298,7 @@ local function GetFrameFontSize(id)
     return 12
 end
 local function GetEditBoxHeight()
-    return min(60, max(18, ECHAT.DB().editBoxHeight or 23))
+    return min(60, max(10, ECHAT.DB().editBoxHeight or 23))
 end
 local function GetEditBoxFont()
     local key = ECHAT.DB().editBoxFont
@@ -769,7 +769,11 @@ function ECHAT.ApplyBorders()
         end
         if cf and CFD(cf).inputDiv then
             CFD(cf).inputDiv:SetColorTexture(r, g, b, a)
-            CFD(cf).inputDiv:SetShown(not hide)
+            -- Input-on-top: the divider marks the overlaid input's edge, so it
+            -- shares that input's shown state (ECHAT.ApplyInputTopStrip) --
+            -- otherwise it cuts across a message once the strip is released.
+            CFD(cf).inputDiv:SetShown(not hide
+                and (not cfg.inputOnTop or ECHAT.InputTopStripActive(cf)))
         end
     end
     local cf1 = _G.ChatFrame1
@@ -2435,6 +2439,44 @@ function ECHAT.TogglePortalFlyout(anchorBtn)
     end
 end
 
+-- Input-on-top overlays the top strip of the text area, and OUR message frame
+-- hands that strip back (_smfTopExtra) so no line renders under the input.
+-- Reserving it permanently costs a line of chat even while nothing is being
+-- typed -- the strip sits empty and the topmost message is clipped -- so the
+-- reservation follows the edit box's SHOWN state on the permanent frames 1-10,
+-- whose edit boxes may be script-hooked. Temp windows (11+) must never be
+-- hooked (see SkinEditBox's taint note) and keep the static reservation.
+function ECHAT.InputTopStripActive(cf)
+    if not ECHAT.DB().inputOnTop then return false end
+    local name = cf:GetName()
+    local eb = name and _G[name .. "EditBox"]
+    if not eb then return false end
+    local idx = tonumber(name:match("ChatFrame(%d+)"))
+    if idx and idx <= 10 then return eb:IsShown() end
+    return true
+end
+
+-- Re-derive one frame's reserved strip. Only the text area moves: the panel
+-- rect stays put (input-on-top never changed _bgIns), so nothing outside our
+-- message frame is touched. The divider marks the input's edge and would cut
+-- across a message once the strip is released, so it follows the same state.
+function ECHAT.ApplyInputTopStrip(cf)
+    local d = CFD(cf)
+    if not d.bg then return end
+    local active = ECHAT.InputTopStripActive(cf)
+    -- +5 matches the edit box's own top anchor offset (ApplyInputPosition):
+    -- the box sits 5px lower than cf's top edge, so the strip must reach
+    -- that much further to still fully cover it.
+    local want = active and (GetEditBoxHeight() + 4 + 5) or nil
+    local changed = d._smfTopExtra ~= want
+    d._smfTopExtra = want
+    if d.inputDiv then
+        local cfg = ECHAT.DB()
+        d.inputDiv:SetShown(not cfg.hideBorders and (not cfg.inputOnTop or active))
+    end
+    if changed and ECHAT.EngineLayoutWindow then ECHAT.EngineLayoutWindow(cf) end
+end
+
 -- Flip edit box between bottom (default) and top of chat panel
 function ECHAT.ApplyInputPosition()
     local cfg = ECHAT.DB()
@@ -2462,8 +2504,12 @@ function ECHAT.ApplyInputPosition()
                     -- unaffected because chat renders bottom-up from a
                     -- shared bottom edge, and the input covers the
                     -- hit-zones of the lines it hides.
-                    eb:SetPoint("TOPLEFT", cf, "TOPLEFT", -10, 0)
-                    eb:SetPoint("TOPRIGHT", cf, "TOPRIGHT", 5, 0)
+                    -- -5: keeps text (vertically centered in the box) off the
+                    -- tab band at small editBoxHeight values -- the box grows
+                    -- downward from this anchor, so shrinking it moves the
+                    -- centered text closer to a flush top edge otherwise.
+                    eb:SetPoint("TOPLEFT", cf, "TOPLEFT", -10, -5)
+                    eb:SetPoint("TOPRIGHT", cf, "TOPRIGHT", 5, -5)
                     local bgLvl = CFD(cf).bg:GetFrameLevel() or 1
                     if eb:GetFrameLevel() < bgLvl + 5 then
                         eb:SetFrameLevel(bgLvl + 5)
@@ -2501,8 +2547,11 @@ function ECHAT.ApplyInputPosition()
                     b = onTop and -6 or (eb and -(12 + inputHeight) or -6),
                 }
                 -- Input-on-top: the panel keeps its normal rect; only OUR
-                -- message frame's text area shrinks under the overlaid input.
-                d._smfTopExtra = (onTop and eb) and (inputHeight + 4) or nil
+                -- message frame's text area shrinks under the overlaid input,
+                -- and only while that input is actually up (see
+                -- ECHAT.ApplyInputTopStrip). EngineLayoutWindows at the tail
+                -- of this function relayouts every window either way.
+                ECHAT.ApplyInputTopStrip(cf)
                 if ECHAT.PositionChatPanel then ECHAT.PositionChatPanel(cf) end
             end
 
@@ -3449,6 +3498,17 @@ local function SkinEditBox(cf)
     if idx <= 10 then
         eb:HookScript("OnEditFocusGained", function(self)
             ApplyEditBoxHeaderFont(self)
+        end)
+
+        -- Input-on-top: reclaim/release the reserved top strip of the text
+        -- area as the input comes and goes, so an idle chat uses its full
+        -- height. OnShow/OnHide are C-side script hooks -- no field write onto
+        -- the edit box, the hazard the block comment above describes.
+        eb:HookScript("OnShow", function()
+            ECHAT.ApplyInputTopStrip(cf)
+        end)
+        eb:HookScript("OnHide", function()
+            ECHAT.ApplyInputTopStrip(cf)
         end)
 
         -- Plain Up/Down input recall. The Midnight edit box performs no native recall

--- a/EllesmereUIChat/EllesmereUIChat_Engine.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Engine.lua
@@ -150,6 +150,9 @@ end
 ECHAT.EngineLayoutWindows = function()
     for cf in pairs(WINS) do LayoutWindowSMF(cf) end
 end
+-- Single-window relayout: the input-on-top strip is released/reclaimed per
+-- frame as its edit box shows and hides, and only that frame's text area moves.
+ECHAT.EngineLayoutWindow = LayoutWindowSMF
 
 -- Thin scrollbar: visible only while scrolled back (offset > 0) or dragging.
 -- Track/thumb are our frames; drag runs a temporary OnUpdate on the track

--- a/EllesmereUIOptions/EUI_Chat_Options.lua
+++ b/EllesmereUIOptions/EUI_Chat_Options.lua
@@ -1363,7 +1363,7 @@ initFrame:SetScript("OnEvent", function(self)
                   Set("inputOnTop", v)
                   if ECHAT.ApplyInputPosition then ECHAT.ApplyInputPosition() end
               end },
-            { type="slider", text="Edit Box Height", min=18, max=60, step=1,
+            { type="slider", text="Edit Box Height", min=10, max=60, step=1,
               getValue=function() return Cfg("editBoxHeight") or 23 end,
               setValue=function(v)
                   Set("editBoxHeight", v)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

With Chat's "Input on Top" option enabled, a fixed-height strip at the top of the text area was permanently reserved for the overlaid edit box, even while the player wasn't typing -- the strip sat empty and clipped the topmost visible chat line. The reservation now tracks the edit box's actual shown state on the permanent chat frames, so an idle chat window uses its full height and the strip only appears while typing; the input divider follows the same state so it doesn't cut across a message once the strip is released. Temporary whisper windows keep the static (always-reserved) behavior, since their edit boxes are never script-hooked. Also lowers the Edit Box Height slider's minimum from 18 to 10, and nudges the Input on Top anchor down 5px so small edit box heights no longer crowd the tab row (the box's text is vertically centered and grows downward from a fixed top anchor, so shrinking it used to push the text closer to the tabs).

## How was it tested?

Tested in-game on live retail with Input on Top enabled: toggled the edit box open/closed at various Edit Box Height values (10-60) and confirmed the reserved strip and divider appear only while typing, chat text realigns to use the freed space when idle, and text no longer sits flush against the tab row at the minimum height. Also tested with Input on Top disabled to confirm no behavior change from before.

## Screenshots
Before:
<img width="652" height="335" alt="grafik" src="https://github.com/user-attachments/assets/a4f4efea-5208-4f1c-b89a-932f84661a54" />

After:
<img width="654" height="336" alt="grafik" src="https://github.com/user-attachments/assets/366e3d6f-aa13-46fd-aa00-8f173657323f" />
<img width="649" height="340" alt="grafik" src="https://github.com/user-attachments/assets/2c36a5d8-35dc-41b9-999f-e8addcb480b9" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- Input on Top itself already existed and defaults off; this PR only changes its own behavior while enabled and lowers an existing slider's minimum.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- the two new `OnShow`/`OnHide` hooks are registered unconditionally on the docked edit boxes (same as the module's existing focus/text-change hooks), but `ApplyInputTopStrip` no-ops in one comparison when Input on Top is off.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- driven entirely by `OnShow`/`OnHide` script hooks, no timers or per-frame work.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- `HookScript` on `OnShow`/`OnHide`, same as this module's existing edit-box hooks; all new state lives on our own side-table (`CFD`) and our own frames.
- [x] Tested in-game, works on live retail
- [x] No load errors on the 12.1 PTR client; retail-only change (no new API surface)