### PR TITLE
[bugfix] Resolve class color background for NPC reaction on unit frames

### DIFF
--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -12801,24 +12801,48 @@ initFrame:SetScript("OnEvent", function(self)
                   getValue=function() return MVal("customBgAlpha", 100) end,
                   setValue=function(v) MSet("customBgAlpha", v) end },
                 reverseFillWidget);  y = y - h
-            -- Inline Bar Background color swatch (customBgColor) on the slider region.
+            -- inline bg colors - custom swatch + class swatch
+            -- tot/focus use class for player, reaction for npc
+            -- pet resolves to player's class color
             if not EllesmereUI._prebuilding then
-                local rgn = bgRow._leftRegion
-                local bgSwGet = function()
-                    local c = MGet("customBgColor")
-                    if c then return c.r, c.g, c.b end
-                    return 17/255, 17/255, 17/255
-                end
-                local bgSwSet = function(r, g, b)
-                    settingsTable.customBgColor = { r=r, g=g, b=b }
-                    ReloadAndUpdate()
-                end
-                local bgSw, bgSwUpdate = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel() + 5, bgSwGet, bgSwSet, false, 20)
-                bgSw:HookScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(bgSw, "Bar Background Color") end)
-                bgSw:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
-                PP.Point(bgSw, "RIGHT", rgn._lastInline or rgn._control, "LEFT", -8, 0)
-                rgn._lastInline = bgSw
-                RegisterWidgetRefresh(function() bgSwUpdate() end)
+                EllesmereUI.BuildInlineSwatches(bgRow._leftRegion, {
+                    { tooltip = "Custom Background Color", hasAlpha = false,
+                      getValue = function()
+                          local c = MGet("customBgColor")
+                          if c then return c.r, c.g, c.b end
+                          return 17/255, 17/255, 17/255
+                      end,
+                      setValue = function(r, g, b)
+                          settingsTable.customBgColor = { r=r, g=g, b=b }
+                          ReloadAndUpdate()
+                      end,
+                      onClick = function(self)
+                          if MVal("bgClassColored", false) then
+                              settingsTable.bgClassColored = false
+                              ReloadAndUpdate(); EllesmereUI:RefreshPage()
+                              return
+                          end
+                          if self._eabOrigClick then self._eabOrigClick(self) end
+                      end,
+                      refreshAlpha = function()
+                          return MVal("bgClassColored", false) and 0.3 or 1
+                      end },
+                    { tooltip = "Class Colored Background", hasAlpha = false,
+                      getValue = function()
+                          local _, ct = UnitClass("player")
+                          local cc = ct and RAID_CLASS_COLORS[ct]
+                          if cc then return cc.r, cc.g, cc.b end
+                          return 1, 1, 1
+                      end,
+                      setValue = function() end,
+                      onClick = function()
+                          settingsTable.bgClassColored = true
+                          ReloadAndUpdate(); EllesmereUI:RefreshPage()
+                      end,
+                      refreshAlpha = function()
+                          return MVal("bgClassColored", false) and 1 or 0.3
+                      end },
+                })
             end
         end
 

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1655,13 +1655,7 @@ local function ApplyDarkTheme(health)
                 local bgClassR, bgClassG, bgClassB
                 if bgClassColored then
                     local classUnit = ClassColorSourceUnit(uKey, unit or self.unit or uKey)
-                    if classUnit then
-                        local _, ct = UnitClass(classUnit)
-                        -- ct can be secret (out-of-range/uninspectable units).
-                        -- issecretvalue FIRST: truthiness-testing a secret errors.
-                        local cc = not issecretvalue(ct) and ct and EllesmereUI.GetClassColor(ct)
-                        if cc then bgClassR, bgClassG, bgClassB = cc.r, cc.g, cc.b end
-                    end
+                    bgClassR, bgClassG, bgClassB = ns.ResolveBgClassColor(classUnit)
                 end
                 if bgClassR then
                     -- Full class color; opacity comes from customBgAlpha (SetAlpha).
@@ -1693,13 +1687,7 @@ local function ApplyDarkTheme(health)
             local bgClassR, bgClassG, bgClassB
             if bgClassColored then
                 local classUnit = ClassColorSourceUnit(unitKey, unitKey or (health.__owner and health.__owner.unit))
-                if classUnit then
-                    local _, ct = UnitClass(classUnit)
-                    -- ct can be secret (out-of-range/uninspectable units).
-                    -- issecretvalue FIRST: truthiness-testing a secret errors.
-                    local cc = not issecretvalue(ct) and ct and EllesmereUI.GetClassColor(ct)
-                    if cc then bgClassR, bgClassG, bgClassB = cc.r, cc.g, cc.b end
-                end
+                bgClassR, bgClassG, bgClassB = ns.ResolveBgClassColor(classUnit)
             end
             if bgClassR then
                 -- Full class color; PostUpdateColor keeps it correct on updates.
@@ -2035,6 +2023,24 @@ ns.ResolveUnitNameColor = function(unit)
         end
     end
     return nil
+end
+
+-- Background class-color source, enemy-aware. UnitClass() reports WARRIOR for NPCs
+-- rather than nil, so a bare lookup paints every mob Warrior tan. Players (and AI
+-- party members) keep EllesmereUI.GetClassColor (custom colors + Class Color Darken
+-- baked in); NPCs fall through to the reaction color, matching the unit name, the
+-- border and the custom Enemy Colors override. On ns for the local cap.
+ns.ResolveBgClassColor = function(classUnit)
+    if not classUnit then return nil end
+    if UnitIsPlayer(classUnit) or (UnitInPartyIsAI and UnitInPartyIsAI(classUnit)) then
+        local _, ct = UnitClass(classUnit)
+        -- ct can be secret (out-of-range/uninspectable units).
+        -- issecretvalue FIRST: truthiness-testing a secret errors.
+        local cc = not issecretvalue(ct) and ct and EllesmereUI.GetClassColor(ct)
+        if cc then return cc.r, cc.g, cc.b end
+        return nil
+    end
+    return ns.ResolveUnitNameColor(classUnit)
 end
 
 -- External nickname providers key us by this addon name. Suite = "EllesmereUI" (the


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Fixes the resolving of class color background for NPCs. Currently, it just doesn't do the resolving on bg colors and attempts to get class colors for the unit, which isn't correct on NPCs. Just calling `ResolveBgClassColor()` to resolve.

Also, added class color background swatches for mini frames (target of target, focus target, pet) that will use the same method - SavedVariables already stores class color bools for these, just wasn't implemented.

## How was it tested?

Tested on 12.1.0.69299

## Screenshots

### Before:
<img width="431" height="140" alt="image" src="https://github.com/user-attachments/assets/b6e54d87-444b-4758-96e1-c833f07a90b3" />
<img width="452" height="137" alt="image" src="https://github.com/user-attachments/assets/6d6d2607-386c-44e4-a312-71966ca02a6c" />
<img width="446" height="143" alt="image" src="https://github.com/user-attachments/assets/7bd130d5-86d9-47f6-aa74-a724e40daa10" />



### After:
<img width="446" height="153" alt="image" src="https://github.com/user-attachments/assets/b67e87d3-a269-4b1d-b2a9-82b1d9b3ceb6" />
<img width="436" height="142" alt="image" src="https://github.com/user-attachments/assets/47782482-2e3b-45d4-b77e-7dc64788c713" />
<img width="451" height="156" alt="image" src="https://github.com/user-attachments/assets/481c29d6-5937-4297-a578-dd440a2984f1" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
