### PR TITLE
feat: added option to toggle np auras/castbar icons borders

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
@@ -359,7 +359,7 @@ local function BuildNPStyle(kind, variant)
         width = size,
         height = height,
         texCoord = CropCoords(cropped),
-        border = { 0, 0, 0, 1, size = 1 },
+        border = (not ns.GetIconBorderEnabled or ns.GetIconBorderEnabled(kind)) and { 0, 0, 0, 1, size = 1 } or false,
         cooldownReverse = true,
         noDefaultFonts = true,
         noTooltips = true,
@@ -1271,6 +1271,9 @@ function ns.NPC_UpdateLockout(plate)
             f.cd:SetDrawEdge(false)
             local PP = EllesmereUI.PP
             if PP and PP.CreateBorder then PP.CreateBorder(f, 0, 0, 0, 1, 1) end
+            if ns.ApplyFrameIconBorder then
+                ns.ApplyFrameIconBorder(f, ns.GetIconBorderEnabled and ns.GetIconBorderEnabled("ccs"))
+            end
             plate.npcLockout = f
         end
         local size = NPSize("cc")
@@ -1281,6 +1284,9 @@ function ns.NPC_UpdateLockout(plate)
         f.icon:SetTexCoord(tc[1], tc[2], tc[3], tc[4])
         f.cd:SetCooldown(lockout.start, lockout.duration)
         PositionLockout(plate, f, cs)
+        if ns.ApplyFrameIconBorder then
+            ns.ApplyFrameIconBorder(f, ns.GetIconBorderEnabled and ns.GetIconBorderEnabled("ccs"))
+        end
         f:Show()
     elseif f then
         f:Hide()
@@ -1474,7 +1480,8 @@ local function StyleFPFor(kind, idx)
     local durFP = FP(dur.size, dur.x, dur.y, dur.pos, dur.color.r, dur.color.g, dur.color.b)
     local stkFP = FP(stk.size, stk.x, stk.y, stk.pos, stk.color.r, stk.color.g, stk.color.b)
     return FP(kind, size, height, durFP, stkFP, purge,
-        EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("nameplates") or "")
+        EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("nameplates") or "",
+        ns.GetIconBorderEnabled and ns.GetIconBorderEnabled(kind) or true)
 end
 
 local function GeoFP()
@@ -1671,6 +1678,18 @@ function ns.NPC_ReloadAll()
         -- their next attach; active ones right now).
         geoGen = geoGen + 1
         ReanchorActive()
+    end
+    -- Cast-lockout is a hand-built CC icon, not an AuraKit style, so it
+    -- has to pick up Show Border here rather than through RestyleSoon.
+    do
+        local on = ns.GetIconBorderEnabled and ns.GetIconBorderEnabled("ccs")
+        if ns.ApplyFrameIconBorder then
+            for plate in pairs(active) do
+                if plate.npcLockout then
+                    ns.ApplyFrameIconBorder(plate.npcLockout, on)
+                end
+            end
+        end
     end
 end
 

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -129,6 +129,7 @@ function ns._appendDisplayPresetKeys(t)
         "auraDurationTextSize", "auraDurationTextColor",
         "debuffCropIcons", "buffCropIcons", "ccCropIcons",
         "debuffCropPercent", "buffCropPercent", "ccCropPercent",
+        "hideCastIconBorder", "hideDebuffIconBorder", "hideBuffIconBorder", "hideCCIconBorder",
         "showCastLockoutAsCrowdControl",
         "castIconOffsetX", "castIconOffsetY",
         "targetGlowEllesmereUI", "targetGlowBorderColor", "targetGlowHighlight", "targetBorderColor",
