### PR TITLE
Add player aura up/down icon wrap

### DIFF
--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -70,8 +70,8 @@ local FONT_OUTLINE_VALUES = {
 local FONT_OUTLINE_ORDER = { "default", "none", "outline", "thick" }
 local GROW_DIR_VALUES = { LEFT = "Left", RIGHT = "Right", CENTER_HORIZONTAL = "Centered Horizontal", CENTER_VERTICAL = "Centered Vertical", UP = "Up", DOWN = "Down" }
 local GROW_DIR_ORDER = { "LEFT", "RIGHT", "CENTER_HORIZONTAL", "CENTER_VERTICAL", "UP", "DOWN" }
-local ICON_WRAP_VALUES = { LEFT = "Left", RIGHT = "Right" }
-local ICON_WRAP_ORDER = { "LEFT", "RIGHT" }
+local ICON_WRAP_VALUES = { LEFT = "Left", RIGHT = "Right", UP = "Top", DOWN = "Bottom" }
+local ICON_WRAP_ORDER = { "LEFT", "RIGHT", "UP", "DOWN" }
 
 -- Native AuraContainerSortMethod/AuraContainerSortDirection enum names
 -- (in-game dump: AuraContainerSortMethod = {Default=0,
@@ -698,7 +698,20 @@ local function BuildCoreFields(frame, fontPath, sy, cfg, apply, isBuff)
             type = "dropdown", text = "Growth Direction",
             values = GROW_DIR_VALUES, order = GROW_DIR_ORDER,
             getValue = function() return cfg.growDirection or "LEFT" end,
-            setValue = function(v) cfg.growDirection = v; apply() end
+            setValue = function(v)
+                -- Change the wrap direction to be a valid value from the new growth direction
+                if v == "UP" or v == "DOWN" then
+                    if cfg.iconWrapDirection ~= "LEFT" and cfg.iconWrapDirection ~= "RIGHT" then
+                        cfg.iconWrapDirection = "LEFT"
+                    end
+                elseif v == "LEFT" or v == "RIGHT" then
+                    if cfg.iconWrapDirection ~= "UP" and cfg.iconWrapDirection ~= "DOWN" then
+                        cfg.iconWrapDirection = "DOWN"
+                    end
+                end
+
+                cfg.growDirection = v; apply()
+            end
         }
     ); sy = sy - hh
 
@@ -729,9 +742,9 @@ local function BuildCoreFields(frame, fontPath, sy, cfg, apply, isBuff)
         ns._PAMakeCogBtn(rgn, cogShow)
     end
     do
-        -- Icon Wrap: only meaningful for vertical growth (Up/Down) -- decides which
+        -- Icon Wrap: only meaningful for vertical growth (Up/Down) and horizontal growth (Left/Right) -- decides which
         -- side additional columns stack toward when Icons Per Row/Column > 1. Cog-only,
-        -- no separate dropdown row, and only shown while Growth Direction is Up/Down.
+        -- no separate dropdown row, and only shown while Growth Direction is Up/Down or Left/Right.
         local rgn = sizeRow._rightRegion
         local _, cogShow = EllesmereUI.BuildCogPopup({
             title = "Growth",
@@ -739,13 +752,22 @@ local function BuildCoreFields(frame, fontPath, sy, cfg, apply, isBuff)
                 { type = "dropdown", label = "Icon Wrap",
                   values = ICON_WRAP_VALUES, order = ICON_WRAP_ORDER,
                   get = function() return cfg.iconWrapDirection or "LEFT" end,
-                  set = function(v) cfg.iconWrapDirection = v; apply() end },
+                  set = function(v) cfg.iconWrapDirection = v; apply() end,
+                  itemDisabled = function(v)
+                      if cfg.growDirection == "LEFT" or cfg.growDirection == "RIGHT" then
+                        return v == "LEFT" or v == "RIGHT"
+                      elseif cfg.growDirection == "UP" or cfg.growDirection == "DOWN" then
+                        return v == "UP" or v == "DOWN"
+                      end
+                      return false
+                  end,
+                 },
             },
         })
         local cogBtn = ns._PAMakeCogBtn(rgn, cogShow)
         local function UpdateWrapCogVisibility()
             local dir = cfg.growDirection or "LEFT"
