### PR TITLE
Implement secret-safe classToken handling

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -1621,7 +1621,8 @@ local function GetNameColor(unit, s)
         return c.r, c.g, c.b
     else -- "class"
         local _, classToken = UnitClass(unit)
-        if classToken then
+        -- Secret-safe: a secret classToken would throw on GetClassColor's table index.
+        if classToken and not issecretvalue(classToken) then
             local cc = EllesmereUI.GetClassColor(classToken)
             if cc then return cc.r, cc.g, cc.b end
         end
@@ -1637,7 +1638,8 @@ local function GetTopNameBarColor(unit, s)
         return c.r, c.g, c.b
     end
     local _, classToken = UnitClass(unit)
-    if classToken then
+    -- Secret-safe: a secret classToken would throw on GetClassColor's table index.
+    if classToken and not issecretvalue(classToken) then
         local cc = EllesmereUI.GetClassColor(classToken)
         if cc then return cc.r, cc.g, cc.b end
     end
@@ -1723,7 +1725,8 @@ local function GetHealthTextColor(unit, s)
         return 1, 1, 1
     elseif mode == "class" then
         local _, classToken = UnitClass(unit)
-        if classToken then
+        -- Secret-safe: a secret classToken would throw on GetClassColor's table index.
+        if classToken and not issecretvalue(classToken) then
             local cc = EllesmereUI.GetClassColor(classToken)
             if cc then return cc.r, cc.g, cc.b end
         end
@@ -1745,7 +1748,8 @@ function ns.GetHealAbsorbTextColor(unit, s)
         return 1, 0.3, 0.3
     elseif mode == "class" then
         local _, classToken = UnitClass(unit)
-        if classToken then
+        -- Secret-safe: a secret classToken would throw on GetClassColor's table index.
+        if classToken and not issecretvalue(classToken) then
             local cc = EllesmereUI.GetClassColor(classToken)
             if cc then return cc.r, cc.g, cc.b end
         end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1538505471474802688

The issue:

Blizzard introduced "secret values" — data the client marks as unreadable to addons for protected/restricted units (e.g. boss frames). When UnitClass("boss1") returns a secret class token, it can't be used as a Lua table key. Four color-lookup functions in the raid frames module (GetNameColor, GetTopNameBarColor, GetHealthTextColor, and GetHealAbsorbTextColor) passed that token straight into EllesmereUI.GetClassColor(), which indexes a cache table with it — causing the crash when healing/viewing a boss frame with name-by-class-color enabled.

The fix:

Added the same issecretvalue() guard the codebase already uses elsewhere (e.g. GetBgColor) to these four functions: skip the class-color lookup and fall back to the default color (white, or red for heal absorb) whenever the token is secret, instead of indexing with it. Four one-line changes, same file, no other logic touched.