### PR TITLE
Cooldown Manager: bind linked buff slots to the live aura

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -2919,6 +2919,7 @@ local _tbbAssignment   = {}
 local _tbbFrameScratch = {}
 local _tbbConsumed     = {}
 local _tbbFrameSID     = {}  -- frame -> canonical spell id, computed once per call
+local _tbbFrameMember  = {}  -- frame -> live linked-family member, computed once per call
 
 local function CfgWantsSID(cfg, sid)
     -- Cooldown-tracking bars NEVER match buff-viewer frames or buff coverage.
@@ -2968,6 +2969,31 @@ local function TbbFrameNameFamily(frame)
     return TbbNameFamily(nm)
 end
 
+-- Which member of a LINKED FAMILY a buff slot is mirroring right now. Blizzard
+-- binds ONE cooldownID to whichever of its linkedSpellIDs is on the player and
+-- publishes the answer as cooldownInfo.linkedSpellID, maintained on the aura
+-- edges (CooldownViewerItemMixin:NeedsAddedAuraUpdate / OnUnitAuraRemovedEvent),
+-- so Roll the Bones cycles a single slot through every outcome and the hint
+-- follows. Needed because GetSpellID()/GetAuraSpellID() read secret while the
+-- slot is active, leaving the canonical resolver to answer from the clean-read
+-- memo keyed on cooldownID, which still names the member that was up at the last
+-- CLEAN read: the previous outcome keeps the frame and mirrors the new outcome's
+-- timer while the new outcome draws a second bar off the per-spell aura fallback.
+local function TbbLinkedMemberSID(frame)
+    local info = frame.cooldownInfo
+    if not info then
+        local fnGetInfo = frame.GetCooldownInfo
+        if type(fnGetInfo) ~= "function" then return nil end
+        info = fnGetInfo(frame)
+    end
+    local linked = info and info.linkedSpellIDs
+    if type(linked) ~= "table" or #linked < 2 then return nil end
+    -- Set from the added aura's spellId, so it can be secret in restricted content.
+    local sid = info.linkedSpellID
+    if type(sid) ~= "number" or (issecretvalue and issecretvalue(sid)) then return nil end
+    return sid
+end
+
 local function AssignFramesToConfigs(bars)
     local assignment = _tbbAssignment
     -- Memo: pairing moves only on composition edges (player aura events, pool
@@ -2994,9 +3020,28 @@ local function AssignFramesToConfigs(bars)
     local frames = _tbbFrameScratch
     wipe(frames)
     wipe(_tbbFrameSID)
+    wipe(_tbbFrameMember)
     for frame in viewer.itemFramePool:EnumerateActive() do
         frames[#frames + 1] = frame
         _tbbFrameSID[frame] = GetCanonical and GetCanonical(frame) or nil
+        if frame.IsActive and frame:IsActive() then
+            _tbbFrameMember[frame] = TbbLinkedMemberSID(frame)
+        end
+    end
+
+    -- The family hint overrides the canonical memo only where it is UNIQUE among the
+    -- active slots: collided slots each list the whole family (Eclipse Solar and Lunar,
+    -- both up), so an added aura stamps the same member on BOTH and only their
+    -- per-slot memos still tell them apart.
+    for i = 1, #frames do
+        local m = _tbbFrameMember[frames[i]]
+        if m then
+            local unique = true
+            for j = 1, #frames do
+                if j ~= i and _tbbFrameMember[frames[j]] == m then unique = false; break end
+            end
+            if unique then _tbbFrameSID[frames[i]] = m end
+        end
     end
 
     local consumed = _tbbConsumed


### PR DESCRIPTION
## What does this PR do?

Fixes Roll the Bones re-rolls leaving the previous outcome's Tracking Bar up, reset to full duration, alongside a second bar for the new outcome.

A buff slot whose `cooldownInfo` lists several linked spells rebinds to whichever member is on the player, so one slot cycles through every Roll the Bones outcome. `GetSpellID` reads secret while that slot is active, so our canonical resolver answers from the clean-read memo keyed on `cooldownID`, which still names the outcome that was up at the last clean read: the old outcome kept the frame and mirrored the new outcome's timer, while the new outcome drew its own bar off the per-spell aura fallback.

Take the member from `cooldownInfo.linkedSpellID`, which Blizzard maintains on the aura edges, and let it override the memo only where it is unique among the active slots, so collided slots that each list the whole family (Eclipse Solar and Lunar together) keep their per-slot memo.

## How was it tested?

Live, Outlaw Rogue with each Roll the Bones outcome on its own Tracking Bar: re-rolling now retires the old outcome's bar instead of resetting it to full, and only the live outcome shows.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new settings
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: one table read per active viewer frame in an existing memoized pass
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
