### PR TITLE
Fix health value and percent desync after a max-health change

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -4684,6 +4684,20 @@ ns._UpdateButtonHealth = function(button)
     if d.dmDeadSwap then ns.DM_DeadEdge(d, unit) end
 end
 
+-- A max-health change lands in two steps, the max first and the value after, so
+-- a health pass driven by it renders the new max against the pre-change value.
+-- At full health nothing fires afterwards, leaving the mid-transition numbers up
+-- (druid form stamina talents). One next-frame re-read settles it; the flag
+-- collapses a raid-wide change to one pass per button.
+ns._ResettleButtonHealth = function(button)
+    if button._euiHpResettle then return end
+    button._euiHpResettle = true
+    C_Timer.After(0, function()
+        button._euiHpResettle = nil
+        if button:IsVisible() then ns._UpdateButtonHealth(button) end
+    end)
+end
+
 -------------------------------------------------------------------------------
 --  Friendly Boss Frames (any group): five standalone secure unit buttons for
 --  boss1-boss5. A secure visibility driver on [@bossN,help] is the entire
@@ -5823,6 +5837,7 @@ XF.EnsureBuilt = function(count)
             if not b:IsVisible() then return end
             if event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" then
                 ns._UpdateButtonHealth(b)
+                if event == "UNIT_MAXHEALTH" then ns._ResettleButtonHealth(b) end
             elseif event == "UNIT_AURA" then
                     -- Aura displays are engine containers; only the absorb
                     -- overlay is event-driven here.
@@ -5851,6 +5866,10 @@ XF.EnsureBuilt = function(count)
                 or event == "UNIT_HEAL_PREDICTION" or event == "UNIT_MAX_HEALTH_MODIFIERS_CHANGED" then
                 UpdateAbsorb(b, unit)
                 if event == "UNIT_HEAL_ABSORB_AMOUNT_CHANGED" then ns.UpdateHealAbsorbTextFor(b, unit) end
+                if event == "UNIT_MAX_HEALTH_MODIFIERS_CHANGED" then
+                    ns._UpdateButtonHealth(b)
+                    ns._ResettleButtonHealth(b)
+                end
             elseif event == "UNIT_THREAT_LIST_UPDATE" or event == "UNIT_THREAT_SITUATION_UPDATE" then
                 local d = GetFFD(b)
                 if d.threatFrame then
@@ -8126,6 +8145,7 @@ local function OnEvent(self, event, arg1, ...)
                 ns._rezPend[arg1] = nil
             end
             ns._UpdateButtonHealth(btn)
+            ns._ResettleButtonHealth(btn)
             if hadRez then UpdateReadyCheck(btn, arg1) end
         end
     elseif event == "UNIT_POWER_UPDATE" then
@@ -8167,6 +8187,10 @@ local function OnEvent(self, event, arg1, ...)
         if btn then
             UpdateAbsorb(btn, arg1)
             if event == "UNIT_HEAL_ABSORB_AMOUNT_CHANGED" then ns.UpdateHealAbsorbTextFor(btn, arg1) end
+            if event == "UNIT_MAX_HEALTH_MODIFIERS_CHANGED" then
+                ns._UpdateButtonHealth(btn)
+                ns._ResettleButtonHealth(btn)
+            end
         end
     elseif event == "UNIT_NAME_UPDATE" then
         local btn = unitToButton[arg1] or ns._partyUnitToButton[arg1]

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -8893,8 +8893,20 @@ local function OnEvent(self, event, ...)
             UpdatePrimaryBar()
             UpdateSecondaryResource()
         end
-    elseif event == "UNIT_MAXHEALTH" then
+    elseif event == "UNIT_MAXHEALTH" or event == "UNIT_MAX_HEALTH_MODIFIERS_CHANGED" then
         UpdateHealthBar()
+        -- A max-health change lands in two steps, the max first and the value
+        -- after, so this pass renders the new max against the pre-change value.
+        -- At full health nothing fires afterwards, leaving the mid-transition
+        -- numbers up (druid form stamina talents). One next-frame re-read
+        -- settles it.
+        if not self._erbHpResettle then
+            self._erbHpResettle = true
+            C_Timer.After(0, function()
+                self._erbHpResettle = nil
+                UpdateHealthBar()
+            end)
+        end
         -- Stagger / Ignore Pain max derives from player max health
         if cachedSecondary and (cachedSecondary.power == "BREWMASTER_STAGGER"
            or cachedSecondary.power == "IGNOREPAIN_BAR") then
@@ -9263,6 +9275,7 @@ function ERB:OnEnable()
     local eventFrame = _erbEventFrame
     eventFrame:RegisterUnitEvent("UNIT_HEALTH", "player")
     eventFrame:RegisterUnitEvent("UNIT_MAXHEALTH", "player")
+    eventFrame:RegisterUnitEvent("UNIT_MAX_HEALTH_MODIFIERS_CHANGED", "player")
     eventFrame:RegisterUnitEvent("UNIT_POWER_UPDATE", "player")
     eventFrame:RegisterUnitEvent("UNIT_POWER_FREQUENT", "player")
     eventFrame:RegisterUnitEvent("UNIT_MAXPOWER", "player")

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Engine.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Engine.lua
@@ -434,6 +434,18 @@ EllesmereUI._UFEngineForceAll = Engine.ForceAll
 -------------------------------------------------------------------------------
 --  Event routing
 -------------------------------------------------------------------------------
