### PR TITLE
fix(locale): Player Aura Bars names never reached L()

### DIFF
--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -352,7 +352,10 @@ local function BuildBuffBarSubtitle(bar)
                 local f = allFilters[i]
                 if bar.filters[f.id] then
                     totalSelected = totalSelected + 1
-                    if #names < 3 then names[#names + 1] = f.name end
+                    -- L() before the truncate below: preset filters carry raw
+                    -- English names (see PAB's BM2_FILTER_SEED), and truncating
+                    -- first would leave the tail untranslatable.
+                    if #names < 3 then names[#names + 1] = L(f.name) end
                 end
             end
         end
@@ -2029,7 +2032,7 @@ local function BuildBuffBarDetail(frame, fontPath, bar)
     end
     local body = WrapCompensatedBody(frame, scrollTop)
     local by = 0
-    by = BuildBarTitle(body, fontPath, bar.name or L("Buff Bar"), L("Custom buff bar"), by)
+    by = BuildBarTitle(body, fontPath, L(bar.name or "Buff Bar"), L("Custom buff bar"), by)
     by = BuildAssignedBuffsFields(body, fontPath, by, bar, ApplyBar)
     by = BuildCoreFields(body, fontPath, by, bar, ApplyBar, true)
     by = BuildDisplayFields(body, fontPath, by, bar, ApplyBar, true)
@@ -2056,7 +2059,7 @@ local function BuildDebuffBarDetail(frame, fontPath, bar)
     end
     local body = WrapCompensatedBody(frame, scrollTop)
     local by = 0
-    by = BuildBarTitle(body, fontPath, bar.name or L("Debuff Bar"), L("Custom debuff bar"), by)
+    by = BuildBarTitle(body, fontPath, L(bar.name or "Debuff Bar"), L("Custom debuff bar"), by)
     by = BuildAssignedDebuffsFields(body, fontPath, by, bar, ApplyBar)
     by = BuildCoreFields(body, fontPath, by, bar, ApplyBar, false)
     by = BuildDisplayFields(body, fontPath, by, bar, ApplyBar, false)
@@ -2374,7 +2377,7 @@ function ns.PABMP_ShowFilterEditor()
             edit:SetScript("OnLeave", function(self) self:SetAlpha(0.5); EllesmereUI.HideWidgetTooltip() end)
             edit:SetScript("OnClick", function()
                 EditorInput({
-                    title = L("Rename Filter"), placeholder = f.name,
+                    title = L("Rename Filter"), placeholder = L(f.name),
                     confirmText = L("Rename"), cancelText = L("Cancel"),
                     onConfirm = function(text) ns.PAB_RenameFilter(f.id, text); Rebuild() end,
                 })
@@ -2448,7 +2451,7 @@ function ns.PABMP_ShowFilterEditor()
         ren:SetScript("OnLeave", function() rl:SetAlpha(0.9) end)
         ren:SetScript("OnClick", function()
             EditorInput({
-                title = L("Rename Filter"), placeholder = sel.name,
+                title = L("Rename Filter"), placeholder = L(sel.name),
                 confirmText = L("Rename"), cancelText = L("Cancel"),
                 onConfirm = function(text) ns.PAB_RenameFilter(sel.id, text); Rebuild() end,
             })
@@ -3197,7 +3200,7 @@ function ns.PABMP_BuildPage(pageName, parent, yOffset)
                 local kind = isBuff and "buff" or "debuff"
                 tileY = tileY - BuildTile(sectionChild, tileY, {
                     width = sidebarW, fontPath = fontPath,
-                    title = bar.name or (isBuff and L("Buff Bar") or L("Debuff Bar")),
+                    title = L(bar.name or (isBuff and "Buff Bar" or "Debuff Bar")),
                     subtitle = gname,
                     inheritedTooltip = EllesmereUI.Lf("Inherited from %1$s. Editable only there.", gname),
                     selected = (pabInhSel and pabInhSel.kind == kind
@@ -3262,7 +3265,7 @@ function ns.PABMP_BuildPage(pageName, parent, yOffset)
             local bar = buffBars[i]
             tileY = tileY - BuildTile(sidebarChild, tileY, {
                 width = sidebarW, fontPath = fontPath,
-                title = bar.name or L("Buff Bar"),
+                title = L(bar.name or "Buff Bar"),
                 subtitleFn = function() return BuildBuffBarSubtitle(bar) end,
                 selected = (pabSel and pabSel.kind == "buff" and pabSel.id == bar.id
                     and not pabInhSel) and true or false,
@@ -3294,7 +3297,7 @@ function ns.PABMP_BuildPage(pageName, parent, yOffset)
                 end,
                 onRename = function()
                     EllesmereUI:ShowInputPopup({
-                        title = L("Rename Bar"), placeholder = bar.name or L("Buff Bar"),
+                        title = L("Rename Bar"), placeholder = L(bar.name or "Buff Bar"),
                         confirmText = L("Rename"), cancelText = L("Cancel"),
                         onConfirm = function(text)
                             if text and text ~= "" then
@@ -3367,7 +3370,7 @@ function ns.PABMP_BuildPage(pageName, parent, yOffset)
             local bar = debuffBars[i]
             tileY = tileY - BuildTile(sidebarChild, tileY, {
                 width = sidebarW, fontPath = fontPath,
-                title = bar.name or L("Debuff Bar"),
+                title = L(bar.name or "Debuff Bar"),
                 subtitleFn = function() return BuildDebuffBarSubtitle(bar) end,
                 selected = (pabSel and pabSel.kind == "debuff" and pabSel.id == bar.id
                     and not pabInhSel) and true or false,
@@ -3399,7 +3402,7 @@ function ns.PABMP_BuildPage(pageName, parent, yOffset)
                 end,
                 onRename = function()
                     EllesmereUI:ShowInputPopup({
-                        title = L("Rename Bar"), placeholder = bar.name or L("Debuff Bar"),
+                        title = L("Rename Bar"), placeholder = L(bar.name or "Debuff Bar"),
                         confirmText = L("Rename"), cancelText = L("Cancel"),
                         onConfirm = function(text)
                             if text and text ~= "" then


### PR DESCRIPTION
### Problem

On a non-English client, the Player Aura Bars page shows some bar and filter
names in English even though the catalog has translated them. The clearest
case is the seeded External Defensives bar: its sidebar tile reads
`External Defensives` and its subtitle reads `Externals`, while
`L["External Defensives"]` and `L["Externals"]` have shipped in every locale
for a while. Display only - no setting, position or saved value is affected.

Repro: run a non-English client (zhTW here), open Unit Frames -> Player Aura
Bars, and look at the External Defensives tile in the buff bars sidebar.

### Cause

The page renders `bar.name` and `filter.name` straight from the saved config.
Both are user-renameable fields, so the page never passed them through L().
That is fine for a name the user typed, but the seeded and fallback names are
raw English catalog keys, and those never reached the catalog.

The module side is already correct and is not touched here: it deliberately
stores raw English keys and leaves translation to the options page, the
convention recorded in the comment above `DefaultBuffBarName`, which does
exactly `L(ns.PAB_DefaultBuffsName(cfg) or "Buffs")`. Several sites in the
same file already follow it (`rl:SetText(L(f.name))`,
`values[g.key] = L(g.name)`); the ones below did not.

### Fix

`L()` is identity on a miss, so wrapping is safe for user-typed names - they
are not in the catalog and pass through unchanged. Only the untranslated
English defaults change.

- Sidebar tile titles, inherited tile titles and both detail-pane titles:
  `bar.name or L("Buff Bar")` becomes `L(bar.name or "Buff Bar")`, matching
  `DefaultBuffBarName`'s shape.
- The assigned-filters subtitle: wrap `f.name`. This is the one that left
  `Externals` in English. The wrap goes before `TruncateFilterName`, so the
  three-name truncation does not leave an untranslatable tail.
- The four Rename Bar / Rename Filter placeholders, for consistency with the
  list rows that already wrapped the same values. These are placeholder
  hints only; `onConfirm` still stores exactly what the user typed, so no
  translated string can be persisted into saved variables.

### Notes

- Deliberately not changed: the seeded name literal in the module. It is
  written into saved variables once per profile, so editing it would not
  reach anyone who already has the bar, and putting a translated value there
  would freeze the client language into the saved config and be
  indistinguishable from a user rename.
- The Unlock Mode mover label still needs its own entry rather than this
  wrap: the module builds `"PAB: " .. bar.name` and EUI_UnlockMode looks the
  whole composite up as one key. Covered by catalog additions in #1538, not
  by this PR.
- Pre-existing and left alone: `L["Support"]` is shared by the minimap help
  button and the `Support` buff-preset filter category, so that filter now
  renders with the minimap's wording. The Filter Editor list already showed
  it that way before this PR (it already wrapped `f.name`); this change just
  makes it visible in one more place. Fixing it properly means
  disambiguating the key in `EllesmereUI_BuffPresets.lua`, which the
  seed-by-name lookup in `EnsureExtDefCustomBar` would need handling for, so
  it does not belong in this diff.

### Testing

In-game on live (12.1), zhTW client:

- External Defensives tile -> title and subtitle both render translated.
- A bar renamed by hand -> still shows the typed name, untouched.
- Filter Editor rename dialogs -> placeholders match the list rows.
- Compiles under Lua 5.1 (loadstring, compile-only).

### Screenshots

Before: the tile reads `External Defensives` / `Externals` on a zhTW client.
After: it reads the catalog's existing translations for those two keys.

### Checklist

- [x] N/A - no new settings
- [x] N/A - display-path change only, no events, hooks or frames added
- [x] N/A - no new work per frame; the wraps sit on existing page-build paths
- [x] N/A - no Blizzard frames touched
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
