### PR TITLE
Use role icon for group death announcer

### DIFF
--- a/EllesmereUIOptions/EUI_QoL_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_Options.lua
@@ -797,6 +797,16 @@ initFrame:SetScript("OnEvent", function(self)
                         if EllesmereUI._applyGroupDeathAlert then EllesmereUI._applyGroupDeathAlert() end
                         if EllesmereUI._groupDeathShowVisual then EllesmereUI._groupDeathShowVisual() end
                       end },
+                    { type="toggle", label="Role Icon",
+                      tooltip="Shows the dead player's role icon if assigned, instead of the skull icon.",
+                      get=function()
+                        return (EllesmereUIDB and EllesmereUIDB.groupDeathRoleIcon) or false
+                      end,
+                      set=function(v)
+                        if not EllesmereUIDB then EllesmereUIDB = {} end
+                        EllesmereUIDB.groupDeathRoleIcon = v
+                        if EllesmereUI._groupDeathShowVisual then EllesmereUI._groupDeathShowVisual() end
+                      end },
                     { type="dropdown", label="Sound",
                       values=gdSoundValues, order=gdSoundOrder,
                       get=function()
@@ -2809,6 +2819,7 @@ initFrame:SetScript("OnEvent", function(self)
                 if EllesmereUI._applyHideLootHistory then EllesmereUI._applyHideLootHistory() end
                 EllesmereUIDB.announceGroupDeaths = false
                 EllesmereUIDB.groupDeathTextSize = nil
+                EllesmereUIDB.groupDeathRoleIcon = false
                 EllesmereUIDB.groupDeathAlertPos = nil
                 EllesmereUIDB.groupDeathSound = nil      -- legacy boolean (pre-dropdown)
                 EllesmereUIDB.groupDeathSoundKey = nil

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -3591,6 +3591,41 @@ do
 
     local DEFAULT_TEXT_SIZE = 34
 
+    local ROLE_ICON_ATLAS = {
+        TANK    = "UI-LFG-RoleIcon-Tank",
+        HEALER  = "UI-LFG-RoleIcon-Healer",
+        DAMAGER = "UI-LFG-RoleIcon-DPS",
+    }
+    local SKULL_ICON_MARKUP = "|TInterface\\TargetingFrame\\UI-RaidTargetingIcon_8:0|t"
+
+    local function RoleIconEnabled()
+        return (EllesmereUIDB and EllesmereUIDB.groupDeathRoleIcon) and true or false
+    end
+
+    local function RoleIconMarkup(role, size)
+        if not RoleIconEnabled() then return SKULL_ICON_MARKUP end
+        if type(role) ~= "string" or (issecretvalue and issecretvalue(role)) then
+            return SKULL_ICON_MARKUP
+        end
+        local atlas = ROLE_ICON_ATLAS[role]
+        if not atlas then return SKULL_ICON_MARKUP end
+        local px = math.floor(size * 0.5 + 0.5)
+        return CreateAtlasMarkup(atlas, px, px)
+    end
+
+    -- The player's own role for the options previews.
+    local function PlayerRole()
+        if not RoleIconEnabled() then return nil end
+        local role = UnitGroupRolesAssigned("player")
+        if role == nil or role == "NONE" then
+            local spec = GetSpecialization and GetSpecialization()
+            if spec and GetSpecializationRole then
+                role = GetSpecializationRole(spec) or role
+            end
+        end
+        return role
+    end
+
     -- Configured font size + saved position (default center-top).
     local function ApplyOverlaySettings()
         if not alertOverlay then return end
@@ -3645,7 +3680,7 @@ do
         alertOverlay:Hide()
     end
 
-    local function ShowAlert(name, classToken)
+    local function ShowAlert(name, classToken, role)
         if not name then return end
         CreateAlertOverlay()
         ApplyOverlaySettings()
@@ -3655,8 +3690,9 @@ do
         if c then
             colored = "|c" .. (c.colorStr or "ffffffff") .. name .. "|r"
         end
-        local skull = "|TInterface\\TargetingFrame\\UI-RaidTargetingIcon_8:0|t"
-        alertOverlay._text:SetText(skull .. " " .. colored .. " |cffff2020DIED!|r")
+        local size = (EllesmereUIDB and EllesmereUIDB.groupDeathTextSize) or DEFAULT_TEXT_SIZE
+        local icon = RoleIconMarkup(role, size)
+        alertOverlay._text:SetText(icon .. " " .. colored .. " |cffff2020DIED!|r")
 
         alertOverlay._ag:Stop()
         alertOverlay:SetAlpha(1)
@@ -3715,8 +3751,9 @@ do
 
     local function Poll()
         if not (EllesmereUIDB and EllesmereUIDB.announceGroupDeaths) then return end
+        local useRoleIcon = RoleIconEnabled()
         local seen = {}
-        local newlyDeadName, newlyDeadClass, newlyDeadCount
+        local newlyDeadName, newlyDeadClass, newlyDeadRole, newlyDeadCount
         ForEachGroupUnit(function(u)
             local guid = UnitGUID(u)
             if not guid then return end
@@ -3729,6 +3766,7 @@ do
                 local _, classToken = UnitClass(u)
                 newlyDeadName = UnitName(u)
                 newlyDeadClass = classToken
+                if useRoleIcon then newlyDeadRole = UnitGroupRolesAssigned(u) end
                 newlyDeadCount = (newlyDeadCount or 0) + 1
             end
             deadState[guid] = dead
@@ -3738,7 +3776,7 @@ do
         end
         -- One alert per poll (extra ShowAlert calls would just clobber each other) and at most one throttled sound.
         if newlyDeadCount then
-            ShowAlert(newlyDeadName, newlyDeadClass)
+            ShowAlert(newlyDeadName, newlyDeadClass, newlyDeadRole)
             TryPlayDeathSound()
         end
     end
@@ -3781,14 +3819,14 @@ do
     -- Fires a sample alert (with sound) so the look/sound can be checked without a real death; uses your own name/class as preview text.
     EllesmereUI._announceGroupDeathsPreview = function()
         local _, classToken = UnitClass("player")
-        ShowAlert(UnitName("player"), classToken)
+        ShowAlert(UnitName("player"), classToken, PlayerRole())
         PlayDeathSound()
     end
 
     -- Visual-only preview (used by the Text Size slider so dragging it doesn't repeatedly fire the sound).
     EllesmereUI._groupDeathShowVisual = function()
         local _, classToken = UnitClass("player")
-        ShowAlert(UnitName("player"), classToken)
+        ShowAlert(UnitName("player"), classToken, PlayerRole())
     end
 
     EllesmereUI._groupDeathPlaySound = PlayDeathSound


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

For the QoL "Announce Group Deaths" feature, adds an option to show the role icon of the dead player, instead of the generic skull icon.

## How was it tested?

Tested on retail 12.1.0.69382, both with config disabled/enabled

## Screenshots

Disabled (default): https://i.imgur.com/EAr29nf.png
Enabled: https://i.imgur.com/z7yPTTf.png

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
