### PR TITLE
fix(nameplates): re-apply Hide Enemy Nameplates OOC on a settings refresh

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -3267,6 +3267,11 @@ function ns.RefreshAllSettings()
     if ns.ApplyClassPowerSetting then ns.ApplyClassPowerSetting() end
     -- Aura containers: fingerprint-guarded, near-free when no aura setting changed.
     if ns.NPC_ReloadAll then ns.NPC_ReloadAll() end
+    -- Hide Enemy Nameplates OOC is CVar + event driven, and its options setter plus
+    -- PLAYER_LOGIN were its only callers: a value written straight into the profile
+    -- (override group, profile switch, import) flipped the checkbox while plates kept
+    -- the old behaviour. Self-guarded, so an unchanged key costs nothing.
+    if ns.ApplyOOCPlates then ns.ApplyOOCPlates() end
 end
 
 -------------------------------------------------------------------------------
@@ -8439,7 +8444,12 @@ ns.ApplyOOCPlates = function()
         ctl:RegisterEvent("PLAYER_REGEN_ENABLED")
         ctl:RegisterEvent("PLAYER_ENTERING_WORLD")
         ns._oocPlatesOwned = true
-        SetCVar("nameplateShowEnemies", InCombatLockdown() and "1" or "0")
+        -- Read-guarded: RefreshAllSettings calls this on every nameplate settings
+        -- change, and a redundant SetCVar broadcasts CVAR_UPDATE to the whole UI.
+        local want = InCombatLockdown() and "1" or "0"
+        if GetCVar("nameplateShowEnemies") ~= want then
+            SetCVar("nameplateShowEnemies", want)
+        end
     else
         ctl:UnregisterEvent("PLAYER_REGEN_DISABLED")
         ctl:UnregisterEvent("PLAYER_REGEN_ENABLED")


### PR DESCRIPTION
Reported: a conditional override that turns **Hide Enemy Nameplates out of Combat** off in dungeons shows as active but changes nothing.

**Cause:** the setting is CVar plus event driven (`ApplyOOCPlates` arms the combat events and writes `nameplateShowEnemies`), and only its own options setter and PLAYER_LOGIN ever called it. The override engine writes the profile key and calls `RefreshAllSettings`, which never reached it, so the checkbox flipped while plates kept the old behaviour. Profile switches and imports had the same hole.

**Fix:** call `ApplyOOCPlates` from `RefreshAllSettings`, and read-guard its `SetCVar` against `GetCVar` so the added call is free when the key has not changed. Still zero cost when the feature is off.

**Test:** verified in game, both directions (default on / dungeon off and the reverse) and across a profile switch.
