### PR TITLE
Nameplates: gate the dispel glow on what the player can dispel

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
@@ -224,11 +224,58 @@ end
 -- displayed buff is purgeable by construction and no per-aura signal is needed. Style and
 -- color come from the Dispel Glow options.
 
+-- Engine token for "has a dispel type". Blizzard documents it as dispellable
+-- REGARDLESS of whether the player's raid can dispel it, so it narrows the row
+-- but cannot answer "can I remove this" -- that is the capability gate's job.
+local DISPELLABLE = AuraUtil and AuraUtil.AuraFilters and AuraUtil.AuraFilters.Dispellable
+
 -- Effective glow state: with Show All Enemy Buffs on, the row is no
 -- longer dispellable-only, so the glow is suppressed entirely (the style
 -- dropdown and swatch are disabled in the options while that toggle is on).
+-- A character with no offensive dispel gets no glow either -- the option
+-- promises "you can dispel this", and the engine's DISPELLABLE token is
+-- documented as dispellable "regardless of whether the player's raid can
+-- dispel them", so it cannot answer that on its own.
 local function PurgeGlowActive()
-    return not not (ns.GetDispelGlow and ns.GetDispelGlow() and not PVal("showAllEnemyBuffs"))
+    if not (ns.GetDispelGlow and ns.GetDispelGlow()) then return false end
+    if PVal("showAllEnemyBuffs") then return false end
+    -- Without the DISPELLABLE token the row is not dispellable-only, so nothing
+    -- in it can be claimed to be dispellable by anyone.
+    if not DISPELLABLE then return false end
+    local magic, enrage = false, false
+    if ns.GetOffensiveDispelTypes then magic, enrage = ns.GetOffensiveDispelTypes() end
+    return magic or enrage
+end
+
+-- Buff row split. DISPELLABLE admits Magic buffs AND enrages, and the player
+-- rarely removes both, so the row is cut into two groups whose candidate
+-- filters are exact complements: group "np" carries Magic, group "np2" carries
+-- everything else, which on an enemy buff means an enrage. An enrage has no
+-- dispelName, so includeDispelTypes rejects it (a nil key reads as "not in the
+-- list") and excludeDispelTypes keeps it -- proven live against Agitation.
+-- Nothing is hidden by the split; only the glow follows capability.
+local BUFF_MAGIC = { includeDispelTypes = { Magic = true } }
+local BUFF_NONMAGIC = { excludeDispelTypes = { Magic = true } }
+
+-- The split costs an extra engine group per plate, so take it only when the
+-- two halves must look different: one dispel type known and not the other, or
+-- both known and drawn in their own colors.
+local function BuffSplit()
+    if not PurgeGlowActive() then return false end
+    local magic, enrage = ns.GetOffensiveDispelTypes()
+    if magic ~= enrage then return true end
+    return (ns.GetDispelGlowUseTypeColor and ns.GetDispelGlowUseTypeColor()) or false
+end
+
+-- Glow state and dispel type for buff group idx (1 = Magic, or the whole row
+-- while unsplit; 2 = non-Magic). The type is passed on unconditionally --
+-- GetDispelGlowColor ignores it unless per-type colors are on.
+local function BuffGroupGlow(idx)
+    if not PurgeGlowActive() then return false, nil end
+    if not BuffSplit() then return idx ~= 2, nil end
+    local magic, enrage = ns.GetOffensiveDispelTypes()
+    if idx == 2 then return enrage == true, "enrage" end
+    return magic == true, "magic"
 end
 
 -- PANDEMIC_GLOW_STYLES index -> shared EllesmereUI.Glows.STYLES index (the
@@ -288,7 +335,9 @@ local function ApplyNPBuffExtra(button, d, style)
     end
 end
 
-local function BuildNPStyle(kind)
+-- idx picks the buff group (see BuffGroupGlow); it is meaningless for the
+-- other kinds.
+local function BuildNPStyle(kind, idx)
     local size = NPSize(kind)
     local height, cropped = NPHeight(kind, size)
     -- User text settings, resolved through the legacy fallback chains, so
@@ -324,16 +373,29 @@ local function BuildNPStyle(kind)
         stackOffY = stk.y,
     }
     if kind == "buffs" then
-        style.purgeGlow = PurgeGlowActive()
+        -- Per-aura dispel type is unreadable under 12.1 secrecy, so the type is
+        -- a property of the GROUP and resolves once, here.
+        local glow, dispelType = BuffGroupGlow(idx or 1)
+        style.purgeGlow = glow
         style.purgeStyle = (ns.GetDispelGlowStyle and ns.GetDispelGlowStyle()) or 2
-        -- Type-color option removed (per-aura type is unreadable under
-        -- 12.1 secrecy); the glow always uses the custom color.
         if ns.GetDispelGlowColor then
-            style.purgeR, style.purgeG, style.purgeB = ns.GetDispelGlowColor(nil)
+            style.purgeR, style.purgeG, style.purgeB = ns.GetDispelGlowColor(dispelType)
         end
         style.applyExtra = ApplyNPBuffExtra
     end
     return style
+end
+
+-- Buff group -> style key. Group keys and style keys are both fixed; only the
+-- style CONTENTS follow capability, so a talent swap never has to re-declare a
+-- group (the engine bakes the style in at declaration).
+local BUFF_STYLE = { "np:buffs", "np:buffs2" }
+
+local function BuildNPStyles()
+    for i = 1, #KINDS do
+        AK.styles["np:" .. KINDS[i]] = BuildNPStyle(KINDS[i])
+    end
+    AK.styles["np:buffs2"] = BuildNPStyle("buffs", 2)
 end
 
 ------------------------------------------------------------------------------
@@ -745,20 +807,26 @@ end
 
 -- Builds one bundle container from a pre-born shell when available (group add + finish
 -- are combat-legal -- probe T1/T1b), else creates fresh (OOC only; the callers guard).
-local function BundleContainer(b, kind, groupSpec)
+local function BundleContainer(b, kind, groupSpecs)
     local shell = b.shells and b.shells[kind]
     if shell then
         b.shells[kind] = nil
-        AK.AddGroupToContainer(shell, groupSpec)
+        for i = 1, #groupSpecs do
+            AK.AddGroupToContainer(shell, groupSpecs[i])
+        end
         AK.FinishContainer(shell, "none")
         return shell
     end
     return (AK.CreateContainer(b.holder, "none", {
         point = { "CENTER", b.holder, "CENTER" },
-        groups = { groupSpec },
+        groups = groupSpecs,
     }))
 end
 
+-- Declared up top (near PurgeGlowActive, which reads it) rather than here: a
+-- file-scope local is invisible to functions defined above it, and the earlier
+-- reference would silently resolve to a nil global.
+--
 -- Enemy buff narrowing belongs in the FILTER STRING, not in candidateFilters. A candidate
 -- filter is a Lua compare against auraData.isStealable, and aura data on an enemy unit is
 -- SECRET in instanced PvP: there "isStealable ~= true" is true for every buff, so the group
@@ -767,7 +835,6 @@ end
 -- the engine in C, like every filter string, so it stays plain under restriction -- which is
 -- also why the debuff row never broke. Clients predating the token keep the old candidate
 -- filter: no worse than before, and PvE is unaffected either way.
-local DISPELLABLE = AuraUtil and AuraUtil.AuraFilters and AuraUtil.AuraFilters.Dispellable
 
 -- INCLUDE_NAME_PLATE_ONLY matches Blizzard's own buffFilterString: without it a
 -- nameplate-only enemy buff never enters the container at all.
@@ -779,13 +846,16 @@ local function BuffFilter()
     return t
 end
 
+-- Candidate filter for buff group 1. While split it carries Magic only; the
+-- rest of the row moves to group 2.
 local function BuffCand()
+    if BuffSplit() then return BUFF_MAGIC end
     if DISPELLABLE or PVal("showAllEnemyBuffs") then return nil end
     return { isStealable = true }
 end
 
 local function AddBundleDebuffs(b)
-    b.containers.debuffs = BundleContainer(b, "debuffs", {
+    b.containers.debuffs = BundleContainer(b, "debuffs", { {
         key = "np",
         filter = { "HARMFUL", "PLAYER", "INCLUDE_NAME_PLATE_ONLY", "!CROWD_CONTROL" },
         maxFrameCount = PVal("maxDebuffs") or 5,
@@ -793,41 +863,75 @@ local function AddBundleDebuffs(b)
         candidateFilters = DebuffCand(),
         style = "np:debuffs",
         layout = { elementWidth = 26, elementHeight = 26, elementSpacing = 4, lineSpacing = 4 },
-    })
+    } })
 end
 
-local function AddBundleBuffs(b)
-    -- Default: dispellable (purgeable/stealable) enemy buffs only, matching
-    -- the live behavior; "Show All Enemy Buffs" drops the narrowing live
-    -- and falls back to the important-sorted full set.
-    b.containers.buffs = BundleContainer(b, "buffs", {
-        key = "np",
+-- One buff group spec. idx 1 is the whole row while unsplit and the Magic half
+-- while split; idx 2 is the non-Magic half and is only ever declared while the
+-- split is on (it parks at 0 frames afterwards rather than being removed).
+local function BuffGroupSpec(idx)
+    local styleKey = BUFF_STYLE[idx]
+    return {
+        key = (idx == 1) and "np" or "np2",
         filter = BuffFilter(),
         maxFrameCount = 4,
         sortMethod = SORT_IMPORTANT,
-        candidateFilters = BuffCand(),
-        style = "np:buffs",
+        candidateFilters = (idx == 1) and BuffCand() or BUFF_NONMAGIC,
+        style = styleKey,
         -- Purge glow: built on first paint so a button born while the glow is
         -- already on does not wait for the next style pass.
         extraInit = function(btn, dd)
-            local style = AK.styles["np:buffs"]
+            local style = AK.styles[styleKey]
             if style and style.purgeGlow then
                 ApplyNPBuffExtra(btn, dd, style)
             end
         end,
         layout = { elementWidth = 24, elementHeight = 24, elementSpacing = 4, lineSpacing = 4 },
-    })
+    }
+end
+
+local function AddBundleBuffs(b)
+    -- Default: dispellable (purgeable/stealable) enemy buffs only, matching
+    -- the live behavior; "Show All Enemy Buffs" drops the narrowing live
+    -- and falls back to the important-sorted full set. Group 2 is declared
+    -- only once the split is on -- see NPB_ApplyContainer for the later
+    -- declare, which is combat-legal.
+    local specs = { BuffGroupSpec(1) }
+    if BuffSplit() then specs[2] = BuffGroupSpec(2) end
+    b.containers.buffs = BundleContainer(b, "buffs", specs)
+    if #specs > 1 then b.containers.buffs._npbSplit = true end
 end
 
 local function AddBundleCC(b)
-    b.containers.cc = BundleContainer(b, "cc", {
+    b.containers.cc = BundleContainer(b, "cc", { {
         key = "np",
         filter = { "HARMFUL", "CROWD_CONTROL" },
         maxFrameCount = 2,
         sortMethod = SORT_DEFAULT,
         style = "np:cc",
         layout = { elementWidth = 24, elementHeight = 24, elementSpacing = 4, lineSpacing = 4 },
-    })
+    } })
+end
+
+-- Declares or parks the non-Magic buff group to match the current split.
+-- Group frames are never freed, so a group that falls out of the split parks
+-- at 0 rather than being removed.
+local function NPB_ApplyContainer(container)
+    if not container then return end
+    local split = BuffSplit()
+    if split and not container._npbSplit then
+        AK.AddGroupToContainer(container, BuffGroupSpec(2))
+        container._npbSplit = true
+        -- The new group carries the declaration's placeholder sizing until an
+        -- anchor pass reaches it, and that pass skips containers whose layout
+        -- stamp is current -- so drop the stamp.
+        container._npcGeoGen = nil
+        -- A group added after FinishContainer's parse renders nothing until the
+        -- next SetUnit unless this container is asked to re-parse now.
+        if container._npcBoundUnit then container:UpdateAllAuras() end
+    elseif container._npbSplit then
+        container:SetAuraGroupMaxFrameCount("np2", split and 4 or 0)
+    end
 end
 
 -- A skeleton = holder + three bare container shells, born in the early
@@ -994,6 +1098,10 @@ local function AnchorNPContainer(container, kind, plate, slotVal)
         elementSpacing = spacing, lineSpacing = spacing,
     }
     container:SetAuraGroupLayout("np", gLayout)
