### PR TITLE
CDM: force a reanchor once Blizzard's data catches up

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -9262,6 +9262,10 @@ function ECME:OnEnable()
             if CheckCDMDataLoaded() then
                 self:UnregisterAllEvents()
                 self:SetScript("OnEvent", nil)
+                -- SetupViewerHooks' own 0.2/1/3/6s reanchor retries can all fire before
+                -- Blizzard's data actually becomes ready on a slow login and never try
+                -- again. Catch up now.
+                if ns.QueueReanchor then ns.QueueReanchor() end
             end
         end)
     end


### PR DESCRIPTION
Cause: on a slow login, CDM icons can be missing (only our own preset racial/trinket icons render) and the racial icon stretches to fill a bar sized for the full set. The layout runs before SetupViewerHooks installs, and its 0.2/1/3/6s reanchor retries can all fire before Blizzard's CDM data is actually ready, with nothing trying again after.

Fix: queue a reanchor on the existing CheckCDMDataLoaded readiness signal instead of relying only on the fixed retries.

Test: verified in-game on a cold login.

<img width="350" height="192" alt="Carl Weathers Friendship GIF (1)" src="https://github.com/user-attachments/assets/cc63168a-de92-4bc0-bc75-054018fd2460" />
