### PR TITLE
Fix combat item comparison tooltips

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2657,6 +2657,7 @@ do
     GameTooltip:HookScript("OnHide", function(tt)
         -- Only fires for unparked hides (a parked tooltip is never visible); clears the default-anchored flag promptly.
         _defaultAnchored = false
+        if not (_comparisonSupportActive or _comparisonStateWatcherRegistered) then return end
         if EllesmereUI._tooltipSuppressedByMode(tt) then
             QueueSuppressedComparisonClear()
         end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2494,6 +2494,8 @@ do
     -- combat when alwaysCompareItems is enabled.  Keep the cleanup in this global
     -- tooltip controller rather than in ActionBars: bags, world items, and every
     -- other default-anchored item tooltip use the same comparison manager.
+    -- Use Blizzard's existing comparison-suppression flag; addon-owned state
+    -- stays in locals so no custom state is stored on Blizzard frames.
     local _comparisonTooltips = { ShoppingTooltip1, ShoppingTooltip2 }
     local _comparisonClearPending = false
     local _comparisonFlagOwned = false
@@ -2577,16 +2579,17 @@ do
         end
     end
 
+    local function RunSuppressedComparisonClear()
+        _comparisonClearPending = false
+        ClearSuppressedComparisons()
+    end
     local function QueueSuppressedComparisonClear()
         if _comparisonClearPending then return end
         _comparisonClearPending = true
         -- This hook can run from Blizzard's protected tooltip/action-button path.
         -- Defer all Hide/Clear calls out of that stack, matching the existing EUI
         -- tooltip-skin deferral rules.
-        C_Timer.After(0, function()
-            _comparisonClearPending = false
-            ClearSuppressedComparisons()
-        end)
+        C_Timer.After(0, RunSuppressedComparisonClear)
     end
 
     -- Catch both the normal comparison-manager path and a direct Show/SetShown

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2518,14 +2518,11 @@ do
         return false
     end
 
-    -- Item comparisons are rendered by separate ShoppingTooltip frames.  Parking
+    -- Item comparisons are rendered by separate ShoppingTooltip frames. Parking
     -- GameTooltip alone therefore leaves the side-by-side comparison visible in
-    -- combat when alwaysCompareItems is enabled.  Keep the cleanup in this global
+    -- combat when alwaysCompareItems is enabled. Keep the cleanup in this global
     -- tooltip controller rather than in ActionBars: bags, world items, and every
     -- other default-anchored item tooltip use the same comparison manager.
-    -- Use Blizzard's existing comparison-suppression control field; addon-owned
-    -- state stays in the shared weak-keyed FFD table so no custom state is stored
-    -- on Blizzard frames.
     local _comparisonTooltips
     local _comparisonClearPending = false
 
@@ -2534,99 +2531,6 @@ do
             _comparisonTooltips = { ShoppingTooltip1, ShoppingTooltip2 }
         end
         return _comparisonTooltips
-    end
-
-    local function GetComparisonState(tooltip, create)
-        local state = FFD[tooltip]
-        if not state and create then
-            state = {}
-            FFD[tooltip] = state
-        end
-        return state
-    end
-
-    local function WriteComparisonSuppressionFlag(tooltip, value)
-        -- Blizzard exposes this field as the per-tooltip opt-out for automatic
-        -- comparisons. It is a Blizzard control input, not addon-owned state.
-        tooltip.suppressAutomaticCompareItem = value
-    end
-
-    local function SetComparisonSuppressionFlag(tooltip, value)
-        return pcall(WriteComparisonSuppressionFlag, tooltip, value)
-    end
-
-    local function ReleaseComparisonSuppression(tooltip)
-        if not _comparisonSupportActive or tooltip ~= GameTooltip then return end
-        local state = GetComparisonState(tooltip, false)
-        if not state or not state.comparisonFlagOwned then return end
-        if not SetComparisonSuppressionFlag(tooltip, state.comparisonFlagPrevious) then return end
-        state.comparisonFlagPrevious = nil
-        state.comparisonFlagOwned = nil
-    end
-
-    local function ArmComparisonSuppression(tooltip)
-        if tooltip ~= GameTooltip then return end
-        local state = GetComparisonState(tooltip, true)
-        local owned = state.comparisonFlagOwned
-        if not owned then
-            state.comparisonFlagPrevious = tooltip.suppressAutomaticCompareItem
-            state.comparisonFlagOwned = true
-        end
-        -- GameTooltip_SetDefaultAnchor runs before ActionButton_SetTooltip calls
-        -- SetAction, so this prevents the comparison from being created in the
-        -- first place.  The deferred cleanup below still handles comparisons that
-        -- were already shown or are refreshed by Blizzard after this hook.
-        if not SetComparisonSuppressionFlag(tooltip, true) and not owned then
-            state.comparisonFlagPrevious = nil
-            state.comparisonFlagOwned = nil
-        end
-    end
-
-    -- Anchor suppression normally arms the flag before ActionButton:SetAction,
-    -- but item data can be processed again later by TOOLTIP_DATA_UPDATE.  Put a
-    -- second guard directly before Blizzard's item finalizer asks whether it
-    -- should compare.  This closes the one-frame window where the comparison
-    -- manager could otherwise create ShoppingTooltip frames before our deferred
-    -- cleanup runs.
-    local _comparisonPreCallInstalled = false
-    local function OnItemTooltipPreCall(tooltip)
-        if not _comparisonSupportActive or tooltip ~= GameTooltip then return end
-        if not ComparisonSuppressionModeEnabled() then
-            ReleaseComparisonSuppression(tooltip)
-            return
-        end
-        if EllesmereUI._tooltipSuppressedByMode(tooltip) then
-            ArmComparisonSuppression(tooltip)
-        else
-            ReleaseComparisonSuppression(tooltip)
-        end
-    end
-    local function InstallComparisonPreCall()
-        if _comparisonPreCallInstalled then return true end
-        if not (TooltipDataProcessor and TooltipDataProcessor.AddTooltipPreCall
-            and Enum and Enum.TooltipDataType and Enum.TooltipDataType.Item) then
-            return false
-        end
-        TooltipDataProcessor.AddTooltipPreCall(Enum.TooltipDataType.Item, OnItemTooltipPreCall)
-        _comparisonPreCallInstalled = true
-        return true
-    end
-
-    local _comparisonPreCallRetry
-    local function EnsureComparisonPreCall()
-        if InstallComparisonPreCall() or _comparisonPreCallRetry then return end
-        -- The normal client has these APIs before addon Lua loads, but retry at
-        -- PLAYER_LOGIN so a load-order change does not silently remove the
-        -- primary no-comparison guard for the whole session.
-        _comparisonPreCallRetry = CreateFrame("Frame")
-        _comparisonPreCallRetry:RegisterEvent("PLAYER_LOGIN")
-        _comparisonPreCallRetry:SetScript("OnEvent", function(self)
-            self:UnregisterAllEvents()
-            _comparisonPreCallRetry = nil
-            if ComparisonSuppressionModeEnabled() then
-                InstallComparisonPreCall()
-            end
-        end)
     end
 
     local function ClearSuppressedComparisons()
@@ -2692,7 +2596,6 @@ do
     EnsureComparisonSupport = function()
         if not ComparisonSuppressionModeEnabled() then return false end
         _comparisonSupportActive = true
-        EnsureComparisonPreCall()
         InstallComparisonHooks()
         return true
     end
@@ -2733,11 +2636,9 @@ do
     end
     local function ApplySuppression(tt)
         if EllesmereUI._tooltipSuppressedByMode(tt) then
-            ArmComparisonSuppression(tt)
             ParkTooltip(tt)
             QueueSuppressedComparisonClear()
         else
-            ReleaseComparisonSuppression(tt)
             UnparkTooltip(tt)
         end
     end
@@ -2750,16 +2651,12 @@ do
         hooksecurefunc("GameTooltip_SetDefaultAnchor", SuppressTooltipByMode)
     end
     hooksecurefunc(GameTooltip, "SetOwner", function(tt)
-        -- SetOwner begins every new tooltip build.  Release a flag owned by the
-        -- previous suppressed build before the default-anchor hook re-arms it.
-        ReleaseComparisonSuppression(tt)
         _defaultAnchored = false
         UnparkTooltip(tt)
     end)
     GameTooltip:HookScript("OnHide", function(tt)
         -- Only fires for unparked hides (a parked tooltip is never visible); clears the default-anchored flag promptly.
         _defaultAnchored = false
-        ReleaseComparisonSuppression(tt)
         if EllesmereUI._tooltipSuppressedByMode(tt) then
             QueueSuppressedComparisonClear()
         end
@@ -2791,7 +2688,6 @@ do
     end
     UpdateStateWatcher = function()
         if not ComparisonSuppressionModeEnabled() then
-            ReleaseComparisonSuppression(GameTooltip)
             _comparisonSupportActive = false
             UnregisterStateWatcher()
             return
@@ -2868,7 +2764,6 @@ do
         if down == 1 then
             if _parked and GameTooltip:IsShown() then
                 -- The parked tip is alive and current under the cursor (built by the secure hover path): just reveal it, never rebuild from here (see the parking note above).
-                ReleaseComparisonSuppression(GameTooltip)
                 UnparkTooltip(GameTooltip)
             else
                 -- No live tip: module-built tips (raid frames, CDM) skip building while suppressed, so re-drive the hovered frame's OnEnter -- with the modifier now held they build normally.
@@ -2876,7 +2771,6 @@ do
             end
         elseif GameTooltip:IsShown() and EllesmereUI._tooltipSuppressedByMode(GameTooltip) then
             if _defaultAnchored then
-                ArmComparisonSuppression(GameTooltip)
                 ParkTooltip(GameTooltip)
                 QueueSuppressedComparisonClear()
             else

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2489,6 +2489,122 @@ do
         return false
     end
 
+    -- Item comparisons are rendered by separate ShoppingTooltip frames.  Parking
+    -- GameTooltip alone therefore leaves the side-by-side comparison visible in
+    -- combat when alwaysCompareItems is enabled.  Keep the cleanup in this global
+    -- tooltip controller rather than in ActionBars: bags, world items, and every
+    -- other default-anchored item tooltip use the same comparison manager.
+    local _comparisonTooltips = { ShoppingTooltip1, ShoppingTooltip2 }
+    local _comparisonClearPending = false
+    local _comparisonFlagOwned = false
+    local _comparisonFlagPrevious
+
+    local function ReleaseComparisonSuppression(tooltip)
+        if tooltip ~= GameTooltip or not _comparisonFlagOwned then return end
+        local previous = _comparisonFlagPrevious
+        _comparisonFlagPrevious = nil
+        _comparisonFlagOwned = false
+        tooltip.suppressAutomaticCompareItem = previous
+    end
+
+    local function ArmComparisonSuppression(tooltip)
+        if tooltip ~= GameTooltip then return end
+        if not _comparisonFlagOwned then
+            _comparisonFlagPrevious = tooltip.suppressAutomaticCompareItem
+            _comparisonFlagOwned = true
+        end
+        -- GameTooltip_SetDefaultAnchor runs before ActionButton_SetTooltip calls
+        -- SetAction, so this prevents the comparison from being created in the
+        -- first place.  The deferred cleanup below still handles comparisons that
+        -- were already shown or are refreshed by Blizzard after this hook.
+        tooltip.suppressAutomaticCompareItem = true
+    end
+
+    -- Anchor suppression normally arms the flag before ActionButton:SetAction,
+    -- but item data can be processed again later by TOOLTIP_DATA_UPDATE.  Put a
+    -- second guard directly before Blizzard's item finalizer asks whether it
+    -- should compare.  This closes the one-frame window where the comparison
+    -- manager could otherwise create ShoppingTooltip frames before our deferred
+    -- cleanup runs.
+    local _comparisonPreCallInstalled = false
+    local function OnItemTooltipPreCall(tooltip)
+        if tooltip ~= GameTooltip then return end
+        if EllesmereUI._tooltipSuppressedByMode(tooltip) then
+            ArmComparisonSuppression(tooltip)
+        else
+            ReleaseComparisonSuppression(tooltip)
+        end
+    end
+    local function InstallComparisonPreCall()
+        if _comparisonPreCallInstalled then return true end
+        if not (TooltipDataProcessor and TooltipDataProcessor.AddTooltipPreCall
+            and Enum and Enum.TooltipDataType and Enum.TooltipDataType.Item) then
+            return false
+        end
+        TooltipDataProcessor.AddTooltipPreCall(Enum.TooltipDataType.Item, OnItemTooltipPreCall)
+        _comparisonPreCallInstalled = true
+        return true
+    end
+    InstallComparisonPreCall()
+    if not _comparisonPreCallInstalled then
+        -- The normal client has these APIs before addon Lua loads, but retry at
+        -- PLAYER_LOGIN so a load-order change does not silently remove the
+        -- primary no-comparison guard for the whole session.
+        local preCallRetry = CreateFrame("Frame")
+        preCallRetry:RegisterEvent("PLAYER_LOGIN")
+        preCallRetry:SetScript("OnEvent", function(self)
+            self:UnregisterAllEvents()
+            InstallComparisonPreCall()
+        end)
+    end
+
+    local function ClearSuppressedComparisons()
+        if not EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
+
+        -- Clear the manager's state and its owned shopping frames through the
+        -- same public method Blizzard calls from GameTooltip_OnHide.  Fall back
+        -- to Blizzard's helper only when the manager is unavailable, does not
+        -- own GameTooltip, or errors; avoid a third direct Hide pass over global
+        -- shopping frames that may belong to another tooltip path.
+        local managerCleared = false
+        if TooltipComparisonManager
+            and TooltipComparisonManager.tooltip == GameTooltip
+            and type(TooltipComparisonManager.Clear) == "function" then
+            managerCleared = pcall(TooltipComparisonManager.Clear, TooltipComparisonManager, GameTooltip)
+        end
+        if not managerCleared and GameTooltip_HideShoppingTooltips then
+            pcall(GameTooltip_HideShoppingTooltips, GameTooltip)
+        end
+    end
+
+    local function QueueSuppressedComparisonClear()
+        if _comparisonClearPending then return end
+        _comparisonClearPending = true
+        -- This hook can run from Blizzard's protected tooltip/action-button path.
+        -- Defer all Hide/Clear calls out of that stack, matching the existing EUI
+        -- tooltip-skin deferral rules.
+        C_Timer.After(0, function()
+            _comparisonClearPending = false
+            ClearSuppressedComparisons()
+        end)
+    end
+
+    -- Catch both the normal comparison-manager path and a direct Show/SetShown
+    -- from Blizzard.  OnShow only queues a deferred cleanup; it never mutates a
+    -- Blizzard frame from the protected call stack.
+    for _, comparisonTooltip in ipairs(_comparisonTooltips) do
+        if comparisonTooltip and comparisonTooltip.HookScript then
+            comparisonTooltip:HookScript("OnShow", function()
+                if EllesmereUI._tooltipSuppressedByMode(GameTooltip) then
+                    QueueSuppressedComparisonClear()
+                end
+            end)
+        end
+    end
+    if TooltipComparisonManager and type(TooltipComparisonManager.AnchorShoppingTooltips) == "function" then
+        hooksecurefunc(TooltipComparisonManager, "AnchorShoppingTooltips", QueueSuppressedComparisonClear)
+    end
+
     -- Suppression parks the tooltip in a hidden host frame -- NOT Hide(), NOT alpha.
     -- Hide()-based suppression forced peek to REBUILD the tooltip from our insecure
     -- execution: in combat, action tooltips read secret cooldown data and the rebuild
@@ -2525,8 +2641,11 @@ do
     end
     local function ApplySuppression(tt)
         if EllesmereUI._tooltipSuppressedByMode(tt) then
+            ArmComparisonSuppression(tt)
             ParkTooltip(tt)
+            QueueSuppressedComparisonClear()
         else
+            ReleaseComparisonSuppression(tt)
             UnparkTooltip(tt)
         end
     end
@@ -2539,12 +2658,39 @@ do
         hooksecurefunc("GameTooltip_SetDefaultAnchor", SuppressTooltipByMode)
     end
     hooksecurefunc(GameTooltip, "SetOwner", function(tt)
+        -- SetOwner begins every new tooltip build.  Release a flag owned by the
+        -- previous suppressed build before the default-anchor hook re-arms it.
+        ReleaseComparisonSuppression(tt)
         _defaultAnchored = false
         UnparkTooltip(tt)
     end)
     GameTooltip:HookScript("OnHide", function(tt)
         -- Only fires for unparked hides (a parked tooltip is never visible); clears the default-anchored flag promptly.
         _defaultAnchored = false
+        ReleaseComparisonSuppression(tt)
+        if EllesmereUI._tooltipSuppressedByMode(tt) then
+            QueueSuppressedComparisonClear()
+        end
+    end)
+
+    -- Re-apply the mode when combat/encounter state changes while a tooltip is
+    -- already alive.  Without this, a tooltip opened just before combat could
+    -- keep its shopping comparison until the next hover rebuild.
+    local stateWatcher = CreateFrame("Frame")
+    stateWatcher:RegisterEvent("PLAYER_REGEN_DISABLED")
+    stateWatcher:RegisterEvent("PLAYER_REGEN_ENABLED")
+    stateWatcher:RegisterEvent("ENCOUNTER_START")
+    stateWatcher:RegisterEvent("ENCOUNTER_END")
+    stateWatcher:SetScript("OnEvent", function()
+        -- Only act when the new state requires suppression.  Do not unpark on
+        -- combat/encounter end: the cursor may have left the owner while the
+        -- parked tooltip remained logically shown, and unpark would resurrect
+        -- stale content.  The next SetOwner path restores it normally.
+        if not EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
+        if _defaultAnchored then
+            ApplySuppression(GameTooltip)
+        end
+        QueueSuppressedComparisonClear()
     end)
 
     -- Live peek: pressing the modifier while already hovering reveals the tip
@@ -2600,6 +2746,7 @@ do
         if down == 1 then
             if _parked and GameTooltip:IsShown() then
                 -- The parked tip is alive and current under the cursor (built by the secure hover path): just reveal it, never rebuild from here (see the parking note above).
+                ReleaseComparisonSuppression(GameTooltip)
                 UnparkTooltip(GameTooltip)
             else
                 -- No live tip: module-built tips (raid frames, CDM) skip building while suppressed, so re-drive the hovered frame's OnEnter -- with the modifier now held they build normally.
@@ -2607,7 +2754,9 @@ do
             end
         elseif GameTooltip:IsShown() and EllesmereUI._tooltipSuppressedByMode(GameTooltip) then
             if _defaultAnchored then
+                ArmComparisonSuppression(GameTooltip)
                 ParkTooltip(GameTooltip)
+                QueueSuppressedComparisonClear()
             else
                 GameTooltip:Hide()
             end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2472,6 +2472,7 @@ do
 
     local EnsureComparisonSupport
     local UpdateStateWatcher
+    local _comparisonSupportActive = false
     local _comparisonStateWatcherRegistered = false
 
     local function ComparisonSuppressionModeEnabled()
@@ -2492,14 +2493,14 @@ do
         if tooltip.IsForbidden and tooltip:IsForbidden() then return false end
         -- Gated by the "Reskin Tooltip" master (matches the grayed-out "Show Tooltips" option), so disabling the reskin never leaves tooltips stuck suppressed at, e.g., "Never".
         if EllesmereUIDB and EllesmereUIDB.customTooltips == false then
-            if UpdateStateWatcher and _comparisonStateWatcherRegistered then
+            if UpdateStateWatcher and (_comparisonSupportActive or _comparisonStateWatcherRegistered) then
                 UpdateStateWatcher()
             end
             return false
         end
         local mode = (EllesmereUIDB and EllesmereUIDB.tooltipShowMode) or "always"
         if mode == "always" then
-            if UpdateStateWatcher and _comparisonStateWatcherRegistered then
+            if UpdateStateWatcher and (_comparisonSupportActive or _comparisonStateWatcherRegistered) then
                 UpdateStateWatcher()
             end
             return false
@@ -2555,7 +2556,7 @@ do
     end
 
     local function ReleaseComparisonSuppression(tooltip)
-        if tooltip ~= GameTooltip then return end
+        if not _comparisonSupportActive or tooltip ~= GameTooltip then return end
         local state = GetComparisonState(tooltip, false)
         if not state or not state.comparisonFlagOwned then return end
         if not SetComparisonSuppressionFlag(tooltip, state.comparisonFlagPrevious) then return end
@@ -2589,7 +2590,7 @@ do
     -- cleanup runs.
     local _comparisonPreCallInstalled = false
     local function OnItemTooltipPreCall(tooltip)
-        if tooltip ~= GameTooltip then return end
+        if not _comparisonSupportActive or tooltip ~= GameTooltip then return end
         if not ComparisonSuppressionModeEnabled() then
             ReleaseComparisonSuppression(tooltip)
             return
@@ -2652,6 +2653,7 @@ do
         ClearSuppressedComparisons()
     end
     local function QueueSuppressedComparisonClear()
+        if not _comparisonSupportActive then return end
         if not ComparisonSuppressionModeEnabled()
             or not EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
         if _comparisonClearPending then return end
@@ -2669,6 +2671,7 @@ do
             for _, comparisonTooltip in ipairs(GetComparisonTooltips()) do
                 if comparisonTooltip and comparisonTooltip.HookScript then
                     comparisonTooltip:HookScript("OnShow", function()
+                        if not _comparisonSupportActive then return end
                         if EllesmereUI._tooltipSuppressedByMode(GameTooltip) then
                             QueueSuppressedComparisonClear()
                         end
@@ -2688,6 +2691,7 @@ do
 
     EnsureComparisonSupport = function()
         if not ComparisonSuppressionModeEnabled() then return false end
+        _comparisonSupportActive = true
         EnsureComparisonPreCall()
         InstallComparisonHooks()
         return true
@@ -2787,6 +2791,8 @@ do
     end
     UpdateStateWatcher = function()
         if not ComparisonSuppressionModeEnabled() then
+            ReleaseComparisonSuppression(GameTooltip)
+            _comparisonSupportActive = false
             UnregisterStateWatcher()
             return
         end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2447,9 +2447,10 @@ end
 --    outOfCombat     -> hidden while in combat lockdown
 --    outOfBossCombat -> hidden while a boss encounter is in progress
 --    never           -> hidden always
---  IsEncounterInProgress() is queried inline (outOfBossCombat only), so no ENCOUNTER
---  event bookkeeping. Installed once at load; a no-op for the default mode, costing
---  one table read per tooltip when unused. An optional "peek" modifier
+--  IsEncounterInProgress() is queried inline (outOfBossCombat only) for the visibility
+--  decision. Comparison cleanup support is installed lazily only when a non-default
+--  mode is active; the default mode adds no comparison hooks or state events. An optional
+--  "peek" modifier
 --  (tooltipShowModifier) lifts suppression while held, so a suppressed tip can be
 --  read on hover mid-combat. Suppression keeps the tooltip SHOWN but parked in a
 --  hidden host frame (never Hide, never alpha) so peek is a pure reparent flip:
@@ -2469,15 +2470,42 @@ do
         return ShowModifierHeld()
     end
 
+    local EnsureComparisonSupport
+    local UpdateStateWatcher
+    local _comparisonStateWatcherRegistered = false
+
+    local function ComparisonSuppressionModeEnabled()
+        if EllesmereUIDB and EllesmereUIDB.customTooltips == false then return false end
+        return ((EllesmereUIDB and EllesmereUIDB.tooltipShowMode) or "always") ~= "always"
+    end
+
+    local function ComparisonStateWatcherNeeded()
+        local mode = (EllesmereUIDB and EllesmereUIDB.tooltipShowMode) or "always"
+        return ComparisonSuppressionModeEnabled()
+            and (mode == "outOfCombat" or mode == "outOfBossCombat")
+    end
+
     -- Shared decision: should GameTooltip be suppressed right now given the user's "Show
     -- Tooltips" mode + combat state? Exposed on EllesmereUI so the cursor-anchor hook can honor it too (else cursor re-anchor would re-show a tooltip this hook just hid).
     function EllesmereUI._tooltipSuppressedByMode(tooltip)
         if tooltip ~= GameTooltip then return false end
         if tooltip.IsForbidden and tooltip:IsForbidden() then return false end
         -- Gated by the "Reskin Tooltip" master (matches the grayed-out "Show Tooltips" option), so disabling the reskin never leaves tooltips stuck suppressed at, e.g., "Never".
-        if EllesmereUIDB and EllesmereUIDB.customTooltips == false then return false end
+        if EllesmereUIDB and EllesmereUIDB.customTooltips == false then
+            if UpdateStateWatcher and _comparisonStateWatcherRegistered then
+                UpdateStateWatcher()
+            end
+            return false
+        end
         local mode = (EllesmereUIDB and EllesmereUIDB.tooltipShowMode) or "always"
-        if mode == "always" then return false end
+        if mode == "always" then
+            if UpdateStateWatcher and _comparisonStateWatcherRegistered then
+                UpdateStateWatcher()
+            end
+            return false
+        end
+        if EnsureComparisonSupport then EnsureComparisonSupport() end
+        if UpdateStateWatcher then UpdateStateWatcher() end
         if ShowModifierHeld() then return false end
         if mode == "never" then
             return true
@@ -2494,32 +2522,63 @@ do
     -- combat when alwaysCompareItems is enabled.  Keep the cleanup in this global
     -- tooltip controller rather than in ActionBars: bags, world items, and every
     -- other default-anchored item tooltip use the same comparison manager.
-    -- Use Blizzard's existing comparison-suppression flag; addon-owned state
-    -- stays in locals so no custom state is stored on Blizzard frames.
-    local _comparisonTooltips = { ShoppingTooltip1, ShoppingTooltip2 }
+    -- Use Blizzard's existing comparison-suppression control field; addon-owned
+    -- state stays in the shared weak-keyed FFD table so no custom state is stored
+    -- on Blizzard frames.
+    local _comparisonTooltips
     local _comparisonClearPending = false
-    local _comparisonFlagOwned = false
-    local _comparisonFlagPrevious
+
+    local function GetComparisonTooltips()
+        if not _comparisonTooltips then
+            _comparisonTooltips = { ShoppingTooltip1, ShoppingTooltip2 }
+        end
+        return _comparisonTooltips
+    end
+
+    local function GetComparisonState(tooltip, create)
+        local state = FFD[tooltip]
+        if not state and create then
+            state = {}
+            FFD[tooltip] = state
+        end
+        return state
+    end
+
+    local function WriteComparisonSuppressionFlag(tooltip, value)
+        -- Blizzard exposes this field as the per-tooltip opt-out for automatic
+        -- comparisons. It is a Blizzard control input, not addon-owned state.
+        tooltip.suppressAutomaticCompareItem = value
+    end
+
+    local function SetComparisonSuppressionFlag(tooltip, value)
+        return pcall(WriteComparisonSuppressionFlag, tooltip, value)
+    end
 
     local function ReleaseComparisonSuppression(tooltip)
-        if tooltip ~= GameTooltip or not _comparisonFlagOwned then return end
-        local previous = _comparisonFlagPrevious
-        _comparisonFlagPrevious = nil
-        _comparisonFlagOwned = false
-        tooltip.suppressAutomaticCompareItem = previous
+        if tooltip ~= GameTooltip then return end
+        local state = GetComparisonState(tooltip, false)
+        if not state or not state.comparisonFlagOwned then return end
+        if not SetComparisonSuppressionFlag(tooltip, state.comparisonFlagPrevious) then return end
+        state.comparisonFlagPrevious = nil
+        state.comparisonFlagOwned = nil
     end
 
     local function ArmComparisonSuppression(tooltip)
         if tooltip ~= GameTooltip then return end
-        if not _comparisonFlagOwned then
-            _comparisonFlagPrevious = tooltip.suppressAutomaticCompareItem
-            _comparisonFlagOwned = true
+        local state = GetComparisonState(tooltip, true)
+        local owned = state.comparisonFlagOwned
+        if not owned then
+            state.comparisonFlagPrevious = tooltip.suppressAutomaticCompareItem
+            state.comparisonFlagOwned = true
         end
         -- GameTooltip_SetDefaultAnchor runs before ActionButton_SetTooltip calls
         -- SetAction, so this prevents the comparison from being created in the
         -- first place.  The deferred cleanup below still handles comparisons that
         -- were already shown or are refreshed by Blizzard after this hook.
-        tooltip.suppressAutomaticCompareItem = true
+        if not SetComparisonSuppressionFlag(tooltip, true) and not owned then
+            state.comparisonFlagPrevious = nil
+            state.comparisonFlagOwned = nil
+        end
     end
 
     -- Anchor suppression normally arms the flag before ActionButton:SetAction,
@@ -2531,6 +2590,10 @@ do
     local _comparisonPreCallInstalled = false
     local function OnItemTooltipPreCall(tooltip)
         if tooltip ~= GameTooltip then return end
+        if not ComparisonSuppressionModeEnabled() then
+            ReleaseComparisonSuppression(tooltip)
+            return
+        end
         if EllesmereUI._tooltipSuppressedByMode(tooltip) then
             ArmComparisonSuppression(tooltip)
         else
@@ -2547,16 +2610,21 @@ do
         _comparisonPreCallInstalled = true
         return true
     end
-    InstallComparisonPreCall()
-    if not _comparisonPreCallInstalled then
+
+    local _comparisonPreCallRetry
+    local function EnsureComparisonPreCall()
+        if InstallComparisonPreCall() or _comparisonPreCallRetry then return end
         -- The normal client has these APIs before addon Lua loads, but retry at
         -- PLAYER_LOGIN so a load-order change does not silently remove the
         -- primary no-comparison guard for the whole session.
-        local preCallRetry = CreateFrame("Frame")
-        preCallRetry:RegisterEvent("PLAYER_LOGIN")
-        preCallRetry:SetScript("OnEvent", function(self)
+        _comparisonPreCallRetry = CreateFrame("Frame")
+        _comparisonPreCallRetry:RegisterEvent("PLAYER_LOGIN")
+        _comparisonPreCallRetry:SetScript("OnEvent", function(self)
             self:UnregisterAllEvents()
-            InstallComparisonPreCall()
+            _comparisonPreCallRetry = nil
+            if ComparisonSuppressionModeEnabled() then
+                InstallComparisonPreCall()
+            end
         end)
     end
 
@@ -2584,6 +2652,8 @@ do
         ClearSuppressedComparisons()
     end
     local function QueueSuppressedComparisonClear()
+        if not ComparisonSuppressionModeEnabled()
+            or not EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
         if _comparisonClearPending then return end
         _comparisonClearPending = true
         -- This hook can run from Blizzard's protected tooltip/action-button path.
@@ -2592,20 +2662,35 @@ do
         C_Timer.After(0, RunSuppressedComparisonClear)
     end
 
-    -- Catch both the normal comparison-manager path and a direct Show/SetShown
-    -- from Blizzard.  OnShow only queues a deferred cleanup; it never mutates a
-    -- Blizzard frame from the protected call stack.
-    for _, comparisonTooltip in ipairs(_comparisonTooltips) do
-        if comparisonTooltip and comparisonTooltip.HookScript then
-            comparisonTooltip:HookScript("OnShow", function()
-                if EllesmereUI._tooltipSuppressedByMode(GameTooltip) then
-                    QueueSuppressedComparisonClear()
+    local _comparisonTooltipHooksInstalled = false
+    local _comparisonManagerHookInstalled = false
+    local function InstallComparisonHooks()
+        if not _comparisonTooltipHooksInstalled then
+            for _, comparisonTooltip in ipairs(GetComparisonTooltips()) do
+                if comparisonTooltip and comparisonTooltip.HookScript then
+                    comparisonTooltip:HookScript("OnShow", function()
+                        if EllesmereUI._tooltipSuppressedByMode(GameTooltip) then
+                            QueueSuppressedComparisonClear()
+                        end
+                    end)
                 end
-            end)
+            end
+            _comparisonTooltipHooksInstalled = true
+        end
+
+        if not _comparisonManagerHookInstalled
+            and TooltipComparisonManager
+            and type(TooltipComparisonManager.AnchorShoppingTooltips) == "function" then
+            hooksecurefunc(TooltipComparisonManager, "AnchorShoppingTooltips", QueueSuppressedComparisonClear)
+            _comparisonManagerHookInstalled = true
         end
     end
-    if TooltipComparisonManager and type(TooltipComparisonManager.AnchorShoppingTooltips) == "function" then
-        hooksecurefunc(TooltipComparisonManager, "AnchorShoppingTooltips", QueueSuppressedComparisonClear)
+
+    EnsureComparisonSupport = function()
+        if not ComparisonSuppressionModeEnabled() then return false end
+        EnsureComparisonPreCall()
+        InstallComparisonHooks()
+        return true
     end
 
     -- Suppression parks the tooltip in a hidden host frame -- NOT Hide(), NOT alpha.
@@ -2677,14 +2762,19 @@ do
     end)
 
     -- Re-apply the mode when combat/encounter state changes while a tooltip is
-    -- already alive.  Without this, a tooltip opened just before combat could
-    -- keep its shopping comparison until the next hover rebuild.
-    local stateWatcher = CreateFrame("Frame")
-    stateWatcher:RegisterEvent("PLAYER_REGEN_DISABLED")
-    stateWatcher:RegisterEvent("PLAYER_REGEN_ENABLED")
-    stateWatcher:RegisterEvent("ENCOUNTER_START")
-    stateWatcher:RegisterEvent("ENCOUNTER_END")
-    stateWatcher:SetScript("OnEvent", function()
+    -- already alive.  Install these events only for the two modes that need
+    -- transition handling; "Never" is handled by the tooltip hooks alone.
+    local stateWatcher
+    local function UnregisterStateWatcher()
+        if not _comparisonStateWatcherRegistered then return end
+        stateWatcher:UnregisterAllEvents()
+        _comparisonStateWatcherRegistered = false
+    end
+    local function StateWatcherOnEvent()
+        if not ComparisonStateWatcherNeeded() then
+            UpdateStateWatcher()
+            return
+        end
         -- Only act when the new state requires suppression.  Do not unpark on
         -- combat/encounter end: the cursor may have left the owner while the
         -- parked tooltip remained logically shown, and unpark would resurrect
@@ -2694,7 +2784,30 @@ do
             ApplySuppression(GameTooltip)
         end
         QueueSuppressedComparisonClear()
-    end)
+    end
+    UpdateStateWatcher = function()
+        if not ComparisonSuppressionModeEnabled() then
+            UnregisterStateWatcher()
+            return
+        end
+        EnsureComparisonSupport()
+        if not ComparisonStateWatcherNeeded() then
+            UnregisterStateWatcher()
+            return
+        end
+        if not stateWatcher then
+            stateWatcher = CreateFrame("Frame")
+            stateWatcher:SetScript("OnEvent", StateWatcherOnEvent)
+        end
+        if not _comparisonStateWatcherRegistered then
+            stateWatcher:RegisterEvent("PLAYER_REGEN_DISABLED")
+            stateWatcher:RegisterEvent("PLAYER_REGEN_ENABLED")
+            stateWatcher:RegisterEvent("ENCOUNTER_START")
+            stateWatcher:RegisterEvent("ENCOUNTER_END")
+            _comparisonStateWatcherRegistered = true
+        end
+    end
+    UpdateStateWatcher()
 
     -- Live peek: pressing the modifier while already hovering reveals the tip
     -- for the current frame; releasing hides it again. Moving onto other frames


### PR DESCRIPTION
## What does this PR do?

Bug fix only. This PR fixes item comparison tooltips remaining visible during combat when EllesmereUI's existing `Show Tooltips` mode is set to `Out of Combat` or `Out of Boss Combat`.

This edge case is easy to encounter because active-use trinkets are commonly placed on action bars. When a player clicks or moves the mouse over an active trinket button during combat, Blizzard's action-button tooltip path can create item comparisons even though EllesmereUI is configured to show tooltips only outside combat. The issue is therefore most visible on action-bar trinkets and may not be noticed when hovering equipment in the character panel.

The fix:

- Clears shopping comparison tooltips when they are shown or anchored while the primary tooltip is currently suppressed.
- In `Out of Combat` mode, clears existing shopping comparison tooltips when combat starts; in `Out of Boss Combat` mode, clears them when a boss encounter starts.
- Defers cleanup outside protected tooltip and action-button call stacks.
- Restores comparison behavior after combat or an encounter ends and the item is hovered again.
- Installs comparison hooks lazily on first use of a non-default mode; registers transition events only for `Out of Combat` and `Out of Boss Combat`, and guards callbacks when comparison support is inactive.
- Queues no comparison cleanup while comparison support or the current mode suppression is inactive.

## Root cause

EllesmereUI suppresses the primary `GameTooltip` by parking it in a hidden host, but Blizzard renders item comparisons in separate `ShoppingTooltip` frames managed by `TooltipComparisonManager`.

The important ordering is:

1. Blizzard starts and populates `GameTooltip`.
2. Blizzard's item pipeline calls the comparison manager.
3. The comparison manager creates and shows `ShoppingTooltip1` and `ShoppingTooltip2`.

Therefore, the repo-compliant `OnShow` and `TooltipComparisonManager:AnchorShoppingTooltips` post-hooks can only clear the comparison after Blizzard has shown it. A brief first-frame flash can occur, but the comparison is then removed instead of remaining visible throughout combat.

This PR intentionally accepts that possible one-frame flash. Preventing the comparison from being created would require writing Blizzard's existing `suppressAutomaticCompareItem` control field before item finalization. That would be a write onto a Blizzard-owned frame and would conflict with the repository's zero-taint acceptance criterion. Post-show cleanup is the narrow, repo-compliant tradeoff for this bug fix.

## How was it tested?

- Reproduced with an active-use trinket placed on an action bar in the live WoW Midnight 12.1 client.
- Verified that a comparison tooltip already visible before combat disappears when combat starts.
- Verified that a comparison tooltip already visible when a boss encounter starts disappears immediately.
- Verified that re-hovering an item after combat or the boss encounter ends restores comparison behavior.
- Verified that `Show Tooltips = Always` continues to work.
- Verified that switching modes takes effect on subsequent tooltip or combat-state evaluation and reconciles the lazy event registration.
- No regression was observed in the tested tooltip flows.
- A brief flash while the comparison is first created in combat is expected with this repo-compliant implementation.
- The final inactive-mode guard was additionally static-checked and deployed after the live test.

## Screenshots

Before - the comparison tooltip remains visible during combat:

![Before: comparison tooltip remains visible during combat](https://github.com/user-attachments/assets/6aeb1dbc-5064-4cea-9c88-c413b7c82625)

After - the comparison tooltip is cleared during combat:

![After: comparison tooltip is cleared during combat](https://github.com/user-attachments/assets/72b37e60-8bb9-4ffb-9872-03e88f9fa543)

## Checklist

- [x] New settings default **OFF** - no setting was added; this is a genuine bug fix.
- [x] Zero cost while disabled - comparison state frames and transition events are created or registered lazily when a non-default mode is used. Comparison hooks are installed lazily on first use and return immediately when support is inactive; the default mode creates no comparison hooks, events, or comparison state frame.
- [x] Cheap while enabled - event-driven; no `OnUpdate` polling, wall-clock timing logic, or per-frame table allocations. `C_Timer.After(0)` is used only to defer cleanup outside a protected call stack.
- [x] Zero taint risk - no fields or addon state are written directly onto Blizzard-owned frames. Blizzard frames are observed with `HookScript`/`hooksecurefunc`, and `SetScript` is used only on addon-created frames; cleanup calls are protected with `pcall`.
- [x] Midnight only - tested in-game on live; the final inactive-mode guard was additionally static-checked and deployed, and no version gates or pre-Midnight APIs were added.
