### PR TITLE
Fix(BlizzardSkin): reputation bar applying accent color

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -5376,16 +5376,6 @@ local function SkinRCRow(child, isCurrency)
         end
         cd.styleRight()
     end
-    -- Reputation bar fill color: pooled rows are re-initialized by Blizzard on
-    -- every list update, which re-applies its own standing color (green/blue/etc)
-    -- to the bar. Must re-assert here every pass, same as the strip keys and
-    -- toggle glyph above, or the accent color only survives the row's first-ever
-    -- skin and reverts to stock on the next open/refresh.
-    local rcContent = child.Content
-    local rcBar = rcContent and rcContent.ReputationBar
-    if rcBar and rcBar.SetStatusBarColor then
-        WSkin.ApplyBarFill(rcBar)
-    end
     if d.rcSkinned then return end
     d.rcSkinned = true
     -- Header rows (those carrying the band art) get a subtle house plate and a

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -5376,6 +5376,16 @@ local function SkinRCRow(child, isCurrency)
         end
         cd.styleRight()
     end
+    -- Reputation bar fill color: pooled rows are re-initialized by Blizzard on
+    -- every list update, which re-applies its own standing color (green/blue/etc)
+    -- to the bar. Must re-assert here every pass, same as the strip keys and
+    -- toggle glyph above, or the accent color only survives the row's first-ever
+    -- skin and reverts to stock on the next open/refresh.
+    local rcContent = child.Content
+    local rcBar = rcContent and rcContent.ReputationBar
+    if rcBar and rcBar.SetStatusBarColor then
+        WSkin.ApplyBarFill(rcBar)
+    end
     if d.rcSkinned then return end
     d.rcSkinned = true
     -- Header rows (those carrying the band art) get a subtle house plate and a
@@ -5401,7 +5411,6 @@ local function SkinRCRow(child, isCurrency)
             if fill then keep[fill] = true end
             WSkin.FadeRegions(rb, keep)
             rb:SetStatusBarTexture("Interface\\Buttons\\WHITE8X8")
-            WSkin.ApplyBarFill(rb)
             local rd = GetFFD(rb)
             if not rd.bg then
                 local trough = rb:CreateTexture(nil, "BACKGROUND", nil, -1)


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1524184872355102810

## What does this PR do?

Removes the accent-color tint from reputation bars in the character panel's Reputation tab. They now keep Blizzard's own per-standing colors (green/yellow/blue/etc) instead of being recolored with the addon's accent color, while still using the flat house texture and border/trough from the window reskin.

## How was it tested?

Tested in-game on live.

## Screenshots

Before: 
<img width="513" height="538" alt="grafik" src="https://github.com/user-attachments/assets/cbda035b-c7ed-459e-9d1d-851b6f08eff7" />

After:
<img width="497" height="585" alt="grafik" src="https://github.com/user-attachments/assets/2fe1d242-4316-4bd9-a613-d8da28504af6" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; adjusts existing skin behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A, not a toggleable feature
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - net removes a per-pass `SetStatusBarColor` call, no added cost
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no change to the write pattern, only removes a color write
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added