### PR TITLE
Add optional filtering for disabled Unlock Mode elements

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -2397,6 +2397,11 @@ do
         local info = db and db[childKey]
         local fb = info and info.fallback
         if not fb or not fb.target then HideGhost(g) return end
+        if EllesmereUI._ShouldHideUnlockElement(childKey)
+           or EllesmereUI._ShouldHideUnlockElement(fb.target) then
+            HideGhost(g)
+            return
+        end
         local cx, cy = GhostSnapBase(childKey, fb)
         if not cx then HideGhost(g) return end
         cx = cx + (fb.offsetX or 0)
@@ -3052,6 +3057,11 @@ do
         if g._dragging then return end
         local ov = GhostPos(g)
         if not ov then HideGhost(g) return end
+        if EllesmereUI._ShouldHideUnlockElement(g._childKey)
+           or EllesmereUI._ShouldHideUnlockElement(ov.target) then
+            HideGhost(g)
+            return
+        end
         local cx, cy = OvSnapBase(g._childKey, ov)
         if not cx then HideGhost(g) return end
         cx = cx + (ov.offsetX or 0)
@@ -4691,6 +4701,18 @@ GetBarFrame = function(barKey)
     if barKey == "MicroBar"   then return _G["MicroMenuContainer"] or _G["MicroMenu"] end
     if barKey == "BagBar"     then return _G["BagsBar"] end
     return nil
+end
+
+-- Optional unlock filter for elements explicitly disabled or configured with
+-- Visibility = Never. Contextual visibility (combat, group, mouseover, missing
+-- units, alpha, and current frame state) is intentionally ignored so
+-- situational elements remain available for layout work.
+function EllesmereUI._ShouldHideUnlockElement(key)
+    if not (EllesmereUIDB and EllesmereUIDB.unlockHideDisabled) then return false end
+    local elem = registeredElements[key]
+    if not elem then return false end
+    if elem.isExplicitlyDisabled and elem.isExplicitlyDisabled(key) == true then return true end
+    return elem.isNeverVisible and elem.isNeverVisible(key) == true or false
 end
 
 GetBarLabel = function(barKey)
@@ -6372,8 +6394,9 @@ local function CreateMover(barKey)
 
     -- Skip elements that are intentionally hidden or currently anchored
     -- (keepMoverWhenAnchored elements keep a position-locked mover instead).
-    if elem and ((elem.isHidden and elem.isHidden())
-        or (elem.isAnchored and elem.isAnchored() and not elem.keepMoverWhenAnchored)) then
+    if (elem and ((elem.isHidden and elem.isHidden())
+        or (elem.isAnchored and elem.isAnchored() and not elem.keepMoverWhenAnchored)))
+        or EllesmereUI._ShouldHideUnlockElement(barKey) then
         if existing then existing:Hide() end
         return nil
     end
@@ -7575,8 +7598,9 @@ local function CreateMover(barKey)
         -- bar) must NOT be shown. Mirrors the CreateMover guard so blanket
         -- `for _, m in pairs(movers) do m:Sync() end` loops can't re-show a mover
         -- CreateMover intentionally hid. Action bars resolve elem == nil (no-op); isHidden is read live, so an un-hidden element still syncs.
-        if elem and ((elem.isHidden and elem.isHidden())
-                  or (elem.isAnchored and elem.isAnchored() and not elem.keepMoverWhenAnchored)) then
+        if (elem and ((elem.isHidden and elem.isHidden())
+                  or (elem.isAnchored and elem.isAnchored() and not elem.keepMoverWhenAnchored)))
+           or EllesmereUI._ShouldHideUnlockElement(bk) then
             self:Hide()
             return
         end
@@ -10090,7 +10114,8 @@ do
                 -- re-enabled mid-session -- the drop half always worked, the
                 -- restore half never did). Session temp-hides
                 -- (Shift+Right-Click) stay respected.
-                if elem.isHidden and elem.isHidden() then
+                if (elem.isHidden and elem.isHidden())
+                   or EllesmereUI._ShouldHideUnlockElement(key) then
                     movers[key]:Hide()
                 elseif not movers[key]:IsShown() and not movers[key]._tempHidden then
                     movers[key]:Sync()
@@ -12319,7 +12344,8 @@ function ns.OpenUnlockMode()
                             -- Mover exists but bar frame was not ready on
                             -- first Sync -- re-sync now that it may be available
                             local re = registeredElements[rk]
