### PR TITLE
Fix Passive Pet reminder never showing

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3707,7 +3707,9 @@ local function Refresh()
                 for i = 1, (NUM_PET_ACTION_SLOTS or 10) do
                     local nm, tx, tok, active = GetPetActionInfo(i)
                     if nm == "PET_MODE_PASSIVE" then
-                        if not isSecret(active) then passiveActive = (active == true) end
+                        -- isActive comes back as 1/nil, not a boolean, so the
+                        -- old "== true" was always false and this never fired.
+                        if not isSecret(active) then passiveActive = (active and true or false) end
                         passiveTex, passiveIsToken = tx, tok
                         break
                     end


### PR DESCRIPTION
## What does this PR do?

The Passive Pet reminder in AuraBuff Reminders never shows up. Turn it on, put your
pet on Passive, and nothing happens, no matter the class, spec, zone or whether
you're in combat. There's no Lua error either, it just silently does nothing.

The passive check pulls `isActive` out of `GetPetActionInfo()` and compares it with
`== true`. That return isn't a boolean though, it comes back as `1` or `nil`, so the
comparison is always false and the reminder can never fire. Blizzard's own
`PetActionBarMixin:Update` only ever tests it for truth, and the other addons doing
this same check (NaowhQOL, QUI, Aurstomation) all do the same.

Changed it to a truthiness check and left everything else alone. If that return ever
does become a real boolean the behaviour is identical.

## How was it tested?

Live client, EllesmereUI 8.9.6, Unholy DK with the ghoul out.

Repro is solid: Passive Pet enabled, pet set to Passive, nothing appears in or
out of combat, no Lua error.

The fix itself is NOT confirmed yet though - I thought I'd verified it in game
and I hadn't, the reminder still doesn't show with this change in place. Back to
draft while I work out what's actually gating it. The change here is harmless
either way (identical behaviour if that return is a real boolean) but it's
clearly not the whole story, so don't merge it as-is.

## Screenshots

N/A, nothing visual changed apart from the reminder actually turning up.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting, this is a bug fix to an existing one
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A, nothing added
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - same code path as before, one comparison changed
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A, no Blizzard frames touched
- [ ] Tested in-game on live; no version gates or pre-Midnight APIs added
