### PR TITLE
Fix consumable reminders briefly showing in disabled locations

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -4781,8 +4781,9 @@ mainFrame:SetScript("OnEvent", function(_, e, arg1, arg2, arg3)
         wipe(_dismissedUntilLoad)
         EABR.ScanEatingState()
         if not InCombatLockdown() then EABR.SyncProviderCastSpell() end
-        RequestRefresh()
-        -- Deferred refresh: GetInstanceInfo() can return stale data on the first frame after a loading screen; a second refresh at 0.5s picks up the correct zone.
+        -- GetInstanceInfo() can return stale data on the first frame after a loading screen (e.g. still
+        -- reporting the previous zone on delve entry), which would show a reminder that "Where to Show"
+        -- disables for the new location. Skip the immediate refresh and wait for the corrected one.
         C_Timer.After(0.5, RequestRefresh)
         return
     end


### PR DESCRIPTION
Cause: PLAYER_ENTERING_WORLD refreshed reminders immediately in addition to an already-deferred correction, and GetInstanceInfo() can still report the previous zone on that first frame (e.g. entering a delve). The immediate refresh evaluated "Where to Show" against stale location data, so a reminder disabled for the new zone flashed on until the 0.5s deferred refresh corrected it.

Fix: drop the immediate refresh, rely solely on the deferred one.

Test: reproduced (disable consumables reminder in Delves, enter a delve, reminder flashed), confirmed fixed in-game.