### PR TITLE
feat: unit power/text frames now carry the same unit/menu attrs as the hp frame

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -3929,6 +3929,75 @@ local function ApplyDetachedPortraitShape(backdrop, uSettings, unitToken)
         PP.Point(backdrop._3d, "BOTTOMRIGHT", backdrop, "BOTTOMRIGHT", 0, 0)
     end
 end
+
+-- SecureUnitButton overlays on power and the text bar
+-- carry the same unit/menu attrs as the health barframe.
+local function SilenceMouse(region)
+    if not region then return end
+    region:EnableMouse(false)
+    if region.SetMouseClickEnabled then
+        pcall(region.SetMouseClickEnabled, region, false)
+    end
+end
+
+local function WireBarClicks(frame)
+    if not frame then return end
+    SilenceMouse(frame._barClip)
+    SilenceMouse(frame.Health)
+    SilenceMouse(frame._textOverlay)
+    local function Attach(host, suffix)
+        if not host then return end
+        SilenceMouse(host)
+        SilenceMouse(host._ppTextOvr)
+        SilenceMouse(host._pbBorder)
+        SilenceMouse(host._textOverlay)
+        SilenceMouse(host._classIconHolder)
+        local surf = host._euiClickSurf
+        if not surf then
+            if InCombatLockdown() then return end
+            local n = frame:GetName()
+            surf = CreateFrame("Button", n and (n .. suffix .. "Click") or nil, frame, "SecureUnitButtonTemplate")
+            host._euiClickSurf = surf
+            surf:RegisterForClicks("AnyUp")
+            surf:SetAttribute("useparent-unit", true)
+            surf:SetAttribute("*type1", "target")
+            if EllesmereUI.AttachSecureUnitMenu then
+                EllesmereUI.AttachSecureUnitMenu(surf)
+            else
+                surf:SetAttribute("*type2", "togglemenu")
+            end
+            if type(ClickCastFrames) ~= "table" then ClickCastFrames = {} end
+            ClickCastFrames[surf] = true
+            surf:HookScript("OnEnter", function(self)
+                local o = self:GetParent()
+                if o and o._euiOnEnter then o._euiOnEnter(o) end
+            end)
+            surf:HookScript("OnLeave", function(self)
+                local o = self:GetParent()
+                if o and o._euiOnLeave then o._euiOnLeave(o) end
+            end)
+        elseif InCombatLockdown() then
+            return
+        end
+        surf:SetFrameStrata(host:GetFrameStrata())
+        local hl = host:GetFrameLevel() or 0
+        local ovr = host._ppTextOvr or host._textOverlay
+        if ovr then
+            local ol = ovr:GetFrameLevel() or 0
+            if ol > hl then hl = ol end
+        end
+        local fl = frame:GetFrameLevel() or 0
+        surf:ClearAllPoints()
+        surf:SetAllPoints(host)
+        -- Above bar chrome AND the full-frame raid-marker holder (frame+20).
+        surf:SetFrameLevel(math.max(hl + 5, fl + 25))
+        surf:EnableMouse(true)
+        surf:Show()
+    end
+    Attach(frame.Power, "Power")
+    Attach(frame.BottomTextBar, "BTB")
+end
+
 -- Bottom text bar frame: below the health+power area, above the castbar.
 local function CreateBottomTextBar(frame, unit, settings, anchorFrame, xOffset, overrideWidth)
     local btbH = settings.bottomTextBarHeight or 16
@@ -4100,7 +4169,9 @@ local function CreateBottomTextBar(frame, unit, settings, anchorFrame, xOffset, 
 
     ApplyBTBClassIcon(settings)
     btb._applyBTBClassIcon = ApplyBTBClassIcon
+    btb._classIconHolder = classIconHolder
 
+    WireBarClicks(frame)
     return btb
 end
 
@@ -4183,6 +4254,7 @@ local function ReparentBarsToClip(frame, powerPosition, settings)
             ns.UpdatePowerBorder(frame.Power, settings)
         end
     end
+    WireBarClicks(frame)
 end
 
 
@@ -5450,6 +5522,7 @@ function ns.UpdatePowerBorder(power, settings)
     border:SetFrameLevel(borderLevel)
     local showBorder = (isDet or isAttached) and size > 0
     if showBorder then border:Show() else border:Hide() end
+    SilenceMouse(border)
 
     -- The power text overlay must clear the border: the border shares the bar's strata
     -- and can outrank the overlay's default level, so match strata and lift past it.
@@ -5462,6 +5535,16 @@ function ns.UpdatePowerBorder(power, settings)
             local pf = power:GetParent()
             ovr:SetFrameLevel((pf and pf:GetFrameLevel() or power:GetFrameLevel()) + 15)
         end
+    end
+    local surf = power._euiClickSurf
+    if surf and not InCombatLockdown() then
+        local hl = power:GetFrameLevel() or 0
+        if ovr then
+            local ol = ovr:GetFrameLevel() or 0
+            if ol > hl then hl = ol end
+        end
+        surf:SetFrameStrata(power:GetFrameStrata())
+        surf:SetFrameLevel(hl + 5)
     end
 end
 
@@ -5791,6 +5874,7 @@ local function CreatePowerBar(frame, unit, settings)
 
     -- Power bar border: full when detached, divider when attached; lazy.
     ns.UpdatePowerBorder(power, settings)
+    WireBarClicks(frame)
 
     return power
 end
@@ -7987,6 +8071,7 @@ local function StyleFullFrame(frame, unit)
         frame._btb = frame.BottomTextBar
         -- Cast bar positioning owned by centralized unlock system
     end
+    WireBarClicks(frame)
 end
 
 
@@ -8297,6 +8382,7 @@ local function StyleFocusFrame(frame, unit)
         frame._btb = frame.BottomTextBar
         -- Cast bar positioning owned by centralized unlock system
     end
+    WireBarClicks(frame)
 end
 
 local function StyleSimpleFrame(frame, unit)
@@ -9050,6 +9136,7 @@ local function StyleBossFrame(frame, unit)
     end
     ApplyTextPositions(settings)
     frame._applyTextPositions = ApplyTextPositions
+    WireBarClicks(frame)
 end
 
 
@@ -12353,6 +12440,9 @@ function InitializeFrames()
         end
         frame:HookScript("OnEnter", UnitFrame_OnEnter)
         frame:HookScript("OnLeave", UnitFrame_OnLeave)
+        frame._euiOnEnter = UnitFrame_OnEnter
+        frame._euiOnLeave = UnitFrame_OnLeave
+        WireBarClicks(frame)
         -- Expose to click-casting via the standard global table. EUI unit frames
         -- replace the Blizzard ones, which the click-cast engine registers by name --
         -- but those are hidden, so the engine never reaches the visible frames.


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

### Unit frame power/text bar clicks

Fixes left-click (target) and right-click (menu) on unit-frame power bars and bottom text bars by placing transparent SecureUnitButtonTemplate overlays on those regions. The existing health-bar clicks worked because they fell through to the secure button; power and text-bar chrome sat on top and ate clicks. The overlays carry useparent-unit, *type1=target, and the menu attacher — exactly matching the health-bar’s secure action path.

## How was it tested?

Loaded on 12.1. Clicked power bar — unit targeted. Right-clicked power bar — menu opens. Same on bottom text bar. Verified health bar still works identically. Tested in and out of combat; `/reload` recreates overlays. No taint warnings or Lua errors.

## Screenshots

<img width="569" height="323" alt="image" src="https://github.com/user-attachments/assets/8ea27690-a049-456a-8c07-3e3b3a300a19" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
