### PR TITLE
[Feature] Unit Frame Dynamic Health Color

### DIFF
--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -1108,6 +1108,12 @@ initFrame:SetScript("OnEvent", function(self)
             else
                 hR, hG, hB = 0.8, 0.2, 0.2
             end
+            -- Dynamic Health Color outranks every flat source above, exactly as it
+            -- does on the live bar. The preview's health percent is a known fake,
+            -- so this takes the clean-number twin of the engine curve rather than
+            -- UnitHealthPercent.
+            local pvDynR, pvDynG, pvDynB = ns.UF_PreviewDynamicColor(settings, _previewHealthPct or 0.70)
+            if pvDynR then hR, hG, hB = pvDynR, pvDynG, pvDynB end
             -- Class-colored background (designer shows the player's class), else custom.
             local bgClassCC
             if settings.bgClassColored then
@@ -2481,6 +2487,10 @@ initFrame:SetScript("OnEvent", function(self)
                     else
                         uHR, uHG, uHB = 0.8, 0.2, 0.2
                     end
+                    -- Dynamic Health Color overrides the flat sources above (see the
+                    -- build-time twin); resolved at the preview's fake health percent.
+                    local uDynR, uDynG, uDynB = ns.UF_PreviewDynamicColor(s, _previewHealthPct or 0.70)
+                    if uDynR then uHR, uHG, uHB = uDynR, uDynG, uDynB end
                     -- Class-colored background (designer shows the player's class), else custom.
                     local uBgClassCC
                     if s.bgClassColored then
@@ -5944,6 +5954,13 @@ initFrame:SetScript("OnEvent", function(self)
                   end },
                 { tooltip = "Custom Colored Fill",
                   hasAlpha = false,
+                  -- Dynamic Color resolves the fill from health percent, so the flat
+                  -- custom/class choice below has no effect while it is on. Greyed and
+                  -- click-blocked rather than reset: the stored customFillColor and
+                  -- healthClassColored are left exactly as the user had them and come
+                  -- back untouched the moment Dynamic Color goes to Off.
+                  disabled = function() return SVal("healthColorMode", "none") ~= "none" end,
+                  disabledTooltip = "Dynamic Color is on -- the fill color comes from the unit's health",
                   getValue = function()
                       local c = SGet("customFillColor")
                       if c then return c.r, c.g, c.b end
@@ -5973,6 +5990,12 @@ initFrame:SetScript("OnEvent", function(self)
                   end },
                 { tooltip = "Class Colored Fill",
                   hasAlpha = false,
+                  -- Same as the custom swatch: inert while Dynamic Color is on, so it
+                  -- greys out instead of silently doing nothing. Class Reactive still
+                  -- uses the class color, but as the 100% stop of the curve, not as
+                  -- this flat choice.
+                  disabled = function() return SVal("healthColorMode", "none") ~= "none" end,
+                  disabledTooltip = "Dynamic Color is on -- the fill color comes from the unit's health",
                   getValue = function()
                       local _, ct = UnitClass("player")
                       if ct and RAID_CLASS_COLORS[ct] then
@@ -6100,6 +6123,9 @@ initFrame:SetScript("OnEvent", function(self)
         -- Sync icon: Bar Color (left) -- fill/class color and gradient
         if not EllesmereUI._prebuilding then
             local rgn = sharedHealthColorRow._leftRegion
+            -- Dynamic Color lives in this slot's cog, and its three stops are inline
+            -- swatches on this row, so they travel with the rest of Bar Color.
+            local DYN_STOP_KEYS = { "dynamicColor100", "dynamicColor50", "dynamicColor0" }
             local function ApplyColorTo(keys)
                 local src = UNIT_DB_MAP[selectedUnit]()
                 local cc = src.healthClassColored or false
@@ -6107,6 +6133,7 @@ initFrame:SetScript("OnEvent", function(self)
                 local gEn = src.gradientEnabled or false
                 local gDir = src.gradientDir or "HORIZONTAL"
                 local gc = src.gradientColor
+                local dynMode = src.healthColorMode or "none"
                 for _, key in ipairs(keys) do
                     if key ~= selectedUnit then
                         local d = UNIT_DB_MAP[key]()
@@ -6117,6 +6144,11 @@ initFrame:SetScript("OnEvent", function(self)
                         d.gradientDir = gDir
                         if gc then d.gradientColor = { r=gc.r, g=gc.g, b=gc.b }
                         else d.gradientColor = nil end
+                        d.healthColorMode = dynMode
+                        for _, ck in ipairs(DYN_STOP_KEYS) do
+                            local sc = src[ck]
+                            if sc then d[ck] = { r=sc.r, g=sc.g, b=sc.b } else d[ck] = nil end
+                        end
                     end
                 end
                 ReloadAndUpdate(); EllesmereUI:RefreshPage()
@@ -6139,6 +6171,10 @@ initFrame:SetScript("OnEvent", function(self)
                         if (d.gradientEnabled or false) ~= (src.gradientEnabled or false) then return false end
                         if not colEq(d.gradientColor, src.gradientColor) then return false end
                         if (d.gradientDir or "HORIZONTAL") ~= (src.gradientDir or "HORIZONTAL") then return false end
+                        if (d.healthColorMode or "none") ~= (src.healthColorMode or "none") then return false end
+                        for _, ck in ipairs(DYN_STOP_KEYS) do
+                            if not colEq(d[ck], src[ck]) then return false end
+                        end
                     end
                     return true
                 end,
@@ -6151,12 +6187,29 @@ initFrame:SetScript("OnEvent", function(self)
                 },
             })
         end
-        -- Gradient cog on Bar Color (left region)
+        -- Fill Color cog on Bar Color (left region): the two settings that decide
+        -- what color the fill actually ends up, beyond the flat swatches.
+        -- Dynamic Color and Gradient COMPOSE -- Dynamic picks the color from the
+        -- unit's health percent, Gradient then runs from that color to the
+        -- gradient end color -- so they share one popup rather than fighting.
         if not EllesmereUI._prebuilding then
             local rgn = sharedHealthColorRow._leftRegion
             local _, gradCogShow = EllesmereUI.BuildCogPopup({
-                title = "Gradient Settings",
+                title = "Fill Color Settings",
                 rows = {
+                    -- Ported from the Raid Frames "Fill Color" dropdown: same modes,
+                    -- same curve shape, same stop defaults, so a unit frame and a
+                    -- party frame on the same mode paint the same color at the same
+                    -- health. The 100%/50%/0% stops are swatches on the row itself
+                    -- (cog popups have no color row type).
+                    { type="dropdown", label="Dynamic Color",
+                      tooltip="Color the health bar by how much health is left, instead of a flat color. Classic runs green at full health through yellow to red at empty. Custom Colors blends between the three stop swatches on this row -- full (100%), half (50%) and empty (0%). Class Reactive shows the class color at full health, bleeding into the 50% and 0% colors as the unit takes damage. Off leaves the flat Fill Color swatches in charge; either way the Gradient below still applies, running from whichever color this picks.",
+                      values={ none="Off", classic="Classic",
+                               customDynamic="Custom Colors", classReactive="Class Reactive" },
+                      order={ "none", "classic", "customDynamic", "classReactive" },
+                      get=function() return SVal("healthColorMode", "none") end,
+                      -- RefreshPage re-runs the stop swatches' show/hide pass.
+                      set=function(v) SSet("healthColorMode", v); ReloadAndUpdate(); UpdatePreview(); EllesmereUI:RefreshPage() end },
                     { type="toggle", label="Enable Gradient",
                       get=function() return SVal("gradientEnabled", false) end,
                       set=function(v) SSet("gradientEnabled", v); ReloadAndUpdate(); UpdatePreview(); EllesmereUI:RefreshPage() end },
@@ -6167,6 +6220,60 @@ initFrame:SetScript("OnEvent", function(self)
                 },
             })
             MakeCogBtn(rgn, gradCogShow)
+        end
+        -- Dynamic Color stop swatches (100% | 50% | 0%), chained LEFT of the cog so
+        -- they sit at the far end of the row's inline run: hiding them for the modes
+        -- that don't read them then leaves no hole in the middle of the controls,
+        -- and Off restores exactly the original [cog][gradient][custom][class] look.
+        if not EllesmereUI._prebuilding then
+            local rgn = sharedHealthColorRow._leftRegion
+            local dynDefs = {
+                { key = "dynamicColor100", def = { r = 0, g = 1, b = 0 },
+                  tip = "Health bar color at full (100%) health" },
+                { key = "dynamicColor50",  def = { r = 0xEC/255, g = 0xEC/255, b = 0x32/255 },
+                  tip = "Health bar color at half (50%) health" },
+                { key = "dynamicColor0",   def = { r = 0xE3/255, g = 0x30/255, b = 0x30/255 },
+                  tip = "Health bar color at empty (0%) health" },
+            }
+            local dynSwatches, dynUpdaters = {}, {}
+            local prevAnchor = rgn._lastInline or rgn._control
+            for i = #dynDefs, 1, -1 do
+                local dd = dynDefs[i]
+                local sw, swUpdate = EllesmereUI.BuildColorSwatch(
+                    rgn, sharedHealthColorRow:GetFrameLevel() + 3,
+                    function()
+                        local c = SGet(dd.key) or dd.def
+                        return c.r, c.g, c.b, 1
+                    end,
+                    function(r, g, b)
+                        UNIT_DB_MAP[selectedUnit]()[dd.key] = { r=r, g=g, b=b }
+                        ReloadAndUpdate(); UpdatePreview()
+                    end, false, 18)
+                sw:SetPoint("RIGHT", prevAnchor, "LEFT", -8, 0)
+                sw:HookScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(sw, dd.tip) end)
+                sw:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                dynSwatches[i] = sw
+                dynUpdaters[i] = swUpdate
+                prevAnchor = sw
+            end
+            rgn._lastInline = prevAnchor
+            -- dynSwatches[1] is the 100% stop. Class Reactive drives that stop from
+            -- the unit's own class color, so only 50%/0% are editable there.
+            -- The swatch UPDATERS must run on every refresh too: the stops are
+            -- per-unit, and switching the selected unit refreshes widgets rather
+            -- than rebuilding the page, so without this the swatches keep showing
+            -- the previous unit's colors.
+            local function UpdateDynSwatchVis()
+                local mode = SVal("healthColorMode", "none")
+                local isDynamic = mode == "customDynamic"
+                local isReactive = mode == "classReactive"
+                for i, sw in ipairs(dynSwatches) do
+                    if dynUpdaters[i] then dynUpdaters[i]() end
+                    if isDynamic or (isReactive and i > 1) then sw:Show() else sw:Hide() end
+                end
+            end
+            RegisterWidgetRefresh(UpdateDynSwatchVis)
+            UpdateDynSwatchVis()
         end
 
         -- Dark Mode: disable all Bar Color + Bar Background controls (the flat dark

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1465,6 +1465,216 @@ local function ClassColorSourceUnit(unitKey, unit)
     return unit or unitKey
 end
 
+-------------------------------------------------------------------------------
+--  Health-percent fill colors ("Dynamic Health Color")
+--
+--  The fill color follows how wounded the unit is: full health reads as one
+--  color and bleeds toward another as health drops. Deliberately a PORT of the
+--  Raid Frames implementation (GetClassicHealthCurve / GetCustomDynamicCurve /
+--  GetClassReactiveCurve there) rather than a fresh model, so a unit frame and
+--  a party frame set to the same mode paint the same color at the same health.
+--  Keep the two in step if either side's stops or curve shape ever change.
+--
+--  Secret-value safe by construction: the curve is handed to UnitHealthPercent
+--  and evaluated ENGINE-side, so a restricted unit's health never reaches Lua.
+--  The returned ColorMixin's channels may themselves be secret -- they are only
+--  ever passed to a setter, never inspected or arithmetic'd.
+--
+--  Per-unit settings (all nil-defaulted, so an untouched profile keeps the
+--  existing flat class/custom fill):
+--    healthColorMode  "none" | "classic" | "customDynamic" | "classReactive"
+--    dynamicColor100 / dynamicColor50 / dynamicColor0   gradient stops
+--
+--  Wrapped in do/end: the caches are state these functions own, and the block
+--  releases its registers at the close so the main chunk pays nothing.
+-------------------------------------------------------------------------------
+do
+    -- Stop defaults, shared with the options page's swatch fallbacks. Same
+    -- values the Raid Frames module uses.
+    local DEF100 = { r = 0, g = 1, b = 0 }
+    local DEF50  = { r = 0xEC/255, g = 0xEC/255, b = 0x32/255 }
+    local DEF0   = { r = 0xE3/255, g = 0x30/255, b = 0x30/255 }
+    ns.UF_DYN_DEF100, ns.UF_DYN_DEF50, ns.UF_DYN_DEF0 = DEF100, DEF50, DEF0
+
+    -- Classic: red (dead) -> yellow (mid) -> green (full). One curve, forever.
+    local classicCurve
+    local function GetClassicCurve()
+        if classicCurve then return classicCurve end
+        local curve = C_CurveUtil.CreateColorCurve()
+        curve:SetType(Enum.LuaCurveType.Linear)
+        curve:AddPoint(0, CreateColor(1, 0, 0, 1))
+        curve:AddPoint(0.5, CreateColor(1, 1, 0, 1))
+        curve:AddPoint(1, CreateColor(0, 1, 0, 1))
+        classicCurve = curve
+        return curve
+    end
+
+    -- Custom Dynamic: the Classic path with the unit's three chosen stops.
+    -- ONE cached curve keyed by the stop colors, not by unit: unit frames are
+    -- repainted one at a time, and a rebuild is only the cost of three AddPoint
+    -- calls. Frames configured differently therefore rebuild as they alternate;
+    -- that is bounded by the number of DISTINCT palettes in use (nearly always
+    -- one), not by the paint rate.
+    local dynCurve
+    local d0r, d0g, d0b, d50r, d50g, d50b, d100r, d100g, d100b
+    local function GetDynamicCurve(s)
+        local c0   = s.dynamicColor0   or DEF0
+        local c50  = s.dynamicColor50  or DEF50
+        local c100 = s.dynamicColor100 or DEF100
+        if not (dynCurve
+            and d0r   == c0.r   and d0g   == c0.g   and d0b   == c0.b
+            and d50r  == c50.r  and d50g  == c50.g  and d50b  == c50.b
+            and d100r == c100.r and d100g == c100.g and d100b == c100.b) then
+            dynCurve = C_CurveUtil.CreateColorCurve()
+            dynCurve:SetType(Enum.LuaCurveType.Linear)
+            dynCurve:AddPoint(0,   CreateColor(c0.r,   c0.g,   c0.b,   1))
+            dynCurve:AddPoint(0.5, CreateColor(c50.r,  c50.g,  c50.b,  1))
+            dynCurve:AddPoint(1,   CreateColor(c100.r, c100.g, c100.b, 1))
+            d0r, d0g, d0b       = c0.r, c0.g, c0.b
+            d50r, d50g, d50b    = c50.r, c50.g, c50.b
+            d100r, d100g, d100b = c100.r, c100.g, c100.b
+        end
+        return dynCurve
+    end
+
+    -- Class Color Reactive: the same gradient whose 100% stop is the unit's
+    -- CLASS color, so full health reads as class identity and wounds bleed into
+    -- the reactive palette (fully reactive by 40%). Cached per class token; the
+    -- fingerprint names every input, so a Custom Class Colors edit rebuilds too.
+    local GRAY = { r = 0.5, g = 0.5, b = 0.5 }
+    local reactiveCurves = {}   -- classToken -> { curve, r, g, b } (class color used)
+    local r0r, r0g, r0b, r50r, r50g, r50b
+    local function GetClassReactiveCurve(s, classToken)
+        local c0  = s.dynamicColor0  or DEF0
+        local c50 = s.dynamicColor50 or DEF50
+        if not (r0r == c0.r and r0g == c0.g and r0b == c0.b
+            and r50r == c50.r and r50g == c50.g and r50b == c50.b) then
+            wipe(reactiveCurves)
+            r0r, r0g, r0b    = c0.r, c0.g, c0.b
+            r50r, r50g, r50b = c50.r, c50.g, c50.b
+        end
+        local cc = EllesmereUI.GetClassColor(classToken) or GRAY
+        local e = reactiveCurves[classToken]
+        if not (e and e.r == cc.r and e.g == cc.g and e.b == cc.b) then
+            local curve = C_CurveUtil.CreateColorCurve()
+            curve:SetType(Enum.LuaCurveType.Linear)
+            -- Front-loaded class return: fully reactive at 40% health, and the
+            -- 0.75 stop already carries 75% class weight so identity snaps back
+            -- quickly (40->75% climbs 0->75% class, 75->100% eases in the rest).
+            curve:AddPoint(0,    CreateColor(c0.r,  c0.g,  c0.b,  1))
+            curve:AddPoint(0.4,  CreateColor(c50.r, c50.g, c50.b, 1))
+            curve:AddPoint(0.75, CreateColor(
+                c50.r + (cc.r - c50.r) * 0.75,
+                c50.g + (cc.g - c50.g) * 0.75,
+                c50.b + (cc.b - c50.b) * 0.75, 1))
+            curve:AddPoint(1,    CreateColor(cc.r,  cc.g,  cc.b,  1))
+            e = { curve = curve, r = cc.r, g = cc.g, b = cc.b }
+            reactiveCurves[classToken] = e
+        end
+        return e.curve
+    end
+
+    -- Resolved fill color for a unit under the settings table `s`.
+    -- Returns  ok, r, g, b, secret  -- ok false means "not on a dynamic mode"
+    -- (or the mode could not resolve) and the caller keeps whatever it had.
+    --
+    -- `ok` and `secret` are PLAIN booleans on purpose: on an identity-restricted
+    -- unit r/g/b are SECRET numbers, and both truthiness-testing and comparing
+    -- one throw. They may only ever be handed to a setter -- and `secret` marks
+    -- exactly that case, because SetGradient refuses secrets where
+    -- SetStatusBarColor accepts them.
+    --
+    -- classReactive needs a readable class token; a restricted unit has none, so
+    -- it declines and the flat class/reaction fill already on the bar stands.
+    -- (The Raid Frames twin greys out instead; keeping the real color is
+    -- strictly better here, and only differs on focus/ToT-style units.)
+    function ns.UF_DynamicHealthColor(unit, s)
+        local mode = s and s.healthColorMode
+        if not mode or mode == "none" or not unit then return false end
+        if not (C_CurveUtil and UnitHealthPercent) then return false end
+        local curve
+        if mode == "classic" then
+            curve = GetClassicCurve()
+        elseif mode == "customDynamic" then
+            curve = GetDynamicCurve(s)
+        elseif mode == "classReactive" then
+            local _, classToken = UnitClass(unit)
+            if not classToken or issecretvalue(classToken) then return false end
+            curve = GetClassReactiveCurve(s, classToken)
+        else
+            return false
+        end
+        local color = UnitHealthPercent(unit, true, curve)
+        if not (color and color.GetRGB) then return false end
+        local r, g, b = color:GetRGB()
+        return true, r, g, b, issecretvalue(r)
+    end
+
+    -- Clean-number twins for the options previews, where the health percent is a
+    -- known fake (0-1) rather than a secret. These MUST match the curves above
+    -- or the designer teaches a color the live bar never shows.
+    function ns.UF_ResolveDynamicColor(s, pct01)
+        local c0   = s.dynamicColor0   or DEF0
+        local c50  = s.dynamicColor50  or DEF50
+        local c100 = s.dynamicColor100 or DEF100
+        if pct01 >= 0.5 then
+            local t = (pct01 - 0.5) * 2
+            return c50.r + (c100.r - c50.r) * t,
+                   c50.g + (c100.g - c50.g) * t,
+                   c50.b + (c100.b - c50.b) * t
+        end
+        local t = pct01 * 2
+        return c0.r + (c50.r - c0.r) * t,
+               c0.g + (c50.g - c0.g) * t,
+               c0.b + (c50.b - c0.b) * t
+    end
+
+    function ns.UF_ResolveClassicColor(pct01)
+        if pct01 >= 0.5 then
+            local t = (pct01 - 0.5) * 2
+            return 1 - t, 1, 0
+        end
+        return 1, pct01 * 2, 0
+    end
+
+    function ns.UF_ResolveClassReactiveColor(s, classToken, pct01)
+        local cc = (classToken and EllesmereUI.GetClassColor(classToken)) or GRAY
+        local c0  = s.dynamicColor0  or DEF0
+        local c50 = s.dynamicColor50 or DEF50
+        if pct01 >= 0.4 then
+            local w
+            if pct01 >= 0.75 then
+                w = 0.75 + (pct01 - 0.75)
+            else
+                w = (pct01 - 0.4) / 0.35 * 0.75
+            end
+            return c50.r + (cc.r - c50.r) * w,
+                   c50.g + (cc.g - c50.g) * w,
+                   c50.b + (cc.b - c50.b) * w
+        end
+        local t = pct01 / 0.4
+        return c0.r + (c50.r - c0.r) * t,
+               c0.g + (c50.g - c0.g) * t,
+               c0.b + (c50.b - c0.b) * t
+    end
+
+    -- One entry point for every preview surface: resolves whichever dynamic mode
+    -- `s` is on at a FAKE percent, or nil when the unit is on a flat fill.
+    function ns.UF_PreviewDynamicColor(s, pct01)
+        local mode = s and s.healthColorMode
+        if not mode or mode == "none" then return nil end
+        if mode == "classic" then
+            return ns.UF_ResolveClassicColor(pct01)
+        elseif mode == "customDynamic" then
+            return ns.UF_ResolveDynamicColor(s, pct01)
+        elseif mode == "classReactive" then
+            local _, ct = UnitClass("player")
+            return ns.UF_ResolveClassReactiveColor(s, ct, pct01)
+        end
+        return nil
+    end
+end
+
 -- Carrier for a resolved-but-secret class color. Reused: it is written and consumed inside one
 -- UpdateColor pass (SetStatusBarColor, then PostUpdateColor), and nothing stores it.
 local SECRET_CLASS_COLOR = CreateColor(1, 1, 1, 1)
@@ -1538,7 +1748,11 @@ local function UF_SecretSafeHealthColor(self, event, unit)
     end
 end
 
-local function ApplyDarkTheme(health)
+-- `unit` is optional and used only to converge the setup paint with the repaint
+-- paint (see the PostUpdateColor call at the tail of the non-dark branch). It is
+-- passed by every caller that has it; Health elements never get `__owner`
+-- (only aura elements do), so there is no fallback to recover it from.
+local function ApplyDarkTheme(health, unit)
     if not health then return end
     -- TEMPORARY (see UF_SecretSafeHealthColor). Idempotent: this function
     -- re-runs on settings changes and re-assigning is harmless.
@@ -1621,7 +1835,15 @@ local function ApplyDarkTheme(health)
             -- errors, so it may only ever be handed to a setter.
             local bR, bG, bB
             local haveBase, baseSecret = false, false
-            if cFill and not classColored then
+            -- Dynamic Health Color outranks every FLAT source (custom fill, class,
+            -- reaction): the whole point is that the fill tracks damage taken. It
+            -- does not displace the spatial Gradient below -- it becomes that
+            -- gradient's start color, so the two compose.
+            local haveDyn, dR, dG, dB, dSecret = ns.UF_DynamicHealthColor(unit, uSettings)
+            if haveDyn then
+                bR, bG, bB = dR, dG, dB
+                haveBase, baseSecret = true, dSecret
+            elseif cFill and not classColored then
                 bR, bG, bB = cFill.r, cFill.g, cFill.b
                 haveBase = true
             elseif classColored and uKey == "pet" then
@@ -1645,6 +1867,13 @@ local function ApplyDarkTheme(health)
                 ApplyBarGradient(self:GetStatusBarTexture(), uSettings.gradientDir or "HORIZONTAL",
                     bR, bG, bB, ga,
                     gc and gc.r or 0.20, gc and gc.g or 0.20, gc and gc.b or 0.80, ga)
+            elseif haveDyn then
+                -- Must be written explicitly: the health element painted the flat
+                -- class/reaction color a moment ago, and unlike the pet/custom
+                -- branches below there is no earlier setup pass that pre-applied
+                -- this one. SetStatusBarColor takes secrets, so a restricted unit
+                -- still gets its real curve color here.
+                self:SetStatusBarColor(bR, bG, bB)
             elseif classColored and uKey == "pet" and haveBase then
                 self:SetStatusBarColor(bR, bG, bB)
             elseif cFill and not classColored then
@@ -1701,6 +1930,21 @@ local function ApplyDarkTheme(health)
                 health.bg:SetColorTexture(DARK_HEALTH_R, DARK_HEALTH_G, DARK_HEALTH_B, 1)
             end
         end
+        -- Converge the SETUP paint with the REPAINT paint. Everything above only
+        -- writes the flat class/custom color and then INSTALLS PostUpdateColor
+        -- without ever running it, so any color that PostUpdateColor owns was
+        -- lost until the next health event. That is invisible for a flat fill
+        -- (setup already painted it) but not for Dynamic Health Color, which is
+        -- resolved from the health percent and lives only in PostUpdateColor:
+        -- the bar sat on the class/custom color until the unit was damaged.
+        -- ReloadFrames makes this reachable on every settings change too -- it
+        -- repaints via Engine.ForceAll FIRST and re-runs ApplyDarkTheme after,
+        -- so the setup pass clobbered the correct color a moment after it landed.
+        -- Idempotent by construction: PostUpdateColor is built to run on every
+        -- health event, so one extra call here is free. A nil `color` just means
+        -- the class/reaction tier contributes nothing, which is right at setup --
+        -- the element has not resolved one yet.
+        if health.PostUpdateColor then health:PostUpdateColor(unit, nil) end
     end
 end
 ns.ApplyDarkTheme = ApplyDarkTheme
@@ -1711,7 +1955,7 @@ ns.ApplyDarkTheme = ApplyDarkTheme
 if EllesmereUI.RegisterDarkModeRefresh then
     EllesmereUI.RegisterDarkModeRefresh(function()
         for _, obj in pairs(frames) do
-            if type(obj) == "table" and obj.Health then ApplyDarkTheme(obj.Health) end
+            if type(obj) == "table" and obj.Health then ApplyDarkTheme(obj.Health, obj.unit) end
         end
         -- Boss "Activate Preview" fake frames need their red class-color
         -- substitute re-applied after the dark repaint above.
@@ -4190,7 +4434,7 @@ local function CreateHealthBar(frame, unit, height, xOffset, settings, rightInse
     ApplyHealthBarAlpha(health, UnitToSettingsKey(unit))
     health:SetReverseFill(settings.healthReverseFill and true or false)
     ns.ApplyHealthOrientation(health, settings)
-    ApplyDarkTheme(health)
+    ApplyDarkTheme(health, unit)
 
     -- Smooth bar interpolation (opt-in).
     if settings.smoothBars then
@@ -8055,7 +8299,7 @@ local function StyleSimpleFrame(frame, unit)
     ApplyHealthBarAlpha(health, unitKey)
     health:SetReverseFill(settings.healthReverseFill and true or false)
     ns.ApplyHealthOrientation(health, settings)
-    ApplyDarkTheme(health)
+    ApplyDarkTheme(health, unit)
 
     frame.Health = health
 
@@ -8290,7 +8534,7 @@ local function StylePetFrame(frame, unit)
     ApplyHealthBarAlpha(health, unitKey)
     health:SetReverseFill(settings.healthReverseFill and true or false)
     ns.ApplyHealthOrientation(health, settings)
-    ApplyDarkTheme(health)
+    ApplyDarkTheme(health, unit)
 
     frame.Health = health
 
@@ -11576,7 +11820,7 @@ local function ReloadFrames()
             end
             frame.Health:SetReverseFill(settings.healthReverseFill and true or false)
             ns.ApplyHealthOrientation(frame.Health, settings)
-            ApplyDarkTheme(frame.Health)  -- re-anchors health.bg for the new axis
+            ApplyDarkTheme(frame.Health, unit)  -- re-anchors health.bg for the new axis
             UpdateAbsorbBarReverseFill(frame, settings.healthReverseFill and true or false, settings)
             -- Smooth bar interpolation (live toggle without /reload)
             if settings.smoothBars then


### PR DESCRIPTION
# What it does
Adds the party frame option for dynamic health color and class health gradients to unit frames, making the health color gradient as health decreases/increases.

# Visual
<img width="481" height="204" alt="image" src="https://github.com/user-attachments/assets/21d62ba8-5fe2-4f23-981b-820bfc049e94" />
<img width="269" height="119" alt="image" src="https://github.com/user-attachments/assets/ceded09a-b5da-4dae-8cb5-ef6e2fb16d09" />
<img width="315" height="122" alt="image" src="https://github.com/user-attachments/assets/3e089e5e-7ddf-402d-8a14-6a13f45545be" />

