### PR TITLE
Fix(erb): castbar & gcd pixel snap + icon divider option

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -8062,6 +8062,33 @@ initFrame:SetScript("OnEvent", function(self)
             if hasIcon then pf.iconFrame:Show() else pf.iconFrame:Hide() end
         end
 
+        -- Icon/bar seam divider preview: mirrors the live cast bar's onePixel
+        -- math (PP.perfect / effective scale), NOT the widget-local Snap()
+        -- helper above -- the border itself already renders through that same
+        -- shared PP system (ApplyBorderStyle -> SnapBorderTextures), so the
+        -- divider has to match it, not the panel's own pixel grid.
+        if pf.iconDivider then
+            if hasIcon and cb.showIconDivider then
+                local PPp = EllesmereUI.PP
+                local des = pf.container:GetEffectiveScale()
+                local onePixel = (PPp and des > 0) and (PPp.perfect / des) or 1
+                local dbs = cb.borderSize or 1
+                pf.iconDivider:ClearAllPoints()
+                pf.iconDivider:SetWidth(math.max(onePixel, math.floor(dbs + 0.5) * onePixel))
+                if iconOnRight then
+                    pf.iconDivider:SetPoint("TOPRIGHT", pf.iconFrame, "TOPLEFT", 0, 0)
+                    pf.iconDivider:SetPoint("BOTTOMRIGHT", pf.iconFrame, "BOTTOMLEFT", 0, 0)
+                else
+                    pf.iconDivider:SetPoint("TOPLEFT", pf.iconFrame, "TOPRIGHT", 0, 0)
+                    pf.iconDivider:SetPoint("BOTTOMLEFT", pf.iconFrame, "BOTTOMRIGHT", 0, 0)
+                end
+                pf.iconDivider:SetColorTexture(cb.borderR or 0, cb.borderG or 0, cb.borderB or 0, cb.borderA or 1)
+                pf.iconDivider:Show()
+            else
+                pf.iconDivider:Hide()
+            end
+        end
+
         -- Cast text side-aware layout (mirrors the live cast bar)
         local cbTimerW   = (cb.timerSize or 11) * 2.2
         local cbDurSide   = cb.timerSide or "right"
@@ -8219,6 +8246,14 @@ initFrame:SetScript("OnEvent", function(self)
         if not hasIcon then iconFrame:Hide() end
         _castBarPreviewFrames.iconFrame = iconFrame
         _castBarPreviewFrames.icon = icon
+
+        -- Icon/bar seam divider (mirrors the live cast bar's "Show Icon
+        -- Divider"): parented to bdrFrame, same reasoning as the live one --
+        -- a texture on container itself would sit below the icon/bar child
+        -- frames regardless of draw layer.
+        local iconDivider = bdrFrame:CreateTexture(nil, "OVERLAY", nil, 7)
+        iconDivider:Hide()
+        _castBarPreviewFrames.iconDivider = iconDivider
 
         -- Timer text
         local timerText = bar:CreateFontString(nil, "OVERLAY")
@@ -8436,6 +8471,13 @@ initFrame:SetScript("OnEvent", function(self)
                       set = function(v)
                           local p = DB(); if not p then return end
                           p.castBar.iconOnRight = v; RefreshCast()
+                      end },
+                    { type = "toggle", label = "Show Icon Divider",
+                      tooltip = "Draw a 1px divider between the spell icon and the cast bar, matching the border color.",
+                      get = function() local p = DB(); return p and p.castBar.showIconDivider end,
+                      set = function(v)
+                          local p = DB(); if not p then return end
+                          p.castBar.showIconDivider = v; RefreshCast()
                       end },
                 },
             })

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1274,6 +1274,7 @@ local DEFAULTS = {
             alwaysShow    = false,  -- keep the bar on screen (sitting empty) while nothing is being cast
             showIcon      = true,
             iconOnRight   = false,  -- attach the spell icon to the right of the bar instead of the left
+            showIconDivider = false,  -- draw a 1px divider at the icon/bar seam (interior seam has no border otherwise)
             width         = 220,
             height        = 20,
             anchorX       = 0,
@@ -6343,6 +6344,21 @@ BuildCastBar = function()
         castBarFrame._iconFrame = iconFrame
         castBarFrame._icon = icon
 
+        -- Optional 1px divider at the icon/bar seam (opt-in: "Show Icon Divider").
+        -- That seam is otherwise interior with no border by design (see the clip-inset
+        -- comment below). Parented to the border frame (pl+5), not castBarFrame itself
+        -- (pl+15): a texture drawn directly on castBarFrame renders at castBarFrame's
+        -- own frame level, which sits BELOW the icon and bar/clip child frames -- it
+        -- would be invisible under them regardless of draw layer, since draw layer only
+        -- orders content within the SAME frame, not across frames.
+        local iconDivider = castBarFrame._border:CreateTexture(nil, "OVERLAY", nil, 7)
+        iconDivider:Hide()
+        if iconDivider.SetSnapToPixelGrid then
+            iconDivider:SetSnapToPixelGrid(false)
+            iconDivider:SetTexelSnappingBias(0)
+        end
+        castBarFrame._iconDivider = iconDivider
+
         -- Text overlay frame (above all bar borders)
         local textFrame = CreateFrame("Frame", nil, castBarFrame)
         textFrame:SetAllPoints(bar)
@@ -6452,6 +6468,31 @@ BuildCastBar = function()
         iconFrame:Show()
     else
         iconFrame:Hide()
+    end
+
+    -- Optional icon/bar seam divider (opt-in "Show Icon Divider"). Same
+    -- onePixel math as the perimeter border (SnapBorderTextures) so it reads
+    -- as the same thickness. Anchored to iconFrame's inner edge and given
+    -- only a width (both vertical anchor points already match iconFrame's
+    -- own top/bottom, so it inherits the full bar height automatically).
+    local iconDivider = castBarFrame._iconDivider
+    if hasIcon and cb.showIconDivider then
+        local des = castBarFrame:GetEffectiveScale()
+        local onePixel = des > 0 and (PP.perfect / des) or PP.mult
+        local dbs = cb.borderSize or 1
+        iconDivider:ClearAllPoints()
+        iconDivider:SetWidth(math.max(onePixel, math.floor(dbs + 0.5) * onePixel))
+        if iconOnRight then
+            iconDivider:SetPoint("TOPRIGHT", iconFrame, "TOPLEFT", 0, 0)
+            iconDivider:SetPoint("BOTTOMRIGHT", iconFrame, "BOTTOMLEFT", 0, 0)
+        else
+            iconDivider:SetPoint("TOPLEFT", iconFrame, "TOPRIGHT", 0, 0)
+            iconDivider:SetPoint("BOTTOMLEFT", iconFrame, "BOTTOMRIGHT", 0, 0)
+        end
+        iconDivider:SetColorTexture(cb.borderR or 0, cb.borderG or 0, cb.borderB or 0, cb.borderA or 1)
+        iconDivider:Show()
+    else
+        iconDivider:Hide()
     end
 
     -- Clip frame + bar: beside the icon (or full width), full height

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -6404,7 +6404,15 @@ BuildCastBar = function()
                 local ah = castBarFrame["_barAnim_h"] or h
                 castBarFrame:SetSize(aw, ah)
                 castBarFrame:ClearAllPoints()
-                castBarFrame:SetPoint(cb.unlockPos.point, UIParent, rp, px, py)
+                -- Snap the stored CENTER/CENTER position to the pixel grid, dimension-
+                -- aware (SnapXY -> SnapCenterForDim): an odd-pixel-height frame needs a
+                -- +0.5px center offset for BOTH top and bottom edges to land on whole
+                -- pixels. The unlock-mode drag path (castApply, near ERB_CastBar's MK()
+                -- registration above) already does this; this normal-build path never
+                -- did, so a raw stored position landed the center off-grid, and the
+                -- border rendered thicker on one edge and missing on the opposite one.
+                local sx, sy = SnapXY(px, py, castBarFrame, cb.unlockPos)
+                castBarFrame:SetPoint(cb.unlockPos.point, UIParent, rp, sx, sy)
             end
             SmoothBarAnimate(castBarFrame, "w", totalW, function() ApplyCastUnlockTransform() end)
             SmoothBarAnimate(castBarFrame, "h", h, function() ApplyCastUnlockTransform() end)
@@ -8046,7 +8054,12 @@ BuildGCDBar = function()
             if not (anchored and gcdBarFrame:GetLeft()) then
                 local rp = g.unlockPos.relPoint or g.unlockPos.point
                 gcdBarFrame:ClearAllPoints()
-                gcdBarFrame:SetPoint(g.unlockPos.point, UIParent, rp, g.unlockPos.x or 0, g.unlockPos.y or 0)
+                -- Same dimension-aware snap as the cast bar above: the unlock-mode
+                -- drag path (gcdApply, near ERB_GCDBar's MK() registration) already
+                -- snaps; this normal-build path didn't, leaving the stored center
+                -- off-grid on odd-pixel heights.
+                local sx, sy = SnapXY(g.unlockPos.x or 0, g.unlockPos.y or 0, gcdBarFrame, g.unlockPos)
+                gcdBarFrame:SetPoint(g.unlockPos.point, UIParent, rp, sx, sy)
             end
         end
     else


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

Bugreport: https://discord.com/channels/585577383847788554/1526330850633977939

## What does this PR do?

Fixes two pixel-alignment issues on the ResourceBars cast bar and GCD bar, and adds one small opt-in feature discovered while chasing them down.

**Center position never snapped to the pixel grid:** Unlock mode's drag path already snapped the stored `unlockPos` before applying it, but the normal build path (used on every login and settings change) set the raw stored x/y directly. For a CENTER/CENTER anchor, an odd-pixel-height frame needs a +0.5px center offset so both top and bottom edges land on whole pixels; skipping it left the center off-grid, rendering the border thicker on one edge and missing on the opposite one. Both build paths now call the same pixel-snap helper the drag path already used.

**Optional icon/bar divider:** The seam between the cast bar icon and the bar itself is interior by design (no border drawn there, so the fill never gets an inset background ring), which reads as a missing border on the icon's side. Added an opt-in "Show Icon Divider" toggle (default off, next to Show Spell Icon) that draws a dedicated 1px line at the seam, sized and colored from the existing border settings, mirrored in the options preview.

## How was it tested?

Tested in-game on live.

## Screenshots

Before:
<img width="511" height="74" alt="grafik" src="https://github.com/user-attachments/assets/c63ab900-4a64-467f-89ae-edf378e0b7e3" />
<img width="465" height="53" alt="grafik" src="https://github.com/user-attachments/assets/5397cfbd-f8dd-43ac-9a45-3b66901e8a05" />

After:
<img width="560" height="167" alt="grafik" src="https://github.com/user-attachments/assets/f0ac0c7a-2f9e-4ebe-81d2-77191ac8d9db" />
<img width="455" height="58" alt="grafik" src="https://github.com/user-attachments/assets/9843f02f-ce0c-4ef2-80d0-7ea5713dfe34" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- Show Icon Divider defaults off
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- the divider texture only positions/shows when the toggle is on; the position-snap fix reuses an existing per-apply code path, no new work while idle
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
