### PR TITLE
Refactor IsWarboundExcluded to use bind type checks

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -231,18 +231,25 @@ qolFrame:SetScript("OnEvent", function(self)
         local function BankOpen()
             return (BankFrame and BankFrame:IsShown()) and true or false
         end
-        -- "Exclude Warbound Containers": true only when on AND the slot is confirmed
-        -- warband-bank-eligible. Guarded like the bags module (C_Bank/ItemLocation/
-        -- DoesItemExist can be absent or invalid); any uncertainty returns false so the container opens normally.
+        -- "Exclude Warbound Containers": checks the item's own bind type
+        -- instead of asking the bank if it would accept a deposit right now --
+        -- that answer needs a live bank session and defaults to "no" outdoors,
+        -- which let warbound items open anyway. Bind type works anywhere.
+        local WARBOUND_BIND_TYPES = {
+            [Enum.ItemBind.ToWoWAccount] = true,
+            [Enum.ItemBind.ToBnetAccount] = true,
+            [Enum.ItemBind.ToBnetAccountUntilEquipped] = true,
+        }
         local function IsWarboundExcluded(bag, slot)
             -- Default ON (unset behaves as enabled, matching the options UI's
             -- checked-by-default display); only explicit false disables it -- `not value` would wrongly let nil skip the exclusion.
             if not EllesmereUIDB or EllesmereUIDB.autoOpenContainersExcludeWarbound == false then return false end
-            if not (C_Bank and C_Bank.IsItemAllowedInBankType and ItemLocation
-                and C_Item and C_Item.DoesItemExist) then return false end
-            local loc = ItemLocation:CreateFromBagAndSlot(bag, slot)
-            if not (loc and C_Item.DoesItemExist(loc)) then return false end
-            return C_Bank.IsItemAllowedInBankType(Enum.BankType.Account, loc) and true or false
+            if not (C_Container and C_Container.GetContainerItemInfo and C_Item and C_Item.GetItemInfo) then return false end
+            local info = C_Container.GetContainerItemInfo(bag, slot)
+            if not (info and info.itemID) then return false end
+            local _, _, _, _, _, _, _, _, _, _, _, _, _, bindType = C_Item.GetItemInfo(info.itemID)
+            if not bindType then return false end
+            return WARBOUND_BIND_TYPES[bindType] == true
         end
         local SLOTS_PER_FRAME = 3  -- check 3 slots per OnUpdate tick
 
@@ -257,6 +264,14 @@ qolFrame:SetScript("OnEvent", function(self)
                         return true
                     end
                 end
+            end
+            -- A brand-new item's data can still be loading server-side when
+            -- this first check runs, so an empty tooltip here doesn't mean
+            -- "not openable" -- it can just mean "not loaded yet". Only cache
+            -- the negative once the item's data is actually in, so a real
+            -- negative sticks but an early miss gets rechecked on the next scan.
+            if C_Item and C_Item.IsItemDataCachedByID and not C_Item.IsItemDataCachedByID(itemID) then
+                return false
             end
             _openableCache[itemID] = false
             return false


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1532120849035825162
         https://discord.com/channels/585577383847788554/1538994455875555484

Cache of Void-Touched auto-opening despite "Exclude Warbound Containers"

Issue: The exclude check asked the bank whether it would currently accept a deposit of the item — that requires a live bank session, so it defaulted to "not warbound" outdoors and let the item open anyway.

Fix: Check the item's own bind type instead (works anywhere, no bank needed).

Illustrious Contender's Strongbox never auto-opening

Issue: The addon caches "not openable" permanently the first time it scans an item. If the item's data hasn't finished loading yet (common right after looting/buying something new), that negative gets locked in forever — even though it opens fine manually.

Fix: Don't cache the negative result until the item's data is confirmed loaded; an early miss just gets rechecked on the next scan instead of sticking.

