### PR TITLE
Unit Frames: fix Blizzard class power bar losing visibility after reparent fights

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -12885,6 +12885,9 @@ function InitializeFrames()
         if unit ~= "player" then return end
         if not cpSpecInitDone then return end
         DestroyCustomClassPower()
+        if frames._classPowerBar then
+            frames._classPowerBar.ignoreFramePositionManager = nil
+        end
         frames._classPowerBar = nil
         C_Timer.After(0.1, function()
             if ns.ReloadFrames then ns.ReloadFrames() end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -12776,6 +12776,7 @@ function InitializeFrames()
         if classPowerStyle == "blizzard" then
             if savedClassPowerBar then
                 _blizzCPActive = true
+                savedClassPowerBar.ignoreFramePositionManager = true
                 HookBlizzardClassPower(savedClassPowerBar)
                 PositionClassPowerBar(savedClassPowerBar)
                 frames._classPowerBar = savedClassPowerBar
@@ -12818,6 +12819,7 @@ function InitializeFrames()
         elseif frames._classPowerBar then
             frames._classPowerBar:Hide()
             frames._classPowerBar:ClearAllPoints()
+            frames._classPowerBar.ignoreFramePositionManager = nil
             local origParent = _blizzCPState.origParent or PlayerFrame or UIParent
             frames._classPowerBar:SetParent(origParent)
             frames._classPowerBar = nil
@@ -12846,6 +12848,7 @@ function InitializeFrames()
             if cpFrame then
                 _blizzCPState.origParent = cpFrame:GetParent()
                 _blizzCPActive = true
+                cpFrame.ignoreFramePositionManager = true
                 HookBlizzardClassPower(cpFrame)
                 cpFrame:SetParent(UIParent)
                 frames._classPowerBar = cpFrame


### PR DESCRIPTION
Cause: Blizzard_ManagedFrameSystem reasserts the native class power frame's parent on every OnShow (portals, cutscenes, spec/form swaps), racing our own SetParent hook. The frame could end up shown but not actually visible (IsShown true, IsVisible false).

Fix: set ignoreFramePositionManager on the frame while EUI owns it, the same opt-out flag Blizzard's own managed frames use, and clear it when handing the frame back (including the spec-change teardown path).

Test: reproduced and verified fixed on DK and Warlock, through portals/cutscenes and Blizzard/other style switching.