### PR TITLE
Movement Alert: stop a vehicle degrading the Burning Rush alert

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -1087,6 +1087,7 @@ end
 -- buffActive engine-lane handles (declared here so HideMovementDisplay -- the
 -- universal off-path -- can park the host; defined in the lane block below).
 local buffAlertHost, buffAlertBuilt, buffAlertRegenArm, buffAlertLastCount
+local buffAlertContainer, buffAlertAssist, buffAlertVehicle
 
 -- keepBuffLane: the cooldown display is going away but the buffActive lane is
 -- not. A buffActive spell takes no slot, so an empty cooldown stack is its
@@ -1385,6 +1386,28 @@ local function BuildBuffAlertStyle(entry)
     }
 end
 
+-- Identity gate (Blizzard_AuraContainerUtil.CanApplyIdentityCandidateFilters):
+-- includeSpellIDs is applied to a HELPFUL aura only while UnitCanAssist("player",
+-- unit) holds, and it FAILS OPEN -- when the gate fails the spell-ID filter is
+-- skipped entirely and the aura passes on its filter string alone. Boarding a
+-- vehicle drops the player's own assistability, so this one-button HELPFUL group
+-- stops meaning "Burning Rush" and renders whatever buff it finds first, wearing
+-- the Burning Rush label. Membership is cached per aura instance and UNIT_AURA
+-- only re-parses what changed, so the degraded parse outlived the ride: the alert
+-- stayed up after dismounting until a reload rebuilt the container.
+-- Latched from the vehicle events rather than probed here, because
+-- UnitUsingVehicle is still true across the EXIT transition (see the RF assist
+-- gate's AssistProbe, which guards the same engine gate one unit over).
+local function BuffAlertAssistable()
+    if buffAlertVehicle then return false end
+    -- Cinematics flip the same flag without a vehicle (UNIT_FACTION edge). A
+    -- CLEANLY-false answer denies; unreadable ones stay fail-open, since a
+    -- transient nil must not blank a working alert.
+    local ok, canAssist = pcall(UnitCanAssist, "player", "player")
+    if ok and not IsSecret(canAssist) and canAssist == false then return false end
+    return true
+end
+
 -- Build once per session on first eligible pass (warlock + Movement Alerts on
 -- + Burning Rush checked); later passes only refresh the style (mode/size/
 -- color edits ride RestyleSoon) and the host's shown state. Engine frames are
@@ -1401,8 +1424,24 @@ local function EnsureBuffAlertLane()
         if buffAlertHost then buffAlertHost:Hide() end
         return
     end
+    -- Ahead of the Show() below, not beside it: every pass runs through here,
+    -- so a gate applied anywhere else would be undone by the next tick.
+    if not BuffAlertAssistable() then
+        buffAlertAssist = false
+        if buffAlertHost then buffAlertHost:Hide() end
+        return
+    end
+    local wasDenied = (buffAlertAssist == false)
+    buffAlertAssist = true
     if buffAlertBuilt then
         buffAlertHost:Show()
+        -- Whatever was parsed during the degraded window is wrong, and leaving a
+        -- vehicle produces no aura edge for buffs that were already up, so the
+        -- engine would keep serving the stale membership. One full re-parse
+        -- clears it; bounded to the actual denied->allowed flip.
+        if wasDenied and buffAlertContainer and buffAlertContainer.UpdateAllAuras then
+            buffAlertContainer:UpdateAllAuras()
+        end
         AK.styles[BUFF_ALERT_STYLE] = BuildBuffAlertStyle(entry)
         AK.RestyleSoon(BUFF_ALERT_STYLE)
         return
@@ -1425,6 +1464,7 @@ local function EnsureBuffAlertLane()
         point = { "CENTER", buffAlertHost, "CENTER", 0, 0 },
         layout = { anchorPoint = "CENTER", padding = { 0, 0, 0, 0 }, rowWidth = 400 },
     }, function(container)
