### PR TITLE
Fix Lua error and blank panel when an addon deep-links into options

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -9777,6 +9777,13 @@ function EllesmereUI:NavigateToElementSettings(moduleName, pageName, sectionName
         return nil
     end
 
+    -- First-open split (see _SplitFirstOpen): Show() below returns without
+    -- building the panel on the session's first open, so run the whole deep
+    -- link next frame rather than navigating a panel that does not exist yet.
+    if self:_SplitFirstOpen(function()
+        EllesmereUI:NavigateToElementSettings(moduleName, pageName, sectionName, preSelectFn, highlightText)
+    end) then return end
+
     self:Show()
     self:SelectModule(moduleName)
     self:SelectPage(pageName)
@@ -10719,6 +10726,13 @@ end
 
 function EllesmereUI:SelectModule(folderName)
     if not modules[folderName] then return end
+    -- The panel is not always built when we get here: on the session's first
+    -- open the first-open split (see _SplitFirstOpen) makes Show()/Toggle()
+    -- return BEFORE CreateMainFrame, so a caller that opens the panel and
+    -- selects a module in the same execution arrives with headerFrame nil.
+    -- Bail before activeModule is written -- a half-applied selection also
+    -- suppresses CreateMainFrame's default-module pick, leaving a blank panel.
+    if not headerFrame then return end
     if folderName == activeModule then return end
     -- Excluded modules are locked while an override editing session is
     -- active; blocking at the choke point covers every navigation path

--- a/EllesmereUI_PatchNotesPopup.lua
+++ b/EllesmereUI_PatchNotesPopup.lua
@@ -205,9 +205,10 @@ local function ShowPatchNotesPopup()
             -- Patch Notes is its own sidebar module now (_EUIPatchNotes), not a
             -- page under Global Settings. Select that module directly so the
             -- sidebar highlights Patch Notes (mirrors the sidebar button OnClick).
-            if EllesmereUI.SelectModule then
-                EllesmereUI:Show()
-                EllesmereUI:SelectModule("_EUIPatchNotes")
+            -- ShowModule, not Show + SelectModule: it carries the first-open
+            -- split, so the module still lands when the panel builds next frame.
+            if EllesmereUI.ShowModule then
+                EllesmereUI:ShowModule("_EUIPatchNotes")
             end
         end
     end

--- a/EllesmereUI_Profiles.lua
+++ b/EllesmereUI_Profiles.lua
@@ -5094,6 +5094,15 @@ function EllesmereUI.ImportProfileInteractive(opts)
         return false, "an interactive import is already pending"
     end
 
+    -- First-open split (see _SplitFirstOpen): on the session's first open the
+    -- navigation below only LOADS and the panel builds next frame, so the
+    -- Profiles page -- and with it _ProfilesConsumeApiImport -- does not exist
+    -- yet. Re-run the whole call next frame instead; the session is not created
+    -- until then, so the re-entry is not blocked as "already pending".
+    if EllesmereUI:_SplitFirstOpen(function()
+        EllesmereUI.ImportProfileInteractive(opts)
+    end) then return true end
+
     EllesmereUI._apiImportSession = {
         str      = opts.importString,
         name     = type(opts.profileName) == "string" and opts.profileName or nil,

--- a/EllesmereUI_SpecOverridesPopup.lua
+++ b/EllesmereUI_SpecOverridesPopup.lua
@@ -254,9 +254,10 @@ local function ShowSpecOverridesPopup()
         ReleaseConflictCheck()
         if not showMe then return end
         local target = FirstLoadedCoreModule()
-        if target and EllesmereUI.SelectModule then
-            EllesmereUI:Show()
-            EllesmereUI:SelectModule(target)
+        if target and EllesmereUI.ShowModule then
+            -- ShowModule, not Show + SelectModule: it carries the first-open
+            -- split, so the module still lands when the panel builds next frame.
+            EllesmereUI:ShowModule(target)
             -- Next frame: the toolbar glyph exists once the panel has built.
             C_Timer.After(0, function()
                 if EllesmereUI.SpecOverrides_PulseButton then


### PR DESCRIPTION
**Cause:** 8.8.9's first-open split makes `Show()` return before the panel is built, but `NavigateToElementSettings` kept driving the panel in the same execution, so `SelectModule` ran with `headerFrame` nil (`EllesmereUI.lua:10761`). It had already written `activeModule`, which then suppressed `CreateMainFrame`'s default-module pick, so the panel opened blank and the import never started.

**Fix:** route the deep link and the interactive import through `_SplitFirstOpen` so the navigation runs on the frame the panel is built; guard `SelectModule` before it mutates `activeModule`; move the patch-notes and spec-overrides popups onto `ShowModule`, which already carries the split.

**Test:** fresh login, do not open `/eui` first, then trigger an addon-driven profile import (e.g. a partner installer). Panel opens on Profiles & Presets with the import dialog, no error. Normal `/eui` open unchanged.
