### PR TITLE
feat: added text font & outline override options to unitframe/resource texts

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -97,16 +97,78 @@ initFrame:SetScript("OnEvent", function(self)
     local FONT_PATH = (EllesmereUI and EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("resourceBars"))
         or "Interface\\AddOns\\EllesmereUI\\media\\fonts\\Expressway.TTF"
     local function GetRBOptOutline()
-        return (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag()) or ""
+        return (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("resourceBars")) or ""
     end
     local function GetRBOptUseShadow()
-        return not EllesmereUI or not EllesmereUI.GetFontUseShadow or EllesmereUI.GetFontUseShadow()
+        return not EllesmereUI or not EllesmereUI.GetFontUseShadow or EllesmereUI.GetFontUseShadow("resourceBars")
     end
-    local function SetPVFont(fs, font, size)
+    -- Per-slot font/outline for resource-bar text. "__global"/nil follows the
+    -- resource-bars module font (or EUI Global). Resolve the path at call time.
+    local function SetPVSlotFont(fs, s, prefix, size)
         if not (fs and fs.SetFont) then return end
-        local f = GetRBOptOutline()
-        if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fs, f == "") end
-        fs:SetFont(font, size, f)
+        local font = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("resourceBars"))
+            or FONT_PATH
+        local fontKey = s and s[prefix .. "Font"]
+        if fontKey and fontKey ~= "__global" and EllesmereUI.ResolveFontName then
+            font = EllesmereUI.ResolveFontName(fontKey) or font
+        end
+        local f
+        local mode = s and s[prefix .. "Outline"]
+        if mode and mode ~= "__global" then
+            if mode == "outline" then
+                f = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG"
+            elseif mode == "thick" then
+                f = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("THICKOUTLINE, SLUG")) or "THICKOUTLINE, SLUG"
+            else
+                f = ""
+            end
+        else
+            f = GetRBOptOutline()
+        end
+        if EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fs, f == "") end
+        fs:SetFont(font, size or 12, f)
+    end
+
+    local RB_TEXT_OUTLINE_VALUES = {
+        ["__global"] = { text = "EUI Global Outline" },
+        ["none"]     = { text = "Drop Shadow" },
+        ["outline"]  = { text = "Outline" },
+        ["thick"]    = { text = "Thick Outline" },
+    }
+    local RB_TEXT_OUTLINE_ORDER = { "__global", "none", "outline", "thick" }
+
+    -- Insert Font + Font Outline after Size / Text Size / Timer Size, else after
+    -- leading toggles, else at the top of the cog.
+    local function InsertTextFontCogRows(rows, prefix, getVal, setVal, afterSet)
+        local fontValues, fontOrder = EllesmereUI.BuildFontDropdownData()
+        local insertAt = 0
+        local sizeAt
+        for i, row in ipairs(rows) do
+            local label = row.label
+            if label == "Size" or label == "Text Size" or label == "Timer Size" then
+                sizeAt = i
+                break
+            elseif row.type == "toggle" and not sizeAt then
+                insertAt = i
+            end
+        end
+        if sizeAt then insertAt = sizeAt end
+        table.insert(rows, insertAt + 1, {
+            type = "dropdown", label = "Font", values = fontValues, order = fontOrder,
+            get = function() return getVal(prefix .. "Font", "__global") end,
+            set = function(v)
+                setVal(prefix .. "Font", v)
+                if afterSet then afterSet() end
+            end,
+        })
+        table.insert(rows, insertAt + 2, {
+            type = "dropdown", label = "Font Outline", values = RB_TEXT_OUTLINE_VALUES, order = RB_TEXT_OUTLINE_ORDER,
+            get = function() return getVal(prefix .. "Outline", "__global") end,
+            set = function(v)
+                setVal(prefix .. "Outline", v)
+                if afterSet then afterSet() end
+            end,
+        })
     end
     local CONTENT_PAD = 45
     local SIDE_PAD = 20
