### PR TITLE
Resource Bars: fix the bar border disappearing after opening EUI options

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1752,6 +1752,13 @@ local function MakePixelBorder(parent, r, g, b, a, size, textureKey, texOffset, 
             if shown then PP.ShowBorder(bf) else PP.HideBorder(bf) end
         end,
         ApplyStyle = function(self, newSz, cr, cg, cb, ca, texKey, texOff, texOffY, sX, sY, addonKey, sizeKey)
+            -- A bar repositioned by the unlock anchor system loses this frame's
+            -- SetAllPoints edge: GetPoint still reports TOPLEFT/BOTTOMRIGHT to the bar,
+            -- but the rect stops resolving (GetLeft() nil, GetWidth() 0). The strips are
+            -- anchored here, so each one falls back to WHITE8X8's natural 8px on the
+            -- dimension it takes from anchors and the border disappears until the border
+            -- SIZE changes. Re-issuing the same SetAllPoints restores it.
+            if not bf:GetLeft() then bf:SetAllPoints(parent) end
             EllesmereUI.ApplyBorderStyle(bf, newSz, cr, cg, cb, ca or 1, texKey or "solid", texOff, texOffY, sX, sY, addonKey, sizeKey)
         end,
     }


### PR DESCRIPTION
**Cause:** a bar repositioned by the unlock anchor system loses its border frame's `SetAllPoints` edge. `GetPoint` still reports TOPLEFT/BOTTOMRIGHT to the bar and the bar's own rect stays valid, but the border frame stops resolving (`GetLeft()` nil, `GetWidth()` 0). The four strips anchor to that frame, so each falls back to WHITE8X8's natural 8px on whichever dimension comes from anchors (top 8x1, left 1x8) and the border vanishes.

It only returned on a border **size** change, the one input that misses the geometry guard in `SnapBorderTextures` and re-issues the strips' `SetPoint` calls, which re-resolves the chain. Height, colour and every other apply skipped it, so the border stayed gone for the session.

**Fix:** re-issue the same `SetAllPoints` when the rect has stopped resolving, in `MakePixelBorder`'s `ApplyStyle` (the single funnel for every Resource Bars border: status bars, pips, class resource).

**Test:** reported by SanAryon and indigo (power bar border gone after opening EUI options, back only after wiggling Border Size). Diagnosed with a probe addon dumping frame state in all three states; of a parent `SetSize`, a re-`SetAllPoints` and an explicit two-point anchor, only re-`SetAllPoints` restored the rect. Confirmed fixed in game by SanAryon on a test build.
