### PR TITLE
fix(cdm): two causes of an icon rendering invisible in its own slot

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -1181,6 +1181,19 @@ RestoreAllCdState = function()
     end
 end
 
+-- Is this frame one WE inject? customActiveStates is only editable from the
+-- per-icon menu's "Custom Active State" section, offered for exactly these
+-- frames (EUI_CooldownManager_Options.lua isCustomInjected). A Blizzard viewer
+-- frame carries none of the flags, so a user rule reaching one is an orphan:
+-- removing a custom spell clears customSpellIDs but not the profile-level
+-- active state, and no menu can then show or clear it -- which hid a plainly
+-- tracked spell with nothing to explain why.
+local function IsInjectedFrame(f)
+    return (f._isCustomSpellFrame or f._isRacialFrame or f._isPresetFrame
+            or f._isItemPresetFrame or f._isTrinketFrame) and true or false
+end
+ns.CdmIsInjectedFrame = IsInjectedFrame
+
 -- One full evaluation pass. Driven by the ticker (continuous) AND called
 -- synchronously at the end of a re-arm, so a settings change does not leave the
 -- icon shown for a tick before the next poll re-hides it.
@@ -1209,7 +1222,11 @@ EvalCdStateNow = function()
                 for i = 1, #list do
                     local f = list[i]
                     local fc = f and FCt[f]
-                    if fc and KeyMatches(sid, fc.spellID) then
+                    -- rule.user rules come from the profile store; built-in rules
+                    -- (FAKE_ACTIVE_RULES) deliberately decorate Blizzard icons and
+                    -- keep their reach.
+                    if fc and KeyMatches(sid, fc.spellID)
+                       and (not rule.user or IsInjectedFrame(f)) then
                         hasIcon = true
                         if eff then ApplyCdState(f, fc, cas, eff, onCD, ready) end
                     end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6773,6 +6773,18 @@ local function UpdateAllCDMBars(dt) end
 --  Bar Visibility (always / in combat / never) + Housing
 -------------------------------------------------------------------------------
 
+-- Does this cd/utility bar draw any frame out of the BuffIcon viewer? True for a
+-- hosted buff (spellID-keyed) and for a cd-claimed collided buff slot. Called
+-- only for the BuffIcon viewer's vote below, so bars pay nothing in the common
+-- case where nothing is hosted. On ns, not a file local: this file sits at
+-- Lua's 200-local cap.
+function ns.BarUsesBuffViewer(barKey)
+    local sd = ns.GetBarSpellData and ns.GetBarSpellData(barKey)
+    if not sd then return false end
+    if sd.hostedBuffSpellIDs and next(sd.hostedBuffSpellIDs) then return true end
+    return (ns.CollectCdClaimSet and ns.CollectCdClaimSet(sd)) and true or false
+end
+
 _CDMApplyVisibility = function()
     local p = ECME.db and ECME.db.profile
     if not p then return end
@@ -6935,6 +6947,16 @@ _CDMApplyVisibility = function()
                             if bt == "buffs" and viewerBarKey == "buffs" then
                                 anyVisible = true; break
                             elseif bt ~= "buffs" and (viewerBarKey == "cooldowns" or viewerBarKey == "utility") then
+                                anyVisible = true; break
+                            -- A HOSTED buff renders on a cd/utility bar but its frame
+                            -- still comes out of the BuffIcon viewer pool and is never
+                            -- reparented, so it inherits that viewer's alpha. Without
+                            -- this vote a visible cd/utility bar hosting a buff went
+                            -- dark the moment the buffs bar was hidden: the aura-down
+                            -- placeholder (our own frame, parented to UIParent) kept
+                            -- rendering while the live buff did not.
+                            elseif bt ~= "buffs" and viewerBarKey == "buffs"
+                                   and ns.BarUsesBuffViewer(barData.key) then
                                 anyVisible = true; break
                             end
                         end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -1246,6 +1246,11 @@ end
 function ns.PresetHasCdState(frame)
     local fc = ns._ecmeFC and ns._ecmeFC[frame]
     if not fc or not fc.spellID then return false end
+    -- Only frames WE inject can own a custom active state -- same gate the
+    -- Fake-Active engine applies before honoring one. Without it an orphaned
+    -- profile-level entry both hid a plain tracked spell and stopped the
+    -- appearance refresh from ever clearing the flag it set.
+    if ns.CdmIsInjectedFrame and not ns.CdmIsInjectedFrame(frame) then return false end
     local cas = ns.GetEffectiveCustomActiveState(fc.spellID)
     local eff = cas and cas.cdStateEffect
     if eff == false then eff = nil end  -- blocking-false = no effect


### PR DESCRIPTION
## What does this PR do?

Fixes two independent reasons a Cooldown Manager icon renders at alpha 0 while
sitting correctly in its slot. Both were reported together on 8.9.1 by
@Tankmedaddy (Mistweaver monk) and reproduced locally with that profile.

