### PR TITLE
Fix: Sync chat font size changes from tab menu

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -298,47 +298,6 @@ local function GetFrameFontSize(id)
     return 12
 end
 
--- Blizzard fires UPDATE_CHAT_WINDOWS after SetChatWindowSize, including the
--- Font Size action in a chat tab's right-click menu. Keep a small baseline so
--- that event can mirror native changes into the EUI profile without polling
--- or hooking any Blizzard chat function.
-local _chatFontSizesSeen = {}
-local function SeedChatFontSizes()
-    if not FCF_GetChatWindowInfo then return end
-    for i = 1, 20 do
-        local cf = _G["ChatFrame" .. i]
-        if cf then
-            local size = GetFrameFontSize(i)
-            if size and size > 0 then _chatFontSizesSeen[i] = size end
-        end
-    end
-end
-
-local function SyncChatFontSizeFromBlizzard()
-    if not FCF_GetChatWindowInfo then return end
-    local changedSize
-    for i = 1, 20 do
-        local cf = _G["ChatFrame" .. i]
-        if cf then
-            local size = GetFrameFontSize(i)
-            if size and size > 0 then
-                local previous = _chatFontSizesSeen[i]
-                if previous and previous ~= size then changedSize = size end
-                _chatFontSizesSeen[i] = size
-            end
-        end
-    end
-    if changedSize then
-        local cfg = ECHAT.DB()
-        if cfg and cfg.chatFontSize ~= changedSize then
-            cfg.chatFontSize = changedSize
-        end
-    end
-end
-
-SeedChatFontSizes()
-ECHAT.SyncChatFontSizeFromBlizzard = SyncChatFontSizeFromBlizzard
-
 local function GetEditBoxHeight()
     return min(60, max(10, ECHAT.DB().editBoxHeight or 23))
 end
@@ -694,10 +653,10 @@ end
 -- means "not yet captured") is the source of truth; Blizzard's per-window
 -- storage stays the delivery vehicle via ApplyChatFontSize, so the taint
 -- posture is unchanged. Genesis: seeded from the FIRST character's live
--- size at the first settled sight (pixel-invisible on that character).
--- Native tab-menu changes are mirrored back into this profile value by the
--- UPDATE_CHAT_WINDOWS handler, and every later login re-asserts it across
--- windows.
+-- size at the first settled sight (pixel-invisible on that character); every
+-- later login re-asserts the profile value across windows. The interaction
+-- follower mirrors native tab-menu changes because that menu writes the
+-- frame font directly without emitting UPDATE_CHAT_WINDOWS.
 function ECHAT.SyncChatFontSize()
     local cfg = ECHAT.DB()
     if not cfg then return end
@@ -709,11 +668,9 @@ function ECHAT.SyncChatFontSize()
                 cfg.chatFontSize = math.floor(fh + 0.5)
             end
         end
-        SeedChatFontSizes()
         return -- live sizes already match what was just captured
     end
     ECHAT.ApplyChatFontSize(cfg.chatFontSize)
-    SeedChatFontSizes()
 end
 
 -- Class-colored names in message BODIES only: the engine's display
@@ -1130,8 +1087,18 @@ do
     local accum = 0
     local lastSelected
     local lastShown = {}
-    local lastFontH = {}
+    local lastFontSize = {}
     local lastDockCount
+
+    -- Seed before the first interaction so a fast tab-menu change is still
+    -- recognized as a change from the settled Blizzard value.
+    for i = 1, 20 do
+        local cf = _G["ChatFrame" .. i]
+        if cf and cf.GetFont then
+            local size = GetFrameFontSize(i)
+            if size and size > 0 then lastFontSize[i] = size end
+        end
+    end
 
     follower:SetScript("OnUpdate", function(_, elapsed)
         -- Geometry every frame while armed: drags need per-frame follow.
@@ -1168,19 +1135,25 @@ do
                 if ECHAT.QueueTabPass then ECHAT.QueueTabPass() end
             end
         end
-        -- Per-window font size can change from Blizzard's tab menu (secure
-        -- flow we never touch); the UPDATE_CHAT_WINDOWS handler mirrors that
-        -- value into the EUI profile. This existing watcher only refreshes
-        -- our visible copy from Blizzard's storage.
+        -- Blizzard's tab menu writes the frame font directly and does not emit
+        -- UPDATE_CHAT_WINDOWS. Mirror the changed stored size into the EUI
+        -- profile while this existing interaction-only watcher is armed, then
+        -- refresh our visible copy from Blizzard's storage.
         for i = 1, 20 do
             local cf = _G["ChatFrame" .. i]
             if cf and cf.GetFont then
