### PR TITLE
feat(cdm): minimum bar width

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -3962,6 +3962,17 @@ local function ComputeTopRowStride(barData, count)
     return stride, numRows, topCount
 end
 
+-- Minimum Bar Size, counted in icon slots along the GROWTH axis. That axis is ALWAYS the `stride`
+-- term of the size formulas (width on horizontal bars, height on vertical), so one rule covers both
+-- orientations. Returns the stride the CONTAINER reserves; the LAYOUT stride is never replaced --
+-- grid wrapping (col = idx % stride) and per-row centering keep using the real icon count, and the
+-- reserved surplus becomes a single centering offset. nil/0 (the default) is a straight passthrough.
+local function ReserveStride(barData, stride)
+    local minN = barData.minSizeIcons
+    if minN and minN > stride then return minN end
+    return stride
+end
+
 -- Empty custom bars still need a stable footprint so unlock mode can keep a visible mover and convert drag positions correctly before any icons exist.
 local EMPTY_CDM_BAR_SIZE = { 100, 36 }
 
@@ -3988,14 +3999,17 @@ local function ComputeCDMBarSize(barData, count)
     -- custom top-row split's second row is empty, so no empty row is reserved.
     local stride, rows = ComputeTopRowStride(barData, count)
     if rows < 1 then rows = 1 end
+    -- Minimum Bar Size reserves extra growth-axis slots (no-op when unset). Unlike LayoutCDMBar
+    -- there is no match gate here: this is the pre-layout footprint estimate, and a matched bar's live frame rect (checked first by GetStableCDMBarSize) always wins over it.
+    local resStride = ReserveStride(barData, stride)
     local grow = barData.growDirection or "CENTER"
     local isH = (grow == "RIGHT" or grow == "LEFT" or grow == "CENTER")
     if isH then
-        return stride * iW + (stride - 1) * sp,
+        return resStride * iW + (resStride - 1) * sp,
                rows * iH + (rows - 1) * sp
     end
     return rows * iW + (rows - 1) * sp,
-           stride * iH + (stride - 1) * sp
+           resStride * iH + (resStride - 1) * sp
 end
 
 -- Authoritative footprint for unlock mode: live frame when it has bounds, else derived from bar config, else the stable empty-bar placeholder.
@@ -4235,6 +4249,24 @@ LayoutCDMBar = function(barKey)
         perRowActive = true
     end
 
+    -- Minimum Bar Size: reserve growth-axis room for at least minSizeIcons icon slots so a bar that
+    -- loses icons (spec/talent swap, shift-hidden cooldowns) keeps its footprint -- everything
+    -- matching its width or anchored to its edges then stays put, and the icons still present are
+    -- centered in the surplus. SKIPPED while the GROWTH axis is match-owned: that axis measures
+    -- exactly what the match target dictates and padding it would overshoot. A match on the
+    -- PERPENDICULAR axis is fine -- the growth axis still varies with icon count there.
+    local growMatched
+    if isHoriz then growMatched = widthMatchTarget else growMatched = heightMatchTarget end
+    local resStride = growMatched and stride or ReserveStride(barData, stride)
+    -- What resStride real icons measure at the BASE icon size, spacing included. Integer physical px like every other term here, so both bar edges stay on the pixel grid.
+    local reservedPx = 0
+    if resStride > stride then
+        local basePx = isHoriz and iconWPx or iconHPx
+        reservedPx = resStride * basePx + (resStride - 1) * spacingPx
+    end
+    -- Offset that centers the real icon block inside the surplus (uniform layout only; the per-row branch centers each row inside the total already).
+    local padOffsetPx = 0
+
     local totalWPx, totalHPx
     if perRowActive then
         -- Two rows, independent icon sizes. Top row = customTopCount icons, the bottom takes the
@@ -4245,19 +4277,30 @@ LayoutCDMBar = function(barKey)
             local topRowW = topN * rowWPx[1] + math.max(0, topN - 1) * spacingPx
             local botRowW = botN * rowWPx[2] + math.max(0, botN - 1) * spacingPx
             totalWPx = math.max(topRowW, botRowW)
+            -- No pad offset needed: both rows are centered against totalWPx below, so growing it IS the centering.
+            if reservedPx > totalWPx then totalWPx = reservedPx end
             totalHPx = rowHPx[1] + rowHPx[2] + spacingPx
         else
             local topColH = topN * rowHPx[1] + math.max(0, topN - 1) * spacingPx
             local botColH = botN * rowHPx[2] + math.max(0, botN - 1) * spacingPx
             totalHPx = math.max(topColH, botColH)
+            if reservedPx > totalHPx then totalHPx = reservedPx end
             totalWPx = rowWPx[1] + rowWPx[2] + spacingPx
         end
     elseif isHoriz then
         totalWPx = stride  * iconWPx + (stride  - 1) * spacingPx + extraPixels
         totalHPx = effRows * iconHPx + (effRows - 1) * spacingPx + extraPixelsH
