### PR TITLE
Fix(nameplates): border losing its bottom edge after a wrapped cast bar

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2393,10 +2393,24 @@ do
         -- Degenerate PARENT-scale guard, OPT-IN via container._scaleGuard (nameplates, see
         -- PP.CreateBorder): those containers are scale-DECOUPLED so their own es pins to 1
         -- and onePixel cannot explode, but the plate they anchor to hits near-zero scale during
-        -- recycle/hide/PEW (SetScale(0.001)) -- snapping against that rect is churn, skip it (the next valid pass re-asserts); UIParent-based borders leave the flag unset.
+        -- recycle/hide/PEW (SetScale(0.001)) -- snapping against that rect is churn, skip it (the skipped state is re-asserted via ArmPendingSnap below -- do NOT assume some later pass comes on its own, pooled plates get none); UIParent-based borders leave the flag unset.
         if container._scaleGuard then
             local pok, pes = pcall(frame.GetEffectiveScale, frame)
-            if pok and pes and pes < 0.1 then return end
+            if pok and pes and pes < 0.1 then
+                -- Skipping the snap is right (the rect is collapsed, snapping against it is
+                -- churn), but the CALLER'S INTENT MUST NOT BE LOST. A state change that lands
+                -- in this window is otherwise dropped for good: the nameplate cast-bar wrap
+                -- clears its hidden-bottom seam when the cast ends, which for a dying/despawning
+                -- unit happens exactly while the plate is collapsed -- and since plates are
+                -- POOLED and the paths that would re-snap on re-use are appearance-generation
+                -- cached, the bottom strip then stays hidden for every unit that plate is
+                -- recycled onto. Drop the geometry key so the next pass cannot match it as
+                -- identical and skip, and arm a one-shot re-snap for when the container is
+                -- visible again.
+                container._snapEdge = nil
+                PP.ArmPendingSnap(container, frame)
+                return
+            end
         end
         local onePixel = es > 0 and (PP.perfect / es) or PP.mult
         local bs = borderSize or 1
@@ -2482,6 +2496,34 @@ do
             l:SetVertexColor(bc[1], bc[2], bc[3], bc[4])
             r:SetVertexColor(bc[1], bc[2], bc[3], bc[4])
         end
+    end
+
+    --  Deferred re-snap for a guarded container whose snap was swallowed at degenerate parent
+    --  scale (rationale at the guard in SnapBorderTextures). OnShow is the trigger because it is
+    --  exactly the moment the plate un-collapses, costs nothing while idle, and needs no ticker.
+    --  Nothing else scripts OnShow on a border container, so SetScript is safe here; the handler
+    --  is shared, NOT a per-container closure (these arm on pooled nameplate borders).
+    --  Two further nets catch a container whose OnShow never fires: the cleared _snapEdge means
+    --  no later snap can skip it as unchanged, and PP.ResnapAllBorders re-snaps it wholesale.
+    function PP._pendingSnapOnShow(container)
+        local frame = container._pendingSnap
+        if not frame then
+            container:SetScript("OnShow", nil)
+            return
+        end
+        local pok, pes = pcall(frame.GetEffectiveScale, frame)
+        -- Still collapsed (shown inside a hidden/zero-scale ancestor): stay armed for the next show.
+        if not pok or not pes or pes < 0.1 then return end
+        container._pendingSnap = nil
+        container:SetScript("OnShow", nil)
+        local bd = _ppBorderData[frame]
+        SnapBorderTextures(container, frame, bd and bd.borderSize or 1)
+    end
+
+    function PP.ArmPendingSnap(container, frame)
+        if container._pendingSnap then return end
+        container._pendingSnap = frame
+        container:SetScript("OnShow", PP._pendingSnapOnShow)
     end
 
     ---------------------------------------------------------------------------


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1537428130254430228

## What does this PR do?

Fixes nameplates permanently losing the bottom edge of their health bar border once "Wrap Border Around Castbar" has been used. With the option enabled, the border would end up open at the bottom on more and more nameplates the longer a session ran, and stayed that way until a reload; disabling the option was the only workaround.

The wrap feature hides the health border's bottom edge on purpose while a cast bar is shown, so the health bar and cast bar read as one continuous outline, and clears that seam again when the cast ends. The clear itself worked, but the re-snap that makes the strip visible again was being dropped: `SnapBorderTextures` deliberately skips its work while a scale-guarded border's parent sits at a degenerate effective scale, on the assumption that some later valid pass re-asserts whatever was skipped. For nameplate borders that assumption does not hold. When a unit dies or despawns mid-cast, the cast bar hides while the plate is already collapsed, so the restoring snap is swallowed; the plate then returns to the frame pool with a hidden bottom strip, and the only path that would re-snap it on re-use (`ApplyAppearance`) is skipped by the appearance-generation cache. Every unit that plate is later recycled onto inherits the missing edge.

The skip is still correct and stays, but it no longer discards the caller's intent. It now clears the cached geometry key so no later snap can match it as unchanged and skip, and arms a one-shot re-snap that fires when the container becomes visible again; if the scale is still degenerate at that point, it stays armed for the next show. The handler is a single shared function rather than a per-container closure, and it is only installed on a border that actually had a snap swallowed, so borders that never hit the guard carry no script at all. Two independent safety nets cover a container whose `OnShow` never arrives: the cleared geometry key, and the existing wholesale `PP.ResnapAllBorders`.

The change sits in the shared border engine, but only nameplate borders pass the `scaleGuard` flag that reaches this path, so Unit Frames, Raid Frames, AuraKit and the options UI are unaffected.

## How was it tested?

Live retail by Bugreporter.

## Screenshots
### Before:
<img width="1008" height="606" alt="grafik" src="https://github.com/user-attachments/assets/4c5db3fc-aebb-4ac4-84b5-babe01880a52" />
<img width="1022" height="740" alt="grafik" src="https://github.com/user-attachments/assets/8204ba45-5956-462c-93cf-d43cf986d6f3" />

### After:
<img width="582" height="308" alt="grafik" src="https://github.com/user-attachments/assets/242efa6f-49d9-4b56-8dd5-bc0ee36bdee8" />
<img width="482" height="170" alt="grafik" src="https://github.com/user-attachments/assets/ea0279a0-6aae-4f80-b0fc-071ab37ee5d8" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; this is a defect fix in existing behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- no new events, hooks or frames; the new code is only reachable from a border that is already scale-guarded and only when a snap is actually skipped
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- one-shot `OnShow` script, shared handler function (no per-container closure), removed again after the first valid re-snap
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- the `SetScript` is on an addon-created border container, never on a Blizzard frame; border state stays in the existing weak-keyed table
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client -- live retail yes