### PR TITLE
Fix(questtracker): shared pool header click

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -432,20 +432,55 @@ local function SkinHeader(header, knownCollapsed)
     -- 1px divider beneath the header (Line Color: Class / Custom / Accent).
     EnsureAccentDivider(header)
 
-    -- Click-anywhere-on-header overlay REMOVED (2026-08-15). It forwarded a
-    -- click to the header's own MinimizeButton via Click(), which taints
+    -- Click-anywhere-on-header, without any addon code in the click path.
+    --
+    -- The addon-owned overlay this replaces (removed 2026-08-15) forwarded a
+    -- click to the header's own MinimizeButton via Click(). That runs
+    -- Blizzard's collapse cascade from OUR execution, tainting
     -- ObjectiveTrackerContainer's shared dispatch loop for whatever module
-    -- owns that header. That taint doesn't clear on zone change: forwarding
-    -- a click on Quests' header while OUT of any instance, then later
-    -- entering a dungeon/raid/scenario, still throws a GetAuraDataByIndex
-    -- secret-value error out of ScenarioObjectiveTracker/UIWidgetObjective-
-    -- Tracker's LayoutContents (via ShouldShowMawBuffs) the next time the
-    -- container processes all modules together -- confirmed by in-game
-    -- repro, including a gate on IsInInstance() at click time, which only
-    -- narrowed the reproduction window instead of closing it. The native
-    -- +/- button never reproduces this (its OnClick is Blizzard's own,
-    -- never touched here), so collapsing a section still works -- just not
-    -- by clicking the title text anymore.
+    -- owns the header -- and the taint outlives the zone change: clicking a
+    -- header outside any instance, then entering a dungeon, still threw
+    -- GetAuraDataByIndex secret-value errors out of ScenarioObjectiveTracker/
+    -- UIWidgetObjectiveTracker's LayoutContents (via ShouldShowMawBuffs) once
+    -- the container processed every module together. Gating the forward on
+    -- IsInCombat/IsInInstance only narrowed the repro window, never closed it.
+    --
+    -- Widening the NATIVE MinimizeButton's hit rect across the header instead
+    -- means no Click() forward exists at all: the client dispatches the click
+    -- straight to Blizzard's own OnClick closure (set in the header mixin's
+    -- OnLoad, never touched here), which is bit-for-bit the path a bare +/-
+    -- press already takes -- the one the repro never reproduced on. Blizzard
+    -- never calls SetHitRectInsets on these buttons itself (verified against
+    -- Gethe/wow-ui-source), so nothing fights this, and the header frame
+    -- itself is not mouse-enabled, so it can't swallow the click.
+    if minBtn and minBtn.SetHitRectInsets then
+        local headerW = header.GetWidth and header:GetWidth() or 0
+        local headerH = header.GetHeight and header:GetHeight() or 0
+        local btnW    = minBtn.GetWidth and minBtn:GetWidth() or 0
+        local btnH    = minBtn.GetHeight and minBtn:GetHeight() or 0
+        if headerW > 0 and btnW > 0 then
+            -- Stop short of the FilterButton while it's showing (master header
+            -- only, hidden by default) so it keeps its own clicks. XML anchors
+            -- it 2px left of MinimizeButton.
+            local reserved = btnW
+            local filter = header.FilterButton
+            if filter and filter.IsShown and filter:IsShown() then
+                reserved = reserved + ((filter.GetWidth and filter:GetWidth()) or 0) + 2
+            end
+            -- Negative inset expands the hit rect outward from that edge.
+            -- Re-applied on every skin pass so it tracks header size changes
+            -- (Edit Mode resize); clamped so a stale/short header can never
+            -- leave a hit area hanging off the header into empty screen.
+            local extendX = headerW - reserved
+            if extendX < 0 then extendX = 0 end
+            -- The button is shorter than the header (16 vs 26 on section
+            -- headers), so match the header's height as well or the top and
+            -- bottom few pixels of the title stay dead.
+            local extendY = (headerH - btnH) / 2
+            if extendY < 0 then extendY = 0 end
+            minBtn:SetHitRectInsets(-extendX, 0, -extendY, -extendY)
+        end
+    end
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -457,6 +457,23 @@ local function SkinHeader(header, knownCollapsed)
         overlay:SetPoint("BOTTOMRIGHT", minBtn, "BOTTOMLEFT", -2, 0)
         overlay:SetScript("OnClick", function()
             if InCombatLockdown() then return end
+            -- Forwarding Click() taints ObjectiveTrackerContainer's dispatch
+            -- loop for whichever module owns this header. Outside an instance
+            -- that's harmless (confirmed by in-game repro, 2026-08-15): click
+            -- Quests' header, then a dungeon/scenario module's own +/- button,
+            -- then Quests again -- only inside the instance does the shared
+            -- Container update loop later carry that taint into
+            -- ScenarioObjectiveTracker/UIWidgetObjectiveTracker's LayoutContents
+            -- (GetAuraDataByIndex secret-value error via ShouldShowMawBuffs).
+            -- The native +/- button alone never reproduces it. So the
+            -- click-forward is disabled for every header while in a party/
+            -- raid/scenario instance; the native +/- button keeps working
+            -- everywhere since we never touch its own OnClick.
+            local inInstance, instanceType = IsInInstance()
+            if inInstance and (instanceType == "party" or instanceType == "raid"
+                                or instanceType == "scenario") then
+                return
+            end
             if minBtn and minBtn:IsShown() then
                 minBtn:Click()
             end

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -443,7 +443,12 @@ local function SkinHeader(header, knownCollapsed)
     -- threw combat errors of its own. The plain-Click() form shipped here is the
     -- field-tested-clean one -- do not "fix" it back to a secure redirect without
     -- fresh taint-log evidence.
-    if not _headerClickOverlays[header] and header.MinimizeButton then
+    -- Never install the click-forward on ScenarioObjectiveTracker/
+    -- UIWidgetObjectiveTracker headers: their MinimizeButton:Click() runs
+    -- Blizzard's SetCollapsed() on a shares-widget-pool tracker, the same
+    -- taint surface SharesWidgetPool() guards everywhere else in this file.
+    if not _headerClickOverlays[header] and header.MinimizeButton
+       and not SharesWidgetPool(header:GetParent()) then
         local minBtn = header.MinimizeButton
         local overlay = CreateFrame("Button", nil, header)
         overlay:SetFrameLevel(header:GetFrameLevel() + 1)

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -88,7 +88,6 @@ local _blockIcons        = setmetatable({}, { __mode = "k" })  -- block -> our i
 -- iteration of its own tables never sees our additions. This is the
 -- canonical taint-avoidance pattern per CLAUDE.md.
 local _blockFocus        = setmetatable({}, { __mode = "k" })  -- block -> focus texture
-local _headerClickOverlays = setmetatable({}, { __mode = "k" })  -- header -> click overlay
 local _masterHeaderCollapseHooked = false  -- guards the SetCollapsed re-skin hook below
 
 -------------------------------------------------------------------------------
@@ -433,53 +432,20 @@ local function SkinHeader(header, knownCollapsed)
     -- 1px divider beneath the header (Line Color: Class / Custom / Accent).
     EnsureAccentDivider(header)
 
-    -- Click-anywhere-on-header overlay: clicking the title text (not just the +/-
-    -- button) toggles the section, by forwarding to the MinimizeButton via a plain
-    -- button's Click() out of combat. History (2026-07-20, PR #879): this WAS a
-    -- SecureActionButtonTemplate click-redirect under the belief that a programmatic
-    -- Click() taints the collapse cascade. That evidence was confounded: the constant
-    -- taint injector was TightenTopAnchor's insecure SetPoint inside its SetPoint hook
-    -- (since removed, see the topModulePadding comment below), and the secure redirect
-    -- threw combat errors of its own. The plain-Click() form shipped here is the
-    -- field-tested-clean one -- do not "fix" it back to a secure redirect without
-    -- fresh taint-log evidence.
-    -- Never install the click-forward on ScenarioObjectiveTracker/
-    -- UIWidgetObjectiveTracker headers: their MinimizeButton:Click() runs
-    -- Blizzard's SetCollapsed() on a shares-widget-pool tracker, the same
-    -- taint surface SharesWidgetPool() guards everywhere else in this file.
-    if not _headerClickOverlays[header] and header.MinimizeButton
-       and not SharesWidgetPool(header:GetParent()) then
-        local minBtn = header.MinimizeButton
-        local overlay = CreateFrame("Button", nil, header)
-        overlay:SetFrameLevel(header:GetFrameLevel() + 1)
-        overlay:RegisterForClicks("LeftButtonUp")
-        overlay:SetPoint("TOPLEFT", header, "TOPLEFT", 0, 0)
-        overlay:SetPoint("BOTTOMRIGHT", minBtn, "BOTTOMLEFT", -2, 0)
-        overlay:SetScript("OnClick", function()
-            if InCombatLockdown() then return end
-            -- Forwarding Click() taints ObjectiveTrackerContainer's dispatch
-            -- loop for whichever module owns this header. Outside an instance
-            -- that's harmless (confirmed by in-game repro, 2026-08-15): click
-            -- Quests' header, then a dungeon/scenario module's own +/- button,
-            -- then Quests again -- only inside the instance does the shared
-            -- Container update loop later carry that taint into
-            -- ScenarioObjectiveTracker/UIWidgetObjectiveTracker's LayoutContents
-            -- (GetAuraDataByIndex secret-value error via ShouldShowMawBuffs).
-            -- The native +/- button alone never reproduces it. So the
-            -- click-forward is disabled for every header while in a party/
-            -- raid/scenario instance; the native +/- button keeps working
-            -- everywhere since we never touch its own OnClick.
-            local inInstance, instanceType = IsInInstance()
-            if inInstance and (instanceType == "party" or instanceType == "raid"
-                                or instanceType == "scenario") then
-                return
-            end
-            if minBtn and minBtn:IsShown() then
-                minBtn:Click()
-            end
-        end)
-        _headerClickOverlays[header] = overlay
-    end
+    -- Click-anywhere-on-header overlay REMOVED (2026-08-15). It forwarded a
+    -- click to the header's own MinimizeButton via Click(), which taints
+    -- ObjectiveTrackerContainer's shared dispatch loop for whatever module
+    -- owns that header. That taint doesn't clear on zone change: forwarding
+    -- a click on Quests' header while OUT of any instance, then later
+    -- entering a dungeon/raid/scenario, still throws a GetAuraDataByIndex
+    -- secret-value error out of ScenarioObjectiveTracker/UIWidgetObjective-
+    -- Tracker's LayoutContents (via ShouldShowMawBuffs) the next time the
+    -- container processes all modules together -- confirmed by in-game
+    -- repro, including a gate on IsInInstance() at click time, which only
+    -- narrowed the reproduction window instead of closing it. The native
+    -- +/- button never reproduces this (its OnClick is Blizzard's own,
+    -- never touched here), so collapsing a section still works -- just not
+    -- by clicking the title text anymore.
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a taint error that Quest Tracker users hit in dungeons and raids, reported by several people independently as `GetAuraDataByIndex(): Auras cannot be accessed when secret while tainted by 'EllesmereUIQuestTracker'`, thrown out of `ShouldShowMawBuffs` via `ScenarioObjectiveTracker:LayoutContents`. The click-anywhere-on-header feature is preserved, just implemented differently.

The cause was the click-anywhere-on-header overlay. It forwarded a click to the header's own MinimizeButton via `Click()`, which runs Blizzard's collapse cascade from addon execution and taints `ObjectiveTrackerContainer`'s shared dispatch loop for whichever module owns that header. Once tainted, the next pass where the container processes every module together carries that taint into `ScenarioObjectiveTracker`/`UIWidgetObjectiveTracker`'s `LayoutContents`, where the aura read raises. The taint outlives the zone change, which is why the in-game repro only surfaced inside an instance while the actual trigger was often a header click taken outside one, and why the reported call stacks contain no addon frames at all.

The fix removes the click forward entirely and widens the native MinimizeButton's own hit rect across the header instead. No addon code runs at click time anymore: the client dispatches the click straight to Blizzard's `OnClick` closure, which is bit-for-bit the path a bare +/- press already takes, and that path never reproduced the error. Verified against Gethe/wow-ui-source: both header templates (`ObjectiveTrackerContainerHeaderTemplate`, `ObjectiveTrackerModuleHeaderTemplate`) are plain Frames with no `enableMouse`, so the header cannot swallow the click; their MinimizeButton `OnClick` is set by Blizzard in the mixin `OnLoad` and is never touched here; and Blizzard never calls `SetHitRectInsets` on these buttons itself, so nothing resets it.

The insets are recomputed on every skin pass so they track Edit Mode resizes, clamped at zero so a stale header can never leave a hit area hanging off into empty screen, expanded vertically to the full header height (the button is 16px against a 26px section header, so the top and bottom few pixels of the title would otherwise stay dead), and stop short of the FilterButton while it is showing so it keeps its own clicks.

For the player nothing changes in behavior: clicking a section title still collapses and expands it, and the +/- button works exactly as before. The only visible difference is that hovering anywhere over the header now lights up that header's +/- highlight, since the button itself is what the cursor is over.

## How was it tested?

Tested in game on the live retail client. The reporters' repro sequence was reproduced first on the unfixed build to confirm the trigger: collapse the Quests header by clicking its title, then collapse a dungeon/scenario section with its own +/- button, then click Quests again, which throws the error inside an instance. Clicking only the +/- buttons never produced it, and clicking headers outside an instance produced it later on entering one.

Two intermediate attempts were tested and rejected against that repro before the final approach. Skipping the overlay only on the shared-widget-pool trackers did not help, since the taint enters through whichever header is clicked rather than through the scenario header specifically. Gating the click forward on `IsInInstance()` at click time narrowed the reproduction window but did not close it, because the taint planted outside the instance persists across the zone change.

With the hit-rect implementation, the full repro sequence was re-run in a dungeon and no longer throws, including while in combat. Collapsing and expanding sections by clicking the title and by pressing +/- both behave as before, in and out of the instance.

## Screenshots

Not applicable. No visual change beyond the +/- highlight lighting up on header hover, which is Blizzard's own highlight texture reacting to the widened hit area.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting; this is a bug fix to an existing feature, whose behavior is unchanged for the player
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- the whole block sits inside `SkinHeader`, which already returns early when `skinHeaders` is off
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- strictly cheaper than what it replaces: a `CreateFrame` plus an `OnClick` closure per header is gone, replaced by four arithmetic ops and one `SetHitRectInsets` on the existing skin pass; no new events, timers, or hooks
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- no fields are written onto Blizzard frames, and the weak-keyed overlay table this feature used is removed along with it; `SetHitRectInsets` is a plain frame-geometry setter of the same class as the `SetAtlas`/`SetVertexColor` calls already applied to this button, and no `SetScript` is involved
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added -- `SetHitRectInsets` is long-standing frame API