### PR TITLE
Fix Metamorphosis tracking

### DIFF
--- a/EllesmereUI_BuffPresets.lua
+++ b/EllesmereUI_BuffPresets.lua
@@ -248,7 +248,7 @@ spells = {
     offensive = {
         [1249658] = { class = "DEATHKNIGHT", alts = { 152279 } },
         [42650] = { class = "DEATHKNIGHT" },
-        [191427] = { class = "DEMONHUNTER", alts = { 187827, 321067, 321068 } },
+        [191427] = { class = "DEMONHUNTER", alts = { 187827, 321067, 321068, 162264 } },
         [471306] = { class = "DEMONHUNTER", alts = { 1217605, 1225789, 473671, 1217607 } },
         [194223] = { class = "DRUID" },
         [106951] = { class = "DRUID" },

--- a/EllesmereUI_BuffPresets.lua
+++ b/EllesmereUI_BuffPresets.lua
@@ -249,7 +249,7 @@ spells = {
         [1249658] = { class = "DEATHKNIGHT", alts = { 152279 } },
         [42650] = { class = "DEATHKNIGHT" },
         [191427] = { class = "DEMONHUNTER", alts = { 187827, 321067, 321068, 162264 } },
-        [471306] = { class = "DEMONHUNTER", alts = { 1217605, 1225789, 473671, 1217607 } },
+        [471306] = { class = "DEMONHUNTER", alts = { 1217605, 473671, 1217607 } },
         [194223] = { class = "DRUID" },
         [106951] = { class = "DRUID" },
         [50334] = { class = "DRUID" },


### PR DESCRIPTION
## What does this PR do?

### Havoc
In the buff presets, Metamorphosis is listed with the ID of the spell being cast (191427). However, to be displayed correctly as a buff in the party frames, it should use the ID of the aura applied to the character (162264). 

This PR adds the correct ID as an additional `alt` of 191427 rather than replacing it, to avoid resetting existing on/off settings, which are stored against that ID.


### Devourer
In the buff presets, Devourer's Metamorphosis is listed with the ID of the spell that tracks the soul stacks required to enter Metamorphosis (1225789). As a result, the buff also shows in the party frames while souls are being generated, outside of Metamorphosis itself. 

This PR removes that ID. 1217607, which is only active while the player is transformed, is already present. Existing settings remain unaffected, as the row is keyed on a different ID (471306) and 1225789 was only listed as an `alt`.


### Vengeance
This PR does not affect Vengeance. Just a note: Metamorphosis is listed under both offensive and a defensive CDs, and when both filters are tracked the buff shows twice.  You may want to take a look if this is not intentional.


## How was it tested?

Tested in game; the buff now displays as expected.

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [N/A] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [N/A] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [N/A] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
