### PR TITLE
fix(quest tracker): unclickable group finder button

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -865,6 +865,33 @@ local function SuppressPOI(block)
     end
 end
 
+-- Raise the block's right-edge buttons (quest item / group finder) above the
+-- block itself. Blizzard acquires both the block and its right-edge frames from
+-- the same module pool, so they are siblings on ContentsFrame at the *same*
+-- frame level; the block then wins hit-testing and swallows the button's clicks.
+--
+-- Only the quest item button is stored under a named field
+-- (block.ItemButton, Blizzard_QuestObjectiveTracker.lua). The group finder
+-- button has no named field at all -- block.rightEdgeFrame holds just the last
+-- one added, which is the item button whenever a quest has both. The complete
+-- set is block.addedRegions (ObjectiveTrackerBlockMixin:OnAddedRegion), so walk
+-- that and raise every Button in it. Objective lines, timer bars and progress
+-- bars are Frames and stay untouched.
+local function RaiseRightEdgeButtons(block)
+    local bl = block.GetFrameLevel and block:GetFrameLevel() or 0
+    if block.ItemButton and block.ItemButton.SetFrameLevel then
+        block.ItemButton:SetFrameLevel(bl + 5)
+    end
+    local regions = block.addedRegions
+    if type(regions) ~= "table" then return end
+    for region in pairs(regions) do
+        if type(region) == "table" and region.SetFrameLevel and region.GetObjectType
+           and region:GetObjectType() == "Button" then
+            region:SetFrameLevel(bl + 5)
+        end
+    end
+end
+
 local function SkinBlock(block)
     if not block then return end
     if ShouldSkipSkin() then return end
@@ -873,6 +900,11 @@ local function SkinBlock(block)
     -- Suppress POI on every entry -- Blizzard may assign a new pooled
     -- poiButton to the block between skin passes.
     SuppressPOI(block)
+
+    -- Also on every entry: a block can gain a right-edge button after it was
+    -- first skinned (a quest becomes groupable, an item is granted), and the
+    -- pooled Init/Reset paths reset the level back to the block's.
+    RaiseRightEdgeButtons(block)
 
     -- Skip blocks already fully skinned. The heavy work (strip textures,
     -- style fontstrings, walk children) only needs to happen once per block.
@@ -884,18 +916,6 @@ local function SkinBlock(block)
     end
 
     HookBlockLineMethods(block)
-
-    -- Raise ItemButton / GroupFinderButton frame levels above the block on EVERY skin
-    -- pass. Blizzard pools the block + Init/Reset paths can lower the level back to the
-    -- block's, after which clicks fall through to the block instead of the icon button.
-    -- Re-applying every pass is cheap and guarantees correct hit-testing.
-    local bl = block.GetFrameLevel and block:GetFrameLevel() or 0
-    if block.ItemButton and block.ItemButton.SetFrameLevel then
-        block.ItemButton:SetFrameLevel(bl + 5)
-    end
-    if block.GroupFinderButton and block.GroupFinderButton.SetFrameLevel then
-        block.GroupFinderButton:SetFrameLevel(bl + 5)
-    end
 
     -- Strip named decorative textures by key.
     for _, k in ipairs({


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1537312146931847319

## What does this PR do?

Fixes the group finder ("eye") button on a Quest Tracker block being impossible to click. Players could see the button on a groupable quest, but clicking it did nothing -- the click landed on the quest block underneath instead, which super-tracked the quest rather than opening the group finder. The quest item button on the same right edge was unaffected.

Blizzard acquires a quest block and its right-edge frames from the same module pool, so they end up as siblings on `QuestObjectiveTracker.ContentsFrame` at the *same* frame level. With levels tied, the block can win hit-testing and swallow the button's clicks. The skin already had a guard that raised right-edge buttons above the block, but it probed `block.GroupFinderButton`, a field that does not exist -- Blizzard stores only the quest item button under a named field (`block.ItemButton` in `Blizzard_QuestObjectiveTracker.lua`), so that branch was dead code and the group finder button was never raised. `block.rightEdgeFrame` is not a usable substitute either, since it holds just the last right-edge frame added, which is the item button whenever a quest has both.

The fix walks `block.addedRegions` -- Blizzard's own registry of everything added through `AddRightEdgeFrame` -- and raises every `Button` it holds above the block. Objective lines, timer bars and progress bars are `Frame`s and are left untouched. The call also moved ahead of the already-skinned early return so it genuinely runs on every skin pass, as its comment already claimed: a block can gain a right-edge button *after* it was first skinned (a quest becomes groupable, a quest item is granted), which previously left the button unraised for good.

## How was it tested?

Live retail. Reproduced with `/fstack` on a groupable quest: the group finder button and the quest block both reported frame level `<4>`, with the block listed above the button in the frame stack. After the change the button sits at block level + 5 and clicking it opens the group finder as expected; super-tracking by clicking the block itself, the quest item button, and the POI button are all unchanged. `luac5.1 -p` clean.

## Screenshots

Not applicable -- no visual change, the button's appearance and position are identical. Only its frame level, and therefore hit-testing, changed.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting; this is a bug fix to existing behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- gated behind the module's existing `ShouldSkipSkin()` path, no new events, hooks or frames
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- one `pairs()` walk over a block's handful of added regions inside the existing per-block skin pass; no allocations, no timers, no `OnUpdate`
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- `block.addedRegions` is only read, never written; the only call on Blizzard frames is `SetFrameLevel` on the insecure right-edge buttons, matching what the existing `block.ItemButton` line already did. No new hooks or scripts
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client -- verified on live retail; **not yet loaded on the 12.1 PTR client**