### PR TITLE
Character/Inspect Sheet: flag missing enchant on off-hand weapons

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -4485,6 +4485,8 @@ local function SkinCharacterSheet()
         [INVSLOT_FINGER1] = true,
         [INVSLOT_FINGER2] = true,
         [INVSLOT_MAINHAND] = true,
+        -- INVSLOT_OFFHAND deliberately absent: whether it can be enchanted depends on
+        -- what's equipped there (weapon vs. shield/held item), checked dynamically below.
     }
 
     -- Update one slot's item level, enchant and upgrade-track labels.
@@ -4505,6 +4507,13 @@ local function SkinCharacterSheet()
         local itemQuality = nil
         local slotID = slot:GetID()
         local canHaveEnchant = ENCHANT_SLOTS[slotID]
+        -- Off-hand only takes a weapon enchant when it's actually holding a weapon
+        -- (dual-wield); shields and held items (tomes, etc.) can't be enchanted, so
+        -- the slot alone can't gate this like the other static slots above.
+        if slotID == INVSLOT_OFFHAND and itemLink then
+            local _, _, _, _, _, classID = GetItemInfoInstant(itemLink)
+            canHaveEnchant = (classID == Enum.ItemClass.Weapon)
+        end
 
         if itemLink then
             local _, _, quality, ilvl = GetItemInfo(itemLink)

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -4507,9 +4507,6 @@ local function SkinCharacterSheet()
         local itemQuality = nil
         local slotID = slot:GetID()
         local canHaveEnchant = ENCHANT_SLOTS[slotID]
-        -- Off-hand only takes a weapon enchant when it's actually holding a weapon
-        -- (dual-wield); shields and held items (tomes, etc.) can't be enchanted, so
-        -- the slot alone can't gate this like the other static slots above.
         if slotID == INVSLOT_OFFHAND and itemLink then
             local _, _, _, _, _, classID = GetItemInfoInstant(itemLink)
             canHaveEnchant = (classID == Enum.ItemClass.Weapon)

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
@@ -73,6 +73,8 @@ local INSPECT_ENCHANT_SLOTS = {
     [INVSLOT_FINGER1] = true,
     [INVSLOT_FINGER2] = true,
     [INVSLOT_MAINHAND] = true,
+    -- INVSLOT_OFFHAND deliberately absent: checked dynamically below (weapon vs.
+    -- shield/held item), like CharacterSheet.
 }
 
 -- Drop every label a previous styling pass left on this slot. The widgets
@@ -173,6 +175,10 @@ local function EUI_UpdateSlotStyle(slotName, slotID, textOverlayFrame, isRightCo
         local enchantSize = EllesmereUIDB and EllesmereUIDB.charSheetEnchantSize or 9
         local enchantText = EllesmereUI.GetEnchantText(slotID, inspectUnit)
         local canHaveEnchant = INSPECT_ENCHANT_SLOTS[slotID]
+        if slotID == INVSLOT_OFFHAND then
+            local _, _, _, _, _, classID = GetItemInfoInstant(itemLink)
+            canHaveEnchant = (classID == Enum.ItemClass.Weapon)
+        end
         local inspLvl = UnitLevel(inspectUnit)
         local atEnchantLevel = inspLvl and not (issecretvalue and issecretvalue(inspLvl)) and inspLvl >= 90 or false
         local isMissing = atEnchantLevel and canHaveEnchant and itemLink and (enchantText == "" or not enchantText)


### PR DESCRIPTION
Cause: ENCHANT_SLOTS (and its Inspect Sheet mirror) only listed the main-hand slot, so dual-wielders never got the missing-enchant marker on an unenchanted off-hand weapon, on their own sheet or when inspecting another player.

Fix: off-hand can't be gated statically like the other slots since it may hold a shield or held item instead of a weapon. Check the equipped item's class dynamically and only flag it when it's actually a weapon.

Test: luac -p on both files, verified in game on a dual-wield character.