@@ -290,6 +291,9 @@ local defaults = {
     debuffCropPercent = 10,  -- per-side trim % for cropped mode (5-25); 10 == the fixed 80%-of-width crop
     buffCropPercent = 10,
     ccCropPercent = 10,
+    hideDebuffIconBorder = false,
+    hideBuffIconBorder = false,
+    hideCCIconBorder = false,
     debuffIconSize = 26,
     buffIconSize = 24,
     buffTextSize = 12,
@@ -399,6 +403,7 @@ local defaults = {
     castIconOnRight = false,
     castIconFullSize = false,
     castIconTargetBorder = false,
+    hideCastIconBorder = false,
     bgAlpha = 1.0,
     bgColor = { r = 0.12, g = 0.12, b = 0.12 },
     hoverColor = { r = 1, g = 1, b = 1 },
@@ -1371,6 +1376,36 @@ local function IsBorderEnabled()
     return v
 end
 ns.IsBorderEnabled = IsBorderEnabled
+-- Per-icon 1px borders (cast / buff / debuff / CC). nil = border shown
+-- (old profiles without the key keep their borders). Setting a hide key
+-- to true hides the border; false shows it.
+function ns.GetIconBorderEnabled(kind)
+    local key
+    if kind == "cast" then
+        key = "hideCastIconBorder"
+    elseif kind == "debuffs" then
+        key = "hideDebuffIconBorder"
+    elseif kind == "buffs" then
+        key = "hideBuffIconBorder"
+    else
+        key = "hideCCIconBorder"
+    end
+    local v = p and p[key]
+    if v == nil then
+        v = defaults[key]
+        if v == nil then return false end  -- nil default → border shown
+    end
+    return not v
+end
+function ns.ApplyFrameIconBorder(frame, enabled)
+    local PP = EllesmereUI and EllesmereUI.PP
+    if not (frame and PP and PP.GetBorders and PP.GetBorders(frame)) then return end
+    if enabled then
+        if PP.ShowBorder then PP.ShowBorder(frame) end
+    elseif PP.HideBorder then
+        PP.HideBorder(frame)
+    end
+end
 local function GetBorderColor()
     local c = (p and p.borderColor) or defaults.borderColor
     return c.r, c.g, c.b
@@ -2764,6 +2799,9 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
             plate:ApplyCastBorder()
             plate:ApplyCastBorderColor()
         end
+        if plate.castIconFrame then
+            ns.ApplyFrameIconBorder(plate.castIconFrame, ns.GetIconBorderEnabled("cast"))
+        end
     end
     plate:ApplyCastBorder()
     plate.castLeftBorder = plate.cast:CreateTexture(nil, "OVERLAY", nil, 7)
@@ -2778,6 +2816,7 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
     plate.castIconFrame:SetFrameLevel(plate.health:GetFrameLevel() + 1)
     ns.LayoutCastIcon(plate, CAST_H)
     AddBorder(plate.castIconFrame)
+    ns.ApplyFrameIconBorder(plate.castIconFrame, ns.GetIconBorderEnabled("cast"))
     plate.castIcon = plate.castIconFrame:CreateTexture(nil, "ARTWORK")
     -- Fill the frame (inset 0) so the 1px OVERLAY border draws ON TOP of the icon's rim: the
     -- visible edge IS the border's inner edge, no bare frame gap. DisablePixelSnap matches the
@@ -2948,6 +2987,7 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
         PP.Size(d, 26, 26)
         PP.Point(d, "BOTTOM", plate.name, "TOP", (i - (maxDbf + 1) / 2) * 30, 2)
         AddBorder(d)
+        ns.ApplyFrameIconBorder(d, ns.GetIconBorderEnabled("debuffs"))
         d.icon = d:CreateTexture(nil, "ARTWORK")
         PP.Point(d.icon, "TOPLEFT", d, "TOPLEFT", 1, -1)
         PP.Point(d.icon, "BOTTOMRIGHT", d, "BOTTOMRIGHT", -1, 1)
@@ -2997,6 +3037,7 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
         PP.Size(b, 24, 24)
         PP.Point(b, "RIGHT", plate.health, "LEFT", -2 - (i - 1) * 26, 0)
         AddBorder(b)
+        ns.ApplyFrameIconBorder(b, ns.GetIconBorderEnabled("buffs"))
         b.icon = b:CreateTexture(nil, "ARTWORK")
         PP.Point(b.icon, "TOPLEFT", b, "TOPLEFT", 1, -1)
         PP.Point(b.icon, "BOTTOMRIGHT", b, "BOTTOMRIGHT", -1, 1)
@@ -3041,6 +3082,7 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
         PP.Size(c, 24, 24)
         PP.Point(c, "LEFT", plate.health, "RIGHT", 2 + (i - 1) * 26, 0)
         AddBorder(c)
+        ns.ApplyFrameIconBorder(c, ns.GetIconBorderEnabled("ccs"))
         c.icon = c:CreateTexture(nil, "ARTWORK")
         PP.Point(c.icon, "TOPLEFT", c, "TOPLEFT", 1, -1)
         PP.Point(c.icon, "BOTTOMRIGHT", c, "BOTTOMRIGHT", -1, 1)
@@ -5454,6 +5496,7 @@ function NameplateFrame:ApplyAppearance()
     self._ovTgtTex, self._ovFocTex, self._ovHoverTex = nil, nil, nil
     ns.LayoutCastBar(self, ns.GetHealthBarWidth(), castH)
     ns.LayoutCastIcon(self, castH)
+    ns.ApplyFrameIconBorder(self.castIconFrame, ns.GetIconBorderEnabled("cast"))
     local showIcon = GetShowCastIcon()
     if showIcon then
         self.castIconFrame:Show()
@@ -5653,9 +5696,11 @@ function NameplateFrame:ApplyAppearance()
     local debuffSlot, buffSlot, ccSlot = GetAuraSlots()
     for i = 1, #self.debuffs do
         ns.ApplyAuraSlotCrop(self.debuffs[i], debuffCrop, debuffSz)
+        ns.ApplyFrameIconBorder(self.debuffs[i], ns.GetIconBorderEnabled("debuffs"))
     end
     for i = 1, 4 do
         ns.ApplyAuraSlotCrop(self.buffs[i], buffCrop, buffSz)
+        ns.ApplyFrameIconBorder(self.buffs[i], ns.GetIconBorderEnabled("buffs"))
         if self.buffs[i].cd and self.buffs[i].cd.text then
             SetFSFont(self.buffs[i].cd.text, buffDur.size, "OUTLINE, SLUG")
             self.buffs[i].cd.text:SetTextColor(buffDur.color.r, buffDur.color.g, buffDur.color.b, 1)
@@ -5670,6 +5715,7 @@ function NameplateFrame:ApplyAppearance()
     PositionAuraSlot(self.buffs, 4, buffSlot, self, buffSz, buffH, GetAuraSpacing("buffs"), GetAuraSlotOffsets("buffSlot"))
     for i = 1, 2 do
         ns.ApplyAuraSlotCrop(self.cc[i], ccCrop, ccSz)
+        ns.ApplyFrameIconBorder(self.cc[i], ns.GetIconBorderEnabled("ccs"))
         if self.cc[i].cd and self.cc[i].cd.text then
             SetFSFont(self.cc[i].cd.text, ccDur.size, "OUTLINE, SLUG")
             self.cc[i].cd.text:SetTextColor(ccDur.color.r, ccDur.color.g, ccDur.color.b, 1)

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -278,6 +278,7 @@ initFrame:SetScript("OnEvent", function(self)
             -- Vertical edges inset between horizontal edges to avoid corner overlap
             local l = mkB(); l:SetPoint("TOPLEFT", t, "BOTTOMLEFT", 0, 0); l:SetPoint("BOTTOMLEFT", b, "TOPLEFT", 0, 0); l:SetWidth(px)
             local r = mkB(); r:SetPoint("TOPRIGHT", t, "BOTTOMRIGHT", 0, 0); r:SetPoint("BOTTOMRIGHT", b, "TOPRIGHT", 0, 0); r:SetWidth(px)
+            f._euiIconEdges = { t, b, l, r }
             _borderRefreshers[#_borderRefreshers + 1] = function()
                 local npx = Snap(1)
                 t:SetHeight(npx); b:SetHeight(npx)
@@ -734,7 +735,7 @@ initFrame:SetScript("OnEvent", function(self)
             d.icon:SetPoint("BOTTOMRIGHT", d, "BOTTOMRIGHT", -px, px)
             d.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
             d.icon:SetTexture(debuffData[i].icon)
-            _insetIcons[#_insetIcons + 1] = { tex = d.icon, parent = d }
+            _insetIcons[#_insetIcons + 1] = { tex = d.icon, parent = d, kind = "debuffs" }
 
             -- Text child frame: sits above the icon frame so highlights can be sandwiched between icon artwork and text via frame levels.
             local textFrame = CreateFrame("Frame", nil, d)
@@ -779,7 +780,7 @@ initFrame:SetScript("OnEvent", function(self)
             bf.icon:SetPoint("BOTTOMRIGHT", bf, "BOTTOMRIGHT", -px, px)
             bf.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
             bf.icon:SetTexture(buffData[i].icon)
-            _insetIcons[#_insetIcons + 1] = { tex = bf.icon, parent = bf }
+            _insetIcons[#_insetIcons + 1] = { tex = bf.icon, parent = bf, kind = "buffs" }
             local bfTextFrame = CreateFrame("Frame", nil, bf)
             bfTextFrame:SetAllPoints()
             bfTextFrame:SetFrameLevel(bf:GetFrameLevel() + 2)
@@ -807,7 +808,7 @@ initFrame:SetScript("OnEvent", function(self)
             cf.icon:SetPoint("BOTTOMRIGHT", cf, "BOTTOMRIGHT", -px, px)
             cf.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
             cf.icon:SetTexture(ccData[i].icon)
-            _insetIcons[#_insetIcons + 1] = { tex = cf.icon, parent = cf }
+            _insetIcons[#_insetIcons + 1] = { tex = cf.icon, parent = cf, kind = "ccs" }
             local cfTextFrame = CreateFrame("Frame", nil, cf)
             cfTextFrame:SetAllPoints()
             cfTextFrame:SetFrameLevel(cf:GetFrameLevel() + 2)
@@ -942,13 +943,29 @@ initFrame:SetScript("OnEvent", function(self)
 
             -- Refresh all 1px AddBorder edges (cast icon, aura icons)
             for _, refreshFn in ipairs(_borderRefreshers) do refreshFn() end
+            do
+                local function setEdges(f, on)
+                    local e = f and f._euiIconEdges
+                    if not e then return end
+                    for i = 1, #e do e[i]:SetShown(on) end
+                end
+                local ib = ns.GetIconBorderEnabled
+                setEdges(castParts.iconFrame, not ib or ib("cast"))
+                for i = 1, PV_CONST.DEBUFF_COUNT do setEdges(debuffs[i], not ib or ib("debuffs")) end
+                for i = 1, PV_CONST.BUFF_COUNT do setEdges(buffs[i], not ib or ib("buffs")) end
+                for i = 1, PV_CONST.CC_COUNT do setEdges(ccs[i], not ib or ib("ccs")) end
+            end
 
             -- Refresh icon insets (1px from border) for current scale
             local curPx = Snap(1)
             for _, entry in ipairs(_insetIcons) do
+                local inset = curPx
+                if entry.kind and ns.GetIconBorderEnabled and not ns.GetIconBorderEnabled(entry.kind) then
+                    inset = 0
+                end
                 entry.tex:ClearAllPoints()
-                entry.tex:SetPoint("TOPLEFT", entry.parent, "TOPLEFT", curPx, -curPx)
-                entry.tex:SetPoint("BOTTOMRIGHT", entry.parent, "BOTTOMRIGHT", -curPx, curPx)
+                entry.tex:SetPoint("TOPLEFT", entry.parent, "TOPLEFT", inset, -inset)
+                entry.tex:SetPoint("BOTTOMRIGHT", entry.parent, "BOTTOMRIGHT", -inset, inset)
             end
 
             local bc = (DB() and DB().borderColor) or defaults.borderColor
@@ -6205,6 +6222,27 @@ initFrame:SetScript("OnEvent", function(self)
                     opts.cropPctGet = function() return DBVal(cropPctKey) or 10 end
                     opts.cropPctSet = function(v) DB()[cropPctKey] = v; RefreshAllSlots(); UpdatePreview() end
                 end
+                local borderKey
+                if element == "debuffs" then
+                    borderKey = "hideDebuffIconBorder"
+                elseif element == "buffs" then
+                    borderKey = "hideBuffIconBorder"
+                elseif element == "ccs" then
+                    borderKey = "hideCCIconBorder"
+                end
+                if borderKey then
+                    opts.toggleLabel = "Hide Border"
+                    opts.toggleGet = function()
+                        local v = DBVal(borderKey)
+                        if v == nil then return false end
+                        return v and true or false
+                    end
+                    opts.toggleSet = function(v)
+                        DB()[borderKey] = v and true or false
+                        RefreshAllSlots()
+                        UpdatePreview()
+                    end
+                end
                 -- Rare/Quest Indicator: "Show In Instances" lifts the open-world-only gates (UpdateClassification render gate + IsQuestMob's tooltip-scan gate); RefreshQuestObjective wipes quest-mob caches AND re-runs UpdateClassification everywhere.
                 if element == "classification" then
                     opts.toggleLabel = "Show In Instances"
@@ -6787,6 +6825,18 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       set=function(v)
                         DB().castIconFullSize = v
+                        ns.RefreshAllSettings()
+                        UpdatePreview()
+                      end },
+                    { type="toggle", label="Hide Border",
+                      tooltip="Hide the 1-pixel border around the cast bar spell icon.",
+                      get=function()
+                        local db = DB()
+                        if db and db.hideCastIconBorder ~= nil then return db.hideCastIconBorder and true or false end
+                        return false
+                      end,
+                      set=function(v)
+                        DB().hideCastIconBorder = v and true or false
                         ns.RefreshAllSettings()
                         UpdatePreview()
                       end },


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

### Nameplate aura / castbar icon borders

Adds a Hide Border toggle per icon type: cast bar spell icon, debuff icons, buff icons, and crowd‑control icons on nameplates. Each toggle lives in the relevant slot’s cog popup (cast icon cog or Core Position slot cog). Default is off (border shown), preserving the current visual on update. The toggle hides/shows the 1‑pixel PP.CreateBorder and adjusts the texture inset to remove the border gap.

## How was it tested?

Loaded on 12.1. Toggled each Hide Border option — cast icon, buffs, debuffs, and CC icons each hide/show their 1px border independently. Preview updated live. Verified border inset (texture filling to edges) matches the hidden state to avoid a 1‑pixel visual gap. Reloaded UI; settings persist. Tested on friend and enemy nameplates.

## Screenshots

<img width="596" height="545" alt="image" src="https://github.com/user-attachments/assets/aeadf9b1-7373-42c5-b0eb-fbbac75a681a" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
