### PR TITLE
fix(locale): wrap display strings that never reached L()

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -6089,7 +6089,7 @@ function EUI_BagsWindow:RefreshBags()
                 else
                     local bInvID = C_Container.ContainerIDToInventoryID(bagIdx)
                     local bLink = GetInventoryItemLink("player", bInvID)
-                    bName = bLink and GetItemInfo(bLink) or ("Bag " .. bagIdx)
+                    bName = bLink and GetItemInfo(bLink) or EUI.Lf("Bag %1$d", bagIdx)
                 end
                 local bTotal = C_Container.GetContainerNumSlots(bagIdx)
                 local bFree = C_Container.GetContainerNumFreeSlots(bagIdx)

--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -145,7 +145,7 @@ local function GetCharacterBankTabs()
                 if numSlots > 0 then
                     local icon = td.icon
                     if not icon or icon == 134400 then icon = GetFallbackIcon(bagID) end
-                    tabs[#tabs + 1] = { bagID = bagID, numSlots = numSlots, name = td.name or ("Bank Tab " .. i), icon = icon, depositFlags = td.depositFlags or 0 }
+                    tabs[#tabs + 1] = { bagID = bagID, numSlots = numSlots, name = td.name or EUI.Lf("Bank Tab %1$d", i), icon = icon, depositFlags = td.depositFlags or 0 }
                 end
             end
         end
@@ -153,7 +153,7 @@ local function GetCharacterBankTabs()
         for i, bagID in ipairs(CHARACTER_BANK_BAGS) do
             local numSlots = C_Container.GetContainerNumSlots(bagID)
             if numSlots > 0 then
-                tabs[#tabs + 1] = { bagID = bagID, numSlots = numSlots, name = "Bank Tab " .. #tabs + 1, icon = GetFallbackIcon(bagID), depositFlags = 0 }
+                tabs[#tabs + 1] = { bagID = bagID, numSlots = numSlots, name = EUI.Lf("Bank Tab %1$d", #tabs + 1), icon = GetFallbackIcon(bagID), depositFlags = 0 }
             end
         end
     end
@@ -178,7 +178,7 @@ local function GetWarbandBankTabs()
             if bagID then
                 local numSlots = C_Container.GetContainerNumSlots(bagID)
                 if numSlots > 0 then
-                    local name = td.name or ("Tab " .. i)
+                    local name = td.name or EUI.Lf("Tab %1$d", i)
                     local icon = td.icon
                     if not icon or icon == 134400 then icon = GetFallbackIcon(bagID) end
                     tabs[#tabs + 1] = { bagID = bagID, numSlots = numSlots, name = EUI.L("Warbank") .. " " .. name, icon = icon, depositFlags = td.depositFlags or 0 }
@@ -189,7 +189,7 @@ local function GetWarbandBankTabs()
         for i, bagID in ipairs(WARBAND_BANK_BAGS) do
             local numSlots = C_Container.GetContainerNumSlots(bagID)
             if numSlots > 0 then
-                tabs[#tabs + 1] = { bagID = bagID, numSlots = numSlots, name = EUI.L("Warbank") .. " Tab " .. #tabs + 1, icon = GetFallbackIcon(bagID), depositFlags = 0 }
+                tabs[#tabs + 1] = { bagID = bagID, numSlots = numSlots, name = EUI.L("Warbank") .. " " .. EUI.Lf("Tab %1$d", #tabs + 1), icon = GetFallbackIcon(bagID), depositFlags = 0 }
             end
         end
     end
@@ -796,7 +796,7 @@ local function EnsureBankTabConfigFrame()
         if parent.bankType and parent.tabId then
             local newName = bankTabNameEditBox:GetText()
             if not newName or newName == "" then
-                newName = parent.fallbackName or ("Tab " .. tostring(parent.tabId))
+                newName = parent.fallbackName or EUI.Lf("Tab %1$d", parent.tabId)
             end
 
             C_Bank.UpdateBankTabSettings(parent.bankType, parent.tabId, newName, parent.icon, parent.depositFlags or 0)

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -966,7 +966,9 @@ local function SkinCharacterSheet()
         INVTYPE_FINGER = {slots = {11, 12}, name = "Ring"},
         INVTYPE_TRINKET = {slots = {13, 14}, name = "Trinket"},
         -- A cloak's equip-location string is INVTYPE_CLOAK, never INVTYPE_BACK.
-        INVTYPE_CLOAK = {slot = 15, name = "Back"},
+        -- "Cloak" (not "Back") so this doesn't collide with the "Back" nav-button
+        -- key elsewhere in the catalog; matches EUI_UpgradeCalc.lua's slotNames[15].
+        INVTYPE_CLOAK = {slot = 15, name = "Cloak"},
         -- One-hand weapons report INVTYPE_WEAPONMAINHAND / INVTYPE_WEAPONOFFHAND;
         -- INVTYPE_MAINHAND / INVTYPE_OFFHAND do not exist and match no item. An
         -- ambiguous one-hander (INVTYPE_WEAPON) can go in either slot.
@@ -1322,7 +1324,7 @@ local function SkinCharacterSheet()
             for i = 1, maxShow do
                 local item = betterItems[i]
                 local leftText = string.format("|T%s:16|t  %s (iLvl %d)", item.icon, item.name, item.level)
-                GameTooltip:AddDoubleLine(leftText, item.slot, 1, 1, 1, 0.7, 0.7, 0.7)
+                GameTooltip:AddDoubleLine(leftText, L(item.slot), 1, 1, 1, 0.7, 0.7, 0.7)
             end
 
             if #betterItems > 10 then
@@ -1342,7 +1344,7 @@ local function SkinCharacterSheet()
             local maxShow = math.min(#betterItems, 10)
             for i = 1, maxShow do
                 local item = betterItems[i]
-                local text = string.format("%s (iLvl %d) - %s", item.name, item.level, item.slot)
+                local text = string.format("%s (iLvl %d) - %s", item.name, item.level, L(item.slot))
                 -- Rough estimate: ~6 pixels per character + icon space
                 local estimatedWidth = #text * 6 + 30
                 if estimatedWidth > maxWidth then
@@ -2214,7 +2216,7 @@ local function SkinCharacterSheet()
                         if currencyInfo then
                             local earned = currencyInfo.totalEarned or 0
                             local maximum = currencyInfo.maxQuantity or 0
-                            GameTooltip:AddLine(L(stat.name) .. " Crests", scR, scG, scB, 1)
+                            GameTooltip:AddLine(L(stat.name) .. L(" Crests"), scR, scG, scB, 1)
                             GameTooltip:AddLine(string.format("%d / %d", earned, maximum), 1, 1, 1, true)
                         end
                     -- Secondary stats with raw rating
@@ -3236,8 +3238,10 @@ local function SkinCharacterSheet()
         if not setItems then return {} end
 
         local missing = {}
+        -- "Cloak" (not "Back") so this doesn't collide with the "Back" nav-button
+        -- key elsewhere in the catalog; matches EUI_UpgradeCalc.lua's slotNames[15].
         local slotNames = {
-            "Head", "Neck", "Shoulder", "Back",
+            "Head", "Neck", "Shoulder", "Cloak",
             "Chest", "Waist", "Legs", "Feet",
             "Wrist", "Hands", "Finger 1", "Finger 2",
             "Trinket 1", "Trinket 2", "Main Hand", "Off Hand",
@@ -3464,7 +3468,7 @@ local function SkinCharacterSheet()
                                 or (GetItemIcon and GetItemIcon(item.itemID))
                             local iconText = icon and string.format("|T%s:16|t", icon) or ""
                             GameTooltip:AddLine(
-                                string.format("%s %s: %s", iconText, item.slot, item.itemName),
+                                string.format("%s %s: %s", iconText, L(item.slot), item.itemName),
                                 1, 1, 1, true)
                         end
                         GameTooltip:Show()

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_SocketPanel.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_SocketPanel.lua
@@ -432,7 +432,8 @@ local function AcquireIcon(i)
             -- Empty socket: plain-text hint uses the EUI widget tooltip.
             if EllesmereUI and EllesmereUI.ShowWidgetTooltip then
                 EllesmereUI.ShowWidgetTooltip(self,
-                    (rec.emptyName or "Empty Socket") .. "\nPick a gem from the list to socket it.",
+                    EllesmereUI.L(rec.emptyName or "Empty Socket")
+                        .. EllesmereUI.L("\nPick a gem from the list to socket it."),
                     { anchor = "right" })
             end
         end
@@ -668,7 +669,7 @@ local function PopulateFlyout()
         local row = AcquireGemRow(1)
         row.icon:SetTexture(nil)
         row.icon:SetColorTexture(0, 0, 0, 0)
-        row.label:SetText("No gems in bags.")
+        row.label:SetText(EllesmereUI.L("No gems in bags."))
         row.label:SetTextColor(0.5, 0.5, 0.5)
         row.count:SetText("")
         row.gemItemID = nil

--- a/EllesmereUIOptions/EUI_Quickdraw_Options.lua
+++ b/EllesmereUIOptions/EUI_Quickdraw_Options.lua
@@ -459,9 +459,9 @@ initFrame:SetScript("OnEvent", function(self)
                 local cap = ns.NestChildCap and ns.NestChildCap(editPalette)
                 local child = ns.ChildIndex(slot)
                 local kids = ns.ChildSlots and ns.ChildSlots(child, cap)
-                caption = ("nested action menu, %d %s"):format(
-                    kids and #kids or 0,
-                    (kids and #kids == 1) and "entry" or "entries")
+                caption = (kids and #kids == 1)
+                    and EllesmereUI.Lf("nested action menu, %1$d entry", 1)
+                    or  EllesmereUI.Lf("nested action menu, %1$d entries", kids and #kids or 0)
                 -- Said where the user meets it, rather than left to be
                 -- discovered by counting the entries that turned up: a menu
                 -- holding more than the halo can show looks broken otherwise.
@@ -2522,11 +2522,11 @@ initFrame:SetScript("OnEvent", function(self)
             -- Right-click means two different things on a plainMouse picker
             -- depending on whether it is armed, so it has to say which.
             local tip = plainMouse
-                and "Left-click to set a keybind, then press any key or\n"
+                and EllesmereUI.L("Left-click to set a keybind, then press any key or\n"
                     .. "click any mouse button to use it.\n"
-                    .. "Escape cancels. Right-click here to unbind."
-                or "Left-click to set a keybind.\nRight-click to unbind."
-            if intro then tip = intro .. "\n\n" .. tip end
+                    .. "Escape cancels. Right-click here to unbind.")
+                or EllesmereUI.L("Left-click to set a keybind.\nRight-click to unbind.")
+            if intro then tip = EllesmereUI.L(intro) .. "\n\n" .. tip end
             EllesmereUI.ShowWidgetTooltip(self, tip)
         end)
         kbBtn:SetScript("OnLeave", function()

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -709,9 +709,10 @@ qolFrame:SetScript("OnEvent", function(self)
             trainBtn:SetScript("OnEnter", function(self)
                 local n, gold = TrainableSummary()
                 if n <= 0 then return end
-                local msg = string.format("Learn %d skill%s for %s",
-                    n, n == 1 and "" or "s",
-                    C_CurrencyInfo.GetCoinTextureString(gold))
+                local goldStr = C_CurrencyInfo.GetCoinTextureString(gold)
+                local msg = (n == 1)
+                    and EllesmereUI.Lf("Learn %1$d skill for %2$s", n, goldStr)
+                    or  EllesmereUI.Lf("Learn %1$d skills for %2$s", n, goldStr)
                 EllesmereUI.ShowWidgetTooltip(self, msg)
             end)
             trainBtn:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)


### PR DESCRIPTION
### Problem

On non-English clients (zhTW etc.), several tooltips and fallback
labels always render in English even when a translation already
exists in the locale catalog, because the literal text never passes
through `L()`/`Lf()` before being displayed:

- Character sheet: the "you have N better items" tooltip's per-item
  slot name, and the equipment-set "Missing Items:" tooltip's slot
  name, both render in English.
- Character sheet: a Crests currency line shows the " Crests" suffix
  in English (concatenated outside the `L()` call).
- Socket panel: the empty-socket tooltip and the "No gems in bags."
  flyout row render in English.
- Quickdraw keybind picker: the "Left-click to set..." tooltip (and
  its optional intro line) render in English.
- Quickdraw nested-menu preview: the "N entries" caption is built by
  `string.format` before it reaches `L()`, so it can never match a
  catalog key.
- Bags/Bank: fallback tab and bag names ("Bag N", "Tab N", "Bank Tab
  N") are built by concatenation, so they can never be localized.
- QoL trainer button tooltip ("Learn N skill(s) for ...") is not
  localized at all.

### Cause

All of these compose the final string with plain concatenation or
`string.format` before (or instead of) calling `L()`. `L()`/`Lf()` do
a literal key lookup, so a runtime-composed string can never match a
catalog entry -- the fix has to happen at the point the string is
composed, not by translating the composed text afterward.

Separately, the character-sheet slot-name literal for the cloak slot
was "Back", which collides with the existing "Back" catalog entry used
by a handful of navigation buttons. Wrapping it as-is would have shown
the nav-button translation on the cloak slot instead. Renamed to
"Cloak", matching the name `EUI_UpgradeCalc.lua`'s own slot table
already uses for the same slot (15) -- "Cloak" already has a
translation in every shipped locale, no catalog changes needed.

### Fix

- Wrapped each display site in `L()` (existing catalog keys) or
  `Lf()` (new keys, English fallback until translated) at the point
  the string is composed, not after.
- Split the two `%d %s`-style plural constructions ("N entr(y|ies)",
  "Learn N skill(s)...") into separate singular/plural `Lf()` keys
  instead of concatenating an English plural suffix -- that shape
  can't be localized correctly (Chinese has no plural form).
- Renamed the character-sheet cloak-slot literal "Back" -> "Cloak" to
  avoid the catalog collision described above.

### Notes

- `EllesmereUIQoL.lua`'s "Train All" button label is a separate
  never-wrapped literal noticed in passing; left out to keep this PR
  scoped to the string-composition bug.
- Two larger items surfaced during the same triage are intentionally
  NOT in this PR: `EUI_PlayerAuraBars_ManagerPages.lua`'s seeded
  bar/filter names (needs a scoped-lookup design decision -- wrapping
  with the global `L()` risks colliding with the 65 single-word
  Search Keywords catalog entries) and `EllesmereUI_VideoGuides.lua`'s
  popup fields (larger, multi-site change). Both tracked separately.
- New `Lf()` keys added by this PR have no zhTW translation yet; they
  render in English until a follow-up locale PR adds them -- same as
  before this fix, no regression.

### Testing

In-game, on live, zhTW client:

- Character sheet, hover equipped-item-level tooltip with a
  higher-ilvl cloak in bags -> slot label shows "披風"
- Character sheet, hover an incomplete equipment-set tile missing a
  cloak -> "Missing Items:" line shows "披風"
- Character sheet, hover a Crests-tracked secondary stat -> line shows
  "<stat> 紋章" with no stray space
- Character sheet socket panel, hover an empty socket -> "空插槽" +
  "從清單中挑選一顆寶石進行鑲嵌。"
- Character sheet socket panel, open gem flyout with no gems in bags
  -> "背包中沒有寶石。"
- Quickdraw options, hover a keybind-picker button -> tooltip in
  Chinese, including the intro line where present
- Quickdraw options, hover a nested-action-menu slot -> caption
  renders "nested action menu, N entry/entries" (not yet translated,
  renders correctly in English, no Lua error)
- Bags/Bank fallback names and QoL trainer tooltip -> spot-checked, no
  Lua error, English output unchanged from before this PR (not yet
  translated)

### Checklist

- [x] N/A - no new settings, this is a display-string bug fix
- [x] N/A - not gated behind a setting, zero cost either way
- [x] Cheap while enabled - wraps are O(1) catalog lookups on existing
      hot paths, no new event registration or polling
- [x] No writes onto Blizzard-owned frames - unchanged by this PR
- [x] Tested in-game on live; no version gates or pre-Midnight APIs
      added
