### PR TITLE
add 40 man raid

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_Options.lua
@@ -4290,8 +4290,8 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- One row per defined custom raid size.
         do
-            local CUSTOM_TIERS = { 10, 15, 25, 30 }
-            local TIER_LABELS = { [10] = "10 Man", [15] = "15 Man", [25] = "25 Man", [30] = "30 Man" }
+            local CUSTOM_TIERS = { 10, 15, 25, 30, 40 }
+            local TIER_LABELS = { [10] = "10 Man", [15] = "15 Man", [25] = "25 Man", [30] = "30 Man", [40] = "40 Man" }
             local overrides = db.profile.raidSizeOverrides
             local EYE_VISIBLE   = EllesmereUI.EYE_VISIBLE_ICON
             local EYE_INVISIBLE = EllesmereUI.EYE_INVISIBLE_ICON
@@ -4476,6 +4476,8 @@ initFrame:SetScript("OnEvent", function(self)
                                      tip = "Group size at which this layout takes over from the 20 Man layout." },
                             [30] = { key = "sizeMin", label = "Switch At", def = 26, min = 22, max = 40,
                                      tip = "Group size at which this layout takes over from the 25 Man layout." },
+                            [40] = { key = "sizeMin", label = "Switch At", def = 31, min = 31, max = 40,
+                                     tip = "Group size at which this layout takes over from the 30 Man layout." },
                         }
                         local tb = TIER_BOUNDS[tier]
                         local _, cogShow = EllesmereUI.BuildCogPopup({

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -1192,7 +1192,7 @@ end
 -------------------------------------------------------------------------------
 --  Raid size tier resolution: width/height for a group size from the defined
 --  overrides, cascading toward 20-man (the base) when a tier is undefined.
---  Tiers: 10, 15, 20(base), 25, 30
+--  Tiers: 10, 15, 20(base), 25, 30, 40
 -------------------------------------------------------------------------------
 ns._GetRaidSizeFrameDimensions = function(groupSize)
     local s = db.profile
@@ -7203,26 +7203,30 @@ ns._RFResolveTierOverride = function(numMembers)
     -- User-tunable switch boundaries (per-tier cog sliders): the LOWER tiers
     -- store the highest count they COVER (sizeCap), the UPPER tiers the
     -- count they ENGAGE at (sizeMin). Absent keys reproduce the classic
-    -- cascade exactly (10/15/20, 25 engaging at 21, 30 at 26), so profiles
-    -- that never touch the sliders resolve byte-identically.
-    local o10, o15, o25, o30 = overrides[10], overrides[15], overrides[25], overrides[30]
+    -- cascade exactly (10/15/20, 25 engaging at 21, 30 at 26, 40 at 31), so
+    -- profiles that never touch the sliders resolve byte-identically.
+    local o10, o15, o25, o30, o40 = overrides[10], overrides[15], overrides[25], overrides[30], overrides[40]
     local b10 = (o10 and o10.sizeCap) or 10
     local b15 = (o15 and o15.sizeCap) or 15
     local b25 = (o25 and o25.sizeMin) or 21
     local b30 = (o30 and o30.sizeMin) or 26
+    local b40 = (o40 and o40.sizeMin) or 31
     local tier
     if numMembers <= b10 then    tier = 10
     elseif numMembers <= b15 then tier = 15
     elseif numMembers < b25 then tier = 20
     elseif numMembers < b30 then tier = 25
-    else                         tier = 30
+    elseif numMembers < b40 then tier = 30
+    else                         tier = 40
     end
     if tier == 20 then return 20, nil end
     local ov
     if tier < 20 then
         ov = overrides[tier] or (tier == 10 and overrides[15]) or nil
     else
-        ov = overrides[tier] or (tier == 30 and overrides[25]) or nil
+        ov = overrides[tier]
+        if not ov and tier == 30 then ov = overrides[25] end
+        if not ov and tier == 40 then ov = overrides[30] or overrides[25] end
     end
     return tier, ov or nil
 end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

add 40 man option for open world stuff

## How was it tested?

Tested in game 

## Screenshots

<img width="1460" height="891" alt="image" src="https://github.com/user-attachments/assets/2eeab23b-76d8-4ebf-a996-449669488106" />
<img width="1682" height="913" alt="image" src="https://github.com/user-attachments/assets/2e5d58c7-4d52-47fe-baa6-8ae15e5b94f8" />

## Checklist

N/A

- [y] New settings default **OFF** (no behavior change without opt-in)
- [y ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ y] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [y ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [y ] Tested in-game on live; no version gates or pre-Midnight APIs added
