### PR TITLE
[bugfix] Fix shadow added around absorbs

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -2040,9 +2040,12 @@ local function CreateAbsorbBar(button, healthBar)
     -- CLAMPTOBLACKADDITIVE is what makes the mask a BOUND: the default wrap
     -- extends the white edge pixels past the mask's rect, so the backfill
     -- rendered unmasked over missing health (doubled onto the forward bar).
+    -- NEAREST because WHITE8X8 is 8x8: stretched over the rect, bilinear blends
+    -- the edge texel with the black border across the outer 1/16 of each side,
+    -- and that alpha ramp read as a shadow along the overshield's edges.
     local curMask = healthBar:CreateMaskTexture()
     curMask:SetAllPoints(curClip)
-    curMask:SetTexture("Interface\\Buttons\\WHITE8X8", "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+    curMask:SetTexture("Interface\\Buttons\\WHITE8X8", "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE", "NEAREST")
 
     -- Backfill bar (overflow): grows into filled health from the right edge.
     -- Child of the HEALTH BAR, not curClip -- the filled-region bound rides


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

A recent update to absorbs added a shadow around absorb textures. This PR fixes it.

## How was it tested?

live - 12.1.0.69382

## Screenshots
before:
<img width="175" height="97" alt="image" src="https://github.com/user-attachments/assets/2f4fbd34-8371-4cf4-ad14-26100bc99476" />

after:
<img width="175" height="100" alt="image" src="https://github.com/user-attachments/assets/8e27b99e-fc11-4f1d-9acb-5c232ca7e6d2" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
