### PR TITLE
Fix QoL tutorial hiding hitch at login

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -3363,17 +3363,6 @@ do
         if root.GetChildren then pcall(ScanFrame, root) end
     end
 
-    -- One-time full walk (no allocation, no timer) to catch panels already open when the feature is switched on.
-    local function SweepAll()
-        local fp = GetFingerprint()
-        if not fp then return end
-        local frame = EnumerateFrames()
-        while frame do
-            if frame.ShowTooltip == fp then HideButton(frame) end
-            frame = EnumerateFrames(frame)
-        end
-    end
-
     local function RestoreButtons()
         for btn in pairs(hiddenByUs) do
             btn:SetAlpha(1)
@@ -3426,7 +3415,10 @@ do
             pcall(SetCVar, "hideHelptips", "1")
             pcall(SetCVar, "showTutorials", "0")
             weSetCVar = true
-            SweepAll()
+            -- Avoid a global EnumerateFrames walk here. Addon-heavy UIs can
+            -- contain enough frames for that scan to block PLAYER_LOGIN for
+            -- several seconds. ShowUIPanel scans each relevant panel when it
+            -- opens, preserving normal behavior without the reload spike.
             HideOpenTips()
         else
             if weSetCVar then


### PR DESCRIPTION
## What does this PR do?

Removes the one-time global `EnumerateFrames()` sweep from the existing Hide Tutorial Pop-ups QoL option.

On addon-heavy UIs, that sweep can walk a very large frame graph during `PLAYER_LOGIN` and block login for several seconds. The existing event-driven behavior remains in place:

- `ShowUIPanel` scans a panel subtree when a relevant panel opens.
- `HelpTip.Show` hides active help tips.
- `HelpPlate` tooltip hooks hide tutorial tooltips.
- The existing CVar changes and restore path are unchanged.

This is a focused bug/performance fix for an existing opt-in option. It adds no settings, events, timers, polling, frames, or compatibility branches.

## Behavior tradeoff

If the option is switched on while a Blizzard panel is already open, tutorial "i" buttons in that currently open panel are not hidden immediately. Closing and reopening the panel runs the existing `ShowUIPanel` hook and hides them; a UI reload is not required. Panels opened after the option is enabled continue to be handled normally.

This avoids reintroducing any broad or speculative frame scan at option enable/login time.

## How was it tested?

- WoW Retail / Midnight client with an addon-heavy UI and repeated `/reload` tests.
- A local performance probe isolated the old `Hide Tutorials` lifecycle callback at approximately 7.5 seconds on the affected setup; removing the global sweep eliminated that spike.
- Verified in game that tutorial/help UI remains hidden after reload with the option enabled.
- Verified the toggle tradeoff in game: an already open panel is not updated immediately, but closing and reopening it hides the tutorial "i" button.
- Lua 5.1 syntax validation passed.
- `git diff --check` passed.

## Checklist

- [x] New settings default **OFF** (N/A: no new setting; the existing `hideTutorials` option remains opt-in)
- [x] Zero cost while disabled: no new events, polling, hooks, or frames
- [x] Cheap while enabled: removes the global frame walk and adds no replacement polling, timer, or allocation path
- [x] No writes onto Blizzard-owned frames introduced; the existing weak-table tracking and `hooksecurefunc` hooks are unchanged
- [x] Tested in game on live