### PR TITLE
Add Korean translations for Buff Manager features

### DIFF
--- a/EllesmereUILocales/koKR.lua
+++ b/EllesmereUILocales/koKR.lua
@@ -6928,6 +6928,20 @@ L["House Level %d: %d / %d"] = "집 레벨 %d: %d / %d"
 L["ADDITIONAL BAR OFFSET"] = "추가 바 오프셋"
 L["Extra horizontal shift stacked on top of this bar's normal position. Unlock mode shows the base position; the offset re-applies when you exit."] = "이 바의 기본 위치 위에 추가로 적용되는 가로 이동 거리입니다. 프레임 이동 모드에서는 기본 위치가 표시되며, 이동 모드를 종료하면 오프셋이 다시 적용됩니다."
 L["Extra vertical shift stacked on top of this bar's normal position. Unlock mode shows the base position; the offset re-applies when you exit."] = "이 바의 기본 위치 위에 추가로 적용되는 세로 이동 거리입니다. 프레임 이동 모드에서는 기본 위치가 표시되며, 이동 모드를 종료하면 오프셋이 다시 적용됩니다."
+L["All Buffs or Has Duration is selected, so every buff already shows. Use the red Hide box to exclude these instead."] = "'모든 버프' 또는 '지속시간 있음'이 선택되어 있어 모든 버프가 이미 표시됩니다. 제외하려면 대신 빨간색 숨기기 상자를 사용하세요."
+L["Copy from %1$s Buff Manager"] = "%1$s 버프 관리자에서 복사"
+L["Copy from main Buff Manager"] = "기본 버프 관리자에서 복사"
+L["Create Custom Buff Manager"] = "사용자 정의 버프 관리자 생성"
+L["Only show this bar while the tracked buff/cooldown is active. Unchecked keeps an empty bar on screen at all times."] = "추적 중인 버프/재사용 대기시간이 활성화된 상태일 때만 바를 표시합니다. 해제하면 화면에 빈 바가 항상 유지됩니다."
+L["Precise Below (minutes, 0 = off)"] = "이하일 때 정밀 표시 (분 단위, 0 = 끔)"
+L["This will create a fully unique Buff Manager for this conditional group. Changes made to your default Buff Manager will no longer affect it."] = "이 조건부 그룹을 위한 완전히 독립된 버프 관리자를 생성합니다. 기본 버프 관리자를 변경해도 이 그룹에는 더 이상 영향을 주지 않습니다."
+L["This will create a fully unique Buff Manager for this override group. Changes made to your default Buff Manager will no longer affect these specs."] = "이 오버라이드 그룹을 위한 완전히 독립된 버프 관리자를 생성합니다. 기본 버프 관리자를 변경해도 이 전문화들에는 더 이상 영향을 주지 않습니다."
+L["%1$s Specialization Ability"] = "%1$s 전문화 능력"
+L["Dashed"] = "파선"
+L["Indicators added here show on every spec in this group. The Base Icons grid lives in %1$s."] = "여기에 추가된 아이콘은 이 그룹의 모든 전문화에 표시됩니다. 기본 아이콘 격자는 %1$s에 있습니다."
+L["No indicator selected"] = "선택된 아이콘 없음"
+L["Start From"] = "시작 지점"
+L["This override has no indicators for this spec, so nothing shows here until you add some."] = "이 오버라이드에는 현재 전문화에 대한 아이콘이 없으므로, 추가하기 전까지는 아무것도 표시되지 않습니다."
 
 --편의 기능 
 L["Hide Loot Rolls Window"] = "전리품 주사위 창 숨기기"
@@ -6936,6 +6950,13 @@ L["Loot Rolls Window Settings"] = "전리품 주사위 창 설정"
 L["Hide Completely"] = "완전히 숨기기"
 L["Close After Delay"] = "일정 시간 후 닫기"
 L["Close After (sec)"] = "닫기 지연 시간 (초)"
+L["A spec override owns this setting, so this conditional value never applies outside an editing session. Remove the spec override to let it through."] = "전문화 오버라이드가 이 설정을 제어하고 있으므로, 편집 세션 외에는 이 조건부 값이 적용되지 않습니다. 적용하려면 전문화 오버라이드를 제거하세요."
+L["Changes here edit the shared default; overrides keep their own values."] = "여기서 수정하면 공유되는 기본값이 변경되며, 오버라이드된 항목은 고유의 값을 유지합니다."
+L["Default Preset"] = "기본 프리셋"
+L["Empty Preset"] = "빈 프리셋"
+L["Hide when Skyriding Mounted"] = "하늘비행 탑승 시 숨기기"
+L["Overridden by:"] = "다음 항목에 의해 덮어씌워짐:"
+L["Support Team"] = "지원 팀"
 
 --기본 UI 개선
 L["The ready check prompt with its Yes / No buttons, plus the initiator's response list."] = "수락 / 거절 단추가 포함된 전투 준비 창과 전투 준비를 시작한 사람의 응답 현황 목록입니다."