+    -- The buff row's non-Magic group shares the row's element sizing.
+    if container._npbSplit then
+        container:SetAuraGroupLayout("np2", gLayout)
+    end
     -- NPF record groups share the row's element sizing.
     if container._npfGroups then
         for gkey in pairs(container._npfGroups) do
@@ -1237,7 +1345,7 @@ end
 
 local npFP = {}
 
-local function StyleFPFor(kind)
+local function StyleFPFor(kind, idx)
     local size = NPSize(kind)
     local height = NPHeight(kind, size)
     -- Text settings feed BuildNPStyle, so every input must flip this
@@ -1247,11 +1355,14 @@ local function StyleFPFor(kind)
     local stk = StackCfg()
     local purge = "-"
     if kind == "buffs" and ns.GetDispelGlow then
+        -- Capability and the per-type color toggle both feed BuildNPStyle, so
+        -- they have to reach this fingerprint or a talent swap never restyles.
+        local glow, dispelType = BuffGroupGlow(idx or 1)
         local pr, pg, pb = 0, 0, 0
         if ns.GetDispelGlowColor then
-            pr, pg, pb = ns.GetDispelGlowColor(nil)
+            pr, pg, pb = ns.GetDispelGlowColor(dispelType)
         end
-        purge = FP(PurgeGlowActive(), ns.GetDispelGlowStyle and ns.GetDispelGlowStyle() or 2, pr, pg, pb)
+        purge = FP(idx or 1, glow, ns.GetDispelGlowStyle and ns.GetDispelGlowStyle() or 2, pr, pg, pb)
     end
     local durFP = FP(dur.size, dur.x, dur.y, dur.pos, dur.color.r, dur.color.g, dur.color.b)
     local stkFP = FP(stk.size, stk.x, stk.y, stk.pos, stk.color.r, stk.color.g, stk.color.b)
