### PR TITLE
refactor(aurakit): build the dispel ring from four solid strips

### DIFF
--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -309,39 +309,71 @@ local function ApplyStyleToRegions(button, style)
         end
     end
 
-    -- Engine dispel-type border (style.dispelBorder): one texture the engine shows
-    -- only on typed (dispellable) auras and tints per dispel type -- per-aura dispel
-    -- data is secret, so show/hide and color are ENGINE decisions. The Color style
-    -- never assigns a texture file, only vertex- tints: the ring ART is entirely ours
-    -- (media/textures/square-ring.png, a flat white band flush to a 64px canvas, 16
-    -- texels thick), registered purely as a tint target, and the user's dispel palette
-    -- rides in via customDispelColorMap (68824). The ring lives on a dedicated holder
-    -- one frame level over the static border host so the recolor always draws ON TOP
-    -- of the border strips; the text carrier sits one more above. Registration follows
-    -- the static border: no border configured, no dispel recolor (live parity). 68914
-    -- reworked the border API into the dispel-type texture system: the
-    -- tint-our-own-art style is now PreserveAsset on
+    -- Engine dispel-type border (style.dispelBorder): textures the engine shows only on
+    -- typed (dispellable) auras and tints per dispel type -- per-aura dispel data is
+    -- secret, so show/hide and color are ENGINE decisions. The ART is entirely ours,
+    -- registered purely as a tint target, and the user's dispel palette rides in via
+    -- customDispelColorMap (68824).
+    --
+    -- FOUR SOLID STRIPS, not one ring-shaped texture. Blizzard iterates every registered
+    -- texture ("for _index, dispelTypeTexture in ipairs(self.dispelTypeTextures)" in
+    -- Blizzard_CustomAuraButton.lua), each with its own options, its own visibility test
+    -- and its own SetVertexColor, so a four-texture ring is as legal as a one-texture
+    -- one. It buys three things. Thickness becomes GEOMETRY: the ring used to be one
+    -- band texture cropped per icon size, which went sub-texel above a certain drawn
+    -- size, and the bilinear filter then rendered it at alpha < 1 so the static border
+    -- underneath bled through and mixed with the dispel tint (field-reported 2026-08-14
+    -- on Player Aura Bars debuffs above Icon Size 34). Solid strips do no texel sampling
+    -- at all and hold at any size. It also keeps us off SetTexCoord, which
+    -- AddDispelTypeTexture stamps as a secret aspect on every texture it takes (along
+    -- with Alpha, VertexColor and Shown). And it drops the dependency on style.width
+    -- being accurate: the strips hang off the holder, which SetAllPoints the button, so
+    -- the button rect drives the ring without ever being read (button rects are
+    -- restricted).
+    --
+    -- The strips live on a dedicated holder one frame level over the static border host
+    -- so the recolor always draws ON TOP of the border strips; the text carrier sits one
+    -- more above. Registration follows the static border: no border configured, no
+    -- dispel recolor (live parity). 68914 reworked the border API into the dispel-type
+    -- texture system: the tint-our-own-art style is now PreserveAsset on
     -- Enum.CustomAuraButtonDispelTypeTextureStyle (the old CustomAuraButtonBorderStyle
-    -- enum is deleted; its Color value is the ancestor, kept as a fallback for stale
-    -- PTR builds). The style MUST resolve: registering without it takes the
-    -- BorderWithIcon default, which stamps Blizzard atlas art over our ring texture.
+    -- enum is deleted; its Color value is the ancestor, kept as a fallback for stale PTR
+    -- builds). The style MUST resolve: registering without it takes the BorderWithIcon
+    -- default, which stamps Blizzard atlas art over ours. PreserveAsset is also the only
+    -- style that leaves our geometry alone -- it calls SetAuraBorderColor and nothing
+    -- else, no SetTexture and no SetTexCoord.
     local dispelTint = Enum and Enum.CustomAuraButtonDispelTypeTextureStyle
         and Enum.CustomAuraButtonDispelTypeTextureStyle.PreserveAsset
     if dispelTint == nil then
         local legacy = (Enum and Enum.CustomAuraButtonBorderStyle) or AuraButtonBorderStyle
         dispelTint = legacy and legacy.Color
     end