-            cogBtn:SetShown(dir == "UP" or dir == "DOWN")
+            cogBtn:SetShown(dir == "UP" or dir == "DOWN" or dir == "LEFT" or dir == "RIGHT")
         end
         EllesmereUI.RegisterWidgetRefresh(UpdateWrapCogVisibility)
         UpdateWrapCogVisibility()

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -70,7 +70,7 @@ local FONT_OUTLINE_VALUES = {
 local FONT_OUTLINE_ORDER = { "default", "none", "outline", "thick" }
 local GROW_DIR_VALUES = { LEFT = "Left", RIGHT = "Right", CENTER_HORIZONTAL = "Centered Horizontal", CENTER_VERTICAL = "Centered Vertical", UP = "Up", DOWN = "Down" }
 local GROW_DIR_ORDER = { "LEFT", "RIGHT", "CENTER_HORIZONTAL", "CENTER_VERTICAL", "UP", "DOWN" }
-local ICON_WRAP_VALUES = { LEFT = "Left", RIGHT = "Right", UP = "Top", DOWN = "Bottom" }
+local ICON_WRAP_VALUES = { LEFT = "Left", RIGHT = "Right", UP = "Up", DOWN = "Down" }
 local ICON_WRAP_ORDER = { "LEFT", "RIGHT", "UP", "DOWN" }
 
 -- Native AuraContainerSortMethod/AuraContainerSortDirection enum names

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -1547,11 +1547,11 @@ local function ToGrowthH(dirStr, wrapStr)
     end
     return (dirStr == "RIGHT" or dirStr == "CENTER_HORIZONTAL") and FlowDir.Right or FlowDir.Left
 end
-local function ToGrowthV(dirStr)
+local function ToGrowthV(dirStr, wrapStr)
     local FlowDir = AnchorUtil and AnchorUtil.FlowDirection
     if not FlowDir then return nil end
-    if dirStr == "UP" then return FlowDir.Up end
-    if dirStr == "DOWN" then return FlowDir.Down end
+    if dirStr == "UP" or wrapStr == "UP" then return FlowDir.Up end
+    if dirStr == "DOWN" or wrapStr == "DOWN" then return FlowDir.Down end
     return FlowDir.Down -- horizontal growth: rows always wrap downward
 end
 -- Corner = the flow's fixed start point = (opposite of growthV side) + (opposite of
@@ -1564,7 +1564,12 @@ local function CornerFor(dirStr, wrapStr)
         local hSide = (wrapStr == "RIGHT") and "LEFT" or "RIGHT"
         return vSide .. hSide
     end
-    return (dirStr == "RIGHT" or dirStr == "CENTER_HORIZONTAL") and "TOPLEFT" or "TOPRIGHT"
+    if dirStr == "LEFT" or dirStr == "RIGHT" then
+        local vSide = (wrapStr == "UP") and "BOTTOM" or "TOP"
+        local hSide = (dirStr == "RIGHT") and "LEFT" or "RIGHT"
+        return vSide .. hSide
+    end
+    return (dirStr == "CENTER_HORIZONTAL") and "TOPLEFT" or "TOPRIGHT"
 end
 
 -- Shared by every container, default and custom alike: builds the AK.RequestContainer
@@ -1586,7 +1591,7 @@ local function BuildContainerSpec(parent, cfg, grid)
             padding = { 0, 0, 0, 0 },
             rowWidth = grid.rowWidth,
             growthH = ToGrowthH(dir, wrap),
-            growthV = ToGrowthV(dir),
+            growthV = ToGrowthV(dir, wrap),
         },
     }, vertical
 end
@@ -3998,6 +4003,7 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
     local halfPrimary, halfCross = blockW / 2, blockH / 2
     local growUp = (growDir == "UP")
     local wrapRight = (wrapDir == "RIGHT")
+    local wrapUp = (wrapDir == "UP")
 
     for i = 1, math.max(total, #icons) do
         if i <= total then
@@ -4028,8 +4034,8 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
                 btnY = growUp and (-halfPrimary + withinLineStep) or (halfPrimary - withinLineStep)
                 btnX = wrapRight and (-halfCross + acrossLinesStep) or (halfCross - acrossLinesStep)
             else
-                btnX = (corner == "TOPRIGHT") and (halfPrimary - withinLineStep) or (-halfPrimary + withinLineStep)
-                btnY = halfCross - acrossLinesStep
+                btnY = wrapUp and (-halfCross + acrossLinesStep) or (halfCross - acrossLinesStep)
+                btnX = (corner == "TOPRIGHT" or corner =="BOTTOMRIGHT") and (halfPrimary - withinLineStep) or (-halfPrimary + withinLineStep)
             end
             btn:ClearAllPoints()
             btn:SetPoint(centeredVertical and "CENTER" or corner, box, "CENTER", btnX, btnY)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->
Add the Up/Down Icon wrap for the Left/Right Growth Direction in the Player Aura Bars.

This changes allow replication of the default UI behavior with Icon Wrap Up and Icon Direction Right for example.

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

12.1.0. Tested with all combinations of growth direction and icon wrap.

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

<img width="337" height="217" alt="image" src="https://github.com/user-attachments/assets/a001edbb-e7d8-4bb8-af2a-a59218d98cb8" />

<img width="351" height="222" alt="image" src="https://github.com/user-attachments/assets/8c14964c-6c0a-46be-88a5-0955228a8a05" />

Growth Direction: Left & Icon Wrap: Up
<img width="252" height="274" alt="image" src="https://github.com/user-attachments/assets/7efeaee2-fc52-4291-98dd-e8c37fa53968" />

Growth Direction: Left & Icon Wrap: Down (default)
<img width="246" height="269" alt="image" src="https://github.com/user-attachments/assets/a6e26210-fe24-4d1b-9345-638ad4aef0b9" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
