### PR TITLE
CDM: stop the buff loss sound firing on an aura replacement

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6107,16 +6107,75 @@ ns.EnsureFocusCastProxy = EnsureFocusCastProxy
 -- clean canonical id via GetCanonicalSpellIDForFrame (the same id the options menu writes the
 -- setting under) -- never index a table with the live secret id. Hooked-frame + throttle state
 -- live in a do-block, off the Blizzard frame table per the no-custom-props rule. Reuses the
--- FocusKick sound table (option list identical to Focus Cast Sound); the two edges use separate throttle tables so they never suppress each other.
+-- FocusKick sound table (option list identical to Focus Cast Sound). Edges are COALESCED to
+-- the end of the frame rather than played on the spot: some auras are reapplied by REPLACING
+-- the instance instead of refreshing it, and Blizzard checks its removed-alert triggers before
+-- the item frames adopt the new instance, so the drop edge fires while the buff is still up.
+-- Death and Decay does this on every entry into the circle, cueing a loss at the moment the
+-- buff was GAINED. One frame is the whole window -- both alerts fire inside a single
+-- ProcessUnitAuraEvent -- so both edges on one spell in one frame is that replacement.
 do
     local _soundHooked = setmetatable({}, { __mode = "k" })
-    local _soundThrottle = {}            -- [spellID] = last GetTime() (gain dedupe)
-    local _soundThrottleLost = {}        -- [spellID] = last GetTime() (loss dedupe)
+    -- Edges seen this frame: [spellID] = sound key, or false for "edge happened,
+    -- configured silent". A silent edge MUST still be recorded or a replacement
+    -- whose gain has no sound (the usual setup -- loss cue only) never pairs.
+    local _pendGain = {}
+    local _pendLoss = {}
+    local _flushQueued = false
+    local _pendStamp = 0                 -- GetTime() of the frame the pending edges belong to
+    -- Overlap guard, NOT an edge filter: two cues for the same spell and edge closer
+    -- together than this would talk over each other. Replacements are cancelled by the
+    -- pairing above, so this no longer hides them.
+    local _soundThrottle = {}            -- [spellID] = last GetTime() (gain)
+    local _soundThrottleLost = {}        -- [spellID] = last GetTime() (loss)
     local SOUND_MIN_GAP = 0.3
-    -- Resolve the per-icon sound for one edge and play it (throttled). `field` is
-    -- the spell-setting key ("buffActiveSoundKey" gain / "buffLostSoundKey" loss);
-    -- `throttle` is the matching dedupe table. Identical resolution for both edges.
-    local function PlayBuffEdgeSound(f, field, throttle)
+
+    -- Per-spell tier then bar tier, for one setting key. nil = silent.
+    local function PickBuffSoundKey(ss, sid, field)
+        local k = ss and ss[field]
+        if not k then k = ns.FindBuffSoundKey and ns.FindBuffSoundKey(sid, field) end
+        if not k or k == "none" then return nil end
+        return k
+    end
+
+    local function PlayThrottled(key, sid, throttle)
+        if not key then return end
+        local now = GetTime()
+        local last = throttle[sid]
+        if last and (now - last) < SOUND_MIN_GAP then return end
+        throttle[sid] = now
+        local path = FOCUSKICK_SOUND_PATHS[key]
+        if path then PlaySoundFile(path, "Master") end
+    end
+
+    local function FlushBuffEdges()
+        _flushQueued = false
+        -- Still inside the frame these edges were recorded in (the timer can tick
+        -- after some of the frame's aura events but before the rest): a later edge
+        -- could still pair with them, so decide next frame instead.
+        if GetTime() == _pendStamp then
+            _flushQueued = true
+            C_Timer.After(0, FlushBuffEdges)
+            return
+        end
+        -- Entries are cleared BEFORE playing so a throw inside PlaySoundFile cannot
+        -- strand one and have it cancel an unrelated edge on a later flush.
+        for sid, key in pairs(_pendLoss) do
+            -- Paired with a gain this frame = replacement: the buff never left, so
+            -- NEITHER cue is real. A true gain fires in its own, earlier frame.
+            local paired = _pendGain[sid] ~= nil
+            _pendGain[sid] = nil
+            _pendLoss[sid] = nil
+            if not paired then PlayThrottled(key, sid, _soundThrottleLost) end
+        end
+        for sid, key in pairs(_pendGain) do
+            _pendGain[sid] = nil
+            PlayThrottled(key, sid, _soundThrottle)
+        end
+    end
+
+    -- Record one edge for the end-of-frame flush. gainEdge picks the side.
+    local function RecordBuffEdge(f, gainEdge)
         -- Loading screen / login settle: buffs re-apply and viewer frames re-show
         -- across a zone/login, firing phantom apply/remove alerts. Drop them.
         if ns._cdmSoundSuppressed and ns._cdmSoundSuppressed() then return end
@@ -6126,23 +6185,37 @@ do
         -- handles variant/override spells). Falls back to an id-only lookup for the
         -- FIRST gain after login, whose alert fires before DecorateFrame populates
         -- _ecmeFC -- keying off that context dropped the very first cue.