+-- A max-health change lands in two steps: the max moves first, the health
+-- value follows. A paint driven by UNIT_MAXHEALTH can run between them and
+-- render the new max against the pre-change value, and same-frame dedupe drops
+-- the UNIT_HEALTH that would have corrected it. At full health nothing else
+-- fires afterwards, so the frame keeps the mid-transition numbers -- a druid
+-- shifting form with a stamina talent sat at "600K | 96%" indefinitely (field
+-- report, Lycara's Inspiration). One next-frame repaint reads settled values.
+local RESETTLE_EVENTS = {
+    UNIT_MAXHEALTH = true,
+    UNIT_MAX_HEALTH_MODIFIERS_CHANGED = true,
+}
+
 -- tracker.channelsByEvent: event -> { channelName, ... } for its frame.
 local function TrackerOnEvent(self, event, unitToken, ...)
     local frame = self._euiFrame
@@ -451,6 +463,16 @@ local function TrackerOnEvent(self, event, unitToken, ...)
         else
             Paint(frame, ch, event)
         end
+    end
+
+    if RESETTLE_EVENTS[event] and not self._euiResettle then
+        self._euiResettle = true
+        C_Timer.After(0, function()
+            self._euiResettle = nil
+            local f = self._euiFrame
+            if not f or not f:IsShown() then return end
+            for i = 1, #chans do Paint(f, chans[i], "Resettle") end
+        end)
     end
 end
 

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_Engine.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_Engine.lua
@@ -53,7 +53,14 @@ end
 --  absorb covers both absorb kinds plus heal prediction.)
 -------------------------------------------------------------------------------
 local CHANNEL_EVENTS = {
-    health   = { "UNIT_HEALTH", "UNIT_MAXHEALTH", "UNIT_CONNECTION", "UNIT_FACTION" },
+    -- UNIT_MAX_HEALTH_MODIFIERS_CHANGED on health/text: a max-health modifier
+    -- (druid form stamina talents, temp max health loss) moves the health value
+    -- and the effective max with no UNIT_HEALTH or UNIT_MAXHEALTH behind it, so
+    -- the bar and the value/percent text hold the pre-shift numbers until some
+    -- unrelated event repaints them. Blizzard's UnitFrame_OnEvent calls
+    -- UnitFrameHealthBar_OnUpdate from this event for the same reason.
+    health   = { "UNIT_HEALTH", "UNIT_MAXHEALTH", "UNIT_CONNECTION", "UNIT_FACTION",
+                 "UNIT_MAX_HEALTH_MODIFIERS_CHANGED" },
     power    = { "UNIT_POWER_UPDATE", "UNIT_MAXPOWER", "UNIT_DISPLAYPOWER", "UNIT_POWER_BAR_SHOW", "UNIT_POWER_BAR_HIDE", "UNIT_CONNECTION" },
     -- UNIT_AURA for the same reason as the absorb channel below: the long-form
     -- Absorb / Heal Absorb text zones render from PaintText, so a shield lost to
@@ -61,7 +68,8 @@ local CHANNEL_EVENTS = {
     -- _absGate lockstep instead, which the absorb channel already covers.)
     text     = { "UNIT_HEALTH", "UNIT_MAXHEALTH", "UNIT_POWER_UPDATE", "UNIT_MAXPOWER", "UNIT_DISPLAYPOWER",
                  "UNIT_NAME_UPDATE", "UNIT_LEVEL", "UNIT_CONNECTION", "UNIT_AURA",
-                 "UNIT_ABSORB_AMOUNT_CHANGED", "UNIT_HEAL_ABSORB_AMOUNT_CHANGED" },
+                 "UNIT_ABSORB_AMOUNT_CHANGED", "UNIT_HEAL_ABSORB_AMOUNT_CHANGED",
+                 "UNIT_MAX_HEALTH_MODIFIERS_CHANGED" },
     -- (UNIT_HEAL_PREDICTION deliberately absent: the absorb painter never
     -- rendered incoming heals and early-returned on it; not delivering it at
     -- all is the same behavior for less dispatch.)


### PR DESCRIPTION
**Cause:** A max-health change lands in two steps, the max first and the value after. The health pass driven by `UNIT_MAXHEALTH` renders the new max against the pre-change value, and same-frame dedupe drops the `UNIT_HEALTH` that would have corrected it. At full health nothing fires afterwards, so a druid shifting form with a stamina talent (Lycara's Inspiration) sat at `600K | 96%` indefinitely. Unit Frames and Resource Bars also never handled `UNIT_MAX_HEALTH_MODIFIERS_CHANGED` on their health paths, and Raid Frames registered it but routed it to absorbs only.

**Fix:** Route the modifier event to the health and text paths in all three modules, and schedule one next-frame health re-read after a max-health change so the display lands on settled values. Guarded per frame/button and armed only on max-health changes, so the hot paths are untouched.

**Test:** Confirmed in game by the reporter on a test build: shifting in and out of forms with Lycara's Inspiration now settles on the correct value and 100% on the player frame, raid frames and the resource bar.
