### PR TITLE
fix(raidframes): correct the fill axis on vertical buff manager bars

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -1346,6 +1346,17 @@ local function BmApplyBar(button, dd, style)
     local ind = style.ind
     local r, g, b = BmColor(ind.color, 12 / 255, 210 / 255, 157 / 255)
     dd.bar:GetStatusBarTexture():SetVertexColor(r, g, b, (ind.barColorOpacity or 100) / 100)
+    -- Fill AXIS, mirroring what the preview has always done in BM_PlaceBar.
+    -- Change-guarded like the frame-level write below: SetOrientation resets the
+    -- bar's fill, so calling it on every restyle would visibly stutter a running
+    -- bar. Orientation has to be in BmVisualKey for this to run at all -- it
+    -- otherwise lives only in the geometry fingerprint, which drives the anchor
+    -- pass and never reaches here.
+    local isVert = (ind.orientation or "HORIZONTAL") == "VERTICAL"
+    if dd.bmBarVert ~= isVert then
+        dd.bmBarVert = isVert
+        dd.bar:SetOrientation(isVert and "VERTICAL" or "HORIZONTAL")
+    end
     dd.bar:SetReverseFill(ind.reverseFill == true)
     local bgr, bgg, bgb = BmColor(ind.barBgColor, 0, 0, 0)
     dd.barBg:SetColorTexture(bgr, bgg, bgb, (ind.barBgOpacity or 50) / 100)
@@ -1437,6 +1448,14 @@ local function BmBarInit(button, dd, style, ind, health)
     dd.bar = bar
     dd.barBg = bar:CreateTexture(nil, "BACKGROUND")
     dd.barBg:SetAllPoints(bar)
+
+    -- Fill AXIS. A StatusBar defaults to HORIZONTAL, so a vertical bar rendered
+    -- tall and narrow (BmAnchorOneSlot) while still draining sideways until this
+    -- landed. Set BEFORE the engine registration below in case the axis is
+    -- snapshotted there; BmApplyBar re-drives it for live toggles.
+    local initVert = ((style.ind and style.ind.orientation) or "HORIZONTAL") == "VERTICAL"
+    bar:SetOrientation(initVert and "VERTICAL" or "HORIZONTAL")
+    dd.bmBarVert = initVert
 
     local opts = {}
     if Enum.StatusBarInterpolation then opts.interpolation = Enum.StatusBarInterpolation.Immediate end
@@ -1921,7 +1940,10 @@ local function BmVisualKey(kind, ind, size, font, spellID)
             ind.displayGlowR, ind.displayGlowG, ind.displayGlowB)
     end
     if kind == "bar" then
-        return FP(CK(ind.color), ind.barColorOpacity, ind.reverseFill,
+        -- orientation is the one geometry field that is ALSO a visual: it swaps
+        -- the bar's screen axis (BmGeoFP, anchor pass) and its fill axis
+        -- (BmApplyBar). The other bar geometry stays out on purpose.
+        return FP(CK(ind.color), ind.barColorOpacity, ind.reverseFill, ind.orientation,
             CK(ind.barBgColor), ind.barBgOpacity, ind.frameLevel, tostring(BmTipMode()))
     end
     return FP(ind.type, CK(ind.color), ind.opacity, ind.borderWidth, ind.borderOpacity,


### PR DESCRIPTION
A bar indicator set to Vertical rendered tall and narrow but still drained sideways.

BmAnchorOneSlot reads ind.orientation to swap the bar's width/height and which edges it pins, and BmGeoFP carries it so that anchor pass re-runs -- but nothing ever called SetOrientation, and a StatusBar defaults to HORIZONTAL. So the shape rotated and the fill axis did not.

The preview path has always been correct: BM_PlaceBar sets the orientation before placing the bar. The comment on the live path says it "mirrors the legacy BM_PlaceBar rules onto the slot button" -- it mirrored the geometry rules and dropped the orientation call. The rule is already stated elsewhere in the addon: "Vertical health fill: SetOrientation drives the fill AXIS."

Three lines:
  - BmBarInit sets the axis BEFORE button:SetDurationBar, in case the engine snapshots it at registration.
  - BmApplyBar re-drives it for live toggles, change-guarded because SetOrientation resets the fill and would otherwise stutter a running bar on every restyle.
  - BmVisualKey's bar fingerprint gains orientation, without which the apply pass never runs on a change: orientation otherwise lives only in the geometry fingerprint, which drives the anchor pass and never reaches BmApplyBar.

BmSignature is untouched, so a toggle restyles rather than rebuilding the container.

Note for review: vertical StatusBars fill bottom-to-top, so a RemainingTime bar now drains downward and Reverse Fill flips it. Anyone who set Reverse Fill to compensate while vertical bars behaved horizontally will see their bar change direction once this lands.

## What does this PR do?

Changes the fill orientation of buff managers bars that are set to Vertical (previously, they still filled horizontally).

## How was it tested?

12.1.0 live build 69283. Tested both horizontal and vertical orientations, as well as toggling between, in and out of combat.

## Screenshots

Before:
<img width="37" height="88" alt="image" src="https://github.com/user-attachments/assets/eaebcc88-4b5c-42e6-847c-7e80f1438f12" />

After:
<img width="50" height="89" alt="image" src="https://github.com/user-attachments/assets/b8abce4c-3ed1-431b-a2ca-bd95c003c467" />

## Checklist

- [NA] New settings default **OFF** (no behavior change without opt-in)
- [X] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [X] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [X] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [X] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