-        local key
+        local ss
         local fc = _ecmeFC[f]
         local barKey = fc and fc.barKey
         if barKey then
             local sd = ns.GetBarSpellData and ns.GetBarSpellData(barKey)
-            local ss = ns.ResolveSpellSettings and ns.ResolveSpellSettings(f, sid, sd, barKey)
-            key = ss and ss[field]
+            ss = ns.ResolveSpellSettings and ns.ResolveSpellSettings(f, sid, sd, barKey)
         end
-        if not key then key = ns.FindBuffSoundKey and ns.FindBuffSoundKey(sid, field) end
-        if not key or key == "none" then return end
+        -- A silent edge still has to be recorded so it can cancel its partner, but only
+        -- when the OTHER edge has a cue -- so the second lookup runs only on that path.
+        local key = PickBuffSoundKey(ss, sid, gainEdge and "buffActiveSoundKey" or "buffLostSoundKey")
+        if not key and not PickBuffSoundKey(ss, sid, gainEdge and "buffLostSoundKey" or "buffActiveSoundKey") then
+            return
+        end
+        -- A new frame closes the previous batch: pairing must never reach across the
+        -- boundary, or a real drop and an unrelated real gain a frame later cancel out.
         local now = GetTime()
-        local last = throttle[sid]
-        if last and (now - last) < SOUND_MIN_GAP then return end
-        throttle[sid] = now
-        local path = FOCUSKICK_SOUND_PATHS[key]
-        if path then PlaySoundFile(path, "Master") end
+        if now ~= _pendStamp then
+            FlushBuffEdges()
+            _pendStamp = now
+        end
+        if gainEdge then
+            _pendGain[sid] = key or false
+        else
+            _pendLoss[sid] = key or false
+        end
+        if not _flushQueued then
+            _flushQueued = true
+            C_Timer.After(0, FlushBuffEdges)
+        end
     end
