### PR TITLE
Fix action bar / cooldown manager preview row clipping

### DIFF
--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -695,7 +695,7 @@ initFrame:SetScript("OnEvent", function(self)
                 -- a row in half; topInset is the space above row 1 (matches gridStartY).
                 local topInset = Snap(10) + bgTopInset
                 local rowStep = scaledBtnH + scaledPad
-                local visibleRows = math.max(1, math.floor((maxH / self._previewScale - topInset + scaledPad) / rowStep))
+                local visibleRows = math.max(1, math.floor((maxH / self._previewScale - topInset + scaledPad) / rowStep + 0.001))
                 visibleRows = math.min(visibleRows, gridRows)
                 local cappedLocalH = Snap(topInset + visibleRows * scaledBtnH + (visibleRows - 1) * scaledPad)
                 self._wrapper:SetHeight(math.min(maxH, cappedLocalH * self._previewScale))

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -691,7 +691,14 @@ initFrame:SetScript("OnEvent", function(self)
                 -- Bottom padding so the last row is fully visible when scrolled down
                 local paddedH = Snap(gridH + 20 + bgTopInset + bgBottomInset + scaledBtnH)
                 self:SetHeight(paddedH)
-                self._wrapper:SetHeight(maxH)
+                -- Snap the viewport to a whole number of rows so the cap never slices
+                -- a row in half; topInset is the space above row 1 (matches gridStartY).
+                local topInset = Snap(10) + bgTopInset
+                local rowStep = scaledBtnH + scaledPad
+                local visibleRows = math.max(1, math.floor((maxH / self._previewScale - topInset + scaledPad) / rowStep))
+                visibleRows = math.min(visibleRows, gridRows)
+                local cappedLocalH = Snap(topInset + visibleRows * scaledBtnH + (visibleRows - 1) * scaledPad)
+                self._wrapper:SetHeight(math.min(maxH, cappedLocalH * self._previewScale))
             else
                 self._wrapper:SetHeight(parentH)
                 -- Reset scroll when content fits without scrolling

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -15352,7 +15352,21 @@ initFrame:SetScript("OnEvent", function(self)
             if parentH > maxH then
                 -- Add bottom padding so info text is fully visible when scrolled down
                 self:SetHeight(self:GetHeight() + 30)
-                self._wrapper:SetHeight(maxH)
+                -- If the cap would slice into the icon grid itself, snap the viewport to
+                -- a whole row instead -- cropping into the hint text below is harmless,
+                -- cropping an icon row in half isn't.
+                local stackRows = isVert and stride or numRows
+                local topInset = 5
+                local rowStep = iconH + spacing
+                local gridBottomLocal = topInset + stackRows * iconH + (stackRows - 1) * spacing
+                if gridBottomLocal * self._previewScale > maxH then
+                    local visibleRows = math.max(1, math.floor((maxH / self._previewScale - topInset + spacing) / rowStep + 0.001))
+                    visibleRows = math.min(visibleRows, stackRows)
+                    local cappedLocalH = topInset + visibleRows * iconH + (visibleRows - 1) * spacing
+                    self._wrapper:SetHeight(math.min(maxH, cappedLocalH * self._previewScale))
+                else
+                    self._wrapper:SetHeight(maxH)
+                end
             else
                 self._wrapper:SetHeight(parentH)
                 if self._scrollFrame then self._scrollFrame:SetVerticalScroll(0) end


### PR DESCRIPTION
Cause: the Bar Display and Cooldown Manager live previews clip to a fixed 200px viewport once content grows past it. The cap wasn't row-aligned, so a bar with enough rows to cross it (easy at smaller UI scales, which inflate the preview's on-screen size) got its bottom icon row sliced in half instead of cropping between rows.

Fix: snap the capped viewport to the last fully visible row in both preview builders, so overflow always crops between rows, not through one. CDM only applies the snap when the cap would land inside the icon grid, since its overflow can also come from hint text below the grid.

Test: luac -p on both files, verified in game that Action Bar and CDM bar previews at 2+ rows no longer slice a row.