-                local _, fh = cf:GetFont()
-                if fh and fh ~= lastFontH[i] then
-                    if lastFontH[i] and ECHAT.EngineApplyFontTo then
+                local size = GetFrameFontSize(i)
+                if size and size ~= lastFontSize[i] then
+                    if lastFontSize[i] then
+                        local cfg = ECHAT.DB()
+                        if cfg and cfg.chatFontSize ~= size then
+                            cfg.chatFontSize = size
+                        end
+                    end
+                    if lastFontSize[i] and ECHAT.EngineApplyFontTo then
                         ECHAT.EngineApplyFontTo(cf)
                     end
-                    lastFontH[i] = fh
+                    lastFontSize[i] = size
                 end
             end
         end
@@ -4989,12 +4962,7 @@ initFrame:SetScript("OnEvent", function(self)
     tabPassFrame:RegisterEvent("UPDATE_FLOATING_CHAT_WINDOWS")
     tabPassFrame:RegisterEvent("UI_SCALE_CHANGED")
     tabPassFrame:RegisterEvent("DISPLAY_SIZE_CHANGED")
-    tabPassFrame:SetScript("OnEvent", function(self, event)
-        if event == "UPDATE_CHAT_WINDOWS" and ECHAT.SyncChatFontSizeFromBlizzard then
-            ECHAT.SyncChatFontSizeFromBlizzard()
-        end
-        QueueFullPass()
-    end)
+    tabPassFrame:SetScript("OnEvent", QueueFullPass)
     -- Edit Mode can rebuild the chat dock and tab geometry after a panel resize.
     -- Re-assert tab appearance only once that update has left Blizzard's
     -- event/script stack; the short second pass covers the final size commit

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -289,7 +289,7 @@ local function GetInnerBorderColor(cfg)
 end
 
 -- Chat frame text size is Blizzard's per-frame setting (right-click tab ->
--- Font Size); we only control font family + outline.
+-- Font Size); the EUI profile mirrors the latest user-selected value.
 local function GetFrameFontSize(id)
     if FCF_GetChatWindowInfo then
         local _, fontSize = FCF_GetChatWindowInfo(id)
@@ -297,6 +297,48 @@ local function GetFrameFontSize(id)
     end
     return 12
 end
+
+-- Blizzard fires UPDATE_CHAT_WINDOWS after SetChatWindowSize, including the
+-- Font Size action in a chat tab's right-click menu. Keep a small baseline so
+-- that event can mirror native changes into the EUI profile without polling
+-- or hooking any Blizzard chat function.
+local _chatFontSizesSeen = {}
+local function SeedChatFontSizes()
+    if not FCF_GetChatWindowInfo then return end
+    for i = 1, 20 do
+        local cf = _G["ChatFrame" .. i]
+        if cf then
+            local size = GetFrameFontSize(i)
+            if size and size > 0 then _chatFontSizesSeen[i] = size end
+        end
+    end
+end
+
+local function SyncChatFontSizeFromBlizzard()
+    if not FCF_GetChatWindowInfo then return end
+    local changedSize
+    for i = 1, 20 do
+        local cf = _G["ChatFrame" .. i]
+        if cf then
+            local size = GetFrameFontSize(i)
+            if size and size > 0 then
+                local previous = _chatFontSizesSeen[i]
+                if previous and previous ~= size then changedSize = size end
+                _chatFontSizesSeen[i] = size
+            end
+        end
+    end
+    if changedSize then
+        local cfg = ECHAT.DB()
+        if cfg and cfg.chatFontSize ~= changedSize then
+            cfg.chatFontSize = changedSize
+        end
+    end
+end
+
+SeedChatFontSizes()
+ECHAT.SyncChatFontSizeFromBlizzard = SyncChatFontSizeFromBlizzard
+
 local function GetEditBoxHeight()
     return min(60, max(10, ECHAT.DB().editBoxHeight or 23))
 end
@@ -620,9 +662,10 @@ function ECHAT.ApplyFonts()
 end
 
 -- One size for every chat window (the options slider). Persistence rides
--- Blizzard's own per-window storage -- SetChatWindowSize is a plain C write,
--- so there is no DB key, no migration, their tab menu keeps working for
--- later per-window tweaks, and their login pass re-applies it. NEVER route
+-- Blizzard's own per-window storage -- SetChatWindowSize is a plain C write.
+-- The EUI profile mirrors the latest size selected either here or through a
+-- chat tab's right-click menu, so the native menu choice survives reload.
+-- NEVER route
 -- this through FCF_SetChatWindowFontSize: the old in-place skin's size
 -- control rippled through Blizzard's tab-resize/dock machinery measuring
 -- secret label widths under our taint (the v7.15-era removal). Under the
@@ -651,9 +694,10 @@ end
 -- means "not yet captured") is the source of truth; Blizzard's per-window
 -- storage stays the delivery vehicle via ApplyChatFontSize, so the taint
 -- posture is unchanged. Genesis: seeded from the FIRST character's live
