### PR TITLE
Power color overrides not working

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4457,6 +4457,18 @@ end
 --      the REAL color in altR/altG/altB (what oUF paints the bar with), so use it.
 --   3) Token unmatched, no alt color, standard integer type -> custom color (safety net).
 function EllesmereUI.ResolveUnitPowerColor(unit)
+    -- Color by the forced display power type, if one is set, not the
+    -- unit's real current power type. Computed fresh each call, not read
+    -- from a cache, so it can't lag behind a setting or spec change.
+    if unit == "player" and EllesmereUI.GetPlayerPowerOverride then
+        local override = EllesmereUI.GetPlayerPowerOverride()
+        if override ~= nil then
+            local overrideKey = EllesmereUI.POWER_ENUM_TO_KEY[override]
+            local overrideInfo = overrideKey and EllesmereUI.GetPowerColor(overrideKey)
+            if overrideInfo then return overrideInfo.r, overrideInfo.g, overrideInfo.b end
+        end
+    end
+    
     local pType, pToken, altR, altG, altB = UnitPowerType(unit)
     local info = EllesmereUI.GetPowerColor(pToken)
     if info then return info.r, info.g, info.b end

--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -1325,10 +1325,8 @@ initFrame:SetScript("OnEvent", function(self)
         local function PreviewPowerColor(fs, contentKey, usePowerColor)
             if not fs or not usePowerColor then return end
             if contentKey == "perpp" or contentKey == "curpp" or contentKey == "curhp_curpp" or contentKey == "perhp_perpp" then
-                -- EUI global power color (player's current power) as the real frame
-                -- uses, not hardcoded blue.
-                local _, pToken = UnitPowerType("player")
-                local info = EllesmereUI.GetPowerColor(pToken or "MANA")
+                local pcR, pcG, pcB = EllesmereUI.ResolveUnitPowerColor("player")
+                local info = pcR and { r = pcR, g = pcG, b = pcB }
                 if info then fs:SetTextColor(info.r, info.g, info.b)
                 else fs:SetTextColor(1, 1, 1) end
             end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1977,6 +1977,31 @@ end
 -- Balance Druid showing Mana instead of Astral Power).
 _G._EUI_ResolvedPowerType = _G._EUI_ResolvedPowerType or {}
 
+local PLAYER_POWER_DEFAULT = {
+    PRIEST = { [3] = 0 },   -- Shadow: default to Mana
+}
+local PLAYER_POWER_ALT = {
+    DRUID  = { [1] = 0, [2] = 0, [3] = 0 },  -- Balance/Feral/Guardian -> Mana
+    PRIEST = { [3] = nil },                     -- Shadow alt -> Insanity (UnitPowerType)
+    SHAMAN = { [1] = 0 },                       -- Elemental -> Mana
+}
+
+function EllesmereUI.GetPlayerPowerOverride()
+    local _, classFile = UnitClass("player")
+    local classDef = PLAYER_POWER_DEFAULT[classFile]
+    local classAlt = PLAYER_POWER_ALT[classFile]
+    if not (classDef or classAlt) then return nil end
+    local spec = GetSpecialization and GetSpecialization()
+    if not spec then return nil end
+    local ov = db.profile.player and db.profile.player.powerTypeOverride
+    if ov and ov[spec] and classAlt then
+        return classAlt[spec]
+    elseif classDef and classDef[spec] ~= nil then
+        return classDef[spec]
+    end
+    return nil
+end
+
 -- (The perpp/curpp/absorb piece functions live in the zone-formatter block
 -- below; they read the _EUI_ globals above.)
 
@@ -5465,32 +5490,10 @@ local function CreatePowerBar(frame, unit, settings)
     -- other specs default to UnitPowerType.
     if unit == "player" then
         local _, classFile = UnitClass("player")
-        -- Specs whose addon default differs from UnitPowerType (forced value).
-        local SPEC_DEFAULT_POWER = {
-            PRIEST = { [3] = 0 },   -- Shadow: default to Mana
-        }
-        -- Specs with an alternative choice; value = powerType to force
-        -- (nil = remove the override and let UnitPowerType decide).
-        local SPEC_ALT_POWER = {
-            DRUID  = { [1] = 0, [2] = 0, [3] = 0 },  -- Balance/Feral/Guardian -> Mana
-            PRIEST = { [3] = nil },                     -- Shadow alt -> Insanity (UnitPowerType)
-            SHAMAN = { [1] = 0 },                       -- Elemental -> Mana
-        }
-        local classDef = SPEC_DEFAULT_POWER[classFile]
-        local classAlt = SPEC_ALT_POWER[classFile]
-        if classDef or classAlt then
+        if PLAYER_POWER_DEFAULT[classFile] or PLAYER_POWER_ALT[classFile] then
             power.displayAltPower = true
             power.GetDisplayPower = function(self, u)
-                local spec = GetSpecialization and GetSpecialization()
-                if not spec then return nil end
-                local resolved
-                local ps = GetSettingsForUnit("player")
-                local ov = ps and ps.powerTypeOverride
-                if ov and ov[spec] and classAlt then
-                    resolved = classAlt[spec]  -- nil = UnitPowerType, number = forced
-                elseif classDef and classDef[spec] ~= nil then
-                    resolved = classDef[spec]
-                end
+                local resolved = EllesmereUI.GetPlayerPowerOverride()
                 -- Publish for tags so the text matches the bar.
                 _G._EUI_ResolvedPowerType[u or "player"] = resolved
                 return resolved


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1538617898434695278

Issue: For Shadow Priests using EUI's "display Mana instead of Insanity" option, the power bar showed mana values but was colored purple (Insanity's color) instead of blue (Mana's color). The bar color logic asked the game for the character's real current power type, ignoring the addon's override — and the same bug also affected the color swatches in the settings menu. On top of that, the swatches sometimes lagged behind spec/setting changes because they read from a cache that only updated when the power bar itself refreshed.

Fix: Added one shared function that always computes the correct forced power type live, based on your current spec and setting. The bar color, the settings-menu swatches, and the power text all now pull from this same fresh source, so they stay in sync with each other and with any changes you make — no cache, no lag, no more purple-on-Mana.