-                            if not (re and re.isHidden and re.isHidden()) then
+                            if not (re and re.isHidden and re.isHidden())
+                               and not EllesmereUI._ShouldHideUnlockElement(rk) then
                                 local rm = movers[rk]
                                 rm:Sync()
                                 if rm:IsShown() then

--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -5617,6 +5617,8 @@ EllesmereUI._rowCounters     = rowCounters
 --    setWidth   (function(key, w))  set element width and rebuild
 --    setHeight  (function(key, h))  set element height and rebuild
 --    isHidden   (function(key)) -> bool  true if element is disabled/hidden
+--    isExplicitlyDisabled (function(key)) -> bool  saved config makes the element unavailable
+--    isNeverVisible (function(key)) -> bool  saved Visibility is exactly Never
 --    isAnchored (function(key)) -> bool  true if anchored to another element
 --    onLiveMove (function(key))  called after every mover-driven placement of
 --               the frame: drag start, each drag frame, drag stop, arrow/cog
@@ -5639,6 +5641,8 @@ function EllesmereUI.MakeUnlockElement(opts)
         setWidth      = opts.setWidth,
         setHeight     = opts.setHeight,
         isHidden      = opts.isHidden,
+        isExplicitlyDisabled = opts.isExplicitlyDisabled,
+        isNeverVisible = opts.isNeverVisible,
         isAnchored    = opts.isAnchored,
         onLiveMove    = opts.onLiveMove,
         linkedKeys    = opts.linkedKeys,

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -12000,6 +12000,14 @@ local function RegisterWithUnlockMode()
             label = info.label,
             group = "Action Bars",
             order = orderBase + idx,
+            isExplicitlyDisabled = function()
+                local s = EAB.db.profile.bars[info.key]
+                return s and s.enabled == false or false
+            end,
+            isNeverVisible = function()
+                local s = EAB.db.profile.bars[info.key]
+                return s and (s.alwaysHidden or s.barVisibility == "never") or false
+            end,
             isHidden = function()
                 local s = EAB.db.profile.bars[info.key]
                 if not s then return false end
@@ -12228,6 +12236,14 @@ local function RegisterWithUnlockMode()
                 group = "Action Bars",
                 order = blizzOrder,
                 noResize = true,
+                isExplicitlyDisabled = function()
+                    local s = EAB.db.profile.bars[bk]
+                    return s and s.enabled == false or false
+                end,
+                isNeverVisible = function()
+                    local s = EAB.db.profile.bars[bk]
+                    return s and (s.alwaysHidden or s.barVisibility == "never") or false
+                end,
                 getFrame = function() return blizzMovableHolders[bk] end,
                 getSize = function()
                     local ov = BLIZZ_MOVABLE_OVERLAY[bk]
@@ -14772,6 +14788,14 @@ local function RegisterDataBarsWithUnlockMode()
                 label = info.label,
                 group = "Action Bars",
                 order = orderBase + idx,
+                isExplicitlyDisabled = function()
+                    local s = EAB.db.profile.bars[bk]
+                    return s and s.enabled == false or false
+                end,
+                isNeverVisible = function()
+                    local s = EAB.db.profile.bars[bk]
+                    return s and (s.alwaysHidden or s.barVisibility == "never") or false
+                end,
                 getFrame = function() return dataBarFrames[bk] end,
                 getSize = function()
                     -- Return stored DB values so cog menu shows what the
@@ -15742,6 +15766,14 @@ local function RegisterExtraBarsWithUnlockMode()
                 noResize = true,
                 noAnchorTo = isBlizzOwned,
                 noAnchorTarget = isBlizzOwned,
+                isExplicitlyDisabled = function()
+                    local s = EAB.db.profile.bars[bk]
+                    return s and s.enabled == false or false
+                end,
+                isNeverVisible = function()
+                    local s = EAB.db.profile.bars[bk]
+                    return s and (s.alwaysHidden or s.barVisibility == "never") or false
+                end,
                 isHidden = function()
                     local s = EAB.db.profile.bars[bk]
                     if not s then return false end

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3964,6 +3964,10 @@ local function RegisterUnlockElements()
             noAnchorTarget = true,  -- icon count changes dynamically with auras
             -- Icon size is driven solely by the Scale slider. No drag-resize: row width is count-dependent, so restoring a stored width under a different count would corrupt the persisted scale (matches External Defensives).
             noResize = true,
+            isExplicitlyDisabled = function()
+                local display = db and db.profile and db.profile.display
+                return display and display.remindersEnabled == false or false
+            end,
             getFrame = function() return iconAnchor end,
             getSize = function()
                 local p = db.profile.display

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2356,6 +2356,9 @@ do
                 isHidden = function()
                     return not WantFixed()
                 end,
