### PR TITLE
Allow negative Player Aura Bars row spacing

### DIFF
--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -886,7 +886,7 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
             rows = {
                 -- nil = 12px default -- deliberately
                 -- decoupled from Spacing/padding, no longer mirrors it.
-                { type = "slider", label = "Row Spacing", min = 0, max = 20, step = 1,
+                { type = "slider", label = "Row Spacing", min = -5, max = 20, step = 1,
                   get = function() return cfg.rowSpacing or 12 end,
                   set = function(v) cfg.rowSpacing = v; apply() end },
             },


### PR DESCRIPTION
- Allow Row Spacing to use the same -5 minimum as icon Spacing.

<img width="477" height="139" alt="image" src="https://github.com/user-attachments/assets/bbce5dc5-4387-4fc8-b571-2518fbb2b493" />
<img width="334" height="129" alt="image" src="https://github.com/user-attachments/assets/60612894-a6d5-4f47-958d-6ed8b537fb8f" />