-    if style.dispelBorder and not d.dispelBorder and d.dispelHolder
+    if style.dispelBorder and not d.dispelStrips and d.dispelHolder
         and (button.AddDispelTypeTexture or button.SetAuraBorder) and dispelTint ~= nil then
-        d.dispelBorder = d.dispelHolder:CreateTexture(nil, "OVERLAY")
-        d.dispelBorder:SetTexture("Interface\\AddOns\\EllesmereUI\\media\\textures\\square-ring.png")
-        if d.dispelBorder.SetSnapToPixelGrid then
-            d.dispelBorder:SetSnapToPixelGrid(false)
-            d.dispelBorder:SetTexelSnappingBias(0)
+        -- Flat white: the engine multiplies its dispel color in through SetVertexColor,
+        -- so white is the neutral tint base. Written once here, while VertexColor is
+        -- still ours -- registration turns it into a secret aspect. Textures on our own
+        -- holder, never parented to the button, so creating them outside the button's
+        -- one legal creation window is fine.
+        --
+        -- Hidden on creation. A texture is shown by default, and the engine is what
+        -- shows these (per aura, on a typed one) -- if the registration below is denied
+        -- while auras are secret, an unhidden strip set would sit on the icon as a plain
+        -- WHITE ring until the restriction lifts and the deferred restyle re-runs.
+        local strips = {}
+        for i = 1, 4 do
+            local tex = d.dispelHolder:CreateTexture(nil, "OVERLAY")
+            tex:SetColorTexture(1, 1, 1, 1)
+            if tex.SetSnapToPixelGrid then
+                tex:SetSnapToPixelGrid(false)
+                tex:SetTexelSnappingBias(0)
+            end
+            tex:Hide()
+            strips[i] = tex
         end
-        d.dispelBorder:SetAllPoints(d.dispelHolder)
+        d.dispelStrips = strips
     end
-    if d.dispelBorder then
+    if d.dispelStrips then
         -- Level re-assert (change-guarded): a style can move the border host's level;
         -- the ring stays FOUR levels above it (PP strip container at +1, DM fx
         -- border-override container at +2, DM per-filter glow at +3 -- the dispel
@@ -353,17 +385,12 @@ local function ApplyStyleToRegions(button, style)
             if d.stackCarrier then d.stackCarrier:SetFrameLevel(bl + 5) end
             d.akDispelLvl = bl
         end
-        -- Physical-pixel thickness by SOURCE CROPPING, never stretching:
-        -- the art is a flush band of B = 16 texels on a C = 64 canvas
-        -- (B/C = 1/4). Shrinking the sampled window inward by fraction a
-        -- per side leaves (B - C*a) band texels over a C*(1-2a) span, so
-        -- the rendered thickness at drawn size s is
-        --   t = s*(B - C*a) / (C*(1-2a))   =>   a = (s - 4t) / (4*(s - 2t)).
-        -- t converts the user's physical-pixel setting into this frame's
-        -- units via the holder's effective scale (our frame -- readable);
-        -- s is the style size, never a rect read (button rects are
-        -- restricted). The cropped band stays solid at any icon size.
-        local sw = style.width or 18
+        -- Physical-pixel thickness by GEOMETRY. t converts the user's setting into this
+        -- frame's units via the holder's effective scale (our frame -- readable). The
+        -- side strips are inset by t top and bottom so no two strips ever overlap at a
+        -- corner: a dispel color carrying alpha < 1 would double-blend there and read as
+        -- four darker corner pixels. Change-guarded on t alone -- the anchors are fixed
+        -- to the holder, which tracks the button, so nothing else can move them.
         local px = style.dispelBorderPx or 2
         local t = px
         local eff = d.dispelHolder:GetEffectiveScale()
@@ -371,12 +398,25 @@ local function ApplyStyleToRegions(button, style)
             local PPx = EllesmereUI.PP
             t = px * ((PPx and PPx.perfect) or 0.75) / eff
         end
-        local a = 0
-        if sw > 4 * t then a = (sw - 4 * t) / (4 * (sw - 2 * t)) end
-        local cropKey = string.format("%s|%.4f", tostring(sw), a)
-        if d.akDispelCrop ~= cropKey then
-            d.dispelBorder:SetTexCoord(a, 1 - a, a, 1 - a)
-            d.akDispelCrop = cropKey
+        if d.akDispelT ~= t then
+            local st = d.dispelStrips
+            st[1]:ClearAllPoints()
+            st[1]:SetPoint("TOPLEFT", d.dispelHolder, "TOPLEFT", 0, 0)
+            st[1]:SetPoint("TOPRIGHT", d.dispelHolder, "TOPRIGHT", 0, 0)
+            st[1]:SetHeight(t)
+            st[2]:ClearAllPoints()
+            st[2]:SetPoint("BOTTOMLEFT", d.dispelHolder, "BOTTOMLEFT", 0, 0)
+            st[2]:SetPoint("BOTTOMRIGHT", d.dispelHolder, "BOTTOMRIGHT", 0, 0)
+            st[2]:SetHeight(t)
+            st[3]:ClearAllPoints()
+            st[3]:SetPoint("TOPLEFT", d.dispelHolder, "TOPLEFT", 0, -t)
+            st[3]:SetPoint("BOTTOMLEFT", d.dispelHolder, "BOTTOMLEFT", 0, t)
+            st[3]:SetWidth(t)
+            st[4]:ClearAllPoints()
+            st[4]:SetPoint("TOPRIGHT", d.dispelHolder, "TOPRIGHT", 0, -t)
+            st[4]:SetPoint("BOTTOMRIGHT", d.dispelHolder, "BOTTOMRIGHT", 0, t)
+            st[4]:SetWidth(t)
+            d.akDispelT = t
         end
         -- Registration follows the static border AND a nonzero thickness
         -- (0 = the user disabled the dispel recolor outright).
@@ -391,25 +431,50 @@ local function ApplyStyleToRegions(button, style)
             -- old set-semantics alias), so a re-registration must clear first -- and
             -- if the clear is denied, the add is skipped too, or the button would
             -- accumulate duplicate entries.
