### PR TITLE
fix: width match lost on spec swap, and Blizzard equipment cooldown entries

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -1466,6 +1466,25 @@ function EllesmereUI.ScheduleSettleReapply()
         if EllesmereUI._MigrateAnchorFollowBaselines then
             pcall(EllesmereUI._MigrateAnchorFollowBaselines)
         end
+        -- Re-pull every width/height MATCH before the anchor pass. A match child
+        -- is corrected only by a full pass or by its target's own resize notify,
+        -- and a spec swap ends with resizes that reach neither: the authoritative
+        -- passes (OnSpecSwitchComplete, CDM's reanchor pass) run before the CDM
+        -- retry ladder re-lays out the bar, and a size change landing inside the
+        -- 50ms notify throttle is dropped outright with nothing to re-run it. The
+        -- child then stays pinned to the size its target held mid-rebuild until a
+        -- reload -- the power bar <- Essential Cooldowns mismatch. Quiescence
+        -- means every target is at its final size, so this is the same correction
+        -- a reload performs. Gated on a non-empty store: no matches, no work.
+        local wdb = EllesmereUIDB and EllesmereUIDB.unlockWidthMatch
+        local hdb = EllesmereUIDB and EllesmereUIDB.unlockHeightMatch
+        if ((wdb and next(wdb)) or (hdb and next(hdb)))
+           and EllesmereUI.ApplyAllWidthHeightMatches then
+            EllesmereUI._settleReapplyInProgress = true
+            EllesmereUI._settleSuppressUntil = GetTime() + 0.75
+            pcall(EllesmereUI.ApplyAllWidthHeightMatches)
+            EllesmereUI._settleReapplyInProgress = false
+        end
         if EllesmereUI.ReapplyAllUnlockAnchorsForced then
             EllesmereUI._settleReapplyInProgress = true
             EllesmereUI._settleSuppressUntil = GetTime() + 0.75
@@ -1521,6 +1540,14 @@ end
 local _resizeNotifyThrottle = {}  -- [key] = GetTime() of last notify
 local _resizeLastSize = {}  -- [key] = { w = ..., h = ... }
 local RESIZE_THROTTLE_SEC = 0.05 -- ignore rapid-fire size changes within 50ms
+-- Trailing re-run bookkeeping (this file is at the 200-local cap, so it lives on
+-- EllesmereUI rather than in locals). pending[key] = a re-run is queued;
+-- at[key] = when the last one ran, floored to one per 0.5s. That floor is the
+-- hard spin guard: an element whose re-apply is not pixel-stable (1 physical px
+-- exceeds the 0.5 UI-unit epsilon at low UI scale) would otherwise re-arm a
+-- trailing run every 50ms forever. It costs no real correction, since the tail of
+-- a same-frame burst always lands within the first throttle window.
+EllesmereUI._resizeTrail = { pending = {}, at = {} }
 
 -- Set by LayoutBar (action bars) to suppress position re-application during
 -- SetSize; LayoutBar handles its own edge re-anchoring.
@@ -1543,9 +1570,28 @@ function EllesmereUI.NotifyElementResized(key)
     -- 1px on the new pip count) strands anchored children with no event to re-cascade them.
     local suppressMatchProp = EllesmereUI._specProfileSwitching
                            or EllesmereUI._zoneTransitionActive
-    -- Throttle: skip if we just processed this key
+    -- Throttle: skip if we just processed this key, but re-run once when the
+    -- window closes. Dropping outright loses the LAST size of a burst, and that
+    -- is exactly where a rebuild's final SetSize lands (BuildAllCDMBars then the
+    -- synchronous CollectAndReanchor, both inside one frame): the first pass
+    -- propagated a transient width to every matched child and the settled one
+    -- never propagated at all, so the child stayed wrong until a reload. The
+    -- deferred call takes the normal path below and converges, since a size that
+    -- no longer changes fires no further OnSizeChanged. One pending re-run per key.
     local now = GetTime()
-    if _resizeNotifyThrottle[key] and (now - _resizeNotifyThrottle[key]) < RESIZE_THROTTLE_SEC then
+    local lastNotify = _resizeNotifyThrottle[key]
+    if lastNotify and (now - lastNotify) < RESIZE_THROTTLE_SEC then
+        local trail = EllesmereUI._resizeTrail
+        local lastTrail = trail.at[key]
+        if not trail.pending[key]
+           and (not lastTrail or (now - lastTrail) >= 0.5) then
+            trail.pending[key] = true
+            C_Timer.After(RESIZE_THROTTLE_SEC - (now - lastNotify), function()
+                trail.pending[key] = nil
+                trail.at[key] = GetTime()
+                EllesmereUI.NotifyElementResized(key)
+            end)
+        end
         return
     end
     _resizeNotifyThrottle[key] = now

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -663,6 +663,12 @@ local _divertedSpellsCD   = {}
 -- canonical spellID) is tracked on a custom bar by cooldownID (cd-claim marker in
 -- assignedSpells, ns.CdClaimMarker); checked BEFORE the sid map, so it outranks a pair claim.
 local _divertedBuffCdIDs  = {}
