### PR TITLE
Implement hyperlink stripping in chat display

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat_Engine.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Engine.lua
@@ -1172,6 +1172,14 @@ function ECHAT.EngineGetMessageLines(cf, out)
     return n
 end
 
+-- Backfilled lines have no matching entry in the real chat frame, so a
+-- click on one can't resolve to a real hyperlink target. Strip link escape
+-- codes down to plain text to avoid handing a bad link to the click handler.
+local function StripHyperlinks(text)
+    if type(text) ~= "string" then return text end
+    return text:gsub("|H.-|h(.-)|h", "%1")
+end
+
 -- Session history replay: push one restored line into a window's display.
 -- The extraLines allowance keeps the divergence check from reading replayed
 -- lines (which exist only on our side) as a cleared Blizzard buffer.
@@ -1181,7 +1189,8 @@ function ECHAT.EngineBackfillLine(cf, text, r, g, b, id)
     -- DisplayText keeps replayed history consistent with the current
     -- abbreviation setting; the scanner is idempotent on stored lines that
     -- were captured already shortened.
-    win.smf:BackFillMessage(DisplayText(text), r, g, b, id)
+    local display = StripHyperlinks(DisplayText(text))
+    win.smf:BackFillMessage(display, r, g, b, id)
     win.extraLines = (win.extraLines or 0) + 1
     return true
 end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1537389495203405844

Issue: After looting/receiving an item link, clicking it could crash with SetItemRef getting plain "[Runic Hammer]" instead of a real hyperlink.

Root cause: Session-history restore backfills old chat lines into your display frame only — the real chat frame never gets them. Since the display frame has mouse input disabled and clicks pass through to the real frame underneath, a click on a backfilled link lands on whatever's really at that screen row in the other frame — not the link you see. This restore is triggered on leaving combat, which is why it correlated with "Out of Combat" visibility and post-combat timing.

Fix: Strip hyperlink escape codes from backfilled lines before displaying them, so they show as plain (non-clickable-looking) text instead of a link with no valid click target.