--- size at the first settled sight (pixel-invisible on that character);
--- every later login re-asserts the profile value, flattening per-character
--- and per-window sizes to it.
+-- size at the first settled sight (pixel-invisible on that character).
+-- Native tab-menu changes are mirrored back into this profile value by the
+-- UPDATE_CHAT_WINDOWS handler, and every later login re-asserts it across
+-- windows.
 function ECHAT.SyncChatFontSize()
     local cfg = ECHAT.DB()
     if not cfg then return end
@@ -665,9 +709,11 @@ function ECHAT.SyncChatFontSize()
                 cfg.chatFontSize = math.floor(fh + 0.5)
             end
         end
+        SeedChatFontSizes()
         return -- live sizes already match what was just captured
     end
     ECHAT.ApplyChatFontSize(cfg.chatFontSize)
+    SeedChatFontSizes()
 end
 
 -- Class-colored names in message BODIES only: the engine's display
@@ -1123,8 +1169,9 @@ do
             end
         end
         -- Per-window font size can change from Blizzard's tab menu (secure
-        -- flow we never touch); our view follows by re-reading the provider.
-        -- First sight only seeds the cache.
+        -- flow we never touch); the UPDATE_CHAT_WINDOWS handler mirrors that
+        -- value into the EUI profile. This existing watcher only refreshes
+        -- our visible copy from Blizzard's storage.
         for i = 1, 20 do
             local cf = _G["ChatFrame" .. i]
             if cf and cf.GetFont then
@@ -4942,7 +4989,12 @@ initFrame:SetScript("OnEvent", function(self)
     tabPassFrame:RegisterEvent("UPDATE_FLOATING_CHAT_WINDOWS")
     tabPassFrame:RegisterEvent("UI_SCALE_CHANGED")
     tabPassFrame:RegisterEvent("DISPLAY_SIZE_CHANGED")
-    tabPassFrame:SetScript("OnEvent", QueueFullPass)
+    tabPassFrame:SetScript("OnEvent", function(self, event)
+        if event == "UPDATE_CHAT_WINDOWS" and ECHAT.SyncChatFontSizeFromBlizzard then
+            ECHAT.SyncChatFontSizeFromBlizzard()
+        end
+        QueueFullPass()
+    end)
     -- Edit Mode can rebuild the chat dock and tab geometry after a panel resize.
     -- Re-assert tab appearance only once that update has left Blizzard's
     -- event/script stack; the short second pass covers the final size commit


### PR DESCRIPTION
## What does this PR do?

Fixes a chat font size persistence bug. When a player changes Font Size from a chat tab's right-click menu, the selected value is mirrored into EUI's `chatFontSize` profile setting. After a UI reload, EUI no longer overwrites that native choice with the previous profile value.

## Root cause

EUI's Chat options write `chatFontSize` and apply it through Blizzard's `SetChatWindowSize`. The native chat tab menu updates Blizzard's per-window storage, and EUI already refreshed its visible copy, but the EUI profile value was never updated. `ECHAT.SyncChatFontSize()` then reapplied the stale profile value on reload.

The first draft used `UPDATE_CHAT_WINDOWS` for synchronization. That event is not emitted by the native Font Size menu path: Blizzard directly calls `chatFrame:SetFont(...)` and `SetChatWindowSize(...)`. An event-only listener therefore cannot observe this user action.

## Fix

The fix reuses EUI Chat's existing interaction-only follower. It seeds the current Blizzard font sizes before interaction, compares the stored per-window size while the follower is already armed for chat interaction, and updates the EUI profile only after detecting a real native-menu change. The visible EUI copy is then refreshed from the same Blizzard value.

This keeps the implementation within the existing interaction lifecycle: no new frame, event registration, Blizzard function hook, timer-based logic, or per-frame allocation was added. The only new persistent write is to EUI profile data.

This is a bug fix, not a new setting or feature. The edge case is easy to hit because the native chat tab context menu is a normal way to adjust the font size of an individual chat window.

## How was it tested?

- Deployed the corrected interaction-observer implementation from rebased commit `d1e2aacc` to the local Midnight 12.1+ WoW client.
- Changed the chat font size through the native chat tab right-click menu.
- Reloaded the UI and confirmed the native selection persisted instead of being overwritten by the previous EUI profile value.
- Confirmed the EUI profile follows the native chat font size after the change.
- Confirmed the repository source and local WoW addon file are identical after deployment.
- `git diff --check` passed.
- No regression was observed in the tested chat behavior.

## Screenshots

Not applicable. This is a persistence and behavior fix; it does not add or change UI visuals or layout.

## Checklist

- [x] New settings default OFF - N/A; this is a genuine bug fix and adds no setting.
- [x] Zero cost while disabled - N/A; there is no new enablement state, frame, or event registration.
- [x] Cheap while active - reuses the existing interaction-only follower; no new recurring driver, timer-based logic, or per-frame allocation was added.
- [x] No writes onto Blizzard-owned frames; no Blizzard function is hooked, and only EUI profile data is updated by the new logic.
- [x] Midnight only; no version gates or pre-Midnight APIs were added.
