### PR TITLE
Fix:Prevent combat item comparison tooltip flash

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2479,9 +2479,10 @@ end
 -------------------------------------------------------------------------------
 --  Show Tooltips (global visibility mode). The "Blizzard Tooltip" dropdown
 --  (EllesmereUIDB.tooltipShowMode, default "always") suppresses the game tooltip
---  by combat state, applied to EVERY default-anchored tooltip via the same
---  GameTooltip_SetDefaultAnchor post-hook the cursor anchor uses (units, world
---  objects, action buttons). Deliberately no per-type logic:
+--  by combat state, applied to every default-anchored tooltip via the same
+--  GameTooltip_SetDefaultAnchor post-hook the cursor anchor uses. Action tooltip
+--  paths can re-own the tooltip explicitly after that hook, so action owners are
+--  recognized separately before SetAction builds the tooltip.
 --    always          -> never suppressed (default; the hook early-outs)
 --    outOfCombat     -> hidden while in combat lockdown
 --    outOfBossCombat -> hidden while a boss encounter is in progress
@@ -2562,6 +2563,9 @@ do
     -- combat when alwaysCompareItems is enabled. Keep the cleanup in this global
     -- tooltip controller rather than in ActionBars: bags, world items, and every
     -- other default-anchored item tooltip use the same comparison manager.
+    -- Use Blizzard's existing comparison-suppression control field; addon-owned
+    -- state stays in the shared weak-keyed FFD table so no custom state is stored
+    -- on Blizzard frames.
     local _comparisonTooltips
     local _comparisonClearPending = false
 
@@ -2570,6 +2574,89 @@ do
             _comparisonTooltips = { ShoppingTooltip1, ShoppingTooltip2 }
         end
         return _comparisonTooltips
+    end
+
+    local _comparisonFlagOwned = false
+    local _parked = false
+    local _modeEligible = false
+    local function GetComparisonState(tooltip, create)
+        local state = FFD[tooltip]
+        if not state and create then
+            state = {}
+            FFD[tooltip] = state
+        end
+        return state
+    end
+
+    local function ReadComparisonSuppressionFlag(tooltip)
+        return tooltip.suppressAutomaticCompareItem
+    end
+
+    local function WriteComparisonSuppressionFlag(tooltip, value)
+        -- Blizzard exposes this field as the per-tooltip opt-out for automatic
+        -- comparisons. It is a Blizzard control input, not addon-owned state.
+        tooltip.suppressAutomaticCompareItem = value
+    end
+
+    local function ForgetComparisonSuppression(tooltip)
+        if not _comparisonFlagOwned or tooltip ~= GameTooltip then return end
+        local state = GetComparisonState(tooltip, false)
+        if state then
+            state.comparisonFlagPrevious = nil
+            state.comparisonFlagOwned = nil
+        end
+        _comparisonFlagOwned = false
+    end
+
+    local function ReleaseComparisonSuppression(tooltip)
+        if not _comparisonFlagOwned or tooltip ~= GameTooltip then return end
+        local state = GetComparisonState(tooltip, false)
+        if not state or not state.comparisonFlagOwned then
+            _comparisonFlagOwned = false
+            return
+        end
+        if not pcall(WriteComparisonSuppressionFlag, tooltip, state.comparisonFlagPrevious) then return end
+        ForgetComparisonSuppression(tooltip)
+    end
+
+    local function ArmComparisonSuppression(tooltip)
+        if tooltip ~= GameTooltip then return end
+        local state = GetComparisonState(tooltip, true)
+        local owned = _comparisonFlagOwned and state.comparisonFlagOwned
+        if not owned then
+            local readOK, previous = pcall(ReadComparisonSuppressionFlag, tooltip)
+            if not readOK then return end
+            state.comparisonFlagPrevious = previous
+            state.comparisonFlagOwned = true
+            _comparisonFlagOwned = true
+        end
+        -- Arm at the default anchor and again from the item pre-call below. Item
+        -- setters can fire OnHide while rebuilding content, which resets this
+        -- Blizzard field after the anchor hook but before comparison finalization.
+        if not pcall(GameTooltip_SuppressAutomaticCompareItem, tooltip) and not owned then
+            ForgetComparisonSuppression(tooltip)
+        end
+    end
+
+    local function OnItemTooltipPreCall(tooltip)
+        -- Parking is the authoritative scope: default-anchored tips suppressed by
+        -- this controller are parked, while SetOwner unparks explicit tooltip paths
+        -- before they process item data. This also survives action-button owner reuse.
+        if tooltip ~= GameTooltip or not _parked then return end
+        ArmComparisonSuppression(tooltip)
+    end
+
+    local function RegisterComparisonPreCall()
+        TooltipDataProcessor.AddTooltipPreCall(Enum.TooltipDataType.Item, OnItemTooltipPreCall)
+    end
+
+    local _comparisonPreCallAttempted = false
+    local function InstallComparisonPreCall()
+        if _comparisonPreCallAttempted then return end
+        _comparisonPreCallAttempted = true
+        -- Midnight provides this processor before addon code loads. Keep the
+        -- registration protected so a missing API falls back to after-show cleanup.
+        pcall(RegisterComparisonPreCall)
     end
 
     local function ClearSuppressedComparisons()