+                isNeverVisible = function()
+                    return EllesmereUIDB and EllesmereUIDB.tooltipShowMode == "never" or false
+                end,
                 getFrame = function()
                     -- MUST stay side-effect-free: unlock mode calls getFrame from its drag
                     -- machinery (OnUpdate/OnDragStop), so parking from saved here would snap a live drag back on release. Boot/applyPos/loadPos do parking + seeding.

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_DragonRiding.lua
@@ -652,6 +652,9 @@ function RegisterUnlockElements()
             label = "Dragon Riding",
             group = "Dragon Riding",
             order = 700,
+            isExplicitlyDisabled = function()
+                return db and db.profile and db.profile.enabled == false or false
+            end,
             getFrame = function() return rootFrame end,
             getSize  = function()
                 local p = db.profile

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -5701,6 +5701,10 @@ initFrame:SetScript("OnEvent", function(self)
                 onLiveMove = function()
                     if ns._KeepMainChatSizeCorner then ns._KeepMainChatSizeCorner() end
                 end,
+                isNeverVisible = function()
+                    local cfg = ECHAT.DB()
+                    return cfg and cfg.visibility == "never" or false
+                end,
                 savePos = function(_, point, relPoint, x, y)
                     local cfg = ECHAT.DB()
                     if not cfg then return end

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -5645,6 +5645,14 @@ function ns.RegisterTBBUnlockElements()
                 -- driven by its own CDM sliders/dynamic content, so it should never be a sizing reference.
                 allowMatchSource  = true,
                 noSizeMatchTarget = true,
+                isExplicitlyDisabled = function()
+                    local p = ECME and ECME.db and ECME.db.profile
+                    if not (p and p.cdmBars and p.cdmBars.enabled) then return true end
+                    if p.cdmBars.useBlizzardBuffBars then return true end
+                    local t = ns.GetTrackedBuffBars()
+                    local c = t and t.bars and t.bars[idx]
+                    return not c or c.enabled == false
+                end,
                 isHidden = function()
                     local t = ns.GetTrackedBuffBars()
                     local b = t and t.bars
@@ -5803,6 +5811,11 @@ function ns.RegisterTBBUnlockElements()
                 noResize = true,
                 allowMatchSource  = true,
                 noSizeMatchTarget = true,
+                isExplicitlyDisabled = function()
+                    local p = ECME and ECME.db and ECME.db.profile
+                    return not (p and p.cdmBars and p.cdmBars.enabled)
+                        or p.cdmBars.useBlizzardBuffBars
+                end,
                 isHidden = function()
                     local gid = ns.TBBLocalGidForGlobal(gk)
                     return not gid or not ns.TBBGroupAnchorIndex(gid)

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8987,9 +8987,19 @@ RegisterCDMUnlockElements = function()
                 linkedKeys = linked,
                 noAnchorTarget = isDynamic,
                 noResize = isDynamic,
+                isExplicitlyDisabled = function()
+                    local p = ECME.db and ECME.db.profile
+                    if p and p.cdmBars and p.cdmBars.enabled == false then return true end
+                    local bd2 = barDataByKey[key]
+                    return not bd2 or bd2.enabled == false
+                end,
                 isHidden = function()
                     -- If this bar key is no longer in the current profile's barDataByKey, it is a stale registration from a previous profile and should not get a mover.
                     return not barDataByKey[key]
+                end,
+                isNeverVisible = function()
+                    local bd2 = barDataByKey[key]
+                    return bd2 and bd2.barVisibility == "never" or false
                 end,
                 getFrame = function() return cdmBarFrames[key] end,
                 getSize = function()

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -463,6 +463,10 @@ ns.RegisterDMUnlock = function()
                 local wdb = idx and WinDB(idx)
                 return wdb and wdb.width or 375, wdb and wdb.height or 150
             end,
+            isNeverVisible = function()
+                local cfg = DB()
+                return cfg and cfg.visibility == "never" or false
+            end,
             setWidth = function(key, newW)
                 local w, idx = winOf(key)
                 if not w or not w.frame then return end
@@ -4792,6 +4796,7 @@ ns.MakeSATimerUnlockElement = function(MK)
             if _saTimer then return _saTimer:GetWidth(), _saTimer:GetHeight() end
             return 60, 20
         end,
+        isExplicitlyDisabled = function() return not DB().standaloneTimer end,
         isHidden = function() return not DB().standaloneTimer end,
         savePos = function(_, point, relPoint, x, y)
             local cfg = DB()

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -2686,6 +2686,13 @@ local function MakeBarElement(barId, orderIdx)
         isHidden = function()
             return cfgOf() == nil
         end,
+        isExplicitlyDisabled = function()
+            return cfgOf() == nil
+        end,
+        isNeverVisible = function()
+            local cfg = cfgOf()
+            return cfg and cfg.visibility == "never" or false
+        end,
         allowMatchSource = true,
     })
 end

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -5314,9 +5314,17 @@ function EBS:OnEnable()
                 getSize  = function()
                     return Minimap:GetWidth(), Minimap:GetHeight()
                 end,
