### PR TITLE
Fix unit context menu taint

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_ClickCast.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_ClickCast.lua
@@ -1054,13 +1054,12 @@ local function SetClickAttr(frame, parsed, actionType, spellOrMacro, macrotext, 
     local suffix = tostring(parsed.buttonNum)
     local typeAttr = prefix .. "type" .. suffix
     -- 12.0.7+ gates a raw "togglemenu" on unit buttons (insecure reopen taints
-    -- protected items); route through the secure proxy instead. TRANSPORT: the
-    -- "click" action itself crashes on a Blizzard typo (SecureTemplates.lua:564,
-    -- aspect check on the mouse-button string) -- use a "/click <proxy>" macro.
+    -- protected items); route through the secure proxy instead.
     if actionType == "togglemenu" and EllesmereUI.GetSecureMenuProxy then
         local proxy = EllesmereUI.GetSecureMenuProxy(frame)
-        SetGatedType(frame, typeAttr, "macro", oocOnly)
-        frame:SetAttribute(prefix .. "macrotext" .. suffix, "/click " .. proxy:GetName())
+        SetGatedType(frame, typeAttr, "click", oocOnly)
+        frame:SetAttribute(prefix .. "clickbutton" .. suffix, proxy)
+        frame:SetAttribute(prefix .. "macrotext" .. suffix, nil)
         return
     end
     -- 12.0.7+ also gates raw "target" on unit buttons, EXCEPT plain unmodified
@@ -1098,12 +1097,12 @@ end
 local function SetKeyAttr(frame, idx, actionType, spellOrMacro, macrotext, oocOnly)
     local suffix = "eui_" .. idx
     local typeAttr = "type-" .. suffix
-    -- Route a "menu" keybind through the secure proxy (see SetClickAttr for
-    -- why this uses the /click macro transport instead of the click action).
+    -- Route a "menu" keybind through the secure proxy.
     if actionType == "togglemenu" and EllesmereUI.GetSecureMenuProxy then
         local proxy = EllesmereUI.GetSecureMenuProxy(frame)
-        SetGatedType(frame, typeAttr, "macro", oocOnly)
-        frame:SetAttribute("macrotext-" .. suffix, "/click " .. proxy:GetName())
+        SetGatedType(frame, typeAttr, "click", oocOnly)
+        frame:SetAttribute("clickbutton-" .. suffix, proxy)
+        frame:SetAttribute("macrotext-" .. suffix, nil)
         return
     end
     -- A "target" keybind is never plain left-click, so it always hits the 12.0.7

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -3758,10 +3758,10 @@ ns._StyleButtonSecure = function(button)
     button:SetAttribute("type1", "target")
     -- Wildcard fallback so left-click target survives if the click-cast engine later clears type1.
     button:SetAttribute("*type1", "target")
-    -- The engine gates SecureUnitButton's togglemenu; route right-click through a SecureActionButton
-    -- proxy so the menu (and protected items like Set Focus) works without taint (*type2 = "click").
+    -- Route right-click through a SecureActionButton proxy and Blizzard's native
+    -- compact-frame menu function so group units stay secure and classify correctly.
     if EllesmereUI.AttachSecureUnitMenu then
-        EllesmereUI.AttachSecureUnitMenu(button)
+        EllesmereUI.AttachSecureUnitMenu(button, true)
     else
         button:SetAttribute("type2", "togglemenu")
         button:SetAttribute("*type2", "togglemenu")

--- a/EllesmereUI_Kick.lua
+++ b/EllesmereUI_Kick.lua
@@ -96,70 +96,23 @@ EllesmereUI.ComputeCastBarTint = ComputeCastBarTint
 --
 -- Fix: route right-click through the UN-gated "click" secure action to a hidden
 -- child SecureActionButton, whose own SecureActionButton_OnClick (NOT gated -- only
--- SecureUnitButton_OnClick is) runs "togglemenu" securely. "useparent-unit" makes
+-- SecureUnitButton_OnClick is) runs the configured menu action securely.
+-- "useparent-unit" makes
 -- the proxy resolve the unit from the parent unit button, so it works for static
 -- frames AND header-managed (party/raid) frames whose unit changes. Call
 -- AttachSecureUnitMenu(frame) on any unit button that needs a right-click menu
 -- instead of setting *type2 = "togglemenu".
