### PR TITLE
fix(ABR): render icon text above borders and glows

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1955,6 +1955,15 @@ local function GetStrata()
     return db and db.profile.display.frameStrata or "MEDIUM"
 end
 
+function EABR.GetIconTextOverlay(f)
+    if f._textOverlay then return f._textOverlay end
+    local overlay = CreateFrame("Frame", nil, f)
+    overlay:SetAllPoints()
+    overlay:SetFrameLevel(f:GetFrameLevel() + 5)
+    f._textOverlay = overlay
+    return overlay
+end
+
 local function GetOrCreateCombatIcon(index)
     if combatIconPool[index] then return combatIconPool[index] end
     local f = CreateFrame("Frame", "EABR_CombatIcon"..index, combatAnchor)
@@ -1967,7 +1976,7 @@ local function GetOrCreateCombatIcon(index)
     f._icon = icon
     local PP = EllesmereUI and EllesmereUI.PP
     if PP then PP.CreateBorder(f, 0, 0, 0, 1, 1, "OVERLAY", 7) end
-    local text = f:CreateFontString(nil, "OVERLAY")
+    local text = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", f, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
     text:SetTextColor(1, 1, 1, 1)
@@ -2072,7 +2081,7 @@ local function GetOrCreateCursorIcon(index)
     f._icon = icon
     local PP = EllesmereUI and EllesmereUI.PP
     if PP then PP.CreateBorder(f, 0, 0, 0, 1, 1, "OVERLAY", 7) end
-    local text = f:CreateFontString(nil, "OVERLAY")
+    local text = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", f, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
     text:SetTextColor(1, 1, 1, 1)
@@ -2217,7 +2226,7 @@ function EABR.EnsureProviderCastButton()
     btn._icon = icon
     local PP = EllesmereUI and EllesmereUI.PP
     if PP then PP.CreateBorder(btn, 0, 0, 0, 1, 1, "OVERLAY", 7) end
-    local text = btn:CreateFontString(nil, "OVERLAY")
+    local text = EABR.GetIconTextOverlay(btn):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", btn, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
     text:SetTextColor(1, 1, 1, 1)
@@ -2469,7 +2478,7 @@ end
 
 function EABR.CreateIconCountOverlay(f)
     if f._count then return f._count end
-    local count = f:CreateFontString(nil, "OVERLAY", "NumberFontNormalLarge")
+    local count = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY", "NumberFontNormalLarge")
     count:SetPoint("CENTER", f._icon, "CENTER", 0, 0)
     count:Hide()
     f._count = count
@@ -2536,7 +2545,7 @@ end
 -- Bag-count badge (how many of the consumable remain), bottom-right corner.
 function EABR.CreateIconBagCountOverlay(f)
     if f._bagCount then return f._bagCount end
-    local fs = f:CreateFontString(nil, "OVERLAY")
+    local fs = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY")
     SetABRFont(fs, ResolveFontPath(), 11)
     fs:Hide()
     f._bagCount = fs
@@ -2697,7 +2706,7 @@ local function GetOrCreateIcon(index)
     local PP = EllesmereUI and EllesmereUI.PP
     if PP then PP.CreateBorder(btn, 0, 0, 0, 1, 1, "OVERLAY", 7) end
 
-    local text = btn:CreateFontString(nil, "OVERLAY")
+    local text = EABR.GetIconTextOverlay(btn):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", btn, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
     text:SetTextColor(1, 1, 1, 1)
@@ -4081,7 +4090,7 @@ local function BeaconMakeIcon(spellID)
     f._spellID = spellID
     local PP = EllesmereUI and EllesmereUI.PP
     if PP then PP.CreateBorder(f, 0, 0, 0, 1, 1, "OVERLAY", 7) end
-    local text = f:CreateFontString(nil, "OVERLAY")
+    local text = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", f, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
     text:SetTextColor(1, 1, 1, 1)

--- a/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
@@ -566,7 +566,10 @@ initFrame:SetScript("OnEvent", function(self)
             local textSize = d and d.textSize or 11
             local textXOff = d and d.textXOffset or 0
             local textYOff = d and d.textYOffset or -2
-            local text = btn:CreateFontString(nil, "OVERLAY")
+            local textOverlay = CreateFrame("Frame", nil, btn)
+            textOverlay:SetAllPoints()
+            textOverlay:SetFrameLevel(btn:GetFrameLevel() + 5)
+            local text = textOverlay:CreateFontString(nil, "OVERLAY")
             do
                 local tp, ip = GetPreviewTextAnchor(d)
                 text:SetPoint(tp, btn, ip, textXOff, textYOff)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

In the AuraBuff Reminders module, icon labels and item counts could render
beneath the icon border and glow when positioned near the icon edge.

The text was attached directly to the base icon frame, while the border and
glow rendered on higher-level child frames.

This PR creates an addon-owned text overlay above the border and glow, giving
the following rendering order:

`icon < border < glow < text`

The AuraBuff Reminders options preview now uses the same rendering order.

No settings, events, hooks, polling, or timers are added.

## How was it tested?

Tested in-game on live retail.

Verified that:

- Icon labels and item counts render above borders and glows.
- The options preview matches the runtime icons.
- Entering and leaving combat does not change icon behavior.
- No other behavioral differences were observed.

## Screenshots
Before :
<img width="313" height="135" alt="image" src="https://github.com/user-attachments/assets/6f5c0baf-97d9-4e5c-97d4-61e32608c2fc" />
<img width="994" height="397" alt="image" src="https://github.com/user-attachments/assets/10ac2ab7-72ea-4bdb-a152-d8563eddaf99" />



After :
<img width="302" height="137" alt="image" src="https://github.com/user-attachments/assets/92b5087b-caad-4127-bcbf-d9120798a0fe" />
<img width="995" height="390" alt="image" src="https://github.com/user-attachments/assets/70320d92-9676-4324-bf26-e1a5b922f4da" />




## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** - N/A: no setting was added
- [x] Zero cost while disabled: overlays are only created with existing ABR icons or when its options preview is opened; no events, polling, or hooks were added
- [x] Cheap while enabled: one reusable overlay frame is created per icon; no polling, timer-based logic, or per-frame allocations were added
- [x] No writes onto Blizzard-owned frames: all affected frames are addon-owned; no hooks or scripts on Blizzard frames were added
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
