### PR TITLE
fix(raid frames): draw Health Bar Color tints with the health bar texture

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
@@ -2067,8 +2067,8 @@ function ns.DMP_RefreshPreview()
                         pv._dmHC = hc
                     end
                     local c = t.color or { r = 1, g = 0.25, b = 0.25 }
-                    hc:SetColorTexture(c.r or 1, c.g or 0.25, c.b or 0.25,
-                        (t.opacity or 45) / 100)
+                    ns.RF_TintOverBarFill(hc, health, c.r or 1, c.g or 0.25,
+                        c.b or 0.25, (t.opacity or 45) / 100)
                     hc:Show()
                 end
             elseif t.type == "glow" then

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -1378,7 +1378,14 @@ local function BmApplyEffect(button, dd, style)
     if ind.type == "healthcolor" or ind.type == "bgcolor" then
         if dd.tex then
             local r, g, b = BmColor(ind.color, 0, 1, 0)
-            dd.tex:SetColorTexture(r, g, b, (ind.opacity or 100) / 100)
+            local a = (ind.opacity or 100) / 100
+            -- healthcolor rides the fill and borrows its texture; bgcolor covers
+            -- the bar's background, which is a flat color fill, so it stays flat.
+            if ind.type == "healthcolor" then
+                ns.RF_TintOverBarFill(dd.tex, dd.bmHealthBar, r, g, b, a)
+            else
+                dd.tex:SetColorTexture(r, g, b, a)
+            end
         end
     elseif ind.type == "border" then
         -- Full legacy renderer (solid/dashed/textured/sweep) on the border host --
@@ -1475,6 +1482,7 @@ local function BmEffectInit(button, dd, style, ind, health)
         -- opaque heal absorb. Anchored to the fill texture so only the filled portion
         -- tints, not empty/missing health.
         button:SetFrameLevel(health:GetFrameLevel())
+        dd.bmHealthBar = health  -- apply pass borrows this bar's fill texture
         dd.tex = button:CreateTexture(nil, "ARTWORK", nil, 2)
         local fillTex = health.GetStatusBarTexture and health:GetStatusBarTexture()
         if fillTex then
@@ -1482,6 +1490,7 @@ local function BmEffectInit(button, dd, style, ind, health)
         else
             dd.tex:SetAllPoints(health)
         end
+        ns.RF_RegisterBarTint(health, dd.tex, nil, "bm")
     elseif ind.type == "bgcolor" then
         -- Background Color: whole health area, ARTWORK -2 = below fill (sublevel 0)
         -- and healthcolor tint (+2), above the bar's own backdrop -- reads as bg.
@@ -2705,6 +2714,11 @@ local function ReloadBm(button, d, s, cls)
         if d.rfcBm then AK.ReleaseContainer(d.rfcBm) end
         d.rfcBm, d.rfcBmFrames, d.rfcBmMeta, d.rfcBmChain = nil, nil, nil, nil
         d.rfcBmSig = nil