--- 12.1 zoned-out raid member -> PET menu misclassification fix. The proxy's
--- "togglemenu" secure action classifies the menu through a UnitIsUnit chain
--- that checks "pet" BEFORE UnitIsPlayer, and its token special-cases cover
--- party/boss/focus/arena but NOT raid (SecureTemplates.lua SECURE_ACTIONS.
--- togglemenu, marked "Unused by Blizzard code" -- the default UI never runs
--- it, which is why base frames don't show the bug; party frames are immune
--- via the token special-case, matching the raid-only field report). For a
--- raid member whose unit data has not streamed (zoned elsewhere), the
--- engine-side UnitIsUnit(raidN, "pet") comparison can misfire and the whole
--- chain resolves PET. Post-hook the opener: a PET-family menu opening for a
--- raid/party token whose GUID is a Player is that exact misfire -- re-open
--- the correct player menu. The re-open runs from this (tainted) hook, so
--- protected items (Set Focus/Follow) can throw for THAT menu instance only;
--- the trade for not showing a pet menu on a player. Legitimate pet menus
--- (unit "pet"/"partypetN"/"raidpetN") never match the signature, and the
--- correct which comes from the TOKEN (no unit APIs -- UnitInRaid/identity
--- reads can be SECRET for exactly these unstreamed units). Installed lazily
--- with the first menu proxy; zero cost until a menu actually opens.
-local menuFixHooked = false
-local function InstallMenuClassifierFix()
-    if menuFixHooked or type(UnitPopup_OpenMenu) ~= "function" then return end
-    menuFixHooked = true
-    local reopening = false
-    hooksecurefunc("UnitPopup_OpenMenu", function(which, contextData)
-        if reopening then return end
-        if which ~= "PET" and which ~= "OTHERPET" and which ~= "OTHERBATTLEPET" then return end
-        local unit = contextData and contextData.unit
-        if type(unit) ~= "string" then return end
-        local lu = unit:lower()
-        local isRaidToken = lu:match("^raid[0-9]+$") ~= nil
-        if not isRaidToken and not lu:match("^party[0-9]+$") then return end
-        local guid = UnitGUID(unit)
-        if issecretvalue and issecretvalue(guid) then return end
-        if type(guid) ~= "string" or not guid:find("^Player%-") then return end
-        reopening = true
-        -- FRESH context table, never the inbound one: OpenMenu ENRICHES its
-        -- contextData in place (playerLocation/accountInfo) and asserts those
-        -- fields are nil on entry -- re-passing the first open's table throws
-        -- "assertion failed" at UnitPopupShared:53 (field-caught 2026-08-14;
-        -- the live misfire classifies as OTHERBATTLEPET, same field capture).
-        UnitPopup_OpenMenu(isRaidToken and "RAID_PLAYER" or "PARTY", { unit = unit })
-        reopening = false
-    end)
-end
-
 local menuProxies = setmetatable({}, { __mode = "k" })
--- 12.1: proxies are GLOBALLY NAMED so bindings can reach them via "/click
--- <name>" (macro transport). 12.1 broke the "click" secure action outright
--- (a typo: SecureTemplates.lua:564 calls HasAnyForbiddenAspects on the
--- mouse-button STRING instead of the delegate); /click hits
--- SecureActionButton_OnClick directly and is unaffected.
 local proxyCounter = 0
 
 -- Create (once) and return the hidden SecureActionButton proxy for a unit button.
 -- Use this when wiring a SPECIFIC click/key binding to the menu -- it does NOT
 -- touch the frame's own type attributes (so it won't clobber other bindings).
-function EllesmereUI.GetSecureMenuProxy(frame)
+-- Group frames use Blizzard's native compact-frame menu function rather than
+-- the addon-facing "togglemenu" classifier, whose raid-token handling can
+-- misclassify an unstreamed player as a pet.
+function EllesmereUI.GetSecureMenuProxy(frame, useCompactMenu)
     if not frame then return end
-    InstallMenuClassifierFix()
     local proxy = menuProxies[frame]
     if not proxy then
         local proxyName
@@ -180,6 +133,11 @@ function EllesmereUI.GetSecureMenuProxy(frame)
         -- up-click when ActionButtonUseKeyDown is on (the delegate fires an up).
         proxy:SetAttribute("useOnKeyDown", false)
         menuProxies[frame] = proxy
+    end
+    if useCompactMenu and type(CompactUnitFrame_OpenMenu) == "function" then
+        proxy:SetAttribute("type", "menu")
+        for i = 1, 5 do proxy:SetAttribute("type" .. i, "menu") end
+        proxy:SetAttribute("menu-function", CompactUnitFrame_OpenMenu)
     end
     return proxy
 end
@@ -217,15 +175,13 @@ end
 
 -- Route a unit button's default RIGHT-CLICK to the secure menu proxy via the
 -- ungated "click" action. Clears any specific type2 so the wildcard governs.
-function EllesmereUI.AttachSecureUnitMenu(frame)
+function EllesmereUI.AttachSecureUnitMenu(frame, useCompactMenu)
     if not frame then return end
-    local proxy = EllesmereUI.GetSecureMenuProxy(frame)
+    local proxy = EllesmereUI.GetSecureMenuProxy(frame, useCompactMenu)
     frame:SetAttribute("type2", nil)
-    -- Macro transport ("/click <proxy>") instead of the "click" action:
-    -- the 12.1 click action crashes on a Blizzard typo (see above).
-    frame:SetAttribute("*type2", "macro")
-    frame:SetAttribute("*macrotext2", "/click " .. proxy:GetName())
-    frame:SetAttribute("*clickbutton2", nil)
+    frame:SetAttribute("*type2", "click")
+    frame:SetAttribute("*clickbutton2", proxy)
+    frame:SetAttribute("*macrotext2", nil)
     return proxy
 end
 


### PR DESCRIPTION
## Summary
- route unit context-menu proxy clicks through Blizzard's native secure click action instead of macro clicks
- use Blizzard's compact-unit menu function for raid and party frames
- remove the insecure UnitPopup_OpenMenu reopen that tainted distance-gated menu entries