### PR TITLE
Make the Shift Elements Extra Y Offset sliders pixel units

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -7544,7 +7544,7 @@ initFrame:SetScript("OnEvent", function(self)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Shift Offset",
                 rows = {
-                    { type = "slider", label = "Extra Y Offset", min = -50, max = 50, step = 1,
+                    { type = "slider", pixel = true, label = "Extra Y Offset", min = -50, max = 50, step = 1,
                       get = function() local p = DB(); return (p and p.secondary.shiftElementsIfNoResourceExtraY) or 0 end,
                       set = function(v)
                           local p = DB(); if not p then return end
@@ -7589,7 +7589,7 @@ initFrame:SetScript("OnEvent", function(self)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Shift Offset",
                 rows = {
-                    { type = "slider", label = "Extra Y Offset", min = -50, max = 50, step = 1,
+                    { type = "slider", pixel = true, label = "Extra Y Offset", min = -50, max = 50, step = 1,
                       get = function() local p = DB(); return (p and p.primary.shiftElementsIfNoPowerExtraY) or 0 end,
                       set = function(v)
                           local p = DB(); if not p then return end


### PR DESCRIPTION
## What does this PR do?

"Shift Elements if No Resource" and "Shift Elements if No Power" each expose an **Extra Y Offset** in their cog popup. That value is stored and consumed as UIParent coordinate units, so its granularity follows the UI scale instead of the screen: at 4K with uiScale 0.71 one coordinate unit is ~1.997 physical pixels, so an offset of 1 moves the anchored elements **2 px** and an odd pixel offset can't be reached at all.

This marks both sliders `pixel = true` -- the same treatment the other spacing/offset sliders already get. The value is entered and displayed in physical pixels and converted to coordinate units on write, so 1 means 1 pixel on any resolution and UI scale.

Two lines, no behavioural change for anyone already on a pixel-perfect scale (there 1 coord unit == 1 px, so the conversion is the identity).

### Why the fix reaches all the way to the screen

The offset never leaves our own arithmetic, so the fractional coordinate a pixel slider stores is not rounded away:

- `EUI_UnlockMode.lua` -- `ApplyAnchorPosition` adds it to the UIParent-space centre: `cy = cy + dir * ((tT - tB) + (extraY or 0))`
- the final position is then snapped with `PP.SnapForES` / `PP.SnapCenterForDim`

Both snappers quantise to the **physical pixel grid** (`onePixel = PP.perfect / es`), which makes them equivariant under whole-pixel translation: shifting the pre-snap value by exactly N physical pixels moves the snapped result by exactly N physical pixels, for whole-pixel and parity-aware half-pixel centres alike. So the sub-unit value survives to the screen rather than being rounded back to a whole coordinate unit.

## How was it tested?

- In game on live retail at 3840x2160 / uiScale 0.71: Extra Y Offset -1 moved the anchored elements 2 px before the change and exactly 1 px after; odd pixel offsets are now reachable on both the Resource and the Power shift.
- Offline against the real `PP` helpers (Lua 5.1), reproducing `ApplyAnchorPosition`'s shift + snap:
  - slider round-trips px -> coordinate units -> px exactly for +/-1..3 px
  - an offset of -1 moves 2 px before and exactly 1 px after (matches the in-game observation)
  - snap equivariance holds across 1500 cases: 5 child scales (0.6 / 0.71 / 0.85 / 1.0 / 1.2) x 5 frame heights including odd pixel dims (20/21/32/33/47) x 5 base positions x +/-1..3 px x both `SnapForES` and `SnapCenterForDim`
- `luac -p` clean; added code is ASCII-only; `Locales/_keys.txt` unchanged (no new strings).

## Migration note

Saved values keep their meaning -- an existing offset of 1 was always ~2 px on a 0.71 scale, and now simply reads as "2" instead of "1". Nothing moves on upgrade; only the number shown becomes honest.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A: no new setting. The change is a unit correction on two existing sliders, and it is the identity at pixel-perfect UI scales
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- options-layer only; the conversion happens when the slider is read or written
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- two arithmetic conversions in the existing accessors
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- nothing here touches a frame
- [x] Tested in-game, works on live retail