### PR TITLE
Add SameBaseSpell function to compare ability IDs

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -2809,6 +2809,7 @@ local _tbbStickyFrame = {}
 -- only trust a binding while the pooled frame still serves the same cooldown
 -- slot (Blizzard reuses frame objects fast in combat). cooldownID stays a
 -- plain readable number in secret windows (the clean-sid cache keys on it).
+-- cooldownID a sticky frame had when bound, to catch object reuse for a different slot.
 local _tbbStickyCdID = {}
 
 function ns.InvalidateTBBFrameCache()
@@ -2949,14 +2950,12 @@ local function AssignFramesToConfigs(bars)
                     _tbbStickyCdID[cfg]  = nil
                 end
             elseif bound.cooldownID == _tbbStickyCdID[cfg] then
-                -- Secret/combat, but the frame still serves the cooldown slot it
-                -- was bound under: trust the binding locked in earlier.
+                -- Secret/combat, but still the same cooldown slot: trust the binding locked in earlier.
                 assignment[cfg] = bound
                 consumed[bound] = true
             else
-                -- Same frame object, different cooldown slot (pool reused it
-                -- mid-secret-window) -- a stale binding here is exactly the
-                -- wrong-name/wrong-icon report; drop it rather than guess.
+                -- Same frame object, different cooldown slot now (pool reused it) -- don't guess.
+                 _tbbStickyFrame[cfg] = nil
                 _tbbStickyFrame[cfg] = nil
                 _tbbStickyCdID[cfg]  = nil
             end
@@ -2982,11 +2981,9 @@ local function AssignFramesToConfigs(bars)
         end
     end
 
-    -- Pass 3: cooldownInfo/linkedSpellIDs struct fallback. NEVER sticky a fuzzy
-    -- match: let a later clean read re-pair it exactly in pass 2. Binds only
-    -- when the match is unique BOTH ways (one frame fits this cfg, and no other
-    -- unassigned cfg fits that frame) -- shared linkedSpellIDs data makes fuzzy
-    -- matches ambiguous, and a guessed pairing is worse than a blank bar.
+    -- Pass 3: cooldownInfo/linkedSpellIDs struct fallback. NEVER sticky a fuzzy match:
+    -- let a later clean read re-pair it exactly in pass 2. Only bind if unique both
+    -- ways, else skip -- a guess is worse than a blank bar.
     for _, cfg in ipairs(bars) do
         if not assignment[cfg] then
             local candidate, matches = nil, 0
@@ -3272,14 +3269,33 @@ end
 -- restriction, and both feed StatusBar:SetValue/FontString:SetText natively. The
 -- instance-id query is the fallback for an unpopulated cache and HARD-ERRORS on 12.1
 -- restricted units, hence the pcall and the secret-iid guard.
-local function ReadStackApplications(blzChild)
+-- Aura spellId behind a Blizzard child, for identity checks. nil if unreadable.
+local function BlzChildAuraSID(blzChild)
     local ad = blzChild.auraDataCached
-    if ad and ad.applications then return ad.applications end
+    if ad and ad.spellId then return ad.spellId end
     local auraInstID = blzChild.auraInstanceID
     local auraUnit = blzChild.auraDataUnit
     if auraInstID and auraUnit and not issecretvalue(auraInstID) then
         local ok, d = pcall(C_UnitAuras.GetAuraDataByAuraInstanceID, auraUnit, auraInstID)
-        if ok and d and d.applications then return d.applications end
+        if ok and d and d.spellId then return d.spellId end
+    end
+    return nil
+end
+
+local function ReadStackApplications(blzChild, cfg)
+    local ad = blzChild.auraDataCached
+    if ad and ad.applications then
+        if CfgWantsSID(cfg, ad.spellId) then return ad.applications end
+        return nil, true
+    end
+    local auraInstID = blzChild.auraInstanceID
+    local auraUnit = blzChild.auraDataUnit
+    if auraInstID and auraUnit and not issecretvalue(auraInstID) then
+        local ok, d = pcall(C_UnitAuras.GetAuraDataByAuraInstanceID, auraUnit, auraInstID)
+        if ok and d and d.applications then
+            if CfgWantsSID(cfg, d.spellId) then return d.applications end
+            return nil, true
+        end
     end
     return nil
 end
@@ -3294,7 +3310,7 @@ local function UpdateStacks(bar, blzChild, cfg)
         -- Stack-based bar: skip the Blizzard text mirror (blank below 2 stacks) and drive
         -- fill/text from the aura data. This helper only runs for active frames, so the aura is
         -- up and a readable count floors at 1; a secret count passes through to SetValue/SetText untouched.
-        local apps = ReadStackApplications(blzChild)
+        local apps = ReadStackApplications(blzChild, cfg)
         if apps then
             if not issecretvalue(apps) and apps < 1 then apps = 1 end
             bar._stackCount = apps
@@ -3314,7 +3330,30 @@ local function UpdateStacks(bar, blzChild, cfg)
         end
         return
     end
-    -- Read stacks from blzChild.Icon.Applications FontString.
+    -- Prefer a validated count over Blizzard's raw text mirror.
+    local rejected
+    if blzChild then
+        local apps
+        apps, rejected = ReadStackApplications(blzChild, cfg)
+        if apps then
+            if bar._stacksText and not bar._stacksHidden then
+                bar._stacksText:SetText(apps)
+                bar._stacksText:Show()
+            elseif bar._stacksText then
+                bar._stacksText:Hide()
+            end
+            bar._stackCount = apps
+            return
+        end
+    end
+    -- Already know this frame's aura isn't ours -- raw text would be the same wrong data.
+    if rejected then
+        if bar._stacksText then bar._stacksText:Hide() end
+        bar._stackCount = 0
+        return
+    end
+    -- Fallback: Blizzard's own rendered text, only when a validated read
+    -- above wasn't available (e.g. secret instance id in combat).
     if blzChild and blzChild.Icon and blzChild.Icon.Applications then
         -- NEVER compare the text (it may be secret); SetText takes it natively.
         local ok, txt = pcall(blzChild.Icon.Applications.GetText, blzChild.Icon.Applications)