+            local clearFn = button.ClearDispelTypeTextures or button.ClearAuraBorder
             if want then
                 local proceed = true
                 if d.dispelBorderOn then
-                    local clearFn = button.ClearDispelTypeTextures or button.ClearAuraBorder
                     proceed = (clearFn and pcall(clearFn, button)) and true or false
                 end
-                local addFn = button.AddDispelTypeTexture or button.SetAuraBorder
-                if proceed and pcall(addFn, button, d.dispelBorder,
-                    { style = dispelTint, showWhenHarmful = true, showWhenHelpful = false,
-                      customDispelColorMap = style.dispelColorMap }) then
-                    d.dispelBorderOn = want
-                    d.akDispelMapFP = mapFP
+                if proceed then
+                    -- Four adds, ALL OR NOTHING. A denial can land on any one of them,
+                    -- and a partial set is worse than none: the engine would tint two or
+                    -- three sides and leave the rest sitting in the user's static border
+                    -- color. On any failure the whole set is cleared again (the clear is
+                    -- a full reset -- "self.dispelTypeTextures = {}") and the style key
+                    -- is deferred to the restriction lift, which re-runs this from a
+                    -- known-empty state. One options table for all four: the engine
+                    -- securecopies it per call, so sharing it cannot leak between them.
+                    local addFn = button.AddDispelTypeTexture or button.SetAuraBorder
+                    local opts = { style = dispelTint, showWhenHarmful = true,
+                        showWhenHelpful = false, customDispelColorMap = style.dispelColorMap }
+                    local added = true
+                    for i = 1, 4 do
+                        if not pcall(addFn, button, d.dispelStrips[i], opts) then
+                            added = false
+                            break
+                        end
+                    end
+                    if added then
+                        d.dispelBorderOn = want
+                        d.akDispelMapFP = mapFP
+                    else
+                        -- Rollback. dispelBorderOn goes FALSE rather than keeping its old
+                        -- value: the clear above already succeeded, so nothing is
+                        -- registered now whatever the flag said before.
+                        if clearFn then pcall(clearFn, button) end
+                        d.dispelBorderOn = false
+                        if d.styleKey and AK.AurasRestricted() then
+                            deferredRestyles[d.styleKey] = true
+                        end
+                    end
                 elseif d.styleKey and AK.AurasRestricted() then
                     deferredRestyles[d.styleKey] = true
                 end
             else
