### PR TITLE
feat: added option to remove borders from the databar

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -41,7 +41,7 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 --   ns.LOC_MAX_WIDTH_DEFAULT               Manual-mode width before one is set
 --   ns.BlockTextDynamic(blockType) -> r, g, b   state-driven Text Color swatch
 --   ns.UpdateAllBarVisibility()
---   ns.MakePreviewBackdrop(host, themeCfg)
+--   ns.MakePreviewBackdrop(host, themeCfg, showBorder)
 --   ns.BLOCK_TYPES / ns.BLOCK_DEFAULTS / ns.EDB_VIS_CAPS / ns.EDGE_PAD
 --
 --  The one call that runs the other way (options file -> runtime): a block
@@ -1709,7 +1709,7 @@ local function EnsureThemeTextures(host)
     UpdateBgTexCoords()
 end
 
-local function ApplyThemeToHost(host, theme, texKey)
+local function ApplyThemeToHost(host, theme, texKey, showBorder)
     EnsureThemeTextures(host)
     theme = theme or {}
     -- Bar Texture (per-bar cfg.barTexture): resolved through the shared
@@ -1752,13 +1752,20 @@ local function ApplyThemeToHost(host, theme, texKey)
     end
     -- Bar Opacity carries the border with it: the base border alpha (0.8)
     -- is baked into the strip textures, frame alpha multiplies on top.
-    -- SetAlpha is combat-legal even on implicitly protected bars.
-    if host._edbBorder then host._edbBorder:SetAlpha(op) end
+    -- SetAlpha is combat-legal even on implicitly protected bars. Off
+    -- (cfg.hideBorder == true) zeros it rather than Hide(), same reason.
+    if host._edbBorder then
+        if showBorder == false then
+            host._edbBorder:SetAlpha(0)
+        else
+            host._edbBorder:SetAlpha(op)
+        end
+    end
 end
 
 -- Exposed so the options preview strip renders the exact same recipe.
-function ns.MakePreviewBackdrop(host, themeCfg)
-    ApplyThemeToHost(host, themeCfg)
+function ns.MakePreviewBackdrop(host, themeCfg, showBorder)
+    ApplyThemeToHost(host, themeCfg, nil, showBorder)
 end
 
 -------------------------------------------------------------------------------
@@ -2194,7 +2201,7 @@ function ns.ApplyBar(id)
     end
 
     ApplyBarPosition(id)
-    ApplyThemeToHost(rec.bar, cfg.theme, cfg.barTexture)
+    ApplyThemeToHost(rec.bar, cfg.theme, cfg.barTexture, not cfg.hideBorder)
 
     -- Reconcile block instances against cfg.blocks
     local want = {}
@@ -2255,7 +2262,7 @@ function ns.ApplyTheme(id)
     local rec = live[id]
     local cfg = ns.GetBar(id)
     if not (rec and rec.bar and cfg) then return end
-    ApplyThemeToHost(rec.bar, cfg.theme, cfg.barTexture)
+    ApplyThemeToHost(rec.bar, cfg.theme, cfg.barTexture, not cfg.hideBorder)
 end
 
 function ns.GetLiveAutoLength(barId, blockId)

--- a/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
@@ -134,7 +134,7 @@ initFrame:SetScript("OnEvent", function(self)
     local function RefreshPreviewTheme()
         local cfg = SelectedBar()
         if _edbPreviewHost and _edbPreviewHost:IsShown() and cfg then
-            ns.MakePreviewBackdrop(_edbPreviewHost, cfg.theme)
+            ns.MakePreviewBackdrop(_edbPreviewHost, cfg.theme, not cfg.hideBorder)
         end
     end
 
@@ -678,7 +678,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Border handle set BEFORE the backdrop so the theme pass can fade
         -- it with Bar Opacity, exactly like the live bar.
         strip._edbBorder = PP.CreateBorder(strip, 0, 0, 0, 0.8, 1, "OVERLAY", 7)
-        ns.MakePreviewBackdrop(strip, cfg.theme)
+        ns.MakePreviewBackdrop(strip, cfg.theme, not cfg.hideBorder)
         _edbPreviewHost = strip
 
         local stripUsable = stripLen - SEDGE * 2
@@ -1911,6 +1911,14 @@ initFrame:SetScript("OnEvent", function(self)
                   cfg.hoverHighlight = v and true or false
                   Apply()
               end }
+        local showBorderCfg = { type = "toggle", text = "Hide Border",
+              tooltip = "Hide the 1-pixel outline around the bar.",
+              getValue = function() return cfg.hideBorder == true end,
+              setValue = function(v)
+                  cfg.hideBorder = v and true or false
+                  ns.ApplyTheme(barId)
+                  RefreshPreviewTheme()
+              end }
         -- Bar Opacity drives BOTH styles: the Modern flat color's alpha or
         -- the EllesmereUI shell's backdrop dim, whichever is active.
         local opacityRow
@@ -2057,6 +2065,7 @@ initFrame:SetScript("OnEvent", function(self)
               end });  y = y - h
 
         _, h = W:DualRow(parent, y, scaleCfg, hoverBlocksCfg);  y = y - h
+        _, h = W:DualRow(parent, y, showBorderCfg);  y = y - h
 
         -- Bar deletion lives in the selector dropdown's inline delete -- no
         -- body row. Visibility moved to the top of the section; rename =
@@ -3334,6 +3343,7 @@ initFrame:SetScript("OnEvent", function(self)
             cfg.thickness = 30
             cfg.fontScale = 100
             cfg.theme = { style = "eui", euiAlpha = 0.5, modernColor = { r = 0.067, g = 0.067, b = 0.067, a = 0.95 } }
+            cfg.hideBorder = nil
             cfg.visibility = "always"
             cfg.visibilityModes = nil
             for _, item in ipairs(EllesmereUI.VIS_OPT_ITEMS) do


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

### DataBar border toggle

Adds a Hide Border toggle to each EllesmereUI DataBar. When toggled on, the 1‑pixel border outline around the bar is hidden. Default is off (border shown), preserving the current visual on update. The border alpha follows Bar Opacity when shown, and is set to `0` (not `Hide()`) in the hidden state for combat safety.

## How was it tested?

Loaded on 12.1. Toggled Hide Border on a DataBar — border disappears. Toggled off — border reappears at the correct alpha. Adjusted Bar Opacity with border shown — border fades proportionally. Tested in and out of combat (no errors).

## Screenshots

<img width="946" height="122" alt="image" src="https://github.com/user-attachments/assets/56cea692-4c64-4b8c-9a22-e4d2c7c0fb2e" />
<img width="990" height="112" alt="image" src="https://github.com/user-attachments/assets/85ecd85f-dbb0-4c11-a7f4-4a25af064088" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
