### PR TITLE
Fix Damage Meter Disable Snapping not persisting across reload

### DIFF
--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -2041,7 +2041,7 @@ local function CreateDMWindow(winIdx)
     W.isHovered    = false
     W.resizing     = false
     W.windowLocked = wdb.locked or false
-    W.snapDisabled = false
+    W.snapDisabled = wdb.snapDisabled or false
     W.sourceOpen   = false
     W.sourceGUID   = nil
     W.sourceCreatureID = nil
@@ -2503,6 +2503,7 @@ local function CreateDMWindow(winIdx)
               min = MIN_H },
             { text = W.snapDisabled and L("Enable Snapping") or L("Disable Snapping"), onClick = function()
                 W.snapDisabled = not W.snapDisabled
+                wdb.snapDisabled = W.snapDisabled
             end },
             { text = L("Hide Timer"), isActive = wdb.hideTimer, onClick = function()
                 wdb.hideTimer = not wdb.hideTimer


### PR DESCRIPTION
Cause: `snapDisabled` was pure in-memory window state, never read from or written to the window's saved profile, so it reset to enabled on every reload/relog.

Fix: persist it the same way `windowLocked` already does, reading `wdb.snapDisabled` on window creation and writing back on toggle.

Test: reproduced (disable snapping, reload, snapping was back on), confirmed fixed in-game after the change.