### PR TITLE
Fix Ascendance buff tracking for Elemental Shamans

### DIFF
--- a/EllesmereUI_BuffPresets.lua
+++ b/EllesmereUI_BuffPresets.lua
@@ -261,7 +261,7 @@ spells = {
         [365350] = { class = "MAGE" },
         [1249625] = { class = "MONK" },
         [10060] = { class = "PRIEST" },
-        [114050] = { class = "SHAMAN", alts = { 114051, 114052 } },
+        [114050] = { class = "SHAMAN", alts = { 114051, 114052, 1219480 } },
         [107574] = { class = "WARRIOR" },
     },
     movement = {


### PR DESCRIPTION
## What does this PR do?

In the buff presets, Ascendance is listed with the ID of the spell being cast (114050). However, to be displayed correctly as a buff in the party frames, it should use the ID of the aura applied to the character (1219480). Notably, this mismatch only occurs for Elemental Shamans, as both the Restoration and Enhancement versions of Ascendance share the same ID between the cast spell and the applied aura.

This PR adds the correct ID as an additional `alt` of 114050 rather than replacing it, to avoid resetting existing on/off settings, which are stored against that ID.

## How was it tested?

Tested in game; the buff now displays as expected.

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [N/A] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [N/A] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [N/A] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