+        buffAlertContainer = container
         AK.AddGroupToContainer(container, {
             key = "buffalert",
             filter = { "HELPFUL" },
@@ -2019,6 +2059,14 @@ local function UpdateEventRegistration()
         loader:RegisterEvent("SPELL_UPDATE_CHARGES")
         loader:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
         loader:RegisterUnitEvent("UNIT_AURA", "player")
+        -- buffActive lane's identity gate (see BuffAlertAssistable): the
+        -- occupancy latch plus the faction edge cinematics flip. Player-only,
+        -- and only while the tracker is on. ENTERING as well as ENTERED --
+        -- the filters degrade from the boarding transition.
+        loader:RegisterUnitEvent("UNIT_ENTERING_VEHICLE", "player")
+        loader:RegisterUnitEvent("UNIT_ENTERED_VEHICLE", "player")
+        loader:RegisterUnitEvent("UNIT_EXITED_VEHICLE", "player")
+        loader:RegisterUnitEvent("UNIT_FACTION", "player")
         movementEventsRegistered = true
     elseif not moveOn and movementEventsRegistered then
         loader:UnregisterEvent("SPELL_UPDATE_USABLE")
@@ -2026,6 +2074,10 @@ local function UpdateEventRegistration()
         loader:UnregisterEvent("SPELL_UPDATE_CHARGES")
         loader:UnregisterEvent("UNIT_SPELLCAST_SUCCEEDED")
         loader:UnregisterEvent("UNIT_AURA")
+        loader:UnregisterEvent("UNIT_ENTERING_VEHICLE")
+        loader:UnregisterEvent("UNIT_EXITED_VEHICLE")
+        loader:UnregisterEvent("UNIT_ENTERED_VEHICLE")
+        loader:UnregisterEvent("UNIT_FACTION")
         movementEventsRegistered = false
         CancelMovementCountdown()
     end
@@ -2141,6 +2193,11 @@ loader:SetScript("OnEvent", function(self, event, ...)
         CheckMovementCooldown()
     elseif event == "PLAYER_ENTERING_WORLD" then
         inCombat = UnitAffectingCombat("player")
+        -- Safety net for an exit that never fires UNIT_EXITED_VEHICLE (being
+        -- teleported out of one): reconcile the latch against the live flag
+        -- rather than leaving the lane suppressed for the session.
+        local probe = UnitUsingVehicle or UnitInVehicle
+        buffAlertVehicle = (probe and probe("player")) and true or false
         wipe(timeSpiralActiveSpells)
         timeSpiralActiveTime = nil
         CacheMovementSpells(true)
@@ -2176,6 +2233,18 @@ loader:SetScript("OnEvent", function(self, event, ...)
     elseif event == "UNIT_AURA" then
         local unit, updateInfo = ...
         UpdateCachedCharges()
+        CheckMovementCooldown()
+    elseif event == "UNIT_ENTERING_VEHICLE" or event == "UNIT_ENTERED_VEHICLE" then
+        buffAlertVehicle = true
+        CheckMovementCooldown()
+    elseif event == "UNIT_EXITED_VEHICLE" then
+        buffAlertVehicle = false
+        CheckMovementCooldown()
+    elseif event == "UNIT_FACTION" then
+        -- Re-drive ONLY: a cinematic flips assistability with no vehicle
+        -- involved, and BuffAlertAssistable's own probe reads that. This must
+        -- not touch the latch -- UNIT_FACTION also fires on the BOARDING
+        -- transition, where clearing it would undo the suppression we just set.
         CheckMovementCooldown()
     elseif event == "PLAYER_DEAD" then
         CheckMovementCooldown()

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -1408,6 +1408,16 @@ local function BuffAlertAssistable()
     return true
 end
 
+-- Reconcile the latch against the live flag. Needed wherever the EXITED edge
+-- could have been missed: while the tracker's events are unregistered nothing
+-- clears the latch, so a tracker switched off mid-ride (or a profile swap, or
+-- being teleported out of a vehicle) would otherwise come back with the lane
+-- suppressed for the rest of the session.
+local function SyncBuffAlertVehicleLatch()
+    local probe = UnitUsingVehicle or UnitInVehicle
+    buffAlertVehicle = (probe and probe("player")) and true or false
+end
+
 -- Build once per session on first eligible pass (warlock + Movement Alerts on
 -- + Burning Rush checked); later passes only refresh the style (mode/size/
 -- color edits ride RestyleSoon) and the host's shown state. Engine frames are
@@ -1424,21 +1434,20 @@ local function EnsureBuffAlertLane()
         if buffAlertHost then buffAlertHost:Hide() end
         return
     end
-    -- Ahead of the Show() below, not beside it: every pass runs through here,
-    -- so a gate applied anywhere else would be undone by the next tick.
-    if not BuffAlertAssistable() then
-        buffAlertAssist = false
-        if buffAlertHost then buffAlertHost:Hide() end
-        return
-    end
+    -- Resolved ahead of the Show() below, not beside it: every pass runs through
+    -- here, so a gate applied anywhere else would be undone by the next tick.
+    local assist = BuffAlertAssistable()
     local wasDenied = (buffAlertAssist == false)
-    buffAlertAssist = true
+    buffAlertAssist = assist
     if buffAlertBuilt then
+        if not assist then buffAlertHost:Hide(); return end
         buffAlertHost:Show()
         -- Whatever was parsed during the degraded window is wrong, and leaving a
         -- vehicle produces no aura edge for buffs that were already up, so the
-        -- engine would keep serving the stale membership. One full re-parse
-        -- clears it; bounded to the actual denied->allowed flip.
+        -- engine would keep serving the stale membership. The Show() above
+        -- re-parses on its own (OnShow_Intrinsic), and this is the same lever
+        -- stated outright, so the recovery does not silently depend on the host
+        -- being hidden rather than faded. Bounded to the real denied->allowed flip.
         if wasDenied and buffAlertContainer and buffAlertContainer.UpdateAllAuras then
             buffAlertContainer:UpdateAllAuras()
         end
@@ -1446,6 +1455,12 @@ local function EnsureBuffAlertLane()
         AK.RestyleSoon(BUFF_ALERT_STYLE)
         return
     end
+    -- Denial must not postpone the BUILD, only the display: logging in inside a
+    -- vehicle (or behind an intro cinematic) would otherwise defer creation to
+    -- the first allowed pass, and if that landed in combat AK.RequestContainer
+    -- queues it to PLAYER_REGEN_ENABLED -- no alert for the whole fight. Build
+    -- unconditionally and park at the end; the container is created and hidden
+    -- inside one call, so nothing renders in between.
     buffAlertBuilt = true
     buffAlertHost = CreateFrame("Frame", nil, UIParent)
     buffAlertHost:SetSize(2, 2)
@@ -1474,6 +1489,7 @@ local function EnsureBuffAlertLane()
             layout = { anchorPoint = "CENTER", padding = { 0, 0, 0, 0 }, rowWidth = 400 },
         })
     end)
+    if not assist then buffAlertHost:Hide() end
 end
 
 -- Numeric follow of the alert stack's top (slots grow UP from movementFrame's
@@ -2062,11 +2078,17 @@ local function UpdateEventRegistration()
         -- buffActive lane's identity gate (see BuffAlertAssistable): the
         -- occupancy latch plus the faction edge cinematics flip. Player-only,
         -- and only while the tracker is on. ENTERING as well as ENTERED --
-        -- the filters degrade from the boarding transition.
+        -- the filters degrade from the boarding transition. CINEMATIC_STOP
+        -- covers the addon-cancelled skip, whose faction restore can order
+        -- ahead of the edge above (the RF gate carries it for the same reason);
+        -- the lane runs no ticker, so a missed restore leaves it hidden.
         loader:RegisterUnitEvent("UNIT_ENTERING_VEHICLE", "player")
         loader:RegisterUnitEvent("UNIT_ENTERED_VEHICLE", "player")
         loader:RegisterUnitEvent("UNIT_EXITED_VEHICLE", "player")
         loader:RegisterUnitEvent("UNIT_FACTION", "player")
+        loader:RegisterEvent("CINEMATIC_STOP")
+        -- The EXITED edge cannot reach a lane whose events are unregistered.
+        SyncBuffAlertVehicleLatch()
         movementEventsRegistered = true
     elseif not moveOn and movementEventsRegistered then
         loader:UnregisterEvent("SPELL_UPDATE_USABLE")
@@ -2078,6 +2100,7 @@ local function UpdateEventRegistration()
         loader:UnregisterEvent("UNIT_EXITED_VEHICLE")
         loader:UnregisterEvent("UNIT_ENTERED_VEHICLE")
         loader:UnregisterEvent("UNIT_FACTION")
+        loader:UnregisterEvent("CINEMATIC_STOP")
         movementEventsRegistered = false
         CancelMovementCountdown()
     end
@@ -2194,10 +2217,8 @@ loader:SetScript("OnEvent", function(self, event, ...)
     elseif event == "PLAYER_ENTERING_WORLD" then
         inCombat = UnitAffectingCombat("player")
         -- Safety net for an exit that never fires UNIT_EXITED_VEHICLE (being
-        -- teleported out of one): reconcile the latch against the live flag
-        -- rather than leaving the lane suppressed for the session.
-        local probe = UnitUsingVehicle or UnitInVehicle
-        buffAlertVehicle = (probe and probe("player")) and true or false
+        -- teleported out of one).
+        SyncBuffAlertVehicleLatch()
         wipe(timeSpiralActiveSpells)
         timeSpiralActiveTime = nil
         CacheMovementSpells(true)
@@ -2240,10 +2261,10 @@ loader:SetScript("OnEvent", function(self, event, ...)
     elseif event == "UNIT_EXITED_VEHICLE" then
         buffAlertVehicle = false
         CheckMovementCooldown()
-    elseif event == "UNIT_FACTION" then
+    elseif event == "UNIT_FACTION" or event == "CINEMATIC_STOP" then
         -- Re-drive ONLY: a cinematic flips assistability with no vehicle
-        -- involved, and BuffAlertAssistable's own probe reads that. This must
-        -- not touch the latch -- UNIT_FACTION also fires on the BOARDING
+        -- involved, and BuffAlertAssistable's own probe reads that. Neither
+        -- may touch the latch -- UNIT_FACTION also fires on the BOARDING
         -- transition, where clearing it would undo the suppression we just set.
         CheckMovementCooldown()
     elseif event == "PLAYER_DEAD" then

--- a/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_MovementAlert.lua
@@ -1386,10 +1386,12 @@ local function BuildBuffAlertStyle(entry)
     }
 end
 
--- Identity gate (Blizzard_AuraContainerUtil.CanApplyIdentityCandidateFilters):
--- includeSpellIDs is applied to a HELPFUL aura only while UnitCanAssist("player",
--- unit) holds, and it FAILS OPEN -- when the gate fails the spell-ID filter is
--- skipped entirely and the aura passes on its filter string alone. Boarding a
+-- Identity gate (Blizzard_AuraContainer/Blizzard_AuraContainerUtil.lua,
+-- AuraContainerUtil.CanApplyIdentityCandidateFilters + DoesAuraPassCandidateFilters,
+-- verified 12.1.0.69299): includeSpellIDs is applied to a HELPFUL aura only while
+-- UnitCanAssist("player", unit) holds, and it FAILS OPEN -- when the gate fails the
+-- spell-ID filter is skipped entirely and the aura passes on its filter string
+-- alone, so a group asking for one spell renders every buff. Boarding a
 -- vehicle drops the player's own assistability, so this one-button HELPFUL group
 -- stops meaning "Burning Rush" and renders whatever buff it finds first, wearing
 -- the Burning Rush label. Membership is cached per aura instance and UNIT_AURA
@@ -1444,10 +1446,16 @@ local function EnsureBuffAlertLane()
         buffAlertHost:Show()
         -- Whatever was parsed during the degraded window is wrong, and leaving a
         -- vehicle produces no aura edge for buffs that were already up, so the
-        -- engine would keep serving the stale membership. The Show() above
-        -- re-parses on its own (OnShow_Intrinsic), and this is the same lever
-        -- stated outright, so the recovery does not silently depend on the host
-        -- being hidden rather than faded. Bounded to the real denied->allowed flip.
+        -- engine would keep serving the stale membership (it is cached per aura
+        -- instance; UNIT_AURA re-parses only what changed). The Show() above
+        -- re-parses on its own -- AuraContainerPrivateMixin:OnShow_Intrinsic in
+        -- Blizzard_AuraContainer/Blizzard_AuraContainer.lua calls UpdateAllAuras --
+        -- and this is that same lever stated outright, so the recovery does not
+        -- silently depend on the host being hidden rather than faded. NOTE the
+        -- method is a no-op on AuraContainerSharedMixin; the real
+        -- MarkDirty(FullAuraRebuild) is ManagedAuraContainerSharedMixin's
+        -- override, which reaches the addon-callable partition through
+        -- ManagedAuraContainerInboundMixin. Bounded to the real denied->allowed flip.
         if wasDenied and buffAlertContainer and buffAlertContainer.UpdateAllAuras then
             buffAlertContainer:UpdateAllAuras()
         end


### PR DESCRIPTION
**Cause:** the Burning Rush alert is one engine AuraContainer button narrowed by `includeSpellIDs`. Boarding a vehicle drops the player's self-assistability, and `CanApplyIdentityCandidateFilters` then SKIPS the spell-ID filter rather than failing closed, so the button rendered the first helpful aura it found, wearing the Burning Rush label. Membership is cached per aura instance and `UNIT_AURA` re-parses only what changed, so the bad parse outlived the ride until a reload.

**Fix:** suppress the lane while the player is in a vehicle (latched from the vehicle events -- `UnitUsingVehicle` is still true across the exit transition) or while self-assist reads cleanly false, and force one `UpdateAllAuras()` on the denied->allowed flip. Gates the display, never the build, so a denied first pass cannot defer container creation into combat. Same gate the Raid Frames assist probe and the player aura bars already guard.

**Test:** warlock with Burning Rush checked -- alert stays absent across vehicle entry/exit and fires normally afterwards; confirmed in game by the reporter. Verified against Blizzard source 12.1.0.69299.
