### PR TITLE
Fix bank search to use Blizzard container item filter

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -270,6 +270,7 @@ searchClear:Hide()
 searchClear:SetScript("OnClick", function()
     bankSearch:SetText("")
     bankSearch:ClearFocus()
+    C_Container.SetItemSearch("")
 end)
 
 bankSearch:SetScript("OnEnterPressed", function(self)
@@ -278,12 +279,17 @@ end)
 bankSearch:SetScript("OnEscapePressed", function(self)
     self:SetText("")
     self:ClearFocus()
+    C_Container.SetItemSearch("")
 end)
 bankSearch:SetScript("OnTextChanged", function(self)
     local text = self:GetText()
     searchPlaceholder:SetShown(text == "")
     searchClear:SetShown(text ~= "")
+    C_Container.SetItemSearch(text)
     if EUI_Bank:IsVisible() then EUI_Bank:RefreshBank() end
+    if EUI_Bags and EUI_Bags:IsVisible() and EUI_Bags.RefreshInventory then
+        EUI_Bags:RefreshInventory()
+    end
 end)
 
 -- Sort button
@@ -1615,7 +1621,6 @@ function EUI_Bank:RefreshBank()
     local searchQuery = ""
     if EUI_Bank._searchBox then
         searchQuery = EUI_Bank._searchBox:GetText() or ""
-        searchQuery = searchQuery:lower()
     end
     local hasSearch = searchQuery ~= ""
 
@@ -1645,10 +1650,7 @@ function EUI_Bank:RefreshBank()
         if not hasSearch then return true end
         local info = C_Container.GetContainerItemInfo(bagID, slot)
         if not info then return false end
-        local link = C_Container.GetContainerItemLink(bagID, slot)
-        local itemName = link and GetItemInfo(link)
-        if not itemName then return false end
-        return itemName:lower():find(searchQuery, 1, true) ~= nil
+        return not info.isFiltered
     end
 
     -- Phase 1: Build flat layout list (no button creation, just positions).
@@ -2369,6 +2371,7 @@ eventFrame:SetScript("OnEvent", function(_, event)
             EUI_Bank._searchBox:SetText("")
             EUI_Bank._searchBox:ClearFocus()
         end
+        C_Container.SetItemSearch("")
         local bankScale = BP().bagScale or 1
         EUI_Bank:SetScale(bankScale)
         EUI_Bank:Show()
@@ -2411,6 +2414,7 @@ eventFrame:SetScript("OnEvent", function(_, event)
             EUI_Bank._searchBox:SetText("")
             EUI_Bank._searchBox:ClearFocus()
         end
+        C_Container.SetItemSearch("")
         EUI_Bank:Hide()
         -- Auto-close bags if we auto-opened them
         if EUI_Bank._autoOpenedBags and EUI_Bags and EUI_Bags:IsVisible() then


### PR DESCRIPTION
## What does this PR do?

Bank search now uses the same Blizzard container search API as bag search (`C_Container.SetItemSearch` + `info.isFiltered`), so queries match tooltip content such as armor type, upgrade track, and item stats -- not just the item display name.

## How was it tested?

**Requires in-game verification on Midnight/retail:**

1. Run `link-wow-addons.ps1` from elevated Windows PowerShell (once) so WoW loads this branch from the git checkout.
2. `/reload` in-game.
3. Open the banker with EllesmereUI bags enabled.
4. Search for `plate` -- plate items and items mentioning plate in their tooltip should remain visible; others should hide.
5. Search for an upgrade track or tooltip stat term (e.g. a tier name or stat abbreviation).
6. Confirm bag search still works when bank is open alongside bags.
7. Clear search with Escape or the clear button; confirm both bank and bags reset.
8. `/reload` and confirm no Lua errors.

## Screenshots

Not included -- submit before/after bank search screenshots from in-game testing if possible.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, bug fix only
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- search handlers only run when bank UI is open and user types
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- uses existing RefreshBank path and Blizzard filter
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added -- **pending contributor in-game test**