### PR TITLE
fix(Unit Frames): keep the cast bar reserve for a free-positioned bar

### DIFF
--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -896,6 +896,13 @@ initFrame:SetScript("OnEvent", function(self)
         else
             castbarH = (settings.showCastbar ~= false) and (settings.castbarHeight or 14) or 0
         end
+        -- A cast bar moved out of the strip below the frame reserves no space in
+        -- the live layout, so the preview must not draw it there either (same
+        -- decision, one helper: EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua).
+        if castbarH > 0 and EllesmereUI.UF_CastbarBelowFrame
+           and not EllesmereUI.UF_CastbarBelowFrame(unitKey) then
+            castbarH = 0
+        end
         local barH = healthH + initPpExtra
         local isAttachedInit = (settings.portraitStyle or db.profile.portraitStyle or "attached") == "attached"
         local portraitW = (showPortrait and isAttachedInit) and barH or 0
@@ -2310,6 +2317,11 @@ initFrame:SetScript("OnEvent", function(self)
             local pvPpIsAtt = (pvPpPos == "below" or pvPpPos == "above")
             local pvPpExtra = pvPpIsAtt and ph or 0
             local ch = (unitKey == "player") and (s.showPlayerCastbar and (s.playerCastbarHeight and s.playerCastbarHeight > 0 and s.playerCastbarHeight or 14) or 0) or ((s.showCastbar ~= false) and (s.castbarHeight or 14) or 0)
+            -- Mirrors the live reserve decision (see the build path above).
+            if ch > 0 and EllesmereUI.UF_CastbarBelowFrame
+               and not EllesmereUI.UF_CastbarBelowFrame(unitKey) then
+                ch = 0
+            end
             local bh = hh + pvPpExtra
             -- Class power "above" position adds height above health bar ("top" floats outside)
             local cpStyle = (unitKey == "player") and (s.classPowerStyle or "none") or "none"

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
@@ -772,7 +772,7 @@ end
 -- Fails toward KEEPING the reserve: no frame, no bounds yet (pre-layout) or a
 -- unit with no movable cast bar of its own (boss) all answer true, which is what
 -- the bottom-anchor path did before. The saved cast bar position lands on the
--- unlock system's deferred pass, so the settle hook further down re-runs this
+-- unlock system's deferred pass, so the settle timers further down re-run this
 -- once the bar is actually where the user put it.
 local CB_STRIP_SLACK = 8 -- physical pixels of tolerance on the strip's edges
 local CB_FRAME_NAMES = {
@@ -797,12 +797,16 @@ local function CastbarBelowFrame(unit, frame)
     cl, cr, ct, cbot = cl * cs, cr * cs, ct * cs, cbot * cs
     -- Beside the frame rather than under it: nothing to reserve.
     if cl >= fr or cr <= fl then return false end
-    -- The bar's top edge must land in the band from one bar height below the
-    -- frame's bottom to slightly above it: flush is 0, a hand-aligned bar is a
-    -- few pixels either way, a bar parked elsewhere is far outside.
+    -- How far the bar's top edge hangs below the frame's bottom: 0 is flush, a
+    -- hand-aligned bar is a few pixels either way. The reserve itself is a fixed
+    -- -castbarHeight, so it only ever clears a bar sitting AT the frame's edge;
+    -- once the drop reaches a full bar height the reserve would park the icons
+    -- on top of the bar rather than above it, so the stack docks to the frame
+    -- instead. Overlap into the frame stays allowed within the tolerance.
     local h = ct - cbot
     if h <= 0 then h = 14 end
-    return ct <= fb + CB_STRIP_SLACK and ct >= fb - h - CB_STRIP_SLACK
+    local drop = fb - ct
+    return drop < h and drop >= -CB_STRIP_SLACK
 end
 ns.UF_CastbarBelowFrame = CastbarBelowFrame
 -- Cross-addon: the options preview mirrors this decision so its layout matches

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
@@ -756,20 +756,58 @@ local function BuildStyle(unit, base, s, unitFrame)
     }
 end
 
--- A cast bar that was free-moved off the frame in unlock mode no longer sits
--- between the frame and a bottom-anchored aura stack, so the stack must not
--- reserve its height. Detached = the unlock anchor record is gone AND a saved
--- free position exists; with neither (fresh install, anchor seed not yet run)
--- the reserve is kept.
-local CB_UNLOCK_KEYS = { player = "playerCastbar", target = "targetCastbar", focus = "focusCastbar" }
-local function CastbarDetached(unit)
-    local key = CB_UNLOCK_KEYS[unit]
-    if not key then return false end
-    if EllesmereUI.IsUnlockAnchored and EllesmereUI.IsUnlockAnchored(key) then return false end
-    local db = ns.db
-    local pos = db and db.profile and db.profile.positions
-    return (pos and pos[key]) ~= nil
+-- Does the unit's cast bar occupy the strip directly below the frame -- the
+-- space a bottom-anchored aura stack would otherwise take? Answered from LIVE
+-- GEOMETRY, not from "has the user ever moved it": a bar that was free-moved in
+-- unlock mode but still parks under its frame (the common case) keeps the
+-- reserve, and only a bar genuinely somewhere else drops it.
+--
+-- The previous rule read ns.db, which is assigned one frame LATER than every
+-- other input here (SetupOptionsPanel runs off C_Timer.After(0), while the
+-- settings come from ns.UF_GetSettings, live since frame creation). Whether the
+-- deferred container build landed before or after that frame decided the answer,
+-- so the reserve differed between a cold login and a /reload with identical
+-- saved data.
+--
+-- Fails toward KEEPING the reserve: no frame, no bounds yet (pre-layout) or a
+-- unit with no movable cast bar of its own (boss) all answer true, which is what
+-- the bottom-anchor path did before. The saved cast bar position lands on the
+-- unlock system's deferred pass, so the settle hook further down re-runs this
+-- once the bar is actually where the user put it.
+local CB_STRIP_SLACK = 8 -- physical pixels of tolerance on the strip's edges
+local CB_FRAME_NAMES = {
+    player = "EllesmereUIUnitFrames_Player",
+    target = "EllesmereUIUnitFrames_Target",
+    focus  = "EllesmereUIUnitFrames_Focus",
+}
+local function CastbarBelowFrame(unit, frame)
+    if not CB_FRAME_NAMES[unit] then return true end
+    frame = frame or _G[CB_FRAME_NAMES[unit]]
+    -- frame.Castbar is the status bar; its PARENT is the holder the unlock
+    -- system moves (see CreateCastBar in EllesmereUIUnitFrames.lua).
+    local cb = frame and frame.Castbar and frame.Castbar:GetParent()
+    if not cb then return true end
+    local fl, fr, fb = frame:GetLeft(), frame:GetRight(), frame:GetBottom()
+    local cl, cr, ct, cbot = cb:GetLeft(), cb:GetRight(), cb:GetTop(), cb:GetBottom()
+    if not (fl and fr and fb and cl and cr and ct and cbot) then return true end
+    -- Physical pixels: the holder is positioned independently of the frame and
+    -- can carry its own effective scale, so raw coordinates are not comparable.
+    local fs, cs = frame:GetEffectiveScale(), cb:GetEffectiveScale()
+    fl, fr, fb = fl * fs, fr * fs, fb * fs
+    cl, cr, ct, cbot = cl * cs, cr * cs, ct * cs, cbot * cs
+    -- Beside the frame rather than under it: nothing to reserve.
+    if cl >= fr or cr <= fl then return false end
+    -- The bar's top edge must land in the band from one bar height below the
+    -- frame's bottom to slightly above it: flush is 0, a hand-aligned bar is a
+    -- few pixels either way, a bar parked elsewhere is far outside.
+    local h = ct - cbot
+    if h <= 0 then h = 14 end
+    return ct <= fb + CB_STRIP_SLACK and ct >= fb - h - CB_STRIP_SLACK
 end
+ns.UF_CastbarBelowFrame = CastbarBelowFrame
+-- Cross-addon: the options preview mirrors this decision so its layout matches
+-- the live frames (EllesmereUIOptions/EUI_UnitFrames_Options.lua).
+EllesmereUI.UF_CastbarBelowFrame = CastbarBelowFrame
 
 -- Container anchoring: mirrors the legacy element's SetPoint(ia, frame, fp,
 -- ox + userX, oy + castbarPush + userY) with gap = 1.
@@ -840,7 +878,7 @@ local function AnchorContainer(container, frame, unit, base, s, buffContainer)
     -- (field case: boss left-anchored debuffs sat ~castbarHeight low). The
     -- oUF-element anchor path has always been bottom-only; this matches it.
     if showCb and (anchor == "bottomleft" or anchor == "bottomright")
-        and not CastbarDetached(unit) then
+        and CastbarBelowFrame(unit, frame) then
         if not cbH or cbH <= 0 then cbH = 14 end
         cbOff = -cbH
     end
@@ -1092,7 +1130,7 @@ end
 -- (computed values like ElementSize and the pixel-scaled spacings capture
 -- scale changes implicitly). The chain composition is covered separately by
 -- entry.sig; a sig change swaps the container and forces this pass anyway.
-local function CfgFP(unit, base, s)
+local function CfgFP(unit, base, s, frame)
     local PP = EllesmereUI.PP
     local isBuff = (base == "HELPFUL")
     local size, h = ElementSize(unit, base, s)
@@ -1131,7 +1169,7 @@ local function CfgFP(unit, base, s)
         mAB, mAB and s.debuffAnchor or nil, mAB and s.debuffGrowth or nil,
         mAB and s.debuffOffsetX or nil, mAB and s.debuffOffsetY or nil,
         mAB and s.debuffSpacingY or nil,
-        CastbarDetached(unit),
+        CastbarBelowFrame(unit, frame),
         -- Tracked Auras lists: ApplyGroupConfig reads both (the shared
         -- excludes), and TRI-STATE flips don't move the chain sig -- an
         -- entry's enable checkbox must re-drive this pass.
@@ -1449,7 +1487,7 @@ function ns.UF_ReloadAuraContainers(frame, unit)
         end
 
         if container then
-            local cfgV = CfgFP(unit, base, s)
+            local cfgV = CfgFP(unit, base, s, frame)
             if force or st.cfg ~= cfgV then
                 st.cfg = cfgV
                 AnchorContainer(container, frame, unit, base, s, entry.buffs) -- self-skips on anchor "none"
@@ -1547,6 +1585,51 @@ function ns.UF_ReloadAllAuraContainers()
         if entry.frame then
             ns.UF_ReloadAuraContainers(entry.frame, unitKey)
         end
+    end
+end
+
+-- Cast bar settle: the bar's saved position is applied by the unlock system's
+-- deferred login pass (EUI_UnlockMode.lua fires it ~1.5s after
+-- PLAYER_ENTERING_WORLD, or CDM owns it), which lands AFTER these containers
+-- anchored -- so the bottom-anchor reserve was decided against the bar's
+-- provisional position. Re-run the pass once the positions are in, and again
+-- whenever unlock mode closes (the bar may have been dragged into or out of the
+-- strip below the frame). Both are no-ops unless the reserve actually changed:
+-- UF_ReloadAuraContainers only re-anchors on a config fingerprint change.
+-- A profile swap needs no trigger of its own: it runs through RefreshAllAddons
+-- -> ReloadFrames, which ends in UF_ReloadAllAuraContainers already.
+-- Cost: two login timers, one unlock listener. No per-frame work, no allocation
+-- on any chatty event.
+--
+-- Deliberately NOT a hook on EllesmereUI._applySavedPositions: that field is
+-- passed by reference into C_Timer.After by the action bars module
+-- (EllesmereUIActionBars.lua), and replacing it there made that call raise.
+do
+    local pending = false
+    local function Settle()
+        pending = false
+        ns.UF_ReloadAllAuraContainers()
+    end
+    local function Queue()
+        if pending then return end
+        pending = true
+        C_Timer.After(0, Settle)
+    end
+    local settleWatcher = CreateFrame("Frame")
+    settleWatcher:RegisterEvent("PLAYER_ENTERING_WORLD")
+    settleWatcher:SetScript("OnEvent", function(self)
+        self:UnregisterEvent("PLAYER_ENTERING_WORLD")
+        -- Two passes: the first clears the unlock system's own deferred pass
+        -- (~1.5s after this event), the second covers a CDM-owned run of it,
+        -- which waits for async icon population and can land later. Whichever
+        -- lands second is a no-op unless the reserve actually changed.
+        C_Timer.After(2, Queue)
+        C_Timer.After(5, Queue)
+    end)
+    if EllesmereUI.RegisterUnlockModeListener then
+        EllesmereUI:RegisterUnlockModeListener("EUF_AuraContainers", function(unlockActive)
+            if not unlockActive then Queue() end
+        end)
     end
 end
 


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1537638048211271800

## What does this PR do?

Fixes bottom-anchored unit frame buffs and debuffs rendering flush against the health bar, with no room left for the cast bar, until the next `/reload`. The aura stack reserves the cast bar's height so the bar has space between the frame and the icons. Whether to reserve it was decided from "has this cast bar ever been free-moved in unlock mode", and that check read `ns.db`, which is assigned one frame later than every other input on the anchor path: the settings come from `ns.UF_GetSettings`, live since frame creation, while `ns.db` arrives with `SetupOptionsPanel` off a `C_Timer.After(0)`. Whether the deferred aura container build landed before or after that frame decided the answer, so identical saved data produced the reserve on one login and dropped it on the next. A `/reload` appeared to fix it because it reshuffled that ordering, not because it changed anything the user had configured.

The reserve is now decided from live geometry: it applies when the cast bar holder actually occupies the strip directly below the frame, measured in physical pixels with an 8 pixel tolerance so a hand-aligned bar still counts. That also fixes a case the old rule got wrong by design, a cast bar the user dragged in unlock mode but parked under its own frame anyway, which lost its reserve purely for having been touched. Units with no movable cast bar of their own (boss frames) and every call made before the frames have bounds answer exactly as they did before, so nothing moves for setups that were already correct.

The cast bar's saved position is applied by the unlock system's deferred login pass, which lands after the aura containers first anchored, so the fingerprinted container reload now re-runs once that has settled and again whenever unlock mode closes. Both runs are no-ops unless the reserve actually changed. The options preview computed the same reserve unconditionally and therefore never matched a frame whose bar sits somewhere else; it now asks the same helper, so preview and live agree in every position.

## How was it tested?

Tested in game on live. Fresh login on a character with target buffs anchored bottom-left, debuffs bottom-right, buff offsets at their defaults and the target cast bar free-positioned below the frame: the gap for the cast bar is now present immediately, without a `/reload`, and a `/reload` in the same session produces an identical layout instead of a different one. Also confirmed that no Lua errors are raised during login or reload, after an earlier iteration of this change hooked `EllesmereUI._applySavedPositions` and broke the action bars module, which passes that field by reference into `C_Timer.After`; the hook was dropped rather than worked around, since a profile swap already reaches the container reload through `RefreshAllAddons` and `ReloadFrames`.

The inverse direction was verified too: dragging the cast bar out of the strip below the frame and closing unlock mode moves the icons flush against the health bar, since there is no longer a bar to leave room for, and dragging it back under the frame restores the gap, both without a `/reload`.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; this is a fix to an existing layout decision
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A, no toggle involved
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - two one-shot timers on the first `PLAYER_ENTERING_WORLD` and one unlock mode listener; no `OnUpdate`, no per-frame work, no allocation on any frequent event, and the reload they trigger is fingerprint-gated
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no hooks and no Blizzard frames touched; the geometry reads and the `SetPoint` calls are all on our own frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added