@@ -2609,7 +2696,26 @@ do
 
     local _comparisonTooltipHooksInstalled = false
     local _comparisonManagerHookInstalled = false
+    local _comparisonLifecycleHooksInstalled = false
     local function InstallComparisonHooks()
+        InstallComparisonPreCall()
+
+        if not _comparisonLifecycleHooksInstalled then
+            -- SetOwner starts a new build, so restore the previous build before a
+            -- following default-anchor hook can arm suppression again. The main
+            -- SetOwner hook below already restores before an explicit action path
+            -- arms, so do not immediately undo that new ownership here.
+            hooksecurefunc(GameTooltip, "SetOwner", function(tooltip)
+                if not _modeEligible then
+                    ReleaseComparisonSuppression(tooltip)
+                end
+            end)
+            -- Blizzard resets the field itself before hooks run, so only forget
+            -- our ownership; restoring would overwrite Blizzard's reset.
+            GameTooltip:HookScript("OnHide", ForgetComparisonSuppression)
+            _comparisonLifecycleHooksInstalled = true
+        end
+
         if not _comparisonTooltipHooksInstalled then
             for _, comparisonTooltip in ipairs(GetComparisonTooltips()) do
                 if comparisonTooltip and comparisonTooltip.HookScript then
@@ -2655,8 +2761,6 @@ do
     -- default-anchored builds re-park right after in the SetDefaultAnchor post-hook (its internal SetOwner runs first).
     local _suppressHost = CreateFrame("Frame", nil, UIParent)
     _suppressHost:Hide()
-    local _parked = false
-    local _defaultAnchored = false
     local _origParent, _origStrata
     local function ParkTooltip(tt)
         if _parked then return end
@@ -2675,6 +2779,7 @@ do
     end
     local function ApplySuppression(tt)
         if EllesmereUI._tooltipSuppressedByMode(tt) then
+            ArmComparisonSuppression(tt)
             ParkTooltip(tt)
             QueueSuppressedComparisonClear()
         else
@@ -2683,19 +2788,39 @@ do
     end
     local function SuppressTooltipByMode(tooltip)
         if tooltip ~= GameTooltip then return end
-        _defaultAnchored = true
+        _modeEligible = true
         ApplySuppression(tooltip)
     end
     if GameTooltip_SetDefaultAnchor then
         hooksecurefunc("GameTooltip_SetDefaultAnchor", SuppressTooltipByMode)
     end