+                isExplicitlyDisabled = function()
+                    local m = MDB()
+                    return not m or not m.enabled
+                end,
                 isHidden = function()
                     local m = MDB()
                     return not m or not m.enabled
+                end,
+                isNeverVisible = function()
+                    local m = MDB()
+                    return m and m.visibility == "never" or false
                 end,
                 savePos = function(_, point, relPoint, x, y)
                     local m = MDB(); if not m then return end

--- a/EllesmereUIMythicTimer/EUI_MythicTimer_TargetFocusBars.lua
+++ b/EllesmereUIMythicTimer/EUI_MythicTimer_TargetFocusBars.lua
@@ -964,6 +964,10 @@ local function MakeBarUnlockElement(which, label, order)
         -- so a match survives reloads exactly like a slider value.
         noResize = true,
         allowMatchSource = true,
+        isExplicitlyDisabled = function()
+            local cfg = BarCfg(which)
+            return not (cfg and cfg.enabled == true)
+        end,
         isHidden = function()
             local cfg = BarCfg(which)
             return not (cfg and cfg.enabled == true)

--- a/EllesmereUIMythicTimer/EUI_MythicTimer_TargetedSpellBars.lua
+++ b/EllesmereUIMythicTimer/EUI_MythicTimer_TargetedSpellBars.lua
@@ -647,6 +647,10 @@ local function RegisterUnlock()
             -- the sliders write (per-bar size; the container relayouts).
             noResize = true,
             allowMatchSource = true,
+            isExplicitlyDisabled = function()
+                local cfg = Cfg()
+                return not (cfg and cfg.enabled == true)
+            end,
             isHidden = function()
                 local cfg = Cfg()
                 return not (cfg and cfg.enabled == true)

--- a/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
+++ b/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
@@ -2893,6 +2893,9 @@ function EMT:OnEnable()
                 group = "Mythic+",
                 order = 520,
                 noResize = true,
+                isExplicitlyDisabled = function()
+                    return db and db.profile and db.profile.enabled == false or false
+                end,
                 getFrame = function()
                     return _G._EMT_GetStandaloneFrame and _G._EMT_GetStandaloneFrame()
                 end,

--- a/EllesmereUIOptions/EUI__General_Options.lua
+++ b/EllesmereUIOptions/EUI__General_Options.lua
@@ -3137,7 +3137,15 @@ initFrame:SetScript("OnEvent", function(self)
                   EllesmereUI:InvalidatePageCache()
                   EllesmereUI:RefreshPage(true)
               end },
-            { type="label", text="" });  y = y - h
+            { type="toggle", text="Hide Disabled Unlock Elements",
+              tooltip="Hide elements in Unlock Mode when their feature is disabled or their saved Visibility setting is Never. Combat, group, mouseover, and other situationally hidden elements remain available.",
+              getValue=function()
+                  return EllesmereUIDB and EllesmereUIDB.unlockHideDisabled == true
+              end,
+              setValue=function(v)
+                  if not EllesmereUIDB then EllesmereUIDB = {} end
+                  EllesmereUIDB.unlockHideDisabled = v and true or nil
+              end });  y = y - h
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
@@ -8518,6 +8526,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.unlockAnchors = nil
                 EllesmereUIDB.unlockWidthMatch = nil
                 EllesmereUIDB.unlockHeightMatch = nil
+                EllesmereUIDB.unlockHideDisabled = nil
                 -- QoL Features are NOT reset here; they have their own module reset
             end
             if EllesmereUI._applyRightClickTarget then

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -2505,6 +2505,9 @@ do
                 -- Dragged by the Secondary Stats element while attached. Read
                 -- live, so detaching restores the mover without re-registering.
                 isHidden = IsAttached,
+                isExplicitlyDisabled = function()
+                    return not EllesmereUI.QoLExtrasGet("showFPS")
+                end,
                 getFrame = function()
                     if not fpsFrame then CreateFPSCounter() end
                     return fpsFrame
