### PR TITLE
fix(unlock): X/Y cog and Center on Screen reading odd-width bars 1px off

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -7483,7 +7483,19 @@ local function CreateMover(barKey)
                 if type(pos) == "table" and pos.point == "CENTER"
                    and (pos.relPoint or "CENTER") == "CENTER"
                    and pos.x and pos.y then
-                    fs:SetText(format("%.0f, %.0f", toPx(pos.x), toPx(pos.y)))
+                    -- Dim-aware, matching the live-geometry branch below: an odd-pixel-
+                    -- dimension bar's stored center sits on a half pixel, and plain
+                    -- ToPixels reads that back one pixel high.
+                    local sb = GetBarFrame(bk)
+                    local c2pS = PPi and PPi.CenterToPixels
+                    local px, py
+                    if c2pS and sb then
+                        px = c2pS(pos.x, sb:GetWidth(), sb:GetEffectiveScale())
+                        py = c2pS(pos.y, sb:GetHeight(), sb:GetEffectiveScale())
+                    else
+                        px, py = toPx(pos.x), toPx(pos.y)
+                    end
+                    fs:SetText(format("%.0f, %.0f", px, py))
                     fs:Show()
                     return
                 end
@@ -9455,7 +9467,17 @@ local function CreateMover(barKey)
                         if type(pos) == "table" and pos.point == "CENTER"
                            and (pos.relPoint or "CENTER") == "CENTER"
                            and pos.x and pos.y then
-                            if ax == "X" then return PPi.ToPixels(pos.x) end
+                            -- Dim-aware, matching the live-geometry conversion below: an
+                            -- odd-pixel-dimension bar stores its center on a half pixel, and
+                            -- plain ToPixels reads that back one pixel high (the same misread
+                            -- the comment above the live branch describes).
+                            local sb = GetBarFrame(barKey)
+                            local c2pS = PPi.CenterToPixels
+                            if ax == "X" then
+                                if c2pS and sb then return c2pS(pos.x, sb:GetWidth(), sb:GetEffectiveScale()) end
+                                return PPi.ToPixels(pos.x)
+                            end
+                            if c2pS and sb then return c2pS(pos.y, sb:GetHeight(), sb:GetEffectiveScale()) end
                             return PPi.ToPixels(pos.y)
                         end
                     end
@@ -9692,7 +9714,10 @@ local function CreateMover(barKey)
                 if type(pos) == "table" and pos.point == "CENTER"
                    and (pos.relPoint or "CENTER") == "CENTER"
                    and pos.x and pos.y then
-                    curPx = PPc.ToPixels(pos.x)
+                    -- Dim-aware, matching the cog X box and coordinate readout: an
+                    -- odd-pixel-width bar's stored center sits on a half pixel.
+                    local c2pC = PPc.CenterToPixels
+                    curPx = (c2pC and c2pC(pos.x, b:GetWidth(), b:GetEffectiveScale())) or PPc.ToPixels(pos.x)
                 end
             end
             if curPx == nil then


### PR DESCRIPTION
## Summary
- `AxisToPx`, `UpdateCoordText`, and `Center on Screen` in the unlock-mode cog each read a saved CENTER/CENTER position through plain `PP.ToPixels` instead of the dimension-aware `PP.CenterToPixels` their own live-geometry fallbacks already use.
- For an odd-pixel-width bar the stored center legitimately sits on a half pixel; `ToPixels` reads that back one pixel high, so typing `0` into AB1's X box read the bar as already at `1`, computed a `-1` delta, and landed it at `-1`.

## Fix
All three now go through `CenterToPixels` with the bar's own width/height and effective scale, matching the pattern `NudgeMover` already used to avoid baking the same half-pixel drift into saved positions.

## Test
- [x] Reported repro (AB1 X set to 0) confirmed fixed in-game
- [x] `luac -p` clean