### PR TITLE
Fix(UnitFrames): UnitFrames Class Resource pips getting stuck after a max change

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -9391,6 +9391,11 @@ local function CreateCustomClassPower(playerFrame, style)
     end
 
     local pips = {}
+    -- Tracks how many pips are CURRENTLY shown, separate from #pips: pip frames
+    -- are only ever Hide()'d when the resource max drops (never removed from the
+    -- table), so #pips is a high-water mark that stops matching a shrunk-then-
+    -- regrown max and silently skips the rebuild below.
+    local shownPipCount = 0
     local staggerBar  -- set only in bar mode
     if isBarMode then
         -- Single StatusBar filling the container; color updates per-tier.
@@ -9408,6 +9413,7 @@ local function CreateCustomClassPower(playerFrame, style)
         for i = 1, maxPower do
             pips[i] = MakePip(container, i)
         end
+        shownPipCount = maxPower
     end
 
     -- Update function
@@ -9506,8 +9512,11 @@ local function CreateCustomClassPower(playerFrame, style)
             end
         end
 
-        -- Rebuild pips if max changed
-        if max ~= #pips and max > 0 then
+        -- Rebuild pips if max changed. Compare against shownPipCount, not #pips:
+        -- #pips only ever grows (hidden pips stay in the table), so it stops
+        -- matching once max shrinks and regrows to a previously-seen value,
+        -- leaving the high pips stuck hidden and the container stuck narrow.
+        if max ~= shownPipCount and max > 0 then
             for _, p in ipairs(pips) do p:Hide() end
             local newTotalW = max * pipSize + (max - 1) * gap + pad
             container:SetWidth(newTotalW)
@@ -9521,6 +9530,7 @@ local function CreateCustomClassPower(playerFrame, style)
                 PP.Size(pips[i], pipSize, pipH)
                 pips[i]:Show()
             end
+            shownPipCount = max
             -- Re-stretch pips if in "above" position
             if container._repositionForWidth then
                 local fw = db and db.profile and db.profile.player and db.profile.player.frameWidth or 181


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1540033094629724291

## What does this PR do?

Fixes the Unit Frames Class Resource pip display getting stuck once a class resource's maximum has changed and changed back during a session. The clearest repro is a Rogue combo point bar: after combo point max temporarily rises (for example from a talent/buff that briefly allows more than the base maximum) and then returns to normal, the highest pip stays visually broken - it shows a faint stray tint at 0 points and never lights up fully again even at max, until the UI is reloaded. The rebuild logic that resizes the pip row and re-shows the top pip(s) was gated on comparing the new max against the pip table's length, but that length only ever grows (hidden pips are kept, not removed), so once a resource had reached its highest max once, the same check silently stopped firing the next time max grew back to that value. This only affected the Unit Frames Class Resource display; the separate Resource & Castbars Class Resource display uses different code and was not affected.

## How was it tested?

Tested in-game on live.

## Screenshots

Before: 
<img width="271" height="75" alt="grafik" src="https://github.com/user-attachments/assets/fb080f6c-0256-410e-a0f2-fe36d141270a" />

After:
<img width="271" height="75" alt="grafik" src="https://github.com/user-attachments/assets/8876b047-b27b-4a29-8fb9-f761256dd270" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; fixes existing pip refresh behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A, only touches the rebuild path that already runs when Class Resource is enabled
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - adds one local variable update, no new events/timers/allocations
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no change to the write pattern, only fixes the rebuild condition
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