@@ -1283,8 +1394,10 @@ local function GeoFP()
 end
 
 local function CfgFP()
+    -- BuffSplit decides how many groups the buff row runs, so it belongs with
+    -- the container config rather than with the styles.
     return FP(PVal("maxDebuffs"), PVal("showAllDebuffs"), PVal("showAllEnemyBuffs"),
-        PVal("debuffIncludeCC"), ns.NPF_FP())
+        PVal("debuffIncludeCC"), BuffSplit(), ns.NPF_FP())
 end
 
 local function ReanchorActive()
@@ -1341,6 +1454,9 @@ local function QueueBundleEnsure(b)
         ensure("debuffs", ds, AddBundleDebuffs)
         ensure("buffs", bs, AddBundleBuffs)
         ensure("cc", cs, AddBundleCC)
+        -- Buff split: declare or park the non-Magic group on containers that
+        -- already existed when the player's dispel capability changed.
+        NPB_ApplyContainer(b.containers.buffs)
         -- NPF record groups (Tracked Auras): declare missing variants,
         -- park stale ones, drive the np groups' counts by the configs.
         NPF_EnsureRecords(b)
@@ -1371,14 +1487,15 @@ function ns.NPC_ReloadAll()
         for _, b in pairs(active) do scan(b) end
     end
 