@@ -2548,6 +2551,9 @@ do
                 label = "Secondary Stats",
                 group = "General",
                 order = 710,
+                isExplicitlyDisabled = function()
+                    return not EllesmereUI.QoLExtrasGet("showSecondaryStats")
+                end,
                 getFrame = function()
                     local f = EllesmereUI._getSecondaryStatsFrame and EllesmereUI._getSecondaryStatsFrame()
                     return f
@@ -3689,6 +3695,9 @@ do
                 group    = "Quality of Life",
                 order    = 720,
                 noResize = true,
+                isExplicitlyDisabled = function()
+                    return not (EllesmereUIDB and EllesmereUIDB.announceGroupDeaths)
+                end,
                 isHidden = function()
                     return not (EllesmereUIDB and EllesmereUIDB.announceGroupDeaths)
                 end,
@@ -3915,6 +3924,9 @@ do
                 group    = "Quality of Life",
                 order    = 721,
                 noResize = true,
+                isExplicitlyDisabled = function()
+                    return not (EllesmereUIDB and EllesmereUIDB.combatAlertEnabled)
+                end,
                 isHidden = function()
                     return not (EllesmereUIDB and EllesmereUIDB.combatAlertEnabled)
                 end,
@@ -4199,6 +4211,9 @@ do
                 group    = "Quality of Life",
                 order    = 722,
                 noResize = true,
+                isExplicitlyDisabled = function()
+                    return not IsEnabled()
+                end,
                 isHidden = function()
                     return not IsEnabled()
                 end,

--- a/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
@@ -648,6 +648,14 @@ local function RegisterUnlock()
             group = "Quality of Life",
             order = 600,
             noAnchorTarget = true,  -- icon size changes; nothing should be anchored to it
+            isExplicitlyDisabled = function()
+                local p = P()
+                return not p or not p.enabled
+            end,
+            isNeverVisible = function()
+                local p = P()
+                return p and p.visibility == "NEVER" or false
+            end,
             isHidden = function()
                 local p = P()
                 return not p or not p.enabled or (p.visibility == "NEVER")

--- a/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
@@ -792,6 +792,14 @@ local function RegisterUnlock()
             group = "Quality of Life",
             order = 601,
             noAnchorTarget = true,  -- icon size changes; nothing should anchor to it
+            isExplicitlyDisabled = function()
+                local p = P()
+                return not p or not p.enabled
+            end,
+            isNeverVisible = function()
+                local p = P()
+                return p and p.visibility == "NEVER" or false
+            end,
             isHidden = function()
                 local p = P()
                 return not p or not p.enabled or (p.visibility == "NEVER")

--- a/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
@@ -994,6 +994,10 @@ local function RegisterUnlockElements()
             label = "GCD Circle",
             group = "Cursor Lite",
             order = 500,
+            isExplicitlyDisabled = function()
+                local cfg = GCD_DB()
+                return not cfg.enabled or cfg.attached ~= false
+            end,
             getFrame = function() return gcdRoot end,
             getSize = function()
                 local g2 = GCD_DB()
@@ -1050,6 +1054,10 @@ local function RegisterUnlockElements()
             label = "Cast Bar Circle",
             group = "Cursor Lite",
             order = 501,
