### PR TITLE
fix(minimap): stop calling Hide() on protected buttons in combat

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -1172,7 +1172,15 @@ local addonButtonHooks = {}
 
 local function HideMinimapChild(btn)
     _suppressVisTrack = true
-    btn:Hide()
+    -- Hide() on a protected frame is blocked inside lockdown for ANY insecure caller,
+    -- taint or not, and the block is silent (no Lua error) -- so the SetAlpha below
+    -- still ran and the button just went invisible-but-shown. Skip only the blocked
+    -- call and queue the re-apply, which performs the real Hide() on PLAYER_REGEN_ENABLED.
+    if InCombatLockdown() and btn:IsProtected() then
+        QueueApplyAll()
+    else
+        btn:Hide()
+    end
     btn:SetAlpha(0)
     _suppressVisTrack = false
     if not addonButtonHooks[btn] then


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1537387894669320213

## What does this PR do?

Fixes a stream of `ADDON_ACTION_BLOCKED` errors from the minimap module: `AddOn 'EllesmereUIMinimap' tried to call the protected function 'UNKNOWN()'`, reported up to 14x in a single session.

`ApplyMinimap` installs an `ADDON_LOADED` poll that re-runs `HideAllMinimapButtons` 0.1s after any addon loads, so late-attaching minimap buttons get swept up. `ApplyMinimap` itself is combat-guarded, but the poll callback it installs is not — and LoadOnDemand addons routinely load during combat. When that sweep reached a protected minimap button (typically a secure button parented to the minimap by a third-party addon) inside lockdown, its `Hide()` was blocked. The block is silent rather than a Lua error, so execution continued into the following `SetAlpha(0)`: the button ended up invisible but still `IsShown()` and mouse-enabled, leaving a clickable hitbox on the minimap on top of the error spam. Note this is not a taint issue — `Hide()` on a protected frame in lockdown is blocked for any insecure caller regardless of taint.

The fix skips only the call that actually gets blocked, and only for protected frames while in combat, then queues a re-apply through the module's existing `pendingApply` / `PLAYER_REGEN_ENABLED` path so the real `Hide()` runs once combat ends. `SetAlpha(0)` still runs unconditionally, so the on-screen result during combat is identical to before — this is an error-and-hitbox fix, not a visual change. The guard sits in `HideMinimapChild` rather than in the poll callback, which covers both of its callers rather than just the one in the reported stack trace, and avoids the alternative of guarding the whole poll (that would leave a newly loaded addon's button fully visible on the minimap for the rest of the fight).

## How was it tested?
No inital error, cant replicate the issue.

## Screenshots

Not applicable - no visual change.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; this is a bugfix inside an existing code path
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no new events, timers, hooks or frames; nothing added outside the existing sweep
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - adds one `InCombatLockdown()` and one `IsProtected()` call per button in a sweep that already ran, no allocations, and the queued re-apply reuses the module's existing `PLAYER_REGEN_ENABLED` handler
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no `SetScript` and no new hooks; the surrounding `Show`/`Hide` hooks are pre-existing `hooksecurefunc`. To be explicit: `HideMinimapChild` does call `Hide()`/`SetAlpha()` on frames it does not own, which is pre-existing behavior of this module and is what this PR makes safer during lockdown, not something it introduces
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client