+--- Equipment-slot diversions, inventory slot -> barKey. Blizzard's own equipment
+--- cooldown entry carries an equipSlot and NO spell of its own, so the slot is its
+--- only routing key; a bar listing that slot (-13/-14 et al) claims the frame the
+--- same way listing a spellID claims a spell. On ns, not a local: this file is at
+--- the 200-local cap.
+ns._divertedSlotCD = {}
 -- EXACT assigned ids, split from the maps above (which also hold variant-family
 -- derived keys). One cooldown slot can carry several family members on different
 -- bars (Divine Toll/override Holy Bulwark share cooldownID 29342, base 375576);
@@ -815,6 +821,7 @@ function ns.RebuildSpellRouteMap()
     wipe(_divertedVarBaseBuff)
     wipe(_divertedVarBaseCD)
     wipe(_divertedBuffCdIDs)
+    wipe(ns._divertedSlotCD)
     _routeMapBuilt = false
 
     local p = ECME.db and ECME.db.profile
@@ -863,6 +870,13 @@ function ns.RebuildSpellRouteMap()
         for _, sid in ipairs(sd.assignedSpells) do
             if type(sid) == "number" and sid > 0 then
                 StoreDirect(targetMap, sid, bd.key)
+            else
+                -- Equipment slot entry: routes Blizzard's own equipment cooldown
+                -- for that slot, which has no spellID to key on. Same overwrite
+                -- order as the sid maps above, so a custom bar outranks the
+                -- default (pass 3) and a ghost bar hides it (pass 4).
+                local slot = ns.SlotIDFromKey and ns.SlotIDFromKey(sid)
+                if slot then ns._divertedSlotCD[slot] = bd.key end
             end
         end
     end
@@ -1009,6 +1023,17 @@ local function ResolveCDIDToBar(cdID, viewerDefaultBar)
     if CdidIDReadable(info.spellID) and CdidIDReadable(info.overrideSpellID)
        and info.overrideSpellID ~= info.spellID then
         _learnVariantBase(info.overrideSpellID, info.spellID)
+    end
+
+    -- Equipment-backed entry: the slot is the only identity it has, so it routes
+    -- before every sid probe below (all of which would miss). Memoized like any
+    -- other resolve; the slot map is rebuilt with the rest.
+    if CdidIDReadable(info.equipSlot) then
+        local slotBar = ns._divertedSlotCD[info.equipSlot]
+        if slotBar then
+            _cdidRouteMap[cdID] = slotBar
+            return slotBar
+        end
     end
 
     local routedBar = nil
@@ -6223,20 +6248,19 @@ local function CollectAndReanchor()
                                     -- below and was parked invisible once the retry
                                     -- budget ran out -- while every pass kept the
                                     -- retry ladder re-firing against an id that can
-                                    -- never resolve. Claimed like a category entry.
-                                    -- Skipped when this bar already lists that slot:
-                                    -- our own slot frame draws the same equipped item,
-                                    -- and two icons for one trinket is worse than none.
+                                    -- never resolve. Claimed under OUR OWN slot key
+                                    -- (-13/-14 et al) rather than the inert band: that
+                                    -- is the id the picker lists, the route map routes
+                                    -- and the sort ranks, so a Blizzard equipment
+                                    -- cooldown becomes orderable, movable to another
+                                    -- bar and hideable like any other icon, and the
+                                    -- trinket-slot injection below stands down instead
+                                    -- of drawing the same physical item twice. Only for
+                                    -- slots we have a key for; anything else keeps the
+                                    -- inert identity and merely renders.
                                     local eqSlot = catInfo and catInfo.equipSlot