-                local clearFn = button.ClearDispelTypeTextures or button.ClearAuraBorder
                 if clearFn and pcall(clearFn, button) then
-                    d.dispelBorder:Hide()
+                    for i = 1, 4 do d.dispelStrips[i]:Hide() end
                     d.dispelBorderOn = want
                 elseif d.styleKey and AK.AurasRestricted() then
                     deferredRestyles[d.styleKey] = true


### PR DESCRIPTION
## What does this PR do?

Rebuilds the engine dispel-type ring on aura icons out of four solid strips instead of one cropped ring texture, which fixes the ring rendering semi-transparent at larger icon sizes and blending the dispel color into the user's own border color. Reported on Player Aura Bars debuffs, on both the default Debuffs bar and custom bars, at Icon Size 36 and above and most obvious around 50: a red 1px border plus a Magic debuff produced a muddy purple ring, with only the four corners showing the true dispel color.

The ring art is ours, registered with the engine purely as a tint target, because per-aura dispel data is secret and the show/hide and coloring decisions belong to Blizzard. To hold the ring at the user's physical-pixel border thickness instead of letting it scale with the icon, AuraKit cropped the source window rather than stretching the texture. The band that survives that crop measures `C*t / (2*(s - 2t))` texels for canvas `C`, thickness `t` and drawn size `s`, and it fell below a single texel once the drawn size passed `34 * t`. Under one texel the bilinear filter samples across the band's inner edge into the transparent interior, so the ring renders at alpha below 1 and the static border underneath bleeds through. The corners stayed correct because the band covers both axes there, which is exactly the artifact in the report.

Blizzard iterates every registered dispel texture rather than only the first, in `Blizzard_CustomAuraButton.lua`:

```lua
for _index, dispelTypeTexture in ipairs(self.dispelTypeTextures) do
	ApplyDispelTypeTexture(dispelTypeTexture, unitToken, auraData);
end
```

Each entry gets its own visibility test against its own options, its own `SetVertexColor` and its own `Show`/`Hide`, so a four-texture ring is exactly as supported as a one-texture ring. The ring is therefore now four flat white color textures that the engine tints, with thickness expressed as geometry. Solid strips do no texel sampling at all, so the ring holds at any icon size instead of degrading past a threshold.

Two things fall out of that beyond the bug itself. It keeps us off `SetTexCoord`, which `AddDispelTypeTexture` stamps as a secret aspect on every texture it takes, alongside `Alpha`, `VertexColor` and `Shown`. And it removes the dependency on `style.width` being accurate: the strips hang off the dispel holder, which `SetAllPoints` the button, so the button rect drives the ring geometry without ever being read, and button rects are restricted.

The side strips are inset by the thickness at top and bottom so no two strips overlap at a corner, which would double-blend a dispel color carrying alpha below 1 into four darker corner pixels. Registration is all or nothing: a denial can land on any of the four adds, and a partial set would leave the engine tinting some sides while the others keep sitting in the user's static border color, so any failure clears the whole set and defers the style key to the restriction lift, which re-runs from a known-empty state. That path also corrects a pre-existing inconsistency in the single-texture code, where a successful clear followed by a failed add left `dispelBorderOn` true with nothing actually registered. Strips are created hidden, because a texture is shown by default and the engine is what shows these; a denied registration would otherwise leave a plain white ring on the icon until the deferred restyle ran. That was equally true of the old single ring texture.

The style contract is unchanged (`dispelBorder`, `dispelBorderPx`, `dispelColorMap`, `dispelColorFP`), so Unit Frames, Raid Frames, Nameplates and Player Aura Bars need no changes and inherit the fix. `media/textures/square-ring.png` becomes unused; it is deliberately left in the tree in this PR rather than deleted, so that this branch and the alternative below do not fight over the same file. It can be removed in a follow-up once one of the two lands.

