### PR TITLE
Allow buff bars decimal treshold under 3s

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmTbbDecimals.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmTbbDecimals.lua
@@ -46,7 +46,7 @@ local AK -- EllesmereUI.AuraKit, resolved at first sync
 -- distinct threshold; bounded by the slider range, so no eviction needed).
 local function ClampThr(v)
     v = tonumber(v) or 5
-    if v < 3 then v = 3 elseif v > 120 then v = 120 end
+    if v < 1 then v = 1 elseif v > 120 then v = 120 end
     return math.floor(v + 0.5)
 end
 

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -5066,7 +5066,7 @@ initFrame:SetScript("OnEvent", function(self)
                           bd.timerDecimals = v or nil; RefreshTBB()
                       end })
                 table.insert(durationRows, 3,
-                    { type = "slider", label = "Decimal Threshold", min = 3, max = 120, step = 1,
+                    { type = "slider", label = "Decimal Threshold", min = 1, max = 120, step = 1,
                       disabled = function()
                           local bd = SelectedTBB()
                           return not (bd and bd.timerDecimals)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

As title, allow users to set a treshold under 3s for decimals display for cdm buff bars. Unsure if there was a technical limitation for this 3s value but changing it doesn't seem to cause any apparent issue so.

## How was it tested?

Tested on live by setting the value under 3s.

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
<img width="450" height="299" alt="image" src="https://github.com/user-attachments/assets/40e1cba3-64c5-4685-9579-70cd56ee948e" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
