### PR TITLE
fix: borders covering text on skinned bars

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2638,7 +2638,7 @@ do
         -- 4 strips instead of BackdropTemplate: NineSlice corner sub-frames render as black boxes on nameplates.
         local container = CreateFrame("Frame", nil, frame)
         container:SetAllPoints(frame)
-        container:SetFrameLevel(frame:GetFrameLevel() + 1)
+        container:SetFrameLevel(frame:GetFrameLevel())
 
         local WHITE = "Interface\\Buttons\\WHITE8X8"
         local function MakeTex()

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowEngine.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowEngine.lua
@@ -77,7 +77,7 @@ local function AddBorder(frame, r, g, b, a)
     if GetFFD(frame).border then return end
     local PP = EUI and (EUI.PanelPP or EUI.PP)
     if PP and PP.CreateBorder then
-        PP.CreateBorder(frame, r or Theme.brdR, g or Theme.brdG, b or Theme.brdB, a or Theme.brdA, 1, "OVERLAY", 7)
+        PP.CreateBorder(frame, r or Theme.brdR, g or Theme.brdG, b or Theme.brdB, a or Theme.brdA, 1, "BORDER", -7)
         GetFFD(frame).border = true
     end
 end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?
Fix borders on skinned bars (experience bar, reputation bar, etc.) covering text by lowering AddBorder drawLayer from OVERLAY to BORDER and removing the +1 frame level offset in PP.CreateBorder.
<!-- User-facing description: what changes for the player? -->

## How was it tested?
In-game: verified reputation bar labels and experience bar text are no
longer occluded by borders.
<!-- Client build, what you tested in game, etc. -->

## Screenshots
<img width="796" height="97" alt="image" src="https://github.com/user-attachments/assets/1e91a654-5551-4c94-9655-10d349624736" />
<img width="814" height="111" alt="image" src="https://github.com/user-attachments/assets/ccf0a337-3274-4507-8b5c-76f5ff4c01d8" />

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
