### PR TITLE
ruRU: honour bundled fonts that carry Cyrillic glyphs

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -1436,6 +1436,9 @@ _G.EllesmereUI = EllesmereUI
 EllesmereUI.GLOBAL_KEY = "_EUIGlobal"
 EllesmereUI.ADDON_ROSTER = ADDON_ROSTER
 EllesmereUI.LOCALE_FONT_FALLBACK = LOCALE_FONT_FALLBACK
+-- Script the fallback stands in for: "cyrillic" | "cjk" | nil. Table field, not a
+-- file-scope local: this file sits on the Lua 5.1 200-local cap.
+EllesmereUI.LOCALE_SCRIPT = EllesmereUI._localeScript
 EllesmereUI.EXPRESSWAY = LOCALE_FONT_FALLBACK or EXPRESSWAY
 
 -- Taint-safe print: AddMessage, never global print() (its C-side handler taints the chat
@@ -3644,6 +3647,28 @@ EllesmereUI.FONT_FILES = {
     ["Morpheus"]            = nil,  -- Blizzard font
     ["Skurri"]              = nil,  -- Blizzard font
 }
+-- Bundled faces whose cmap covers the FULL Russian alphabet (U+0410-U+044F plus U+0401
+-- and U+0451, i.e. the Yo pair): these stay
+-- usable in ruRU instead of being swapped for the system glyph font. Verified per file
+-- against its cmap table -- everything omitted here (Poppins, Exo, Gotham, Changa, Cinzel,
+-- Future X Black, Homespun, KMT Ninja Naruto, Barlow Condensed) has ZERO Cyrillic and would
+-- render boxes. Re-check coverage before adding a face; a wrong entry ships unreadable text.
+-- Deliberately NOT extended to FONT_BLIZZARD: the Cyrillic-capable Blizzard face is
+-- FRIZQT___CYR (already the fallback), and the plain ones vary by installed client locale.
+EllesmereUI.FONT_CYRILLIC = {
+    ["Expressway"]       = true,
+    ["Expressway Bold"]  = true,
+    ["Avant Garde"]      = true,
+    ["Arial Bold"]       = true,
+    ["Arial Narrow"]     = true,
+    ["Fira Sans Medium"] = true,
+    ["Fira Sans Bold"]   = true,
+    ["Fira Sans Light"]  = true,
+    ["KMT Kimberley"]    = true,
+    ["Russo One"]        = true,
+    ["Ubuntu"]           = true,
+}
+
 -- Blizzard built-in font paths (not in our media folder)
 EllesmereUI.FONT_BLIZZARD = {
     ["Friz Quadrata"] = "Fonts\\FRIZQT__.TTF",
@@ -3745,7 +3770,12 @@ function EllesmereUI.GetFontsDB()
     if not EllesmereUIDB then EllesmereUIDB = {} end
     if not EllesmereUIDB.fonts then
         EllesmereUIDB.fonts = {
-            global      = "Expressway",
+            -- Cyrillic locales seed the system glyph font, not Expressway: the FONT_CYRILLIC
+            -- faces do render ruRU correctly, but they stay an explicit opt-in so a fresh
+            -- install looks exactly like every prior version. Existing installs are pinned
+            -- by the ru_cyrillic_font_optin_v1 migration.
+            global      = (EllesmereUI.LOCALE_SCRIPT == "cyrillic")
+                          and EllesmereUI.SYSTEM_FONT_KEY or "Expressway",
             outlineMode = "shadow",
         }
     end
@@ -3759,11 +3789,20 @@ local function ResolveFontName(fontName)
     if fontName == EllesmereUI.EXPRESSWAY_FORCED_KEY then
         return MEDIA_PATH .. "fonts\\Expressway.TTF"
     end
-    -- Glyph-restricted locales (CJK, Cyrillic): bundled fonts are Latin-only, so they
-    -- and the System Default sentinel map to the system glyph font. Only an external
-    -- SharedMedia font may override. Bundled names are excluded first (they are also
-    -- LSM-registered and would resolve Latin).
+    -- Glyph-restricted locales (CJK, Cyrillic): bundled fonts without coverage for the
+    -- script, and the System Default sentinel, map to the system glyph font. Only an
+    -- external SharedMedia font (or a FONT_CYRILLIC face in ruRU, handled first) may
+    -- override. Bundled names are excluded below because they are LSM-registered too and
+    -- would otherwise resolve to their Latin file.
     if LOCALE_FONT_FALLBACK then
+        -- Cyrillic locales: a bundled face with verified Cyrillic coverage renders ruRU
+        -- text correctly, so honour the pick instead of forcing the system glyph font.
+        -- Gated on LOCALE_SCRIPT, not on the fallback alone: CJK has no bundled coverage.
+        if EllesmereUI.LOCALE_SCRIPT == "cyrillic" and fontName
+           and EllesmereUI.FONT_CYRILLIC[fontName] then
+            local cyrFile = EllesmereUI.FONT_FILES[fontName]
+            if cyrFile then return MEDIA_PATH .. "fonts\\" .. cyrFile end
+        end
         if fontName
            and not EllesmereUI.FONT_FILES[fontName]
            and not EllesmereUI.FONT_BLIZZARD[fontName] then

--- a/EllesmereUIOptions/EUI__General_Options.lua
+++ b/EllesmereUIOptions/EUI__General_Options.lua
@@ -3415,21 +3415,45 @@ initFrame:SetScript("OnEvent", function(self)
         -------------------------------------------------------------------
         _, h = W:SectionHeader(parent, "GLOBAL FONT", y);  y = y - h
 
-        -- Glyph-restricted locales (CJK, Cyrillic): bundled fonts are Latin-only and cannot render the script, so the picker offers only
-        -- "System Default" plus external SharedMedia fonts (which may carry the right glyphs). Per-module fonts and the game-text swap stay hidden (Latin).
+        -- Glyph-restricted locales (CJK, Cyrillic): most bundled fonts are Latin-only and cannot render the script, so the picker
+        -- offers "System Default" plus external SharedMedia fonts (which may carry the right glyphs).
         local localeRestricted = EllesmereUI.LOCALE_FONT_FALLBACK ~= nil
+        -- ruRU is only PARTLY restricted: the faces listed in FONT_CYRILLIC carry the full
+        -- Cyrillic block (verified cmap), so they are offered as normal entries and
+        -- ResolveFontName honours them. CJK keeps the old System-Default-only picker.
+        local localeCyrillic = localeRestricted and EllesmereUI.LOCALE_SCRIPT == "cyrillic"
 
         local fontDropValues = {}
         local fontDropOrder  = {}
         if localeRestricted then
-            -- System Default + an explicit Expressway entry + external SharedMedia.
-            -- Other bundled Latin fonts are omitted (render local script as
-            -- boxes); Expressway is the informed opt-in, using a distinct sentinel key so the untouched default still maps to System Default.
             fontDropValues[EllesmereUI.SYSTEM_FONT_KEY] = { text = "System Default", font = EllesmereUI.LOCALE_FONT_FALLBACK }
             fontDropOrder[#fontDropOrder + 1] = EllesmereUI.SYSTEM_FONT_KEY
-            fontDropValues[EllesmereUI.EXPRESSWAY_FORCED_KEY] = { text = "Expressway (Latin only)",
-                font = EllesmereUI.MEDIA_PATH .. "fonts\\Expressway.TTF" }
-            fontDropOrder[#fontDropOrder + 1] = EllesmereUI.EXPRESSWAY_FORCED_KEY
+            if localeCyrillic then
+                -- Cyrillic-capable bundled faces, kept in FONT_ORDER sequence so the
+                -- picker matches the Latin-locale ordering. Latin-only bundles stay out.
+                local FONT_DIR_CYR = EllesmereUI.MEDIA_PATH .. "fonts\\"
+                local sepDone = false
+                for _, name in ipairs(EllesmereUI.FONT_ORDER) do
+                    local cyrFile = name ~= "---" and EllesmereUI.FONT_CYRILLIC[name]
+                        and EllesmereUI.FONT_FILES[name]
+                    if cyrFile then
+                        if not sepDone then
+                            fontDropOrder[#fontDropOrder + 1] = "---"
+                            sepDone = true
+                        end
+                        fontDropValues[name] = {
+                            text = (EllesmereUI.FONT_DISPLAY_NAMES and EllesmereUI.FONT_DISPLAY_NAMES[name]) or name,
+                            font = FONT_DIR_CYR .. cyrFile,
+                        }
+                        fontDropOrder[#fontDropOrder + 1] = name
+                    end
+                end
+            else
+                -- Expressway is the informed Latin opt-in, using a distinct sentinel key so the untouched default still maps to System Default.
+                fontDropValues[EllesmereUI.EXPRESSWAY_FORCED_KEY] = { text = "Expressway (Latin only)",
+                    font = EllesmereUI.MEDIA_PATH .. "fonts\\Expressway.TTF" }
+                fontDropOrder[#fontDropOrder + 1] = EllesmereUI.EXPRESSWAY_FORCED_KEY
+            end
             if EllesmereUI.AppendExternalSharedMediaFonts then
                 EllesmereUI.AppendExternalSharedMediaFonts(fontDropValues, fontDropOrder)
             end
@@ -3478,7 +3502,11 @@ initFrame:SetScript("OnEvent", function(self)
               values=fontDropValues, order=fontDropOrder,
               getValue=function()
                   local g = EllesmereUI.GetFontsDB().global or "Expressway"
-                  -- In glyph-restricted locales the stored bundled-font default maps to the System Default entry; a chosen SM font shows as-is.
+                  -- Cyrillic locales list Expressway as a normal entry, so an older
+                  -- __expressway opt-in collapses onto it (same file) instead of falling
+                  -- through to System Default and misreporting the active face.
+                  if localeCyrillic and g == EllesmereUI.EXPRESSWAY_FORCED_KEY then return "Expressway" end
+                  -- In glyph-restricted locales a stored Latin-only bundled font maps to the System Default entry; a chosen SM font shows as-is.
                   if localeRestricted and not fontDropValues[g] then return EllesmereUI.SYSTEM_FONT_KEY end
                   return g
               end,

--- a/EllesmereUI_Locale.lua
+++ b/EllesmereUI_Locale.lua
@@ -111,6 +111,15 @@ local function GlyphFont(locale)
     return nil
 end
 
+-- Script class behind the glyph font. The two classes are NOT interchangeable: several
+-- bundled faces carry the full Cyrillic block, so ruRU can honour a bundled pick
+-- (see EllesmereUI.FONT_CYRILLIC), while no bundled face has CJK coverage at all.
+local function GlyphScript(locale)
+    if locale == "zhCN" or locale == "zhTW" or locale == "koKR" then return "cjk" end
+    if locale == "ruRU" then return "cyrillic" end
+    return nil
+end
+
 local function Activate()
     local client = GetLocale()
     if client == "enGB" then client = "enUS" end
@@ -124,6 +133,7 @@ local function Activate()
     EllesmereUI.LOCALE     = locale
     EllesmereUI.IS_ENGLISH = (locale == "enUS")
     EllesmereUI._localeFont = GlyphFont(locale)
+    EllesmereUI._localeScript = GlyphScript(locale)
 
     reverse = {}
     if locale == "enUS" then

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -3852,3 +3852,31 @@ EllesmereUI.RegisterMigration({
         end
     end,
 })
+
+--------------------------------------------------------------------------------
+--  Cyrillic locales gained real font choice: several bundled faces carry the
+--  full Cyrillic block (EllesmereUI.FONT_CYRILLIC) and ResolveFontName now
+--  honours them instead of forcing the system glyph font. That must not change
+--  what anyone already sees, so existing installs are pinned to System Default
+--  and the new faces stay an opt-in pick.
+--
+--  Detecting "untouched" is exact here: before this change the ruRU picker could
+--  only ever store the __system sentinel, the __expressway sentinel, or an
+--  external SharedMedia name. Plain "Expressway" was unreachable as a choice, so
+--  it can only be the seeded default -- rewriting just that value leaves every
+--  deliberate pick alone. Fresh installs never reach this body; GetFontsDB seeds
+--  the correct default for them directly.
+--------------------------------------------------------------------------------
+EllesmereUI.RegisterMigration({
+    id          = "ru_cyrillic_font_optin_v1",
+    scope       = "global",
+    description = "Pin existing Cyrillic-locale installs to the system glyph font so the newly selectable bundled Cyrillic faces stay opt-in.",
+    body        = function(ctx)
+        if EllesmereUI.LOCALE_SCRIPT ~= "cyrillic" then return end
+        local fonts = ctx.db and ctx.db.fonts
+        if not fonts then return end            -- fresh install: GetFontsDB seeds it
+        if fonts.global == "Expressway" then
+            fonts.global = EllesmereUI.SYSTEM_FONT_KEY
+        end
+    end,
+})


### PR DESCRIPTION
## What does this PR do?

On a Russian client, EllesmereUI replaces every bundled font with the system glyph font,
so the font picker effectively offers no choice at all. This fixes that.

`ResolveFontName` assumes all bundled fonts are Latin-only in glyph-restricted locales:

```lua
if LOCALE_FONT_FALLBACK then
    if fontName
       and not EllesmereUI.FONT_FILES[fontName]      -- bundled -> excluded
       and not EllesmereUI.FONT_BLIZZARD[fontName] then
        ...
    end
    return LOCALE_FONT_FALLBACK
end
```

The assumption does not hold. I checked the `cmap` table of every file in `media/fonts/`
against the full Russian alphabet (U+0410-U+044F plus U+0401/U+0451):

| Full Cyrillic coverage (66/66) | No Cyrillic (0/66) |
| --- | --- |
| Expressway, Expressway Bold, Avant Garde Naowh, Arial Bold, Arial Narrow, FiraSans Bold/Light/Medium, KMT Kimberley, Russo One, Ubuntu | Poppins, Exo, Changa, Cinzel Decorative, Gotham Narrow, Gotham Narrow Ultra, Future X Black, Homespun, KMT Ninja Naruto, Barlow Condensed |

Expressway renders Russian perfectly, yet a ruRU user could never get it: the picker only
offered "System Default", "Expressway (Latin only)" and external SharedMedia fonts, and the
`(Latin only)` label is simply wrong for this face.

CJK is genuinely uncovered - no bundled face has CJK glyphs - so it is deliberately left alone.

**Changes (4 files, +121/-15):**

1. `EllesmereUI_Locale.lua` - `GlyphScript(locale)` sets `_localeScript` to
   `"cyrillic"` / `"cjk"` / `nil`. Previously only the fallback path existed and the two
   cases were indistinguishable.
2. `EllesmereUI.lua` - `EllesmereUI.FONT_CYRILLIC` whitelist plus a branch in
   `ResolveFontName`, gated on `LOCALE_SCRIPT == "cyrillic"`.
3. `EllesmereUIOptions/EUI__General_Options.lua` - the ruRU picker lists those faces in
   `FONT_ORDER` sequence. CJK keeps the existing System-Default-only picker.
4. `EllesmereUI_Migration.lua` - `ru_cyrillic_font_optin_v1`, see below.

**Nothing changes for existing users.** Making the fonts resolvable is not sufficient on its
own: the seeded default is `fonts.global = "Expressway"`, so every existing ruRU install
would have silently switched from the system font to Expressway on update. Two changes keep
the visible result identical:

- `GetFontsDB()` seeds `SYSTEM_FONT_KEY` instead of `"Expressway"` in Cyrillic locales.
- A `global`-scope migration rewrites a stored `"Expressway"` to `SYSTEM_FONT_KEY`.

The migration is exact rather than heuristic. Before this change the ruRU picker could only
ever store `__system`, `__expressway`, or an external SharedMedia name - plain `"Expressway"`
was unreachable as a choice, so it is provably the seeded default and never a deliberate
pick. Explicit choices are left untouched.

## How was it tested?

Live client, 12.1 (`Interface: 120100`), ruRU locale.

Confirmed the bug first: on ruRU the picker exposed no usable bundled font and everything
fell back to the system glyph font regardless of what was selected.

**Upgrade path (no visible change).** Restored an untouched default (`fonts.global =
"Expressway"`), cleared the migration flag, reloaded. Result: `fonts.global` became
`__system` and `GetFontPath()` returned `Fonts\FRIZQT___CYR.TTF` - identical rendering to
before the change, which is the point.

**An explicit pick sticks.** Selected Ubuntu in the picker and reloaded: `fonts.global` is
`Ubuntu`, `GetFontPath()` returns `...\media\fonts\Ubuntu.ttf`, and Russian text renders
correctly with no missing glyphs.

**A stored `__expressway` reads back correctly.** Set `fonts.global = "__expressway"` and
reloaded: the picker displays "Expressway" rather than falling through to "System Default",
and `GetFontPath()` returns `...\media\fonts\Expressway.TTF`. The options panel itself
renders Russian in that face.

**CJK is untouched.** With `LOCALE_SCRIPT` forced to `"cjk"`, `ResolveFontName("Ubuntu")`
returns the locale fallback rather than the bundled path, so the new branch cannot hand a
Latin/Cyrillic-only face to a CJK locale.

Font coverage was not eyeballed: every file in `media/fonts/` was checked programmatically
against its `cmap` table, which is where the table above comes from. All four changed files
parse as Lua 5.1, and every line added is ASCII-only.

### Known limitation (pre-existing, unchanged)

`LOCALE_SCRIPT` is snapshotted at file-load, so like the existing `LOCALE_FONT_FALLBACK` it
reflects the client locale and not a `displayLocale` override. I mirrored the existing
behaviour rather than changing it; happy to address it separately if you would like.

## Screenshots

**Before** - the Global Font picker on a ruRU client: only "System Default" and
"Expressway (Latin only)" are offered, so there is effectively no choice.

<img width="328" height="306" alt="picker before" src="https://github.com/user-attachments/assets/28a40450-8dce-42c6-a87d-142e97223ec1" />

**After** - the Cyrillic-capable bundled faces are listed and selectable.

<img width="459" height="349" alt="picker after" src="https://github.com/user-attachments/assets/38cc45d9-de9b-47aa-b023-4593d9be9311" />

**Addon text rendered in Ubuntu on a ruRU client** - Russian glyphs render correctly,
no missing-glyph boxes.

<img width="2559" height="1439" alt="Ubuntu on ruRU" src="https://github.com/user-attachments/assets/f2190a6c-60ec-46c8-a9b8-f6f89a2ac08e" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - no new setting; the
      existing default is explicitly preserved via the seed change plus migration
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -
      a table lookup inside the existing (memoized) font resolution path
- [x] No writes onto Blizzard-owned frames - N/A, `ResolveFontName` returns a path as before
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added

---

I saw the contribution freeze, so to be explicit about scope: I am filing this as a
localization bug rather than a feature. The fonts already ship and already support Cyrillic -
they are simply unreachable on ruRU - and no new setting is introduced. If you would rather
land it after 12.1 settles, that is completely fine.
