### PR TITLE
fix(cdm): two custom active state lifecycle bugs on preset icons

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -1155,7 +1155,14 @@ ApplyCdState = function(frame, fc, cas, eff, onCD, ready)
     local glow = fd and fd.glowOverlay
     if not glow then return end
     if not onCD then
-        if not fd._presetCdGlowOn then
+        -- Re-assert against the overlay's REAL state (overlay._glowActive), not
+        -- our flag alone. fd.glowOverlay is shared with the proc-glow and
+        -- appearance passes, and twelve of the thirteen sites that stop it never
+        -- tell this engine -- so the flag said "lit" while the overlay was dark
+        -- and a ready preset stayed unglowed until the next re-arm. Only ever
+        -- starts a glow when nothing is running, so it cannot stomp another
+        -- owner's.
+        if not fd._presetCdGlowOn or not glow._glowActive then
             local gr, gg, gb = ns.ResolveGlowColor and ns.ResolveGlowColor(cas or {})
             ns.StartNativeGlow(glow, eff == "pixelGlowReady" and 1 or 3, gr or 1, gg or 1, gb or 1)
             fd._presetCdGlowOn = true

--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -162,6 +162,13 @@ end
 -- shrinks this window to the brief login gap it was written for.
 local _slotKeyNextTry = 0
 local function KeyMatches(ruleKey, frameKey)
+    -- An icon with no resolved identity matches NO rule. fc.spellID is nil for a
+    -- window on every rebuild: BuildAllCDMBars clears it on each live icon, and
+    -- FullCDMRebuild re-arms (which evaluates every rule) before the reanchor
+    -- re-stamps it. Without this guard both lookups below fall through to
+    -- nil == nil, so EVERY user rule claimed EVERY identity-less icon and any
+    -- Hidden (CD Ready / On CD) rule alpha-0'd unrelated potions and trinkets.
+    if ruleKey == nil or frameKey == nil then return false end
     if ruleKey == frameKey then return true end
     if not next(_slotItemKey) then
         local now = GetTime()
@@ -1138,6 +1145,11 @@ ApplyCdState = function(frame, fc, cas, eff, onCD, ready)
         return
     end
     -- Glow modes: glow while the ability is READY (off cooldown). Not a hide.
+    -- Restore the alpha as well as the flag, exactly as the appearance refresh
+    -- does on this transition: once a bar has settled nothing else re-asserts a
+    -- preset frame's alpha, so clearing the flag alone leaves a hide from an
+    -- earlier state painted for good.
+    if fc._cdStateHidden then frame:SetAlpha(FrameBaseAlpha(fc)) end
     fc._cdStateHidden = false
     if ns.SetCdStateShiftHidden then ns.SetCdStateShiftHidden(fc, false) end
     local glow = fd and fd.glowOverlay


### PR DESCRIPTION
Two bugs in the CDM custom active state engine, both found from one field
report and both confirmed fixed in game.

## 1. Reordering a spell made an unrelated potion icon vanish

Dragging a spell to a new position in any CDM bar, the buffs bar included,
made a potion icon on a different bar disappear while its slot stayed
reserved.

A drag runs FullCDMRebuild. BuildAllCDMBars clears `iifc.spellID` on every
live icon of each custom bar, and FullCDMRebuild then re-arms the engine --
which evaluates every rule -- before the reanchor re-stamps that id. In that
window `KeyMatches` receives `frameKey = nil`, and its
`_slotItemKey[ruleKey] == frameKey` test falls through to `nil == nil`, so
every rule matches every identity-less icon. Each Hidden (CD Ready) rule
then sets alpha 0 and `fc._cdStateHidden` on potions and trinkets unrelated
to it.

The layout reserves a slot for an icon flagged `_cdStateHidden`, hence the
gap. `RefreshCDMIconAppearance` clears the stale flag, but skips frames
where `PresetHasCdState` is true -- so a preset carrying a cd-state entry of
its own kept it, and its own glow rule then cleared the flag without
repainting the alpha. Only presets with an entry stayed dark, which is what
made this read as one specific icon rather than a whole bar.

Fix: `KeyMatches` returns false for a nil key on either side, and the glow
branch restores the alpha when it clears a hide.

## 2. A preset's CD-ready glow did not come back after a reload

A Pixel Glow (CD Ready) on a potion was absent after a reload and reappeared
after any CDM bar edit.

`fd.glowOverlay` has several owners. The engine guards its start on
`fd._presetCdGlowOn`, but thirteen sites call `StopNativeGlow` on that
overlay and one clears the flag. `RefreshCDMIconAppearance`'s proc-glow
branch stops it during the first layout after login, so the flag read "lit"
while the overlay was dark. `RestoreAllCdState` clears the flag and runs
only on a re-arm, which is why an unrelated bar edit revived the glow.

Fix: test the overlay's own `_glowActive`, which StartNativeGlow and
StopNativeGlow already maintain, alongside the flag. The 0.12s poll then
restores the glow whichever pass took the overlay, and it only starts one
when nothing is running, so it cannot stomp another owner's.

## Scope note

`RefreshCDMIconAppearance` guards its own glow the same way, on
`ifd._cdStateGlowOn`, so a per-spell CD-ready glow on an ordinary cooldown
is likely exposed to the same latch. Left alone: no reproduction for it yet,
and this change is verified in game for the preset path only.

## Testing

Reproduced and confirmed fixed live on a Racial + Pots bar carrying a
racial, three potion presets and a trinket slot, with Hide Items if Missing
on. Traced with a per-frame Hide/ClearAllPoints/SetAlpha/SetPoint hook,
which put both stacks directly on `ApplyCdState`. Before: the icon sat at
alpha 0.00 with its slot held. After: it survives drags on every bar, and
the glow is present on reload without an edit.