### PR TITLE
Trade: move the change glow onto the item that moved

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -13514,6 +13514,9 @@ function HP.ApplyTrade()
                 HP.CloseButton(f, f.CloseButton or _G.TradeFrameCloseButton)
             end,
             function() HP.TradeHidePortrait() end,
+            -- Behavior, not chrome, but it rides the phase list for the
+            -- same crash isolation. No-op after its first run.
+            function() HP.TradeAlertFix() end,
         }
     end
 
@@ -13561,6 +13564,100 @@ function HP.TradeSlots()
             HP.SkinTradeSlot(_G["TradePlayerItem" .. i])
             HP.SkinTradeSlot(_G["TradeRecipientItem" .. i])
         end
+end
+
+-- THE CHANGE GLOW FOLLOWS THE ITEM. A drag between trade slots is a REMOVE
+-- then an ADD (OnDragStart and OnReceiveDrag both call ClickTradeButton), so
+-- two slots change and TradeFrame_AlertItemIfChanged lights the wrong one:
+-- the emptied slot alerts, and the filled one stays silent while its itemKey
+-- is nil -- Blizzard skips a slot's first item, and the enchant slot behind
+-- "Will not be traded" is almost always in that state. Latched per side: a
+-- slot going empty arms its side, the next slot on that side to gain an item
+-- consumes the latch. side -> the Alert frame left glowing on the empty slot.
+HP.tradeVacated = {}
+
+-- Named so the state above can be dropped between trades. Slot 7 is the
+-- enchant slot on both halves.
+HP.TRADE_ALERT_BUTTONS = {}
+for i = 1, 7 do
+    HP.TRADE_ALERT_BUTTONS[#HP.TRADE_ALERT_BUTTONS + 1] = "TradePlayerItem" .. i .. "ItemButton"
+    HP.TRADE_ALERT_BUTTONS[#HP.TRADE_ALERT_BUTTONS + 1] = "TradeRecipientItem" .. i .. "ItemButton"
+end
+
+-- Stop() alone lands the alpha at 0 only if the group is still running;
+-- zeroing it too covers a stop between steps, which is when this is called.
+function HP.TradeAlertStop(alert)
+    if not alert or (alert.IsForbidden and alert:IsForbidden()) then return end
+    if alert.ItemIconAlertAnim then alert.ItemIconAlertAnim:Stop() end
+    if alert.LoopFlipbook then alert.LoopFlipbook:SetAlpha(0) end
+end
+
+-- Which half a button is on, read off its name: the two halves use otherwise
+-- identical templates and share this one alert function, and a partner
+-- rearranging their offer must not steal the glow off yours.
+function HP.TradeButtonSide(btn)
+    local n = btn and btn.GetName and btn:GetName()
+    if not n then return end
+    if n:find("TradePlayerItem", 1, true) == 1 then return "player" end
+    if n:find("TradeRecipientItem", 1, true) == 1 then return "recipient" end
+end
+
+-- Only a MOVE is redirected: an item that leaves the offer for good never gets
+-- its latch consumed, so its removal glow survives. That is a CHANGE warning,
+-- not the accept state (TradeHighlightPlayer/Recipient, left stock below).
+-- Blizzard's oldItemKey is gone by the time a post-hook runs, hence the shadow
+-- flag -- which also makes a button's FIRST sighting quiet, so a /reload
+-- mid-trade initializes instead of alerting on all fourteen slots.
+function HP.OnTradeItemAlert(btn, itemID)
+    if not btn or (btn.IsForbidden and btn:IsForbidden()) then return end
+    local side = HP.TradeButtonSide(btn)
+    if not side then return end
+    local d = GetFFD(btn)
+    local had = d.tradeHadItem
+    -- Blizzard's own emptiness test: an empty slot reports 0, not nil.
+    local has = (itemID or 0) > 0
+    d.tradeHadItem = has
+    if had and not has then
+        HP.tradeVacated[side] = btn.Alert
+    elseif has and not had then
+        local src = HP.tradeVacated[side]
+        if not src then return end
+        HP.tradeVacated[side] = nil
+        -- Source first: dropping an item back where it came from makes src and
+        -- the destination the same frame, so the restart has to win.
+        HP.TradeAlertStop(src)
+        local alert = btn.Alert
+        if alert and alert.ItemIconAlertAnim and not (alert.IsForbidden and alert:IsForbidden()) then
+            alert.ItemIconAlertAnim:Restart()
+        end
+    end
+end
+
+-- Dropped with the window. A trade cancelled with items still in its slots
+-- would otherwise leave them flagged as filled, and the next trade's first
+-- update would read as an emptying and arm the latch against nothing.
+function HP.TradeAlertReset()
+    wipe(HP.tradeVacated)
+    for i = 1, #HP.TRADE_ALERT_BUTTONS do
+        local btn = _G[HP.TRADE_ALERT_BUTTONS[i]]
+        if btn then GetFFD(btn).tradeHadItem = nil end
+    end
+end
+
+-- Once per session, from the pack because this window has no other owner.
+function HP.TradeAlertFix()
+    if HP.tradeAlertHooked then return end
+    if type(_G.TradeFrame_AlertItemIfChanged) ~= "function" then return end
+    HP.tradeAlertHooked = true
+    hooksecurefunc("TradeFrame_AlertItemIfChanged", function(btn, itemID)
+        -- Inside Blizzard's event handler: a throw would surface as an error
+        -- in their update, not ours.
+        pcall(HP.OnTradeItemAlert, btn, itemID)
+    end)
+    local f = _G.TradeFrame
+    if f and not f:IsForbidden() then
+        f:HookScript("OnHide", function() pcall(HP.TradeAlertReset) end)
+    end
 end
 
 -- Both player names and both "Will not be traded" enchant captions. White,


### PR DESCRIPTION
## The bug

Drag an item between trade slots -- say from the main list into "Will not be
traded" -- and the item moves but the proc glow stays behind on the slot it
came from.

## Why

Blizzard fires the `TradeItemAlertTemplate` flipbook from
`TradeFrame_AlertItemIfChanged` on any slot whose contents differ from what
that slot last held.

A drag between slots is not a reposition. `PlayerTradeItemTemplate`'s
`OnDragStart` and `OnReceiveDrag` both call `ClickTradeButton`, so the item is
removed from the offer and then added back, and two slots change:

* the slot you emptied alerts, because its contents changed;
* the slot you filled does not, because Blizzard skips the alert while a
  slot's `itemKey` is still nil -- "We don't alert the first time an item is
  placed in the slot".

The enchant slot behind "Will not be traded" is almost always in that state, so
dragging an item there always left the glow on an empty box.

## The fix

Post-hook `TradeFrame_AlertItemIfChanged` with a per-side latch. A slot going
empty arms its side; the next slot on the same side to gain an item consumes
the latch, alerts, and stops the source.

Only a move is redirected, which is why this is a latch rather than a blanket
mute on emptied slots. An item that leaves the offer for good never gets its
latch consumed, so its removal glow plays out in full. That glow is the
per-slot half of the change warning `TRADE_WARNING_CHANGED_OFFER` gives on the
Trade button, and it is the signal a mid-trade swap depends on you missing.

It is not the accept state -- that is `TradeHighlightPlayer` /
`TradeHighlightRecipient`, the green wash over a column, driven only by
`TRADE_ACCEPT_UPDATE` and left stock as before.

Per side, so a partner rearranging their offer cannot steal the glow off yours.

Blizzard's `oldItemKey` is already overwritten by the time a post-hook runs, so
the fix keeps a shadow flag in frame data. That flag also makes a button's
first sighting quiet, which keeps a `/reload` mid-trade from alerting on all
fourteen slots at once.

## Testing

Verified in game: the glow now lands on the destination slot.

Also run offline against a verbatim copy of Blizzard's
`TradeFrame_AlertItemIfChanged` -- 15 assertions over 7 scenarios:

* fresh trade, first item placed, stays quiet
* player slot 1 -> slot 7 moves the glow
* an item removed from the offer entirely keeps its removal glow
* the two halves do not cross-talk while both change
* `/reload` mid-trade with items already in slots alerts nothing
* a trade cancelled with items still in its slots does not poison the next one
* pick an item up and drop it straight back, slot still glows

## Known limitation

While the item is on the cursor the source slot keeps glowing, because Blizzard
lights it the instant `OnDragStart` fires and the hook can only stop it once
the destination fills. Suppressing that would mean reading `CursorHasItem()` at
pickup and watching `CURSOR_CHANGED` to tell a move from a removal, plus a
deferral so the cursor clearing does not beat the slot update. Left out of this
change.