+        if reservedPx > totalWPx then
+            padOffsetPx = math.floor((reservedPx - totalWPx) / 2 + 0.5)
+            totalWPx = reservedPx
+        end
     else
         totalWPx = effRows * iconWPx + (effRows - 1) * spacingPx + extraPixels
         totalHPx = stride  * iconHPx + (stride  - 1) * spacingPx + extraPixelsH
+        if reservedPx > totalHPx then
+            padOffsetPx = math.floor((reservedPx - totalHPx) / 2 + 0.5)
+            totalHPx = reservedPx
+        end
     end
 
     -- Do NOT force an even totalWPx for CENTER grow: SnapCenterForDim (used by ApplyBarPositionCentered
@@ -4371,6 +4414,8 @@ LayoutCDMBar = function(barKey)
     -- Uniform icon size: every bar except the 2-row per-row-size case above.
     local stepW = iconW + spacing
     local stepH = iconH + spacing
+    -- Minimum Bar Size surplus in coord space: shifts the whole icon block along the GROWTH axis so it sits centered in the reserved footprint. 0 whenever the reservation is off or already filled.
+    local padOffset = padOffsetPx * onePx
 
     local topRowCount = customTopCount
     if topRowCount < 0 then topRowCount = 0 end
@@ -4470,7 +4515,7 @@ LayoutCDMBar = function(barKey)
                 rowOffset = math.floor((stride - rowCount) * stepW / 2 + 0.5)
             end
             anchorPt, anchorRelPt = "TOPLEFT", "TOPLEFT"
-            anchorX = (posX + rowOffset) * iS
+            anchorX = (posX + rowOffset + padOffset) * iS
             anchorY = -(posY + extraBeforeR) * iS
         else
             if rowHasLess then
@@ -4478,7 +4523,7 @@ LayoutCDMBar = function(barKey)
             end
             anchorPt, anchorRelPt = "TOPLEFT", "TOPLEFT"
             anchorX = (vRow * stepW + extraBeforeR) * iS
-            anchorY = -(col * stepH + extraBefore + rowOffset) * iS
+            anchorY = -(col * stepH + extraBefore + rowOffset + padOffset) * iS
         end
 
         if anchorPt then
@@ -9188,6 +9233,8 @@ function ECME:CDMFinishSetup()
                             -- Effective row count: collapses to 1 when a custom top-row split has no icons in its second row yet.
                             local stride, numRows = ComputeTopRowStride(barData, cachedCount)
                             if numRows < 1 then numRows = 1 end
+                            -- Minimum Bar Size reserves extra growth-axis slots (no-op when unset); without it a bar under its minimum pre-sizes too small and visibly snaps once real data lands.
+                            local resStride = ReserveStride(barData, stride)
                             local isHoriz = (grow == "RIGHT" or grow == "LEFT" or (grow == "CENTER" and not barData.verticalOrientation))
                             -- Compute total in integer phys px to avoid PP.Scale floor losing 1 px to floating-point dust on the multiply.
                             local PPpc = EllesmereUI and EllesmereUI.PP
@@ -9197,11 +9244,11 @@ function ECME:CDMFinishSetup()
                             local spacingPx = math.floor(spacing / onePxPc + 0.5)
                             local totalWPx, totalHPx
                             if isHoriz then
-                                totalWPx = stride  * iconWPx + (stride  - 1) * spacingPx
-                                totalHPx = numRows * iconHPx + (numRows - 1) * spacingPx
+                                totalWPx = resStride * iconWPx + (resStride - 1) * spacingPx
+                                totalHPx = numRows   * iconHPx + (numRows   - 1) * spacingPx
                             else
-                                totalWPx = numRows * iconWPx + (numRows - 1) * spacingPx
-                                totalHPx = stride  * iconHPx + (stride  - 1) * spacingPx
+                                totalWPx = numRows   * iconWPx + (numRows   - 1) * spacingPx
+                                totalHPx = resStride * iconHPx + (resStride - 1) * spacingPx
                             end
                             local totalW = totalWPx * onePxPc
                             local totalH = totalHPx * onePxPc

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -16736,25 +16736,65 @@ initFrame:SetScript("OnEvent", function(self)
             -- (Hide Buffs When Inactive toggle removed: always forced ON.)
         end
 
-        -- Keep Buffs in Same Place (native buff bars): reserves every tracked buff's slot so
-        -- active buffs never reposition; inactive slots are invisible. Reuses the Always-Show
-        -- placeholder path internally (placeholders injected, then rendered alpha 0). Mutually exclusive with Always Show Buffs -- disabled while that is on.
+        -- Minimum Bar Size | Keep Buffs in Same Place (native buff bars).
+        --
+        -- Minimum Bar Size reserves room for at least N icon slots along the bar's GROWTH axis, so
+        -- a bar that loses icons (spec/talent swap) keeps its footprint instead of dragging
+        -- width-matched and edge-anchored elements inward; the icons still shown render centered in
+        -- the reserved space. The label tracks orientation (growth axis = width on horizontal bars,
+        -- height on vertical); build-time resolution is safe because the page rebuilds on
+        -- orientation flips and bar switches (same reasoning as the Row Growth dropdown above).
+        -- Locked while the GROWTH axis is width/height matched -- the match owns that axis -- but a
+        -- bar with a value already set stays editable so it can be cleared.
+        --
+        -- Keep Buffs in Same Place reserves every tracked buff's slot so active buffs never
+        -- reposition; inactive slots are invisible. Reuses the Always-Show placeholder path
+        -- internally (placeholders injected, then rendered alpha 0). Mutually exclusive with Always Show Buffs -- disabled while that is on.
+        local minSizeVert = BD().verticalOrientation == true
+        local minSizeDis, minSizeTip = EllesmereUI.MatchGuard("CDM_" .. barKey, minSizeVert and "Height" or "Width")
+        local minSizeRight
         if isBuffBar then
-            _, h = W:DualRow(parent, y,
-                { type="toggle", text="Keep Buffs in Same Place",
-                  disabled=function()
-                      local b = BD()
-                      return b.showInactiveBuffIcons == true or AnyIconAlwaysShowOn(b.key)
-                  end,
-                  disabledTooltip="Disabled while Always Show Buffs is enabled (on the bar, or on any individual buff)", rawTooltip=true,
-                  getValue=function() return BD().hidePlaceholderIcon == true end,
-                  setValue=function(v)
-                      BD().hidePlaceholderIcon = v
-                      ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
-                      EllesmereUI:RefreshPage()
-                  end },
-                { type="label", text="" }); y = y - h
+            minSizeRight = { type="toggle", text="Keep Buffs in Same Place",
+                disabled=function()
+                    local b = BD()
+                    return b.showInactiveBuffIcons == true or AnyIconAlwaysShowOn(b.key)
+                end,
+                disabledTooltip="Disabled while Always Show Buffs is enabled (on the bar, or on any individual buff)", rawTooltip=true,
+                getValue=function() return BD().hidePlaceholderIcon == true end,
+                setValue=function(v)
+                    BD().hidePlaceholderIcon = v
+                    ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
+                    EllesmereUI:RefreshPage()
+                end }
+        else
+            minSizeRight = { type="label", text="" }
         end
+        _, h = W:DualRow(parent, y,
+            { type="slider", text=minSizeVert and "Minimum Height (0 = Off)" or "Minimum Width (0 = Off)",
+              min=0, max=20, step=1,
+              tooltip=minSizeVert
+                  and "Counted in icons. The bar never becomes shorter than this many icon slots -- fewer icons render centered in the reserved space, so anything matching its height or anchored to its top/bottom edge stays put."
+                  or "Counted in icons. The bar never becomes narrower than this many icon slots -- fewer icons render centered in the reserved space, so anything matching its width or anchored to its left/right edge stays put.",
+              -- A matched bar with a value already set can still lower/clear it -- a disabled control must never trap an existing value on.
+              disabled=function()
+                  local b = BD()
+                  return minSizeDis() and not (b.minSizeIcons and b.minSizeIcons > 0)
+              end,
+              disabledTooltip=minSizeTip, rawTooltip=true,
+              getValue=function() return BD().minSizeIcons or 0 end,
+              setValue=function(v)
+                  if v == 0 then v = nil end
+                  local bd = BD()
+                  bd.minSizeIcons = v
+                  -- Growth-axis extent changed, so any cached match dims no longer apply.
+                  bd._matchIconPhys = nil
+                  bd._matchExtraPixels = nil
+                  bd._matchStride = nil
+                  bd._matchExtraPixelsH = nil
+                  bd._matchStrideH = nil
+                  ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
+              end },
+            minSizeRight); y = y - h
 
         end -- not isFocusKick (Bar Layout section)
 


### PR DESCRIPTION
## What does this PR do?

Adds a per-bar **Minimum Width** (Minimum Height on vertical bars) setting to
Cooldown Manager bars, counted in icon slots. Range 1-20, `0 = Off`, default off.

When a bar drops below the set number of icons - spec change, talent swap, a
shift-hidden cooldown - the bar keeps the exact size that many real icons would
occupy, and the icons that are shown render centered inside it. Because the
reservation is applied to the bar frame itself, elements that width-match the bar
or anchor to its left/right edge stop collapsing inward when the icon count drops.

The reservation applies to the bar's growth axis (width on horizontal bars,
height on vertical), and is skipped while that axis is owned by a width/height
match, so matching a CDM bar to another element stays exact. Size math is done in
integer physical pixels, so the reserved width is pixel-identical to a full bar.

## How was it tested?

12.1 live, tried multiple sizes, multiple padding settings, things anchored to the sides and things with matched dimensions adjust accordingly. Vertical orientation works too. Background follows the minimum setting as well.

## Screenshots

<img width="1347" height="504" alt="image" src="https://github.com/user-attachments/assets/7bf01c0f-4eff-4549-9953-da79b5c4c430" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live