### PR TITLE
fix(chat): input-on-top not masking text on non-first tabs

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -2650,14 +2650,45 @@ local INPUT_TOP_DROP = 5
 -- reservation follows the edit box's SHOWN state on the permanent frames 1-10,
 -- whose edit boxes may be script-hooked. Temp windows (11+) must never be
 -- hooked (see SkinEditBox's taint note) and keep the static reservation.
+-- The box overlaying a window is NOT always that window's own. Blizzard's
+-- DEFAULT chatStyle ("classic") routes every window's input through
+-- DEFAULT_CHAT_FRAME's box -- ChatFrameUtil.ChooseBoxForSend returns
+-- DEFAULT_CHAT_FRAME.editBox outright in that mode, before it ever looks at
+-- the preferred frame -- so on any tab but the first, ChatFrame1EditBox is
+-- what appears over the text while that tab's OWN edit box stays hidden.
+-- Keying the strip off cf's own box therefore left every other tab unmasked
+-- (reported 2026-08-14) and reserved a strip on ChatFrame1's hidden window
+-- instead. Docked windows share one rect, so a box shown on any docked frame
+-- is drawn over whichever docked frame is currently visible.
+local function DockedEditBoxShown()
+    for i = 1, 10 do
+        local owner = _G["ChatFrame" .. i]
+        local box = owner and _G["ChatFrame" .. i .. "EditBox"]
+        if box and box:IsShown() and owner.isDocked then return true end
+    end
+    return false
+end
+
 function ECHAT.InputTopStripActive(cf)
     if not ECHAT.DB().inputOnTop then return false end
     local name = cf:GetName()
     local eb = name and _G[name .. "EditBox"]
     if not eb then return false end
     local idx = tonumber(name:match("ChatFrame(%d+)"))
-    if idx and idx <= 10 then return eb:IsShown() end
-    return true
+    if not (idx and idx <= 10) then return true end
+    -- Own box up: "im" style, and any undocked window, keep the old rule.
+    if eb:IsShown() then return true end
+    return (cf.isDocked and cf:IsShown() and DockedEditBoxShown()) and true or false
+end
+
+-- Every managed frame, not just one: the box that showed belongs to ChatFrame1
+-- while the strip is owed to the selected tab (see InputTopStripActive), so a
+-- single-frame re-derive off the edit box hooks updates the wrong window.
+function ECHAT.RefreshInputTopStrips()
+    for i = 1, 20 do
+        local cf = _G["ChatFrame" .. i]
+        if cf and CFD(cf).bg then ECHAT.ApplyInputTopStrip(cf) end
+    end
 end
 
 -- Re-derive one frame's reserved strip. Only the text area moves: the panel
@@ -3796,10 +3827,10 @@ local function SkinEditBox(cf)
         -- height. OnShow/OnHide are C-side script hooks -- no field write onto
         -- the edit box, the hazard the block comment above describes.
         eb:HookScript("OnShow", function()
-            ECHAT.ApplyInputTopStrip(cf)
+            ECHAT.RefreshInputTopStrips()
         end)
         eb:HookScript("OnHide", function()
-            ECHAT.ApplyInputTopStrip(cf)
+            ECHAT.RefreshInputTopStrips()
         end)
 
         -- Plain Up/Down input recall. The Midnight edit box performs no native recall


### PR DESCRIPTION
## What does this PR do?

Fixes the Chat module's "Input on Top" option not masking chat text on any tab other than the first one. With the option enabled, the input box overlays the top strip of the text area and the message view hands that strip back so no line renders underneath. That only worked on the General tab: on every other tab the "Say:" input was drawn directly on top of the chat text, overlapping it instead of covering a reserved strip.

The cause is which edit box actually opens. Blizzard's default chat style ("classic") routes every window's input through DEFAULT_CHAT_FRAME's edit box, and `ChatFrameUtil.ChooseBoxForSend` returns that box outright in this mode, before it ever considers the preferred chat frame. The strip reservation was keyed off each chat frame's own edit box being shown, so on a non-first tab the visible window reported no strip while a strip was reserved on ChatFrame1's hidden window instead.

The reservation now falls back to the frame that is docked and shown whenever any docked edit box is up, since docked windows share a single rect and the box is therefore drawn over whichever of them is currently selected. Where a window's own edit box does open, the previous rule still applies, so the "im" chat style and undocked windows are unaffected. The edit box show/hide hooks were also re-deriving only their own frame, which updated the wrong window for the same reason, and now re-derive every managed frame.

No new settings, no default changes. Behavior is unchanged unless "Input on Top" is enabled, and unchanged on the first tab even then.

## How was it tested?

Tested in game on the live retail client. With "Input on Top" enabled, opened chat input on a user-created tab (right-click a tab, New Window) and confirmed the message text is now masked behind the input line instead of running into it, which was the reported symptom. Confirmed the General tab still behaves exactly as before, that switching tabs with the input open moves the reserved strip to the newly selected tab rather than leaving it on the previous one, and that with "Input on Top" disabled the bottom-anchored input path is untouched.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- no new settings; this only corrects the existing "Input on Top" option, which is off by default
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- `InputTopStripActive` returns on the `inputOnTop` check before any of the new work runs
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- no OnUpdate and no new registrations; the added scan runs on edit box show/hide only, is bounded at 10 frames, and allocates nothing. The existing hook closures were reused rather than added to
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- the new code only reads `IsShown()` and Blizzard's `isDocked` field; per-frame state stays in the existing CFD side table and the two edit box hooks are the pre-existing `HookScript` ones
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added