### PR TITLE
fix(chat): pass the full hyperlink string to SetItemRef

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat_Engine.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Engine.lua
@@ -346,8 +346,12 @@ end
 
 -- Byte-index link scan: |Hlink|hlabel|h spans in raw escaped text, the same
 -- byte semantics FindCharacterIndexAtCoordinate returns (Blizzard's own
--- selection copy slices these indexes with :sub). Returns link, label when
--- idx falls inside a span.
+-- selection copy slices these indexes with :sub). Returns the link data and
+-- the WHOLE clickable string (leading |cxxxxxxxx / trailing |r included when
+-- present) -- that second value is SetItemRef's "text" argument, and the
+-- bare label is NOT a valid value for it: Blizzard's GetFixedLink does
+-- strfind(text, "|H") and then arithmetic on the result, and several
+-- ItemRefHandlers re-parse the full hyperlink out of it.
 local function LinkAtIndex(text, idx)
     local pos = 1
     while true do
@@ -358,7 +362,12 @@ local function LinkAtIndex(text, idx)
         local ce = text:find("|h", le + 2, true)
         if not ce then return nil end
         if idx >= hs and idx <= ce + 1 then
-            return text:sub(hs + 2, le - 1), text:sub(le + 2, ce - 1)
+            local s, e = hs, ce + 1
+            if hs > 10 and text:sub(hs - 10, hs - 1):match("^|c%x%x%x%x%x%x%x%x$") then
+                s = hs - 10
+            end
+            if text:sub(ce + 2, ce + 3) == "|r" then e = ce + 3 end
+            return text:sub(hs + 2, le - 1), text:sub(s, e)
         end
         pos = ce + 2
     end
@@ -389,9 +398,9 @@ local function BuildLinkOverlay(win)
     ov:Hide()
     win.linkOverlay = ov
 
-    local curLink, curLabel
-    local function SetHover(link, label)
-        curLabel = label
+    local curLink, curText
+    local function SetHover(link, linkText)
+        curText = linkText
         if link == curLink then return end
         if curLink then WinLinkLeave(smf) end
         curLink = link
@@ -400,7 +409,7 @@ local function BuildLinkOverlay(win)
     end
     local function HoverTick()
         local x, y = smf:GetScaledCursorPosition()
-        local link, label
+        local link, linkText
         local lines = smf.visibleLines
         if lines then
             for i = 1, #lines do
@@ -418,14 +427,14 @@ local function BuildLinkOverlay(win)
                     if ci and inside then
                         local t = fs:GetText()
                         if type(t) == "string" and not (issecretL and issecretL(t)) then
-                            link, label = LinkAtIndex(t, ci)
+                            link, linkText = LinkAtIndex(t, ci)
                         end
                         break
                     end
                 end
             end
         end
-        SetHover(link, label)
+        SetHover(link, linkText)
     end
     ov:SetScript("OnEnter", function(self)
         self:SetScript("OnUpdate", HoverTick)
@@ -440,7 +449,7 @@ local function BuildLinkOverlay(win)
     end)
     ov:SetScript("OnMouseUp", function(_, btn)
         if curLink then
-            WinLinkClick(smf, curLink, curLabel, btn)
+            WinLinkClick(smf, curLink, curText, btn)
         end
     end)
 end


### PR DESCRIPTION
## What does this PR do?

Fixes a Lua error thrown when a player clicks a hyperlink in chat while the link overlay is armed (it arms whenever Shortened Channel Names or Timestamp All Messages is on, since both make our rendered line differ from Blizzard's invisible hit-zone layout). The overlay does its own hit-testing and forwards the click to `SetItemRef`, but it passed only the label between `|h...|h` as `SetItemRef`'s `text` argument. Blizzard's `GetFixedLink` does `strfind(text, "|H")` and then arithmetic on the result, so a bare label left `startLink` nil and threw `attempt to perform arithmetic on local 'startLink' (a nil value)` out of `ItemRef.lua:39`. Several handlers in `ItemRefHandlers.lua` also re-parse the full hyperlink out of that same argument, so the label was never a valid value for it.

`LinkAtIndex` now returns the whole clickable span instead of the inner label, including a leading `|cxxxxxxxx` colour escape and a trailing `|r` when present. That is what the engine's own `OnHyperlinkClick` delivers to Blizzard's chat frames, and it also lets `GetFixedLink`'s existing `if not strfind(text, "|c")` short-circuit apply, so a coloured link is returned untouched exactly as it is in stock chat. Without a colour escape the `|H` is still present, so the arithmetic is safe in both shapes.

For the player this means chat links clicked while either of those two options is on now open normally instead of erroring. The change is confined to one local function and its two call sites in `EllesmereUIChat_Engine.lua`; the returned link data (first return value) is unchanged.

Not in scope, but worth knowing about: club/community links (`clubTicket`, `clubFinder`, `community`) hit a separate, pre-existing taint problem on this same overlay path. `CommunitiesHyperlink.OnClickLink` lazily creates its `ticketListener` frame and caches it for the session, so a click arriving through the overlay creates that frame tainted and its `OnEvent` then trips `ADDON_ACTION_FORBIDDEN` on the protected `C_Club.GetLastTicketResponse`. Those handlers never call `GetFixedLink`, so that issue predates this PR and is untouched by it.

## How was it tested?

Reported from live retail by a user who hit the error clicking an instance link with the overlay armed. The fix was applied and re-tested in game by the same reporter, who confirmed the arithmetic error no longer occurs and the click now reaches Blizzard's link handlers. Blizzard's side of the contract was verified against the shipped source of `GetFixedLink` in `Blizzard_UIPanels_Game/Mainline/ItemRef.lua` and the handler registrations in `ItemRefHandlers.lua` rather than from memory.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting is introduced
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A in the sense that nothing was added; the overlay's arming conditions are unchanged
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- the added work is two `string.sub` calls and one `string.match` on the already-located span, and only on the tick where a link is actually under the cursor; no new per-frame allocation and no new timer
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- the change lives entirely inside our own module's local scan function; no Blizzard frame is read or written
- [x] Tested in-game, works on live retail