### PR TITLE
[Fix] Reskin Widget bar + Nameplate Bars

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -3257,6 +3257,9 @@ end
         -- Set at PLAYER_LOGIN only when the setting is on. Nothing here has
         -- run while this is false.
         installed = false,
+        -- Minimum on-screen bar height, cached from the setting. Seeded at
+        -- login and re-read only when the options cog writes it.
+        minPx = 12,
     }
 
     local NAMED_CONTAINERS = {
@@ -3436,12 +3439,108 @@ end
         occ:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", COVER_PAD_X, -grow)
     end
 
+    -- Smallest HEIGHT, in real screen pixels, a cover is allowed to render at.
+    --
+    -- The cover sits exactly on Blizzard's bar rect, and that is correct for
+    -- every bar that lives in a panel. A NAMEPLATE carries its own scale,
+    -- though, and a plate scaled down -- a small or trivial unit, a lowered
+    -- nameplate scale, a global scale below 1 -- drags its widget bar and the
+    -- label inside it down with it. Mirroring the rect faithfully then means
+    -- reproducing something unreadable, which is what "the bars come out VERY
+    -- small on smaller units" is.
+    --
+    -- This is only newly POSSIBLE because HideBarArt alphas Blizzard's own
+    -- art. The long-standing rule was that a cover can never be SMALLER than
+    -- their bar without exposing the art it exists to hide; nothing ever
+    -- stopped it being BIGGER, because once their BG, border, spark and glow
+    -- are at alpha 0 there is nothing left underneath to expose. The old
+    -- "hard floor: Blizzard's own bar height" note is about the other
+    -- direction and still stands.
+    -- USER-FACING, via the cog on "Reskin Widget Bars". This is the number to
+    -- move if the bars read wrong -- everything else about the correction is
+    -- derived from it.
+    local DEFAULT_MIN_BAR_PX = 12
+    -- Slider ceiling. Well past anything readable; the cap exists so a stray
+    -- value cannot ask for a bar taller than the nameplate it belongs to.
+    local MAX_MIN_BAR_PX = 24
+    -- Ceiling on the correction. A bar rendering at 1px (a plate mid-fade, a
+    -- scale still settling) would otherwise ask for 12x and drop a slab across
+    -- the screen -- the same failure mode the border-texture anchoring used to
+    -- produce. Past this, small is the better wrong answer.
+    local MAX_UPSCALE = 3
+
+    -- Resolved ONCE and cached on HUD, not read per bar per pass. SyncCover
+    -- runs for every covered bar on every sweep, and a sweep can run every
+    -- frame while a fill animates; a settings read in there is the kind of
+    -- per-frame cost this system was rebuilt to remove. The options cog calls
+    -- the seam below when it changes, which is the only time it can.
+    --
+    -- 0 is a real value and means OFF: mirror Blizzard's rect exactly, whatever
+    -- size that turns out to be. That is the behaviour before the floor
+    -- existed, so the slider bottoms out at "as it was".
+    local function ReadMinPx()
+        local v = EllesmereUIDB and EllesmereUIDB.widgetBarMinSize
+        if type(v) ~= "number" then return DEFAULT_MIN_BAR_PX end
+        if v < 0 then return 0 end
+        if v > MAX_MIN_BAR_PX then return MAX_MIN_BAR_PX end
+        return v
+    end
+
+    -- How much to enlarge a cover so it clears MIN_BAR_PX. 1 = leave it alone,
+    -- which is the answer for every panel bar (they are 12-15px at scale 1) and
+    -- for any nameplate at normal scale.
+    --
+    -- Deliberately a SCALE and not a taller rect: the label is a child of the
+    -- cover, so scaling brings the text up with the bar. Growing only the
+    -- height would leave the same unreadable caption inside a fatter bar,
+    -- which is not what was being complained about.
+    local function CoverScale(bar)
+        local min = HUD.minPx
+        if not (type(min) == "number" and min > 0) then return 1 end
+        local okH, h = pcall(bar.GetHeight, bar)
+        if not okH or type(h) ~= "number" or h <= 0 then return 1 end
+        local okE, es = pcall(bar.GetEffectiveScale, bar)
+        if not okE or type(es) ~= "number" or es <= 0 then return 1 end
+        local px = h * es
+        if px <= 0 or px >= min then return 1 end
+        local s = min / px
+        if s > MAX_UPSCALE then s = MAX_UPSCALE end
+        return s
+    end
+
     local function AnchorCover(c, bar, pad)
+        local s = CoverScale(bar)
         c:ClearAllPoints()
-        -- EXACTLY the bar's rect. With their art hidden there is nothing to
-        -- reach past, so no pad, no overhang, no slab.
-        c:SetPoint("TOPLEFT", bar, "TOPLEFT", 0, 0)
-        c:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", 0, 0)
+        if s <= 1 then
+            -- EXACTLY the bar's rect. With their art hidden there is nothing to
+            -- reach past, so no pad, no overhang, no slab.
+            if c.euiScale ~= 1 then c:SetScale(1); c.euiScale = 1 end
+            c.euiMin = HUD.minPx
+            c:SetPoint("TOPLEFT", bar, "TOPLEFT", 0, 0)
+            c:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", 0, 0)
+            return
+        end
+        -- Scaled: CENTER to CENTER with an explicit size, never the two-corner
+        -- anchor. Corner anchors DERIVE the size from the bar, so they would
+        -- undo the scale as fast as it was applied -- the cover would render
+        -- the same size as before with a bigger font in it. CENTER with zero
+        -- offsets is the one anchor that needs no scale conversion, so the
+        -- cover stays centred on the bar it mirrors and grows symmetrically.
+        local okW, w = pcall(bar.GetWidth, bar)
+        local okH, h = pcall(bar.GetHeight, bar)
+        if not (okW and okH) or type(w) ~= "number" or type(h) ~= "number"
+           or w <= 0 or h <= 0 then
+            if c.euiScale ~= 1 then c:SetScale(1); c.euiScale = 1 end
+            c.euiMin = HUD.minPx
+            c:SetPoint("TOPLEFT", bar, "TOPLEFT", 0, 0)
+            c:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", 0, 0)
+            return
+        end
+        c:SetScale(s)
+        c.euiScale = s
+        c.euiMin = HUD.minPx
+        c:SetSize(w, h)
+        c:SetPoint("CENTER", bar, "CENTER", 0, 0)
     end
 
     local function BuildCover(bar)
@@ -3462,6 +3561,7 @@ end
         -- Anchored, never re-parented: position needs no polling because the
         -- anchor does it, including when a nameplate moves.
         c.euiPad = VPad(bar)
+        c.euiScale = 1
         AnchorCover(c, bar, c.euiPad)
         c:SetStatusBarTexture(FLAT)
         -- OPAQUE trough, not the usual 0.85: this one has to hide Blizzard's
@@ -3615,8 +3715,21 @@ end
             pad = VPad(bar)
             c.euiPadH = hOk and curH or nil
         end
-        if pad ~= c.euiPad then
+        -- The bar's EFFECTIVE scale is the second re-anchor trigger, and it
+        -- moves without the height moving at all: a nameplate's scale lives on
+        -- the plate, so the bar's own local height reads the same before and
+        -- after. Watching only the height therefore leaves a cover stuck at
+        -- whatever size the plate happened to be when it was built.
+        local esOk, curES = pcall(bar.GetEffectiveScale, bar)
+        local es = esOk and type(curES) == "number" and curES or nil
+        -- ...and the FLOOR ITSELF is the third trigger. Dragging the cog's
+        -- slider changes neither the bar's height nor the plate's scale, so
+        -- without this the covers already on screen keep whatever size they
+        -- were built at and the slider looks like it does nothing until the
+        -- next zone change.
+        if pad ~= c.euiPad or es ~= c.euiES or c.euiMin ~= HUD.minPx then
             c.euiPad = pad
+            c.euiES = es
             AnchorCover(c, bar, pad)
         end
 
@@ -3936,6 +4049,16 @@ end
             -- something else happened to fire.
             self:RegisterEvent("UPDATE_ALL_UI_WIDGETS")
             EllesmereUI._HUDWidgetAdopt = HUDWidgetAdopt
+            -- The options cog's write-through. Published on the same terms as
+            -- the adopt seam -- at login, only with the feature on -- so with
+            -- the reskin off it is nil and the cog is greyed out anyway.
+            -- Re-reads the setting and books one refresh; SyncCover notices the
+            -- floor moved and re-anchors every live cover.
+            HUD.minPx = ReadMinPx()
+            EllesmereUI._HUDWidgetSetMinSize = function()
+                HUD.minPx = ReadMinPx()
+                Refresh()
+            end
             -- Looks redundant next to PLAYER_ENTERING_WORLD, which follows
             -- login and does the same two calls. Kept because it makes the
             -- install complete on its own: if the event order ever surprises
@@ -4019,6 +4142,37 @@ end
     --  on a short sweep after each. It CLEARS rather than alphas, because the
     --  button's flash animation drives alpha and would restore it.
     ---------------------------------------------------------------------------
+    -- Detach every mask from a texture.
+    --
+    -- ExtraActionButtonTemplate declares an IconMask
+    -- (UI-HUD-ActionBar-IconFrame-Mask) bound to the icon via
+    -- <MaskedTexture childKey="icon"/>, and a MASKED TEXTURE REJECTS
+    -- SetTexCoord OUTRIGHT -- a hard Lua error, which is exactly why
+    -- WSkin.SquareIcon refuses masked icons rather than cropping them.
+    --
+    -- The crop below was pcall'd, so that error has been swallowed silently
+    -- since the button was first skinned: the icon kept its FULL uncropped
+    -- art while every other icon in this skin is cropped to 0.08-0.92. How
+    -- obvious that is depends entirely on how much dead border the granted
+    -- spell's own icon carries -- which is what "sometimes, unless this is
+    -- just spell specific" describes.
+    --
+    -- Removing the mask writes to the ICON's own mask list, not to the secure
+    -- button, and it is the same call Blizzard's map canvas makes on its own
+    -- pins. GetNumMaskTextures is declared with SecretReturnsForAspect, so the
+    -- count is rejected as secret before it can be used as a loop bound.
+    local function Unmask(tex)
+        if not tex or type(tex.GetNumMaskTextures) ~= "function" then return end
+        local okN, n = pcall(tex.GetNumMaskTextures, tex)
+        if not okN then return end
+        if _isSecretV and n ~= nil and _isSecretV(n) then return end
+        if type(n) ~= "number" or n <= 0 then return end
+        for i = n, 1, -1 do
+            local okM, m = pcall(tex.GetMaskTexture, tex, i)
+            if okM and m then pcall(tex.RemoveMaskTexture, tex, m) end
+        end
+    end
+
     local function StripExtraAction()
         local btn = _G.ExtraActionButton1
         if not btn or btn:IsForbidden() then return end
@@ -4044,12 +4198,20 @@ end
             -- ring gone the 52px art would otherwise float inside a ~256px
             -- frame. These are writes on the icon TEXTURE, never on the secure
             -- button.
-            if not d.iconAnchored then
-                d.iconAnchored = true
-                btn.icon:ClearAllPoints()
-                btn.icon:SetPoint("TOPLEFT", btn, "TOPLEFT", 0, 0)
-                btn.icon:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", 0, 0)
-            end
+            --
+            -- RE-ASSERTED EVERY PASS rather than guarded by a one-shot flag.
+            -- Blizzard re-arts this button for every ability it grants, and a
+            -- one-shot anchor that one of those paths clobbers fails with NO
+            -- visible change at the moment it is applied -- the same trap the
+            -- PlayerChoice close button cost several rounds to find. Two
+            -- SetPoints on a texture, on a path that runs when an ability is
+            -- granted, is not worth a guard.
+            btn.icon:ClearAllPoints()
+            btn.icon:SetPoint("TOPLEFT", btn, "TOPLEFT", 0, 0)
+            btn.icon:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", 0, 0)
+            -- Before the crop, never after: SetTexCoord on a masked texture
+            -- throws, and the pcall around it would hide that it did nothing.
+            Unmask(btn.icon)
             pcall(btn.icon.SetTexCoord, btn.icon, 0.08, 0.92, 0.08, 0.92)
         end
         if not d.border then
@@ -4068,6 +4230,7 @@ end
     end
 
     local eabEv = CreateFrame("Frame")
+    local _eabUpdateHooked = false
     eabEv:RegisterEvent("PLAYER_LOGIN")
     eabEv:RegisterEvent("UPDATE_EXTRA_ACTIONBAR")
     eabEv:SetScript("OnEvent", function()
@@ -4078,6 +4241,18 @@ end
         if btn and not GetFFD(btn).showHook then
             GetFFD(btn).showHook = true
             btn:HookScript("OnShow", StripExtraAction)
+        end
+        -- THE AUTHORITATIVE PATH. ExtraActionBar_Update is the one place
+        -- Blizzard re-arts this button -- it re-assigns bar.button.style from
+        -- C_ActionBar.GetOverrideBarSkin() on every grant -- and it runs from
+        -- ActionBarController's own UPDATE_EXTRA_ACTIONBAR handler. Reacting
+        -- to the same EVENT means racing that handler for registration order;
+        -- hooking the function means running after it by construction. This
+        -- is the shape the zone ability button already uses with
+        -- UpdateDisplayedZoneAbilities.
+        if not _eabUpdateHooked and type(_G.ExtraActionBar_Update) == "function" then
+            _eabUpdateHooked = true
+            hooksecurefunc("ExtraActionBar_Update", StripExtraAction)
         end
         if not (EllesmereUIDB and EllesmereUIDB.reskinExtraActionButton == true) then return end
         StripExtraAction()

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
@@ -1052,9 +1052,165 @@ local function Skin_RaidFinder()
     if rfSB then SkinScrollBar(rfSB) end
 end
 
+-------------------------------------------------------------------------------
+--  Reward tiles (Dungeon Finder + Raid Finder) and the M+ dungeon icon row.
+-------------------------------------------------------------------------------
+
+-- Rings and plates stacked on a LargeItemButtonTemplate icon. The same list the
+-- quest reward tiles use, and for the same reason: IconBorder is a ROUNDED
+-- quality ring drawn OVER the icon, so it defeats the square crop underneath
+-- it, and NameFrame is the parchment plate behind the label.
+local REWARD_ART = { "IconBorder", "IconOverlay", "IconOverlay2", "IconBorder2", "NameFrame" }
+
+-- Rarity color for one reward tile, or nil for "no rarity" -- which the border
+-- draws black rather than skipping.
+--
+-- The color has to be derived HERE, unlike on quest rewards where the square
+-- border reads it straight off Blizzard's own IconBorder ring.
+-- LFGRewardsFrame_SetItemButton only ever calls SetItemButtonTexture and
+-- SetItemButtonCount, never SetItemButtonQuality, so on these tiles that ring
+-- stays hidden and carries no color at all. Each tile does record what it is
+-- showing though (SetID(rewardIndex) plus .dungeonID / .shortageIndex), so the
+-- quality reads back out of the same API Blizzard filled the tile from.
+local function RewardQualityColor(btn)
+    local did, si = btn.dungeonID, btn.shortageIndex
+    local id = btn.GetID and btn:GetID()
+    if type(did) ~= "number" or type(id) ~= "number" or id <= 0 then return end
+    -- `_` is declared LOCAL rather than left to fall through to the global of
+    -- that name: this runs inside Blizzard's own call stack from a hook, and a
+    -- stray global write from there is exactly the kind of thing this file's
+    -- taint rules exist to avoid.
+    local ok, _, numItems, rewardType, rewardID, quality
+    if si ~= nil then
+        if type(GetLFGDungeonShortageRewardInfo) ~= "function" then return end
+        ok, _, _, numItems, _, rewardType, rewardID, quality =
+            pcall(GetLFGDungeonShortageRewardInfo, did, si, id)
+    else
+        if type(GetLFGDungeonRewardInfo) ~= "function" then return end
+        ok, _, _, numItems, _, rewardType, rewardID, quality =
+            pcall(GetLFGDungeonRewardInfo, did, id)
+    end
+    if not ok then return end
+    -- Currency CONTAINERS carry their own quality, not the raw currency's.
+    -- Blizzard remaps it one line before it fills the tile, so a skin that
+    -- skips this paints a bag of gold with the wrong rarity.
+    if rewardType == "currency" and rewardID ~= nil and C_CurrencyInfo
+       and C_CurrencyInfo.IsCurrencyContainer and CurrencyContainerUtil then
+        local okC, isC = pcall(C_CurrencyInfo.IsCurrencyContainer, rewardID, numItems)
+        if okC and isC then
+            local okQ, _, _, _, q = pcall(CurrencyContainerUtil.GetCurrencyContainerInfo,
+                                          rewardID, numItems, nil, nil, quality)
+            if okQ then quality = q end
+        end
+    end
+    if quality == nil or issecretvalue(quality) or type(quality) ~= "number" then return end
+    local col = ITEM_QUALITY_COLORS and ITEM_QUALITY_COLORS[quality]
+    if not (col and col.r) then return end
+    -- Achromatic qualities (poor grey, common white) are not a cue -- they read
+    -- as a colored border that happens to be grey. Same chroma test the engine
+    -- applies when it reads a ring, so the two surfaces agree on what counts.
+    local hi = math.max(col.r, col.g, col.b)
+    local lo = math.min(col.r, col.g, col.b)
+    if (hi - lo) <= 0.1 then return end
+    return col.r, col.g, col.b
+end
+
+-- One reward tile, treated exactly like a quest reward: strip the rings and the
+-- parchment plate, square the icon, put the rarity back as a SQUARE border.
+local function SkinRewardTile(btn)
+    if not btn or btn:IsForbidden() then return end
+    for i = 1, #REWARD_ART do
+        local t = btn[REWARD_ART[i]]
+        if t and t.SetAlpha and t.IsObjectType and t:IsObjectType("Texture") then
+            t:SetAlpha(0)
+        end
+    end
+    if btn.Name and btn.Name.SetTextColor then btn.Name:SetTextColor(1, 1, 1) end
+    local wsk = ns.WSkin
+    if not (wsk and wsk.SquareIcon and btn.Icon) then return end
+    local r, g, b = RewardQualityColor(btn)
+    if r then
+        -- Crop first, and only border what actually cropped: SquareIcon leaves a
+        -- masked icon fully native, and a square border round something the mask
+        -- renders as a different shape is worse than no border.
+        if wsk.SquareIcon(btn.Icon, nil) and wsk.QualityBorder then
+            wsk.QualityBorder(btn, btn.Icon, r, g, b)
+        end
+    else
+        -- No rarity worth showing: let the engine draw its black edge.
+        wsk.SquareIcon(btn.Icon, btn, true)
+    end
+end
+
+-- Every tile in one rewards panel. Shared by the Dungeon Finder and the Raid
+-- Finder: RaidFinderQueueFrameRewards_UpdateFrame delegates to
+-- LFGRewardsFrame_UpdateFrame with its own child frame, so hooking the shared
+-- updater covers both panels in one place.
+--
+-- The item rows are GLOBALS ($parentItem1..n), created on demand and counted by
+-- parentFrame.numRewardFrames; MoneyReward is a parentKey. Both inherit
+-- LargeItemButtonTemplate, so both take the same treatment -- the gold row is
+-- the one in the screenshot.
+local function SkinRewardsFrame(parentFrame)
+    if not parentFrame or parentFrame:IsForbidden() then return end
+    local name = parentFrame.GetName and parentFrame:GetName()
+    local n = parentFrame.numRewardFrames
+    if name and type(n) == "number" then
+        for i = 1, n do
+            SkinRewardTile(_G[name .. "Item" .. i])
+        end
+    end
+    SkinRewardTile(parentFrame.MoneyReward)
+end
+
+-- The M+ dungeon icon row.
+--
+-- ChallengesDungeonIconFrameTemplate puts its Icon on the BACKGROUND layer and a
+-- ChallengeMode-DungeonIconFrame atlas on BORDER -- a ROUNDED frame drawn OVER
+-- the icon. Cropping alone therefore looks like it did nothing: the round thing
+-- on top is the entire visible result. That texture is declared inline with no
+-- name and no parentKey, so the only way to reach it is to walk the frame's
+-- regions, which is what FadeRegions with the Icon kept does.
+local function SquareDungeonIcons()
+    local cf = _G.ChallengesFrame
+    local icons = cf and cf.DungeonIcons
+    if type(icons) ~= "table" then return end
+    for i = 1, #icons do
+        local f = icons[i]
+        if f and not f:IsForbidden() and f.Icon then
+            FadeRegions(f, { [f.Icon] = true })
+            f.Icon:ClearAllPoints()
+            f.Icon:SetAllPoints(f)
+            local wsk = ns.WSkin
+            if wsk and wsk.SquareIcon then
+                if wsk.SquareIcon(f.Icon, nil) and wsk.QualityBorder then
+                    wsk.QualityBorder(f, f.Icon, 0, 0, 0)
+                end
+            elseif f.Icon.SetTexCoord then
+                f.Icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+            end
+        end
+    end
+end
+
+local _challengesHooked = false
+
 local function Skin_Challenges()
     if not _G.ChallengesFrame then return end
     local cf = _G.ChallengesFrame
+    -- ChallengesFrameMixin:Update REBUILDS the icon row -- CreateFrames grows
+    -- the array, LineUpFrames re-lays it out -- and it runs on show and on every
+    -- C_MythicPlus data refresh. Squaring only at panel-skin time therefore
+    -- catches whichever icons happened to exist at that instant: the first visit
+    -- of a session usually lands before the map list has arrived, so the rest
+    -- are created afterwards and stay round. That is the "sometimes they don't
+    -- square" shape, and this hook is the fix for it.
+    if not _challengesHooked and type(cf.Update) == "function" then
+        _challengesHooked = true
+        hooksecurefunc(cf, "Update", function()
+            if SkinEnabled() then SquareDungeonIcons() end
+        end)
+    end
     SkinPanel(cf, { noBg = true, noBorder = true })
     -- The M+ main-area scenic backdrop (ChallengesFrame.Background + an anon
     -- BG texture) defeated every ALPHA approach we tried -- Blizzard re-raises
@@ -1070,6 +1226,7 @@ local function Skin_Challenges()
         if kf.StartButton then SkinButton(kf.StartButton) end
         if kf.CloseButton then SkinCloseButton(kf.CloseButton) end
     end
+    SquareDungeonIcons()
 end
 
 -- PvP tab (PVPUIFrame, Blizzard_PVPUI -- separate LoD addon): the D&R
@@ -1222,10 +1379,15 @@ local function InstallHooks()
     -- rewards/role/raid update; one-shot fades never stick against them, so
     -- re-fade from the updaters themselves.
     if LFGRewardsFrame_UpdateFrame then
-        hooksecurefunc("LFGRewardsFrame_UpdateFrame", function(_, _, background)
+        hooksecurefunc("LFGRewardsFrame_UpdateFrame", function(parentFrame, _, background)
             if background and not issecretvalue(background) and background.SetAlpha then
                 background:SetAlpha(0)
             end
+            -- Reward tiles are re-filled from scratch on every one of these
+            -- passes (SetItemButtonTexture re-shows the rings), so the skin has
+            -- to ride the updater rather than being applied once when the panel
+            -- is built.
+            SkinRewardsFrame(parentFrame)
         end)
     end
     if RaidFinderQueueFrameRewards_UpdateFrame then

--- a/EllesmereUIOptions/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIOptions/EUI_BlizzardSkin_Options.lua
@@ -757,9 +757,10 @@ initFrame:SetScript("OnEvent", function(self)
         -----------------------------------------------------------------------
         _, h = W:SectionHeader(parent, "BLIZZARD HUD", y);  y = y - h
 
-        _, h = W:DualRow(parent, y,
+        local hudRow
+        hudRow, h = W:DualRow(parent, y,
             { type="toggle", text="Reskin Widget Bars",
-              tooltip="Restyles Blizzard's on-screen progress bars (event objectives, nameplate counters) to the EUI look. Requires reload to apply.\n\nThese bars are drawn over rather than modified, so if the game ever reports their contents as protected the original bar is shown instead.",
+              tooltip="Restyles Blizzard's on-screen progress bars (event objectives, nameplate counters) to the EUI look. Requires reload to apply.\n\nThese bars are drawn over rather than modified, so if the game ever reports their contents as protected the original bar is shown instead.\n\nUse the cog to set a minimum size, so bars on shrunken nameplates stay readable.",
               getValue=function()
                   return not EllesmereUIDB or EllesmereUIDB.reskinWidgetBars ~= false
               end,
@@ -790,6 +791,91 @@ initFrame:SetScript("OnEvent", function(self)
                   EllesmereUIDB.reskinExtraActionButton = v and true or false
               end })
         y = y - h
+
+        -----------------------------------------------------------------------
+        --  Minimum widget bar size, as a cog on "Reskin Widget Bars".
+        --
+        --  A cog rather than a third toggle in the row above: W:DualRow takes
+        --  exactly two configs and SILENTLY DROPS a third, and this is a
+        --  sub-setting of the widget bar reskin rather than a peer of it.
+        --
+        --  The cover mirrors Blizzard's bar rect exactly, which is right in a
+        --  panel and wrong on a nameplate -- a plate scaled down for a small
+        --  unit drags its bar, and the label inside it, down with it. This is
+        --  the floor below which the cover scales itself up instead. 0 turns
+        --  the correction off entirely and mirrors the rect whatever its size.
+        -----------------------------------------------------------------------
+        if hudRow and hudRow._leftRegion and not EllesmereUI._prebuilding then
+            local PP    = EllesmereUI.PanelPP
+            local lrgn  = hudRow._leftRegion
+            local _, showMinSize = EllesmereUI.BuildCogPopup({
+                title = "Widget Bar Size",
+                rows  = {
+                    { type="slider", label="Minimum", min=0, max=24, step=1,
+                      get=function()
+                          local v = EllesmereUIDB and EllesmereUIDB.widgetBarMinSize
+                          if type(v) == "number" then return v end
+                          return 12
+                      end,
+                      set=function(v)
+                          if not EllesmereUIDB then EllesmereUIDB = {} end
+                          EllesmereUIDB.widgetBarMinSize = v
+                          -- Live, no reload. The seam re-reads the setting and
+                          -- books one refresh, which re-anchors every cover
+                          -- already on screen. It is only published when the
+                          -- reskin is on -- and the cog is greyed out then, so
+                          -- the nil case is unreachable from here rather than
+                          -- merely guarded.
+                          if EllesmereUI._HUDWidgetSetMinSize then
+                              EllesmereUI._HUDWidgetSetMinSize()
+                          end
+                      end },
+                },
+            })
+
+            local cog = CreateFrame("Button", nil, lrgn)
+            cog:SetSize(26, 26)
+            PP.Point(cog, "RIGHT", lrgn._control or lrgn, "LEFT", -8, 0)
+            cog:SetFrameLevel(lrgn:GetFrameLevel() + 5)
+            local cogTex = cog:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints()
+            cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
+
+            local function CogOff()
+                -- Same default-on test the toggle itself uses: nil means on.
+                return not (not EllesmereUIDB or EllesmereUIDB.reskinWidgetBars ~= false)
+            end
+            -- Canonical cog alphas: .15 disabled, .4 idle, .75 hover. Applied
+            -- at build time as well as on refresh -- widget refresh only fires
+            -- on LATER changes, so without the call every cog opens lit.
+            local function UpdCogState()
+                local off = CogOff()
+                cog:SetAlpha(off and 0.15 or 0.4)
+                cog:EnableMouse(not off)
+            end
+            EllesmereUI.RegisterWidgetRefresh(UpdCogState)
+            UpdCogState()
+
+            cog:SetScript("OnClick", function(self)
+                if not CogOff() then showMinSize(self) end
+            end)
+            cog:SetScript("OnEnter", function(self)
+                if not CogOff() then self:SetAlpha(0.75) end
+                if EllesmereUI.ShowWidgetTooltip then
+                    EllesmereUI.ShowWidgetTooltip(self,
+                        "Smallest on-screen size a reskinned bar is drawn at.\n\n" ..
+                        "Widget bars on a nameplate inherit that nameplate's scale, so " ..
+                        "they come out tiny on small units. Below this size the bar is " ..
+                        "scaled up instead, text and all.\n\nSet to 0 to mirror " ..
+                        "Blizzard's size exactly.")
+                end
+            end)
+            cog:SetScript("OnLeave", function()
+                UpdCogState()
+                if EllesmereUI.HideWidgetTooltip then EllesmereUI.HideWidgetTooltip() end
+            end)
+            lrgn._lastInline = cog
+        end
 
         return math.abs(y)
     end
@@ -3098,6 +3184,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.reskinPlayerChoice = nil
                 EllesmereUIDB.reskinTrade = nil
                 EllesmereUIDB.reskinWidgetBars = nil
+                EllesmereUIDB.widgetBarMinSize = nil
                 EllesmereUIDB.reskinExtraActionButton = nil
                 EllesmereUIDB.lfgRememberRoles = nil
                 EllesmereUIDB.lfgSavedRoles = nil


### PR DESCRIPTION
Four small fixes to the Blizzard skin.

**Bars on nameplates came out tiny.** The progress bars that show above enemies shrink along with the nameplate, so on smaller enemies they ended up too small to read. They now have a minimum size and grow themselves — text and all — when they'd fall below it.

There's a new cog next to "Reskin Widget Bars" to set that size, or set it to 0 to leave the bars exactly as the game draws them. Takes effect straight away, no reload.

**Dungeon Finder / Raid Finder rewards** were still the default look. They now match the quest reward style used everywhere else: square icons, no parchment plate behind the name, and a coloured edge showing the item's quality. The gold reward is included.

**The extra action button** icon wasn't getting trimmed the way every other icon in the skin is, so it kept the dark edge that's part of the artwork. How obvious that was depended on the spell, which is why it looked like it only went wrong sometimes.

**Mythic+ dungeon icons** weren't being squared off, and they now stay square when the list refreshes or grows — that's why some of them looked right and others didn't.
