### PR TITLE
Resource Bars: fix Threshold Percent mode for Devourer soul fragments

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -5253,6 +5253,9 @@ local function UpdateSecondaryResource()
                         end
                     elseif _tsEntry and powerType == "SOUL_FRAGMENTS_DEVOURER" then
                         local threshVal = _tsThreshCount or 30
+                        if _tsEntry.thresholdMode ~= "value" and maxC and maxC > 0 then
+                            threshVal = maxC * threshVal / 100
+                        end
                         if _spTextInstead then
                             -- Fill at base; tint the count text when at/over the threshold.
                             ft:SetVertexColor(r, g, b, a)


### PR DESCRIPTION
Cause: the Devourer soul fragments fill-tint branch compared the raw fragment count against the configured threshold, ignoring Threshold as: Percent. Devourer max varies (40 in Void Meta, 50/35 outside, +50 with the PvP talent), so a percent threshold silently behaved as a flat value.

Fix: convert the threshold to a fragment count from the current max when thresholdMode is not "value", matching the conversion already used by the other threshold branches (curve bars, Ignore Pain).

Test: luac clean, style check clean.