**1. A hosted buff goes dark once the buffs bar is hidden.**

A buff hosted on a cd/utility bar renders there, but its frame still comes out
of `BuffIconCooldownViewer`, and a diverted viewer frame is never reparented --
only `SetPoint`'d -- so it keeps inheriting that viewer's alpha.
`_CDMApplyVisibility` derives each viewer's alpha from which bars use it, and
that vote mapped bars to viewers by `barType` alone, so a cd/utility bar never
voted for the buff viewer. With the buffs bar on Visibility "never" the viewer
dropped to alpha 0 and took every hosted buff with it the moment its aura came
up -- while the aura-down placeholder, our own frame parented to `UIParent`,
kept rendering. That asymmetry is exactly what the report described: the icon
was visible while the buff was missing and gone while it was up.

A cd/utility bar that hosts a buff, or claims a collided buff slot, now votes
for the BuffIcon viewer too.

**2. An orphaned custom active state hides a plainly tracked spell.**

`customActiveStates` is a profile-level store keyed by bare spellID, but the
options row that writes it is offered only for frames we inject (`spellID < 0`,
a racial, or a `customSpellIDs` entry -- `isCustomInjected`).
`RemoveSpellFromBar` clears `customSpellIDs` and never the active state, so a
spell removed as a Custom Spell ID and re-added through the spell picker kept a
`cdStateEffect` of `"hiddenReady"` that no menu in the UI can show or clear. On
a spell with no cooldown that is permanent invisibility.

The user rules in `EvalCdStateNow`, and `ns.PresetHasCdState` with them, are now
gated on the frame being one we inject -- the same test the options page applies
before offering the row. Built-in rules (Ebon Might) decorate Blizzard icons on
purpose and keep their reach. Clearing the entry in `RemoveSpellFromBar` was the
other candidate and is wrong: `AddTrackedSpell` moves a spell between bars
through that same path, so it would discard a working active state on every
move. Profiles already carrying an orphan self-heal, because the appearance
refresh reclaims the icon's alpha once `PresetHasCdState` stops claiming it.

Neither is a regression from 8.9.x. `git log -S"anyVisible"` puts the viewer
vote unchanged since v5.9, long before hosted buffs shipped in 8.4, and the
orphan path is equally old. Both are latent and only fire after a configuration
change, which is why they arrive as "this worked last week".

## How was it tested?

Live retail, Mistweaver monk, with the reporter's profile. Verified by reading
each frame's own alpha, its parent's alpha and its anchor separately, so a
routing failure and an opacity failure could not be confused:

- Buffs bar on "never", Vivacious Vivification hosted on the Utility bar: the
  live icon now appears on Rising Sun Kick and swaps back to the placeholder
  when the aura drops. Its effective alpha went 0.00 -> 1.00.
- Vivify / Sheilun's Gift added to the Utility bar via the spell picker: now
  renders. Own alpha went 0.00 -> 1.00.
- Buffs bar still hidden: all five of its own buff icons remain at effective
  alpha 0.00 individually, so raising the viewer's alpha does not leak a hidden
  buffs bar back on screen.
- Buffs bar returned to "always": buffs render on it as before, hosted buff
  still correct on the Utility bar.
- Cooldowns bar on "never": Revival and Celestial Conduit stay hidden.
- The preserved path: a Custom Spell ID carrying `cdStateEffect = "hiddenReady"`
  is still hidden while ready, while a trinket frame and a preset frame without
  a cd-state on other bars stay at alpha 1.00 -- the gate discriminates rather
  than rejecting every injected frame.
- `/reload` with the aura up and down: no flash, no stale alpha.
- Instanced content (follower dungeon): no errors. Both paths read
  `hostedBuffSpellIDs` and our own frame flags rather than aura data, so there
  is no secret-value exposure to capture.

Known gap: a trinket **slot** whose active state is keyed by the equipped item
through `ResolveCustomActiveKey` *and* carries `hiddenReady`. Nothing in the
test profile sets that up, so that sub-case is reasoned rather than observed.

## Screenshots

<!-- to add: Utility bar before/after with the buffs bar hidden -->

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; both changes are bug fixes to existing behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added

Cost: no new events, no `OnUpdate`, no per-frame work. `ns.BarUsesBuffViewer`
runs only inside `_CDMApplyVisibility` (combat enter/exit, vehicle, group
change, login settle), only for the BuffIcon viewer's vote, and only when the
buffs bar is hidden -- the default configuration short-circuits first. It
allocates nothing unless a cd-claim marker exists. The injected-frame gate is
five field reads inside a loop that only ticks for users who have an Active
State effect configured, and it makes `PresetHasCdState` cheaper on Blizzard
frames by returning before the store lookup.
