### PR TITLE
fix(qol): movement alert dies on an undefined ns

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -1088,14 +1088,17 @@ end
 -- universal off-path -- can park the host; defined in the lane block below).
 local buffAlertHost, buffAlertBuilt, buffAlertRegenArm, buffAlertLastCount
 
-local function HideMovementDisplay()
+-- keepBuffLane: the cooldown display is going away but the buffActive lane is
+-- not. A buffActive spell takes no slot, so an empty cooldown stack is its
+-- NORMAL state -- parking the host there would hide the alert permanently.
+local function HideMovementDisplay(keepBuffLane)
     wipe(readyAlertShown)
     movementFrame:Hide()
     for _, slot in ipairs(displayPool) do
         slot.text:Hide(); slot.icon:Hide(); slot.icon.cooldown:Clear(); slot.bar:Hide(); HideEngineCountdown(slot); slot:Hide()
     end
     activeSlotCount = 0
-    if buffAlertHost then buffAlertHost:Hide() end
+    if buffAlertHost and not keepBuffLane then buffAlertHost:Hide() end
     CancelMovementCountdown()
 end
 
@@ -1614,7 +1617,9 @@ CheckMovementCooldown = function()
         movementCountdownTimer = C_Timer.NewTimer(0.1, CheckMovementCooldown)
     else
         activeSlotCount = 0
-        HideMovementDisplay()
+        -- EnsureBuffAlertLane just showed/parked the host for this pass; leave
+        -- its verdict alone (see keepBuffLane).
+        HideMovementDisplay(true)
     end
 end
 EllesmereUI._CheckMovementCooldown = function() if CheckMovementCooldown then CheckMovementCooldown() end end

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -1086,7 +1086,7 @@ end
 
 -- buffActive engine-lane handles (declared here so HideMovementDisplay -- the
 -- universal off-path -- can park the host; defined in the lane block below).
-local buffAlertHost, buffAlertBuilt, buffAlertRegenArm
+local buffAlertHost, buffAlertBuilt, buffAlertRegenArm, buffAlertLastCount
 
 local function HideMovementDisplay()
     wipe(readyAlertShown)
@@ -1440,13 +1440,13 @@ end
 -- counted stack height.
 local function RepositionBuffAlertHost(count)
     if not buffAlertHost then return end
-    ns._maLastSlotCount = count
+    buffAlertLastCount = count
     if InCombatLockdown() then
         if not buffAlertRegenArm then
             buffAlertRegenArm = CreateFrame("Frame")
             buffAlertRegenArm:SetScript("OnEvent", function(self)
                 self:UnregisterEvent("PLAYER_REGEN_ENABLED")
-                RepositionBuffAlertHost(ns._maLastSlotCount or 0)
+                RepositionBuffAlertHost(buffAlertLastCount or 0)
             end)
         end
         buffAlertRegenArm:RegisterEvent("PLAYER_REGEN_ENABLED")


### PR DESCRIPTION
**Cause:** `RepositionBuffAlertHost` stored its slot count on `ns`, a name EllesmereUIQoL_MovementAlert.lua never captures from the addon varargs, so the write threw every render pass once a buffActive spell (Burning Rush) built the host. The throw aborted `CheckMovementCooldown` before the show/refresh block, so no alert rendered and the host kept its provisional CENTER seat.

**Fix:** keep the count in a file-local alongside the other buff-alert handles.

**Test:** warlock with Burning Rush enabled in Movement Alerts, activate it in and out of combat: alert shows and the icon seats at the alert stack, no Lua error.