### PR TITLE
fix(player castbar) Hide border for the castbar when borderSize is 0

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -6397,14 +6397,19 @@ BuildCastBar = function()
     -- Border: update the dedicated child border frame (PP or textured)
     if castBarFrame._border then
         local bs = cb.borderSize or 0
-        local texKey = cb.borderTexture or "solid"
-        -- "Show Behind": +5 in front of the bar, level-1 behind it.
-        local pl = castBarFrame:GetFrameLevel()
-        castBarFrame._border:SetFrameLevel(cb.borderBehind and math.max(0, pl - 1) or (pl + 5))
-        EllesmereUI.ApplyBorderStyle(castBarFrame._border, bs,
-            cb.borderR or 0, cb.borderG or 0, cb.borderB or 0, cb.borderA or 1,
-            texKey, cb.borderTextureOffset, cb.borderTextureOffsetY,
-            cb.borderTextureShiftX, cb.borderTextureShiftY, "resourcebars", bs)
+        if bs > 0 then
+            local texKey = cb.borderTexture or "solid"
+            -- "Show Behind": +5 in front of the bar, level-1 behind it.
+            local pl = castBarFrame:GetFrameLevel()
+            castBarFrame._border:SetFrameLevel(cb.borderBehind and math.max(0, pl - 1) or (pl + 5))
+            EllesmereUI.ApplyBorderStyle(castBarFrame._border, bs,
+                cb.borderR or 0, cb.borderG or 0, cb.borderB or 0, cb.borderA or 1,
+                texKey, cb.borderTextureOffset, cb.borderTextureOffsetY,
+                cb.borderTextureShiftX, cb.borderTextureShiftY, "resourcebars", bs)
+            if PP and PP.ShowBorder then PP.ShowBorder(castBarFrame._border) end
+        else
+            if PP and PP.HideBorder then PP.HideBorder(castBarFrame._border) end
+        end
     end
 
     -- Icon: left or right side (iconOnRight), full height, no inset
@@ -6426,15 +6431,19 @@ BuildCastBar = function()
     -- Clip frame + bar: beside the icon (or full width), full height
     local clipFrame = castBarFrame._barClip
     local bar = castBarFrame._bar
-    local bdrInset = (PP and PP.mult) or 1
+    local bs = cb.borderSize or 0
+    local bdrInset = (bs > 0 and PP and PP.mult) or 0
     clipFrame:ClearAllPoints()
+    
     -- The icon-adjacent side sits FLUSH against the icon (no inset): that seam is
     -- interior with no border, and insetting it exposes a 1px background column
     -- next to the icon. Outer edges keep the inset so the fill never bleeds out.
-    local clipLeft  = (hasIcon and not iconOnRight) and h or bdrInset
-    local clipRight = iconOnRight and h or bdrInset
-    clipFrame:SetPoint("TOPLEFT", castBarFrame, "TOPLEFT", clipLeft, -bdrInset)
-    clipFrame:SetPoint("BOTTOMRIGHT", castBarFrame, "BOTTOMRIGHT", -clipRight, bdrInset)
+    local clipLeft  = (hasIcon and not iconOnRight) and h or (bs > 0 and bdrInset or 0)
+    local clipRight = (hasIcon and iconOnRight) and h or (bs > 0 and bdrInset or 0)
+    local clipTopBot = (bs > 0 and bdrInset or 0)
+
+    clipFrame:SetPoint("TOPLEFT", castBarFrame, "TOPLEFT", clipLeft, -clipTopBot)
+    clipFrame:SetPoint("BOTTOMRIGHT", castBarFrame, "BOTTOMRIGHT", -clipRight, clipTopBot)
     clipFrame:SetFrameLevel(castBarFrame:GetFrameLevel() + 1)
     bar:ClearAllPoints()
     bar:SetAllPoints(clipFrame)
@@ -7115,7 +7124,12 @@ function ns.ApplyCastBgAnchor()
     local bar = castBarFrame._bar
     local casting = castBarFrame._casting or castBarFrame._channeling or castBarFrame._empowering
     castBarFrame._bg:ClearAllPoints()
-    if casting and (cb.fillOpacity or 100) < 100 then
+    
+    local bs = cb.borderSize or 0
+    if bs == 0 then
+        -- No border: Background strictly covers the active bar clip area
+        castBarFrame._bg:SetAllPoints(castBarFrame._barClip or castBarFrame)
+    elseif casting and (cb.fillOpacity or 100) < 100 then
         castBarFrame._bg:SetPoint("TOPLEFT", bar:GetStatusBarTexture(), "TOPRIGHT", 0, 0)
         castBarFrame._bg:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", 0, 0)
     else
@@ -7916,7 +7930,7 @@ BuildGCDBar = function()
     -- it eats the whole height of very thin bars (height 1-2 -> nothing visible).
     local clipFrame = gcdBarFrame._barClip
     local bar = gcdBarFrame._bar
-    local bdrInset = ((g.borderSize or 0) > 0 and PP and PP.mult) or 0
+    local bdrInset = ((cb.borderSize or 0) > 0 and PP and PP.mult) or 0
     clipFrame:ClearAllPoints()
     clipFrame:SetPoint("TOPLEFT", gcdBarFrame, "TOPLEFT", bdrInset, -bdrInset)
     clipFrame:SetPoint("BOTTOMRIGHT", gcdBarFrame, "BOTTOMRIGHT", -bdrInset, bdrInset)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Bug report: https://discord.com/channels/585577383847788554/1537251571593912371

Even when set the border size = 0 for the cast bar, when casting something, the border still shows. This PR hides the border when borderSize is 0

<!-- User-facing description: what changes for the player? -->

## How was it tested?

<!-- Client build, what you tested in game, etc. -->

Tested in-game with multiple settings with border size is 0 or > 0.
Also enable the show Icon to make sure everything works fine without breaking.


## Screenshots

With border size = 0
<img width="2548" height="1417" alt="after0" src="https://github.com/user-attachments/assets/3f2dedce-18a9-4171-a43f-bfe978c6321a" />

With border size > 0
<img width="2368" height="1467" alt="after1" src="https://github.com/user-attachments/assets/37dc19de-4be7-4613-9477-619879d7a930" />


<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
