### PR TITLE
Fix(Nameplates): Uninterruptible cast color with plate opacity

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -7118,6 +7118,16 @@ function NameplateFrame:ApplyCastColor(uninterruptible)
         normalCastTint = sc
     end
     local cr, cg, cb = ComputeCastBarTint(kickReadyTint, normalCastTint)
+
+    -- Match the base cast fill to uninterruptible casts so plate opacity
+    -- doesn't reveal the interruptible color underneath the overlay.
+    if C_CurveUtil and C_CurveUtil.EvaluateColorValueFromBoolean then
+        local unintColor = cfg.castBarUninterruptible or defaults.castBarUninterruptible
+        local ev = C_CurveUtil.EvaluateColorValueFromBoolean
+        cr = ev(uninterruptible, unintColor.r, cr)
+        cg = ev(uninterruptible, unintColor.g, cg)
+        cb = ev(uninterruptible, unintColor.b, cb)
+    end
     self.cast:GetStatusBarTexture():SetVertexColor(cr, cg, cb)
     -- Shield icon is opt-out: when disabled it never shows, even on uninterruptible casts. The
     -- setting is a clean boolean, so it gates the (possibly SECRET) flag without evaluating it.


### PR DESCRIPTION
## What does this PR do?

Persists Uninterruptible cast color for Nameplates where Opacity != 100.
Previously Interruptible cast color was applied to Uninterruptible casts on plates that had different opacity than 100, instead of them keeping their Uninterruptible cast color.

## How was it tested?

Tested in-game on Retail 12.1, does not alter interruptible cast colors, or kick not ready color, etc.

## Screenshots
As a basis:
Interruptible casts are set to Green.
Uninterruptible casts are set to Grey.

Screen before the fix letting Interruptible cast color show for Uninterruptible casts when nameplates have different opacity than 100:
<img width="352" height="245" alt="image" src="https://github.com/user-attachments/assets/a4621d4a-ca61-473f-bf91-c14020e2e82e" />
Screen after the fix retaining Uninterruptible cast color with different opacities:
<img width="315" height="233" alt="image" src="https://github.com/user-attachments/assets/5dda9bba-f1e5-425e-9164-f489cca99343" />

## Checklist

- [N/A] New settings default **OFF** (no behavior change without opt-in)
- [✅] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [✅] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [✅] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [✅] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
