### PR TITLE
perf(player auras): install the swipe Show hook only when it is needed

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -657,7 +657,11 @@ local function PAB_ApplyExtraText(button, d, style)
     --      (post-instance-change re-shows do this).
     if d.cooldown then
         d.pabHideSwipe = style.hideSwipe == true
-        if not d._pabSwipeHooked then
+        -- Install lazily on the first apply that actually hides the swipe. The
+        -- hook reads the live flag, so a later toggle back on still works, and a
+        -- user who never turns the setting off never gets a closure or a secure
+        -- hook on this cooldown's Show at all.
+        if d.pabHideSwipe and not d._pabSwipeHooked then
             d._pabSwipeHooked = true
             hooksecurefunc(d.cooldown, "Show", function()
                 if d.pabHideSwipe then d.cooldown:Hide() end


### PR DESCRIPTION
## What does this PR do?

One-line change plus a comment.

`PAB_ApplyExtraText`'s hidden-swipe defense installed its closure and its
`hooksecurefunc` under `if d.cooldown then`, with no check on the setting it exists
for. So every PlayerAuraBars button got a closure and a permanent secure hook on its
cooldown's `Show` - which the comment directly above it says fires on aura content
churn - whether or not the user had ever turned "Show Duration Swipe" off.

Gating the install on `d.pabHideSwipe` removes that for everyone who leaves the
setting alone, which is the default. The hook already reads the flag live, so
toggling the setting off later installs it then and toggling back on behaves exactly
as before. The alpha layer below it is untouched.

## How was it tested?

Live retail (12.1). No visual change with the setting on or off, which is the
expected result: this only changes *when* the hook is installed, not what it does.

This started as a larger refactor of the shared `AuraKit` swipe gate. That part was
dropped - it was justified by #1340, which turns out to have been fixed in 8.8.5 (see
that issue), so the refactor had no reproducible problem behind it and was not worth
the blast radius on a file with eight consumers. What is left is the one measurable
win that stands on its own.

No IS_121-gated paths are touched.

## Screenshots

Not applicable - no visual change.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new
      settings
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing
      work, no frames built - this is precisely what the change fixes: the hook is no
      longer installed for users who have not enabled the setting
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no
      per-frame allocations) - unchanged when enabled; one boolean test added on the
      style pass
- [x] No writes onto Blizzard-owned frames (weak-table pattern used);
      `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -
      unchanged; per-button state stays in AuraKit's weak-keyed table
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client -
      verified on live retail (12.1); the PTR half no longer applies now that 12.1
      has launched
