### PR TITLE
Cast bars freeze on empowered spells (Fire Breath / Dream Breath) in PvP

### DIFF
--- a/EllesmereUIMythicTimer/EUI_MythicTimer_TargetedSpellBars.lua
+++ b/EllesmereUIMythicTimer/EUI_MythicTimer_TargetedSpellBars.lua
@@ -436,13 +436,15 @@ local UPDATE_EVENTS = {
 local PROBE_EVENTS = {
     UNIT_SPELLCAST_STOP = true,
     UNIT_SPELLCAST_FAILED = true,
-    UNIT_SPELLCAST_EMPOWER_STOP = true,
 }
 -- CHANNEL_STOP releases directly instead of re-probing: in restricted
 -- execution UnitCastingInfo can return secret values (not nil) for a stale
 -- channel, making a probe think it is still active (nameplate lesson).
+-- Release directly for these instead of re-probing: a stale channel or
+-- empowered cast can read back as a secret, non-nil value in PvP.
 local RELEASE_EVENTS = {
     UNIT_SPELLCAST_CHANNEL_STOP = true,
+    UNIT_SPELLCAST_EMPOWER_STOP = true,
     UNIT_SPELLCAST_INTERRUPTED = true,
 }
 

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -7915,7 +7915,30 @@ function NameplateFrame:UNIT_SPELLCAST_EMPOWER_UPDATE()
     self:UpdateCast()
 end
 function NameplateFrame:UNIT_SPELLCAST_EMPOWER_STOP()
-    self:UpdateCast()
+    -- Stop directly. Re-checking cast info here can return a stale secret
+    -- value in PvP and look like the cast is still going.
+    local wasCasting = self.isCasting
+    self.isCasting = false
+    self:HideKickTick()
+    self:ClearImportantCastGlow()
+    self:ApplyScale()
+    if not self._interrupted then
+        self.cast:Hide()
+    end
+    self:ApplyNameVisibility()
+    self.castTimer:SetText("")
+    if wasCasting then
+        if self._castFallback then
+            self._castFallback = nil
+            _fallbackPlates[self] = nil
+            fallbackCastCount = math.max(0, fallbackCastCount - 1)
+            if fallbackCastCount == 0 then castFallbackFrame:Hide() end
+        end
+        NotifyCastEnded(self)
+    end
+    if GetShowClassPower() and classPowerType and self._cpPips and self.unit and UnitIsUnit(self.unit, "target") then
+        UpdateClassPowerOnPlate(self)
+    end
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540122386198696016

Issue: WoW returns "secret" placeholder values for enemy cast data in PvP. When an empowered cast (like Fire Breath or Dream Breath) ends, re-checking that unit's cast info can wrongly return a stale secret value instead of nil, making the addon think the cast is still active. The cast bar never hides.

Fix: On the empower-stop event, the bar now closes immediately without re-checking cast info — matching how channeled casts already handle this same edge case. Applied to both the nameplate cast bar and the floating spell-tracking bar.