### PR TITLE
fix(cdm): minimum cdm bar width availability

### DIFF
--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -17262,42 +17262,6 @@ initFrame:SetScript("OnEvent", function(self)
                       ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
                   end });  y = y - h
 
-            -- Inline cog on Icon Scale: Minimum Bar Size (growth-axis icon-slot
-            -- reservation; lives here rather than as its own Bar Layout row,
-            -- user-directed). The popup slider stays always-editable -- the
-            -- runtime skips the reservation while the growth axis is
-            -- width/height matched, so no MatchGuard lock is needed and an
-            -- existing value can always be lowered or cleared. Orientation
-            -- resolves at build time; the page rebuilds on orientation flips.
-            if not isFocusKick then
-                local minVert = BD().verticalOrientation == true
-                local _, minCogShow = EllesmereUI.BuildCogPopup({
-                    title = minVert and "Minimum Height" or "Minimum Width",
-                    rows = {
-                        { type="slider",
-                          label=minVert and "Icon Slots Tall (0 = Off)" or "Icon Slots Wide (0 = Off)",
-                          min=0, max=20, step=1,
-                          get=function() return BD().minSizeIcons or 0 end,
-                          set=function(v)
-                              if v == 0 then v = nil end
-                              local bd = BD()
-                              bd.minSizeIcons = v
-                              -- Growth-axis extent changed: cached match dims stale.
-                              bd._matchIconPhys = nil
-                              bd._matchExtraPixels = nil
-                              bd._matchStride = nil
-                              bd._matchExtraPixelsH = nil
-                              bd._matchStrideH = nil
-                              ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
-                          end },
-                    },
-                })
-                if not EllesmereUI._prebuilding then
-                    local rgn = scaleAnimRow._rightRegion
-                    MakeCogBtn(rgn, minCogShow, nil, EllesmereUI.RESIZE_ICON)
-                end
-            end
-
             -- Inline cog on Always Show Buffs toggle (per-bar; native buff bars)
             if isBuffBar then
                 local _, asbCogShow = EllesmereUI.BuildCogPopup({
@@ -17822,6 +17786,47 @@ initFrame:SetScript("OnEvent", function(self)
         })
         end
         end -- isBuffBar else
+
+        -- Inline cog on Icon Scale: Minimum Bar Size (growth-axis icon-slot
+        -- reservation; lives here rather than as its own Bar Layout row,
+        -- user-directed). Placed AFTER the isBuffGlowBar branch because each
+        -- side builds its own scaleAnimRow -- and Icon Scale sits in a
+        -- different slot on each: buff-family rows put Always Show Buffs on the
+        -- left and Icon Scale on the right, every other bar type has Icon Scale
+        -- on the left (Icon Spacing on the right).
+        -- The popup slider stays always-editable -- the runtime skips the
+        -- reservation while the growth axis is width/height matched, so no
+        -- MatchGuard lock is needed and an existing value can always be lowered
+        -- or cleared. Orientation resolves at build time; the page rebuilds on
+        -- orientation flips. FocusKick is excluded: it is nameplate-anchored, so nothing matches or anchors to its edges.
+        if not isFocusKick then
+            local minVert = BD().verticalOrientation == true
+            local _, minCogShow = EllesmereUI.BuildCogPopup({
+                title = minVert and "Minimum Height" or "Minimum Width",
+                rows = {
+                    { type="slider",
+                      label=minVert and "Icon Slots Tall (0 = Off)" or "Icon Slots Wide (0 = Off)",
+                      min=0, max=20, step=1,
+                      get=function() return BD().minSizeIcons or 0 end,
+                      set=function(v)
+                          if v == 0 then v = nil end
+                          local bd = BD()
+                          bd.minSizeIcons = v
+                          -- Growth-axis extent changed: cached match dims stale.
+                          bd._matchIconPhys = nil
+                          bd._matchExtraPixels = nil
+                          bd._matchStride = nil
+                          bd._matchExtraPixelsH = nil
+                          bd._matchStrideH = nil
+                          ns.BuildAllCDMBars(); Refresh(); UpdateCDMPreviewAndResize()
+                      end },
+                },
+            })
+            if not EllesmereUI._prebuilding then
+                local rgn = isBuffGlowBar and scaleAnimRow._rightRegion or scaleAnimRow._leftRegion
+                MakeCogBtn(rgn, minCogShow, nil, EllesmereUI.RESIZE_ICON)
+            end
+        end
 
         -- Border Style dropdown (CD/utility and non-buff bars only)
         if not isBuffGlowBar then


### PR DESCRIPTION
## What does this PR do?

Makes the **Minimum Bar Size** cog (on the Icon Scale slider) reachable on every
Cooldown Manager bar type. Since v8.8.9 it only appeared on buff-family bars, so
Cooldowns, Utility and custom bars -- the ones most likely to be width-matched or
anchored to -- had no way to reach the setting even though the runtime supported it.

The ICON DISPLAY section builds its Icon Scale row in two branches
(`if isBuffGlowBar then ... else ... end`) and the cog was attached inside the buff
branch only. Moved it to after both branches and selected the region per branch,
because Icon Scale sits in the row's right slot on buff bars (left slot is Always
Show Buffs) and in the left slot on every other bar type.

No behavior change for buff bars, and no runtime changes -- options wiring only.
FocusKick stays excluded as before.

## How was it tested?

12.1 live, checked cooldown bar and utility bar.

## Screenshots

<img width="469" height="160" alt="image" src="https://github.com/user-attachments/assets/de71a72e-bd19-482c-91cc-26d83a5b3190" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting; exposes an existing one that defaults off
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added