### PR TITLE
koKR: current-season dungeon abbreviations + 40-man frame labels

### DIFF
--- a/EllesmereUILocales/koKR.lua
+++ b/EllesmereUILocales/koKR.lua
@@ -6120,6 +6120,8 @@ L["25 Man Frame Height"] = "25인 프레임 높이"
 L["25 Man Frame Width"] = "25인 프레임 너비"
 L["30 Man Frame Height"] = "30인 프레임 높이"
 L["30 Man Frame Width"] = "30인 프레임 너비"
+L["40 Man Frame Height"] = "40인 프레임 높이"
+L["40 Man Frame Width"] = "40인 프레임 너비"
 L["a Glow Type other than None"] = "없음 외의 발광 유형"
 L["Action Bars Font"] = "행동 단축바 글꼴"
 L["Action Bars Outline"] = "행동 단축바 외곽선"
@@ -7038,14 +7040,14 @@ L["Reset failed - there are still players inside the instance."] = "초기화 �
 -- == M+ keystone dungeon abbreviations (신화+ 던전 약어 -> 한글 단축명) ==
 -- Minimap portal table (spellID -> code) + bag keystone display produce these English codes;
 -- the render hook then shows the short Korean name.
-L["AA"]  = "대학"
-L["MC"]  = "동굴"
-L["MT"]  = "마정"
-L["NPX"] = "제나스"
-L["PoS"] = "사론"
-L["SoT"] = "삼두정"
-L["SR"]  = "하늘탑"
-L["WRS"] = "첨탑"
+L["MR"]  = "골목"
+L["DoN"]  = "날로라크"
+L["VA"]  = "투기장"
+L["BV"] = "골짜기"
+L["AoF"] = "송곳니"
+L["RLP"] = "루비"
+L["ToS"]  = "세스랄"
+L["KR"] = "왕안"
 
 -- Bag keystone dungeon abbreviation overrides (koKR). AbbrevDungeon in
 -- EllesmereUIBags cuts the localized dungeon name to first-letters, which in


### PR DESCRIPTION
Korean locale only -- no source changes. Ten keys in
`EllesmereUILocales/koKR.lua`: eight dungeon abbreviations swapped for the
current season's pool, and two option labels that still showed English.

**Dungeon abbreviations (8).** The abbreviation keys are per-season, so last
season's entries no longer match anything in the current pool. Replaced with
this season's eight. The values are short Korean names rather than a
letter-by-letter cut of the localized dungeon name, which in Korean produces
awkward two-character fragments.

| Key | Korean |
|---|---|
| `MR` | 골목 |
| `DoN` | 날로라크 |
| `VA` | 투기장 |
| `BV` | 골짜기 |
| `AoF` | 송곳니 |
| `RLP` | 루비 |
| `ToS` | 세스랄 |
| `KR` | 왕안 |

The eight removed (`AA`, `MC`, `MT`, `NPX`, `PoS`, `SoT`, `SR`, `WRS`) belong to
the previous season and are dead entries now.

**Two option labels (2).** `40 Man Frame Height` and `40 Man Frame Width` had no
Korean, so those two rows read English between Korean neighbours.

| Key | Korean |
|---|---|
| `40 Man Frame Height` | 40인 프레임 높이 |
| `40 Man Frame Width` | 40인 프레임 너비 |

Both are placed in the Raid Frames section they belong to, not appended at the
end of the file.

## How was it tested?

Running on a koKR 12.1 client. Both frame labels were confirmed in the Raid
Frames options page, and the abbreviations were confirmed on keystones for the
current pool.

File-level checks: parses clean, 6,779 keys with zero duplicates (case
sensitive, matching the engine), UTF-8 without BOM, no raw newline inside a
string literal, no odd-quote lines, and LF line endings.



## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