+
     function ns.EnsureBuffSoundHook(frame)
         if not frame or _soundHooked[frame] then return end
         -- Own placeholder/custom frames (and anything that isn't a Blizzard buff
@@ -6153,12 +6226,12 @@ do
         end
         _soundHooked[frame] = true
         hooksecurefunc(frame, "TriggerAuraAppliedAlert", function(f)
-            PlayBuffEdgeSound(f, "buffActiveSoundKey", _soundThrottle)
+            RecordBuffEdge(f, true)
         end)
         -- Loss edge: Blizzard fires TriggerAuraRemovedAlert when the buff drops.
         if type(frame.TriggerAuraRemovedAlert) == "function" then
             hooksecurefunc(frame, "TriggerAuraRemovedAlert", function(f)
-                PlayBuffEdgeSound(f, "buffLostSoundKey", _soundThrottleLost)
+                RecordBuffEdge(f, false)
             end)
         end
     end


### PR DESCRIPTION
## What does this PR do?

Fixes "Audio on Buff Loss" firing at the moment a buff is GAINED.

Some auras are reapplied by REPLACING the instance rather than refreshing it. The
client destroys aura instance N and creates N+1 inside a single `UNIT_AURA` batch, and
`CooldownViewerMixin:ProcessUnitAuraEvent` checks its removed-alert triggers BEFORE the
item frames adopt the new instance (`Blizzard_CooldownViewer/CooldownViewer.lua:1646`).
The frame still holds N, the ids match, and `TriggerAuraRemovedAlert` fires while the
buff is still up.

Death and Decay does this on every entry into the circle, so a Death Knight with a loss
cue on it heard the sound when gaining the buff, again on every boundary crossing, and
again at the end. Traced live with a `UNIT_AURA` printer:

```
[14.42] ADD    inst=735  spell=188290   <- player gains DnD
[14.42] ADD    inst=737  spell=391459
[14.60] ADD    inst=739  spell=188290   <- replaced one frame later
[14.60] REMOVE inst=735                 <- loss cue fired here
```

`GetTime()` is frame-granular, so identical timestamps are one frame. Every spurious cue
in the captures is a same-frame ADD+REMOVE pair of one spell; every genuine loss is a
REMOVE with no paired ADD. A true in-place refresh arrives as `updatedAuraInstanceIDs`
and fires no alert at all, so replacement is the only case that reaches this code.

Both edges are now coalesced to an end-of-frame flush, and a spell that sees both edges
in one frame plays neither. A silent edge is still recorded (as `false`) so a
replacement whose gain has no sound -- the reported setup, loss cue only -- still pairs.
Edges carry a frame stamp so pairing can never reach across a frame boundary and cancel
a real drop against an unrelated later gain.

Cues now fire one frame (~16ms) later than before. Anyone who had a *gain* cue on a
replacing aura previously heard one per replacement and will now hear only real gains.

## How was it tested?

Live, 12.1 (`120100`), Death Knight with Death and Decay tracked as a CDM buff.

| Case | Before | After |
|---|---|---|
| No Cleaving Strikes: cast / out / in / out | 4 cues | 2, both real |
| Cleaving Strikes, same run | 4 cues (6 edges, 2 eaten by the throttle) | 1 |
| Stay inside the circle for the full 10s | gain-time cue + end cue | 1 gain, 1 loss |
| Gain and loss both set, distinct sounds | -- | each edge plays its own cue |
| Both rows set to None | -- | silent |
| Control auras `43265` / `440289` / `440290` | 1 cue each | 1 each, unchanged |
| First cast after `/reload` and after a zone change | -- | settle window still suppresses, first real cue survives |

Not verified: gain cue set with loss set to None. It exercises the `false`-encoding path
in the gain direction; the loss direction of the same path is covered by rows 1 and 2.

## Screenshots

N/A -- audio only, no visual change.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new
      settings; behaviour changes only for users who already configured a sound
- [x] Zero cost while disabled: hook attach is still gated on `ns._cdmAnyBuffSound`, no
      new events registered and no frames built
- [x] Cheap while enabled -- see the note below on the flush timer
- [x] No writes onto Blizzard-owned frames: all state lives in do-block locals plus the
      existing weak-keyed hooked-frame table; `hooksecurefunc` only, no `SetScript`
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added

### Note on "no timer-based logic"

This adds a `C_Timer.After(0, FlushBuffEdges)`. It is a one-shot deferral to the end of
the current frame, not a poll: it is armed by an aura edge, fires at most once per frame
that actually had one, and only for users with a buff sound configured. One frame is the
correct window because Blizzard fires both alerts inside a single
`ProcessUnitAuraEvent`. `FlushBuffEdges` is a named upvalue, so no closure is allocated,
though `C_Timer.After` itself allocates a ticker per call -- one per edge-bearing frame.
The same pattern is already used throughout `EllesmereUICdmHooks.lua`. Happy to swap it
for a shown/hidden `OnUpdate` frame if reviewers would rather have zero allocation.

## Known remaining, not addressed here

A walk-out Death and Decay still produces two loss cues, and both are genuine aura
removals. One CDM icon is backed by two auras -- `43265`, the 10-second ground effect,
and the `188290` family carried while standing inside -- and the icon stays present the
whole time while its backing aura swaps.

| Moment | Aura removed | Frame afterwards | About the player? |
|---|---|---|---|
| Step out of the circle | `188290` | still active, shows `43265` | yes, the damage bonus is gone |
| DnD's 10s duration ends | `43265` | inactive | no, the player already left |

This PR's pairing cannot see it: reverting to an aura that is already running adds
nothing, so there is no `addedAuras` entry to pair with. The obvious fix -- suppress a
loss while `CooldownViewerItemMixin:IsActive()` is still true -- gets it backwards,
silencing the step-out cue the player cares about and keeping the expiry cue that fires
when nothing happened to them. Left open deliberately; it needs a decision about which
cue users want, not more code.