### Relationship to the other open PR

PR #1435 fixes the same bug a different way, by re-cutting `square-ring.png` at a higher resolution so the cropped band keeps enough texels to stay opaque. The two cannot both be merged: they change the same block of `ApplyStyleToRegions`. Both are offered so the choice is yours rather than mine, and the honest trade is below.

What this PR does better:

- It removes the failure mode instead of moving it. The asset PR raises the threshold from icon size 34 to roughly 66 with comfortable margin, which clears today's 16 to 60 Icon Size slider but would need revisiting if that maximum is ever raised. Solid strips have no threshold at all.
- It stops writing `SetTexCoord` on a registered texture. Blizzard marks `TexCoords` as a secret aspect the moment `AddDispelTypeTexture` takes the texture. That write currently works, and the reported symptom proves it still lands, but the cropping approach depends on it continuing to be permitted, and this one does not depend on it at all.
- It drops the `style.width` dependency. The crop math needs the style size to match what is actually drawn, or the ring thickness is wrong; strips derive from the holder rect and cannot disagree with the button.
- It removes a shipped media file from the render path, along with its texture memory.
- It fixes the `dispelBorderOn` rollback inconsistency described above, which the asset PR leaves in place.

What the asset PR does better:

- It is far smaller: 18 changed lines and a re-cut PNG, against 114 insertions and 49 deletions here, in shared code that four modules consume.
- It touches no logic at all, so there is nothing new to review in the restricted-execution path. This PR adds a four-call registration loop and a rollback branch that did not exist before.
- It costs one texture object per aura button. This PR costs four, which multiplies across Raid Frames at full raid size. Fill cost likely moves the other way, since four thin quads beat one mostly-transparent full-icon quad, but the object count is strictly higher.

## How was it tested?

Live retail (Midnight 12.1). Verified on a Player Aura Bars debuff bar that the strips render in the engine's dispel color rather than white, that the ring thickness matches the configured border size, and that the mixing with the border color at Icon Size 50 is gone. Furthermore I tested multiple icon sizes, border sizes and colors. Border Size 0 = no color/border. Tested with dev mode in dungeon.

Still needs testing: Other affected auras like UnitFrames, RaidFrames and Nameplates.

## Screenshots

Before: Icon Size 56, 1px red border, Magic debuff. The ring reads as a blend of red and the Magic dispel color, with only single corner pixels showing the true color.
<img width="349" height="174" alt="grafik" src="https://github.com/user-attachments/assets/c84dd0a2-e782-4521-bfdd-eba6412e18f2" />
<img width="166" height="106" alt="grafik" src="https://github.com/user-attachments/assets/e6769d0d-7aa5-4f1d-a6d4-ab3dcf4fa0d5" />


After: multiple size settings, the ring renders in the flat Magic dispel color at the same 1px thickness.
<img width="334" height="405" alt="grafik" src="https://github.com/user-attachments/assets/38feda40-614c-4444-9a0c-247e1e0adff4" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
  - N/A. No new settings. This is a bug fix to an existing, already opt-in display, which the criteria explicitly allow to change behavior without a new opt-in.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
  - Nothing is built unless a style asks for `dispelBorder`. The strips are created lazily on first styling of such a button, exactly where the single ring texture was created before. No new events, hooks or frames anywhere.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
  - No polling and no OnUpdate. Geometry is change-guarded on the computed thickness, so a restyle that does not move it writes nothing, replacing the previous crop-key guard one for one. The registration loop runs only when the on/off state or the color-map fingerprint changes, not per aura update. The one honest regression is four texture objects per aura button instead of one, and one options table allocated per re-registration.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
  - The strips are textures we create on our own holder frame and hand to the engine through its own `AddDispelTypeTexture` API. No Blizzard frame is written to and no script is replaced. Per-button state stays on AuraKit's existing weak-keyed side table.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
  - Verified on live as described above. No version gates. The existing 12.1 dispel-type texture path is used as documented, including the `PreserveAsset` style, which is the only style that leaves our asset and texture coordinates untouched.