-                                    if eqSlot and ns.GetBarSpellData then
-                                        local sdEq = ns.GetBarSpellData(barKey)
-                                        local listEq = sdEq and sdEq.assignedSpells
-                                        for i = 1, (listEq and #listEq or 0) do
-                                            if ns.SlotIDFromKey(listEq[i]) == eqSlot then
-                                                eqSlot = nil
-                                                break
-                                            end
-                                        end
+                                    if eqSlot and not (ns.SlotIDFromKey and ns.SlotIDFromKey(-eqSlot)) then
+                                        eqSlot = nil
                                     end
                                     if catInfo and (catInfo.spellCategoryID or eqSlot) then
                                         if not cdFrames[barKey] then cdFrames[barKey] = {} end
@@ -6253,7 +6277,8 @@ local function CollectAndReanchor()
                                         -- and outside every other marker band
                                         -- (item presets are small negatives, hosted
                                         -- markers start at -2000000000).
-                                        fc.spellID = -(1000000000 + cdID)
+                                        fc.spellID = eqSlot and -eqSlot
+                                            or -(1000000000 + cdID)
                                         fc.isHostedBuff = nil
                                     else
                                         -- Routed to one of our bars, but the spell
@@ -6920,6 +6945,14 @@ local function CollectAndReanchor()
                             -- <= -100, so -sid would otherwise be taken as an itemID and
                             -- fed to GetItemCooldown, which errors outside int32 range
                             -- (cd-claim markers are -(CD_CLAIM_MARKER_BASE + cooldownID)).
+                        elseif sid and ns.SlotIDFromKey(sid) and _globalClaimSet[sid] then
+                            -- Native-first, injection-fallback (the racial rule
+                            -- below, applied to equipment): Blizzard's own cooldown
+                            -- for this slot is live and claimed under this same slot
+                            -- key, so it renders the slot and our frame stands down.
+                            -- One physical trinket, one icon.
+                            local tfN = _trinketFrames[ns.SlotIDFromKey(sid)]
+                            if tfN then tfN:Hide() end
                         elseif sid and ns.SlotIDFromKey(sid) then
                             -- Equipment slot (trinkets -13/-14, user-added slots)
                             local slot = ns.SlotIDFromKey(sid)

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -6215,7 +6215,30 @@ local function CollectAndReanchor()
                                     -- a spell or lack spellCategoryID entirely.
                                     local catInfo = cdID and C_CooldownViewer
                                         and C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID)
-                                    if catInfo and catInfo.spellCategoryID then
+                                    -- An equipment-backed entry (trinkets and the rest
+                                    -- of the EQUIP_ACTIVE group) lands here the moment
+                                    -- it is dragged into Essential/Utility: it carries
+                                    -- an inventory slot instead of a spell OR a
+                                    -- category, so it fell to the transient branch
+                                    -- below and was parked invisible once the retry
+                                    -- budget ran out -- while every pass kept the
+                                    -- retry ladder re-firing against an id that can
+                                    -- never resolve. Claimed like a category entry.
+                                    -- Skipped when this bar already lists that slot:
+                                    -- our own slot frame draws the same equipped item,
+                                    -- and two icons for one trinket is worse than none.
+                                    local eqSlot = catInfo and catInfo.equipSlot
+                                    if eqSlot and ns.GetBarSpellData then
+                                        local sdEq = ns.GetBarSpellData(barKey)
+                                        local listEq = sdEq and sdEq.assignedSpells
+                                        for i = 1, (listEq and #listEq or 0) do
+                                            if ns.SlotIDFromKey(listEq[i]) == eqSlot then
+                                                eqSlot = nil
+                                                break
+                                            end
+                                        end
+                                    end
+                                    if catInfo and (catInfo.spellCategoryID or eqSlot) then
                                         if not cdFrames[barKey] then cdFrames[barKey] = {} end
                                         local frames = cdFrames[barKey]
                                         frames[#frames + 1] = frame


### PR DESCRIPTION
**Cause:** A spec swap lays a CDM bar out twice inside one frame, so the settled SetSize landed inside the 50ms resize-notify throttle and was dropped, leaving width-matched children (power bar <- Essential Cooldowns) pinned to the transient size until a reload. Separately, a Blizzard equipment cooldown entry dragged out of the Items group into Essential/Utility carries neither a spellID nor a spellCategoryID, so it was parked invisible while re-firing the unresolved retry ladder on every pass, which supplied the late resizes the first bug needed.

**Fix:** The throttle now queues one trailing re-run per key, floored to one per 0.5s so an element whose re-apply is not pixel-stable cannot spin it, and the settle debounce re-applies width/height matches before its anchor pass. Equipment entries are claimed under our own slot key (-13/-14 et al), the id the picker, route map and sort already speak, so they can be ordered, moved and hidden; the trinket-slot injection stands down when Blizzard's frame for that slot is claimed, native-first like racials.

**Test:** In game, a power bar width-matched to Essential Cooldowns holds through repeated spec swaps with no reload. A trinket dragged from Items into Essential now draws, follows the bar listing its slot, and does not double up with our own trinket icon. Entries left in the Items group create no frame and are unaffected.