### PR TITLE
fix(chat): stop chat font growing on CJK clients

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -4452,7 +4452,15 @@ initFrame:SetScript("OnEvent", function(self)
             if cf and _skinned[cf] then
                 local curFont = cf:GetFont()
                 if curFont and curFont ~= wantFont then
-                    local _, sz = cf:GetFont()
+                    -- Size from Blizzard's stored per-window setting, NEVER read
+                    -- back off the widget: under a font family cf:GetFont()
+                    -- answers for the ACTIVE alphabet, so on a CJK client it
+                    -- returns the CJK member -- a file that never equals
+                    -- wantFont, at that member's own height. Feeding it back in
+                    -- re-seeded the family from its own output, and this pass
+                    -- runs on UPDATE_(FLOATING_)CHAT_WINDOWS, so chat text grew
+                    -- on every login, reload and tab switch.
+                    local sz = GetFrameFontSize(cf:GetID())
                     local fam = ECHAT.EngineFontFamily
                         and ECHAT.EngineFontFamily(cf:GetID(), wantFont, sz, wantOutline)
                     if fam then

--- a/EllesmereUIChat/EllesmereUIChat_Engine.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Engine.lua
@@ -540,6 +540,21 @@ local CJK_FILES = {
     simplifiedchinese  = "Fonts\\ARKai_T.ttf",
     traditionalchinese = "Fonts\\blei00d.TTF",
 }
+-- The +2 below is a legibility nudge for CJK dropped INTO a western-locale
+-- chat. On a CJK client it is not a nudge, it is the whole window: every line
+-- is that alphabet, so a user asking for 17 read 19 and the glyphs outgrew the
+-- line box the roman height sizes (the "spacing got tighter" half of the same
+-- report). Blizzard's own families carry one height across every member for
+-- this reason, so the client's own alphabet takes the size unmodified.
+local CJK_CLIENT_ALPHABET = ({
+    koKR = "korean",
+    zhCN = "simplifiedchinese",
+    zhTW = "traditionalchinese",
+})[GetLocale()]
+local function CJKHeight(alphabet, size)
+    if alphabet == CJK_CLIENT_ALPHABET then return size end
+    return size + 2
+end
 function ECHAT.EngineFontFamily(id, font, size, flags)
     flags = flags or ""
     local fam = FAMS[id]
@@ -551,9 +566,10 @@ function ECHAT.EngineFontFamily(id, font, size, flags)
             { alphabet = "russian", file = font, height = size, flags = flags },
         }
         -- CJK renders +2px: ideographs at latin point sizes read visibly
-        -- smaller (dense glyphs, no ascender/descender whitespace).
+        -- smaller (dense glyphs, no ascender/descender whitespace). Not on the
+        -- client's own alphabet -- see CJKHeight.
         for alphabet, file in pairs(CJK_FILES) do
-            members[#members + 1] = { alphabet = alphabet, file = file, height = size + 2, flags = flags }
+            members[#members + 1] = { alphabet = alphabet, file = file, height = CJKHeight(alphabet, size), flags = flags }
         end
         local ok, created = pcall(CreateFontFamily, "EUIChatFontFamily" .. id, members)
         if not ok or not created then FAMS[id] = false; return nil end
@@ -564,7 +580,7 @@ function ECHAT.EngineFontFamily(id, font, size, flags)
         fam:GetFontObjectForAlphabet("roman"):SetFont(font, size, flags)
         fam:GetFontObjectForAlphabet("russian"):SetFont(font, size, flags)
         for alphabet, file in pairs(CJK_FILES) do
-            fam:GetFontObjectForAlphabet(alphabet):SetFont(file, size + 2, flags)
+            fam:GetFontObjectForAlphabet(alphabet):SetFont(file, CJKHeight(alphabet, size), flags)
         end
     end)
     if not ok then return nil end

--- a/EllesmereUIChat/EllesmereUIChat_Engine.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Engine.lua
@@ -544,8 +544,14 @@ local CJK_FILES = {
 -- chat. On a CJK client it is not a nudge, it is the whole window: every line
 -- is that alphabet, so a user asking for 17 read 19 and the glyphs outgrew the
 -- line box the roman height sizes (the "spacing got tighter" half of the same
--- report). Blizzard's own families carry one height across every member for
--- this reason, so the client's own alphabet takes the size unmodified.
+-- report). Blizzard's per-alphabet heights vary family by family, but their
+-- CHAT font is the one that matters here and it bumps nothing upward:
+-- ChatFontNormal inherits NumberFont_Shadow_Med, whose members are roman 14,
+-- simplifiedchinese 14, traditionalchinese 14, korean 13. Their tab-menu size
+-- control then bypasses the family entirely (FCF_SetChatWindowFontSize raw
+-- SetFonts the active alphabet's file at the chosen number), so a size the
+-- user picked renders literally. Ours does the same: the client's own
+-- alphabet takes the size unmodified.
 local CJK_CLIENT_ALPHABET = ({
     koKR = "korean",
     zhCN = "simplifiedchinese",


### PR DESCRIPTION
**Cause:** `SkinPass` repaired the chat font with a size read back off the widget. Under a font family `cf:GetFont()` answers for the ACTIVE alphabet, so on koKR/zhCN/zhTW it returns the CJK member: a file that never equals the wanted font, at that member's own height. The pass therefore fired every time and fed its own output back in, and it runs on `UPDATE_FLOATING_CHAT_WINDOWS`, so chat text grew on every login, reload and tab switch. Separately, the `+2` CJK legibility offset also applied on CJK clients, where it is every line, so a user asking for 17 read 19.

**Fix:** size now comes from Blizzard's stored per-window setting, never a readback. The client's own alphabet takes the size unmodified, matching Blizzard's chat font (`ChatFontNormal` inherits `NumberFont_Shadow_Med`: roman 14, SC 14, TC 14, korean 13) and their own size control, which raw `SetFont`s the chosen number.

<img width="450" height="325" alt="rachel mcadams season GIF" src="https://github.com/user-attachments/assets/86d36063-f640-4bbf-abad-17da57bbee05" />