-    local v = StyleFPFor("debuffs") .. ";" .. StyleFPFor("buffs") .. ";" .. StyleFPFor("cc")
+    local v = StyleFPFor("debuffs") .. ";" .. StyleFPFor("buffs") .. ";"
+        .. StyleFPFor("buffs", 2) .. ";" .. StyleFPFor("cc")
     if npFP.style ~= v then
         npFP.style = v
+        BuildNPStyles()
         for i = 1, #KINDS do
-            local kind = KINDS[i]
-            AK.styles["np:" .. kind] = BuildNPStyle(kind)
-            AK.RestyleSoon("np:" .. kind)
+            AK.RestyleSoon("np:" .. KINDS[i])
         end
+        AK.RestyleSoon("np:buffs2")
     end
 
     v = CfgFP()
@@ -1410,6 +1527,9 @@ function ns.NPC_ReloadAll()
                 -- toggle has to re-drive the string (the setter no-ops when unchanged).
                 if b.containers.buffs.SetAuraGroupFilterString then
                     b.containers.buffs:SetAuraGroupFilterString("np", buffFilter)
+                    if b.containers.buffs._npbSplit then
+                        b.containers.buffs:SetAuraGroupFilterString("np2", buffFilter)
+                    end
                 end
             end
             -- NPF record groups + np counts: declares run on the queued,
