### PR TITLE
Adding Pawn support for EllesmereBagUI

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -621,6 +621,73 @@ local reagentSlots = {}
 local bagSlots     = {}
 
 -------------------------------------------------------------------------------
+--  Pawn bag upgrade advisor integration
+-------------------------------------------------------------------------------
+local pawnRegistered = false
+local pawnPending = setmetatable({}, { __mode = "k" })
+local pawnPositioned = setmetatable({}, { __mode = "k" })
+local pawnRetryScheduled = false
+local UpdatePawnArrow
+
+local function RetryPawnArrows()
+    pawnRetryScheduled = false
+    local pending = pawnPending
+    pawnPending = setmetatable({}, { __mode = "k" })
+
+    for btn, expectedLink in pairs(pending) do
+        local parent = btn:GetParent()
+        local currentLink = parent and C_Container.GetContainerItemLink(parent:GetID(), btn:GetID())
+        if btn:IsShown() and currentLink == expectedLink then
+            UpdatePawnArrow(btn, currentLink)
+        end
+    end
+end
+
+UpdatePawnArrow = function(btn, itemLink)
+    if not pawnRegistered or not btn.UpgradeIcon then return end
+    if not pawnPositioned[btn] then
+        btn.UpgradeIcon:ClearAllPoints()
+        btn.UpgradeIcon:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", -1, 1)
+        btn.UpgradeIcon:SetSize(16, 16)
+        pawnPositioned[btn] = true
+    end
+    btn.UpgradeIcon:Hide()
+
+    if not itemLink or not PawnCommon or not PawnCommon.ShowBagUpgradeAdvisor then
+        pawnPending[btn] = nil
+        return
+    end
+
+    local isUpgrade = PawnShouldItemLinkHaveUpgradeArrow(itemLink, true)
+    if isUpgrade == nil then
+        pawnPending[btn] = itemLink
+        if not pawnRetryScheduled then
+            pawnRetryScheduled = true
+            C_Timer.After(0, RetryPawnArrows)
+        end
+    else
+        pawnPending[btn] = nil
+        btn.UpgradeIcon:SetShown(isUpgrade)
+    end
+end
+
+local function RefreshPawnArrows()
+    if EUI_Bags:IsVisible() then EUI_Bags:RefreshInventory() end
+    if EUI_BagsReagent:IsVisible() then EUI_BagsReagent:RefreshInventory() end
+end
+
+local function RegisterPawnIntegration()
+    if pawnRegistered or BP().enhancedBags == false then return end
+    if type(PawnRegisterThirdPartyBag) ~= "function"
+        or type(PawnShouldItemLinkHaveUpgradeArrow) ~= "function" then return end
+
+    pawnRegistered = true
+    PawnRegisterThirdPartyBag("EllesmereUI Bags", {
+        RefreshAll = RefreshPawnArrows,
+    })
+end
+
+-------------------------------------------------------------------------------
 --  Per-category state (for targeted sidebar updates on item count changes)
 -------------------------------------------------------------------------------
 local _slotCategories = {}     -- bag*1000+slot -> categoryIndex from last full refresh
@@ -2578,6 +2645,7 @@ local function RenderButton(btn, data, _, col, row, startX, currentY, _, interac
         end
 
     end
+    UpdatePawnArrow(btn, data.itemLink)
 end
 
 -------------------------------------------------------------------------------
@@ -6192,6 +6260,7 @@ function EUI_BagsReagent:RefreshInventory()
         btn:Show()
         btn:SetID(data.slot)
         parent:SetID(data.bag)
+        local itemLink = data.info and C_Container.GetContainerItemLink(data.bag, data.slot)
 
         if not data.info then
             btn:SetItemButtonTexture(nil)
@@ -6212,7 +6281,6 @@ function EUI_BagsReagent:RefreshInventory()
             if btn.ItemLevelText and data.info.itemID then
                 local showItemlevel = BP().showItemlevelInBags ~= false
                 if showItemlevel then
-                    local itemLink = C_Container.GetContainerItemLink(data.bag, data.slot)
                     if itemLink then
                         local _, _, quality, level = GetItemInfo(itemLink)
                         if IsGearItem(itemLink) then
@@ -6236,6 +6304,7 @@ function EUI_BagsReagent:RefreshInventory()
             if c then SetInsetBorderColor(btn, c.r, c.g, c.b, 1)
             else SetInsetBorderColor(btn, 0.25, 0.25, 0.25, 1) end
         end
+        UpdatePawnArrow(btn, itemLink)
 
         local col = (i - 1) % REAGENT_COLUMNS
         local row = math.floor((i - 1) / REAGENT_COLUMNS)
@@ -6313,6 +6382,8 @@ end
 --  StartAddon
 -------------------------------------------------------------------------------
 local function StartAddon()
+    RegisterPawnIntegration()
+
     -- Apply default view based on setting (DB now available)
     local _dbt = GetDefaultBagType()
     if _dbt == "onebag" then


### PR DESCRIPTION
## What does this PR do?
 
 This adds Pawn upgrade-arrow support to EllesmereUI Bags. Addressing ISSUE: #1401 
 
 EllesmereUI uses its own pooled bag buttons, so Pawn's Blizzard-container hooks never update their `UpgradeIcon` textures. The bags module now registers through Pawn's third-party bag API, evaluates rendered item links, clears stale state when buttons are recycled, and refreshes arrows when Pawn settings or scales change.
 
 Upgrade arrows are displayed at the bottom-right of item icons. Pawn remains an optional dependency, and no integration work runs when Pawn or enhanced bags are disabled.
 
 ## How was it tested?
 
 Tested locally on WoW Retail/Midnight build `12.1.0.69299` with Pawn 2.13.14.
 
 - Confirmed known upgrade items display a green arrow at the bottom-right.
 - Confirmed non-upgrades and empty slots do not display an arrow.
 - Changed categories and sorted bags to verify pooled buttons do not retain stale arrows.
 - Tested the detached reagent bag.
 - Toggled Pawn's bag upgrade advisor off and on and confirmed arrows refresh.
 - Reloaded the UI with script errors enabled and observed no Lua errors.
 
 ## Screenshots
 
<img width="1016" height="543" alt="image" src="https://github.com/user-attachments/assets/4fe56c93-65bc-4095-a098-d22e7d6f6499" />
 
 ## Checklist
 
 - [x] N/A - no new setting was added; this fixes compatibility with an already-enabled Pawn feature
 - [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
 - [x] Cheap while enabled: event-driven, with reused weak tables and no recurring polling or per-frame allocations. Pawn's API-required `nil` result uses one coalesced next-frame retry.
 - [x] No writes onto Blizzard-owned frames (weak-table pattern used); only addon-owned item buttons created from Blizzard's template are repositioned
 - [ ] Tested in-game on live; no version gates or pre-Midnight APIs added