@@ -3329,9 +3368,7 @@ local function UpdateStacks(bar, blzChild, cfg)
             elseif bar._stacksText then
                 bar._stacksText:Hide()
             end
-            -- Stack count for the threshold overlay: applications can be a secret number we
-            -- cannot compare, but the overlay consumes it via SetValue (FeedTBBThresholdOverlay), which accepts secrets.
-            bar._stackCount = ReadStackApplications(blzChild) or 0
+            bar._stackCount = 0
             return
         end
     end
@@ -3345,7 +3382,7 @@ local function UpdateStacks(bar, blzChild, cfg)
                     bar._stacksText:SetText(txt)
                     bar._stacksText:Show()
                 end
-                bar._stackCount = ReadStackApplications(blzChild) or 0
+                bar._stackCount = 0
                 return
             end
         end
@@ -4690,6 +4727,12 @@ function ns.UpdateTrackedBuffBarTimers()
                 elseif blzChild.IsShown then
                     isActive = blzChild:IsShown() or false
                 end
+                if isActive then
+                    local seenSID = BlzChildAuraSID(blzChild)
+                    if seenSID and not CfgWantsSID(cfg, seenSID) then
+                        isActive = false
+                    end
+                end
             end
 
             -- Blizzard viewer bind-miss / not-tracked-at-all fallback: covers (1) the
@@ -4789,14 +4832,8 @@ function ns.UpdateTrackedBuffBarTimers()
                         end
                     end
 
-                    -- Name from the bar's own configured spellID -- deterministic, and
-                    -- spell-data APIs stay readable while auras are secret. NEVER from
-                    -- Blizzard's label FontString: their pooled frames recycle fast in
-                    -- combat and the label can lag a tick behind the icon, so scraping
-                    -- it faithfully copied a leftover name from the frame's previous
-                    -- occupant (the in-combat wrong-name field report). Live aura data
-                    -- is the last resort for unloaded spell data, and only when its
-                    -- spellId actually matches this config (instance ids recycle too).
+                    -- Name comes from the bar's own spellID, not Blizzard's label text,
+                    -- which can lag the icon after a pool reuse.
                     if bar._nameText and bar._nameText:IsShown() then
                         local nameStr
                         if cfg.spellID and cfg.spellID > 0 then

--- a/EllesmereUICooldownManager/EllesmereUICdmTbbDecimals.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmTbbDecimals.lua
@@ -125,6 +125,15 @@ local function AddCleanID(include, id)
     AddVariants(include, id)
 end
 
+-- True if two ids are forms of the same ability, not just linked in the same group.
+local function SameBaseSpell(a, b)
+    if a == b then return true end
+    if not (C_Spell and C_Spell.GetBaseSpell) then return false end
+    local ba = C_Spell.GetBaseSpell(a)
+    local bb = C_Spell.GetBaseSpell(b)
+    return (ba or a) == (bb or b)
+end
+
 -- Reconcile a config's include set against Blizzard's cooldown info -- the SAME source
 -- of truth the tick's frame matching trusts (MatchesSID). The aura that actually
 -- appears often carries an id that exists ONLY in linkedSpellIDs (variant chains:
@@ -146,8 +155,14 @@ local function AddCooldownInfoIDs(include, cfg)
     AddCleanID(include, info.overrideSpellID)
     AddCleanID(include, info.overrideTooltipSpellID)
     if info.linkedSpellIDs then
+        -- Only widen the filter for ids that are truly the same ability.
+        local root = cfg.spellID or cfg.baseSpellID
         for k = 1, #info.linkedSpellIDs do
-            AddCleanID(include, info.linkedSpellIDs[k])
+            local lid = info.linkedSpellIDs[k]
+            if not (issecretvalue and issecretvalue(lid)) and type(lid) == "number"
+               and root and SameBaseSpell(lid, root) then
+                AddCleanID(include, lid)
+            end
         end
     end
 end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1538355647706431601

The issue

Tracking Bars could show data from the wrong spell — wrong name, wrong stack count, and the bar could even appear "active" for a spell that hadn't actually triggered. Root cause across all three: the code trusted whatever Blizzard's own frame was currently bound to (name, applications, active state) without checking that it was actually still bound to this bar's spell. Blizzard's frame pool reuses objects fast, especially in combat, so a bar could end up silently reading — and faithfully displaying — a completely different spell's data.

A related bug lived in the decimal-precision timer: it widened its "which aura is mine" filter using Blizzard's linkedSpellIDs, which groups mechanically-related-but-different spells together (e.g. an ability that requires a separate buff), not just true form-variants of the same spell.

The fix

Every place that reads identity-bearing data off a Blizzard frame now validates it against the bar's own configured spell before trusting it:

Name: derived from the bar's own spellID directly, not copied from Blizzard's label text.
Stacks: validated against the bar's spellID; if a read is proven to belong to a different spell, the raw Blizzard text fallback is skipped too (same wrong data, just unstructured) and the bar shows blank instead of a wrong number.
Active/shown state: same validation — a frame proven to belong to a different spell can no longer make the bar light up.
Decimal timer filter: only widens to a linked spell if it's genuinely a form-variant of the bar's own spell (same base spell), not just grouped in the same cooldown family.

Consistent principle throughout: an unvalidated guess is worse than a blank bar, so every fallback now fails safe rather than showing possibly-wrong data.