### PR TITLE
Fix(mythyplus focus-/castbar): nil fill texture on unstyled Mythic+ target/focus cast bars

### DIFF
--- a/EllesmereUIMythicTimer/EUI_MythicTimer_TargetFocusBars.lua
+++ b/EllesmereUIMythicTimer/EUI_MythicTimer_TargetFocusBars.lua
@@ -99,6 +99,10 @@ local function BuildBar(which)
     bar.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
 
     bar.sb = CreateFrame("StatusBar", nil, holder)
+    -- Placeholder fill: a StatusBar has NO texture object until one is set, and
+    -- the fill-edge riders below plus every GetStatusBarTexture() call on the
+    -- cast path would index nil on a bar that never reached StyleBar.
+    bar.sb:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
     bar.sb:SetPoint("TOPLEFT", bar.iconFrame, "TOPRIGHT", 0, 0)
     bar.sb:SetPoint("BOTTOMRIGHT", holder, "BOTTOMRIGHT", 0, 0)
     bar.sb:SetMinMaxValues(0, 1)
@@ -712,6 +716,11 @@ end
 
 -- Mid-cast interruptibility flips: re-read protection once, store, refresh.
 local function KickProtectionChanged(bar)
+    -- The unit events cover both tokens whenever EITHER bar is enabled, and a
+    -- disabled bar can still exist (unlock getFrame builds it), so gate here --
+    -- UpdateCast's own gate runs too late for this one.
+    local cfg = BarCfg(bar.which)
+    if not (cfg and cfg.enabled == true) then return end
     local kickProtected
     local sName, _, _, _, _, _, _, kp = UnitCastingInfo(bar.unit)
     if type(sName) ~= "nil" then
@@ -731,6 +740,8 @@ end
 local function ShowInterruptedFlash(bar, interrupterGUID)
     local tf = TF()
     if not tf or tf.interruptedFlash == false then return end
+    local cfg = BarCfg(bar.which)
+    if not (cfg and cfg.enabled == true) then return end
     local protected = bar._kickProtected
     if type(interrupterGUID) == "nil" then return end
     if not ((issecretvalue and issecretvalue(protected)) or not protected) then return end


### PR DESCRIPTION
## What does this PR do?

Fixes a Lua error in the Mythic+ Target/Focus cast bars (`attempt to index a nil value` in `ApplyCastColor`) that fired when a mob's cast changed its interruptibility mid-cast. A `StatusBar` has no texture object until `SetStatusBarTexture` is called, and `BuildBar` never set one — the only call lived in `StyleBar`. The unlock system builds both bars at login regardless of whether they are enabled (`ApplySavedPositions` calls `getFrame` on every registered element that has an `applyPosition`, with no `isHidden` filter), while `StyleBar` only runs for enabled bars, so a disabled bar sat in the `bars` table with no fill texture. Since the unit events are registered for both `"target"` and `"focus"` as soon as *either* bar is enabled, `UNIT_SPELLCAST_INTERRUPTIBLE` / `UNIT_SPELLCAST_NOT_INTERRUPTIBLE` on the disabled unit reached `KickProtectionChanged` → `ApplyCastColor`, which indexed that nil texture. `UpdateCast` has its own enabled gate, but it runs after `KickProtectionChanged` in the event handler.

The fill texture is now set at creation (a placeholder `WHITE8x8`, the same approach the Unit Frames cast bar already uses), so `GetStatusBarTexture()` can never be nil. That also repairs the build-time overlay and spark anchors, which were passing nil to `SetAllPoints`/`SetPoint` and silently anchoring to the parent instead of the fill edge until the first `StyleBar` re-pin. On top of that, `KickProtectionChanged` and `ShowInterruptedFlash` now check `cfg.enabled` — the second guard also removes a visible bug where a *disabled* cast bar would pop up an "Interrupted" flash for one second whenever a successful kick landed on that unit.

## How was it tested?

Live retail client. Reproduced with exactly one of the two bars enabled and the other disabled (the state that leaves an unstyled bar in the table), then observed a target cast that flips interruptibility mid-cast; the error no longer occurs and the enabled bar tints correctly. Also verified that a successful interrupt on the disabled unit no longer shows a stray "Interrupted" flash, and that enabling/disabling either bar, unlock mode, and the options preview still behave as before. `luac5.1 -p` passes on the changed file.

## Screenshots

Not applicable — the change removes an error and a stray frame; there is no intended visual change to an enabled bar.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) — N/A, no new settings
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built — improved: the two new `cfg.enabled` guards stop work on disabled bars. The bars themselves are still built at login by the unlock system's `getFrame`, which is pre-existing behavior and out of scope here.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) — unchanged; one extra `SetStatusBarTexture` at creation, and one table lookup per interruptibility event
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames — N/A, all frames are addon-owned
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client

Secret-value note: no change to how the (possibly secret) interruptibility flag is handled — it is still stored raw and only fed to `SetAlphaFromBoolean` / `C_CurveUtil` colour curves, never compared or branched on.