### PR TITLE
Fix Sacred Weapon disappearing from Cooldown Manager bars

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -853,6 +853,32 @@ function ns.ResetVariantBaseStore()
     local sv = _variantBaseSV()
     if sv then sv._variantBase = nil end
 end
+
+-- Public equivalence check for the picker/list helpers.  The ordinary spell
+-- APIs cannot always walk both directions of a rotating override (notably
+-- Sacred Weapon/Holy Bulwark), while this spec-scoped ledger remembers the
+-- stable base observed from the viewer.  Following the short chain also keeps
+-- the helper correct if Blizzard reports an override of an override.
+function ns.IsLearnedVariantOf(a, b)
+    if type(a) ~= "number" or type(b) ~= "number" then
+        return false
+    end
+    if (issecretvalue and (issecretvalue(a) or issecretvalue(b))) then
+        return false
+    end
+    if a <= 0 or b <= 0 then return false end
+    _loadVariantBases()
+    local function Root(id)
+        local hops = 0
+        while _variantBaseLearned[id] and _variantBaseLearned[id] ~= id
+              and hops < 8 do
+            id = _variantBaseLearned[id]
+            hops = hops + 1
+        end
+        return id
+    end
+    return Root(a) == Root(b)
+end
 ns._divertedSpellsBuff = _divertedSpellsBuff
 ns._divertedSpellsCD   = _divertedSpellsCD
 
@@ -924,13 +950,15 @@ function ns.RebuildSpellRouteMap()
         end
     end
 
-    local function CollectDiversionsFor(bd)
+    local function CollectDiversionsFor(bd, skipPositiveSet)
         local sd = ns.GetBarSpellData(bd.key)
         if not sd or not sd.assignedSpells then return end
         local targetMap = IsBuffFamily and IsBuffFamily(bd) and _divertedSpellsBuff or _divertedSpellsCD
         for _, sid in ipairs(sd.assignedSpells) do
             if type(sid) == "number" and sid > 0 then
-                StoreDirect(targetMap, sid, bd.key)
+                if not skipPositiveSet or not skipPositiveSet[sid] then
+                    StoreDirect(targetMap, sid, bd.key)
+                end
             else
                 -- Equipment slot entry: routes Blizzard's own equipment cooldown
                 -- for that slot, which has no spellID to key on. Same overwrite
@@ -1018,12 +1046,43 @@ function ns.RebuildSpellRouteMap()
             end
         end
     end
-    -- Pass 4: ghost bars LAST = HIGHEST priority. A spell the user HID stays
-    -- hidden even if also on a visible bar ("both-state"). ns.AddSpellToBar
-    -- removes it from the ghost, so this never hides a deliberate placement.
+    -- Build the visible CD-family closure before ghosts are collected.  The
+    -- normal add path removes a spell from the ghost when it is placed, but a
+    -- rotating override can be stored under IDs whose relationship is only
+    -- observable in the other form.  That produced a stale both-state such as
+    -- visible Divine Toll/base 375576 + ghost Holy Bulwark 432459: the ghost's
+    -- exact-ID claim won and Sacred Weapon vanished from the live bar even
+    -- though it remained in the options.  Current API-derived keys are already
+    -- in _divertedSpellsCD; extend that set with the persisted, spec-scoped
+    -- variant/base ledger so a visible family always suppresses its stale ghost
+    -- alias.  This is routing-only--the saved ghost entry remains available if
+    -- the visible assignment is later removed.
+    local visibleCDClaims = {}
+    for sid in pairs(_divertedSpellsCD) do visibleCDClaims[sid] = true end
+    local expanded
+    repeat
+        expanded = false
+        for variant, base in pairs(_variantBaseLearned) do
+            if visibleCDClaims[variant] or visibleCDClaims[base] then
+                if not visibleCDClaims[variant] then
+                    visibleCDClaims[variant] = true
+                    expanded = true
+                end
+                if not visibleCDClaims[base] then
+                    visibleCDClaims[base] = true
+                    expanded = true
+                end
+            end
+        end
+    until not expanded
+
+    -- Pass 4: ghost bars remain highest priority for genuinely hidden spells.
+    -- A stale alternate-ID ghost of a visible rotating spell is skipped using
+    -- the closure above; otherwise it would defeat the one-spell/one-home
+    -- invariant that the picker enforces.
     for _, bd in ipairs(p.cdmBars.bars) do
         if bd.enabled and bd.isGhostBar then
-            CollectDiversionsFor(bd)
+            CollectDiversionsFor(bd, visibleCDClaims)
         end
     end
 

--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -97,6 +97,14 @@ end
 local function IsVariantOf(spellIDA, spellIDB)
     if not _IsUsableSID(spellIDA) or not _IsUsableSID(spellIDB) then return false end
     if spellIDA == spellIDB then return true end
+    -- Some rotating viewer spells expose no reversible relationship through
+    -- GetBaseSpell/GetOverrideSpell in one of their live states.  The hook
+    -- layer persists the clean, spec-scoped pairing when the viewer does expose
+    -- it; consult that ledger so moving/re-adding Sacred Weapon also removes a
+    -- stale Holy Bulwark/base entry from the old bar or ghost list.
+    if ns.IsLearnedVariantOf and ns.IsLearnedVariantOf(spellIDA, spellIDB) then
+        return true
+    end
     if _GetBase(spellIDA) == spellIDB or _GetBase(spellIDB) == spellIDA then return true end
     if _GetOverride(spellIDA) == spellIDB or _GetOverride(spellIDB) == spellIDA then return true end
     local baseA = _GetBase(spellIDA)


### PR DESCRIPTION
## What does this PR do?

Fixes a Cooldown Manager routing conflict where Sacred Weapon could remain visible in bar settings but disappear from the live panel.

Rotating paladin overrides can be persisted under different spell IDs. A visible base assignment (for example, Divine Toll `375576`) could coexist with a stale ghost entry for Holy Bulwark `432459`. Because ghost routing has the highest priority, the stale alternate ID won and hid Sacred Weapon.

This change:

- treats persisted, spec-scoped variant/base pairs as one spell family in picker operations;
- builds a closure of visible cooldown spell families before processing ghost bars;
- skips stale ghost aliases when another learned variant is visibly assigned.

The saved ghost entry is preserved, so it becomes effective again if the visible assignment is later removed.

## How was it tested?

- Reproduced the conflict from live SavedVariables containing visible `375576` and ghost `432459`, both mapped to the same learned spell family.
- Parsed both modified Lua files successfully with `luaparse`.
- Ran a focused routing simulation confirming that the visible base expands to the Sacred Weapon/Holy Bulwark variants and suppresses the stale ghost claim.
- Confirmed in game that Sacred Weapon appears on the configured cooldown panel.

## Checklist

- [x] N/A — no new setting
- [x] N/A — no feature toggle or disabled path changed
- [x] Cheap while enabled: work runs during route-map rebuild; no polling, timers, or per-frame allocation added
- [x] No writes onto Blizzard-owned frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
