### PR TITLE
Raid Frames: allow Self Position with Merge Groups

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_Options.lua
@@ -4850,8 +4850,6 @@ initFrame:SetScript("OnEvent", function(self)
                       if SVal("showSelfFirst", false) then return "first" end
                       return "none"
                   end,
-                  disabled=function() return SVal("mergeGroups", false) end,
-                  disabledTooltip="Not available with Merge Groups enabled", rawTooltip=true,
                   setValue=function(v)
                       SSet("showSelfFirst", v == "first")
                       SSet("showSelfLast", v == "last")

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -711,6 +711,7 @@ local separatedHdrs  = {}   -- [1..8] group headers
 local containerFrame = nil  -- top-level positioning frame
 ns._flatButtons      = {}   -- buttons owned by the flat (merged) header
 ns._flatHeader       = nil  -- single header for merge-groups mode
+ns._flatGfStr        = nil  -- merged groupFilter LayoutGroups would write (Self Position fallback)
 local eventFrame     = CreateFrame("Frame")
 local unitTrackers   = {}  -- [unitToken] = tracker frame
 local inCombat       = false
@@ -6054,7 +6055,8 @@ end -- XF scope block
 --  per-group nameList listing every member with the player first, so the
 --  secure header orders natively -- no SetPoint override, no flicker.
 --  showPlayer can't exclude the player in a raid, so the party-style self
---  button doesn't apply here. Non-merged only (ignored when Merge Groups on).
+--  button doesn't apply here. Merged mode pins the player via a whole-raid
+--  nameList instead (ns._BuildMergedSelfNameList below).
 -------------------------------------------------------------------------------
 -- Player's raid subgroup (1-8). Party/solo collapses to group 1.
 function ns._GetPlayerSubgroup()
@@ -6229,10 +6231,54 @@ function ns._BuildArenaNameList(hideSelf, selfFirst, selfLast, sortByRole, roleO
     return table.concat(names, ",")
 end
 
+-- Whole-raid nameList for Merge Groups + Self Position: player pinned first
+-- (or last), everyone else in the active sort (role blocks in ROLE mode, raid
+-- index otherwise). Replaces the flat header's groupFilter, so members of
+-- groups hidden via Show Groups are simply not listed. Bails to nil while any
+-- name is unresolved (a nameList missing a member HIDES that frame); the
+-- caller falls back to the engine path until names resolve.
+function ns._BuildMergedSelfNameList(sortByRole, roleOrder, selfLast, visibleGroups)
+    if not IsInRaid() then return nil end
+    local pri
+    if sortByRole then
+        pri = {}
+        for p, r in ipairs(roleOrder) do pri[r] = p end
+    end
+    local members = {}
+    local n = GetNumGroupMembers()
+    for i = 1, n do
+        local name, _, subgroup = GetRaidRosterInfo(i)
+        if not name or name == UNKNOWNOBJECT then return nil end
+        if not visibleGroups or visibleGroups[subgroup] ~= false then
+            local unit = "raid" .. i
+            local rp = 99
+            if pri then rp = pri[UnitGroupRolesAssigned(unit)] or 99 end
+            members[#members + 1] = {
+                name = name,
+                isPlayer = UnitIsUnit(unit, "player"),
+                rolePri = rp,
+                index = i,
+            }
+        end
+    end
+    if #members == 0 then return nil end
+    table.sort(members, function(a, b)
+        -- Player to top (self-first) or bottom (self-last); exactly one of a/b
+        -- is the player in this branch, so the XOR with selfLast flips it.
+        if a.isPlayer ~= b.isPlayer then return a.isPlayer ~= selfLast end
+        if sortByRole and a.rolePri ~= b.rolePri then return a.rolePri < b.rolePri end
+        return a.index < b.index
+    end)
+    local names = {}
+    for _, m in ipairs(members) do names[#names + 1] = m.name end
+    return table.concat(names, ",")
+end
+
 -------------------------------------------------------------------------------
 --  Apply sort attributes to all headers. Show Self First (raid) uses the
---  per-group nameList (see the Show Self First banner above). Non-merged,
---  in-raid only. Expensive Hide/Show runs only when an attribute actually changed.
+--  per-group nameList (see the Show Self First banner above); merged mode
+--  uses the whole-raid nameList (ns._BuildMergedSelfNameList). Expensive
+--  Hide/Show runs only when an attribute actually changed.
 -------------------------------------------------------------------------------
 local function ApplySortToHeaders()
     if not containerFrame or InCombatLockdown() then return end
@@ -6274,9 +6320,22 @@ local function ApplySortToHeaders()
     end
 
     if s.mergeGroups and ns._flatHeader then
-        -- Flat header's groupFilter is managed by LayoutGroups; pass it through.
-        applySortTo(ns._flatHeader, baseGroupBy, baseSortMethod, baseGroupingOrder, nil,
-            ns._flatHeader:GetAttribute("groupFilter"))
+        -- Self Position in merged mode: a whole-raid nameList owns the order
+        -- (player pinned, rest by the active sort), so groupFilter must be
+        -- CLEARED -- the list itself only names visible groups' members --
+        -- and groupBy nil so the list order is what the header uses (same
+        -- combo as the non-merged player's-group path). While names are
+        -- unresolved (builder bailed) the engine path runs instead, with
+        -- LayoutGroups' groupFilter restored from ns._flatGfStr.
+        local mergedSelf = (s.showSelfFirst or s.showSelfLast) and IsInRaid()
+        local mergedList = mergedSelf
+            and ns._BuildMergedSelfNameList(sortByRole, roleOrder, selfLast, s.visibleGroups) or nil
+        if mergedList then
+            applySortTo(ns._flatHeader, nil, "NAMELIST", "", mergedList, nil)
+        else
+            applySortTo(ns._flatHeader, baseGroupBy, baseSortMethod, baseGroupingOrder, nil,
+                ns._flatGfStr or ns._flatHeader:GetAttribute("groupFilter"))
+        end
     else
         for group = 1, 8 do
             local hdr = separatedHdrs[group]
@@ -6632,7 +6691,14 @@ ns._LayoutGroupsImpl = function()
             ns._flatHeader:ClearAllPoints()
             ns._flatHeader:SetPoint("TOPLEFT", containerFrame, "TOPLEFT", 0, 0)
             local layoutChanged = false
-            if ns._flatHeader:GetAttribute("groupFilter") ~= gfStr then
+            -- While Self Position owns the merged header (whole-raid nameList,
+            -- applied by ApplySortToHeaders at the end of this pass), a
+            -- groupFilter write here would fight its clear on every pass. Cache
+            -- the string instead -- ApplySortToHeaders restores it whenever the
+            -- nameList bails on unresolved names.
+            ns._flatGfStr = gfStr
+            local selfOwnsHeader = (s.showSelfFirst or s.showSelfLast) and IsInRaid()
+            if not selfOwnsHeader and ns._flatHeader:GetAttribute("groupFilter") ~= gfStr then
                 ns._flatHeader:SetAttribute("groupFilter", gfStr)
             end
             if ns._flatHeader:GetAttribute("point") ~= hdrPoint
@@ -11418,10 +11484,13 @@ local function BuildPreviewRoles()
 
     -- Sort within each group based on sort settings
     local sortMode = db.profile.sortMode or "INDEX"
-    -- Self ordering is non-merged only (ignored when Merge Groups is enabled).
-    -- showSelfFirst here means "self ordering active"; selfLast picks the end.
-    local selfLast = db.profile.showSelfLast and not db.profile.mergeGroups
-    local showSelfFirst = (db.profile.showSelfFirst or db.profile.showSelfLast) and not db.profile.mergeGroups
+    -- Self ordering pins the player first (or last). Separated mode moves the
+    -- player within each preview group; merged mode flows the whole grid in
+    -- one sort, which the per-group preview approximates with the player at
+    -- the first cell. showSelfFirst here means "self ordering active";
+    -- selfLast picks the end.
+    local selfLast = db.profile.showSelfLast
+    local showSelfFirst = db.profile.showSelfFirst or db.profile.showSelfLast
     previewRoles._playerSlot = 1  -- default: player is slot 1
 
     if sortMode == "ROLE" or showSelfFirst then


### PR DESCRIPTION
## What does this PR do?

Self Position (Show Self First / Show Self Last) was previously unavailable for raid frames with Merge Groups enabled - the option was intentionally gated off because the two mechanisms conflict: Merge Groups drives its flat header with `groupFilter`, while Self Position works via a `nameList`, which the secure header engine only honors when `groupFilter` is unset.

This PR makes the combination work. When Self Position is active in merged mode, the flat header switches from filter-driven to list-driven:

- New `ns._BuildMergedSelfNameList`: one roster pass producing a comma-separated name list - player pinned first (or last), remaining members ordered by the active sort (role order when Sort by Role is on, raid index otherwise), restricted to visible groups. Bails out while any name is unresolved (e.g. right after a loading screen) so the engine path stays in charge until names exist.
- `ApplySortToHeaders` applies the list to the flat header with `groupFilter` cleared and `groupBy` nil (the same combination the non-merged player's-group path uses). When the builder bails, the cached filter is reapplied as before.
- `LayoutGroups` caches its `groupFilter` string (`ns._flatGfStr`) and skips the attribute write while the nameList owns the header, so the two mechanisms don't fight on every layout pass; the cache is what the fallback path restores.
- The UI gating is removed so the Self Position selector is usable with Merge Groups enabled.

No new settings: this uses the existing Self Position options (still default OFF). No file-scope locals added; new state lives on the `ns` namespace. Attribute writes are protected in combat, so a member joining mid-pull appears when the list rebuilds at combat end - identical to the existing non-merged Show Self First behavior.

## How was it tested?

Tested in-game in a raid group: Self Position works with Merge Groups, no Lua errors.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - no new settings; existing Self Position options are unchanged and default OFF. Users who never enabled Self Position see zero difference; the only activation case is a profile that already had Self Position explicitly set.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - the builder only runs inside existing sort re-evaluation, gated on Self Position active + Merge Groups + in raid.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - one roster pass + sort of at most 40 members, only when a sort re-evaluation already runs; UNIT_NAME_UPDATE rebuilds are debounced to one pass; nothing extra runs in combat.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - writes are attribute sets on addon-created secure headers, same as the existing sort paths.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
