### PR TITLE
feat(pab): allow custom shapes and zoom for player aura icons like action bars

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2739,6 +2739,62 @@ do
         if bd then bd.container:Show() end
     end
 
+    -- Variable-thickness border ring drawn from a single pre-shaped texture (natively
+    -- 7px thick), scaled by (7 - rawBorderSize) and clipped by `mask`. Called with `:`
+    -- so self.Point resolves to whichever PP module owns host's frame hierarchy
+    -- (world PP vs PanelPP) -- calling with `.` shifts every argument left by one.
+    function PP:ApplyMaskedShapeBorder(host, mask, texPath, rawBorderSize, r, g, b, a)
+        if not host then return end
+        rawBorderSize = rawBorderSize or 0
+        if rawBorderSize <= 0 or not texPath then
+            if host._shapeBorderShown then
+                host._shapeBorderTex:Hide()
+                host._shapeBorderShown = nil
+            end
+            return
+        end
+        r, g, b, a = r or 0, g or 0, b or 0, a or 1
+        -- Every field guarded: callers invoke this on every restyle pass regardless
+        -- of whether the border changed, and Remove/AddMaskTexture aren't cheap.
+        if host._shapeBorderShown and host._sbTex == texPath and host._sbSize == rawBorderSize
+            and host._sbMask == mask and host._sbR == r and host._sbG == g
+            and host._sbB == b and host._sbA == a then
+            return
+        end
+        if not host._shapeBorderTex then
+            host._shapeBorderTex = host:CreateTexture(nil, "OVERLAY")
+            local t = host._shapeBorderTex
+            if t.SetSnapToPixelGrid then t:SetSnapToPixelGrid(false); t:SetTexelSnappingBias(0) end
+        end
+        local tex = host._shapeBorderTex
+        local bExp = 7 - math.min(rawBorderSize, 7)
+        tex:ClearAllPoints()
+        self.Point(tex, "TOPLEFT", host, "TOPLEFT", -bExp, bExp)
+        self.Point(tex, "BOTTOMRIGHT", host, "BOTTOMRIGHT", bExp, -bExp)
+        if mask then
+            pcall(tex.RemoveMaskTexture, tex, mask)
+            pcall(tex.AddMaskTexture, tex, mask)
+        end
+        tex:SetTexture(texPath)
+        tex:SetVertexColor(r, g, b, a)
+        tex:Show()
+        host._sbTex, host._sbSize, host._sbMask, host._sbR, host._sbG, host._sbB, host._sbA =
+            texPath, rawBorderSize, mask, r, g, b, a
+        host._shapeBorderShown = true
+    end
+
+    -- Callers switching away from a shaped border (to the plain-line border, or off
+    -- entirely) must hide _shapeBorderTex through this, not a raw :Hide() -- the guard
+    -- above trusts _shapeBorderShown, so an external hide it doesn't know about leaves
+    -- a later ApplyMaskedShapeBorder call with the exact same args wrongly skipping
+    -- its own Show().
+    function PP:HideMaskedShapeBorder(host)
+        if host and host._shapeBorderShown then
+            host._shapeBorderTex:Hide()
+            host._shapeBorderShown = nil
+        end
+    end
+
     ---------------------------------------------------------------------------
     --  Scale change watcher
     ---------------------------------------------------------------------------
@@ -2861,6 +2917,8 @@ do
     PanelPP.UpdateBorder  = PP.UpdateBorder
     PanelPP.HideBorder    = PP.HideBorder
     PanelPP.ShowBorder    = PP.ShowBorder
