### PR TITLE
feat(nameplates): disable nontank aggro color

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -105,7 +105,8 @@ function ns._appendDisplayPresetKeys(t)
         "textSlotTopColor", "textSlotRightColor", "textSlotLeftColor", "textSlotCenterColor",
         "tankHasAggroEnabled", "tankHasAggro", "classicTankAggro", "tankHasAggroOverrideMobType",
         "tankHasAggroOverrideBoss",
-        "dpsHasAggro", "dpsNearAggro", "offTankAggroEnabled", "offTankAggro",
+        "dpsHasAggroEnabled", "dpsHasAggro", "dpsNearAggroEnabled", "dpsNearAggro",
+        "offTankAggroEnabled", "offTankAggro",
         "dpsNoAggroEnabled", "dpsNoAggro", "dpsNoAggroOverrideMiniBoss", "dpsNoAggroOverrideCaster",
         "targetArrowDouble", "targetArrowStyle", "targetArrowColor", "targetArrowClassColor",
         "auraStackTextSize", "auraStackTextColor",
@@ -185,8 +186,10 @@ local defaults = {
     tankLosingAggro = { r = 0.81, g = 0.72, b = 0.19 },
     tankNoAggro = { r = 1.00, g = 0.22, b = 0.17 },
     dpsNearAggro = { r = 0.81, g = 0.72, b = 0.19 },
+    dpsNearAggroEnabled = true,  -- off: near-aggro does not recolor (glow also stays off)
     threatNearAggroGlow = false,  -- Non-Tank Threat cog: red glow while the Near Aggro color is active
     dpsHasAggro = { r = 1.00, g = 0.50, b = 0.00 },
+    dpsHasAggroEnabled = true,  -- off: has-aggro does not recolor; caster/miniboss/etc. stay
     offTankAggro = { r = 0.188, g = 0.761, b = 0.812 },
     offTankAggroEnabled = true,
     dpsNoAggro = { r = 0.35, g = 0.75, b = 0.35 },
@@ -4652,7 +4655,8 @@ local function GetReactionColor(unit)
         return qc.r, qc.g, qc.b
     end
     -- Threat colors that can NEVER be overwritten:
-    -- Non-tank: has aggro, near aggro Tank: losing aggro, no aggro
+    -- Non-tank: has aggro, near aggro (each skippable via dpsHasAggroEnabled /
+    -- dpsNearAggroEnabled; both default on) Tank: losing aggro, no aggro
     local isThreatUnit = false   -- set true when threat data exists
     local threatStatus = 0
     if InRealInstancedContent() then
@@ -4665,12 +4669,21 @@ local function GetReactionColor(unit)
                 -- Only apply when in a group (solo players always have aggro)
                 if IsInGroup() then
                 if status >= 3 then
-                    local c = _C("dpsHasAggro")
-                    return c.r, c.g, c.b
+                    -- Off: fall through so caster/miniboss/etc. keep their color.
+                    local enabled = defaults.dpsHasAggroEnabled
+                    if db.dpsHasAggroEnabled ~= nil then enabled = db.dpsHasAggroEnabled end
+                    if enabled then
+                        local c = _C("dpsHasAggro")
+                        return c.r, c.g, c.b
+                    end
                 elseif status >= 2 then
-                    ns._reactionNearAggro = true
-                    local c = _C("dpsNearAggro")
-                    return c.r, c.g, c.b
+                    local enabled = defaults.dpsNearAggroEnabled
+                    if db.dpsNearAggroEnabled ~= nil then enabled = db.dpsNearAggroEnabled end
+                    if enabled then
+                        ns._reactionNearAggro = true
+                        local c = _C("dpsNearAggro")
+                        return c.r, c.g, c.b
+                    end
                 end
                 end
             else

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -10062,77 +10062,17 @@ initFrame:SetScript("OnEvent", function(self)
         -----------------------------------------------------------------------
         _, h = W:SectionHeader(parent, SECTION_THREAT, y);  y = y - h
 
-        -- Row 1: Tank Threat (left) ---- Non-Tank Threat (right)
-        local threatRow
-        threatRow, h = W:DualRow(parent, y,
-            { type="multiSwatch", text="Tank Threat",
-              swatches = {
-                { tooltip = "Losing Aggro",
-                  getValue = function() return DBColor("tankLosingAggro") end,
-                  setValue = function(r, g, b)
-                    DB().tankLosingAggro = { r = r, g = g, b = b }
-                    RefreshAllPlates()
-                  end },
-                { tooltip = "No Aggro",
-                  getValue = function() return DBColor("tankNoAggro") end,
-                  setValue = function(r, g, b)
-                    DB().tankNoAggro = { r = r, g = g, b = b }
-                    RefreshAllPlates()
-                  end },
-              } },
-            { type="multiSwatch", text="Non-Tank Threat",
-              swatches = {
-                { tooltip = "Has Aggro",
-                  getValue = function() return DBColor("dpsHasAggro") end,
-                  setValue = function(r, g, b)
-                    DB().dpsHasAggro = { r = r, g = g, b = b }
-                    RefreshAllPlates()
-                  end },
-                { tooltip = "Near Aggro",
-                  getValue = function() return DBColor("dpsNearAggro") end,
-                  setValue = function(r, g, b)
-                    DB().dpsNearAggro = { r = r, g = g, b = b }
-                    RefreshAllPlates()
-                  end },
-              } });  y = y - h
-
-        -- Inline cog on "Non-Tank Threat": steady red execute-style glow
-        -- while the Near Aggro color is active (see EnsureNearAggroGlow).
-        if not EllesmereUI._prebuilding then
-            local rgn = threatRow._rightRegion
-            local _, ntCogShow = EllesmereUI.BuildCogPopup({
-                title = "Near Aggro",
-                rows = {
-                    { type="toggle", label="Glow Nameplate When Near Aggro",
-                      tooltip="Adds a steady red glow around the nameplate while the Near Aggro color is active.",
-                      get=function()
-                        local db = DB()
-                        local v = db and db.threatNearAggroGlow
-                        if v == nil then v = defaults.threatNearAggroGlow end
-                        return v
-                      end,
-                      set=function(v)
-                        DB().threatNearAggroGlow = v and true or false
-                        for _, plate in pairs(ns.plates) do
-                            plate:UpdateHealthColor()
-                        end
-                      end },
-                },
-            })
-            local ntCogBtn = CreateFrame("Button", nil, rgn)
-            ntCogBtn:SetSize(26, 26)
-            ntCogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-            rgn._lastInline = ntCogBtn
-            ntCogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
-            ntCogBtn:SetAlpha(0.4)
-            local ntCogTex = ntCogBtn:CreateTexture(nil, "OVERLAY")
-            ntCogTex:SetAllPoints(); ntCogTex:SetTexture(EllesmereUI.COGS_ICON)
-            ntCogBtn:SetScript("OnEnter", function(s) s:SetAlpha(0.7) end)
-            ntCogBtn:SetScript("OnLeave", function(s) s:SetAlpha(0.4) end)
-            ntCogBtn:SetScript("OnClick", function(s) ntCogShow(s) end)
+        -- Disabled-state helpers (shared across Row 1 swatches / Row 2-4)
+        local function isDpsHasAggroDisabled()
+            local db = DB()
+            if db and db.dpsHasAggroEnabled ~= nil then return not db.dpsHasAggroEnabled end
+            return not defaults.dpsHasAggroEnabled
         end
-
-        -- Disabled-state helpers (shared across Row 2 / Row 3 swatches)
+        local function isDpsNearAggroDisabled()
+            local db = DB()
+            if db and db.dpsNearAggroEnabled ~= nil then return not db.dpsNearAggroEnabled end
+            return not defaults.dpsNearAggroEnabled
+        end
         local function isTankHasAggroDisabled()
             local db = DB()
             if db and db.tankHasAggroEnabled ~= nil then return not db.tankHasAggroEnabled end
@@ -10154,7 +10094,119 @@ initFrame:SetScript("OnEvent", function(self)
             return not defaults.dpsNoAggroEnabled
         end
 
-        -- Row 2: DPS: Show Special "No Aggro" Color (left) ---- Classic Tank Aggro (right)
+        -- Row 1: Tank Threat (left) ---- Non-Tank Threat (right)
+        local threatRow
+        threatRow, h = W:DualRow(parent, y,
+            { type="multiSwatch", text="Tank Threat",
+              swatches = {
+                { tooltip = "Losing Aggro",
+                  getValue = function() return DBColor("tankLosingAggro") end,
+                  setValue = function(r, g, b)
+                    DB().tankLosingAggro = { r = r, g = g, b = b }
+                    RefreshAllPlates()
+                  end },
+                { tooltip = "No Aggro",
+                  getValue = function() return DBColor("tankNoAggro") end,
+                  setValue = function(r, g, b)
+                    DB().tankNoAggro = { r = r, g = g, b = b }
+                    RefreshAllPlates()
+                  end },
+              } },
+            { type="multiSwatch", text="Non-Tank Threat",
+              swatches = {
+                { tooltip = "Has Aggro",
+                  disabled = isDpsHasAggroDisabled,
+                  disabledTooltip = "DPS: Show \"Has Aggro\" Color",
+                  getValue = function() return DBColor("dpsHasAggro") end,
+                  setValue = function(r, g, b)
+                    DB().dpsHasAggro = { r = r, g = g, b = b }
+                    RefreshAllPlates()
+                  end },
+                { tooltip = "Near Aggro",
+                  disabled = isDpsNearAggroDisabled,
+                  disabledTooltip = "DPS: Show \"Near Aggro\" Color",
+                  getValue = function() return DBColor("dpsNearAggro") end,
+                  setValue = function(r, g, b)
+                    DB().dpsNearAggro = { r = r, g = g, b = b }
+                    RefreshAllPlates()
+                  end },
+              } });  y = y - h
+
+        -- Inline cog on "Non-Tank Threat": steady red execute-style glow
+        -- while the Near Aggro color is active (see EnsureNearAggroGlow).
+        if not EllesmereUI._prebuilding then
+            local rgn = threatRow._rightRegion
+            local _, ntCogShow = EllesmereUI.BuildCogPopup({
+                title = "Near Aggro",
+                rows = {
+                    { type="toggle", label="Glow Nameplate When Near Aggro",
+                      tooltip="Adds a steady red glow around the nameplate while the Near Aggro color is active.",
+                      disabled=isDpsNearAggroDisabled,
+                      disabledTooltip="DPS: Show \"Near Aggro\" Color",
+                      get=function()
+                        local db = DB()
+                        local v = db and db.threatNearAggroGlow
+                        if v == nil then v = defaults.threatNearAggroGlow end
+                        return v
+                      end,
+                      set=function(v)
+                        DB().threatNearAggroGlow = v and true or false
+                        for _, plate in pairs(ns.plates) do
+                            plate:UpdateHealthColor()
+                        end
+                      end },
+                },
+            })
+            local ntCogBtn = CreateFrame("Button", nil, rgn)
+            ntCogBtn:SetSize(26, 26)
+            ntCogBtn:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
+            rgn._lastInline = ntCogBtn
+            ntCogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            local ntCogTex = ntCogBtn:CreateTexture(nil, "OVERLAY")
+            ntCogTex:SetAllPoints(); ntCogTex:SetTexture(EllesmereUI.COGS_ICON)
+            ntCogBtn:SetScript("OnEnter", function(s) if not isDpsNearAggroDisabled() then s:SetAlpha(0.7) end end)
+            ntCogBtn:SetScript("OnLeave", function(s) if not isDpsNearAggroDisabled() then s:SetAlpha(0.4) end end)
+            ntCogBtn:SetScript("OnClick", function(s) if not isDpsNearAggroDisabled() then ntCogShow(s) end end)
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local cogOff = isDpsNearAggroDisabled()
+                ntCogBtn:SetAlpha(cogOff and 0.15 or 0.4)
+                ntCogBtn:EnableMouse(not cogOff)
+            end)
+            do
+                local cogOff = isDpsNearAggroDisabled()
+                ntCogBtn:SetAlpha(cogOff and 0.15 or 0.4)
+                ntCogBtn:EnableMouse(not cogOff)
+            end
+        end
+
+        -- Row 2: DPS: Show "Has Aggro" Color (left) ---- DPS: Show "Near Aggro" Color (right)
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="DPS: Show \"Has Aggro\" Color",
+              tooltip="Recolors nameplates when you have aggro, including casters and mini-bosses. Disable to keep enemy-type colors.",
+              getValue=function()
+                local db = DB()
+                if db and db.dpsHasAggroEnabled ~= nil then return db.dpsHasAggroEnabled end
+                return defaults.dpsHasAggroEnabled
+              end,
+              setValue=function(v)
+                DB().dpsHasAggroEnabled = v
+                RefreshAllPlates()
+                EllesmereUI:RefreshPage()
+              end },
+            { type="toggle", text="DPS: Show \"Near Aggro\" Color",
+              tooltip="Recolors nameplates when you are close to pulling aggro, including casters and mini-bosses. Disable to keep enemy-type colors.",
+              getValue=function()
+                local db = DB()
+                if db and db.dpsNearAggroEnabled ~= nil then return db.dpsNearAggroEnabled end
+                return defaults.dpsNearAggroEnabled
+              end,
+              setValue=function(v)
+                DB().dpsNearAggroEnabled = v
+                RefreshAllPlates()
+                EllesmereUI:RefreshPage()
+              end });  y = y - h
+
+        -- Row 3: DPS: Show Special "No Aggro" Color (left) ---- Classic Tank Aggro (right)
         local dpsDualFrame
         dpsDualFrame, h = W:DualRow(parent, y,
             { type="toggle", text="DPS: Show Special \"No Aggro\" Color",
@@ -10264,7 +10316,7 @@ initFrame:SetScript("OnEvent", function(self)
             swatch:EnableMouse(not off)
         end
 
-        -- Row 3: Tank: Show Special "Has Aggro" Color (left) ---- Tank: Show Special "Off-Tank" Color (right)
+        -- Row 4: Tank: Show Special "Has Aggro" Color (left) ---- Tank: Show Special "Off-Tank" Color (right)
         local tankDualFrame
         tankDualFrame, h = W:DualRow(parent, y,
             { type="toggle", text="Tank: Show Special \"Has Aggro\" Color",

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -10116,7 +10116,7 @@ initFrame:SetScript("OnEvent", function(self)
               swatches = {
                 { tooltip = "Has Aggro",
                   disabled = isDpsHasAggroDisabled,
-                  disabledTooltip = "DPS: Show \"Has Aggro\" Color",
+                  disabledTooltip = "DPS: Has Aggro Color",
                   getValue = function() return DBColor("dpsHasAggro") end,
                   setValue = function(r, g, b)
                     DB().dpsHasAggro = { r = r, g = g, b = b }
@@ -10124,7 +10124,7 @@ initFrame:SetScript("OnEvent", function(self)
                   end },
                 { tooltip = "Near Aggro",
                   disabled = isDpsNearAggroDisabled,
-                  disabledTooltip = "DPS: Show \"Near Aggro\" Color",
+                  disabledTooltip = "DPS: Near Aggro Color",
                   getValue = function() return DBColor("dpsNearAggro") end,
                   setValue = function(r, g, b)
                     DB().dpsNearAggro = { r = r, g = g, b = b }
@@ -10142,7 +10142,7 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="toggle", label="Glow Nameplate When Near Aggro",
                       tooltip="Adds a steady red glow around the nameplate while the Near Aggro color is active.",
                       disabled=isDpsNearAggroDisabled,
-                      disabledTooltip="DPS: Show \"Near Aggro\" Color",
+                      disabledTooltip="DPS: Near Aggro Color",
                       get=function()
                         local db = DB()
                         local v = db and db.threatNearAggroGlow
@@ -10179,9 +10179,9 @@ initFrame:SetScript("OnEvent", function(self)
             end
         end
 
-        -- Row 2: DPS: Show "Has Aggro" Color (left) ---- DPS: Show "Near Aggro" Color (right)
+        -- Row 2: DPS: Has Aggro Color (left) ---- DPS: Near Aggro Color (right)
         _, h = W:DualRow(parent, y,
-            { type="toggle", text="DPS: Show \"Has Aggro\" Color",
+            { type="toggle", text="DPS: Has Aggro Color",
               tooltip="Recolors nameplates when you have aggro, including casters and mini-bosses. Disable to keep enemy-type colors.",
               getValue=function()
                 local db = DB()
@@ -10193,7 +10193,7 @@ initFrame:SetScript("OnEvent", function(self)
                 RefreshAllPlates()
                 EllesmereUI:RefreshPage()
               end },
-            { type="toggle", text="DPS: Show \"Near Aggro\" Color",
+            { type="toggle", text="DPS: Near Aggro Color",
               tooltip="Recolors nameplates when you are close to pulling aggro, including casters and mini-bosses. Disable to keep enemy-type colors.",
               getValue=function()
                 local db = DB()


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Non-tank Has Aggro and Near Aggro colors can be turned off.

Until now those two colors always overrode caster, mini-boss, and other enemy-type colors the moment you had (or were near) aggro. There were swatches to recolor them, but no way to disable the override. Inspired by this conversation of my guildies: 

<img width="1831" height="859" alt="image" src="https://github.com/user-attachments/assets/7b879d64-0bb5-464f-9272-51afa4c263c1" />

## How was it tested?

Live retail, follower dungeon, queued as DPS. Pulled casters with Has Aggro on (plates went to the aggro color, including casters) and off (casters kept their type color while I still had aggro).

## Screenshots

<img width="947" height="266" alt="image" src="https://github.com/user-attachments/assets/ef5aed63-59c9-472b-b0b0-7450756fa3e2" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [ ] New settings default **OFF** (no behavior change without opt-in) -> Technically, it should be the new default
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