@@ -1501,9 +1621,7 @@ boot:SetScript("OnEvent", function(self, event)
         if AuraContainerSortDirection then
             SORT_DIR = AuraContainerSortDirection.Normal
         end
-        for i = 1, #KINDS do
-            AK.styles["np:" .. KINDS[i]] = BuildNPStyle(KINDS[i])
-        end
+        BuildNPStyles()
         -- No skeleton pre-birth: creation is combat-legal since 68914, so pool jobs
         -- birth their skeletons inline whenever they run. Plates that spawn before the
         -- first bundles land wait in `waiting` and are serviced as bundles complete.

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -703,38 +703,17 @@ function ns.GetPandemicGlowBackgroundColor()
     return c.r or 0, c.g or 0, c.b or 0
 end
 
--- Dispellable buff glow: taint-safe detection via GetAuraDispelTypeColor
+-- Offensive dispel capability. This asks what the PLAYER knows, never what an
+-- aura is, so it keeps working in restricted content, where a tainted addon's
+-- aura reads are denied outright rather than merely classified.
 do
-    -- Dispel type IDs from SpellDispelType (DB2)
-    local DISPEL_NONE    = 0
-    local DISPEL_MAGIC   = 1
-    local DISPEL_CURSE   = 2
-    local DISPEL_DISEASE = 3
-    local DISPEL_POISON  = 4
-    local DISPEL_ENRAGE  = 9
-
-    -- Color curve for taint-safe dispel detection. Step curve: each point = exact ID. Magic->blue, Enrage->red, others transparent.
-    local dispelDetectionCurve
-    if C_CurveUtil and C_CurveUtil.CreateColorCurve and Enum and Enum.LuaCurveType then
-        dispelDetectionCurve = C_CurveUtil.CreateColorCurve()
-        dispelDetectionCurve:SetType(Enum.LuaCurveType.Step)
-        local clear = CreateColor(0, 0, 0, 0)
-        local blue  = CreateColor(0.2, 0.6, 1.0, 1)
-        local red   = CreateColor(1.0, 0.2, 0.2, 1)
-        dispelDetectionCurve:AddPoint(DISPEL_NONE,    clear)
-        dispelDetectionCurve:AddPoint(DISPEL_MAGIC,   blue)
-        dispelDetectionCurve:AddPoint(DISPEL_CURSE,   clear)
-        dispelDetectionCurve:AddPoint(DISPEL_DISEASE, clear)
-        dispelDetectionCurve:AddPoint(DISPEL_POISON,  clear)
-        dispelDetectionCurve:AddPoint(DISPEL_ENRAGE,  red)
-    end
-
     local _, playerClass = UnitClass("player")
     -- { spellID, category ("Magic", "Enrage", or "Both"), requiredClass or nil, requiredTalent or nil }
     local OFFENSIVE_DISPEL_SPELLS = {
         { 370,    "Magic",  nil       },  -- Purge (Shaman)
         { 378773, "Magic",  nil       },  -- Greater Purge (Shaman)
         { 528,    "Magic",  nil       },  -- Dispel Magic (Priest)
+        { 32375,  "Magic",  nil       },  -- Mass Dispel (Priest)
         { 278326, "Magic",  nil       },  -- Consume Magic (Demon Hunter)
         { 19505,  "Magic",  "WARLOCK" },  -- Devour Magic (Felhunter)
         { 19801,  "Both",   nil       },  -- Tranquilizing Shot (Hunter)
@@ -743,32 +722,41 @@ do
         { 115078, "Enrage", "MONK", 450432 },  -- Paralysis (w/ Pressure Points talent)
     }
     local canDispelMagic, canDispelEnrage = false, false
+    local built = false
+    local BANK = Enum and Enum.SpellBookSpellBank
+
+    -- IsSpellKnown answers "does the player have this", which is the question a
+    -- PASSIVE talent needs -- IsSpellInSpellBook says no for one. The globals
+    -- this used to call (IsPlayerSpell, IsSpellKnown) exist only in
+    -- Blizzard_DeprecatedSpellBook, behind the loadDeprecationFallbacks CVar and
+    -- removed next expansion; with that CVar off the talent branch never fired.
+    local function Knows(spellID, bank)
+        if not (C_SpellBook and C_SpellBook.IsSpellKnown and BANK) then return false end
+        local ok, v = pcall(C_SpellBook.IsSpellKnown, spellID, bank or BANK.Player)
+        return ok and v == true
+    end
+    local function InBook(spellID, bank)
+        if not (C_SpellBook and BANK) then return false end
+        if not C_SpellBook.IsSpellKnownOrInSpellBook then return Knows(spellID, bank) end
+        local ok, v = pcall(C_SpellBook.IsSpellKnownOrInSpellBook, spellID, bank or BANK.Player)
+        return ok and v == true
+    end
+
     local function RebuildDispelTypes()
+        local wasMagic, wasEnrage = canDispelMagic, canDispelEnrage
         canDispelMagic, canDispelEnrage = false, false
         for _, entry in ipairs(OFFENSIVE_DISPEL_SPELLS) do
             local spellID, cat, reqClass, reqTalent = entry[1], entry[2], entry[3], entry[4]
-            if reqClass and playerClass ~= reqClass then
-            else
-                local known = false
-                if reqClass and not reqTalent then
-                    -- Class-gated pet spell: check via pet bank
-                    if C_SpellBook and C_SpellBook.IsSpellKnownOrInSpellBook
-                        and Enum and Enum.SpellBookSpellBank then
-                        known = C_SpellBook.IsSpellKnownOrInSpellBook(spellID, Enum.SpellBookSpellBank.Pet)
-                    elseif IsSpellKnown then
-                        known = IsSpellKnown(spellID, true)
-                    end
-                elseif reqTalent then
-                    -- Talent-gated: check if the talent is known
-                    if IsPlayerSpell then
-                        known = IsPlayerSpell(reqTalent)
-                    elseif IsSpellKnown then
-                        known = IsSpellKnown(reqTalent, false)
-                    end
-                elseif C_SpellBook and C_SpellBook.IsSpellKnownOrInSpellBook then
-                    known = C_SpellBook.IsSpellKnownOrInSpellBook(spellID)
-                elseif IsSpellKnown then
-                    known = IsSpellKnown(spellID, false)
+            if not (reqClass and playerClass ~= reqClass) then
+                local known
+                if reqTalent then
+                    known = Knows(reqTalent)
+                elseif reqClass then
+                    -- Pet bank: true only while that pet is actually out, which
+                    -- is why UNIT_PET is registered below.
+                    known = InBook(spellID, BANK and BANK.Pet)
+                else
+                    known = InBook(spellID)
                 end
                 if known then
                     if cat == "Magic" or cat == "Both" then canDispelMagic = true end
@@ -776,28 +764,34 @@ do
                 end
             end
         end
+        -- Capability picks the buff row's candidate filter, so a change has to
+        -- rebuild the containers, not merely repaint them. The first pass has
+        -- nothing to compare against and nothing built yet, so it never
+        -- notifies -- the pool build reads capability when it runs.
+        if built and (wasMagic ~= canDispelMagic or wasEnrage ~= canDispelEnrage) then
+            if ns.NPC_ReloadAll then ns.NPC_ReloadAll() end
+        end
+        built = true
     end
     local dispelFrame = CreateFrame("Frame")
     dispelFrame:RegisterEvent("SPELLS_CHANGED")
     dispelFrame:RegisterEvent("UNIT_PET")
+    -- A talent swap does not reliably reach SPELLS_CHANGED first, and without
+    -- these a talent-gated entry is only correct after a /reload.
+    dispelFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
+    dispelFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
     dispelFrame:SetScript("OnEvent", function(_, event, unit)
         if event == "UNIT_PET" and unit ~= "player" then return end
         RebuildDispelTypes()
     end)
     RebuildDispelTypes()
 
-    -- Returns shouldGlow, typeColor (ColorMixin or nil). Enemy aura fields are secret in
-    -- Midnight; the curve's typeColor alpha drives visibility (Magic/Enrage=1, else 0). Secret
-    -- RGBA passes safely to C visual functions (SetAlpha/SetVertexColor) since Lua never tests it.
-    ns.CanDispelAura = function(unit, aura)
-        if not (canDispelMagic or canDispelEnrage) then return false end
-        local typeColor
-        if dispelDetectionCurve and C_UnitAuras and C_UnitAuras.GetAuraDispelTypeColor then
-            local ok, c = pcall(C_UnitAuras.GetAuraDispelTypeColor, unit, aura.auraInstanceID, dispelDetectionCurve)
-            if ok and c then typeColor = c end
-        end
-        return true, typeColor
+    -- canDispelMagic, canDispelEnrage. Consumed by the buff row to pick its
+    -- candidate filter and by the glow gate.
+    ns.GetOffensiveDispelTypes = function()
+        return canDispelMagic, canDispelEnrage
     end
+
     ns.GetDispelGlow = function()
         return (p and p.dispelGlow) or defaults.dispelGlow
     end
@@ -807,11 +801,24 @@ do
         if type(raw) == "number" then return raw end
         return 2
     end
-    ns.GetDispelGlowColor = function(typeColor)
-        local useType = (p and p.dispelGlowUseTypeColor)
-        if useType == nil then useType = defaults.dispelGlowUseTypeColor end
-        if useType and typeColor then
-            return typeColor:GetRGBA()  -- secret values pass through to visual ops
+    -- Per-type colors. The buff row is split into a Magic group and a non-Magic
+    -- (enrage) group, so the type is a property of the GROUP and resolves once at
+    -- style-build time -- no per-aura read, which is what made the old
+    -- ColorMixin-per-aura version impossible under 12.1.
+    local TYPE_COLOR = {
+        magic  = { r = 0.2, g = 0.6, b = 1.0 },
+        enrage = { r = 1.0, g = 0.2, b = 0.2 },
+    }
+    function ns.GetDispelGlowUseTypeColor()
+        local v = p and p.dispelGlowUseTypeColor
+        if v == nil then v = defaults.dispelGlowUseTypeColor end
+        return v == true
+    end
+    -- dispelType is "magic", "enrage", or nil for the undifferentiated row.
+    ns.GetDispelGlowColor = function(dispelType)
+        if dispelType and ns.GetDispelGlowUseTypeColor() then
+            local c = TYPE_COLOR[dispelType]
+            if c then return c.r, c.g, c.b end
         end
         local c = (p and p.dispelGlowColor) or defaults.dispelGlowColor
         return c.r, c.g, c.b
@@ -1427,7 +1434,9 @@ local function StopDispelGlow(slot)
     dg.active = false
 end
 
-local function StartDispelGlow(slot, slotSize, typeColor)
+-- Preview only: the live nameplate glow runs through EllesmereUI.Glows on the
+-- engine buttons. dispelType is "magic" / "enrage" / nil.
+local function StartDispelGlow(slot, slotSize, dispelType)
     local dg = slot.dispelGlow
     local styleIdx = ns.GetDispelGlowStyle()
     local styles = PANDEMIC_GLOW_STYLES
@@ -1459,7 +1468,7 @@ local function StartDispelGlow(slot, slotSize, typeColor)
         StopDispelGlow(slot)
     end
 
-    local cr, cg, cb = ns.GetDispelGlowColor(typeColor)
+    local cr, cg, cb = ns.GetDispelGlowColor(dispelType)
 
     if entry.procedural then
         dg.flipTex:Hide()
@@ -1517,14 +1526,10 @@ local function StartDispelGlow(slot, slotSize, typeColor)
     dg.wrapper:Show()
     dg.active = true
     dg.styleIdx = styleIdx
-    -- Curve color alpha controls visibility (Magic/Enrage=1, else 0); it's a secret number, but
-    -- SetAlpha (a C function) accepts secrets. typeColor is nil in preview mode -> fallback alpha 1.
-    if typeColor then
-        local _, _, _, a = typeColor:GetRGBA()
-        dg.wrapper:SetAlpha(a)
-    else
-        dg.wrapper:SetAlpha(1)
-    end
+    -- Always opaque. Visibility used to ride a per-aura dispel-type curve's alpha;
+    -- dispellability is now decided by which aura GROUP the button belongs to, and
+    -- this path only ever draws the options preview.
+    dg.wrapper:SetAlpha(1)
 end
 
 ns.StopDispelGlow = StopDispelGlow

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -300,8 +300,14 @@ initFrame:SetScript("OnEvent", function(self)
             BUFF_COUNT = 1,
             CC_COUNT = 1,
         }
-        -- Type colors for preview dispel glow: Magic (blue), Enrage (red)
-        local previewDispelColors = { CreateColor(0.2, 0.6, 1.0, 1), CreateColor(1.0, 0.2, 0.2, 1) }
+        -- There is one preview buff slot, so it shows the type THIS character removes -- and nil (no glow at all) for a character with no offensive dispel, which is what their nameplates will do.
+        local function PreviewDispelType()
+            local magic, enrage = false, false
+            if ns.GetOffensiveDispelTypes then magic, enrage = ns.GetOffensiveDispelTypes() end
+            if magic then return "magic" end
+            if enrage then return "enrage" end
+            return nil
+        end
         if not _previewHpPct then RandomizePreviewValues() end
         local previewHpPct = _previewHpPct
         local previewHpVal = math.floor(PV_CONST.FAKE_MAX_HP * previewHpPct / 100)
@@ -1702,12 +1708,13 @@ initFrame:SetScript("OnEvent", function(self)
                     ApplyTimerPos(buffs[i].durationText, buffs[i], buffTPos, buffDurSz, buffDurX, buffDurY, buffDurC)
                     PlaceInSlot(buffs[i], buffSlotVal, i, PV_CONST.BUFF_COUNT, buffSz, buffH, buffSpacing, buffXOff, buffYOff)
                     -- Dispel glow preview (always stop first to pick up color/style changes)
+                    local previewType = PreviewDispelType()
                     if showDispelGlowPreview and DBVal("dispelGlow") == true
-                        and DBVal("showAllEnemyBuffs") ~= true then
+                        and DBVal("showAllEnemyBuffs") ~= true and previewType then
                         if buffs[i].dispelGlow and buffs[i].dispelGlow.active then
                             ns.StopDispelGlow(buffs[i])
                         end
-                        ns.StartDispelGlow(buffs[i], buffSz, previewDispelColors[i])
+                        ns.StartDispelGlow(buffs[i], buffSz, previewType)
                     elseif buffs[i].dispelGlow and buffs[i].dispelGlow.active then
                         ns.StopDispelGlow(buffs[i])
                     end
@@ -3301,10 +3308,11 @@ initFrame:SetScript("OnEvent", function(self)
             return DBVal("dispelGlow") ~= true
         end
 
-        -- Shared graying for inline swatch/eye: Show All Enemy Buffs suppresses the glow entirely (not dispellable-only), locking style/color controls.
+        -- Shared graying for inline swatch/eye: Show All Enemy Buffs suppresses the glow entirely (not dispellable-only), locking style/color controls. checkTypeColor additionally locks the custom color, which per-type coloring replaces.
         local function dispelGlowLocked(checkTypeColor)
             if dispelGlowOff() then return true end
-            return DBVal("showAllEnemyBuffs") == true
+            if DBVal("showAllEnemyBuffs") == true then return true end
+            return checkTypeColor and DBVal("dispelGlowUseTypeColor") == true
         end
 
         local dispelGlowStyleValues = { [0] = "None" }
@@ -3436,6 +3444,21 @@ initFrame:SetScript("OnEvent", function(self)
                 eyeBtn:EnableMouse(not off)
             end)
         end
+
+        -- Magic buffs and enrages are separate groups in the buff row, so the color can follow the type. Only meaningful when the player removes both kinds; with one kind the row already glows in a single color.
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Color Dispel Glow by Type",
+              tooltip="Blue on Magic buffs, red on enrages.",
+              disabled=function() return dispelGlowLocked(false) end,
+              disabledTooltip="Dispel Glow Style",
+              getValue=function() return DBVal("dispelGlowUseTypeColor") or false end,
+              setValue=function(v)
+                DB().dispelGlowUseTypeColor = v
+                RefreshAllAuras()
+                UpdatePreview()
+                C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
+              end },
+            { type="label", text="" });  y = y - h
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug report (@nCarbon, v8.8.7): the nameplate Dispel Glow lights on enemy
buffs the player cannot dispel, and stays dark on ones they can.

The glow signalled ROW MEMBERSHIP, not capability. The buff row is narrowed with
`AuraUtil.AuraFilters.Dispellable`, which Blizzard documents as dispellable
"regardless of whether the player's raid can dispel them", and the glow then lit
every member of that row. A Mistweaver saw Captain's Bulwark (Magic) glow when
they only have Soothe; a Druid saw an enrage they CAN Soothe stay dark.

The addon already had capability-aware code with zero callers, and it could not
be revived as written: it classified each aura through `GetAuraDispelTypeColor`,
and in restricted content a tainted addon's aura reads are denied outright
rather than merely classified.

So the dispel type becomes a property of the aura GROUP, which the engine
resolves in its own Lua:

* The buff row splits into group `np` (`includeDispelTypes` Magic) and group
  `np2` (`excludeDispelTypes` Magic). The two are exact complements -- an enrage
  has no `dispelName`, so include rejects it and exclude keeps it.
* Only the group matching the player's capability glows. **Nothing is hidden**:
  every dispellable buff still renders, exactly as before.
* The split is taken only when the halves must differ -- one dispel type known
  and not the other, or both known with per-type colors on. A player who removes
  both kinds runs a single group, as today.
* Group 2 is declared lazily and parks at 0 frames when the split ends, so a
  character with no offensive dispel pays nothing.

Capability detection is rebuilt on the same pass. It called `IsPlayerSpell` /
`IsSpellKnown`, which live only in `Blizzard_DeprecatedSpellBook` behind the
`loadDeprecationFallbacks` CVar and are removed next expansion -- with that CVar
off, the talent branch never fired at all. It now uses `C_SpellBook.IsSpellKnown`
for talents (`IsSpellKnownOrInSpellBook` answers no for a passive) and registers
`TRAIT_CONFIG_UPDATED` and `PLAYER_ENTERING_WORLD`, so a talent swap no longer
needs a /reload. Mass Dispel was missing from the Priest entries.

Revives `dispelGlowUseTypeColor`, which had a default and no control: blue on
Magic, red on enrages. Off by default.

### Cost

No new per-frame work and no new allocation on a chatty event. One extra engine
group (4 buttons) per plate, only while split, declared lazily and parked at 0
afterwards. Two new registrations, both rare: `TRAIT_CONFIG_UPDATED` and
`PLAYER_ENTERING_WORLD`, each a 12-entry spellbook scan that no-ops unless
capability actually changed.

### Named trade-offs

1. While split, the row can reach 8 icons (4 per group) where it capped at 4.
   Dispellable enemy buffs are rare enough that this should not materialise in
   practice, but it is a real change.
2. Groups cluster rather than interleave: Magic icons sort ahead of enrages
   regardless of importance within the row.
3. Fail direction is "wrong, never late". A dispellable non-Magic enemy buff
   that is not an enrage would glow for a Soothe-capable player. I know of no
   such aura, but the deduction is ours, not the API's.

## How was it tested?

Live, 12.1.0 (build 69299). All four capability quadrants:

| Player | Magic buff | Enrage |
|---|---|---|
| Druid, Soothe talented | - | glows |
| Druid, untalented in place | - | dark (no /reload) |
| Shaman (Purge) | glows | dark |
| Hunter (Tranquilizing Shot) | glows | glows |
| Warlock, Felhunter out / dismissed | glows / stops | - |

Also verified: per-type colors on (blue/red) and off (single custom color), and
Show All Enemy Buffs suppressing the glow entirely.

**Known gap, stated plainly:** every test above was in unrestricted content. The
split reads `auraData.dispelName` through a candidate filter, and this repo
already documents a field incident where the `isStealable` candidate filter
matched nothing in instanced PvP because enemy aura data was redacted there (see
the comment above `BuffFilter`). If `dispelName` is redacted the same way, every
buff falls into the exclude-Magic group: a Magic-only dispeller would lose the
glow, and an enrage-only dispeller would see all of it glow. Untested. Happy to
gate the split on `AK.AurasRestricted()` as a fallback if reviewers prefer that
over waiting on a restricted-content capture.

Not yet tested: first plates after an in-combat /reload.

## Screenshots

<img width="663" height="498" alt="screenshot-2026-08-16_18-59-00" src="https://github.com/user-attachments/assets/682a3086-5a06-42ad-bf6b-b518fe2f2d30" />
<img width="649" height="565" alt="screenshot-2026-08-16_18-58-47" src="https://github.com/user-attachments/assets/412a621f-b1c1-4277-b71c-d8531e1fa4ba" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- the new
      `dispelGlowUseTypeColor` defaults off. The glow gate itself does change
      behavior without opt-in, because that is the bug being fixed.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added -- this
      REMOVES deprecated API calls rather than adding any
