### PR TITLE
feat: increased unit frame & resource power bar height cap to 100 to match other frames

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -3788,7 +3788,7 @@ initFrame:SetScript("OnEvent", function(self)
         local powerSizeRow
         powerSizeRow, h = W:DualRow(parent, y,
             { type = "slider", text = "Height",
-              min = 1, max = 30, step = 1,
+              min = 1, max = 100, step = 1,
               disabled = phDis, disabledTooltip = phTip, rawTooltip = phRaw,
               getValue = function() local c = cfg(); return c and c.height or 16 end,
               setValue = function(v)

--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -7117,7 +7117,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 1: Bar Height + Bar Position
         local sharedPowerRow1
         sharedPowerRow1, h = W:DualRow(parent, y,
-            { type="slider", text="Power Bar Height", min=0, max=30, step=1,
+            { type="slider", text="Power Bar Height", min=0, max=100, step=1,
               getValue=function() return SValSupported("powerHeight", 6) end,
               setValue=function(v) SSetSupported("powerHeight", v); ReloadAndUpdate(); UpdatePreview() end },
             { type="dropdown", text="Bar Position", values=ppPosValues, order=ppPosOrder,
@@ -9022,7 +9022,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Row 2: Height + Width
         local sharedBtbHeightRow
         sharedBtbHeightRow, h = W:DualRow(parent, y,
-            { type="slider", text="Height", min=0, max=40, step=1,
+            { type="slider", text="Height", min=0, max=100, step=1,
               disabled=function() return not SVal("bottomTextBar", false) end,
               disabledTooltip="Text Bar",
               getValue=function() return SVal("bottomTextBarHeight", 16) end,
@@ -13645,7 +13645,7 @@ initFrame:SetScript("OnEvent", function(self)
             -- Row 1: Power Bar Height (+ Reverse Fill cog) | Above Health Bar toggle
             local pwrRow1
             pwrRow1, h = W:DualRow(parent, y,
-                { type="slider", text="Power Bar Height", min=0, max=30, step=1,
+                { type="slider", text="Power Bar Height", min=0, max=100, step=1,
                   getValue=function() return MVal("powerHeight", 6) end,
                   setValue=function(v) MSet("powerHeight", v) end },
                 { type="toggle", text="Above Health Bar",


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

### Unit frame & resource power bar height cap

Lifts the Power Bar Height slider maximum from 40 to 100 on unit frames and resource bars, matching the Health Bar Height cap that was already 100. Users can now size power bars as tall as health bars.

## How was it tested?

Loaded in 12.1 client, set power bar height to 50, 80, 100 — all render correctly. Health/proportion layout remains accurate.

## Screenshots

<img width="476" height="127" alt="image" src="https://github.com/user-attachments/assets/bea0853a-810e-4b01-984c-ebe431b77c70" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [X] New settings default **OFF** (no behavior change without opt-in)
- [X] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [X] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [X] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [X] Tested in-game on live; no version gates or pre-Midnight APIs added
