### PR TITLE
Improve channel stop handling in cast bar

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -7452,9 +7452,15 @@ end
 -- equality test rejects real stops. Blizzard's own CastingBarFrame matches a
 -- castID for plain casts only and accepts any channel/empower stop, which is
 -- what OnEmpowerStop below already does.
+
+-- A channel that gets instantly restarted can have this STOP event arrive
+-- after the new channel's START. Check if a channel is still active before
+-- hiding, so a late stop for an already-replaced channel is ignored.
+
 local function OnChannelStop()
     if not castBarFrame then return end
     if not castBarFrame._channeling then return end
+	if UnitChannelInfo("player") then return end
     castBarFrame._channeling = false
     castBarFrame._castID = nil
     ns.ShowIdleCastBar()


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1538532996615897091

ssue: Your Player Cast Bar's channel tick marks would appear then vanish mid-channel, and the whole bar would sometimes disappear entirely — most noticeably on Arcane Missiles.

Root cause: When a channel gets instantly restarted (e.g. via a proc that lets you recast while still channeling), the game can deliver the "channel stopped" event for the old cast after the "channel started" event for the new one. The addon's stop handler didn't check for this — it hid the bar on any stop event, so it was tearing down the display for a channel that was still actively running.

Fix: Added one guard check in OnChannelStop — before hiding the bar, it now checks whether the player is still actually channeling something. If so, the stop event is stale (belongs to an already-replaced cast) and gets ignored instead of hiding the bar.
