### PR TITLE
[Feature Request] Colour the nameplate enemy name text by their reaction colour

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -259,6 +259,7 @@ local defaults = {
     hitboxScaleY = 100,
     nameplateYOffset = 0,
     enemyNameTextSize = 11,
+    enemyNameTextReactionColor = false,
     debuffTimerColor = { r = 1, g = 1, b = 1 },
     auraTextPosition = "topleft",
     debuffTimerPosition = "topleft",
@@ -4613,6 +4614,25 @@ local function ResolveNeutralColor(unit)
     local c = _C("neutral")
     return c.r, c.g, c.b
 end
+-- Enemy Name Text "Reaction Color" (EXTRAS toggle, default off): colors the name text
+-- Hostile or Neutral to match the unit's reaction, independent of the health-bar palette.
+-- Every NameplateFrame unit is an enemy (HideBlizzardFrame only suppresses Blizzard's frame
+-- on UnitCanAttack units), so only these two reactions are ever relevant here. Same
+-- reaction/UnitCanAttack idiom as the health-bar Neutral check below (GetReactionColor step 5)
+-- so a secret reaction read (identity-restricted units) falls through safely instead of erroring.
+local function GetEnemyNameReactionColor(unit)
+    local reaction = UnitReaction(unit, "player")
+    local isNeutral = (reaction and reaction == 4)
+        or (UnitCanAttack("player", unit) and not UnitIsEnemy(unit, "player"))
+    local db = p or defaults
+    local c
+    if isNeutral then
+        c = db.enemyNameNeutralColor or defaults.neutral
+    else
+        c = db.enemyNameHostileColor or defaults.hostile
+    end
+    return c.r, c.g, c.b
+end
 -- Blizzard's own plate for this unit, colored by untainted code. Under HideBlizzardFrame the
 -- UnitFrame keeps its unit and its events (only castBar is silenced), so its health bar still
 -- carries whatever CompactUnitFrame_UpdateHealthColor last resolved -- including the class
@@ -5330,6 +5350,12 @@ function NameplateFrame:ApplyAppearance()
         local nr, ng, nb = GetTextSlotColor(nameSlotKey)
         self.name:SetTextColor(nr, ng, nb, 1)
     end
+    -- Enemy Name Text "Reaction Color" cache: ApplyAppearance is a second writer of
+    -- self.name's color (the slot-color line above), so invalidate the skip-if-unchanged
+    -- cache here too -- otherwise a stale cache can wrongly skip re-applying the reaction
+    -- color on the very next UpdateHealthColor call (which always runs immediately after
+    -- this, from the same SetUnit), leaving the plate showing this slot color instead.
+    self._lastNameReactR, self._lastNameReactG, self._lastNameReactB = nil, nil, nil
     self:RefreshNamePosition()
     -- Cast text sizes, colors, and offsets
     local cns = (p and p.castNameSize) or defaults.castNameSize
@@ -6286,6 +6312,26 @@ function NameplateFrame:UpdateHealthColor()
     elseif hr ~= self._lastHCr or hg ~= self._lastHCg or hb ~= self._lastHCb then
         self._lastHCr, self._lastHCg, self._lastHCb = hr, hg, hb
         self.health:SetStatusBarColor(hr, hg, hb)
+    end
+    -- Enemy Name Text "Reaction Color" (EXTRAS toggle): zero cost while off (one field read),
+    -- other than the one-time restore below for a plate that was previously colored by this
+    -- feature. Piggybacks on this function's existing event-driven calls rather than
+    -- registering anything of its own.
+    if p and p.enemyNameTextReactionColor then
+        local nnr, nng, nnb = GetEnemyNameReactionColor(unit)
+        if nnr ~= self._lastNameReactR or nng ~= self._lastNameReactG or nnb ~= self._lastNameReactB then
+            self._lastNameReactR, self._lastNameReactG, self._lastNameReactB = nnr, nng, nnb
+            self.name:SetTextColor(nnr, nng, nnb, 1)
+        end
+    elseif self._lastNameReactR then
+        -- Toggled off after having been applied to this plate: restore the slot color
+        -- directly here rather than depending on ApplyAppearance re-running elsewhere.
+        self._lastNameReactR, self._lastNameReactG, self._lastNameReactB = nil, nil, nil
+        local nameSlotKey = ns.FindNameSlot()
+        if nameSlotKey then
+            local nr, ng, nb = GetTextSlotColor(nameSlotKey)
+            self.name:SetTextColor(nr, ng, nb, 1)
+        end
     end
     -- Near-aggro glow (Non-Tank Threat cog): ns._reactionNearAggro was written
     -- by the GetReactionColor call ABOVE (same decision that picked the color).

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -10055,6 +10055,66 @@ initFrame:SetScript("OnEvent", function(self)
             darkenCogBtn:SetScript("OnClick", function(s) darkenCogShow(s) end)
         end
 
+        -- Enemy Name Text Reaction Color: colors the enemy nameplate NAME TEXT (not the
+        -- health bar) Hostile or Neutral to match the unit's reaction. Off by default. The
+        -- two inline swatches fall back to the Hostile/Neutral defaults until the player sets
+        -- their own, and are dimmed/mouse-disabled while the toggle is off -- same pattern as
+        -- the "Enable Quest Mob Color" inline swatch above.
+        local nameReactionRow
+        nameReactionRow, h = W:DualRow(parent, y,
+            { type="toggle", text="Color Name by Reaction",
+              getValue=function() return DBVal("enemyNameTextReactionColor") == true end,
+              setValue=function(v)
+                DB().enemyNameTextReactionColor = v
+                RefreshAllPlates()
+                EllesmereUI:RefreshPage()
+              end,
+              tooltip="Colors the enemy nameplate name text to match the unit's reaction (Hostile or Neutral) instead of the Enemy Name Text color." },
+            { type="label", text="" });  y = y - h
+
+        -- Inline Neutral/Hostile swatches next to the toggle, dimmed and mouse-disabled while off.
+        if not EllesmereUI._prebuilding then
+            local leftRgn = nameReactionRow._leftRegion
+            local isReactionOff = function() return DBVal("enemyNameTextReactionColor") ~= true end
+
+            local hostileGet = function()
+                local c = (DB() and DB().enemyNameHostileColor) or defaults.hostile
+                return c.r, c.g, c.b
+            end
+            local hostileSet = function(r, g, b)
+                DB().enemyNameHostileColor = { r = r, g = g, b = b }
+                RefreshAllPlates()
+            end
+            local hostileSwatch, updateHostileSwatch = EllesmereUI.BuildColorSwatch(leftRgn, leftRgn:GetFrameLevel() + 5, hostileGet, hostileSet, nil, 20)
+            PP.Point(hostileSwatch, "RIGHT", leftRgn._control, "LEFT", -12, 0)
+
+            local neutralGet = function()
+                local c = (DB() and DB().enemyNameNeutralColor) or defaults.neutral
+                return c.r, c.g, c.b
+            end
+            local neutralSet = function(r, g, b)
+                DB().enemyNameNeutralColor = { r = r, g = g, b = b }
+                RefreshAllPlates()
+            end
+            local neutralSwatch, updateNeutralSwatch = EllesmereUI.BuildColorSwatch(leftRgn, leftRgn:GetFrameLevel() + 5, neutralGet, neutralSet, nil, 20)
+            PP.Point(neutralSwatch, "RIGHT", hostileSwatch, "LEFT", -8, 0)
+
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = isReactionOff()
+                hostileSwatch:SetAlpha(off and 0.15 or 1)
+                hostileSwatch:EnableMouse(not off)
+                updateHostileSwatch()
+                neutralSwatch:SetAlpha(off and 0.15 or 1)
+                neutralSwatch:EnableMouse(not off)
+                updateNeutralSwatch()
+            end)
+            local off = isReactionOff()
+            hostileSwatch:SetAlpha(off and 0.15 or 1)
+            hostileSwatch:EnableMouse(not off)
+            neutralSwatch:SetAlpha(off and 0.15 or 1)
+            neutralSwatch:EnableMouse(not off)
+        end
+
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
         -----------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds a toggle (default OFF) - under Nameplates > Colours > Enemy Colours - that colours the Enemy Name text to match the unit's reaction (Hostile or Neutral), independent of the existing Enemy Name text colour. Two inline swatches let the player override the Hostile/Neutral colours, falling back to the existing defaults.hostile/defaults.neutral when unset.

The toggle-off restore logic was moved into `UpdateHealthColor` to solve plates not reliably restoring to the default colour when the setting was disabled. A cache invalidation was added to `ApplyAppearance` to solve the name text becoming stuck on the default colour when an unrelated nameplate appearance setting changed while the toggle was active.

## How was it tested?

WoW Client Build: 12.1.0 (69299)

- Spammed the toggle, confirming the name colour applies and restores as expected.
- Ran M0 world tour
- Ran Delves
- World Questing throughout different zones

<!-- Client build, what you tested in game, etc. -->

## Screenshots
Feature Disabled (Default):
<img width="467" height="548" alt="Namepalte Reaction Colour - Disabled" src="https://github.com/user-attachments/assets/4268461b-3bcf-41e3-b784-e7adcb705964" />
Feature Enabled:
<img width="482" height="614" alt="Namepalte Reaction Colour - Enabled" src="https://github.com/user-attachments/assets/d8d1316a-781e-4e44-ab03-4393ecf8aa23" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
