### PR TITLE
feat(quickdraw): add preset for ping system

### DIFF
--- a/EllesmereUIOptions/EUI_Quickdraw_Options.lua
+++ b/EllesmereUIOptions/EUI_Quickdraw_Options.lua
@@ -1613,6 +1613,41 @@ initFrame:SetScript("OnEvent", function(self)
         return out
     end
 
+    local function PingSlots()
+        return {
+            {
+                kind = "macrotext",
+                name = "Look",
+                macrotext = "/ping look",
+                icon = { atlas = "Ping_Marker_Icon_NonThreat" },
+            },
+            {
+                kind = "macrotext",
+                name = "Assist",
+                macrotext = "/ping assist",
+                icon = { atlas = "Ping_Marker_Icon_Assist" },
+            },
+            {
+                kind = "macrotext",
+                name = "Attack",
+                macrotext = "/ping attack",
+                icon = { atlas = "Ping_Marker_Icon_Attack" },
+            },
+            {
+                kind = "macrotext",
+                name = "Warning",
+                macrotext = "/ping warning",
+                icon = { atlas = "Ping_Marker_Icon_Warning" },
+            },
+            {
+                kind = "macrotext",
+                name = "On My Way",
+                macrotext = "/ping onmyway",
+                icon = { atlas = "Ping_Marker_Icon_OnMyWay" },
+            },
+        }
+    end
+
     -- The base item plus its two expansion siblings, then the toy variants.
     -- The toys all share one cooldown and one destination, so past MAX_SLOTS
     -- the tail is interchangeable with what already made it in.
@@ -1877,6 +1912,7 @@ initFrame:SetScript("OnEvent", function(self)
     local PALETTE_PRESETS = {
         { label = "Target Markers", build = TargetMarkerSlots },
         { label = "World Markers",  build = WorldMarkerSlots },
+        { label = "Pings",          build = PingSlots },
         { label = "Hearthstones",   build = HearthstoneSlots },
         { label = "Teleports",      build = TeleportSlots },
         { label = "Potions",        build = PotionSlots },
@@ -1928,7 +1964,11 @@ initFrame:SetScript("OnEvent", function(self)
     local function MenuRow(menu, i, icon, label, onClick)
         local r = menu:GetRow(i)
         if icon then
-            r.icon:SetTexture(icon)
+            if type(icon) == "table" and icon.atlas then
+                r.icon:SetAtlas(icon.atlas)
+            else
+                r.icon:SetTexture(icon)
+            end
             r.icon:Show()
             r.label:ClearAllPoints()
             r.label:SetPoint("LEFT", r.icon, "RIGHT", 6, 0)

--- a/EllesmereUIQuickdraw/EllesmereUIQuickdraw.lua
+++ b/EllesmereUIQuickdraw/EllesmereUIQuickdraw.lua
@@ -1536,6 +1536,9 @@ local function SlotDisplay(slot)
         return icon or QUESTION_MARK, name or slot.name
 
     elseif k == "macrotext" then
+        if slot.iconAtlas then
+            return { atlas = slot.iconAtlas }, slot.name or "Macro"
+        end
         return slot.icon or QUESTION_MARK, slot.name or "Macro"
 
     elseif k == "dynamicrez" then
@@ -2117,6 +2120,12 @@ end
 -- its first child's marker icon stays whole too. Shared with the options
 -- picker's rows, which draw the same icons at list size.
 local function ApplyIconCrop(tex, icon)
+    -- Atlas-backed icons already have their own UVs and should not be cropped.
+    if type(icon) == "table" and icon.atlas then
+        tex:SetTexCoord(0, 1, 0, 1)
+        return
+    end
+
     if type(icon) == "string"
        and (icon:find("RaidTargetingIcon", 1, true)
             or icon:find("UI-GroupLoot-Pass-Up", 1, true)) then
@@ -2126,6 +2135,15 @@ local function ApplyIconCrop(tex, icon)
     end
 end
 ns.ApplyIconCrop = ApplyIconCrop
+
+local function SetIconTexture(tex, icon)
+    if type(icon) == "table" and icon.atlas then
+        tex:SetAtlas(icon.atlas, true)
+    else
+        tex:SetTexture(icon or QUESTION_MARK)
+    end
+end
+ns.SetIconTexture = SetIconTexture
 
 local function CreateSlotWidget(view, index)
     local w = CreateFrame("Button", nil, view.frame, "BackdropTemplate")
@@ -4751,7 +4769,7 @@ local function PaintCell(w, slot, placeholder, showLabels, showCooldowns, wantLa
     w.usability = (showUsability and not placeholder) and SlotUsability(slot) or nil
 
     local icon, name = SlotDisplay(slot)
-    w.icon:SetTexture(icon or QUESTION_MARK)
+    SetIconTexture(w.icon, icon)
     -- Per paint: the widget is pooled, and the marker textures take the full
     -- rect where everything else takes the crop.
     ApplyIconCrop(w.icon, icon)
@@ -5293,7 +5311,7 @@ function PaletteView:AdvanceLiveIcons()
         local slot = self:CellSlot(index)
         if w and slot then
             local icon = SlotDisplay(slot)
-            w.icon:SetTexture(icon or QUESTION_MARK)
+            SetIconTexture(w.icon, icon)
             ApplyIconCrop(w.icon, icon)
         end
     end


### PR DESCRIPTION
## What does this PR do?

This PR adds a preset entry in the Quickdraw options that sets up a menu for using pings from the ping system. In doing so, it also adds support for rendering texture atlas textures as quickdraw icons. It does not, however, add any option-side support for configuring texture atlas textures on player defined menus. It also does not prevent such support from being added later.

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
I tested on 12.1.0 (Build 69299; current retail build as of this PR). I confirmed that the preset menu item was present and its icon rendered correctly and at the correct scale. I confirmed that choosing the preset creates a new action menu entry that the user can further edit. I tested that the icons are resizable via the existing size controls. I tested that the quickdraw menu renders correctly in-game using the arc, fan, and grid layouts, and that the pings fire when chosen from the menu.

## Screenshots

### Preset Menu Entry
<img width="1308" height="954" alt="image" src="https://github.com/user-attachments/assets/81a6a647-3a3f-4424-9ef3-06521694eaa2" />

### Pings Action Menu Options
<img width="1308" height="954" alt="image" src="https://github.com/user-attachments/assets/66d11649-889d-4bfa-8208-518a47c4601b" />

### In-world Menu Activation
<img width="283" height="272" alt="image" src="https://github.com/user-attachments/assets/76c06158-b02b-4588-9943-7c266148a082" /> <br/>

<img width="291" height="53" alt="image" src="https://github.com/user-attachments/assets/fd1b1774-1da4-47e9-9ca1-e2c4ce6cb38e" /><br/>

<img width="174" height="110" alt="image" src="https://github.com/user-attachments/assets/8ad0b24e-7659-4a82-abfb-9c83c883f91d" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added