### PR TITLE
Hide Interact Icon from enemies

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -5044,16 +5044,11 @@ local function HideBlizzardFrame(nameplate, unit)
                 local base = stf and stf:GetParent()
                 local ufUnit = base and base.namePlateUnitToken
                 if not ufUnit then return end
-                -- Non-self unit comparison: secret boolean whenever the unit is
-                -- identity-restricted -- which is NORMAL for enemies, and hostile
-                -- interactables (skinnable corpses, quest objects) are legitimate
-                -- soft-interact targets. Secret = cannot judge = leave the icon
-                -- alone (stock shows every soft-target icon; fail toward stock,
-                -- never toward hiding -- collapsing secret to hidden killed
-                -- enemy interact icons in the field).
-                local same = UnitIsUnit(ufUnit, "softinteract")
-                if issecretvalue and issecretvalue(same) then return end
-                if same ~= true then self:Hide() end
+                -- Hide only for attackable enemies. NPCs and non-attackable
+                -- objects, even hostile ones, keep the icon.
+                local canAttack = UnitCanAttack("player", ufUnit)
+                if issecretvalue and issecretvalue(canAttack) then return end
+                if canAttack then self:Hide() end
             end)
         end
     end


### PR DESCRIPTION
Issue

The nameplate soft-target icon (the reticle shown when you hover something you can act on) was appearing over enemies too, when it should only show for NPCs and interactable objects.

The old code tried to gate this by comparing the nameplate's unit against the "softinteract" soft-target token. But that identity check returns an unreadable "secret" value for hostile units (a game restriction), so whenever it hit a secret value it gave up and left the icon showing — which is why enemies kept displaying it.

Fix

Replaced the identity check with a simple attackability check: UnitCanAttack("player", ufUnit).

Attackable (real enemies) → icon is hidden.
Not attackable (NPCs, quest objects, skinnable corpses, herbs, etc.) → icon stays, even if they're hostile-faction.

This check isn't restricted the same way, so there's no more "can't tell, so leave it visible" fallback letting enemies slip through.