### PR TITLE
Fix multi-band Amount toggle mismatch on new threshold entries

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -1215,7 +1215,7 @@ initFrame:SetScript("OnEvent", function(self)
             height    = 22,
             getChecked = function(key)
                 local ent = CurrentBandEntry()
-                local isPercent = (_bandLockPercent or (ent and ent.bandMode == "percent")) or false
+                local isPercent = _bandLockPercent or not (ent and ent.bandMode == "value")
                 if key == "percent" then return isPercent else return not isPercent end
             end,
             isDisabled = function() return _bandLockPercent and true or false end,
@@ -1336,7 +1336,7 @@ initFrame:SetScript("OnEvent", function(self)
             local val = tonumber(self:GetText())
             if val then
                 local pctMax = _bandPercentMax or 100
-                local hi = _bandCountBased and 100 or ((not _bandLockPercent and ent.bandMode ~= "percent") and 1000000 or pctMax)
+                local hi = _bandCountBased and 100 or ((not _bandLockPercent and ent.bandMode == "value") and 1000000 or pctMax)
                 val = math.max(1, math.min(hi, math.floor(val + 0.5)))
                 band.to = val
                 SortBands(ent.bands)

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -1336,7 +1336,7 @@ initFrame:SetScript("OnEvent", function(self)
             local val = tonumber(self:GetText())
             if val then
                 local pctMax = _bandPercentMax or 100
-                local hi = _bandCountBased and 100 or ((not _bandLockPercent and ent.bandMode == "value") and 1000000 or pctMax)
+                local hi = _bandCountBased and 100 or ((not _bandLockPercent and ent.bandMode ~= "percent") and 1000000 or pctMax)
                 val = math.max(1, math.min(hi, math.floor(val + 0.5)))
                 band.to = val
                 SortBands(ent.bands)


### PR DESCRIPTION
Cause: a fresh multi-band threshold entry has bandMode unset, which the renderer (ResolveBandConfig) and the value cap both treat as percent. But the Amount/Percent toggle showed "Amount" selected for that same unset state, so an untouched entry looked like it was already in Amount mode while still being capped and rendered as percent, causing values above 100 (e.g. 125 Maelstrom) to silently snap back to 100.

Fix: flip the toggle's default so an unset bandMode correctly shows Percent selected, matching what it's actually capped and rendered as. Explicitly picking Amount still sets bandMode to "value" and unlocks values above 100 as before, now with the render path agreeing.

Test: reproduced the clamp on a fresh multi-band entry, confirmed Percent now shows selected by default, switched to Amount, set a band to 125, confirmed it holds and the color band renders at the correct boundary in game.