### PR TITLE
Fix power type resetting to mana, and its per-spec key colliding across classes

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -7691,23 +7691,34 @@ initFrame:SetScript("OnEvent", function(self)
                     powerTypeRow, h = W:DualRow(parent, y,
                         { type="dropdown", text="Power Type",
                           values = ptValues, order = ptOrder,
+                          -- Stored by SPEC ID, not the GetSpecialization() index:
+                          -- one profile holds one set, so an index key collides
+                          -- across classes (slot 3 is Guardian, Shadow AND
+                          -- Augmentation, which want three different power types).
+                          -- classAlts stays index-keyed, it is already per class.
                           getValue = function()
                               local s = GetSpecialization and GetSpecialization()
                               if not s or not classAlts[s] then return "default" end
+                              local sid = C_SpecializationInfo
+                                  and C_SpecializationInfo.GetSpecializationInfo(s)
+                              if not sid then return "default" end
                               local p = DB(); if not p then return "default" end
                               local ov = p.primary.powerTypeOverride
-                              if ov and ov[s] then return "alt" end
+                              if ov and ov[sid] then return "alt" end
                               return "default"
                           end,
                           setValue = function(v)
                               local s = GetSpecialization and GetSpecialization()
                               if not s then return end
+                              local sid = C_SpecializationInfo
+                                  and C_SpecializationInfo.GetSpecializationInfo(s)
+                              if not sid then return end
                               local p = DB(); if not p then return end
                               if v == "alt" then
                                   if not p.primary.powerTypeOverride then p.primary.powerTypeOverride = {} end
-                                  p.primary.powerTypeOverride[s] = true
+                                  p.primary.powerTypeOverride[sid] = true
                               else
-                                  if p.primary.powerTypeOverride then p.primary.powerTypeOverride[s] = nil end
+                                  if p.primary.powerTypeOverride then p.primary.powerTypeOverride[sid] = nil end
                               end
                               RebuildPower()
                           end },

--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -7923,22 +7923,32 @@ initFrame:SetScript("OnEvent", function(self)
                 sharedPowerRow5, h = W:DualRow(parent, y,
                     { type="dropdown", text="Power Type",
                       values = ptValues, order = ptOrder,
+                      -- Stored by SPEC ID, not the GetSpecialization() index: one
+                      -- profile holds one set, so an index key collides across
+                      -- classes (slot 3 is Guardian, Shadow AND Augmentation).
+                      -- classAlts stays index-keyed, it is already per class.
                       getValue = function()
                           local s = GetSpecialization and GetSpecialization()
                           if not s or not classAlts[s] then return "default" end
+                          local sid = C_SpecializationInfo
+                              and C_SpecializationInfo.GetSpecializationInfo(s)
+                          if not sid then return "default" end
                           local ov = UNIT_DB_MAP["player"]().powerTypeOverride
-                          if ov and ov[s] then return "alt" end
+                          if ov and ov[sid] then return "alt" end
                           return "default"
                       end,
                       setValue = function(v)
                           local s = GetSpecialization and GetSpecialization()
                           if not s then return end
+                          local sid = C_SpecializationInfo
+                              and C_SpecializationInfo.GetSpecializationInfo(s)
+                          if not sid then return end
                           local pdb = UNIT_DB_MAP["player"]()
                           if v == "alt" then
                               if not pdb.powerTypeOverride then pdb.powerTypeOverride = {} end
-                              pdb.powerTypeOverride[s] = true
+                              pdb.powerTypeOverride[sid] = true
                           else
-                              if pdb.powerTypeOverride then pdb.powerTypeOverride[s] = nil end
+                              if pdb.powerTypeOverride then pdb.powerTypeOverride[sid] = nil end
                           end
                           ReloadAndUpdate()
                       end },

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -381,12 +381,18 @@ local function GetPrimaryPowerType()
     local _, classFile = UnitClass("player")
     local spec = GetSpecialization()
     local form = GetShapeshiftFormID()
+    -- powerTypeOverride is keyed by SPEC ID, never by the GetSpecialization()
+    -- index: one profile holds one set, so an index key collides across classes
+    -- and the same flag means opposite things per class (slot 3 is Guardian,
+    -- Shadow and Augmentation, wanting Mana, Insanity and Ebon Might). Cached, so
+    -- this is one table read after the first call per spec.
+    local ovSpec = _G._ERB_ResolveSpecIDCached and _G._ERB_ResolveSpecIDCached() or nil
 
     -- Druid form handling
     if classFile == "DRUID" then
         local pp = ERB.db and ERB.db.profile and ERB.db.profile.primary
         local ov = pp and pp.powerTypeOverride
-        if ov and ov[spec] then
+        if ovSpec and ov and ov[ovSpec] then
             if spec == 1 then return PT.LUNAR_POWER end  -- Balance alt: Astral Power
             return PT.MANA                                -- Feral/Guardian alt: Mana
         end
@@ -398,12 +404,12 @@ local function GetPrimaryPowerType()
     if classFile == "SHAMAN" and spec == 1 then
         local pp = ERB.db and ERB.db.profile and ERB.db.profile.primary
         local ov = pp and pp.powerTypeOverride
-        if ov and ov[spec] then return PT.MAELSTROM end  -- Elemental alt: Maelstrom
+        if ovSpec and ov and ov[ovSpec] then return PT.MAELSTROM end  -- Elemental alt: Maelstrom
     end
     if classFile == "PRIEST" and spec == 3 then
         local pp = ERB.db and ERB.db.profile and ERB.db.profile.primary
         local ov = pp and pp.powerTypeOverride
-        if ov and ov[spec] then return PT.INSANITY end   -- Shadow alt: Insanity
+        if ovSpec and ov and ov[ovSpec] then return PT.INSANITY end   -- Shadow alt: Insanity
     end
     if classFile == "HUNTER" then
         -- BM/MM show Focus as the class resource bar, not power; Survival keeps
@@ -425,7 +431,9 @@ local function GetPrimaryPowerType()
     if classFile == "EVOKER" and spec == 3 then
         local pp = ERB.db and ERB.db.profile and ERB.db.profile.primary
         local ov = pp and pp.powerTypeOverride
-        if not (ov and ov[spec]) then return "EBON_MIGHT" end
+        -- Inverted against the others: Augmentation's DEFAULT is Ebon Might and
+        -- the override opts into plain Mana. Same spec-ID key either way.
+        if not (ovSpec and ov and ov[ovSpec]) then return "EBON_MIGHT" end
         return PT.MANA
     end
 

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -8779,6 +8779,41 @@ do
 end
 
 
+-- Login race on the primary power type. GetPrimaryPowerType branches on
+-- GetSpecialization(), which can still read nil half a second after
+-- PLAYER_ENTERING_WORLD on a slow login (heavy addon load). Every class whose spec
+-- power differs from its class base falls through to MANA on a nil spec -- Shadow
+-- loses Insanity, Guardian loses Rage, Augmentation loses Ebon Might -- and
+-- PLAYER_SPECIALIZATION_CHANGED fires only on a CHANGE, never at login, so the
+-- wrong value stayed cached for the whole session. Reported as "power type resets
+-- to mana every time I log in".
+--
+-- Retry until the spec reads, then re-resolve exactly what the spec-change branch
+-- does. Costs one call and no timer when the spec is already available, which is
+-- the common case. The attempt cap matters: a character with no specialization
+-- chosen reads nil forever, so an uncapped retry would arm timers for the session.
+local _specResolveTries = 0
+local ScheduleSpecResolve
+ScheduleSpecResolve = function()
+    if GetSpecialization() then _specResolveTries = 0; return end
+    if _specResolveTries >= 40 then return end   -- ~20s, then stop rather than spin
+    _specResolveTries = _specResolveTries + 1
+    C_Timer.After(0.5, function()
+        if not GetSpecialization() then
+            ScheduleSpecResolve()
+            return
+        end
+        _specResolveTries = 0
+        ns.InvalidateThresholdCaches()
+        cachedPrimary = GetPrimaryPowerType()
+        cachedSecondary = GetSecondaryResource()
+        BuildBars()
+        UpdatePrimaryBar()
+        UpdateSecondaryResource()
+        UpdateVisibility()
+    end)
+end
+
 -- Event handling
 local function OnEvent(self, event, ...)
     if event == "UNIT_HEALTH" then
@@ -8963,6 +8998,9 @@ local function OnEvent(self, event, ...)
         C_Timer.After(0.5, function()
             ERB:ApplyAll()
             RegisterUnlockElements()
+            -- ApplyAll just cached the power type off a spec that may not have
+            -- loaded yet; correct it once it does.
+            ScheduleSpecResolve()
         end)
     elseif event == "UNIT_SPELLCAST_START" then
         local unit = ...

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2241,8 +2241,16 @@ function EllesmereUI.GetPlayerPowerOverride()
     if not (classDef or classAlt) then return nil end
     local spec = GetSpecialization and GetSpecialization()
     if not spec then return nil end
+    -- powerTypeOverride is keyed by SPEC ID, never the GetSpecialization() index:
+    -- the set is profile-wide, so an index key collides across classes (slot 3 is
+    -- Guardian, Shadow AND Augmentation). classAlt/classDef stay index-keyed --
+    -- they are nested per class already, so they cannot collide. Resource Bars may
+    -- be disabled, hence the direct fallback.
+    local sid = (_G._ERB_ResolveSpecIDCached and _G._ERB_ResolveSpecIDCached())
+        or (C_SpecializationInfo and C_SpecializationInfo.GetSpecializationInfo(spec))
+        or nil
     local ov = db.profile.player and db.profile.player.powerTypeOverride
-    if ov and ov[spec] and classAlt then
+    if sid and ov and ov[sid] and classAlt then
         return classAlt[spec]
     elseif classDef and classDef[spec] ~= nil then
         return classDef[spec]


### PR DESCRIPTION
## Cause
Two bugs stacked. ApplyAll caches the primary power type 0.5s after
PLAYER_ENTERING_WORLD; on a slow login GetSpecialization() still reads nil and
every class whose spec power differs from its class base falls through to MANA
(Shadow loses Insanity, Guardian Rage, Augmentation Ebon Might).
PLAYER_SPECIALIZATION_CHANGED fires only on a change, never at login, so the wrong
value stayed cached. Separately, powerTypeOverride was keyed by the
GetSpecialization() INDEX, and one profile holds one set, so slot 3 is Guardian,
Shadow and Augmentation at once, wanting three different power types.

## Fix
ScheduleSpecResolve retries until the spec reads, then re-resolves what the
spec-change branch does (no timer when the spec is already there; the attempt cap
stops a spec-less character arming timers all session). Both writers and all five
readers now key by spec ID via the existing cached resolver. Per-class
classAlts/PLAYER_POWER_* tables stay index-keyed, being nested per class already.
Old index keys are ignored rather than deleted, since a key of 3 cannot be
attributed to a class after the fact; anyone who had this set re-ticks once.

## Test
Verified in game on a build stamped 8.9.1-powerfix1. Shadow set to Insanity
survives a full logout (previously reverted to mana). With Shadow left on
Insanity, Guardian reads Rage in bear form and Augmentation reads Ebon Might in
the same session, which was impossible before.

<img width="200" height="200" alt="gif" src="https://github.com/user-attachments/assets/8459aef7-723b-4d61-bec2-c65079d02127" />

