### PR TITLE
fix(ABR): show Tidecaller's Guard reminder correctly

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1110,7 +1110,7 @@ local SHAMAN_IMBUES = {
     { key="flametongue", name="Flametongue Weapon", castSpell=318038, buffIDs={319778}, wepEnchID={5400} },
     { key="windfury",    name="Windfury Weapon",    castSpell=33757,  buffIDs={319773},  wepEnchID={5401} },
     { key="earthliving", name="Earthliving Weapon", castSpell=382021, buffIDs={382021, 382022}, wepEnchID={6498} },
-    { key="tidecaller",  name="Tidecaller's Guard", castSpell=457481, knownSpell=445033, buffIDs={457496, 457481}, wepEnchID={7528}, requireShield=true },
+    { key="tidecaller",  name="Tidecaller's Guard", castSpell=457481, buffIDs={457496, 457481}, wepEnchID={7528}, requireShield=true },
     { key="tstrike",     name="Thunderstrike Ward", castSpell=462757, buffIDs={462757, 462742}, wepEnchID={7587} },
 }
 
@@ -3265,7 +3265,7 @@ local specialsActive = EABR.SectionShows(co.specialsWhereToShow, inInstance)
             if playerClass == "SHAMAN" then
                 local hasMH, mhExpire, _, mhEnchID, hasOH, ohExpire, _, ohEnchID = EABR.WeaponEnchants()
                 for _, imbue in ipairs(SHAMAN_IMBUES) do
-                    if co.enabled[imbue.key] and Known(imbue.knownSpell or imbue.castSpell)
+                    if co.enabled[imbue.key] and Known(imbue.castSpell)
                        and (not imbue.requireShield or EABR.HasShieldEquipped()) then
                         local found = false
                         if imbue.wepEnchID then

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -812,6 +812,18 @@ local function GetWeaponCategory(slotID)
     return "NEUTRAL"
 end
 
+function EABR.HasShieldEquipped()
+    local itemID = GetInventoryItemID("player", 17)
+    if not itemID then return false end
+    local _, _, _, equipLoc
+    if C_Item and C_Item.GetItemInfoInstant then
+        _, _, _, equipLoc = C_Item.GetItemInfoInstant(itemID)
+    else
+        _, _, _, equipLoc = GetItemInfoInstant(itemID)
+    end
+    return equipLoc == "INVTYPE_SHIELD"
+end
+
 
 -------------------------------------------------------------------------------
 --  Raid buff beneficiaries (class-level). Only Intellect/Attack Power are stat-restricted (versatility/stamina/
@@ -1098,7 +1110,7 @@ local SHAMAN_IMBUES = {
     { key="flametongue", name="Flametongue Weapon", castSpell=318038, buffIDs={319778}, wepEnchID={5400} },
     { key="windfury",    name="Windfury Weapon",    castSpell=33757,  buffIDs={319773},  wepEnchID={5401} },
     { key="earthliving", name="Earthliving Weapon", castSpell=382021, buffIDs={382021, 382022}, wepEnchID={6498} },
-    { key="tidecaller",  name="Tidecaller's Guard", castSpell=457481, knownSpell=445033, buffIDs={457496, 457481}, wepEnchID={7528} },
+    { key="tidecaller",  name="Tidecaller's Guard", castSpell=457481, knownSpell=445033, buffIDs={457496, 457481}, wepEnchID={7528}, requireShield=true },
     { key="tstrike",     name="Thunderstrike Ward", castSpell=462757, buffIDs={462757, 462742}, wepEnchID={7587} },
 }
 
@@ -3253,7 +3265,8 @@ local specialsActive = EABR.SectionShows(co.specialsWhereToShow, inInstance)
             if playerClass == "SHAMAN" then
                 local hasMH, mhExpire, _, mhEnchID, hasOH, ohExpire, _, ohEnchID = EABR.WeaponEnchants()
                 for _, imbue in ipairs(SHAMAN_IMBUES) do
-                    if co.enabled[imbue.key] and Known(imbue.knownSpell or imbue.castSpell) then
+                    if co.enabled[imbue.key] and Known(imbue.knownSpell or imbue.castSpell)
+                       and (not imbue.requireShield or EABR.HasShieldEquipped()) then
                         local found = false
                         if imbue.wepEnchID then
                             for _, eid in ipairs(imbue.wepEnchID) do

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1098,7 +1098,7 @@ local SHAMAN_IMBUES = {
     { key="flametongue", name="Flametongue Weapon", castSpell=318038, buffIDs={319778}, wepEnchID={5400} },
     { key="windfury",    name="Windfury Weapon",    castSpell=33757,  buffIDs={319773},  wepEnchID={5401} },
     { key="earthliving", name="Earthliving Weapon", castSpell=382021, buffIDs={382021, 382022}, wepEnchID={6498} },
-    { key="tidecaller",  name="Tidecaller's Guard", castSpell=457496, buffIDs={457496, 457481}, wepEnchID={7528} },
+    { key="tidecaller",  name="Tidecaller's Guard", castSpell=457481, knownSpell=445033, buffIDs={457496, 457481}, wepEnchID={7528} },
     { key="tstrike",     name="Thunderstrike Ward", castSpell=462757, buffIDs={462757, 462742}, wepEnchID={7587} },
 }
 
@@ -3253,7 +3253,7 @@ local specialsActive = EABR.SectionShows(co.specialsWhereToShow, inInstance)
             if playerClass == "SHAMAN" then
                 local hasMH, mhExpire, _, mhEnchID, hasOH, ohExpire, _, ohEnchID = EABR.WeaponEnchants()
                 for _, imbue in ipairs(SHAMAN_IMBUES) do
-                    if co.enabled[imbue.key] and Known(imbue.castSpell) then
+                    if co.enabled[imbue.key] and Known(imbue.knownSpell or imbue.castSpell) then
                         local found = false
                         if imbue.wepEnchID then
                             for _, eid in ipairs(imbue.wepEnchID) do


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Bug report : https://discord.com/channels/585577383847788554/1538900516283617402

This PR fixes the Tidecaller's Guard reminder in AuraBuff Reminders.

The reminder never appeared because its `castSpell` was set to `457496`, which is the Tidecaller's Guard buff aura. The known-spell check therefore failed. This changes `castSpell` to `457481`, the actual spell granted by the talent.

After correcting the spell ID, the reminder could appear without a shield equipped. This PR also adds an equipped-shield check for off-hand slot 17.

The reminder now appears only when:

- Tidecaller's Guard spell `457481` is known.
- A shield is equipped.
- Tidecaller's Guard weapon enchant `7528` is not active.

## How was it tested?

Tested on live retail, the behavior matches the other weapon imbues

## Screenshots

<img width="544" height="322" alt="image" src="https://github.com/user-attachments/assets/c4f1407a-262c-4f4d-b25b-6b31e1ca8eda" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: the shield state is checked through the existing `UNIT_INVENTORY_CHANGED` refresh path, so no polling, timers, or per-frame allocations were added.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