-    hooksecurefunc(GameTooltip, "SetOwner", function(tt)
-        _defaultAnchored = false
+    local function ReadActionOwner(owner)
+        return owner.GetAttribute and owner:GetAttribute("action") ~= nil
+    end
+    local function IsActionOwner(owner)
+        if not owner then return false end
+        local ok, result = pcall(ReadActionOwner, owner)
+        return ok and result
+    end
+    hooksecurefunc(GameTooltip, "SetOwner", function(tt, owner)
+        -- Restore the previous build before classifying the new owner. The flag
+        -- makes this a single branch until comparison support has owned it.
+        if _comparisonFlagOwned then
+            ReleaseComparisonSuppression(tt)
+        end
+        _modeEligible = false
         UnparkTooltip(tt)
+        -- Custom action buttons and tooltip-anchor addons can use an explicit
+        -- owner after the default-anchor hook. Recognize the action attribute
+        -- itself instead of inferring the path from the UberTooltips CVar.
+        if ComparisonSuppressionModeEnabled() and IsActionOwner(owner) then
+            _modeEligible = true
+            ApplySuppression(tt)
+        end
     end)
     GameTooltip:HookScript("OnHide", function(tt)
-        -- Only fires for unparked hides (a parked tooltip is never visible); clears the default-anchored flag promptly.
-        _defaultAnchored = false
+        -- Only fires for unparked hides (a parked tooltip is never visible).
+        _modeEligible = false
         if not (_comparisonSupportActive or _comparisonStateWatcherRegistered) then return end
         if EllesmereUI._tooltipSuppressedByMode(tt) then
             QueueSuppressedComparisonClear()
@@ -2721,13 +2846,14 @@ do
         -- parked tooltip remained logically shown, and unpark would resurrect
         -- stale content.  The next SetOwner path restores it normally.
         if not EllesmereUI._tooltipSuppressedByMode(GameTooltip) then return end
-        if _defaultAnchored then
+        if _modeEligible then
             ApplySuppression(GameTooltip)
         end
         QueueSuppressedComparisonClear()
     end
     UpdateStateWatcher = function()
         if not ComparisonSuppressionModeEnabled() then
+            ReleaseComparisonSuppression(GameTooltip)
             _comparisonSupportActive = false
             UnregisterStateWatcher()
             return
@@ -2804,13 +2930,15 @@ do
         if down == 1 then
             if _parked and GameTooltip:IsShown() then
                 -- The parked tip is alive and current under the cursor (built by the secure hover path): just reveal it, never rebuild from here (see the parking note above).
+                ReleaseComparisonSuppression(GameTooltip)
                 UnparkTooltip(GameTooltip)
             else
                 -- No live tip: module-built tips (raid frames, CDM) skip building while suppressed, so re-drive the hovered frame's OnEnter -- with the modifier now held they build normally.
                 FireHoveredOnEnter()
             end
         elseif GameTooltip:IsShown() and EllesmereUI._tooltipSuppressedByMode(GameTooltip) then
-            if _defaultAnchored then
+            if _modeEligible then
+                ArmComparisonSuppression(GameTooltip)
                 ParkTooltip(GameTooltip)
                 QueueSuppressedComparisonClear()
             else


### PR DESCRIPTION
## What does this PR do?

This is a focused follow-up bug fix for #1460. It prevents the brief item-comparison flash that could still occur when EllesmereUI's existing `Show Tooltips` mode suppresses tooltips during combat.

Active-use trinkets and other usable items are commonly placed on action bars. Moving the cursor across those buttons during combat can ask Blizzard to create `ShoppingTooltip1` and `ShoppingTooltip2`. The defensive cleanup from #1460 removes those frames, but it runs after they have already been shown, so a one-frame flash can remain.

## Root cause

Blizzard resets `GameTooltip.suppressAutomaticCompareItem` from an internal `OnHide` while item tooltip content is rebuilt. Arming the field only from `GameTooltip_SetDefaultAnchor` is therefore too early.

Live diagnostics exposed a second action-button edge: an action tooltip can explicitly re-own `GameTooltip` after the default-anchor hook, including while `UberTooltips=1`. The existing `SetOwner` hook treated every explicit owner as unrelated, unparked the tooltip, and cleared its mode eligibility. The item pre-call then observed `_parked=false`, left automatic comparison enabled, and Blizzard showed both shopping tooltips.

The fix now:

- keeps the default-anchor suppression path;
- recognizes an explicit action owner with the taint-safe `GetAttribute("action")` read, protected by `pcall` and fail-open behavior;
- restores the previous comparison field before classifying a new owner, then re-applies mode suppression for an action owner before `SetAction` processes item data;
- uses `_modeEligible` for both default-anchored and explicit action tooltip paths, so combat and encounter transitions apply consistently;
- lazily registers an item pre-call that re-arms comparison suppression after any internal `OnHide`, immediately before Blizzard finalizes item comparison;
- preserves the after-show cleanup from #1460 as a defensive fallback for already queued or later refreshed comparison frames.

Non-action explicit owners, including bag, character-panel, and addon tooltip paths, remain excluded from the pre-call because they unpark `GameTooltip` before processing item data.

## Why this requires a maintainer exception

This PR requests one narrow exception for Blizzard's existing per-tooltip `suppressAutomaticCompareItem` control field.

Setting the field to `true` goes through Blizzard's own `GameTooltip_SuppressAutomaticCompareItem` helper. Restoring the exact previous value requires one direct assignment because Blizzard provides no matching unsuppress helper. The read, helper call, and restore are protected with `pcall`; a failed restore retains ownership so a later lifecycle boundary can retry. No addon-defined keys or other state are written onto Blizzard frames. Addon-owned state remains in the existing weak-keyed `FFD` table.

An after-show-only implementation cannot prevent the flash because the shopping tooltips have already been shown. Hiding, reparenting, or changing the alpha of Blizzard's shopping-tooltip frames is more invasive; cancelling the item build breaks the secure combat tooltip needed by peek behavior; and changing `alwaysCompareItems` would alter the user's global comparison preference.

If this single control-field exception is not acceptable, #1460 remains the compliant fallback and the one-frame flash must remain.

## Acceptance criteria

- **Zero cost unless enabled:** no setting, frame, event registration, `OnUpdate`, timer, or login retry is added. The item pre-call and comparison lifecycle hooks are installed lazily only after a non-`Always` tooltip mode is used. The existing `SetOwner` hook performs a cheap mode early-out, and the protected action-owner read runs only for a non-default mode.
- **Zero behavior change without opt-in:** no new feature or setting is introduced. The change only corrects suppression behavior for the existing non-default modes.
- **Low cost when enabled:** the implementation is hook-driven, has no polling or wall-clock logic gate, and allocates weak-table state only once for `GameTooltip`. Blizzard provides no pre-call unregister API, so the callback remains installed after first enable and performs bounded identity/state early-outs while inactive.
- **Zero taint risk:** satisfied except for the explicitly requested single-field exception above. The action owner is read through `GetAttribute`, protected by `pcall`, with no protected attribute write and fail-open behavior.
- **Midnight only:** no version gates, compatibility branches, locale strings, or pre-Midnight APIs are added.
- **Code style:** Lua 5.1-compatible and ASCII-only; the diff is one focused Lua file.

## How was it tested?

Live diagnostics reproduced the failure with `mode=outOfCombat`, `combat=true`, `peek=false`, and `UberTooltips=1`. Before the final owner fix, the item pre-call observed `eligible=false`, `parked=false`, and `flag=false`, followed by `ShoppingTooltip1/2 OnShow`.

With the final fix, the same action path observed `eligible=true`, `parked=true`, and `flag=true`; neither shopping tooltip received `OnShow`. The diagnostics were then removed, and the clean build passed the same live test. The tested patch-id remained identical after rebasing onto current `main`.

Live test matrix:

- active-use trinket on an action bar in `Out of Combat` mode: no main tooltip or comparison flash on initial hover or while moving directly between item action buttons;
- an already visible comparison disappears when combat begins;
- an already visible tooltip/comparison disappears when a boss encounter begins;
- comparison behavior returns after combat or the encounter ends and the item is hovered again;
- `Always`, `Out of Boss Combat`, explicit bag/character-panel tooltips, mode switching, detailed tooltips, and peek behavior show no regression.

Static checks:

- rebased onto current `upstream/main`;
- `git diff --check`;
- ASCII-only diff;
- one changed source file, with no added `OnUpdate`, frame, event registration, timer, locale call, version gate, `goto`, or label;
- exactly one Blizzard-frame field assignment, the exception documented above;
- no change to `EllesmereUILocales/_keys.txt`; current base contains the generated 738-key list.

## Screenshots

Before - the comparison tooltip remains visible during combat:

![Before: comparison tooltip remains visible during combat](https://github.com/user-attachments/assets/6aeb1dbc-5064-4cea-9c88-c413b7c82625)

After - the comparison tooltip is suppressed:

![After: comparison tooltip is suppressed](https://github.com/user-attachments/assets/72b37e60-8bb9-4ffb-9872-03e88f9fa543)

The first-frame flash itself cannot be represented in a static screenshot and was verified in-game.

## Checklist

- [x] New settings default **OFF** - not applicable; no setting was added and this is a focused bug fix.
- [x] Zero cost while never enabled - support is lazy and no new frame, event, timer, login retry, or polling path is installed for `Always`.
- [x] Cheap while enabled - hook-driven with bounded work and no per-frame allocations.
- [ ] No writes onto Blizzard-owned frames - maintainer exception requested above for `suppressAutomaticCompareItem` only.
- [x] Tested in-game on live - the full matrix above and the clean final build passed.
- [x] Midnight-only and Lua 5.1/ASCII requirements are met.