+    PanelPP.ApplyMaskedShapeBorder = PP.ApplyMaskedShapeBorder
+    PanelPP.HideMaskedShapeBorder = PP.HideMaskedShapeBorder
 end
 
 -- File-level PanelPP reference for panel layout code outside the do block

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -73,6 +73,76 @@ local GROW_DIR_ORDER = { "LEFT", "RIGHT", "CENTER_HORIZONTAL", "CENTER_VERTICAL"
 local ICON_WRAP_VALUES = { LEFT = "Left", RIGHT = "Right", UP = "Up", DOWN = "Down" }
 local ICON_WRAP_ORDER = { "LEFT", "RIGHT", "UP", "DOWN" }
 
+-- Same shape vocabulary and media set as Action Bars' Custom Button Shape
+-- (EUI_ActionBars_Options.lua), minus "cropped" -- PAB has no equivalent
+-- "cropped square" concept.
+local SHAPE_VALUES = {
+    none = "None", square = "Square", circle = "Circle",
+    csquare = "Curved Square", diamond = "Diamond", hexagon = "Hexagon",
+    portrait = "Portrait", shield = "Shield",
+}
+local SHAPE_ORDER = { "none", "square", "circle", "csquare", "diamond", "hexagon", "portrait", "shield" }
+
+-- Levels map 1:1 to Action Bars' ns.BORDER_THICKNESS regular values (thin=1, normal=2,
+-- heavy=3, strong=4), so cfg.borderSize stays the same plain 0-4 number used elsewhere
+-- (regular border thickness, per-filter Icon Effects override).
+local BORDER_SIZE_LEVELS = { "none", "thin", "normal", "heavy", "strong" }
+local BORDER_SIZE_VALUES = { none = "None", thin = "Thin", normal = "Normal", heavy = "Heavy", strong = "Strong" }
+local BORDER_SIZE_NUM = { none = 0, thin = 1, normal = 2, heavy = 3, strong = 4 }
+local BORDER_SIZE_KEY = { [0] = "none", [1] = "thin", [2] = "normal", [3] = "heavy", [4] = "strong" }
+-- Levels with no distinct shape-border rendering (PabShapeBorderSize collapses them
+-- all to "off"); Strong is the only one worth keeping enabled once a shape is active.
+local BORDER_SIZE_SHAPE_DISABLED = { thin = true, normal = true, heavy = true }
+local BORDER_SIZE_DEFAULT_SHAPE = "strong"
+
+-- Every PAB bar (default Buffs/Debuffs plus any custom ones), for the sync-icon
+-- "Apply to: All | Multiple" rows. entry.cfg is the live table, not a copy.
+local function PabAllBarEntries()
+    local s = ns.db and ns.db.profile and ns.db.profile.playerAuraBars
+    if not s then return {} end
+    local list = {}
+    list[#list + 1] = { key = "buffs", label = "Buffs", isBuff = true, cfg = ns.PAB_DefaultBuffsCfg(s) }
+    list[#list + 1] = { key = "debuffs", label = "Debuffs", isBuff = false, cfg = ns.PAB_DefaultDebuffsCfg(s) }
+    local buffBars = ns.PAB_CustomBuffBars and ns.PAB_CustomBuffBars()
+    if buffBars then
+        for i = 1, #buffBars do
+            local bar = buffBars[i]
+            list[#list + 1] = { key = "custombuff_" .. bar.id, label = bar.name or "Buff Bar", isBuff = true, cfg = bar }
+        end
+    end
+    local debuffBars = ns.PAB_CustomDebuffBars and ns.PAB_CustomDebuffBars()
+    if debuffBars then
+        for i = 1, #debuffBars do
+            local bar = debuffBars[i]
+            list[#list + 1] = { key = "customdebuff_" .. bar.id, label = bar.name or "Debuff Bar", isBuff = false, cfg = bar }
+        end
+    end
+    return list
+end
+
+-- Which PabAllBarEntries() row a given (cfg, isBuff) pair is.
+local function PabBarKeyOf(cfg, isBuff)
+    local s = ns.db and ns.db.profile and ns.db.profile.playerAuraBars
+    if s then
+        if cfg == ns.PAB_DefaultBuffsCfg(s) then return "buffs" end
+        if cfg == ns.PAB_DefaultDebuffsCfg(s) then return "debuffs" end
+    end
+    if cfg.id then return (isBuff and "custombuff_" or "customdebuff_") .. cfg.id end
+    return ""
+end
+
+-- Restyles one bar live after the caller has written fields onto entry.cfg.
+local function PabApplyBarEntry(entry)
+    if entry.key == "buffs" or entry.key == "debuffs" then
+        if ns.PAB_Restyle then ns.PAB_Restyle() end
+        if ns.PAB_ApplyLiveConfig then ns.PAB_ApplyLiveConfig(entry.isBuff) end
+    elseif entry.isBuff then
+        if ns.PAB_ReloadCustomBuffBar then ns.PAB_ReloadCustomBuffBar(entry.cfg.id) end
+    else
+        if ns.PAB_ReloadCustomDebuffBar then ns.PAB_ReloadCustomDebuffBar(entry.cfg.id) end
+    end
+end
+
 -- Native AuraContainerSortMethod/AuraContainerSortDirection enum names
 -- (in-game dump: AuraContainerSortMethod = {Default=0,
 -- BigDefensive=1, UnitFrameDebuff=2, ImportantOnly=3, Expiration=4,
@@ -872,9 +942,17 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
     local borderRow
     borderRow, hh = W:DualRow(frame, sy,
         {
-            type = "slider", text = "Border Size", min = 0, max = 4, step = 1, trackWidth = 120,
-            getValue = function() return cfg.borderSize or 1 end,
-            setValue = function(v) cfg.borderSize = v; apply() end
+            type = "dropdown", text = "Border Size",
+            values = BORDER_SIZE_VALUES, order = BORDER_SIZE_LEVELS,
+            itemDisabled = function(v)
+                local shape = cfg.iconShape
+                return shape and shape ~= "none" and BORDER_SIZE_SHAPE_DISABLED[v] or false
+            end,
+            itemDisabledTooltip = function()
+                return "This option requires a non-custom shape to be selected"
+            end,
+            getValue = function() return BORDER_SIZE_KEY[cfg.borderSize or 1] or "thin" end,
+            setValue = function(v) cfg.borderSize = BORDER_SIZE_NUM[v] or 1; apply() end
         },
         {
             type = "slider", text = "Spacing", min = -5, max = 20, step = 1, trackWidth = 120,
@@ -897,6 +975,57 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
         swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
         rgn._lastInline = swatch
         EllesmereUI.RegisterWidgetRefresh(updateSwatch)
+    end
+    do
+        local rgn = borderRow._leftRegion
+        local keys, labels = {}, {}
+        for _, entry in ipairs(PabAllBarEntries()) do
+            keys[#keys + 1] = entry.key
+            labels[entry.key] = entry.label
+        end
+        local function CopyBorderTo(entry)
+            entry.cfg.borderSize = cfg.borderSize
+            entry.cfg.borderR, entry.cfg.borderG, entry.cfg.borderB, entry.cfg.borderA =
+                cfg.borderR, cfg.borderG, cfg.borderB, cfg.borderA
+            PabApplyBarEntry(entry)
+        end
+        EllesmereUI.BuildSyncIcon({
+            region  = rgn,
+            tooltip = "Apply Border Size and Color to all Bars",
+            onClick = function()
+                for _, entry in ipairs(PabAllBarEntries()) do
+                    if entry.cfg ~= cfg then CopyBorderTo(entry) end
+                end
+                EllesmereUI:RefreshPage()
+            end,
+            isSynced = function()
+                local size = cfg.borderSize or 1
+                local r, g, b, a = cfg.borderR or 0, cfg.borderG or 0, cfg.borderB or 0, cfg.borderA or 1
+                for _, entry in ipairs(PabAllBarEntries()) do
+                    local c = entry.cfg
+                    if (c.borderSize or 1) ~= size or (c.borderR or 0) ~= r or (c.borderG or 0) ~= g
+                        or (c.borderB or 0) ~= b or (c.borderA or 1) ~= a then
+                        return false
+                    end
+                end
+                return true
+            end,
+            flashTargets = function() return { rgn } end,
+            multiApply = {
+                elementKeys   = keys,
+                elementLabels = labels,
+                getCurrentKey = function() return PabBarKeyOf(cfg, isBuff) end,
+                onApply       = function(checkedKeys)
+                    local byKey = {}
+                    for _, entry in ipairs(PabAllBarEntries()) do byKey[entry.key] = entry end
+                    for _, key in ipairs(checkedKeys) do
+                        local entry = byKey[key]
+                        if entry then CopyBorderTo(entry) end
+                    end
+                    EllesmereUI:RefreshPage()
+                end,
+            },
+        })
     end
     do
         -- Row Spacing lives here, not in Icons Per Row's cog -- it's spacing between
@@ -948,6 +1077,76 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
             },
         })
         ns._PAMakeCogBtn(rgn, cogShow)
+    end
+
+    -- Icon Shape reuses the base Border Size/Color above -- no separate shape fields.
+    local shapeRow
+    shapeRow, hh = W:DualRow(frame, sy,
+        {
+            type = "dropdown", text = "Icon Shape",
+            values = SHAPE_VALUES, order = SHAPE_ORDER,
+            getValue = function() return cfg.iconShape or "none" end,
+            setValue = function(v)
+                cfg.iconShape = v
+                -- Entering shape mode with a now-disabled Border Size level selected:
+                -- snap to the shape default, same as Action Bars' own shape dropdown
+                -- resetting border thickness on every shape change.
+                local curKey = BORDER_SIZE_KEY[cfg.borderSize or 1] or "thin"
+                if v ~= "none" and BORDER_SIZE_SHAPE_DISABLED[curKey] then
+                    cfg.borderSize = BORDER_SIZE_NUM[BORDER_SIZE_DEFAULT_SHAPE]
+                end
+                apply()
+            end
+        },
+        {
+            -- cfg.iconZoom stays a raw 0-1 fraction (SetTexCoord's own units); the
+            -- slider itself works in percent, like Action Bars' Icon Zoom.
+            type = "slider", text = "Icon Zoom", min = 0, max = 15, step = 0.5, trackWidth = 120,
+            getValue = function() return (cfg.iconZoom or 0.055) * 100 end,
+            setValue = function(v) cfg.iconZoom = v / 100; apply() end
+        }
+    ); sy = sy - hh
+    do
+        local rgn = shapeRow._leftRegion
+        local keys, labels = {}, {}
+        for _, entry in ipairs(PabAllBarEntries()) do
+            keys[#keys + 1] = entry.key
+            labels[entry.key] = entry.label
+        end
+        EllesmereUI.BuildSyncIcon({
+            region  = rgn,
+            tooltip = "Apply Icon Shape to all Bars",
+            onClick = function()
+                local shape = cfg.iconShape
+                for _, entry in ipairs(PabAllBarEntries()) do
+                    if entry.cfg ~= cfg then entry.cfg.iconShape = shape; PabApplyBarEntry(entry) end
+                end
+                EllesmereUI:RefreshPage()
+            end,
+            isSynced = function()
+                local shape = cfg.iconShape or "none"
+                for _, entry in ipairs(PabAllBarEntries()) do
+                    if (entry.cfg.iconShape or "none") ~= shape then return false end
+                end
+                return true
+            end,
+            flashTargets = function() return { rgn } end,
+            multiApply = {
+                elementKeys   = keys,
+                elementLabels = labels,
+                getCurrentKey = function() return PabBarKeyOf(cfg, isBuff) end,
+                onApply       = function(checkedKeys)
+                    local shape = cfg.iconShape
+                    local byKey = {}
+                    for _, entry in ipairs(PabAllBarEntries()) do byKey[entry.key] = entry end
+                    for _, key in ipairs(checkedKeys) do
+                        local entry = byKey[key]
+                        if entry then entry.cfg.iconShape = shape; PabApplyBarEntry(entry) end
+                    end
+                    EllesmereUI:RefreshPage()
+                end,
+            },
+        })
     end
 
     local swipeRow
@@ -1206,9 +1405,17 @@ local function BuildFxEffects(frame, sy, cfg, apply)
         -- filters; 0 = the bar's own icon size).
         local bRow
         bRow, hh = W:DualRow(frame, sy,
-            { type = "slider", text = "Border", min = 0, max = 4, step = 1, trackWidth = 120,
-              getValue = function() return e.borderSize or 0 end,
-              setValue = function(v) e.borderSize = v; apply() end },
+            { type = "dropdown", text = "Border",
+              values = BORDER_SIZE_VALUES, order = BORDER_SIZE_LEVELS,
+              itemDisabled = function(v)
+                  local shape = cfg.iconShape
+                  return shape and shape ~= "none" and BORDER_SIZE_SHAPE_DISABLED[v] or false
+              end,
+              itemDisabledTooltip = function()
+                  return "This option requires a non-custom shape to be selected"
+              end,
+              getValue = function() return BORDER_SIZE_KEY[e.borderSize or 0] or "none" end,
+              setValue = function(v) e.borderSize = BORDER_SIZE_NUM[v] or 0; apply() end },
             { type = "slider", text = "Size", min = 0, max = 400, step = 1, trackWidth = 120,
               getValue = function() return e.size or 0 end,
               setValue = function(v)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -3386,6 +3386,12 @@ local MASK_INSETS = {
     square   = 17,
 }
 
+-- Shared with EllesmereUIUnitFrames_PlayerAuraBars.lua (same addon/ns), which reuses
+-- this shape media set for Player Aura Bars' iconShape feature.
+ns.PORTRAIT_MASKS   = PORTRAIT_MASKS
+ns.PORTRAIT_BORDERS = PORTRAIT_BORDERS
+ns.MASK_INSETS      = MASK_INSETS
+
 -- Apply a detached portrait shape (mask + border overlay) to a portrait backdrop;
 -- creates the mask/border textures on first call, then updates them.
 --   backdrop  : the portrait backdrop frame

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -242,6 +242,25 @@ end
 -- cost (same trade-off as EllesmereUI_AuraKit.lua's dispelHolder) so a later Icon
 -- Effects change never needs a /reload.
 
+-- Icon-size expansion for a masked shape's overhang beyond its logical iconSize
+-- (mirrors EllesmereUIActionBars.lua's SHAPE_BTN_EXPAND).
+local PAB_SHAPE_EXPAND = 8
+local function PabShapeActive(shape)
+    return shape ~= nil and shape ~= "none"
+end
+
+-- Shape borders only render two visually distinct states at aura-icon sizes, same as
+-- Action Bars' own ns.BORDER_THICKNESS table: thin/normal/heavy all carry shape=0,
+-- only strong carries shape=7. Border Size's 0-4 levels mirror that table 1:1 (see
+-- EUI_PlayerAuraBars_ManagerPages.lua's BORDER_SIZE_LEVELS).
+local function PabShapeBorderSize(v)
+    return ((v or 0) >= 4) and 7 or 0
+end
+local function PabShapedSize(rawSize, shape)
+    if PabShapeActive(shape) then return rawSize + PAB_SHAPE_EXPAND end
+    return rawSize
+end
+
 local function PAB_ApplyDmFx(button, d, style)
     local cat = d.dmCat
     local e = style.fxList and PAB_FxBlockFor(style.fxList, cat) or nil
@@ -299,7 +318,9 @@ local function PAB_ApplyDmFx(button, d, style)
         gov:Hide()
     end
 
-    -- Border override: same creation-window pre-make as the glow.
+    -- Border override: same creation-window pre-make as the glow. PP.CreateBorder's
+    -- container is created lazily below (non-shaped branch only) -- a shaped bar
+    -- uses PP.ApplyMaskedShapeBorder instead, which owns its own child texture.
     local bSize = (e and e.borderSize) or 0
     local host = d.pabFxBdr
     if not host and PP then
@@ -309,13 +330,18 @@ local function PAB_ApplyDmFx(button, d, style)
             or (button:GetFrameLevel() + 1)
         host:SetFrameLevel(base + 1)
         host:EnableMouse(false)
-        PP.CreateBorder(host, 0, 0, 0, 1, 1)
         host:Hide()
         d.pabFxBdr = host
     end
     if bSize > 0 and host and PP then
         local bc = e.borderColor or { r = 0, g = 0, b = 0 }
-        PP.UpdateBorder(host, bSize, bc.r or 0, bc.g or 0, bc.b or 0, 1)
+        if style.iconShape and style.iconShape ~= "none" and style.shapeBorderPath and d.shapeMask then
+            PP:ApplyMaskedShapeBorder(host, d.shapeMask, style.shapeBorderPath, PabShapeBorderSize(bSize), bc.r or 0, bc.g or 0, bc.b or 0, 1)
+        else
+            PP:HideMaskedShapeBorder(host)
+            PP.CreateBorder(host, 0, 0, 0, 1, 1)
+            PP.UpdateBorder(host, bSize, bc.r or 0, bc.g or 0, bc.b or 0, 1)
+        end
         host:Show()
     elseif host then
         host:Hide()
@@ -743,7 +769,7 @@ local function BuildStyle(isBuff, cfg)
     -- gap snap) so the rendered size agrees with the container's cross-axis extent
     -- math at any UIParent scale.
     local PP = EllesmereUI.PP
-    local iconSize = PP.Scale(cfg.iconSize or 32)
+    local iconSize = PP.Scale(PabShapedSize(cfg.iconSize or 32, cfg.iconShape))
 
     local style = {
         width = iconSize,
@@ -824,6 +850,19 @@ local function BuildStyle(isBuff, cfg)
 
         border = border,
     }
+
+    -- Custom icon shape (Square/Circle/Hexagon/etc, same media set as Action Bars
+    -- and Unit Frames' detached portraits). ns.PORTRAIT_MASKS/BORDERS/MASK_INSETS are
+    -- exposed by EllesmereUIUnitFrames.lua (same addon/ns); AuraKit itself lives in a
+    -- separate TOC and never touches ns, so resolved paths travel through style.*.
+    local shape = cfg.iconShape
+    if PabShapeActive(shape) then
+        style.iconShape       = shape
+        style.shapeMaskPath   = ns.PORTRAIT_MASKS and ns.PORTRAIT_MASKS[shape]
+        style.shapeBorderPath = ns.PORTRAIT_BORDERS and ns.PORTRAIT_BORDERS[shape]
+        style.shapeInsetPx    = ns.MASK_INSETS and ns.MASK_INSETS[shape]
+        style.shapeBorderSize = cfg.shapeBorderSizeOverride or PabShapeBorderSize(borderSize)
+    end
 
     -- Engine dispel-type border, debuffs only (buffs have no dispel type). AK's gate
     -- (ApplyStyleToRegions) only activates it when `border` above is ALSO non-nil, so
@@ -976,7 +1015,7 @@ end
 -- same size share one variant, everything else riding along via the shallow copy.
 -- Rebuilt unconditionally every pass (settings-apply frequency) rather than
 -- fingerprint-cached.
-local function EnsurePabSizedStyle(baseKey, size)
+local function EnsurePabSizedStyle(baseKey, size, shape)
     local base = AK.styles[baseKey]
     if not base then return baseKey end
     local variantKey = baseKey .. ":sz" .. tostring(size)
@@ -984,10 +1023,12 @@ local function EnsurePabSizedStyle(baseKey, size)
     for k, val in pairs(base) do v[k] = val end
     -- Snapped like BuildStyle's own width/height (same button SetSize path, so a raw
     -- value reintroduces the 1px border/icon disagreement); the variant KEY stays
-    -- keyed by the raw size.
+    -- keyed by the raw size. Shape-expand applies the same as BuildStyle's own
+    -- iconSize -- base already carries iconShape/shapeMaskPath/etc via the shallow
+    -- copy above, only width/height need recomputing for this variant's own size.
     local PP = EllesmereUI.PP
-    v.width = PP.Scale(size)
-    v.height = PP.Scale(size)
+    v.width = PP.Scale(PabShapedSize(size, shape))
+    v.height = PP.Scale(PabShapedSize(size, shape))
     AK.styles[variantKey] = v
     AK.RestyleSoon(variantKey)
     return variantKey
@@ -996,7 +1037,7 @@ end
 local function BuildGroupLayout(cfg, gap, rowGap, size)
     local PP = EllesmereUI.PP
     rowGap = rowGap or gap
-    size = PP.Scale(size or cfg.iconSize or 32)
+    size = PP.Scale(PabShapedSize(size or cfg.iconSize or 32, cfg.iconShape))
     gap = PP.Scale(gap)
     rowGap = PP.Scale(rowGap)
     return {
@@ -1032,7 +1073,7 @@ local function ApplyGroupConfig(container, chain, declaredSet, styleKey, effecti
         -- link.key alone stays the fx CATEGORY identity (d.dmCat / PAB_FxSizeFor).
         local effKey = link.key .. "|" .. table.concat(link.tokens, "")
         if szOv then effKey = effKey .. "|sz" end
-        local linkStyleKey = szOv and EnsurePabSizedStyle(styleKey, szOv) or styleKey
+        local linkStyleKey = szOv and EnsurePabSizedStyle(styleKey, szOv, cfg.iconShape) or styleKey
         local candidateFilters
         if link.cand then
             -- link.cand is from the shared class vocabulary -- copy it so the merges
@@ -1163,9 +1204,10 @@ local function MaxIconSizeFor(isBuff, cfg)
     end
     -- Snap to the physical pixel grid (same reasoning as ApplyGroupConfig's gap/rowGap
     -- snap): a raw iconSize also feeds the container's cross-axis extent math
-    -- (ComputeGrid) at a non-pixel-perfect UIParent scale.
+    -- (ComputeGrid) at a non-pixel-perfect UIParent scale. Shape-expand applied last so
+    -- the bar frame's footprint (ComputeGrid) always matches the buttons' real size.
     local PP = EllesmereUI.PP
-    return PP.Scale(size)
+    return PP.Scale(PabShapedSize(size, cfg.iconShape))
 end
 
 local function ComputeGrid(isBuff, cfg)
@@ -3589,6 +3631,9 @@ local function CreatePreviewIcon(box)
     btn.cooldown:SetHideCountdownNumbers(true)
     btn.cooldown:Hide()
     btn.border = CreateFrame("Frame", nil, btn)
+    -- Plain preview region, not a real AuraKit button -- masking is unguarded here.
+    btn.shapeMask = btn:CreateMaskTexture()
+    btn.shapeMask:Hide()
     btn.textHost = CreateFrame("Frame", nil, btn)
     btn.duration = btn.textHost:CreateFontString(nil, "OVERLAY")
     btn.stack = btn.textHost:CreateFontString(nil, "OVERLAY")
@@ -3639,6 +3684,11 @@ local function ApplyPreviewScale(cfg, comp)
     out.padding = (cfg.padding or 5) * comp
     out.rowSpacing = cfg.rowSpacing and (cfg.rowSpacing * comp) or nil
     out.borderSize = (cfg.borderSize or 1) * comp
+    -- PabShapeBorderSize is keyed by the raw 0-4 level, so it must run BEFORE scaling
+    -- (unlike out.borderSize above) -- resolve the level, then scale the result,
+    -- mirroring iconSize's own scale-after-resolve treatment. BuildStyle prefers this
+    -- over recomputing from the already-scaled out.borderSize when present.
+    out.shapeBorderSizeOverride = PabShapeBorderSize(cfg.borderSize or 1) * comp
     out.durationTextSize = (cfg.durationTextSize or 11) * comp
     out.durationOffsetX = (cfg.durationOffsetX or 0) * comp
     out.durationOffsetY = (cfg.durationOffsetY or 0) * comp
@@ -4035,12 +4085,14 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
     -- override, or the bar's base iconSize) drives its own footprint directly, so
     -- spacing between normal icons stays tight and only an oversized icon's immediate
     -- neighbors get pushed out -- true flow-layout behavior rather than a uniform
-    -- worst-case cell grid (which left too much gap around every normal icon).
+    -- worst-case cell grid (which left too much gap around every normal icon). Shape-
+    -- expanded the same as the live bar's own button SetSize (BuildStyle/
+    -- EnsurePabSizedStyle), so preview spacing/footprint matches the real bar.
     local slotSize = {}
     for i = 1, total do
         local e = fxBySlot and fxBySlot[i]
         local sz = e and tonumber(e.size)
-        slotSize[i] = (sz and sz > 0) and sz or iconSize
+        slotSize[i] = PabShapedSize((sz and sz > 0) and sz or iconSize, cfg.iconShape)
     end
 
     local rowWidth, rowHeight, colOffset, rowYOffset = {}, {}, {}, {}
@@ -4166,7 +4218,39 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
                 btn.icon:SetTexCoord(z, 1 - z, z, 1 - z)
             end
 
-            btn.border:SetAllPoints(btn.icon)
+            -- Mirrors EllesmereUI_AuraKit.lua's ApplyStyleToRegions, unguarded (plain regions).
+            local shapeActive = style.iconShape and style.iconShape ~= "none" and style.shapeMaskPath
+            if shapeActive then
+                btn.shapeMask:SetTexture(style.shapeMaskPath, "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+                btn.shapeMask:SetAllPoints(btn)
+                btn.shapeMask:Show()
+                local sz = slotSize[i]
+                local zoom = style.iconZoom or 0.055
+                local shapeKey = style.iconShape .. "|" .. sz .. "|" .. zoom
+                if btn._shapeApplied ~= shapeKey then
+                    pcall(btn.icon.RemoveMaskTexture, btn.icon, btn.shapeMask)
+                    btn.icon:AddMaskTexture(btn.shapeMask)
+                    local insetPx = style.shapeInsetPx or 17
+                    local visRatio = (128 - 2 * insetPx) / 128
+                    local fullExpand = ((1 / visRatio) - 1) * 0.5
+                    -- Coupled to Icon Zoom, same as the live bar (EllesmereUI_AuraKit.lua).
+                    local expand = math.max(fullExpand * (zoom / 0.055), 0)
+                    btn.icon:ClearAllPoints()
+                    btn.icon:SetPoint("TOPLEFT", btn, "TOPLEFT", -expand * sz, expand * sz)
+                    btn.icon:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", expand * sz, -expand * sz)
+                    btn._shapeApplied = shapeKey
+                end
+            else
+                if btn._shapeApplied then
+                    pcall(btn.icon.RemoveMaskTexture, btn.icon, btn.shapeMask)
+                    btn.icon:ClearAllPoints()
+                    btn.icon:SetAllPoints()
+                    btn._shapeApplied = nil
+                end
+                btn.shapeMask:Hide()
+            end
+
+            btn.border:SetAllPoints(shapeActive and btn or btn.icon)
             btn.border:SetFrameLevel(btn:GetFrameLevel() + 1)
             local PP = EllesmereUI and EllesmereUI.PanelPP
             if PP and style.border then
@@ -4176,22 +4260,41 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
                     br, bg, bb, ba = c.r, c.g, c.b, 1
                 end
                 local size = style.border.size or 1
-                -- PP.CreateBorder is create-ONCE-only -- a second call with a different
-                -- size/color on an already-created host is a silent no-op
-                -- (EllesmereUI.lua's PP.CreateBorder early-returns the cached container
-                -- without touching bd.borderSize/borderColor). Live border-size/color
-                -- changes on an already-created host must go through PP.UpdateBorder
-                -- instead -- the same borderMade branch EllesmereUI_AuraKit.lua's own
-                -- ApplyStyleToRegions uses for the real bar's borders.
-                if btn.borderMade then
-                    PP.UpdateBorder(btn.border, size, br, bg, bb, ba)
-                elseif PP.CreateBorder then
-                    PP.CreateBorder(btn.border, br, bg, bb, ba, size, "OVERLAY", 7)
-                    btn.borderMade = true
+                if shapeActive and style.shapeBorderPath and PP.ApplyMaskedShapeBorder then
+                    PP:ApplyMaskedShapeBorder(btn.border, btn.shapeMask, style.shapeBorderPath, style.shapeBorderSize or size, br, bg, bb, ba)
+                    if PP.ShowBorder then PP.ShowBorder(btn.border) end
+                    btn.border:Show()
+                else
+                    if PP.HideMaskedShapeBorder then PP:HideMaskedShapeBorder(btn.border)
+                    elseif btn.border._shapeBorderTex then btn.border._shapeBorderTex:Hide() end
+                    -- PP.CreateBorder is create-once-only; live size/color changes on an
+                    -- already-created host go through PP.UpdateBorder instead.
+                    if btn.borderMade then
+                        PP.UpdateBorder(btn.border, size, br, bg, bb, ba)
+                    elseif PP.CreateBorder then
+                        PP.CreateBorder(btn.border, br, bg, bb, ba, size, "OVERLAY", 7)
+                        btn.borderMade = true
+                    end
+                    if PP.ShowBorder then PP.ShowBorder(btn.border) else btn.border:Show() end
                 end
-                if PP.ShowBorder then PP.ShowBorder(btn.border) else btn.border:Show() end
             else
                 if PP and PP.HideBorder then PP.HideBorder(btn.border) else btn.border:Hide() end
+                if PP and PP.HideMaskedShapeBorder then PP:HideMaskedShapeBorder(btn.border)
+                elseif btn.border._shapeBorderTex then btn.border._shapeBorderTex:Hide() end
+            end
+
+            local cdMaskKey = shapeActive and style.iconShape or nil
+            if btn._cdShapeApplied ~= cdMaskKey then
+                if cdMaskKey then
+                    pcall(btn.cooldown.AddMaskTexture, btn.cooldown, btn.shapeMask)
+                    if btn.cooldown.SetSwipeTexture then
+                        pcall(btn.cooldown.SetSwipeTexture, btn.cooldown, style.shapeMaskPath)
+                    end
+                else
+                    pcall(btn.cooldown.RemoveMaskTexture, btn.cooldown, btn.shapeMask)
+                    if btn.cooldown.SetSwipeTexture then pcall(btn.cooldown.SetSwipeTexture, btn.cooldown, "") end
+                end
+                btn._cdShapeApplied = cdMaskKey
             end
 
             if slot.kind ~= "placeholder" then

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -194,6 +194,19 @@ local function ApplyStyleToRegions(button, style)
         d.appliedW, d.appliedH = w, h
     end
 
+    -- One mask shared by the icon, cooldown swipe, and base/dispel border art.
+    local shapeActive = style.iconShape and style.iconShape ~= "none" and style.shapeMaskPath
+    if shapeActive then
+        if not d.shapeMask then
+            d.shapeMask = button:CreateMaskTexture()
+        end
+        d.shapeMask:SetTexture(style.shapeMaskPath, "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+        d.shapeMask:SetAllPoints(button)
+        d.shapeMask:Show()
+    elseif d.shapeMask then
+        d.shapeMask:Hide()
+    end
+
     if d.icon then
         if style.texCoord then
             d.icon:SetTexCoord(style.texCoord[1], style.texCoord[2], style.texCoord[3], style.texCoord[4])
@@ -202,6 +215,49 @@ local function ApplyStyleToRegions(button, style)
             d.icon:SetTexCoord(z, 1 - z, z, 1 - z)
         else
             d.icon:SetTexCoord(0, 1, 0, 1)
+        end
+
+        if shapeActive then
+            -- Grows the icon past button's rect to fill the mask's inset opening
+            -- edge-to-edge. SetPoint against button is change-guarded/deferred like
+            -- d.borderHost's anchor below; AddMaskTexture rides the same guard so a
+            -- denial rolls back mask + geometry together.
+            local insetPx = style.shapeInsetPx or 17
+            local visRatio = (128 - 2 * insetPx) / 128
+            local fullExpand = ((1 / visRatio) - 1) * 0.5
+            -- Coupled to Icon Zoom, mirroring Action Bars' shape-fill expansion: below
+            -- the zoom default the forced mask-fill magnification shrinks too (floor 0
+            -- -- button's own rect, no oversizing, at zoom 0), above it it grows past
+            -- fullExpand. 0.055 is PAB's own iconZoom default (BuildStyle), so a bar
+            -- that never touches the zoom slider renders identically to before.
+            local zoom = style.iconZoom or 0.055
+            local expand = math.max(fullExpand * (zoom / 0.055), 0)
+            local iconShapeKey = style.iconShape .. "|" .. w .. "|" .. h .. "|" .. zoom
+            if d.akIconShapeKey ~= iconShapeKey then
+                local ok = pcall(function()
+                    pcall(d.icon.RemoveMaskTexture, d.icon, d.shapeMask)
+                    d.icon:AddMaskTexture(d.shapeMask)
+                    d.icon:ClearAllPoints()
+                    d.icon:SetPoint("TOPLEFT", button, "TOPLEFT", -expand * w, expand * h)
+                    d.icon:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", expand * w, -expand * h)
+                end)
+                if ok then
+                    d.akIconShapeKey = iconShapeKey
+                elseif d.styleKey and AK.AurasRestricted() then
+                    deferredRestyles[d.styleKey] = true
+                end
+            end
+        elseif d.akIconShapeKey then
+            if d.shapeMask then pcall(d.icon.RemoveMaskTexture, d.icon, d.shapeMask) end
+            local ok = pcall(function()
+                d.icon:ClearAllPoints()
+                d.icon:SetAllPoints(button)
+            end)
+            if ok then
+                d.akIconShapeKey = nil
+            elseif d.styleKey and AK.AurasRestricted() then
+                deferredRestyles[d.styleKey] = true
+            end
         end
     end
 
@@ -226,6 +282,23 @@ local function ApplyStyleToRegions(button, style)
         if d.akHideSwipe ~= hideSwipe then
             d.akHideSwipe = hideSwipe
             if d.cooldown.SetDrawSwipe then d.cooldown:SetDrawSwipe(not hideSwipe) end
+        end
+
+        -- Clip the swipe to the shape and recolor its silhouette to match, instead
+        -- of a plain square/circle radial. Both calls are on our own d.cooldown
+        -- region, not the button -- no guard needed.
+        local cdMaskKey = shapeActive and style.iconShape or nil
+        if d.akCdMaskKey ~= cdMaskKey then
+            if cdMaskKey then
+                pcall(d.cooldown.AddMaskTexture, d.cooldown, d.shapeMask)
+                if d.cooldown.SetSwipeTexture then
+                    pcall(d.cooldown.SetSwipeTexture, d.cooldown, style.shapeMaskPath)
+                end
+            else
+                if d.shapeMask then pcall(d.cooldown.RemoveMaskTexture, d.cooldown, d.shapeMask) end
+                if d.cooldown.SetSwipeTexture then pcall(d.cooldown.SetSwipeTexture, d.cooldown, "") end
+            end
+            d.akCdMaskKey = cdMaskKey
         end
     end
 
@@ -270,42 +343,50 @@ local function ApplyStyleToRegions(button, style)
         local PP = EllesmereUI.PP
         local b = style.border
         if PP and b then
-            if b.texture and EllesmereUI.ApplyBorderStyle then
-                -- Aura buttons can expose restricted geometry. Give the owned
-                -- border host an explicit public size (change-guarded because
-                -- anchoring to the aura button is denied while restricted).
-                local borderRect = (style.width or 18) .. "|" .. (style.height or style.width or 18)
-                if d.akBorderRect ~= borderRect then
-                    d.borderHost:ClearAllPoints()
-                    d.borderHost:SetPoint("CENTER", button, "CENTER")
-                    d.borderHost:SetSize(style.width or 18, style.height or style.width or 18)
-                    d.akBorderRect = borderRect
-                end
-                if b.behindUnitFrame then
-                    d.borderHost:SetFrameLevel(math.max(0, (b.unitFrameLevel or 1) - 1))
-                else
-                    d.borderHost:SetFrameLevel(b.behind
-                        and math.max(0, button:GetFrameLevel() - 1)
-                        or (d.cooldown:GetFrameLevel() + 1))
-                end
-                -- addonKey/sizeKey pick the per-module texture offset defaults a
-                -- style leaves nil; CDM passes its own so a textured border sits
-                -- where the module's other icons put theirs.
-                EllesmereUI.ApplySecretSafeBorderStyle(d.borderHost, d, b.size or 1,
-                    b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1,
-                    b.texture or "solid", b.offsetX, b.offsetY, b.shiftX, b.shiftY,
-                    b.addonKey or "unitframes", b.sizeKey or b.size or 1)
-                d.borderMade = true
-            elseif d.borderMade then
-                PP.UpdateBorder(d.borderHost, b.size or 1, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1)
+            if shapeActive and style.shapeBorderPath then
+                if d.borderMade then PP.HideBorder(d.borderHost) end
+                PP:ApplyMaskedShapeBorder(d.borderHost, d.shapeMask, style.shapeBorderPath,
+                    style.shapeBorderSize or b.size or 1, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1)
             else
-                PP.CreateBorder(d.borderHost, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1,
-                    b.size or 1, "OVERLAY", 7)
-                d.borderMade = true
+                PP:HideMaskedShapeBorder(d.borderHost)
+                if b.texture and EllesmereUI.ApplyBorderStyle then
+                    -- Aura buttons can expose restricted geometry. Give the owned
+                    -- border host an explicit public size (change-guarded because
+                    -- anchoring to the aura button is denied while restricted).
+                    local borderRect = (style.width or 18) .. "|" .. (style.height or style.width or 18)
+                    if d.akBorderRect ~= borderRect then
+                        d.borderHost:ClearAllPoints()
+                        d.borderHost:SetPoint("CENTER", button, "CENTER")
+                        d.borderHost:SetSize(style.width or 18, style.height or style.width or 18)
+                        d.akBorderRect = borderRect
+                    end
+                    if b.behindUnitFrame then
+                        d.borderHost:SetFrameLevel(math.max(0, (b.unitFrameLevel or 1) - 1))
+                    else
+                        d.borderHost:SetFrameLevel(b.behind
+                            and math.max(0, button:GetFrameLevel() - 1)
+                            or (d.cooldown:GetFrameLevel() + 1))
+                    end
+                    -- addonKey/sizeKey pick the per-module texture offset defaults a
+                    -- style leaves nil; CDM passes its own so a textured border sits
+                    -- where the module's other icons put theirs.
+                    EllesmereUI.ApplySecretSafeBorderStyle(d.borderHost, d, b.size or 1,
+                        b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1,
+                        b.texture or "solid", b.offsetX, b.offsetY, b.shiftX, b.shiftY,
+                        b.addonKey or "unitframes", b.sizeKey or b.size or 1)
+                    d.borderMade = true
+                elseif d.borderMade then
+                    PP.UpdateBorder(d.borderHost, b.size or 1, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1)
+                else
+                    PP.CreateBorder(d.borderHost, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1,
+                        b.size or 1, "OVERLAY", 7)
+                    d.borderMade = true
+                end
             end
             d.borderHost:Show()
         else
             d.borderHost:Hide()
+            if PP then PP:HideMaskedShapeBorder(d.borderHost) end
         end
     end
 
@@ -338,38 +419,83 @@ local function ApplyStyleToRegions(button, style)
     -- default, which stamps Blizzard atlas art over ours. PreserveAsset is also the only
     -- style that leaves our geometry alone -- it calls SetAuraBorderColor and nothing
     -- else, no SetTexture and no SetTexCoord.
+    --
+    -- Shaped bars (style.iconShape) use a SEPARATE single-texture path (d.dispelShapeTex)
+    -- instead of the 4 strips: a hexagon/circle/etc outline cannot be built from 4
+    -- rectangles. It reuses the pre-shaped <shape>_border.tga art, WHOLE-texture (never
+    -- SetTexCoord-cropped -- that cropping is exactly what caused the bug the strips
+    -- above replaced) and clipped by the hardware mask (d.shapeMask), sized via the same
+    -- mask-expand math as the base border (bExp = 7 - borderPx). The two sets are
+    -- mutually exclusive per button; whichever is inactive is kept hidden every pass so a
+    -- shape toggle never leaves the other set's textures stuck visible after their
+    -- registration is cleared.
     local dispelTint = Enum and Enum.CustomAuraButtonDispelTypeTextureStyle
         and Enum.CustomAuraButtonDispelTypeTextureStyle.PreserveAsset
     if dispelTint == nil then
         local legacy = (Enum and Enum.CustomAuraButtonBorderStyle) or AuraButtonBorderStyle
         dispelTint = legacy and legacy.Color
     end
-    if style.dispelBorder and not d.dispelStrips and d.dispelHolder
+    if style.dispelBorder and d.dispelHolder
         and (button.AddDispelTypeTexture or button.SetAuraBorder) and dispelTint ~= nil then
-        -- Flat white: the engine multiplies its dispel color in through SetVertexColor,
-        -- so white is the neutral tint base. Written once here, while VertexColor is
-        -- still ours -- registration turns it into a secret aspect. Textures on our own
-        -- holder, never parented to the button, so creating them outside the button's
-        -- one legal creation window is fine.
-        --
-        -- Hidden on creation. A texture is shown by default, and the engine is what
-        -- shows these (per aura, on a typed one) -- if the registration below is denied
-        -- while auras are secret, an unhidden strip set would sit on the icon as a plain
-        -- WHITE ring until the restriction lifts and the deferred restyle re-runs.
-        local strips = {}
-        for i = 1, 4 do
-            local tex = d.dispelHolder:CreateTexture(nil, "OVERLAY")
-            tex:SetColorTexture(1, 1, 1, 1)
-            if tex.SetSnapToPixelGrid then
-                tex:SetSnapToPixelGrid(false)
-                tex:SetTexelSnappingBias(0)
+        if shapeActive and style.shapeBorderPath then
+            if not d.dispelShapeTex then
+                -- Neutral white tint base, written ONCE here (same rule as the strips
+                -- below): registration turns VertexColor into an engine-driven secret
+                -- aspect, so this must never be re-written on later restyle passes.
+                local tex = d.dispelHolder:CreateTexture(nil, "OVERLAY")
+                tex:SetVertexColor(1, 1, 1, 1)
+                if tex.SetSnapToPixelGrid then
+                    tex:SetSnapToPixelGrid(false)
+                    tex:SetTexelSnappingBias(0)
+                end
+                tex:Hide()
+                d.dispelShapeTex = tex
             end
-            tex:Hide()
-            strips[i] = tex
+            -- Unlike VertexColor, SetTexture isn't secret-tainted by registration --
+            -- must track shape changes here too, or the ring keeps whatever shape's
+            -- art was loaded when the texture was first created.
+            if d.akDispelShapeTexPath ~= style.shapeBorderPath then
+                d.dispelShapeTex:SetTexture(style.shapeBorderPath)
+                d.akDispelShapeTexPath = style.shapeBorderPath
+            end
+        elseif not d.dispelStrips then
+            -- Flat white: the engine multiplies its dispel color in through SetVertexColor,
+            -- so white is the neutral tint base. Written once here, while VertexColor is
+            -- still ours -- registration turns it into a secret aspect. Textures on our own
+            -- holder, never parented to the button, so creating them outside the button's
+            -- one legal creation window is fine.
+            --
+            -- Hidden on creation. A texture is shown by default, and the engine is what
+            -- shows these (per aura, on a typed one) -- if the registration below is denied
+            -- while auras are secret, an unhidden strip set would sit on the icon as a plain
+            -- WHITE ring until the restriction lifts and the deferred restyle re-runs.
+            local strips = {}
+            for i = 1, 4 do
+                local tex = d.dispelHolder:CreateTexture(nil, "OVERLAY")
+                tex:SetColorTexture(1, 1, 1, 1)
+                if tex.SetSnapToPixelGrid then
+                    tex:SetSnapToPixelGrid(false)
+                    tex:SetTexelSnappingBias(0)
+                end
+                tex:Hide()
+                strips[i] = tex
+            end
+            d.dispelStrips = strips
         end
-        d.dispelStrips = strips
     end
-    if d.dispelStrips then
+
+    local dispelTexSet
+    if shapeActive and d.dispelShapeTex then
+        dispelTexSet = { d.dispelShapeTex }
+        if d.dispelStrips then
+            for i = 1, 4 do d.dispelStrips[i]:Hide() end
+        end
+    elseif d.dispelStrips then
+        dispelTexSet = d.dispelStrips
+        if d.dispelShapeTex then d.dispelShapeTex:Hide() end
+    end
+
+    if dispelTexSet then
         -- Level re-assert (change-guarded): a style can move the border host's level;
         -- the ring stays FOUR levels above it (PP strip container at +1, DM fx
         -- border-override container at +2, DM per-filter glow at +3 -- the dispel
@@ -381,45 +507,87 @@ local function ApplyStyleToRegions(button, style)
             if d.stackCarrier then d.stackCarrier:SetFrameLevel(bl + 5) end
             d.akDispelLvl = bl
         end
-        -- Physical-pixel thickness by GEOMETRY. t converts the user's setting into this
-        -- frame's units via the holder's effective scale (our frame -- readable). The
-        -- side strips are inset by t top and bottom so no two strips ever overlap at a
-        -- corner: a dispel color carrying alpha < 1 would double-blend there and read as
-        -- four darker corner pixels. Change-guarded on t alone -- the anchors are fixed
-        -- to the holder, which tracks the button, so nothing else can move them.
-        local px = style.dispelBorderPx or 2
-        local t = px
-        local eff = d.dispelHolder:GetEffectiveScale()
-        if eff and eff > 0 then
-            local PPx = EllesmereUI.PP
-            t = px * ((PPx and PPx.perfect) or 0.75) / eff
+
+        if shapeActive and d.dispelShapeTex then
+            -- Same bExp mask-expand math as PP.ApplyMaskedShapeBorder, inlined since that
+            -- helper also writes SetVertexColor, which would fight the engine's per-aura
+            -- tint once registered. shapeBorderSize (not raw dispelBorderPx) so this ring
+            -- uses the same remapped units as the base shaped border.
+            local px = style.shapeBorderSize or style.dispelBorderPx or 2
+            local geomKey = style.iconShape .. "|" .. px
+            if d.akDispelGeom ~= geomKey then
+                local PPx = EllesmereUI.PP
+                local bExp = 7 - math.min(px, 7)
+                -- Pcall'd like the icon's own reposition above: an uncaught error would
+                -- abort the rest of this function, and the geomKey guard would never
+                -- retry with the same inputs.
+                local ok = pcall(function()
+                    d.dispelShapeTex:ClearAllPoints()
+                    PPx.Point(d.dispelShapeTex, "TOPLEFT", d.dispelHolder, "TOPLEFT", -bExp, bExp)
+                    PPx.Point(d.dispelShapeTex, "BOTTOMRIGHT", d.dispelHolder, "BOTTOMRIGHT", bExp, -bExp)
+                    if d.shapeMask then
+                        pcall(d.dispelShapeTex.RemoveMaskTexture, d.dispelShapeTex, d.shapeMask)
+                        pcall(d.dispelShapeTex.AddMaskTexture, d.dispelShapeTex, d.shapeMask)
+                    end
+                end)
+                if ok then
+                    d.akDispelGeom = geomKey
+                elseif d.styleKey and AK.AurasRestricted() then
+                    deferredRestyles[d.styleKey] = true
+                end
+            end
+        else
+            -- Physical-pixel thickness by GEOMETRY. t converts the user's setting into this
+            -- frame's units via the holder's effective scale (our frame -- readable). The
+            -- side strips are inset by t top and bottom so no two strips ever overlap at a
+            -- corner: a dispel color carrying alpha < 1 would double-blend there and read as
+            -- four darker corner pixels. Change-guarded on t alone -- the anchors are fixed
+            -- to the holder, which tracks the button, so nothing else can move them.
+            local px = style.dispelBorderPx or 2
+            local t = px
+            local eff = d.dispelHolder:GetEffectiveScale()
+            if eff and eff > 0 then
+                local PPx = EllesmereUI.PP
+                t = px * ((PPx and PPx.perfect) or 0.75) / eff
+            end
+            if d.akDispelT ~= t then
+                local st = d.dispelStrips
+                st[1]:ClearAllPoints()
+                st[1]:SetPoint("TOPLEFT", d.dispelHolder, "TOPLEFT", 0, 0)
+                st[1]:SetPoint("TOPRIGHT", d.dispelHolder, "TOPRIGHT", 0, 0)
+                st[1]:SetHeight(t)
+                st[2]:ClearAllPoints()
+                st[2]:SetPoint("BOTTOMLEFT", d.dispelHolder, "BOTTOMLEFT", 0, 0)
+                st[2]:SetPoint("BOTTOMRIGHT", d.dispelHolder, "BOTTOMRIGHT", 0, 0)
+                st[2]:SetHeight(t)
+                st[3]:ClearAllPoints()
+                st[3]:SetPoint("TOPLEFT", d.dispelHolder, "TOPLEFT", 0, -t)
+                st[3]:SetPoint("BOTTOMLEFT", d.dispelHolder, "BOTTOMLEFT", 0, t)
+                st[3]:SetWidth(t)
+                st[4]:ClearAllPoints()
+                st[4]:SetPoint("TOPRIGHT", d.dispelHolder, "TOPRIGHT", 0, -t)
+                st[4]:SetPoint("BOTTOMRIGHT", d.dispelHolder, "BOTTOMRIGHT", 0, t)
+                st[4]:SetWidth(t)
+                d.akDispelT = t
+            end
         end
-        if d.akDispelT ~= t then
-            local st = d.dispelStrips
-            st[1]:ClearAllPoints()
-            st[1]:SetPoint("TOPLEFT", d.dispelHolder, "TOPLEFT", 0, 0)
-            st[1]:SetPoint("TOPRIGHT", d.dispelHolder, "TOPRIGHT", 0, 0)
-            st[1]:SetHeight(t)
-            st[2]:ClearAllPoints()
-            st[2]:SetPoint("BOTTOMLEFT", d.dispelHolder, "BOTTOMLEFT", 0, 0)
-            st[2]:SetPoint("BOTTOMRIGHT", d.dispelHolder, "BOTTOMRIGHT", 0, 0)
-            st[2]:SetHeight(t)
-            st[3]:ClearAllPoints()
-            st[3]:SetPoint("TOPLEFT", d.dispelHolder, "TOPLEFT", 0, -t)
-            st[3]:SetPoint("BOTTOMLEFT", d.dispelHolder, "BOTTOMLEFT", 0, t)
-            st[3]:SetWidth(t)
-            st[4]:ClearAllPoints()
-            st[4]:SetPoint("TOPRIGHT", d.dispelHolder, "TOPRIGHT", 0, -t)
-            st[4]:SetPoint("BOTTOMRIGHT", d.dispelHolder, "BOTTOMRIGHT", 0, t)
-            st[4]:SetWidth(t)
-            d.akDispelT = t
-        end
+
         -- Registration follows the static border AND a nonzero thickness
-        -- (0 = the user disabled the dispel recolor outright).
+        -- (0 = the user disabled the dispel recolor outright). setKey additionally
+        -- tracks WHICH texture set (strip vs shape) is meant to be registered, so a
+        -- shape toggle forces the same clear+re-add cycle a palette edit does --
+        -- AddDispelTypeTexture has no "swap one entry" semantics, the whole
+        -- registration is all-or-nothing either way.
         local want = (style.dispelBorder and style.border
             and (style.dispelBorderPx or 2) > 0) and true or false
         local mapFP = style.dispelColorFP or ""
-        if d.dispelBorderOn ~= want or (want and d.akDispelMapFP ~= mapFP) then
+        -- Includes the size-derived px: the engine snapshots this texture's geometry
+        -- at registration time, so a border-size-only change (same shape, same want)
+        -- needs the same clear+re-add cycle or the OLD ring geometry keeps rendering.
+        local setKey = (shapeActive and d.dispelShapeTex)
+            and ("shape:" .. style.iconShape .. "|" .. (style.shapeBorderSize or style.dispelBorderPx or 2))
+            or "strip"
+        if d.dispelBorderOn ~= want or (want and (d.akDispelMapFP ~= mapFP or d.akDispelSet ~= setKey)) then
             -- Stamp only on SUCCESS: these are button calls, denied while auras are
             -- secret; a pre-stamped failure would strand the registration in the wrong
             -- state after the restriction lifts. A restricted failure defers this
@@ -434,20 +602,21 @@ local function ApplyStyleToRegions(button, style)
                     proceed = (clearFn and pcall(clearFn, button)) and true or false
                 end
                 if proceed then
-                    -- Four adds, ALL OR NOTHING. A denial can land on any one of them,
-                    -- and a partial set is worse than none: the engine would tint two or
-                    -- three sides and leave the rest sitting in the user's static border
-                    -- color. On any failure the whole set is cleared again (the clear is
-                    -- a full reset -- "self.dispelTypeTextures = {}") and the style key
-                    -- is deferred to the restriction lift, which re-runs this from a
-                    -- known-empty state. One options table for all four: the engine
-                    -- securecopies it per call, so sharing it cannot leak between them.
+                    -- ALL OR NOTHING (1 add for a shape, 4 for strips). A denial can land
+                    -- on any one of them, and a partial set is worse than none: the engine
+                    -- would tint some sides/none and leave the rest sitting in the user's
+                    -- static border color. On any failure the whole set is cleared again
+                    -- (the clear is a full reset -- "self.dispelTypeTextures = {}") and
+                    -- the style key is deferred to the restriction lift, which re-runs
+                    -- this from a known-empty state. One options table shared across every
+                    -- add: the engine securecopies it per call, so sharing it cannot leak
+                    -- between them.
                     local addFn = button.AddDispelTypeTexture or button.SetAuraBorder
                     local opts = { style = dispelTint, showWhenHarmful = true,
                         showWhenHelpful = false, customDispelColorMap = style.dispelColorMap }
                     local added = true
-                    for i = 1, 4 do
-                        if not pcall(addFn, button, d.dispelStrips[i], opts) then
+                    for i = 1, #dispelTexSet do
+                        if not pcall(addFn, button, dispelTexSet[i], opts) then
                             added = false
                             break
                         end
@@ -455,6 +624,7 @@ local function ApplyStyleToRegions(button, style)
                     if added then
                         d.dispelBorderOn = want
                         d.akDispelMapFP = mapFP
+                        d.akDispelSet = setKey
                     else
                         -- Rollback. dispelBorderOn goes FALSE rather than keeping its old
                         -- value: the clear above already succeeded, so nothing is
@@ -470,7 +640,7 @@ local function ApplyStyleToRegions(button, style)
                 end
             else
                 if clearFn and pcall(clearFn, button) then
-                    for i = 1, 4 do d.dispelStrips[i]:Hide() end
+                    for i = 1, #dispelTexSet do dispelTexSet[i]:Hide() end
                     d.dispelBorderOn = want
                 elseif d.styleKey and AK.AurasRestricted() then
                     deferredRestyles[d.styleKey] = true


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds custom **Icon Shape** support to Player Aura Bars (Buffs and Debuffs, default and custom bars), matching Action Bars' shape system:

- New **Icon Shape** dropdown (Square, Circle, Curved Square, Diamond, Hexagon, Portrait, Shield) with masked icons, a matching shaped border, and a shaped dispel-type ring for debuffs.
- **Border Size** changed from a 0-4 slider to a None/Thin/Normal/Heavy/Strong dropdown, mirroring Action Bars' `ns.BORDER_THICKNESS` — Thin/Normal/Heavy are disabled while a shape is active (shape borders only render two visually distinct states at aura-icon sizes), auto-snapping to Strong when entering shape mode from a disabled level.
- New **Icon Zoom** slider (was previously wired end-to-end but had no UI). For custom shapes, zoom is coupled to the mask-fill magnification the same way Action Bars does it, so the zoom slider actually reaches "unzoomed" instead of always forcing extra crop. Untouched for the "None" shape.
- **Apply to: All | Multiple** sync icons on Border Size and Icon Shape, covering every buff/debuff bar (default + custom), matching the Action Bars UX pattern.

## How was it tested?

Tested in-game on live across all Icon Shape options, Border Size levels, and Icon Zoom range, on both the default and a custom buff/debuff bar, in the Manager Page preview and in real combat (buffs and dispellable debuffs). Verified:
- Shape/border/zoom changes apply live without `/reload`.
- Cycling between shapes (including back to a previously-used one) and back to None repeatedly.
- Preview box matches the live bar's rendering at every Border Size level.
- No Lua errors (BugSack) during any of the above.

## Screenshots
Circular buff, Hex debuff (stockades is dark so buff are hard to see, sorry):
<img width="391" height="262" alt="image" src="https://github.com/user-attachments/assets/6e6e4bd7-6cf5-4094-bd51-ff049c7c4f14" />

Diamond buff without border:
<img width="391" height="262" alt="image" src="https://github.com/user-attachments/assets/cf14e695-e0b4-4bec-8f33-bd23838b27c5" />

Shield, colored border, zoomed:
<img width="391" height="262" alt="image" src="https://github.com/user-attachments/assets/26bb3365-5bbb-47a7-9c18-c689d049d958" />

Options, I couldn't figure out a good way to place the "Multiple" link without overlap:
<img width="703" height="290" alt="image" src="https://github.com/user-attachments/assets/9a0dada6-08fc-4e43-8cb7-621cf61a0fad" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) — Icon Shape defaults to None, Icon Zoom defaults to the prior hardcoded value; existing bars render identically until touched.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven, change-guarded (shape/border texture updates skip redundant `Add/RemoveMaskTexture` work when nothing changed)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
