### PR TITLE
Fix Arcane Surge buff tracking

### DIFF
--- a/EllesmereUI_BuffPresets.lua
+++ b/EllesmereUI_BuffPresets.lua
@@ -258,7 +258,7 @@ spells = {
         [186254] = { class = "HUNTER", alts = { 1235388, 1285912, 19574 } },
         [288613] = { class = "HUNTER" },
         [190319] = { class = "MAGE" },
-        [365350] = { class = "MAGE" },
+        [365350] = { class = "MAGE", alts = { 365362 } },
         [1249625] = { class = "MONK" },
         [10060] = { class = "PRIEST" },
         [114050] = { class = "SHAMAN", alts = { 114051, 114052 } },


### PR DESCRIPTION
## What does this PR do?

In the buff presets, Arcane Surge is listed with the ID of the spell being cast (365350). However, to be displayed correctly as a buff in the party frames, it should use the ID of the aura applied to the character (365362).

This PR adds the correct ID as an `alt` of 365350 rather than replacing it, to avoid resetting existing on/off settings, which are stored against that ID.

## How was it tested?

Tested in game; the buff now displays as expected.

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [N/A] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [N/A] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [N/A] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