+        -- Those slot buttons own this bar's Health Bar Color overlays, and engine
+        -- frames are never freed (see above), so their registry entries would pile
+        -- up one set per rebuild and every later layout pass would walk the dead
+        -- ones. The registry is pure cache: the next paint re-adds what is live.
+        ns.RF_ClearBarTints(d.rfcHealth, "bm")
         -- Rebuild through the shared scheduler; the job reads live settings
         -- at run time, so rapid consecutive changes converge.
         AK.QueueBuildJob(function()

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -1186,6 +1186,7 @@ function ns.BM_CreatePreviewIndicators(f, health, PP)
     f._bmIconPool      = iconPool
     f._bmBarPool       = barPool
     f._bmHCOverlay     = hcOverlay
+    f._bmHCBar         = health
     f._bmBGOverlay     = bgOverlay
     f._bmEffectBorder  = effectBorder
 end
@@ -1384,7 +1385,8 @@ function ns.BM_ApplyPreviewIndicators(f, index, s)
                         if wantShow then
                             if indType == "healthcolor" and f._bmHCOverlay then
                                 local c = ind.color or { r=0, g=1, b=0 }
-                                f._bmHCOverlay:SetColorTexture(c.r, c.g, c.b, (ind.opacity or 100) / 100)
+                                ns.RF_TintOverBarFill(f._bmHCOverlay, f._bmHCBar,
+                                    c.r, c.g, c.b, (ind.opacity or 100) / 100)
                                 f._bmHCOverlay:Show()
                             elseif indType == "bgcolor" and f._bmBGOverlay then
                                 local c = ind.color or { r=0, g=1, b=0 }

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_DebuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_DebuffManager.lua
@@ -689,6 +689,7 @@ local function FxCreateVisuals(button, dd, kind, hostBtn, health)
         f:Hide()
         dd.dmFxHcFrame = f
         dd.dmFxHc = tex
+        ns.RF_RegisterBarTint(health, tex, f, "dm")
     elseif kind == "square" then
         local f = CreateFrame("Frame", nil, button)
         f:SetPoint("CENTER", health, "CENTER")
@@ -749,7 +750,9 @@ local function FxApplyInner(button, dd, refs, fx)
         local tex = dd.dmFxHc
         if not (f and tex) then return end -- created in extraInit
         -- Level tie set at creation; NO re-check here -- subtree reads (ours included) are denied outside the creation window and would kill this branch.
-        tex:SetColorTexture(fx.r or 1, fx.g or 0.2, fx.b or 0.2, fx.a or 0.5)
+        -- The bar itself is OURS and outside that subtree, so the tint can read its
+        -- fill texture here and keep the health bar's shading instead of flattening it.
+        ns.RF_TintOverBarFill(tex, refs.health, fx.r or 1, fx.g or 0.2, fx.b or 0.2, fx.a or 0.5)
         f:Show()
 
     elseif fx.kind == "square" then
@@ -1479,9 +1482,15 @@ function ns.DM_ApplyDebuffConfig(container, d, s, styleKey)
         if dmTiles then
             for i = 1, #dmTiles do present[dmTiles[i].id] = true end
         end
+        local stale = false
         for id, c in pairs(live) do
-            if not present[id] then c:Hide() end
+            if not present[id] then c:Hide(); stale = true end
         end
+        -- A parked container keeps its slot buttons, so any healthcolor overlay it
+        -- built stays registered on the health bar and every later layout pass
+        -- walks it. Nothing releases these, so without this they accumulate for
+        -- the session. Live tiles re-register on their next paint.
+        if stale and d.rfcHealth then ns.RF_ClearBarTints(d.rfcHealth, "dm") end
     end
     d.dmGatedTiles = gatedTiles
 end

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -1014,6 +1014,114 @@ ns.RF_ApplyFillRotation = function(bar)
     bar:SetRotatesTexture((vert and not tiled) and true or false)
 end
 
+-------------------------------------------------------------------------------
+--  Health-fill tint overlays
+--
+--  "Health Bar Color" indicators paint over the health FILL. A flat
+--  SetColorTexture slab erases the bar's shading, so a tinted frame reads as a
+--  solid block beside untinted ones (#1339); the overlay borrows the bar's own
+--  fill texture instead and recolors it with a vertex color.
+--
+--  The overlay is anchored to the fill texture, so it inherits the bar's fill
+--  geometry for free: these fills clip by resizing rather than by moving their
+--  tex coords (measured -- identical coords at full and at half fill), so the
+--  overlay stretches exactly as the bar art does with nothing to update per tick.
+--  The coords are copied anyway so anything the orientation pass does to them
+--  comes along, which is also why the refresh runs after that pass.
+--
+--  Live BM/DM slots register on the bar, so a Health Bar Texture change can
+--  re-anchor them to the new fill object and repaint (ReanchorAbsorbToFill for
+--  frames built through StyleButton, FB.ApplyStyle for Focus/Boss). The options
+--  previews are rebuilt wholesale and need no refresh.
+-------------------------------------------------------------------------------
+
+-- host and owner are kept on the overlay rather than in the entry, so a cleared
+-- entry can be rebuilt by the next paint without losing either. host is stored only
+-- when it is NOT the overlay itself -- the Debuff Manager hangs its overlay off a
+-- wrapper frame, and that wrapper is what a fill swap has to re-anchor.
+ns.RF_RegisterBarTint = function(bar, tex, host, owner)
+    if not (bar and tex) then return end
+    if host and host ~= tex then tex._euiTintHost = host end
+    if owner then tex._euiTintOwner = owner end
+    local reg = bar._euiBarTints
+    if not reg then
+        reg = setmetatable({}, { __mode = "k" })
+        bar._euiBarTints = reg
+    end
+    if reg[tex] == nil then reg[tex] = {} end
+end
+
+-- Called when a container that owned overlays on this bar is released. Engine aura
+-- buttons are never freed, so their overlays would otherwise pile up one set per
+-- rebuild -- an indicator edit or a spec change is enough -- and every later layout
+-- pass would walk the dead ones. Entries are re-added by the next paint.
+--
+-- Scoped to the owner being released. Clearing the whole registry would also drop
+-- a live overlay belonging to another owner, and an overlay that is displayed but
+-- not repainted never re-registers -- so the next Health Bar Texture change would
+-- skip it and leave it on the old art, which is the bug this file is fixing.
+ns.RF_ClearBarTints = function(bar, owner)
+    local reg = bar and bar._euiBarTints
+    if not (reg and owner) then return end
+    for tex in pairs(reg) do
+        if tex._euiTintOwner == owner then reg[tex] = nil end
+    end
+end
+
+ns.RF_TintOverBarFill = function(tex, bar, r, g, b, a)
+    if not tex then return end
+    ns.RF_RegisterBarTint(bar, tex)
+    local reg = bar and bar._euiBarTints
+    local ent = reg and reg[tex]
+    -- Stored pre-multiply: the refresh path calls back in with these, so folding
+    -- the fill opacity in here would compound it on every pass.
+    if ent then ent.r, ent.g, ent.b, ent.a = r, g, b, a end
+    -- Inherit the bar's configured Fill Opacity, so a tinted frame is as
+    -- translucent as its untinted neighbours instead of the one solid bar in the
+    -- group. Read from the stamp the style pass leaves, NOT from the live fill
+    -- colour: _ApplyHealthBg drives that alpha down to 0.3 offline and 0.5 dead,
+    -- and nothing repaints tints when a unit reconnects, so a tint painted during
+    -- either would latch dimmed. Dark Mode is deliberately not inherited -- it
+    -- dims the fill texture, and a colour the user picked should not be
+    -- auto-dimmed.
+    if bar then a = a * (bar._euiFillOpacity or 1) end
+    local fill = bar and bar.GetStatusBarTexture and bar:GetStatusBarTexture()
+    local path = fill and fill.GetTexture and fill:GetTexture()
+    if not path then
+        -- Reset both: a texcoord from the textured branch survives the swap, and
+        -- SetColorTexture bakes the color into the texture rather than into the
+        -- vertex color, so a stale vertex color would multiply it.
+        tex:SetTexCoord(0, 1, 0, 1)
+        tex:SetColorTexture(r, g, b, a)
+        tex:SetVertexColor(1, 1, 1, 1)
+        return
+    end
+    tex:SetTexture(path)
+    if fill.GetTexCoord then tex:SetTexCoord(fill:GetTexCoord()) end
+    tex:SetVertexColor(r, g, b, a)
+end
+
+-- Repaint BEFORE re-anchoring, and re-anchor with a bare SetAllPoints: the caller
+-- isolates this, and a ClearAllPoints that succeeded ahead of a denied SetAllPoints
+-- would strand the overlay with no anchor at all for the rest of the session.
+ns.RF_RefreshOneBarTint = function(bar, tex, ent, fill)
+    if ent.r then ns.RF_TintOverBarFill(tex, bar, ent.r, ent.g, ent.b, ent.a) end
+    if fill then (tex._euiTintHost or tex):SetAllPoints(fill) end
+end
+
+-- Isolated per entry: the overlay can hang off an engine aura button, and this
+-- runs from bare ReloadFrames calls where a throw would abort the styling loop
+-- mid-iteration. RF_TintOverBarFill only ever rewrites an entry it was handed, so
+-- the walk cannot gain keys mid-iteration.
+ns.RF_RefreshBarTints = function(bar)
+    local reg = bar and bar._euiBarTints
+    if not reg then return end
+    local fill = bar.GetStatusBarTexture and bar:GetStatusBarTexture()
+    for tex, ent in pairs(reg) do
+        pcall(ns.RF_RefreshOneBarTint, bar, tex, ent, fill)
+    end
+end
+
 ns.RF_ApplyHealthOrientation = function(bar, s)
     if not bar then return false end
     local vert = ns.RF_IsVerticalFill(s)
@@ -2031,6 +2139,13 @@ local function CreateAbsorbBar(button, healthBar)
             or (d._isExtra and ns._scaledExtraProxy) or ns._scaledProfile
         local isVert = ns.RF_ApplyHealthOrientation(healthBar, vs)
         backfillBar._axisVert = isVert  -- read by the blizzardModern spark block
+
+        -- Health Bar Color overlays track this bar's fill, so they follow the swap
+        -- for the same reason the absorb cluster below does. After the orientation
+        -- call, not before: the repaint copies the fill's tex coords, and that call
+        -- is what rotates them.
+        healthBar._euiFillOpacity = (vs.healthBarOpacity or 100) / 100
+        ns.RF_RefreshBarTints(healthBar)
         -- Indexed, not ipairs: the creation-time call runs before the heal/max bars exist, and ipairs stops at the first nil.
         local axisBars = { backfillBar, forwardBar, healAbsorbBar, healPredBar, reducedBar }
         for i = 1, 5 do
@@ -4940,6 +5055,11 @@ FB.ApplyStyle = function(owner)
         if ft then ft:SetHorizTile(false) end
         -- Fill axis follows the raid Health Bar setting. The bg is a full-button texture (not fill-tracking), so nothing else re-anchors.
         ns.RF_ApplyHealthOrientation(b._health, s)
+        -- These carry aura containers (RFC_SetupButton below) and so can carry
+        -- Health Bar Color overlays, but they have no absorb cluster and never
+        -- build ReanchorAbsorbToFill, where every other frame picks the swap up.
+        b._health._euiFillOpacity = (s.healthBarOpacity or 100) / 100
+        ns.RF_RefreshBarTints(b._health)
         -- No power bar / top name bar here: health fills the button.
         b._health:SetHeight(h)
 


### PR DESCRIPTION
Closes #1339.

## What does this PR do?

A "Health Bar Color" indicator painted a flat colour slab over the health fill, so a
tinted frame lost the bar's texture and read as a solid block beside untinted ones.
It now borrows the bar's own fill texture - whatever Health Bar Texture resolves to,
SharedMedia keys included - and recolours that, so a tinted frame keeps the same
shading as its neighbours.

The overlay is anchored to the fill texture, so it tracks the bar's geometry for
free: no polling, no timer, no hook, and no per-tick work.

It also inherits the bar's configured **Fill Opacity**, so a tinted frame is as
translucent as its untinted neighbours. Dark Mode is deliberately not inherited -
that dims the bar automatically, and a colour the user picked should not be
auto-dimmed with it.

Overlays register on the bar so a Health Bar Texture change re-anchors and repaints
them instead of leaving them on the old art: `ReanchorAbsorbToFill` for frames built
through `StyleButton`, `FB.ApplyStyle` for Focus/Boss buttons, which have no absorb
cluster and so never build one. Registrations are dropped when the container that
owns them goes - engine aura buttons are never freed - and rebuilt by the next paint.

Routed through it: the Buff Manager's healthcolor slots, the Debuff Manager's
healthcolor tile, and both options previews. Background Color deliberately keeps its
flat tint, since it covers the health bar's background, which is itself a flat fill.

## How was it tested?

Live retail (12.1). The overlay reports the same texture fileID as the bar's fill and
renders with its shading; a Health Bar Texture change repaints; vertical fill renders
correctly; Fill Opacity is respected and Dark Mode is not.

One behaviour was measured rather than assumed, because the design rests on it: these
fills clip by *resizing* the fill texture, not by rewriting its tex coords -
`GetTexCoord()` reads identical at full and at half fill. That is what makes
anchoring to the fill sufficient with nothing to update per tick. It is a statement
about these bars, whose fills are plain file textures, rather than about StatusBars
generally.

No IS_121-gated paths are touched.

## Screenshots

Control (textured health bar with no Health Bar Color indicator):

<img width="238" height="139" alt="image" src="https://github.com/user-attachments/assets/ee745404-b8aa-4f61-a47e-78f8b2ef55ed" />

Before:
<img width="262" height="147" alt="image" src="https://github.com/user-attachments/assets/1d6a8f9f-4a94-4247-8967-ad1303e51764" />

After:

<img width="256" height="126" alt="image" src="https://github.com/user-attachments/assets/1cc6eeaf-d754-486f-85c0-8dc115d8f25d" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new
      settings; this is a bug fix to an existing indicator's rendering
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing
      work, no frames built - a bar with no healthcolor overlay never allocates a
      registry and the refresh returns immediately
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no
      per-frame allocations) - no OnUpdate, no timers, no per-call allocation; the
      registry is walked once per button on a reload or style pass, never per frame,
      per health tick or per aura update
- [x] No writes onto Blizzard-owned frames (weak-table pattern used);
      `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -
      every frame and texture touched is ours; no hooks added
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client -
      verified on live retail (12.1); the PTR half no longer applies now that 12.1
      has launched
