### PR TITLE
Add Edit button to custom Buff/Debuff Manager fork rows

### DIFF
--- a/EllesmereUI_SpecOverrides.lua
+++ b/EllesmereUI_SpecOverrides.lua
@@ -7467,6 +7467,45 @@ local function BuildUnlockLayoutRow(parent, y, g, opts)
         })
     end)
 
+    -- Edit: opens the fork's OWN editing session, then jumps to its manager page.
+    -- Without this the only way to reach a conditional fork is to be standing in
+    -- its real context, and edits made anywhere else land silently in whichever
+    -- layer happens to be live (usually the shared baseline). Entering the
+    -- session is load-bearing, NOT a convenience: the manager page's prelude
+    -- engages the fork only while the session is open, and Cond.ExitEdit is the
+    -- sole release path -- engaging the swap directly here would strand the
+    -- session flag with nothing to ever bank and restore it.
+    if opts.editKind and opts.editPage then
+        local e = CreateFrame("Button", nil, row)
+        e:SetSize(116, 22)
+        e:SetPoint("RIGHT", b, "LEFT", -8, 0)
+        EllesmereUI.SolidTex(e, "BACKGROUND", 0.10, 0.10, 0.11, 0.9)
+        local ebrd = EllesmereUI.MakeBorder(e, 1, 1, 1, 0.22)
+        local elbl = EllesmereUI.MakeFont(e, 11, nil, 1, 1, 1, 0.8)
+        elbl:SetPoint("CENTER")
+        elbl:SetText(L("Edit"))
+        e:SetScript("OnEnter", function() if ebrd and ebrd.SetColor then ebrd:SetColor(ACCENT_R, ACCENT_G, ACCENT_B, 0.8) end end)
+        e:SetScript("OnLeave", function() if ebrd and ebrd.SetColor then ebrd:SetColor(1, 1, 1, 0.22) end end)
+        e:SetScript("OnClick", function()
+            -- Both entry points refuse (with their own popup) when another fork
+            -- holds the manager page; navigating anyway would show a page bound
+            -- to a different group, so confirm the session actually opened.
+            if opts.editKind == "cond" then
+                if not Cond.EnterEdit then return end
+                Cond.EnterEdit(g)
+                if Cond._edit ~= g then return end
+            else
+                if not EnterGroupEdit then return end
+                EnterGroupEdit(g)
+                if _editGroup ~= g then return end
+            end
+            EllesmereUI:SelectModule("EllesmereUIRaidFrames")
+            if EllesmereUI.SelectPage then
+                EllesmereUI:SelectPage(opts.editPage)
+            end
+        end)
+    end
+
     return row, 38
 end
 
@@ -7476,12 +7515,14 @@ local BM_ROW_SPEC = {
     title = "Delete Custom Buff Manager",
     message = "Delete the custom Buff Manager for '%s'? Its specs return to your default Buff Manager.",
     removeFn = function(gid) EllesmereUI.SpecOverrides_RemoveBmLayout(gid) end,
+    editKind = "spec", editPage = "Buff Manager",
 }
 local BM_ROW_COND = {
     crumb = "Custom Buff Manager",
     title = "Delete Custom Buff Manager",
     message = "Delete the custom Buff Manager for '%s'? Its conditions return to your default Buff Manager.",
     removeFn = function(gid) EllesmereUI.Conditions_RemoveBmLayout(gid) end,
+    editKind = "cond", editPage = "Buff Manager",
 }
 
 --- Row presets for the Debuff Manager forks (spec + conditional variants).
@@ -7490,12 +7531,14 @@ local DM_ROW_SPEC = {
     title = "Delete Custom Debuff Manager",
     message = "Delete the custom Debuff Manager for '%s'? Its specs return to your default Debuff Manager.",
     removeFn = function(gid) EllesmereUI.SpecOverrides_RemoveDmLayout(gid) end,
+    editKind = "spec", editPage = "Debuff Manager",
 }
 local DM_ROW_COND = {
     crumb = "Custom Debuff Manager",
     title = "Delete Custom Debuff Manager",
     message = "Delete the custom Debuff Manager for '%s'? Its conditions return to your default Debuff Manager.",
     removeFn = function(gid) EllesmereUI.Conditions_RemoveDmLayout(gid) end,
+    editKind = "cond", editPage = "Debuff Manager",
 }
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Cause
Conditional Buff/Debuff Manager forks could only be reached by standing in
their real context. The manager page edits whichever layer is currently live,
so editing anywhere else wrote to the shared baseline: the override kept the
copy-of-defaults it was seeded with while the default absorbed the changes.

## Fix
Adds an Edit button beside Delete on the custom Buff/Debuff Manager rows in the
Overrides list. It opens the fork's own editing session, then jumps to its
manager page. Entering the session is what makes this safe: the page prelude
engages the fork only while a session is open, and ExitEdit is the sole release
path, so engaging the swap directly would strand it with nothing to restore it.

## Test
Edit on a Raid conditional fork, add an indicator, close the panel. Out of
raid the indicator does not show and the default is unchanged; in raid
specBmOverrides.active reads cond:2 and the indicator applies. Verified in game
on both halves, plus the spec-fork rows.