@@ -499,7 +561,7 @@ initFrame:SetScript("OnEvent", function(self)
                             fs:SetTextColor(1, 1, 1, 0.9)
                             pip._pvCdText = fs
                         end
-                        SetPVFont(pip._pvCdText, FONT_PATH, sp.textSize)
+                        SetPVSlotFont(pip._pvCdText, sp, "text", sp.textSize)
                         pip._pvCdText:ClearAllPoints()
                         pip._pvCdText:SetPoint("CENTER", pip, "CENTER",
                             sp.textXOffset or 0, sp.textYOffset or 0)
@@ -596,7 +658,7 @@ initFrame:SetScript("OnEvent", function(self)
             -- Count text (centered on bar); DK uses per-pip durations instead
             local isDK = cf == "DEATHKNIGHT"
             if sp.showText and pc._countText and not isDK then
-                SetPVFont(pc._countText, FONT_PATH, sp.textSize)
+                SetPVSlotFont(pc._countText, sp, "text", sp.textSize)
                 pc._countText:ClearAllPoints()
                 local _pvTA = sp.textAnchor or "CENTER"
                 pc._countText:SetPoint(_pvTA, pc, _pvTA, sp.textXOffset or 0, sp.textYOffset or 0)
@@ -750,7 +812,7 @@ initFrame:SetScript("OnEvent", function(self)
         countTextOverlay:SetAllPoints(pipC)
         countTextOverlay:SetFrameLevel(pipC:GetFrameLevel() + 10)
         local countText = countTextOverlay:CreateFontString(nil, "OVERLAY")
-        SetPVFont(countText, FONT_PATH, sp.textSize)
+        SetPVSlotFont(countText, sp, "text", sp.textSize)
         countText:SetTextColor(1, 1, 1, 0.9)
         do local _pvTA = sp.textAnchor or "CENTER"; countText:SetPoint(_pvTA, pipC, _pvTA, sp.textXOffset or 0, sp.textYOffset or 0) end
         pipC._countText = countText
@@ -3544,9 +3606,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Health Text inline cog: anchor + x/y offsets
         if not EllesmereUI._prebuilding then
             local rgn = healthTextSizeRow._leftRegion
-            local _, cogShow = EllesmereUI.BuildCogPopup({
-                title = "Health Text",
-                rows = {
+            local healthTextCogRows = {
                     { type = "dropdown", label = "Anchor",
                       values = { LEFT = "Left", CENTER = "Center", RIGHT = "Right" },
                       order = { "LEFT", "CENTER", "RIGHT" },
@@ -3568,7 +3628,14 @@ initFrame:SetScript("OnEvent", function(self)
                           local c = cfg(); if not c then return end
                           c.textYOffset = v; RefreshHealth()
                       end },
-                },
+            }
+            InsertTextFontCogRows(healthTextCogRows, "text",
+                function(key, default) local c = cfg(); if c and c[key] ~= nil then return c[key] end; return default end,
+                function(key, val) local c = cfg(); if c then c[key] = val end end,
+                RefreshHealth)
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Health Text",
+                rows = healthTextCogRows,
             })
             local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.DIRECTIONS_ICON)
             AddFormTextBtn(rgn, cogBtn, cfg, RefreshHealth)
@@ -4332,9 +4399,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Power Text inline cog: percent sign, anchor, x/y offsets
         if not EllesmereUI._prebuilding then
             local rgn = powerTextSizeRow._leftRegion
-            local _, cogShow = EllesmereUI.BuildCogPopup({
-                title = "Power Text",
-                rows = {
+            local powerTextCogRows = {
                     { type = "toggle", label = "Show %",
                       get = function() local c = cfg(); return (not c) or c.showPercent ~= false end,
                       set = function(v)
@@ -4362,7 +4427,14 @@ initFrame:SetScript("OnEvent", function(self)
                           local c = cfg(); if not c then return end
                           c.textYOffset = v; RefreshPower()
                       end },
-                },
+            }
+            InsertTextFontCogRows(powerTextCogRows, "text",
+                function(key, default) local c = cfg(); if c and c[key] ~= nil then return c[key] end; return default end,
+                function(key, val) local c = cfg(); if c then c[key] = val end end,
+                RefreshPower)
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Power Text",
+                rows = powerTextCogRows,
             })
             local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.DIRECTIONS_ICON)
             AddFormTextBtn(rgn, cogBtn, cfg, RefreshPower)
@@ -5426,6 +5498,14 @@ initFrame:SetScript("OnEvent", function(self)
                         end })
                 end
             end
+            InsertTextFontCogRows(resTextRows, "text",
+                function(key, default)
+                    local p = DB(); local c = p and p.secondary
+                    if c and c[key] ~= nil then return c[key] end
+                    return default
+                end,
+                function(key, val) local p = DB(); if p then p.secondary[key] = val end end,
+                RefreshClass)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Resource Text",
                 rows = resTextRows,
@@ -8096,7 +8176,7 @@ initFrame:SetScript("OnEvent", function(self)
         local cbBarW = pf.bar:GetWidth() or 0
         -- Timer / duration text
         if cb.showTimer then
-            SetPVFont(pf.timerText, FONT_PATH, cb.timerSize or 11)
+            SetPVSlotFont(pf.timerText, cb, "timer", cb.timerSize or 11)
             local pt, xb, jh = ns.GetCastTextAnchor(cbDurSide, false, cbTimerW)
             pf.timerText:ClearAllPoints()
             pf.timerText:SetJustifyH(jh)
@@ -8114,7 +8194,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Spell name text
         if cb.showSpellText then
-            SetPVFont(pf.spellText, FONT_PATH, cb.spellTextSize or 11)
+            SetPVSlotFont(pf.spellText, cb, "spellText", cb.spellTextSize or 11)
             local pt, xb, jh = ns.GetCastTextAnchor(cbSpellSide, cb.showTimer and cbDurSide == cbSpellSide, cbTimerW)
             pf.spellText:ClearAllPoints()
             pf.spellText:SetJustifyH(jh)
@@ -8257,7 +8337,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Timer text
         local timerText = bar:CreateFontString(nil, "OVERLAY")
-        SetPVFont(timerText, FONT_PATH, cb.timerSize or 11)
+        SetPVSlotFont(timerText, cb, "timer", cb.timerSize or 11)
         timerText:SetPoint("RIGHT", bar, "RIGHT", -4 + (cb.timerX or 0), cb.timerY or 0)
         timerText:SetJustifyH("RIGHT")
         if cb.showTimer then
@@ -8273,7 +8353,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Spell name text
         local spellText = bar:CreateFontString(nil, "OVERLAY")
-        SetPVFont(spellText, FONT_PATH, cb.spellTextSize or 11)
+        SetPVSlotFont(spellText, cb, "spellText", cb.spellTextSize or 11)
         spellText:SetPoint("LEFT", bar, "LEFT", 4 + (cb.spellTextX or 0), cb.spellTextY or 0)
         spellText:SetJustifyH("LEFT")
         if cb.showSpellText then
@@ -8869,9 +8949,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline cog (RESIZE) on Spell Text for text size + x/y
         if not EllesmereUI._prebuilding then
             local rgn = textRow._rightRegion
-            local _, cogShow = EllesmereUI.BuildCogPopup({
-                title = "Spell Text Settings",
-                rows = {
+            local spellTextCogRows = {
                     { type = "slider", label = "Text Size", min = 8, max = 24, step = 1,
                       get = function() local p = DB(); return p and p.castBar.spellTextSize or 11 end,
                       set = function(v)
@@ -8890,7 +8968,18 @@ initFrame:SetScript("OnEvent", function(self)
                           local p = DB(); if not p then return end
                           p.castBar.spellTextY = v; RefreshCast()
                       end },
-                },
+            }
+            InsertTextFontCogRows(spellTextCogRows, "spellText",
+                function(key, default)
+                    local p = DB(); local c = p and p.castBar
+                    if c and c[key] ~= nil then return c[key] end
+                    return default
+                end,
+                function(key, val) local p = DB(); if p then p.castBar[key] = val end end,
+                RefreshCast)
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Spell Text Settings",
+                rows = spellTextCogRows,
             })
             local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.DIRECTIONS_ICON)
             local cogDis = CreateFrame("Frame", nil, rgn)
@@ -8947,9 +9036,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline cog (RESIZE) on Duration Text for timer size + x/y
         if not EllesmereUI._prebuilding then
             local rgn = timerRow._leftRegion
-            local _, cogShow = EllesmereUI.BuildCogPopup({
-                title = "Timer Settings",
-                rows = {
+            local timerCogRows = {
                     { type = "slider", label = "Timer Size", min = 8, max = 24, step = 1,
                       get = function() local p = DB(); return p and p.castBar.timerSize or 11 end,
                       set = function(v)
@@ -8968,7 +9055,18 @@ initFrame:SetScript("OnEvent", function(self)
                           local p = DB(); if not p then return end
                           p.castBar.timerY = v; RefreshCast()
                       end },
-                },
+            }
+            InsertTextFontCogRows(timerCogRows, "timer",
+                function(key, default)
+                    local p = DB(); local c = p and p.castBar
+                    if c and c[key] ~= nil then return c[key] end
+                    return default
+                end,
+                function(key, val) local p = DB(); if p then p.castBar[key] = val end end,
+                RefreshCast)
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Timer Settings",
+                rows = timerCogRows,
             })
             local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.DIRECTIONS_ICON)
             local cogDis = CreateFrame("Frame", nil, rgn)

--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -110,6 +110,79 @@ initFrame:SetScript("OnEvent", function(self)
         fs:SetFont(font, size, f)
     end
 
+    -- Per-slot font/outline for health-bar text. "__global"/nil follows the
+    -- unit-frames module font (or EUI Global) -- same sentinel as moduleFonts.
+    -- Resolve the path at call time: PREVIEW_FONT is declared later in this
+    -- function, so closing over that name here would be nil (Lua local scope
+    -- starts at the declaration, not the top of the block).
+    local function SetPVSlotFont(fs, s, prefix, size)
+        if not (fs and fs.SetFont) then return end
+        local font = (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("unitFrames"))
+            or "Fonts\\FRIZQT__.TTF"
+        local fontKey = s and s[prefix .. "Font"]
+        if fontKey and fontKey ~= "__global" and EllesmereUI.ResolveFontName then
+            font = EllesmereUI.ResolveFontName(fontKey) or font
+        end
+        local f
+        local mode = s and s[prefix .. "Outline"]
+        if mode and mode ~= "__global" then
+            if mode == "outline" then
+                f = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG"
+            elseif mode == "thick" then
+                f = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("THICKOUTLINE, SLUG")) or "THICKOUTLINE, SLUG"
+            else
+                f = ""
+            end
+        else
+            f = (EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("unitFrames")) or GetUFOptOutline()
+        end
+        if EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fs, f == "") end
+        fs:SetFont(font, size or 12, f)
+    end
+
+    local UF_TEXT_OUTLINE_VALUES = {
+        ["__global"] = { text = "EUI Global Outline" },
+        ["none"]     = { text = "Drop Shadow" },
+        ["outline"]  = { text = "Outline" },
+        ["thick"]    = { text = "Thick Outline" },
+    }
+    local UF_TEXT_OUTLINE_ORDER = { "__global", "none", "outline", "thick" }
+
+    -- Insert Font + Font Outline after Size / Text Size / Timer Size, else after
+    -- leading toggles, else at the top of the cog.
+    -- getVal/setVal match SVal/SSet and MVal/MSet (key, default) / (key, value).
+    local function InsertTextFontCogRows(rows, prefix, getVal, setVal, afterSet)
+        local fontValues, fontOrder = EllesmereUI.BuildFontDropdownData()
+        local insertAt = 0
+        local sizeAt
+        for i, row in ipairs(rows) do
+            local label = row.label
+            if label == "Size" or label == "Text Size" or label == "Timer Size" then
+                sizeAt = i
+                break
+            elseif row.type == "toggle" and not sizeAt then
+                insertAt = i
+            end
+        end
+        if sizeAt then insertAt = sizeAt end
+        table.insert(rows, insertAt + 1, {
+            type = "dropdown", label = "Font", values = fontValues, order = fontOrder,
+            get = function() return getVal(prefix .. "Font", "__global") end,
+            set = function(v)
+                setVal(prefix .. "Font", v)
+                if afterSet then afterSet() end
+            end,
+        })
+        table.insert(rows, insertAt + 2, {
+            type = "dropdown", label = "Font Outline", values = UF_TEXT_OUTLINE_VALUES, order = UF_TEXT_OUTLINE_ORDER,
+            get = function() return getVal(prefix .. "Outline", "__global") end,
+            set = function(v)
+                setVal(prefix .. "Outline", v)
+                if afterSet then afterSet() end
+            end,
+        })
+    end
+
     ---------------------------------------------------------------------------
     --  Shared helpers
     ---------------------------------------------------------------------------
@@ -1187,25 +1260,25 @@ initFrame:SetScript("OnEvent", function(self)
         local leftTS = settings.leftTextSize or settings.textSize or 12
         local rightTS = settings.rightTextSize or settings.textSize or 12
         local leftFS = textOverlay:CreateFontString(nil, "OVERLAY")
-        SetPVFont(leftFS, PREVIEW_FONT, leftTS)
+        SetPVSlotFont(leftFS, settings, "leftText", leftTS)
         leftFS:SetTextColor(1, 1, 1)
         leftFS:SetWordWrap(false)
 
         -- Right text
         local rightFS = textOverlay:CreateFontString(nil, "OVERLAY")
-        SetPVFont(rightFS, PREVIEW_FONT, rightTS)
+        SetPVSlotFont(rightFS, settings, "rightText", rightTS)
         rightFS:SetTextColor(1, 1, 1)
         rightFS:SetWordWrap(false)
 
         local centerFS = textOverlay:CreateFontString(nil, "OVERLAY")
-        SetPVFont(centerFS, PREVIEW_FONT, settings.centerTextSize or settings.textSize or 12)
+        SetPVSlotFont(centerFS, settings, "centerText", settings.centerTextSize or settings.textSize or 12)
         centerFS:SetTextColor(1, 1, 1)
         centerFS:SetWordWrap(false)
 
         -- Extra Text FontString: anchored per extraTextAlign, never width-constrained
         -- (live frames never truncate it either).
         local extraFS = textOverlay:CreateFontString(nil, "OVERLAY")
-        SetPVFont(extraFS, PREVIEW_FONT, settings.extraTextSize or settings.textSize or 12)
+        SetPVSlotFont(extraFS, settings, "extraText", settings.extraTextSize or settings.textSize or 12)
         extraFS:SetTextColor(1, 1, 1)
         extraFS:SetWordWrap(false)
 
@@ -1358,7 +1431,7 @@ initFrame:SetScript("OnEvent", function(self)
 
 
             local ec = s.extraTextContent or "none"
-            extraFS:SetFont(PREVIEW_FONT, (s.extraTextSize or s.textSize or 12), GetUFOptOutline())
+            SetPVSlotFont(extraFS, s, "extraText", s.extraTextSize or s.textSize or 12)
             extraFS:ClearAllPoints()
             extraFS:SetWidth(0)
             if ec ~= "none" then
@@ -1383,7 +1456,7 @@ initFrame:SetScript("OnEvent", function(self)
             end
 
             -- Each text position renders independently; Center does not hide Left/Right.
-            centerFS:SetFont(PREVIEW_FONT, csz, GetUFOptOutline())
+            SetPVSlotFont(centerFS, s, "centerText", csz)
             centerFS:ClearAllPoints()
             if cc ~= "none" then
                 centerFS:SetJustifyH("CENTER")
@@ -1395,7 +1468,7 @@ initFrame:SetScript("OnEvent", function(self)
                 centerFS:Hide()
             end
 
-            leftFS:SetFont(PREVIEW_FONT, lsz, GetUFOptOutline())
+            SetPVSlotFont(leftFS, s, "leftText", lsz)
             leftFS:ClearAllPoints()
             if lc ~= "none" then
                 leftFS:SetJustifyH("LEFT")
@@ -1417,7 +1490,7 @@ initFrame:SetScript("OnEvent", function(self)
                 leftFS:Hide()
             end
 
-            rightFS:SetFont(PREVIEW_FONT, rsz, GetUFOptOutline())
+            SetPVSlotFont(rightFS, s, "rightText", rsz)
             rightFS:ClearAllPoints()
             if rc ~= "none" then
                 rightFS:SetJustifyH("RIGHT")
@@ -1740,17 +1813,17 @@ initFrame:SetScript("OnEvent", function(self)
             btbTextOvr:SetFrameLevel(barArea:GetFrameLevel() + 10)
 
             btbLeftFS = btbTextOvr:CreateFontString(nil, "OVERLAY")
-            SetPVFont(btbLeftFS, PREVIEW_FONT, settings.btbLeftSize or 11)
+            SetPVSlotFont(btbLeftFS, settings, "btbLeft", settings.btbLeftSize or 11)
             btbLeftFS:SetTextColor(1, 1, 1)
             btbLeftFS:SetWordWrap(false)
 
             btbRightFS = btbTextOvr:CreateFontString(nil, "OVERLAY")
-            SetPVFont(btbRightFS, PREVIEW_FONT, settings.btbRightSize or 11)
+            SetPVSlotFont(btbRightFS, settings, "btbRight", settings.btbRightSize or 11)
             btbRightFS:SetTextColor(1, 1, 1)
             btbRightFS:SetWordWrap(false)
 
             btbCenterFS = btbTextOvr:CreateFontString(nil, "OVERLAY")
-            SetPVFont(btbCenterFS, PREVIEW_FONT, settings.btbCenterSize or 11)
+            SetPVSlotFont(btbCenterFS, settings, "btbCenter", settings.btbCenterSize or 11)
             btbCenterFS:SetTextColor(1, 1, 1)
             btbCenterFS:SetWordWrap(false)
 
@@ -1771,7 +1844,7 @@ initFrame:SetScript("OnEvent", function(self)
                 local rsz = s.btbRightSize or 11
                 local csz = s.btbCenterSize or 11
 
-                btbLeftFS:SetFont(PREVIEW_FONT, lsz, GetUFOptOutline())
+                SetPVSlotFont(btbLeftFS, s, "btbLeft", lsz)
                 btbLeftFS:ClearAllPoints()
                 if lc ~= "none" then
                     btbLeftFS:SetJustifyH("LEFT")
@@ -1782,7 +1855,7 @@ initFrame:SetScript("OnEvent", function(self)
                     PreviewPowerColor(btbLeftFS, lc, s.btbLeftPowerColor)
                 else btbLeftFS:Hide() end
 
-                btbRightFS:SetFont(PREVIEW_FONT, rsz, GetUFOptOutline())
+                SetPVSlotFont(btbRightFS, s, "btbRight", rsz)
                 btbRightFS:ClearAllPoints()
                 if rc ~= "none" then
                     btbRightFS:SetJustifyH("RIGHT")
@@ -1793,7 +1866,7 @@ initFrame:SetScript("OnEvent", function(self)
                     PreviewPowerColor(btbRightFS, rc, s.btbRightPowerColor)
                 else btbRightFS:Hide() end
 
-                btbCenterFS:SetFont(PREVIEW_FONT, csz, GetUFOptOutline())
+                SetPVSlotFont(btbCenterFS, s, "btbCenter", csz)
                 btbCenterFS:ClearAllPoints()
                 if cc ~= "none" then
                     btbCenterFS:SetJustifyH("CENTER")
@@ -2916,7 +2989,7 @@ initFrame:SetScript("OnEvent", function(self)
                     if castNameFS2 then
                         local spellName = (unitKey == "player") and (_previewCastSpell and _previewCastSpell.name or "Spell Name") or "Spell Name"
                         castNameFS2:SetText(spellName)
-                        castNameFS2:SetFont(PREVIEW_FONT, s.castSpellNameSize or 11, GetUFOptOutline())
+                        SetPVSlotFont(castNameFS2, s, "castSpellName", s.castSpellNameSize or 11)
                         local snC = s.castSpellNameColor or { r=1, g=1, b=1 }
                         castNameFS2:SetTextColor(snC.r, snC.g, snC.b)
                         castNameFS2:ClearAllPoints()
@@ -2933,7 +3006,7 @@ initFrame:SetScript("OnEvent", function(self)
                     if castTimeFS then
                         local spCastTime = (_previewCastSpell and _previewCastSpell.castTime) or 3.0
                         castTimeFS:SetText(string.format("%.1f", spCastTime * (1 - (_previewCastFill or 0.6))))
-                        castTimeFS:SetFont(PREVIEW_FONT, s.castDurationSize or 10, GetUFOptOutline())
+                        SetPVSlotFont(castTimeFS, s, "castDuration", s.castDurationSize or 10)
                         local dtC = s.castDurationColor or { r=1, g=1, b=1 }
                         castTimeFS:SetTextColor(dtC.r, dtC.g, dtC.b)
                         castTimeFS:SetShown(showDur)
@@ -2946,7 +3019,7 @@ initFrame:SetScript("OnEvent", function(self)
                         end
                     end
                     if castTargetFS then
-                        castTargetFS:SetFont(PREVIEW_FONT, s.castSpellTargetSize or 11, GetUFOptOutline())
+                        SetPVSlotFont(castTargetFS, s, "castSpellTarget", s.castSpellTargetSize or 11)
                         local tsC = s.castSpellTargetColor or { r=1, g=1, b=1 }
                         castTargetFS:SetTextColor(tsC.r, tsC.g, tsC.b)
                         castTargetFS:SetShown(showTgt)
@@ -4035,10 +4108,16 @@ initFrame:SetScript("OnEvent", function(self)
         castbarHeight        = { target=true, focus=true },
         castbarHideWhenInactive = { player=true, target=true, focus=true },
         castSpellNameSize    = { player=true, target=true, focus=true },
+        castSpellNameFont    = { player=true, target=true, focus=true },
+        castSpellNameOutline = { player=true, target=true, focus=true },
         castSpellNameColor   = { player=true, target=true, focus=true },
         castDurationSize     = { player=true, target=true, focus=true },
+        castDurationFont     = { player=true, target=true, focus=true },
+        castDurationOutline  = { player=true, target=true, focus=true },
         castDurationColor    = { player=true, target=true, focus=true },
         castSpellTargetSize  = { player=true, target=true, focus=true },
+        castSpellTargetFont  = { player=true, target=true, focus=true },
+        castSpellTargetOutline = { player=true, target=true, focus=true },
         castSpellTargetColor = { player=true, target=true, focus=true },
         showCastDuration     = { player=true, target=true, focus=true },
         showCastTarget       = { player=true, target=true, focus=true },
@@ -6369,6 +6448,7 @@ initFrame:SetScript("OnEvent", function(self)
                         d.leftTextSize = src.leftTextSize
                         d.leftTextX, d.leftTextY = src.leftTextX, src.leftTextY
                         d.leftTextWidthPct = src.leftTextWidthPct
+                        d.leftTextFont, d.leftTextOutline = src.leftTextFont, src.leftTextOutline
                     end
                 end
                 ReloadAndUpdate(); EllesmereUI:RefreshPage()
@@ -6392,6 +6472,8 @@ initFrame:SetScript("OnEvent", function(self)
                         if (d.leftTextX or 0) ~= (src.leftTextX or 0) then return false end
                         if (d.leftTextY or 0) ~= (src.leftTextY or 0) then return false end
                         if (d.leftTextWidthPct or 100) ~= (src.leftTextWidthPct or 100) then return false end
+                        if (d.leftTextFont or "__global") ~= (src.leftTextFont or "__global") then return false end
+                        if (d.leftTextOutline or "__global") ~= (src.leftTextOutline or "__global") then return false end
                     end
                     return true
                 end,
@@ -6475,9 +6557,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Cogwheel on Left Text (left region)
         if not EllesmereUI._prebuilding then
             local leftRgn = sharedTextRow._leftRegion
-            local _, leftCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "Left Text Settings",
-                rows = {
+            local leftCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return SVal("leftTextSize", SDB().textSize or 12) end,
                       set=function(v) SSet("leftTextSize", v); UpdatePreview() end },
@@ -6525,7 +6605,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return SVal("leftTextContent","name") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(leftCogRows, "leftText", SVal, SSet, UpdatePreview)
+            local _, leftCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "Left Text Settings",
+                rows = leftCogRows,
             })
             local leftCogShow = leftCogShowRaw
             local leftCogBtn = MakeCogBtn(leftRgn, leftCogShow)
@@ -6559,6 +6643,7 @@ initFrame:SetScript("OnEvent", function(self)
                         d.rightTextSize = src.rightTextSize
                         d.rightTextX, d.rightTextY = src.rightTextX, src.rightTextY
                         d.rightTextWidthPct = src.rightTextWidthPct
+                        d.rightTextFont, d.rightTextOutline = src.rightTextFont, src.rightTextOutline
                     end
                 end
                 ReloadAndUpdate(); EllesmereUI:RefreshPage()
@@ -6582,6 +6667,8 @@ initFrame:SetScript("OnEvent", function(self)
                         if (d.rightTextX or 0) ~= (src.rightTextX or 0) then return false end
                         if (d.rightTextY or 0) ~= (src.rightTextY or 0) then return false end
                         if (d.rightTextWidthPct or 100) ~= (src.rightTextWidthPct or 100) then return false end
+                        if (d.rightTextFont or "__global") ~= (src.rightTextFont or "__global") then return false end
+                        if (d.rightTextOutline or "__global") ~= (src.rightTextOutline or "__global") then return false end
                     end
                     return true
                 end,
@@ -6661,9 +6748,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Cogwheel on Right Text (right region)
         if not EllesmereUI._prebuilding then
             local rightRgn = sharedTextRow._rightRegion
-            local _, rightCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "Right Text Settings",
-                rows = {
+            local rightCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return SVal("rightTextSize", SDB().textSize or 12) end,
                       set=function(v) SSet("rightTextSize", v); UpdatePreview() end },
@@ -6711,7 +6796,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return SVal("rightTextContent","both") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(rightCogRows, "rightText", SVal, SSet, UpdatePreview)
+            local _, rightCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "Right Text Settings",
+                rows = rightCogRows,
             })
             local rightCogShow = rightCogShowRaw
             local rightCogBtn = MakeCogBtn(rightRgn, rightCogShow)
@@ -6761,6 +6850,7 @@ initFrame:SetScript("OnEvent", function(self)
                         d.centerTextSize = src.centerTextSize
                         d.centerTextX, d.centerTextY = src.centerTextX, src.centerTextY
                         d.centerTextWidthPct = src.centerTextWidthPct
+                        d.centerTextFont, d.centerTextOutline = src.centerTextFont, src.centerTextOutline
                     end
                 end
                 ReloadAndUpdate(); EllesmereUI:RefreshPage()
@@ -6784,6 +6874,8 @@ initFrame:SetScript("OnEvent", function(self)
                         if (d.centerTextX or 0) ~= (src.centerTextX or 0) then return false end
                         if (d.centerTextY or 0) ~= (src.centerTextY or 0) then return false end
                         if (d.centerTextWidthPct or 100) ~= (src.centerTextWidthPct or 100) then return false end
+                        if (d.centerTextFont or "__global") ~= (src.centerTextFont or "__global") then return false end
+                        if (d.centerTextOutline or "__global") ~= (src.centerTextOutline or "__global") then return false end
                     end
                     return true
                 end,
@@ -6849,9 +6941,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Cogwheel on Center Text (left region)
         if not EllesmereUI._prebuilding then
             local ctrRgn = sharedCenterTextRow._leftRegion
-            local _, centerCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "Center Text Settings",
-                rows = {
+            local centerCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return SVal("centerTextSize", SDB().textSize or 12) end,
                       set=function(v) SSet("centerTextSize", v); UpdatePreview() end },
@@ -6899,7 +6989,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return SVal("centerTextContent","none") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(centerCogRows, "centerText", SVal, SSet, UpdatePreview)
+            local _, centerCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "Center Text Settings",
+                rows = centerCogRows,
             })
             local centerCogShow = centerCogShowRaw
             local centerCogBtn = MakeCogBtn(ctrRgn, centerCogShow)
@@ -6936,6 +7030,7 @@ initFrame:SetScript("OnEvent", function(self)
                         d.extraTextX, d.extraTextY = src.extraTextX, src.extraTextY
                         d.extraTextAlign = src.extraTextAlign
                         d.extraTextWidthPct = src.extraTextWidthPct
+                        d.extraTextFont, d.extraTextOutline = src.extraTextFont, src.extraTextOutline
                     end
                 end
                 ReloadAndUpdate(); EllesmereUI:RefreshPage()
@@ -6960,6 +7055,8 @@ initFrame:SetScript("OnEvent", function(self)
                         if (d.extraTextY or 0) ~= (src.extraTextY or 0) then return false end
                         if (d.extraTextAlign or "left") ~= (src.extraTextAlign or "left") then return false end
                         if (d.extraTextWidthPct or 100) ~= (src.extraTextWidthPct or 100) then return false end
+                        if (d.extraTextFont or "__global") ~= (src.extraTextFont or "__global") then return false end
+                        if (d.extraTextOutline or "__global") ~= (src.extraTextOutline or "__global") then return false end
                     end
                     return true
                 end,
@@ -7025,9 +7122,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Cogwheel on Extra Text (Center row right region): Alignment + Size/X/Y
         if not EllesmereUI._prebuilding then
             local etrRgn = sharedCenterTextRow._rightRegion
-            local _, extraCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "Extra Text Settings",
-                rows = {
+            local extraCogRows = {
                     { type="dropdown", label="Alignment",
                       values={ ["left"]="Left", ["right"]="Right", ["center"]="Center" }, order={ "left", "right", "center" },
                       get=function() return SVal("extraTextAlign", "left") end,
@@ -7079,7 +7174,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return SVal("extraTextContent","none") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(extraCogRows, "extraText", SVal, SSet, UpdatePreview)
+            local _, extraCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "Extra Text Settings",
+                rows = extraCogRows,
             })
             local extraCogShow = extraCogShowRaw
             local extraCogBtn = MakeCogBtn(etrRgn, extraCogShow)
@@ -8573,6 +8672,7 @@ initFrame:SetScript("OnEvent", function(self)
                       get=function() return SValSupported("castSpellNameY", 0) end,
                       set=function(v) SSetSupported("castSpellNameY", v); ReloadAndUpdate(); UpdatePreview() end },
             }
+            InsertTextFontCogRows(snCogRows, "castSpellName", SValSupported, SSetSupported)
             if selectedUnit == "target" or selectedUnit == "focus" then
                 snCogRows[#snCogRows + 1] = { type="toggle", label="Combine Spell Name and Target",
                     tooltip="Appends the cast target to the spell name (Spell Name - Target), class colored, and disables the separate Spell Target display.",
@@ -8612,9 +8712,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline cog on Duration Size: toggle + X/Y offsets
         if not EllesmereUI._prebuilding then
             local dtCogRgn = castTextRow._rightRegion
-            local _, dtCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "Duration",
-                rows = {
+            local dtCogRows = {
                     { type="slider", label="Size", min=6, max=20, step=1,
                       get=function() return SValSupported("castDurationSize", 10) end,
                       set=function(v) SSetSupported("castDurationSize", v); ReloadAndUpdate(); UpdatePreview() end },
@@ -8624,7 +8722,11 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Y Offset", min=-50, max=50, step=1,
                       get=function() return SValSupported("castDurationY", 0) end,
                       set=function(v) SSetSupported("castDurationY", v); ReloadAndUpdate(); UpdatePreview() end },
-                },
+            }
+            InsertTextFontCogRows(dtCogRows, "castDuration", SValSupported, SSetSupported)
+            local _, dtCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "Duration",
+                rows = dtCogRows,
             })
             local dtCogBtn = MakeCogBtn(dtCogRgn, dtCogShowRaw)
             dtCogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
@@ -8639,20 +8741,27 @@ initFrame:SetScript("OnEvent", function(self)
                 region  = rgn,
                 tooltip = "Apply Spell Name Size and Color to all Frames",
                 onClick = function()
-                    local v = UNIT_DB_MAP[selectedUnit]().castSpellNameSize or 11
-                    local c = UNIT_DB_MAP[selectedUnit]().castSpellNameColor
+                    local src = UNIT_DB_MAP[selectedUnit]()
+                    local v = src.castSpellNameSize or 11
+                    local c = src.castSpellNameColor
                     for _, key in ipairs(GROUP_UNIT_ORDER) do
-                        UNIT_DB_MAP[key]().castSpellNameSize = v
-                        if c then UNIT_DB_MAP[key]().castSpellNameColor = { r=c.r, g=c.g, b=c.b } end
+                        local d = UNIT_DB_MAP[key]()
+                        d.castSpellNameSize = v
+                        d.castSpellNameFont, d.castSpellNameOutline = src.castSpellNameFont, src.castSpellNameOutline
+                        if c then d.castSpellNameColor = { r=c.r, g=c.g, b=c.b } end
                     end
                     ReloadAndUpdate(); EllesmereUI:RefreshPage()
                 end,
                 isSynced = function()
-                    local v = UNIT_DB_MAP[selectedUnit]().castSpellNameSize or 11
-                    local c = UNIT_DB_MAP[selectedUnit]().castSpellNameColor
+                    local src = UNIT_DB_MAP[selectedUnit]()
+                    local v = src.castSpellNameSize or 11
+                    local c = src.castSpellNameColor
                     for _, key in ipairs(GROUP_UNIT_ORDER) do
-                        if (UNIT_DB_MAP[key]().castSpellNameSize or 11) ~= v then return false end
-                        local kc = UNIT_DB_MAP[key]().castSpellNameColor
+                        local d = UNIT_DB_MAP[key]()
+                        if (d.castSpellNameSize or 11) ~= v then return false end
+                        if (d.castSpellNameFont or "__global") ~= (src.castSpellNameFont or "__global") then return false end
+                        if (d.castSpellNameOutline or "__global") ~= (src.castSpellNameOutline or "__global") then return false end
+                        local kc = d.castSpellNameColor
                         if c and kc then
                             if kc.r ~= c.r or kc.g ~= c.g or kc.b ~= c.b then return false end
                         elseif c ~= kc then return false end
@@ -8665,11 +8774,14 @@ initFrame:SetScript("OnEvent", function(self)
                     elementLabels = SHORT_LABELS,
                     getCurrentKey = function() return selectedUnit end,
                     onApply       = function(checkedKeys)
-                        local v = UNIT_DB_MAP[selectedUnit]().castSpellNameSize or 11
-                        local c = UNIT_DB_MAP[selectedUnit]().castSpellNameColor
+                        local src = UNIT_DB_MAP[selectedUnit]()
+                        local v = src.castSpellNameSize or 11
+                        local c = src.castSpellNameColor
                         for _, key in ipairs(checkedKeys) do
-                            UNIT_DB_MAP[key]().castSpellNameSize = v
-                            if c then UNIT_DB_MAP[key]().castSpellNameColor = { r=c.r, g=c.g, b=c.b } end
+                            local d = UNIT_DB_MAP[key]()
+                            d.castSpellNameSize = v
+                            d.castSpellNameFont, d.castSpellNameOutline = src.castSpellNameFont, src.castSpellNameOutline
+                            if c then d.castSpellNameColor = { r=c.r, g=c.g, b=c.b } end
                         end
                         ReloadAndUpdate(); EllesmereUI:RefreshPage()
                     end,
@@ -8682,20 +8794,27 @@ initFrame:SetScript("OnEvent", function(self)
                 region  = rgn,
                 tooltip = "Apply Duration Size and Color to all Frames",
                 onClick = function()
-                    local v = UNIT_DB_MAP[selectedUnit]().castDurationSize or 10
-                    local c = UNIT_DB_MAP[selectedUnit]().castDurationColor
+                    local src = UNIT_DB_MAP[selectedUnit]()
+                    local v = src.castDurationSize or 10
+                    local c = src.castDurationColor
                     for _, key in ipairs(GROUP_UNIT_ORDER) do
-                        UNIT_DB_MAP[key]().castDurationSize = v
-                        if c then UNIT_DB_MAP[key]().castDurationColor = { r=c.r, g=c.g, b=c.b } end
+                        local d = UNIT_DB_MAP[key]()
+                        d.castDurationSize = v
+                        d.castDurationFont, d.castDurationOutline = src.castDurationFont, src.castDurationOutline
+                        if c then d.castDurationColor = { r=c.r, g=c.g, b=c.b } end
                     end
                     ReloadAndUpdate(); EllesmereUI:RefreshPage()
                 end,
                 isSynced = function()
-                    local v = UNIT_DB_MAP[selectedUnit]().castDurationSize or 10
-                    local c = UNIT_DB_MAP[selectedUnit]().castDurationColor
+                    local src = UNIT_DB_MAP[selectedUnit]()
+                    local v = src.castDurationSize or 10
+                    local c = src.castDurationColor
                     for _, key in ipairs(GROUP_UNIT_ORDER) do
-                        if (UNIT_DB_MAP[key]().castDurationSize or 10) ~= v then return false end
-                        local kc = UNIT_DB_MAP[key]().castDurationColor
+                        local d = UNIT_DB_MAP[key]()
+                        if (d.castDurationSize or 10) ~= v then return false end
+                        if (d.castDurationFont or "__global") ~= (src.castDurationFont or "__global") then return false end
+                        if (d.castDurationOutline or "__global") ~= (src.castDurationOutline or "__global") then return false end
+                        local kc = d.castDurationColor
                         if c and kc then
                             if kc.r ~= c.r or kc.g ~= c.g or kc.b ~= c.b then return false end
                         elseif c ~= kc then return false end
@@ -8708,11 +8827,14 @@ initFrame:SetScript("OnEvent", function(self)
                     elementLabels = SHORT_LABELS,
                     getCurrentKey = function() return selectedUnit end,
                     onApply       = function(checkedKeys)
-                        local v = UNIT_DB_MAP[selectedUnit]().castDurationSize or 10
-                        local c = UNIT_DB_MAP[selectedUnit]().castDurationColor
+                        local src = UNIT_DB_MAP[selectedUnit]()
+                        local v = src.castDurationSize or 10
+                        local c = src.castDurationColor
                         for _, key in ipairs(checkedKeys) do
-                            UNIT_DB_MAP[key]().castDurationSize = v
-                            if c then UNIT_DB_MAP[key]().castDurationColor = { r=c.r, g=c.g, b=c.b } end
+                            local d = UNIT_DB_MAP[key]()
+                            d.castDurationSize = v
+                            d.castDurationFont, d.castDurationOutline = src.castDurationFont, src.castDurationOutline
+                            if c then d.castDurationColor = { r=c.r, g=c.g, b=c.b } end
                         end
                         ReloadAndUpdate(); EllesmereUI:RefreshPage()
                     end,
@@ -8769,9 +8891,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Inline cog on Spell Target Size: toggle + X/Y offsets
         if not EllesmereUI._prebuilding then
             local tgCogRgn = castTargetRow._leftRegion
-            local _, tgCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "Spell Target",
-                rows = {
+            local tgCogRows = {
                     { type="slider", label="Size", min=6, max=20, step=1,
                       get=function() return SValSupported("castSpellTargetSize", 10) end,
                       set=function(v) SSetSupported("castSpellTargetSize", v); ReloadAndUpdate(); UpdatePreview() end },
@@ -8781,7 +8901,11 @@ initFrame:SetScript("OnEvent", function(self)
                     { type="slider", label="Y Offset", min=-50, max=50, step=1,
                       get=function() return SValSupported("castSpellTargetY", 0) end,
                       set=function(v) SSetSupported("castSpellTargetY", v); ReloadAndUpdate(); UpdatePreview() end },
-                },
+            }
+            InsertTextFontCogRows(tgCogRows, "castSpellTarget", SValSupported, SSetSupported)
+            local _, tgCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "Spell Target",
+                rows = tgCogRows,
             })
             local tgCogBtn = MakeCogBtn(tgCogRgn, tgCogShowRaw)
             tgCogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
@@ -8796,20 +8920,27 @@ initFrame:SetScript("OnEvent", function(self)
                 region  = rgn,
                 tooltip = "Apply Spell Target Size and Color to all Frames",
                 onClick = function()
-                    local v = UNIT_DB_MAP[selectedUnit]().castSpellTargetSize or 11
-                    local c = UNIT_DB_MAP[selectedUnit]().castSpellTargetColor
+                    local src = UNIT_DB_MAP[selectedUnit]()
+                    local v = src.castSpellTargetSize or 11
+                    local c = src.castSpellTargetColor
                     for _, key in ipairs(GROUP_UNIT_ORDER) do
-                        UNIT_DB_MAP[key]().castSpellTargetSize = v
-                        if c then UNIT_DB_MAP[key]().castSpellTargetColor = { r=c.r, g=c.g, b=c.b } end
+                        local d = UNIT_DB_MAP[key]()
+                        d.castSpellTargetSize = v
+                        d.castSpellTargetFont, d.castSpellTargetOutline = src.castSpellTargetFont, src.castSpellTargetOutline
+                        if c then d.castSpellTargetColor = { r=c.r, g=c.g, b=c.b } end
                     end
                     ReloadAndUpdate(); EllesmereUI:RefreshPage()
                 end,
                 isSynced = function()
-                    local v = UNIT_DB_MAP[selectedUnit]().castSpellTargetSize or 11
-                    local c = UNIT_DB_MAP[selectedUnit]().castSpellTargetColor
+                    local src = UNIT_DB_MAP[selectedUnit]()
+                    local v = src.castSpellTargetSize or 11
+                    local c = src.castSpellTargetColor
                     for _, key in ipairs(GROUP_UNIT_ORDER) do
-                        if (UNIT_DB_MAP[key]().castSpellTargetSize or 11) ~= v then return false end
-                        local kc = UNIT_DB_MAP[key]().castSpellTargetColor
+                        local d = UNIT_DB_MAP[key]()
+                        if (d.castSpellTargetSize or 11) ~= v then return false end
+                        if (d.castSpellTargetFont or "__global") ~= (src.castSpellTargetFont or "__global") then return false end
+                        if (d.castSpellTargetOutline or "__global") ~= (src.castSpellTargetOutline or "__global") then return false end
+                        local kc = d.castSpellTargetColor
                         if c and kc then
                             if kc.r ~= c.r or kc.g ~= c.g or kc.b ~= c.b then return false end
                         elseif c ~= kc then return false end
@@ -8822,11 +8953,14 @@ initFrame:SetScript("OnEvent", function(self)
                     elementLabels = SHORT_LABELS,
                     getCurrentKey = function() return selectedUnit end,
                     onApply       = function(checkedKeys)
-                        local v = UNIT_DB_MAP[selectedUnit]().castSpellTargetSize or 11
-                        local c = UNIT_DB_MAP[selectedUnit]().castSpellTargetColor
+                        local src = UNIT_DB_MAP[selectedUnit]()
+                        local v = src.castSpellTargetSize or 11
+                        local c = src.castSpellTargetColor
                         for _, key in ipairs(checkedKeys) do
-                            UNIT_DB_MAP[key]().castSpellTargetSize = v
-                            if c then UNIT_DB_MAP[key]().castSpellTargetColor = { r=c.r, g=c.g, b=c.b } end
+                            local d = UNIT_DB_MAP[key]()
+                            d.castSpellTargetSize = v
+                            d.castSpellTargetFont, d.castSpellTargetOutline = src.castSpellTargetFont, src.castSpellTargetOutline
+                            if c then d.castSpellTargetColor = { r=c.r, g=c.g, b=c.b } end
                         end
                         ReloadAndUpdate(); EllesmereUI:RefreshPage()
                     end,
@@ -9213,9 +9347,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Cogwheel on BTB Left Text
         if not EllesmereUI._prebuilding then
             local btbLRgn = sharedBtbTextRow._leftRegion
-            local _, btbLeftCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "BTB Left Text Settings",
-                rows = {
+            local btbLeftCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return SVal("btbLeftSize", 11) end,
                       set=function(v) SSet("btbLeftSize", v); UpdatePreview() end },
@@ -9263,7 +9395,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return SVal("btbLeftContent","none") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(btbLeftCogRows, "btbLeft", SVal, SSet, UpdatePreview)
+            local _, btbLeftCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "BTB Left Text Settings",
+                rows = btbLeftCogRows,
             })
             local btbLeftCogShow = btbLeftCogShowRaw
             local btbLCogBtn = MakeCogBtn(btbLRgn, btbLeftCogShow)
@@ -9365,9 +9501,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Cogwheel on BTB Right Text
         if not EllesmereUI._prebuilding then
             local btbRRgn = sharedBtbTextRow._rightRegion
-            local _, btbRightCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "BTB Right Text Settings",
-                rows = {
+            local btbRightCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return SVal("btbRightSize", 11) end,
                       set=function(v) SSet("btbRightSize", v); UpdatePreview() end },
@@ -9415,7 +9549,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return SVal("btbRightContent","none") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(btbRightCogRows, "btbRight", SVal, SSet, UpdatePreview)
+            local _, btbRightCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "BTB Right Text Settings",
+                rows = btbRightCogRows,
             })
             local btbRightCogShow = btbRightCogShowRaw
             local btbRCogBtn = MakeCogBtn(btbRRgn, btbRightCogShow)
@@ -9598,9 +9736,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Cogwheel on BTB Center Text
         if not EllesmereUI._prebuilding then
             local btbCRgn = sharedBtbCenterRow._leftRegion
-            local _, btbCenterCogShowRaw = EllesmereUI.BuildCogPopup({
-                title = "BTB Center Text Settings",
-                rows = {
+            local btbCenterCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return SVal("btbCenterSize", 11) end,
                       set=function(v) SSet("btbCenterSize", v); UpdatePreview() end },
@@ -9648,7 +9784,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return SVal("btbCenterContent","none") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(btbCenterCogRows, "btbCenter", SVal, SSet, UpdatePreview)
+            local _, btbCenterCogShowRaw = EllesmereUI.BuildCogPopup({
+                title = "BTB Center Text Settings",
+                rows = btbCenterCogRows,
             })
             local btbCenterCogShow = btbCenterCogShowRaw
             local btbCCogBtn = MakeCogBtn(btbCRgn, btbCenterCogShow)
@@ -13200,9 +13340,7 @@ initFrame:SetScript("OnEvent", function(self)
             RegisterWidgetRefresh(function() swUp(); classSwUp(); UpdSwatches() end)
             UpdSwatches()
 
-            local _, cogShowFn = EllesmereUI.BuildCogPopup({
-                title = "Left Text Settings",
-                rows = {
+            local mLeftCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return MVal("leftTextSize", settingsTable.textSize or 12) end,
                       set=function(v) MSet("leftTextSize", v) end },
@@ -13250,7 +13388,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return MVal("leftTextContent","name") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(mLeftCogRows, "leftText", MVal, MSet)
+            local _, cogShowFn = EllesmereUI.BuildCogPopup({
+                title = "Left Text Settings",
+                rows = mLeftCogRows,
             })
             local cogBtn = MCogBtn(rgn, cogShowFn)
             local function UpdCog()
@@ -13314,9 +13456,7 @@ initFrame:SetScript("OnEvent", function(self)
             RegisterWidgetRefresh(function() swUp(); classSwUp(); UpdSwatches() end)
             UpdSwatches()
 
-            local _, cogShowFn = EllesmereUI.BuildCogPopup({
-                title = "Right Text Settings",
-                rows = {
+            local mRightCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return MVal("rightTextSize", settingsTable.textSize or 12) end,
                       set=function(v) MSet("rightTextSize", v) end },
@@ -13364,7 +13504,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return MVal("rightTextContent","none") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(mRightCogRows, "rightText", MVal, MSet)
+            local _, cogShowFn = EllesmereUI.BuildCogPopup({
+                title = "Right Text Settings",
+                rows = mRightCogRows,
             })
             local cogBtn = MCogBtn(rgn, cogShowFn)
             local function UpdCog()
@@ -13447,9 +13591,7 @@ initFrame:SetScript("OnEvent", function(self)
             RegisterWidgetRefresh(function() swUp(); classSwUp(); UpdSwatches() end)
             UpdSwatches()
 
-            local _, cogShowFn = EllesmereUI.BuildCogPopup({
-                title = "Center Text Settings",
-                rows = {
+            local mCenterCogRows = {
                     { type="slider", label="Size", min=8, max=100, step=1,
                       get=function() return MVal("centerTextSize", settingsTable.textSize or 12) end,
                       set=function(v) MSet("centerTextSize", v) end },
@@ -13497,7 +13639,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return MVal("centerTextContent","none") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(mCenterCogRows, "centerText", MVal, MSet)
+            local _, cogShowFn = EllesmereUI.BuildCogPopup({
+                title = "Center Text Settings",
+                rows = mCenterCogRows,
             })
             local cogBtn = MCogBtn(rgn, cogShowFn)
             local function UpdCog()
@@ -13564,9 +13710,7 @@ initFrame:SetScript("OnEvent", function(self)
             RegisterWidgetRefresh(function() swUp(); classSwUp(); UpdSwatches() end)
             UpdSwatches()
 
-            local _, cogShowFn = EllesmereUI.BuildCogPopup({
-                title = "Extra Text Settings",
-                rows = {
+            local mExtraCogRows = {
                     { type="dropdown", label="Alignment",
                       values={ ["left"]="Left", ["right"]="Right", ["center"]="Center" }, order={ "left", "right", "center" },
                       get=function() return MVal("extraTextAlign", "left") end,
@@ -13618,7 +13762,11 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       disabled=function() return MVal("extraTextContent","none") ~= "nametotarget" end,
                       disabledTooltip="Only applies when Name > Target is selected." },
-                                    },
+            }
+            InsertTextFontCogRows(mExtraCogRows, "extraText", MVal, MSet)
+            local _, cogShowFn = EllesmereUI.BuildCogPopup({
+                title = "Extra Text Settings",
+                rows = mExtraCogRows,
             })
             local cogBtn = MCogBtn(rgn, cogShowFn)
             local function UpdCog()
@@ -15240,16 +15388,24 @@ initFrame:SetScript("OnEvent", function(self)
             -- runtime and preview already consume (castSpellTargetX/Y ->
             -- _tgtOX/_tgtOY in the cast text zone layout).
             if not EllesmereUI._prebuilding then
-                local _, bossTgtCogShow = EllesmereUI.BuildCogPopup({
-                    title = "Spell Target",
-                    rows = {
+                local bossTgtCogRows = {
                         { type="slider", label="X Offset", min=-300, max=300, step=1,
                           get=function() return db.profile.boss.castSpellTargetX or 0 end,
                           set=function(v) db.profile.boss.castSpellTargetX = v; ReloadAndUpdate() end },
                         { type="slider", label="Y Offset", min=-300, max=300, step=1,
                           get=function() return db.profile.boss.castSpellTargetY or 0 end,
                           set=function(v) db.profile.boss.castSpellTargetY = v; ReloadAndUpdate() end },
-                    },
+                }
+                InsertTextFontCogRows(bossTgtCogRows, "castSpellTarget",
+                    function(key, default)
+                        local v = db.profile.boss[key]
+                        if v ~= nil then return v end
+                        return default
+                    end,
+                    function(key, val) db.profile.boss[key] = val; ReloadAndUpdate() end)
+                local _, bossTgtCogShow = EllesmereUI.BuildCogPopup({
+                    title = "Spell Target",
+                    rows = bossTgtCogRows,
                 })
                 ICogBtn(bossTgtRow._rightRegion, bossTgtCogShow)
             end
@@ -15534,9 +15690,7 @@ initFrame:SetScript("OnEvent", function(self)
                     function(r, g, b) B.castSpellNameColor = { r=r, g=g, b=b }; ReloadAndUpdate() end, false, 20)
                 sw:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -12, 0)
                 rgn._lastInline = sw
-                local _, cogShow = EllesmereUI.BuildCogPopup({
-                    title = "Spell Name",
-                    rows = {
+                local snCogRows = {
                         { type="slider", label="Size", min=6, max=20, step=1,
                           get=function() return B.castSpellNameSize or 11 end,
                           set=function(v) B.castSpellNameSize = v; ReloadAndUpdate() end },
@@ -15546,7 +15700,13 @@ initFrame:SetScript("OnEvent", function(self)
                         { type="slider", label="Y Offset", min=-50, max=50, step=1,
                           get=function() return B.castSpellNameY or 0 end,
                           set=function(v) B.castSpellNameY = v; ReloadAndUpdate() end },
-                    },
+                }
+                InsertTextFontCogRows(snCogRows, "castSpellName",
+                    function(key, default) local v = B[key]; if v ~= nil then return v end; return default end,
+                    function(key, val) B[key] = val; ReloadAndUpdate() end)
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Spell Name",
+                    rows = snCogRows,
                 })
                 CCogBtn(rgn, cogShow)
             end
@@ -15558,9 +15718,7 @@ initFrame:SetScript("OnEvent", function(self)
                     function(r, g, b) B.castDurationColor = { r=r, g=g, b=b }; ReloadAndUpdate() end, false, 20)
                 sw:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -12, 0)
                 rgn._lastInline = sw
-                local _, cogShow = EllesmereUI.BuildCogPopup({
-                    title = "Duration",
-                    rows = {
+                local dtCogRows = {
                         { type="slider", label="Size", min=6, max=20, step=1,
                           get=function() return B.castDurationSize or 10 end,
                           set=function(v) B.castDurationSize = v; ReloadAndUpdate() end },
@@ -15570,7 +15728,13 @@ initFrame:SetScript("OnEvent", function(self)
                         { type="slider", label="Y Offset", min=-50, max=50, step=1,
                           get=function() return B.castDurationY or 0 end,
                           set=function(v) B.castDurationY = v; ReloadAndUpdate() end },
-                    },
+                }
+                InsertTextFontCogRows(dtCogRows, "castDuration",
+                    function(key, default) local v = B[key]; if v ~= nil then return v end; return default end,
+                    function(key, val) B[key] = val; ReloadAndUpdate() end)
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Duration",
+                    rows = dtCogRows,
                 })
                 CCogBtn(rgn, cogShow)
             end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -104,11 +104,35 @@ end
 local function GetRBUseShadow()
     return not EllesmereUI or not EllesmereUI.GetFontUseShadow or EllesmereUI.GetFontUseShadow("resourceBars")
 end
-local function SetRBFont(fs, font, size)
+-- Optional settings+prefix: per-slot Font / Font Outline (__global/nil = module font).
+local function SetRBFont(fs, font, size, settings, prefix)
     if not (fs and fs.SetFont) then return end
-    local f = GetRBOutline()
+    local fontPath, f
+    if type(settings) == "table" then
+        local fontKey = prefix and settings[prefix .. "Font"]
+        local outlineMode = prefix and settings[prefix .. "Outline"]
+        if fontKey and fontKey ~= "__global" and EllesmereUI.ResolveFontName then
+            fontPath = EllesmereUI.ResolveFontName(fontKey) or font or GetRBFont()
+        else
+            fontPath = font or GetRBFont()
+        end
+        if outlineMode and outlineMode ~= "__global" then
+            if outlineMode == "outline" then
+                f = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG"
+            elseif outlineMode == "thick" then
+                f = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("THICKOUTLINE, SLUG")) or "THICKOUTLINE, SLUG"
+            else
+                f = ""
+            end
+        else
+            f = GetRBOutline()
+        end
+    else
+        fontPath = font or GetRBFont()
+        f = GetRBOutline()
+    end
     if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fs, f == "") end
-    fs:SetFont(font, size, f)
+    fs:SetFont(fontPath, size, f)
 end
 
 -- Cast-bar text side anchoring (mirrors nameplate/unit-frame cast text). Spell text
@@ -3090,7 +3114,7 @@ local function BuildBars()
         healthBar._text:ClearAllPoints()
         local _hpTA = hp.textAnchor or "CENTER"
         healthBar._text:SetPoint(_hpTA, healthBar, _hpTA, hp.textXOffset, hp.textYOffset)
-        SetRBFont(healthBar._text, GetRBFont(), hp.textSize)
+        SetRBFont(healthBar._text, GetRBFont(), hp.textSize, hp, "text")
         -- Text color: class color when textCustomColored == false, else custom (default custom)
         if hp.textCustomColored == false then
             local tcc = CLASS_COLORS[cachedClass]
@@ -3259,7 +3283,7 @@ local function BuildBars()
         primaryBar._text:ClearAllPoints()
         local _ppTA = pp.textAnchor or "CENTER"
         primaryBar._text:SetPoint(_ppTA, primaryBar, _ppTA, pp.textXOffset, pp.textYOffset)
-        SetRBFont(primaryBar._text, GetRBFont(), pp.textSize)
+        SetRBFont(primaryBar._text, GetRBFont(), pp.textSize, pp, "text")
         -- Text color: power-type color when textCustomColored == false, else custom (default custom)
         if pp.textCustomColored == false then
             local tpc = POWER_COLORS[cachedPrimary]
@@ -3578,7 +3602,7 @@ local function BuildBars()
                 local cdText = runeFrames[i]._cdText
                 if cdText then
                     cdText:SetTextColor(sp.textR or 1, sp.textG or 1, sp.textB or 1, 0.8)
-                    SetRBFont(cdText, GetRBFont(), sp.textSize or 9)
+                    SetRBFont(cdText, GetRBFont(), sp.textSize or 9, sp, "text")
                     cdText:ClearAllPoints()
                     cdText:SetPoint("CENTER", runeFrames[i], "CENTER",
                         sp.textXOffset or 0, sp.textYOffset or 0)
@@ -3776,7 +3800,7 @@ local function BuildBars()
             secondaryFrame._countText:SetParent(secondaryFrame._countTextOverlay)
             local _spTA = sp.textAnchor or "CENTER"
             secondaryFrame._countText:SetPoint(_spTA, secondaryFrame, _spTA, sp.textXOffset, sp.textYOffset)
-            SetRBFont(secondaryFrame._countText, GetRBFont(), sp.textSize)
+            SetRBFont(secondaryFrame._countText, GetRBFont(), sp.textSize, sp, "text")
             -- "Only if Power Bar Hidden": the fontstring is still created and
             -- updated (so text-value writes never hit nil), just hidden while the
             -- power bar is visible. Re-evaluated every build (spec/power changes
@@ -6641,7 +6665,7 @@ end
     -- Timer / duration text (auto-sized, anchored to its side)
     local timerText = castBarFrame._timerText
     if cb.showTimer then
-        SetRBFont(timerText, GetRBFont(), cb.timerSize or 11)
+        SetRBFont(timerText, GetRBFont(), cb.timerSize or 11, cb, "timer")
         local pt, xb, jh = ns.GetCastTextAnchor(durSide, false, timerW)
         timerText:ClearAllPoints()
         timerText:SetJustifyH(jh)
@@ -6654,7 +6678,7 @@ end
     -- Spell name text
     local nameText = castBarFrame._nameText
     if cb.showSpellText then
-        SetRBFont(nameText, GetRBFont(), cb.spellTextSize or 11)
+        SetRBFont(nameText, GetRBFont(), cb.spellTextSize or 11, cb, "spellText")
         local pt, xb, jh = ns.GetCastTextAnchor(spellSide, cb.showTimer and durSide == spellSide, timerW)
         nameText:ClearAllPoints()
         nameText:SetJustifyH(jh)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -1169,15 +1169,42 @@ local function GetUFUseShadow()
     return not EllesmereUI or not EllesmereUI.GetFontUseShadow or EllesmereUI.GetFontUseShadow("unitFrames")
 end
 
-local function SetFSFont(fs, size, flags)
+-- SetFSFont(fs, size [, flags])
+-- SetFSFont(fs, size, settings, "leftText") -- per-slot font/outline; "__global"/nil follows
+-- the unit-frames module font (or EUI Global). Same inheritance as BattleRes / moduleFonts.
+local function SetFSFont(fs, size, flags, prefix)
   if not (fs and fs.SetFont) then return end
-  -- Outline flag is already slug-gated at the source (GetFontOutlineFlag).
-  local f = flags or (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("unitFrames")) or ""
+  local fontPath, f
+  if type(flags) == "table" then
+    local s = flags
+    local fontKey = prefix and s[prefix .. "Font"]
+    local outlineMode = prefix and s[prefix .. "Outline"]
+    if fontKey and fontKey ~= "__global" and EllesmereUI.ResolveFontName then
+      fontPath = EllesmereUI.ResolveFontName(fontKey)
+    else
+      fontPath = GetSelectedFont()
+    end
+    if outlineMode and outlineMode ~= "__global" then
+      if outlineMode == "outline" then
+        f = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG"
+      elseif outlineMode == "thick" then
+        f = (EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("THICKOUTLINE, SLUG")) or "THICKOUTLINE, SLUG"
+      else
+        f = ""
+      end
+    else
+      f = (EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("unitFrames")) or ""
+    end
+  else
+    -- Outline flag is already slug-gated at the source (GetFontOutlineFlag).
+    f = flags or (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("unitFrames")) or ""
+    fontPath = GetSelectedFont()
+  end
   -- Drop shadows only render from a FontObject; prime before SetFont.
   if EllesmereUI and EllesmereUI.PrimeFontShadow then
     EllesmereUI.PrimeFontShadow(fs, f == "")
   end
-  fs:SetFont(GetSelectedFont(), size or 12, f)
+  fs:SetFont(fontPath, size or 12, f)
 end
 
 -- Shared cast-bar text anchoring (mirrors the nameplate cast text system). Three
@@ -3964,19 +3991,19 @@ local function CreateBottomTextBar(frame, unit, settings, anchorFrame, xOffset, 
     textOvr:SetFrameLevel(frame:GetFrameLevel() + 15)
 
     local leftFS = textOvr:CreateFontString(nil, "OVERLAY")
-    SetFSFont(leftFS, settings.btbLeftSize or 11)
+    SetFSFont(leftFS, settings.btbLeftSize or 11, settings, "btbLeft")
     leftFS:SetWordWrap(false)
     leftFS:SetTextColor(1, 1, 1)
     btb.LeftText = leftFS
 
     local rightFS = textOvr:CreateFontString(nil, "OVERLAY")
-    SetFSFont(rightFS, settings.btbRightSize or 11)
+    SetFSFont(rightFS, settings.btbRightSize or 11, settings, "btbRight")
     rightFS:SetWordWrap(false)
     rightFS:SetTextColor(1, 1, 1)
     btb.RightText = rightFS
 
     local centerFS = textOvr:CreateFontString(nil, "OVERLAY")
-    SetFSFont(centerFS, settings.btbCenterSize or 11)
+    SetFSFont(centerFS, settings.btbCenterSize or 11, settings, "btbCenter")
     centerFS:SetWordWrap(false)
     centerFS:SetTextColor(1, 1, 1)
     btb.CenterText = centerFS
@@ -4021,7 +4048,7 @@ local function CreateBottomTextBar(frame, unit, settings, anchorFrame, xOffset, 
         local rsz = s.btbRightSize or 11
         local csz = s.btbCenterSize or 11
 
-        SetFSFont(leftFS, lsz)
+        SetFSFont(leftFS, lsz, s, "btbLeft")
         leftFS:ClearAllPoints()
         if lc ~= "none" then
             leftFS:SetJustifyH("LEFT")
@@ -4030,7 +4057,7 @@ local function CreateBottomTextBar(frame, unit, settings, anchorFrame, xOffset, 
             leftFS:Show()
         else leftFS:Hide() end
 
-        SetFSFont(rightFS, rsz)
+        SetFSFont(rightFS, rsz, s, "btbRight")
         rightFS:ClearAllPoints()
         if rc ~= "none" then
             rightFS:SetJustifyH("RIGHT")
@@ -4039,7 +4066,7 @@ local function CreateBottomTextBar(frame, unit, settings, anchorFrame, xOffset, 
             rightFS:Show()
         else rightFS:Hide() end
 
-        SetFSFont(centerFS, csz)
+        SetFSFont(centerFS, csz, s, "btbCenter")
         centerFS:ClearAllPoints()
         if cc ~= "none" then
             centerFS:SetJustifyH("CENTER")
@@ -6400,7 +6427,7 @@ local function CreateCastBar(frame, unit, settings)
     textOverlay:SetFrameLevel(frame:GetFrameLevel() + 11)
 
     local text = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(text, settings.castSpellNameSize or 11)
+    SetFSFont(text, settings.castSpellNameSize or 11, settings, "castSpellName")
     text:SetJustifyH("LEFT")
     text:SetWordWrap(false)
     text:SetMaxLines(1)
@@ -6408,7 +6435,7 @@ local function CreateCastBar(frame, unit, settings)
     castbar.Text = text
 
     local time = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(time, settings.castDurationSize or 10)
+    SetFSFont(time, settings.castDurationSize or 10, settings, "castDuration")
     time:SetJustifyH("RIGHT")
     time:SetWordWrap(false)
     time:SetMaxLines(1)
@@ -6416,7 +6443,7 @@ local function CreateCastBar(frame, unit, settings)
     castbar.Time = time
 
     local target = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(target, settings.castSpellTargetSize or 11)
+    SetFSFont(target, settings.castSpellTargetSize or 11, settings, "castSpellTarget")
     target:SetJustifyH("RIGHT")
     target:SetWordWrap(false)
     target:SetMaxLines(1)
@@ -7780,19 +7807,19 @@ local function StyleFullFrame(frame, unit)
     local ets = settings.extraTextSize or settings.textSize or 12
 
     local leftText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(leftText, lts)
+    SetFSFont(leftText, lts, settings, "leftText")
     leftText:SetWordWrap(false)
     leftText:SetTextColor(1, 1, 1)
     frame.LeftText = leftText
 
     local rightText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(rightText, rts)
+    SetFSFont(rightText, rts, settings, "rightText")
     rightText:SetWordWrap(false)
     rightText:SetTextColor(1, 1, 1)
     frame.RightText = rightText
 
     local centerText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(centerText, cts)
+    SetFSFont(centerText, cts, settings, "centerText")
     centerText:SetWordWrap(false)
     centerText:SetTextColor(1, 1, 1)
     frame.CenterText = centerText
@@ -7800,7 +7827,7 @@ local function StyleFullFrame(frame, unit)
     -- Extra Text: a 4th text zone, identical to the others (same tags + absorb gate);
     -- anchors per extraTextAlign, capped at 95% of the bar width (ellipsis truncation).
     local extraText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(extraText, ets)
+    SetFSFont(extraText, ets, settings, "extraText")
     extraText:SetWordWrap(false)
     extraText:SetTextColor(1, 1, 1)
     frame.ExtraText = extraText
@@ -7896,7 +7923,7 @@ local function StyleFullFrame(frame, unit)
         -- Extra Text: anchored per extraTextAlign (left/right/center); ellipsis-
         -- truncated past 95% of health bar width (SetWordWrap(false) + capped width below).
         local ec = s.extraTextContent or "none"
-        SetFSFont(extraText, s.extraTextSize or s.textSize or 12)
+        SetFSFont(extraText, s.extraTextSize or s.textSize or 12, s, "extraText")
         extraText:ClearAllPoints()
         if ec ~= "none" then
             local exo = s.extraTextX or 0
@@ -7918,7 +7945,7 @@ local function StyleFullFrame(frame, unit)
         else extraText:Hide() end
 
         -- Each text position renders independently; Center no longer hides Left/Right.
-        SetFSFont(centerText, csz)
+        SetFSFont(centerText, csz, s, "centerText")
         centerText:ClearAllPoints()
         if cc ~= "none" then
             centerText:SetJustifyH("CENTER")
@@ -7928,7 +7955,7 @@ local function StyleFullFrame(frame, unit)
             ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
         else centerText:Hide() end
 
-        SetFSFont(leftText, lsz)
+        SetFSFont(leftText, lsz, s, "leftText")
         leftText:ClearAllPoints()
         if lc ~= "none" then
             leftText:SetJustifyH("LEFT")
@@ -7944,7 +7971,7 @@ local function StyleFullFrame(frame, unit)
             ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
         else leftText:Hide() end
 
-        SetFSFont(rightText, rsz)
+        SetFSFont(rightText, rsz, s, "rightText")
         rightText:ClearAllPoints()
         if rc ~= "none" then
             rightText:SetJustifyH("RIGHT")
@@ -8102,19 +8129,19 @@ local function StyleFocusFrame(frame, unit)
     local ets = settings.extraTextSize or settings.textSize or 12
 
     local leftText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(leftText, lts)
+    SetFSFont(leftText, lts, settings, "leftText")
     leftText:SetWordWrap(false)
     leftText:SetTextColor(1, 1, 1)
     frame.LeftText = leftText
 
     local rightText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(rightText, rts)
+    SetFSFont(rightText, rts, settings, "rightText")
     rightText:SetWordWrap(false)
     rightText:SetTextColor(1, 1, 1)
     frame.RightText = rightText
 
     local centerText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(centerText, cts)
+    SetFSFont(centerText, cts, settings, "centerText")
     centerText:SetWordWrap(false)
     centerText:SetTextColor(1, 1, 1)
     frame.CenterText = centerText
@@ -8122,7 +8149,7 @@ local function StyleFocusFrame(frame, unit)
     -- Extra Text: a 4th text zone, identical to the others (same tags + absorb gate);
     -- anchors per extraTextAlign, capped at 95% of the bar width (ellipsis truncation).
     local extraText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(extraText, ets)
+    SetFSFont(extraText, ets, settings, "extraText")
     extraText:SetWordWrap(false)
     extraText:SetTextColor(1, 1, 1)
     frame.ExtraText = extraText
@@ -8218,7 +8245,7 @@ local function StyleFocusFrame(frame, unit)
         -- Extra Text: anchored per extraTextAlign (left/right/center); ellipsis-
         -- truncated past 95% of health bar width (SetWordWrap(false) + capped width below).
         local ec = s.extraTextContent or "none"
-        SetFSFont(extraText, s.extraTextSize or s.textSize or 12)
+        SetFSFont(extraText, s.extraTextSize or s.textSize or 12, s, "extraText")
         extraText:ClearAllPoints()
         if ec ~= "none" then
             local exo = s.extraTextX or 0
@@ -8240,7 +8267,7 @@ local function StyleFocusFrame(frame, unit)
         else extraText:Hide() end
 
         -- Each text position renders independently; Center no longer hides Left/Right.
-        SetFSFont(centerText, csz)
+        SetFSFont(centerText, csz, s, "centerText")
         centerText:ClearAllPoints()
         if cc ~= "none" then
             centerText:SetJustifyH("CENTER")
@@ -8250,7 +8277,7 @@ local function StyleFocusFrame(frame, unit)
             ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
         else centerText:Hide() end
 
-        SetFSFont(leftText, lsz)
+        SetFSFont(leftText, lsz, s, "leftText")
         leftText:ClearAllPoints()
         if lc ~= "none" then
             leftText:SetJustifyH("LEFT")
@@ -8265,7 +8292,7 @@ local function StyleFocusFrame(frame, unit)
             ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
         else leftText:Hide() end
 
-        SetFSFont(rightText, rsz)
+        SetFSFont(rightText, rsz, s, "rightText")
         rightText:ClearAllPoints()
         if rc ~= "none" then
             rightText:SetJustifyH("RIGHT")
@@ -8389,19 +8416,19 @@ local function StyleSimpleFrame(frame, unit)
     local centerContent = settings.centerTextContent or "none"
 
     local leftText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(leftText, settings.leftTextSize or settings.textSize or 12)
+    SetFSFont(leftText, settings.leftTextSize or settings.textSize or 12, settings, "leftText")
     leftText:SetWordWrap(false)
     leftText:SetTextColor(1, 1, 1)
     frame.LeftText = leftText
 
     local rightText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(rightText, settings.rightTextSize or settings.textSize or 12)
+    SetFSFont(rightText, settings.rightTextSize or settings.textSize or 12, settings, "rightText")
     rightText:SetWordWrap(false)
     rightText:SetTextColor(1, 1, 1)
     frame.RightText = rightText
 
     local centerText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(centerText, settings.centerTextSize or settings.textSize or 12)
+    SetFSFont(centerText, settings.centerTextSize or settings.textSize or 12, settings, "centerText")
     centerText:SetWordWrap(false)
     centerText:SetTextColor(1, 1, 1)
     frame.CenterText = centerText
@@ -8490,7 +8517,7 @@ local function StyleSimpleFrame(frame, unit)
         local cyo = s.centerTextY or 0
         local barW = s.frameWidth or 100
         -- Each text position renders independently; Center no longer hides Left/Right.
-        SetFSFont(centerText, csz)
+        SetFSFont(centerText, csz, s, "centerText")
         centerText:ClearAllPoints()
         if cc ~= "none" then
             centerText:SetJustifyH("CENTER")
@@ -8500,7 +8527,7 @@ local function StyleSimpleFrame(frame, unit)
             ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
         else centerText:Hide() end
 
-        SetFSFont(leftText, lsz)
+        SetFSFont(leftText, lsz, s, "leftText")
         if lc ~= "none" then
             leftText:ClearAllPoints()
             leftText:SetJustifyH("LEFT")
@@ -8514,7 +8541,7 @@ local function StyleSimpleFrame(frame, unit)
             leftText:Show()
             ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
         else leftText:Hide() end
-        SetFSFont(rightText, rsz)
+        SetFSFont(rightText, rsz, s, "rightText")
         if rc ~= "none" then
             rightText:ClearAllPoints()
             rightText:SetJustifyH("RIGHT")
@@ -8625,19 +8652,19 @@ local function StylePetFrame(frame, unit)
     local centerContent = settings.centerTextContent or "none"
 
     local leftText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(leftText, settings.leftTextSize or settings.textSize or 12)
+    SetFSFont(leftText, settings.leftTextSize or settings.textSize or 12, settings, "leftText")
     leftText:SetWordWrap(false)
     leftText:SetTextColor(1, 1, 1)
     frame.LeftText = leftText
 
     local rightText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(rightText, settings.rightTextSize or settings.textSize or 12)
+    SetFSFont(rightText, settings.rightTextSize or settings.textSize or 12, settings, "rightText")
     rightText:SetWordWrap(false)
     rightText:SetTextColor(1, 1, 1)
     frame.RightText = rightText
 
     local centerText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(centerText, settings.centerTextSize or settings.textSize or 12)
+    SetFSFont(centerText, settings.centerTextSize or settings.textSize or 12, settings, "centerText")
     centerText:SetWordWrap(false)
     centerText:SetTextColor(1, 1, 1)
     frame.CenterText = centerText
@@ -8725,7 +8752,7 @@ local function StylePetFrame(frame, unit)
         local cyo = s.centerTextY or 0
         local barW = s.frameWidth or 100
         -- Each text position renders independently; Center no longer hides Left/Right.
-        SetFSFont(centerText, csz)
+        SetFSFont(centerText, csz, s, "centerText")
         centerText:ClearAllPoints()
         if cc ~= "none" then
             centerText:SetJustifyH("CENTER")
@@ -8735,7 +8762,7 @@ local function StylePetFrame(frame, unit)
             ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
         else centerText:Hide() end
 
-        SetFSFont(leftText, lsz)
+        SetFSFont(leftText, lsz, s, "leftText")
         if lc ~= "none" then
             leftText:ClearAllPoints()
             leftText:SetJustifyH("LEFT")
@@ -8749,7 +8776,7 @@ local function StylePetFrame(frame, unit)
             leftText:Show()
             ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
         else leftText:Hide() end
-        SetFSFont(rightText, rsz)
+        SetFSFont(rightText, rsz, s, "rightText")
         if rc ~= "none" then
             rightText:ClearAllPoints()
             rightText:SetJustifyH("RIGHT")
@@ -8872,19 +8899,19 @@ local function StyleBossFrame(frame, unit)
     local extraContent = settings.extraTextContent or "none"
 
     local leftText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(leftText, settings.leftTextSize or settings.textSize or 12)
+    SetFSFont(leftText, settings.leftTextSize or settings.textSize or 12, settings, "leftText")
     leftText:SetWordWrap(false)
     leftText:SetTextColor(1, 1, 1)
     frame.LeftText = leftText
 
     local rightText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(rightText, settings.rightTextSize or settings.textSize or 12)
+    SetFSFont(rightText, settings.rightTextSize or settings.textSize or 12, settings, "rightText")
     rightText:SetWordWrap(false)
     rightText:SetTextColor(1, 1, 1)
     frame.RightText = rightText
 
     local centerText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(centerText, settings.centerTextSize or settings.textSize or 12)
+    SetFSFont(centerText, settings.centerTextSize or settings.textSize or 12, settings, "centerText")
     centerText:SetWordWrap(false)
     centerText:SetTextColor(1, 1, 1)
     frame.CenterText = centerText
@@ -8893,7 +8920,7 @@ local function StyleBossFrame(frame, unit)
     -- gate); it only anchors per extraTextAlign and is capped at 95% of the bar
     -- width (ellipsis truncation). Mirrors the Main Frames implementation.
     local extraText = textOverlay:CreateFontString(nil, "OVERLAY")
-    SetFSFont(extraText, settings.extraTextSize or settings.textSize or 12)
+    SetFSFont(extraText, settings.extraTextSize or settings.textSize or 12, settings, "extraText")
     extraText:SetWordWrap(false)
     extraText:SetTextColor(1, 1, 1)
     frame.ExtraText = extraText
@@ -8988,7 +9015,7 @@ local function StyleBossFrame(frame, unit)
         -- Extra Text: anchored per extraTextAlign (left/right/center); ellipsis-
         -- truncated past 95% of health bar width (SetWordWrap(false) + capped width below), matching Main Frames.
         local ec = s.extraTextContent or "none"
-        SetFSFont(extraText, s.extraTextSize or s.textSize or 12)
+        SetFSFont(extraText, s.extraTextSize or s.textSize or 12, s, "extraText")
         extraText:ClearAllPoints()
         if ec ~= "none" then
             local exo = s.extraTextX or 0
@@ -9009,7 +9036,7 @@ local function StyleBossFrame(frame, unit)
             ApplyClassColor(extraText, unit, s.extraTextClassColor, s.extraTextColorR, s.extraTextColorG, s.extraTextColorB)
         else extraText:Hide() end
         -- Each text position renders independently; Center no longer hides Left/Right.
-        SetFSFont(centerText, csz)
+        SetFSFont(centerText, csz, s, "centerText")
         centerText:ClearAllPoints()
         if cc ~= "none" then
             centerText:SetJustifyH("CENTER")
@@ -9019,7 +9046,7 @@ local function StyleBossFrame(frame, unit)
             ApplyClassColor(centerText, unit, s.centerTextClassColor, s.centerTextColorR, s.centerTextColorG, s.centerTextColorB)
         else centerText:Hide() end
 
-        SetFSFont(leftText, lsz)
+        SetFSFont(leftText, lsz, s, "leftText")
         if lc ~= "none" then
             leftText:ClearAllPoints()
             leftText:SetJustifyH("LEFT")
@@ -9033,7 +9060,7 @@ local function StyleBossFrame(frame, unit)
             leftText:Show()
             ApplyClassColor(leftText, unit, s.leftTextClassColor, s.leftTextColorR, s.leftTextColorG, s.leftTextColorB)
         else leftText:Hide() end
-        SetFSFont(rightText, rsz)
+        SetFSFont(rightText, rsz, s, "rightText")
         if rc ~= "none" then
             rightText:ClearAllPoints()
             rightText:SetJustifyH("RIGHT")
@@ -10290,13 +10317,13 @@ local function ReloadFrames()
                             -- Apply cast bar text settings
                             if frame.Castbar.Text then
                                 local snSz = settings.castSpellNameSize or 11
-                                SetFSFont(frame.Castbar.Text, snSz)
+                                SetFSFont(frame.Castbar.Text, snSz, settings, "castSpellName")
                                 local snC = settings.castSpellNameColor or { r=1, g=1, b=1 }
                                 frame.Castbar.Text:SetTextColor(snC.r, snC.g, snC.b)
                             end
                             if frame.Castbar.Time then
                                 local dtSz = settings.castDurationSize or 10
-                                SetFSFont(frame.Castbar.Time, dtSz)
+                                SetFSFont(frame.Castbar.Time, dtSz, settings, "castDuration")
                                 local dtC = settings.castDurationColor or { r=1, g=1, b=1 }
                                 frame.Castbar.Time:SetTextColor(dtC.r, dtC.g, dtC.b)
                                 frame.Castbar._showDuration = settings.showCastDuration ~= false
@@ -10310,7 +10337,7 @@ local function ReloadFrames()
                             end
                             if frame.Castbar.Target then
                                 local tsSz = settings.castSpellTargetSize or 11
-                                SetFSFont(frame.Castbar.Target, tsSz)
+                                SetFSFont(frame.Castbar.Target, tsSz, settings, "castSpellTarget")
                                 local tsC = settings.castSpellTargetColor or { r=1, g=1, b=1 }
                                 frame.Castbar.Target:SetTextColor(tsC.r, tsC.g, tsC.b)
                                 frame.Castbar._showTarget = settings.showCastTarget ~= false
@@ -10810,13 +10837,13 @@ local function ReloadFrames()
                         -- Apply cast bar text settings
                         if frame.Castbar.Text then
                             local snSz = settings.castSpellNameSize or 11
-                            SetFSFont(frame.Castbar.Text, snSz)
+                            SetFSFont(frame.Castbar.Text, snSz, settings, "castSpellName")
                             local snC = settings.castSpellNameColor or { r=1, g=1, b=1 }
                             frame.Castbar.Text:SetTextColor(snC.r, snC.g, snC.b)
                         end
                         if frame.Castbar.Time then
                             local dtSz = settings.castDurationSize or 10
-                            SetFSFont(frame.Castbar.Time, dtSz)
+                            SetFSFont(frame.Castbar.Time, dtSz, settings, "castDuration")
                             local dtC = settings.castDurationColor or { r=1, g=1, b=1 }
                             frame.Castbar.Time:SetTextColor(dtC.r, dtC.g, dtC.b)
                             frame.Castbar._showDuration = settings.showCastDuration ~= false
@@ -10829,7 +10856,7 @@ local function ReloadFrames()
                         end
                         if frame.Castbar.Target then
                             local tsSz = settings.castSpellTargetSize or 11
-                            SetFSFont(frame.Castbar.Target, tsSz)
+                            SetFSFont(frame.Castbar.Target, tsSz, settings, "castSpellTarget")
                             local tsC = settings.castSpellTargetColor or { r=1, g=1, b=1 }
                             frame.Castbar.Target:SetTextColor(tsC.r, tsC.g, tsC.b)
                             frame.Castbar._showTarget = settings.showCastTarget ~= false
@@ -11224,13 +11251,13 @@ local function ReloadFrames()
                     -- Apply cast bar text settings
                     if frame.Castbar.Text then
                         local snSz = settings.castSpellNameSize or 11
-                        SetFSFont(frame.Castbar.Text, snSz)
+                        SetFSFont(frame.Castbar.Text, snSz, settings, "castSpellName")
                         local snC = settings.castSpellNameColor or { r=1, g=1, b=1 }
                         frame.Castbar.Text:SetTextColor(snC.r, snC.g, snC.b)
                     end
                     if frame.Castbar.Time then
                         local dtSz = settings.castDurationSize or 10
-                        SetFSFont(frame.Castbar.Time, dtSz)
+                        SetFSFont(frame.Castbar.Time, dtSz, settings, "castDuration")
                         local dtC = settings.castDurationColor or { r=1, g=1, b=1 }
                         frame.Castbar.Time:SetTextColor(dtC.r, dtC.g, dtC.b)
                         frame.Castbar._showDuration = settings.showCastDuration ~= false
@@ -11243,7 +11270,7 @@ local function ReloadFrames()
                     end
                     if frame.Castbar.Target then
                         local tsSz = settings.castSpellTargetSize or 11
-                        SetFSFont(frame.Castbar.Target, tsSz)
+                        SetFSFont(frame.Castbar.Target, tsSz, settings, "castSpellTarget")
                         local tsC = settings.castSpellTargetColor or { r=1, g=1, b=1 }
                         frame.Castbar.Target:SetTextColor(tsC.r, tsC.g, tsC.b)
                         frame.Castbar._showTarget = settings.showCastTarget ~= false
@@ -11601,13 +11628,13 @@ local function ReloadFrames()
                     end
                     if frame.Castbar.Text then
                         local snSz = settings.castSpellNameSize or 11
-                        SetFSFont(frame.Castbar.Text, snSz)
+                        SetFSFont(frame.Castbar.Text, snSz, settings, "castSpellName")
                         local snC = settings.castSpellNameColor or { r=1, g=1, b=1 }
                         frame.Castbar.Text:SetTextColor(snC.r, snC.g, snC.b)
                     end
                     if frame.Castbar.Time then
                         local dtSz = settings.castDurationSize or 10
-                        SetFSFont(frame.Castbar.Time, dtSz)
+                        SetFSFont(frame.Castbar.Time, dtSz, settings, "castDuration")
                         local dtC = settings.castDurationColor or { r=1, g=1, b=1 }
                         frame.Castbar.Time:SetTextColor(dtC.r, dtC.g, dtC.b)
                         frame.Castbar._showDuration = settings.showCastDuration ~= false
@@ -11620,7 +11647,7 @@ local function ReloadFrames()
                     end
                     if frame.Castbar.Target then
                         local tsSz = settings.castSpellTargetSize or 11
-                        SetFSFont(frame.Castbar.Target, tsSz)
+                        SetFSFont(frame.Castbar.Target, tsSz, settings, "castSpellTarget")
                         local tsC = settings.castSpellTargetColor or { r=1, g=1, b=1 }
                         frame.Castbar.Target:SetTextColor(tsC.r, tsC.g, tsC.b)
                         frame.Castbar._showTarget = settings.showCastTarget ~= false
@@ -11990,8 +12017,12 @@ local function ReloadFrames()
             end
 
             -- Helper: set font on a FontString, using donor font for mini frames
-            local function SetMiniFont(fs, sz)
+            local function SetMiniFont(fs, sz, prefix)
                 if not fs or not fs.SetFont then return end
+                if prefix then
+                    SetFSFont(fs, sz, settings, prefix)
+                    return
+                end
                 if isMiniFrame then
                     local f = (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("unitFrames")) or ""
                     if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fs, f == "") end
@@ -12004,20 +12035,25 @@ local function ReloadFrames()
             if frame.NameText then
                 local s = isMiniFrame and donorSettings or GetSettingsForUnit(unit)
                 local rts = s.leftTextSize or s.textSize or 12
-                SetMiniFont(frame.NameText, rts)
+                SetMiniFont(frame.NameText, rts, "leftText")
                 frame.NameText:SetWordWrap(false)
             end
             if frame.HealthValue then
                 local s = isMiniFrame and donorSettings or GetSettingsForUnit(unit)
                 local rts = s.rightTextSize or s.textSize or 12
-                SetMiniFont(frame.HealthValue, rts)
+                SetMiniFont(frame.HealthValue, rts, "rightText")
                 frame.HealthValue:SetWordWrap(false)
             end
             if frame.CenterText then
                 local s = isMiniFrame and donorSettings or GetSettingsForUnit(unit)
                 local cts = s.centerTextSize or s.textSize or 12
-                SetMiniFont(frame.CenterText, cts)
+                SetMiniFont(frame.CenterText, cts, "centerText")
                 frame.CenterText:SetWordWrap(false)
+            end
+            if frame.ExtraText then
+                local s = GetSettingsForUnit(unit) or settings
+                SetMiniFont(frame.ExtraText, s.extraTextSize or s.textSize or 12, "extraText")
+                frame.ExtraText:SetWordWrap(false)
             end
 
             -- Apply text tags and positions for mini frames
@@ -12032,23 +12068,21 @@ local function ReloadFrames()
                 local s = isMiniFrame and donorSettings or settings
                 if frame.Castbar.Text then
                     local snSz = s.castSpellNameSize or 11
-                    SetMiniFont(frame.Castbar.Text, snSz)
+                    SetFSFont(frame.Castbar.Text, snSz, s, "castSpellName")
                 end
                 if frame.Castbar.Time then
                     local dtSz = s.castDurationSize or 10
-                    SetMiniFont(frame.Castbar.Time, dtSz)
+                    SetFSFont(frame.Castbar.Time, dtSz, s, "castDuration")
                 end
                 -- Boss frames get their full cast text refresh in the boss branch above
-                -- (colors/show/sides/bg). Two gaps remain: the donor-font line just above
-                -- set boss cast text to the DONOR size, and that branch re-runs layout from
-                -- CACHED offsets. Re-apply the size from boss settings (keeping the donor
-                -- typeface) and sync X/Y offsets + side layout so live boss frames update
-                -- on every cast-text option change.
+                -- (colors/show/sides/bg). Re-apply size/font from boss settings and
+                -- sync X/Y offsets + side layout so live boss frames update on every
+                -- cast-text option change.
                 if unit:match("^boss") then
                     local cb = frame.Castbar
-                    if cb.Text then SetMiniFont(cb.Text, settings.castSpellNameSize or 11) end
-                    if cb.Time then SetMiniFont(cb.Time, settings.castDurationSize or 10) end
-                    if cb.Target then SetMiniFont(cb.Target, settings.castSpellTargetSize or 11) end
+                    if cb.Text then SetFSFont(cb.Text, settings.castSpellNameSize or 11, settings, "castSpellName") end
+                    if cb.Time then SetFSFont(cb.Time, settings.castDurationSize or 10, settings, "castDuration") end
+                    if cb.Target then SetFSFont(cb.Target, settings.castSpellTargetSize or 11, settings, "castSpellTarget") end
                     if cb._syncOffsetsAndLayout then cb:_syncOffsetsAndLayout(settings) end
                 end
             end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

### Text font & outline override options (unit frames / resource bars)

Adds per-text-slot **Font Family** and **Font Outline** cog overrides to unit-frame and resource-bar text slots (health, power, class, cast name/timer/target, bottom text bar, etc.). A new `__globa`l sentinel keeps the setting read‑as‑no‑override when users never touch it. `SetFSFont` and `SetRBFont` resolve the per-slot key at apply time, falling back through `__global` → the module's own font path → `Fonts\FRIZQT__.TTF`.

## How was it tested?

Loaded on 12.1. Toggled `__global` and two individual font families per slot; confirmed each slot renders its chosen font with its chosen outline. Verified that untouched slots show the same font as before (zero behavior change). Reloaded UI; settings persist.

## Screenshots

<img width="511" height="434" alt="image" src="https://github.com/user-attachments/assets/c250bcc6-b9ab-4a3b-a4f1-864375f7d04f" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