@@ -6948,6 +6969,15 @@ L["Choice Windows"] = "선택창"
 L["Weekly and event choice windows such as Abundance harvests and \"how will you aid...\" pickers: option plates, headers, reward icons and buttons. Option artwork stays."] = "풍요로운 구렁 보상이나 '누구를 도우시겠습니까...' 같은 주간 및 이벤트 선택창을 변경합니다. 선택지 판, 머리말, 보상 아이콘 및 단추가 포함됩니다. 선택지 아트워크는 그대로 유지됩니다."
 L["Trade"] = "거래"
 L["The player-to-player trade window: frame, both item columns, the enchant slots, money rows and buttons. Item icons are squared and carry a rarity border. Both portraits are removed, as on every other window."] = "플레이어 간 거래 창을 변경합니다. 프레임, 양쪽 아이템 칸, 마법부여 칸, 골드 입력 칸 및 단추가 포함됩니다. 아이템 아이콘은 사각형으로 바뀌고 등급별 테두리가 적용됩니다. 다른 창들과 마찬가지로 양쪽 캐릭터 초상화는 제거됩니다."
+L["Armory Slot Group Options"] = "장비 슬롯 그룹 옵션"
+L["Compact Slot Groups"] = "슬롯 그룹 압축"
+L["Frame Footer"] = "창 하단 영역"
+L["Place smaller Armory slot groups beside each other and fill the unused end of each row with empty-slot blocks. Large groups still use full rows."] = "작은 장비 슬롯 그룹들을 나란히 배치하고, 각 행의 남는 공간은 빈 슬롯 블록으로 채웁니다. 큰 그룹은 계속해서 전체 행을 사용합니다."
+L["Prefix the durability percent with \"Durability:\"."] = "내구도 백분율 앞에 \"내구도:\" 텍스트를 붙입니다."
+L["Show Item Durability"] = "아이템 내구도 표시"
+L["Show Label"] = "라벨 표시"
+L["Show total equipped durability above the character model, colored from green to red."] = "캐릭터 모델 위에 장착 중인 장비의 총 내구도를 초록색에서 빨간색으로 색상을 달리하여 표시합니다."
+L["Stats Header"] = "능력치 상단 영역"
 
 --기본 UI 개선 - 툴팁, 메뉴&팝업/알림
 L["BLIZZARD HUD"] = "블리자드 HUD"
@@ -6969,6 +6999,8 @@ L["Colors the enemy nameplate name text to match the unit's reaction (Hostile or
 
 --오라/강화 효과 알림
 L["Pick which content the class-special reminders (poisons/rites/imbues/shields) appear in.\nRested areas (cities and inns) always stay hidden."] = "직업 전용 알림(독/의식/무기 부여/보호막)을 표시할 콘텐츠를 선택합니다. 휴식 지역(도시 및 여관)에서는 항상 숨겨집니다."
+
+
 
 -- == Chat prints (채팅창 print 출력 - 소스 엘키(L/Lf) 삽입 대기) ==================
 -- 원본이 print() 에 영문 리터럴을 직접 쓰는 곳들. 엔진 자동번역 밖이라 소스에서

--- a/EllesmereUILocales/koKR.lua
+++ b/EllesmereUILocales/koKR.lua
@@ -7000,8 +7000,6 @@ L["Colors the enemy nameplate name text to match the unit's reaction (Hostile or
 --오라/강화 효과 알림
 L["Pick which content the class-special reminders (poisons/rites/imbues/shields) appear in.\nRested areas (cities and inns) always stay hidden."] = "직업 전용 알림(독/의식/무기 부여/보호막)을 표시할 콘텐츠를 선택합니다. 휴식 지역(도시 및 여관)에서는 항상 숨겨집니다."
 
-
-
 -- == Chat prints (채팅창 print 출력 - 소스 엘키(L/Lf) 삽입 대기) ==================
 -- 원본이 print() 에 영문 리터럴을 직접 쓰는 곳들. 엔진 자동번역 밖이라 소스에서
 -- L()/Lf() 래핑이 들어가야 적용된다 (보류 목록: project_pending_bags_lwrap 참고).


### PR DESCRIPTION
## What does this PR do?

* Adds Korean (`koKR`) localization strings for new addon configuration options (Buff Manager, Armory slot groups & durability display, conditional overrides, etc.).
* Refines terminology to match the latest World of Warcraft expansion environment and addon UI settings naturally and intuitively.

## How was it tested?

  Verified in-game after applying /reload to confirm that all localized strings and option tooltips render correctly without errors.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