+            isExplicitlyDisabled = function()
+                local cfg = Cast_DB()
+                return not cfg.enabled or cfg.attached ~= false
+            end,
             getFrame = function() return castRoot end,
             getSize = function()
                 local c2 = Cast_DB()

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -2175,6 +2175,10 @@ loader:SetScript("OnEvent", function(self, event, ...)
                     order = order,
                     -- isHiddenKey: profile key name, or a predicate function
                     -- (the movement tracker's enable state is per-class).
+                    isExplicitlyDisabled = function()
+                        if type(isHiddenKey) == "function" then return not isHiddenKey() end
+                        return not MA()[isHiddenKey]
+                    end,
                     isHidden = function()
                         if type(isHiddenKey) == "function" then return not isHiddenKey() end
                         return not MA()[isHiddenKey]

--- a/EllesmereUIQoL/EllesmereUIQoL_RaidTools.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_RaidTools.lua
@@ -1366,6 +1366,9 @@ local function RegisterUnlock()
             group    = "Raid Tools",
             order    = 540 + i,
             noResize = true,
+            isExplicitlyDisabled = function()
+                return Mode() == "never"
+            end,
             getFrame = function()
                 if Mode() == "never" then return nil end
                 -- Nothing to move while the assist gate has the whole feature

--- a/EllesmereUIQoL/EllesmereUIQoL_Shifter.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Shifter.lua
@@ -928,6 +928,10 @@ local function RegisterLootUnlockElements()
             -- to tell them apart from live-frame movers.
             moverBg  = { r = 0.165, g = 0.11, b = 0.055 },
             subtitle = "Disable Loot unlock mode overlays in Shifter once done positioning",
+            isExplicitlyDisabled = function()
+                return not LootEnabled()
+                    or (EllesmereUIDB and EllesmereUIDB.shifterLootHideOverlays) or false
+            end,
             isHidden = function()
                 if not LootEnabled() or not _G[info.name] then return true end
                 -- "Hide Unlock Mode Overlays": the movers stay out of unlock
@@ -1106,6 +1110,10 @@ local function RegisterTopBarUnlockElement()
             noSizeMatchTarget = true,
             moverBg  = { r = 0.165, g = 0.11, b = 0.055 },
             subtitle = "Disable the Top Bar Event Text overlay in Shifter once done positioning",
+            isExplicitlyDisabled = function()
+                return not TopBarEnabled()
+                    or (EllesmereUIDB and EllesmereUIDB.shifterTopBarHideOverlay) or false
+            end,
             isHidden = function()
                 if not TopBarEnabled() or not _G[TOPBAR_NAME] then return true end
                 -- "Hide Unlock Mode Overlay": mover stays out of unlock mode

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -9370,6 +9370,10 @@ local function RegisterWithUnlockMode()
                 local hm = ns._HMSet and ns._HMSet()
                 return not hm or (hm.mode or "none") == "none"
             end,
+            isExplicitlyDisabled = function()
+                local hm = ns._HMSet and ns._HMSet()
+                return not hm or (hm.mode or "none") == "none"
+            end,
             getFrame = function()
                 return ns._hmContainer or (ns._HMEnsureContainer and ns._HMEnsureContainer())
             end,

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -2160,7 +2160,9 @@ local function RegisterUnlockElements()
         elements[#elements + 1] = MK({
             key = "ERB_Health", label = "Health Bar", group = "Resource Bars", order = 500,
             getFrame = function() return healthBar end,
+            isExplicitlyDisabled = function() local s = S(); return not s.enabled or IsSpecDisabled(s) end,
             isHidden = function() local s = S(); return not s.enabled or IsSpecDisabled(s) end,
+            isNeverVisible = function() return SS().visibility == "never" end,
             -- Reported through the ON-SCREEN axes, not the stored ones: a vertical
             -- bar renders through OrientedSize, so stored width is what the player
             -- sees as height; handing the mover the raw stored pair would make it
@@ -2203,7 +2205,9 @@ local function RegisterUnlockElements()
         elements[#elements + 1] = MK({
             key = "ERB_Power", label = "Power Bar", group = "Resource Bars", order = 501,
             getFrame = function() return primaryBar end,
+            isExplicitlyDisabled = function() local s = S(); return s.enabled == false or IsSpecDisabled(s) end,
             isHidden = function() local s = S(); return s.enabled == false or IsSpecDisabled(s) end,
+            isNeverVisible = function() return SS().visibility == "never" end,
             -- On-screen axes, as with the health bar above.
             getSize  = function()
                 local s, g = SS(), ERB.db.profile.general
@@ -2269,7 +2273,9 @@ local function RegisterUnlockElements()
                 end
                 Rebuild()
             end,
+            isExplicitlyDisabled = function() local s = S(); return s.enabled == false or IsSpecDisabled(s) end,
             isHidden = function() local s = S(); return s.enabled == false or IsSpecDisabled(s) end,
+            isNeverVisible = function() return SS().visibility == "never" end,
             isAnchored = function() local s = S(); return s.anchorTo and s.anchorTo ~= "none" end,
             keepMoverWhenAnchored = true,
             onLiveMove = LiveMove,
@@ -2313,6 +2319,7 @@ local function RegisterUnlockElements()
         elements[#elements + 1] = MK({
             key = "ERB_CastBar", label = "Cast Bar", group = "Resource Bars", order = 504,
             noAnchorTarget = true,
+            isExplicitlyDisabled = function() return S().enabled == false end,
             getFrame = function() return castBarFrame end,
             getSize  = function()
                 local cb = S()
@@ -2366,6 +2373,7 @@ local function RegisterUnlockElements()
         elements[#elements + 1] = MK({
             key = "ERB_GCDBar", label = "GCD Bar", group = "Resource Bars", order = 506,
             noAnchorTarget = true,
+            isExplicitlyDisabled = function() return S().enabled == false end,
             getFrame = function() return gcdBarFrame end,
             getSize  = function()
                 local g = S()
@@ -2428,6 +2436,11 @@ local function RegisterUnlockElements()
             key = "ERB_TotemBar", label = "Totem Bar", group = "Resource Bars", order = 505,
             noResize = true,
             noAnchorTarget = true,
+            isExplicitlyDisabled = function()
+                local tb = S()
+                local _, classFile = UnitClass("player")
+                return not (tb.enabledClasses and classFile and tb.enabledClasses[classFile])
+            end,
             getFrame = function() return totemBarFrame end,
             getSize  = function()
                 local tb = S()

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -14812,10 +14812,25 @@ local function RegisterUFUnlockElements()
                 label = UNIT_LABELS[key] or key,
                 group = "Unit Frames",
                 order = orderBase + order,
+                isExplicitlyDisabled = function(k)
+                    if k == "classPower" then
+                        local p = db.profile.player
+                        return ns.GetUnitFrameSource("player") ~= "eui"
+                            or not p.showClassPowerBar
+                            or p.classPowerStyle == "none"
+                            or p.lockClassPowerToFrame
+                    end
+                    return ns.GetUnitFrameSource(k) ~= "eui"
+                end,
                 getFrame = function(k)
                     if k == "boss" then return frames["boss1"] end
                     if k == "classPower" then return frames._classPowerBar end
                     return frames[k]
+                end,
+                isNeverVisible = function(k)
+                    if k == "boss" or k == "classPower" then return false end
+                    local s = GetSettingsForUnit(k)
+                    return s and s.barVisibility == "never" or false
                 end,
                 getSize = function(k)
                     if k == "classPower" then
@@ -15045,6 +15060,13 @@ local function RegisterUFUnlockElements()
                 group = "Unit Frames",
                 order = orderBase + order,
                 getFrame = function() return GetCBFrame() end,
+                isExplicitlyDisabled = function()
+                    if ns.GetUnitFrameSource(unitKey) ~= "eui" then return true end
+                    local s = GetCBSettings()
+                    if not s then return true end
+                    if unitKey == "player" then return not s.showPlayerCastbar end
+                    return s.showCastbar == false
+                end,
                 isHidden = function()
                     -- Live show/hide: mirror the per-unit cast bar enable setting
                     -- (player defaults off; target/focus default on). The mover is

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -2392,6 +2392,12 @@ function RegisterPABUnlock()
             -- Enable toggle: a disabled default bar keeps no mover (custom-bar
             -- parity). Master-disabled and Use Blizzard Buffs stand the
             -- defaults down entirely, mover included.
+            isExplicitlyDisabled = function()
+                local s = PAB()
+                if not s or s.enabled ~= true or s.useBlizzardBuffs == true then return true end
+                local cfg = isBuff and DefaultBuffsCfg(s) or DefaultDebuffsCfg(s)
+                return cfg.enabled == false
+            end,
             isHidden = function()
                 local s = PAB()
                 if not s or s.enabled ~= true or s.useBlizzardBuffs == true then return true end
@@ -3649,6 +3655,12 @@ local function RegisterPABCustomUnlock()
             order = order,
             noResize = true,
             noAnchorTarget = true,
+            isExplicitlyDisabled = function()
+                local s = PAB()
+                if not s or s.enabled ~= true then return true end
+                local b = isBuff and ns.PAB_GetCustomBuffBar(barId) or ns.PAB_GetCustomDebuffBar(barId)
+                return not b or b.enabled == false
+            end,
             isHidden = function()
                 local b, bk
                 if isBuff then b, bk = ns.PAB_GetCustomBuffBar(barId)
@@ -5582,4 +5594,3 @@ function ns.PAB_ArmRecovery()
     -- early-returns for profiles without buckets).
     initFrame:RegisterUnitEvent("PLAYER_SPECIALIZATION_CHANGED", "player")
 end
-


### PR DESCRIPTION
## What does this PR do?

After years and years of using and even helping ElvUI and other UIs, I have decided to switch to EllesmereUI, and so far I love it.

However, I wanted a way to calm down Unlock Mode without removing anchors that are still useful for situational layouts.

This adds an opt-in **Hide Disabled Unlock Elements** setting under General Options. When enabled, Unlock Mode hides elements whose feature is explicitly disabled or whose saved Visibility setting is `Never`.

Combat, group, raid, mouseover, missing-unit, and other situational visibility states are deliberately ignored. Those anchors remain available so players can still lay out elements that are only expected to appear in specific content.

## What changed

- Add a General Options toggle that defaults off and is included in the General Settings reset.
- Extend Unlock Mode registrations with explicit disabled and `Visibility = Never` predicates instead of inferring from current frame visibility.
- Apply the filter consistently to movers, delayed mover sync, re-registration, and fallback/override anchor ghosts.
- Cover enable and visibility settings across Action Bars, Aura/Buff Reminders, Blizzard Skin, Chat, Cooldown Manager, Damage Meters, Data Bars, Minimap, Mythic Timer, QoL, Raid Frames, Resource Bars, and Unit Frames.
- Keep the existing Unlock Mode toolbar unchanged.

## Unlock Mode control placement

We also prototyped and tested this toggle directly in Unlock Mode's top toolbar, including several width and spacing revisions. Even after adjusting the layout, the extra labeled control made the toolbar feel crowded, created awkward spacing around the existing Exit and Save & Exit controls, and added too much visual weight to a preference that does not need frequent changes.

That toolbar version was deliberately discarded rather than left in the final diff. General Options was chosen as the cleaner permanent home for the setting, and the original Unlock Mode toolbar remains unchanged.

## Why explicit callbacks?

The existing `isHidden` callbacks often include temporary state such as not being in a group, not having a target, being out of combat, or a frame currently having no content. Reusing those callbacks hid too much, including raid and party layout anchors.

The new predicates describe saved user intent instead: the feature is disabled, or Visibility is exactly `Never`. This keeps the filter predictable without treating temporary frame state as configuration.

## Chat module note

The contribution guide warns against Chat module changes because modifications to Blizzard chat frames can introduce taint. The Chat change in this PR does not read from, write to, hook, or otherwise interact with a Blizzard-owned frame. It only registers a side-effect-free predicate that reads EllesmereUI's own saved Chat visibility and returns whether it is `never`.

No Chat events, hooks, scripts, or runtime frame behavior are added or changed. Keeping this predicate makes the setting consistent for the Chat anchor while avoiding the risky surfaces called out in the guide.

## Runtime and locale behavior

- The setting defaults off, preserving the existing Unlock Mode roster.
- No events, hooks, frames, or polling are added. Existing Unlock Mode paths perform an early setting check, and existing ghost refresh paths use the same predicate so hidden targets do not leave orphaned ghosts.
- Labels and tooltips continue through the existing runtime locale helpers. The static extractor cannot enumerate configuration strings passed through widgets, while the in-game `/euiloc` harvester can; this matches the translation guide.

## How was it tested?

Tested in-game on live Retail/Midnight 12.1 using the addon installed under the Retail AddOns directory.

- Confirmed the new setting and tooltip render under General Options.
- Confirmed the setting-off view preserves the full Unlock Mode layout.
- Confirmed enabling it removes explicitly disabled anchors, including Aura/Buff Reminders and disabled Cooldown Manager anchors.
- Confirmed elements saved with Visibility set to `Never` are hidden.
- Confirmed contextual Party Frames, Raid Frames, Boss Frames, and other situational elements remain available.
- Confirmed the original Unlock Mode toolbar remains unchanged.

Static validation:

- Lua 5.1 parse: 146 files parsed, 3 pre-existing UTF-8 BOM files skipped, 0 failures.
- Locale extractor: 731 static keys, with no generated `_keys.txt` diff.
- `git diff --check`: clean.
- Added-line ASCII check: clean.

## Screenshots

### General Options Setting

<img width="504" height="151" alt="qZYG54rLqy" src="https://github.com/user-attachments/assets/8e258618-9a74-4ef5-a6f1-f37e80026f8b" />

### Unlock Mode before enabling the filter

<img width="2560" height="1440" alt="QXbI1YTRC2" src="https://github.com/user-attachments/assets/e303564e-5a76-462d-8812-317be97d26af" />

### Unlock Mode after enabling the filter

<img width="2560" height="1440" alt="QRM5BIi4bw" src="https://github.com/user-attachments/assets/d71b821c-e7b5-47da-b024-1f070537e745" />

Disabled Cooldown Manager and Aura/Buff Reminder anchors disappear, while contextual Party, Raid, Boss, and other layout anchors remain.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: no new polling, timer-based logic, or per-frame allocations
- [x] No writes onto Blizzard-owned frames; the Chat addition only reads EllesmereUI saved configuration
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added