### PR TITLE
Add threshold alert sound for class resource bars

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -5909,6 +5909,69 @@ function EllesmereUI.AppendSharedMediaSounds(paths, names, order)
 end
 
 -------------------------------------------------------------------------------
+--  Shared catalogue of the 16 bundled EllesmereUI alert sounds, used by every
+--  "pick a sound" dropdown across the addon suite. Built lazily (so
+--  SharedMedia sounds registered by other addons at login are included) and
+--  memoized after the first call.
+--  Returns: paths, names, order (paths/names keyed the same, order includes
+--  "none" first and a "---" divider before any appended SharedMedia entries).
+-------------------------------------------------------------------------------
+-- Cache lives on EllesmereUI (not new top-level locals) -- this file is at
+-- the Lua 5.1 200-local cap.
+function EllesmereUI.GetSoundCatalog()
+    local c = EllesmereUI._soundCatalog
+    if c then return c.paths, c.names, c.order end
+    local DIR = "Interface\\AddOns\\EllesmereUI\\media\\sounds\\"
+    local paths = {
+        ["airhorn"]   = DIR .. "AirHorn.ogg",
+        ["banana"]    = DIR .. "BananaPeelSlip.ogg",
+        ["bikehorn"]  = DIR .. "BikeHorn.ogg",
+        ["bite"]      = DIR .. "Bite.ogg",
+        ["boxing"]    = DIR .. "BoxingArenaSound.ogg",
+        ["catmeow"]   = DIR .. "CatMeow.ogg",
+        ["catmeow2"]  = DIR .. "CatMeow2.ogg",
+        ["gunshot"]   = DIR .. "FrontalsGunshot.wav",
+        ["glass"]     = DIR .. "Glass.mp3",
+        ["kaching"]   = DIR .. "Kaching.ogg",
+        ["phone"]     = DIR .. "Phone.ogg",
+        ["robotblip"] = DIR .. "RobotBlip.ogg",
+        ["sonar"]     = DIR .. "Sonar.ogg",
+        ["siren"]     = DIR .. "WarningSiren.ogg",
+        ["water"]     = DIR .. "WaterDrop.ogg",
+        ["wilhelm"]   = DIR .. "Wilhelm.ogg",
+    }
+    local names = {
+        ["none"]      = "None",
+        ["airhorn"]   = "Air Horn",
+        ["banana"]    = "Banana Peel Slip",
+        ["bikehorn"]  = "Bike Horn",
+        ["bite"]      = "Bite",
+        ["boxing"]    = "Boxing Arena",
+        ["catmeow"]   = "Cat Meow",
+        ["catmeow2"]  = "Cat Meow 2",
+        ["gunshot"]   = "Frontals Gunshot",
+        ["glass"]     = "Glass",
+        ["kaching"]   = "Kaching",
+        ["phone"]     = "Phone",
+        ["robotblip"] = "Robot Blip",
+        ["sonar"]     = "Sonar",
+        ["siren"]     = "Warning Siren",
+        ["water"]     = "Water Drop",
+        ["wilhelm"]   = "Wilhelm",
+    }
+    local order = {
+        "none", "airhorn", "banana", "bikehorn", "bite", "boxing", "catmeow",
+        "catmeow2", "gunshot", "glass", "kaching", "phone", "robotblip", "sonar",
+        "siren", "water", "wilhelm",
+    }
+    if EllesmereUI.AppendSharedMediaSounds then
+        EllesmereUI.AppendSharedMediaSounds(paths, names, order)
+    end
+    EllesmereUI._soundCatalog = { paths = paths, names = names, order = order }
+    return paths, names, order
+end
+
+-------------------------------------------------------------------------------
 --  Append LibSharedMedia-3.0 fonts into a runtime font dropdown table.
 --  Signature: AppendSharedMediaFonts(values, order, opts)
 --    values  - key -> { text, font } table (or key -> path when keyByName=true)

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -6425,35 +6425,16 @@ initFrame:SetScript("OnEvent", function(self)
 							set = function(v) local e=_thrEnt(); if not e then return end e.thresholdSoundKey=v; RefreshClass() end },
 					},
 				})
-				-- Parent the Sound dropdown's popup menu into this cog popup
-				-- instead of UIParent: BuildDropdownMenu hardcodes its menu
-				-- frame level (200), well below this cog's own level (500), so
-				-- unparented it renders BEHIND the cog and is only visible
-				-- where it spills past the cog's edges. threshCog only exists
-				-- once BuildCogPopup returns, so this has to be set here
-				-- rather than inline in the values table above.
-				threshSoundValues._menuOpts.parent = threshCog
-				-- BuildCogPopup gives no handle to a DSL row's built dropdown
-				-- widget (unlike the hand-built talentDD row above, which
-				-- hooks its own ddBtn), so there's no button to hook here
-				-- directly. threshCog has exactly one dropdown row, so watch
-				-- the shared EllesmereUI._openDropdownMenu instead: whichever
-				-- menu shows while this popup is visible IS this one.
-				-- HookScript("OnUpdate", ...) is inert while threshCog is
-				-- hidden (WoW skips OnUpdate on hidden frames), so this costs
-				-- nothing when the popup isn't open. Bumping STRATA (not just
-				-- level, matching the talentDD pattern above) guarantees it
-				-- renders above threshCog regardless of BuildDropdownMenu's
-				-- hardcoded frame level (200) -- the same gap that hid and
-				-- made unclickable the per-band Sound dropdown in
-				-- EnsureBandRow before it got this same treatment.
-				threshCog:HookScript("OnUpdate", function()
-					local dm = EllesmereUI._openDropdownMenu
-					if dm and dm:IsShown() and not dm._threshCogStrataFixed then
-						dm:SetFrameStrata("TOOLTIP")
-						dm._threshCogStrataFixed = true
-					end
-				end)
+				-- threshCog (BuildCogPopup's first return value) is nil right
+				-- here: the popup frame is built lazily on first show, inside
+				-- showFn's __call, which stashes it on showFn._popupFrame --
+				-- threshCog itself never gets that update (a plain local
+				-- snapshot from the call above, not a live reference), so
+				-- indexing it before the popup has ever been opened throws.
+				-- The one-time setup below (menu parenting + Z-order fix) is
+				-- deferred into the OnClick handler and gated on
+				-- threshCogShow._popupFrame existing, running once right
+				-- after the frame is actually created.
 				local threshCogBtn = CreateFrame("Button", nil, threshRow)
 				threshCogBtn:SetSize(20, 20)
 				threshCogBtn:SetPoint("RIGHT", threshRow, "RIGHT", 0, 0)
@@ -6463,7 +6444,41 @@ initFrame:SetScript("OnEvent", function(self)
 				threshCogTex:SetAllPoints(); threshCogTex:SetTexture(EllesmereUI.COGS_ICON)
 				threshCogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.8) end)
 				threshCogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.5) end)
-				threshCogBtn:SetScript("OnClick", function(self) threshCogShow(self) end)
+				local _threshCogWired = false
+				threshCogBtn:SetScript("OnClick", function(self)
+					threshCogShow(self)
+					if _threshCogWired or not threshCogShow._popupFrame then return end
+					_threshCogWired = true
+					local popup = threshCogShow._popupFrame
+					-- Parent the Sound dropdown's popup menu into this cog
+					-- popup instead of UIParent: BuildDropdownMenu hardcodes
+					-- its menu frame level (200), well below this cog's own
+					-- level (500), so unparented it renders BEHIND the cog
+					-- and is only visible where it spills past its edges.
+					threshSoundValues._menuOpts.parent = popup
+					-- BuildCogPopup gives no handle to a DSL row's built
+					-- dropdown widget (unlike the hand-built talentDD row
+					-- above, which hooks its own ddBtn), so there's no button
+					-- to hook directly. This cog has exactly one dropdown
+					-- row, so watch the shared EllesmereUI._openDropdownMenu
+					-- instead: whichever menu shows while this popup is
+					-- visible IS this one. HookScript("OnUpdate", ...) is
+					-- inert while the popup is hidden (WoW skips OnUpdate on
+					-- hidden frames), so this costs nothing once closed.
+					-- Bumping STRATA (not just level, matching the talentDD
+					-- pattern above) guarantees it renders above the popup
+					-- regardless of BuildDropdownMenu's hardcoded frame level
+					-- -- the same gap that hid and made unclickable the
+					-- per-band Sound dropdown in EnsureBandRow before it got
+					-- this same treatment.
+					popup:HookScript("OnUpdate", function()
+						local dm = EllesmereUI._openDropdownMenu
+						if dm and dm:IsShown() and not dm._threshCogStrataFixed then
+							dm:SetFrameStrata("TOOLTIP")
+							dm._threshCogStrataFixed = true
+						end
+					end)
+				end)
 				local threshEnable, _, threshEnableSnap = EllesmereUI.BuildToggleControl(
 					threshRow, DLVL + 4,
 					function()

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -6217,6 +6217,31 @@ initFrame:SetScript("OnEvent", function(self)
 				local function _thrOptUsable() return _thrEnabled() and not _thrMultiOn() end
 				local function _thrOffTip() if _thrMultiOn() then return BAND_REPLACES_TIP end return "Enable the Threshold toggle to use these options." end
 				local function _thrIsUpTo() local e=_thrEnt(); return (e and e.thresholdReverse) and true or false end
+				local function _thrSoundOn() local e=_thrEnt(); return (e and e.thresholdSoundEnabled) and true or false end
+				-- Sound dropdown: shallow-copy the shared catalogue so _menuOpts
+				-- (preview icon) doesn't pollute the addon-wide table.
+				local threshSoundValues = {}
+				local threshSoundPaths, threshSoundNames, threshSoundOrder = EllesmereUI.GetSoundCatalog()
+				for k, v in pairs(threshSoundNames) do threshSoundValues[k] = v end
+				threshSoundValues._menuOpts = {
+					itemHeight = 26,
+					maxTextWidthPct = 0.8,
+					searchable = true,
+					iconAtlas = function(key)
+						if key == "none" then return nil end
+						if not threshSoundPaths[key] then return nil end
+						return "common-icon-sound"
+					end,
+					iconPressedAtlas = function(key)
+						if key == "none" then return nil end
+						return "common-icon-sound-pressed"
+					end,
+					iconOnClick = function(key)
+						local path = threshSoundPaths[key]
+						if path then PlaySoundFile(path, "Master") end
+					end,
+					iconTooltip = function() return "Preview Sound" end,
+				}
 				local threshCog, threshCogShow = EllesmereUI.BuildCogPopup({
 					title = "Threshold Options", bgAlpha = 1, frameStrata = "FULLSCREEN_DIALOG", frameLevel = 500, minWidth = 320,
 					rows = {
@@ -6245,6 +6270,20 @@ initFrame:SetScript("OnEvent", function(self)
 							end,
 							get = function() local e=_thrEnt(); return (e and e.thresholdPartialOnly) and true or false end,
 							set = function(v) local e=_thrEnt(); if not e then return end e.thresholdPartialOnly=v; RefreshClass(); if RefreshDetail then RefreshDetail() end end },
+						{ type = "toggle", label = "Threshold Sound", rawTooltip = true,
+							disabled = function() return not _thrOptUsable() end,
+							disabledTooltip = function() return _thrOffTip() end,
+							get = function() local e=_thrEnt(); return (e and e.thresholdSoundEnabled) and true or false end,
+							set = function(v) local e=_thrEnt(); if not e then return end e.thresholdSoundEnabled=v; RefreshClass() end },
+						{ type = "dropdown", label = "Sound",
+							values = threshSoundValues, order = threshSoundOrder,
+							disabled = function() return (not _thrOptUsable()) or not _thrSoundOn() end,
+							disabledTooltip = function()
+								if not _thrOptUsable() then return _thrOffTip() end
+								return "Enable Threshold Sound to pick a sound."
+							end,
+							get = function() local e=_thrEnt(); return (e and e.thresholdSoundKey) or "none" end,
+							set = function(v) local e=_thrEnt(); if not e then return end e.thresholdSoundKey=v; RefreshClass() end },
 					},
 				})
 				local threshCogBtn = CreateFrame("Button", nil, threshRow)

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -1115,7 +1115,11 @@ initFrame:SetScript("OnEvent", function(self)
     local _bandModeRow, _bandModeSeg, _bandModeSegRefresh, _bandModeHint, _bandAddBtn, _bandTitleFS
     local _bandReverseRow, _bandReverseSeg, _bandReverseSegRefresh
     local BAND_POPUP_W = 300
-    local BAND_ROW_H = 26
+    -- Two lines per row: boundary/color/delete on top, a per-band alert
+    -- Sound dropdown below it. BAND_ROW_H is the full row pitch (used by
+    -- both row sizing and the stacking step in RefreshBandEditor).
+    local BAND_LINE1_H = 26
+    local BAND_ROW_H = 50
     local BAND_PAD = 14
     local BAND_GAP = 10
     local RefreshBandEditor  -- forward decl
@@ -1125,7 +1129,8 @@ initFrame:SetScript("OnEvent", function(self)
         "Color the bar by ranges instead of a single threshold.\n"
         .. "Up to (<=) / From (>=)\n"
 		.. "Any remaning values outside the bands will use fill color.\n"
-        .. "|cff888888Bars can use % or actual value; pip resources use counts.|r"
+        .. "|cff888888Bars can use % or actual value; pip resources use counts.|r\n"
+        .. "Each band can also play its own sound as you cross into it."
 
     local BAND_REPLACES_TIP =
         "Single threshold is off while Multi-band is on.\n"
@@ -1306,7 +1311,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         local lbl = EllesmereUI.MakeFont(rf, 12, nil, 1, 1, 1)
         lbl:SetAlpha(0.6)
-        lbl:SetPoint("LEFT", rf, "LEFT", 2, 0)
+        lbl:SetPoint("TOPLEFT", rf, "TOPLEFT", 2, -2)
         lbl:SetText(EllesmereUI.L("Up to"))  -- band colors values up to `to`
         row.lbl = lbl
 
@@ -1369,7 +1374,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         local delBtn = CreateFrame("Button", nil, rf)
         delBtn:SetSize(14, 14)
-        delBtn:SetPoint("RIGHT", rf, "RIGHT", -2, 0)
+        delBtn:SetPoint("TOPRIGHT", rf, "TOPRIGHT", -2, -6)
         delBtn:SetFrameLevel(rf:GetFrameLevel() + 3)
         local delIcon = delBtn:CreateTexture(nil, "OVERLAY")
         delIcon:SetAllPoints()
@@ -1386,6 +1391,48 @@ initFrame:SetScript("OnEvent", function(self)
             end
         end)
         row.delBtn = delBtn
+
+        -- Line 2: per-band alert sound, reusing the shared catalogue plumbing
+        -- from the single-threshold Sound dropdown (EllesmereUI.GetSoundCatalog).
+        local soundLbl = EllesmereUI.MakeFont(rf, 10, nil, 1, 1, 1)
+        soundLbl:SetAlpha(0.5)
+        soundLbl:SetPoint("TOPLEFT", rf, "TOPLEFT", 2, -(BAND_LINE1_H + 6))
+        soundLbl:SetText(EllesmereUI.L("Sound"))
+        row.soundLbl = soundLbl
+
+        local soundValues = {}
+        local soundPaths, soundNames, soundOrder = EllesmereUI.GetSoundCatalog()
+        for sk, sv in pairs(soundNames) do soundValues[sk] = sv end
+        soundValues._menuOpts = {
+            itemHeight = 24, maxTextWidthPct = 0.8, searchable = true,
+            iconAtlas = function(key)
+                if key == "none" or not soundPaths[key] then return nil end
+                return "common-icon-sound"
+            end,
+            iconPressedAtlas = function(key)
+                if key == "none" then return nil end
+                return "common-icon-sound-pressed"
+            end,
+            iconOnClick = function(key)
+                local path = soundPaths[key]
+                if path then PlaySoundFile(path, "Master") end
+            end,
+            iconTooltip = function() return "Preview Sound" end,
+        }
+        local soundDD = EllesmereUI.BuildDropdownControl(rf, 150, rf:GetFrameLevel() + 2,
+            soundValues, soundOrder,
+            function()
+                local ent = CurrentBandEntry()
+                local band = ent and ent.bands and ent.bands[row._idx]
+                return (band and band.soundKey) or "none"
+            end,
+            function(v)
+                local ent = CurrentBandEntry()
+                local band = ent and ent.bands and ent.bands[row._idx]
+                if band then band.soundKey = v end
+            end)
+        soundDD:SetPoint("LEFT", soundLbl, "RIGHT", 6, 0)
+        row.soundDD = soundDD
 
         _bandRows[k] = row
         return row
@@ -1439,6 +1486,7 @@ initFrame:SetScript("OnEvent", function(self)
             PP.Point(row.frame, "TOPLEFT", bandPopup, "TOPLEFT", BAND_PAD, curY)
             row.input:SetText(tostring(ent.bands[k].to or 1))
             if row.swatchSnap then row.swatchSnap() end
+            if row.soundDD and row.soundDD._refreshLabel then row.soundDD._refreshLabel() end
             row.frame:Show()
             curY = curY - BAND_ROW_H - 4
         end
@@ -1498,7 +1546,11 @@ initFrame:SetScript("OnEvent", function(self)
     local _buffGetBarData, _buffRefreshFn
     local _buffTitleFS, _buffAddBtn
     local BUFF_POPUP_W = 320
-    local BUFF_ROW_H = 26
+    -- Two lines per row: spellID/name/color/delete on top, Alt Threshold
+    -- toggle+count below it. BUFF_ROW_H is the full row pitch used by both
+    -- layout and the drag-to-reorder math, so it must stay a single constant.
+    local BUFF_LINE1_H = 26
+    local BUFF_ROW_H = 52
     local RefreshBuffEditor  -- forward decl
     -- Drag-to-reorder (list order = buff priority); mirrors the BuildCogPopup 'reorder' row type.
     local _BuffDragTick      -- forward decl; called each frame from popup OnUpdate
@@ -1507,7 +1559,8 @@ initFrame:SetScript("OnEvent", function(self)
     local BUFF_STEP = BUFF_ROW_H + 4
     local BUFF_HELP_TIP =
         "Recolor the bar while you have a buff. The first active buff in the list wins, so order = priority. Overrides threshold coloring while active.\n"
-        .. "You must be tracking the buff in Blizzard CDM, added to EUI CDM, and this only works with CDM trackable buffs."
+        .. "You must be tracking the buff in Blizzard CDM, added to EUI CDM, and this only works with CDM trackable buffs.\n"
+        .. "Alt Threshold: instead of just recoloring, switch the trigger point itself (color and sound) to a different count while the buff is up. Has no effect when Multi-band Coloring is on -- bands never use the single-threshold count."
 
     local function CurrentBuffEntry()
         if not _buffEntryIdx or not _buffGetBarData then return nil end
@@ -1595,7 +1648,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         local input = CreateFrame("EditBox", nil, rf)
         input:SetSize(58, 22)
-        input:SetPoint("LEFT", rf, "LEFT", 16, 0)
+        input:SetPoint("TOPLEFT", rf, "TOPLEFT", 16, -2)
         input:SetFrameLevel(rf:GetFrameLevel() + 2)
         input:SetAutoFocus(false)
         local inFont = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("main") or "Fonts\\FRIZQT__.TTF"
@@ -1612,7 +1665,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Drag grip: list order = buff priority, so rows are draggable
         local grip = CreateFrame("Button", nil, rf)
         grip:SetSize(14, BUFF_ROW_H)
-        grip:SetPoint("LEFT", rf, "LEFT", 0, 0)
+        grip:SetPoint("TOPLEFT", rf, "TOPLEFT", 0, 0)
         grip:SetFrameLevel(rf:GetFrameLevel() + 4)
         local gripFS = grip:CreateFontString(nil, "OVERLAY")
         gripFS:SetFont(inFont, 13, "")
@@ -1674,13 +1727,13 @@ initFrame:SetScript("OnEvent", function(self)
                 local e = ent and ent.buffColors and ent.buffColors[row._idx]
                 if e then e.r, e.g, e.b, e.a = r, g, b, a; if _buffRefreshFn then _buffRefreshFn() end end
             end, true, 19)
-        swatch:SetPoint("RIGHT", rf, "RIGHT", -24, 0)
+        swatch:SetPoint("TOPRIGHT", rf, "TOPRIGHT", -24, -3)
         row.swatch = swatch
         row.swatchSnap = swatchSnap
 
         local delBtn = CreateFrame("Button", nil, rf)
         delBtn:SetSize(14, 14)
-        delBtn:SetPoint("RIGHT", rf, "RIGHT", -2, 0)
+        delBtn:SetPoint("TOPRIGHT", rf, "TOPRIGHT", -2, -6)
         delBtn:SetFrameLevel(rf:GetFrameLevel() + 3)
         local delIcon = delBtn:CreateTexture(nil, "OVERLAY")
         delIcon:SetAllPoints(); delIcon:SetTexture(_bandCloseIcon); delIcon:SetAlpha(0.4)
@@ -1695,6 +1748,58 @@ initFrame:SetScript("OnEvent", function(self)
             end
         end)
         row.delBtn = delBtn
+
+        -- Line 2: Alt Threshold toggle + count. Switches the trigger point
+        -- itself (color and sound) while this buff is active, instead of
+        -- just recoloring. See EllesmereUIResourceBars.lua's
+        -- _activeBuffEntry.useAltThreshold/altThresholdCount consumers.
+        local function _altEntry()
+            local ent = CurrentBuffEntry()
+            return ent and ent.buffColors and ent.buffColors[row._idx]
+        end
+
+        local altToggle, _, altSnap = EllesmereUI.BuildToggleControl(rf, rf:GetFrameLevel() + 2,
+            function() local e = _altEntry(); return (e and e.useAltThreshold) and true or false end,
+            function(v) local e = _altEntry(); if not e then return end e.useAltThreshold = v; if _buffRefreshFn then _buffRefreshFn() end end,
+            { sizeRatio = 0.6 })
+        altToggle:SetPoint("TOPLEFT", rf, "TOPLEFT", 16, -(BUFF_LINE1_H + 6))
+        row.altToggle = altToggle
+        row.altSnap = altSnap
+
+        local altLabel = EllesmereUI.MakeFont(rf, 10, nil, 1, 1, 1)
+        altLabel:SetAlpha(0.6)
+        altLabel:SetPoint("LEFT", altToggle, "RIGHT", 5, 0)
+        altLabel:SetText(EllesmereUI.L("Alt Threshold"))
+
+        local altInput = CreateFrame("EditBox", nil, rf)
+        altInput:SetSize(40, 18)
+        altInput:SetPoint("LEFT", altLabel, "RIGHT", 6, 0)
+        altInput:SetFrameLevel(rf:GetFrameLevel() + 2)
+        altInput:SetAutoFocus(false)
+        altInput:SetFont(inFont, 11, "")
+        altInput:SetTextColor(1, 1, 1, 0.75)
+        altInput:SetJustifyH("CENTER")
+        altInput:SetNumeric(true)
+        altInput:SetMaxLetters(5)
+        local altInBg = altInput:CreateTexture(nil, "BACKGROUND"); altInBg:SetAllPoints()
+        altInBg:SetColorTexture(0.12, 0.12, 0.12, 0.8)
+        EllesmereUI.MakeBorder(altInput, 1, 1, 1, 0.08, PP)
+        local function CommitAltInput(self)
+            if self._cancelCommit then self._cancelCommit = nil; return end
+            local e = _altEntry(); if not e then return end
+            local val = tonumber(self:GetText())
+            e.altThresholdCount = (val and val > 0) and val or nil
+            if _buffRefreshFn then _buffRefreshFn() end
+        end
+        altInput:SetScript("OnEditFocusLost", CommitAltInput)
+        altInput:SetScript("OnEnterPressed", function(self) self:ClearFocus() end)
+        altInput:SetScript("OnEscapePressed", function(self)
+            self._cancelCommit = true
+            local e = _altEntry()
+            self:SetText(e and e.altThresholdCount and tostring(e.altThresholdCount) or "")
+            self:ClearFocus()
+        end)
+        row.altInput = altInput
 
         _buffRows[k] = row
         return row
@@ -1718,6 +1823,11 @@ initFrame:SetScript("OnEvent", function(self)
             row.input:SetText(ent.buffColors[k].spellID and tostring(ent.buffColors[k].spellID) or "")
             if row.RefreshName then row.RefreshName() end
             if row.swatchSnap then row.swatchSnap() end
+            if row.altSnap then row.altSnap() end
+            if row.altInput then
+                local altVal = ent.buffColors[k].altThresholdCount
+                row.altInput:SetText(altVal and tostring(altVal) or "")
+            end
             row.frame:Show()
             curY = curY - BUFF_ROW_H - 4
         end

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -1404,6 +1404,13 @@ initFrame:SetScript("OnEvent", function(self)
         local soundPaths, soundNames, soundOrder = EllesmereUI.GetSoundCatalog()
         for sk, sv in pairs(soundNames) do soundValues[sk] = sv end
         soundValues._menuOpts = {
+            -- Parents the dropdown's popup menu INTO the Color Bands popup
+            -- instead of UIParent, so it inherits the popup's scale and,
+            -- crucially, draws as a child of it rather than competing on raw
+            -- frame level (BuildDropdownMenu hardcodes level 200, well below
+            -- this popup's own level -- unparented, the menu rendered behind
+            -- the popup and only the part spilling past its edges was visible).
+            parent = bandPopup,
             itemHeight = 24, maxTextWidthPct = 0.8, searchable = true,
             iconAtlas = function(key)
                 if key == "none" or not soundPaths[key] then return nil end
@@ -6396,6 +6403,14 @@ initFrame:SetScript("OnEvent", function(self)
 							set = function(v) local e=_thrEnt(); if not e then return end e.thresholdSoundKey=v; RefreshClass() end },
 					},
 				})
+				-- Parent the Sound dropdown's popup menu into this cog popup
+				-- instead of UIParent: BuildDropdownMenu hardcodes its menu
+				-- frame level (200), well below this cog's own level (500), so
+				-- unparented it renders BEHIND the cog and is only visible
+				-- where it spills past the cog's edges. threshCog only exists
+				-- once BuildCogPopup returns, so this has to be set here
+				-- rather than inline in the values table above.
+				threshSoundValues._menuOpts.parent = threshCog
 				local threshCogBtn = CreateFrame("Button", nil, threshRow)
 				threshCogBtn:SetSize(20, 20)
 				threshCogBtn:SetPoint("RIGHT", threshRow, "RIGHT", 0, 0)

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -1455,10 +1455,12 @@ initFrame:SetScript("OnEvent", function(self)
         -- frames (rf:GetFrameLevel(), ~262+) and its click-outside-to-close
         -- catcher (bandPopup:GetFrameLevel()-1 = 259), so the menu still
         -- rendered behind them and clicks on it fell through to the catcher
-        -- instead. Bump it above both once it exists (built lazily on first
-        -- click, hence the hook rather than a one-time SetFrameLevel here).
+        -- instead. Bump its STRATA (not just level -- matches the existing
+        -- talentDD row's "Keep the menu above the cog popups" pattern
+        -- elsewhere in this file) above both once it exists, built lazily on
+        -- first click, hence the hook rather than a one-time set here.
         soundDD:HookScript("OnClick", function(self)
-            if self._ddMenu then self._ddMenu:SetFrameLevel(bandPopup:GetFrameLevel() + 40) end
+            if self._ddMenu then self._ddMenu:SetFrameStrata("TOOLTIP") end
         end)
 
         _bandRows[k] = row
@@ -6431,6 +6433,27 @@ initFrame:SetScript("OnEvent", function(self)
 				-- once BuildCogPopup returns, so this has to be set here
 				-- rather than inline in the values table above.
 				threshSoundValues._menuOpts.parent = threshCog
+				-- BuildCogPopup gives no handle to a DSL row's built dropdown
+				-- widget (unlike the hand-built talentDD row above, which
+				-- hooks its own ddBtn), so there's no button to hook here
+				-- directly. threshCog has exactly one dropdown row, so watch
+				-- the shared EllesmereUI._openDropdownMenu instead: whichever
+				-- menu shows while this popup is visible IS this one.
+				-- HookScript("OnUpdate", ...) is inert while threshCog is
+				-- hidden (WoW skips OnUpdate on hidden frames), so this costs
+				-- nothing when the popup isn't open. Bumping STRATA (not just
+				-- level, matching the talentDD pattern above) guarantees it
+				-- renders above threshCog regardless of BuildDropdownMenu's
+				-- hardcoded frame level (200) -- the same gap that hid and
+				-- made unclickable the per-band Sound dropdown in
+				-- EnsureBandRow before it got this same treatment.
+				threshCog:HookScript("OnUpdate", function()
+					local dm = EllesmereUI._openDropdownMenu
+					if dm and dm:IsShown() and not dm._threshCogStrataFixed then
+						dm:SetFrameStrata("TOOLTIP")
+						dm._threshCogStrataFixed = true
+					end
+				end)
 				local threshCogBtn = CreateFrame("Button", nil, threshRow)
 				threshCogBtn:SetSize(20, 20)
 				threshCogBtn:SetPoint("RIGHT", threshRow, "RIGHT", 0, 0)

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -1168,7 +1168,16 @@ initFrame:SetScript("OnEvent", function(self)
         clickCatcher:SetFrameStrata("FULLSCREEN_DIALOG")
         clickCatcher:SetFrameLevel(bandPopup:GetFrameLevel() - 1)
         clickCatcher:SetAllPoints((EllesmereUI.GetMainFrame and EllesmereUI:GetMainFrame()) or UIParent)
-        clickCatcher:SetScript("OnClick", function() bandPopup:Hide() end)
+        -- Skip the close when an open dropdown menu (e.g. the per-band Sound
+        -- picker) is what's actually under the click -- otherwise the click
+        -- lands on this catcher instead (see the frame-level hook on the
+        -- Sound dropdown in EnsureBandRow) and hides the whole popup instead
+        -- of picking the sound.
+        clickCatcher:SetScript("OnClick", function()
+            local dm = EllesmereUI._openDropdownMenu
+            if dm and dm:IsShown() and dm:IsMouseOver() then return end
+            bandPopup:Hide()
+        end)
         clickCatcher:Hide()
         -- Close on entering combat
         bandPopup:SetScript("OnEvent", function(self, event)
@@ -1440,6 +1449,17 @@ initFrame:SetScript("OnEvent", function(self)
             end)
         soundDD:SetPoint("LEFT", soundLbl, "RIGHT", 6, 0)
         row.soundDD = soundDD
+        -- BuildDropdownMenu hardcodes its menu frame's level to 200 with no
+        -- override -- parenting it into bandPopup (above) fixed which popup
+        -- it renders inside, but 200 is still BELOW this popup's own row
+        -- frames (rf:GetFrameLevel(), ~262+) and its click-outside-to-close
+        -- catcher (bandPopup:GetFrameLevel()-1 = 259), so the menu still
+        -- rendered behind them and clicks on it fell through to the catcher
+        -- instead. Bump it above both once it exists (built lazily on first
+        -- click, hence the hook rather than a one-time SetFrameLevel here).
+        soundDD:HookScript("OnClick", function(self)
+            if self._ddMenu then self._ddMenu:SetFrameLevel(bandPopup:GetFrameLevel() + 40) end
+        end)
 
         _bandRows[k] = row
         return row

--- a/EllesmereUIResourceBars/EUI_ResourceBars_ThresholdSound.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_ThresholdSound.lua
@@ -1,0 +1,86 @@
+-- EUI_ResourceBars_ThresholdSound.lua
+-- Class Resource threshold alert sound: plays a cue on every gain while the
+-- resource is at/above (or, in reverse mode, at/below) its configured
+-- threshold -- not just the initial crossing.
+--
+-- Kept in its own file (mirrors EUI_ResourceBars_EbonMight121.lua) so the
+-- main runtime file only needs a single call at each point it already
+-- resolves `cur` and `useThresh` for a non-secret pip resource. All state
+-- (previous value, throttle, login/zone settle window) lives here.
+--
+-- WoW has no discrete "resource gained a point" event -- UNIT_POWER_UPDATE /
+-- UNIT_POWER_FREQUENT / UNIT_POWER_POINT_CHARGE only mean "power changed, go
+-- re-read it", and already drive UpdateSecondaryResource. Comparing the
+-- freshly-read value against the last-seen one is how a gain is told apart
+-- from a loss or a same-value re-fire; the main file's Essence pip tracker
+-- (_essenceLastCount) uses the same technique for gain/loss detection.
+--
+-- Secret values (WoW 12.0, instanced combat): callers only invoke this from
+-- clean-value (non-secret) branches, so `cur` here is always a plain
+-- comparable number.
+
+local _, ns = ...
+local EllesmereUI = _G.EllesmereUI
+
+local _lastPlay = 0
+local function PlaySoundKey(key)
+    if not key or key == "none" then return end
+    local paths = EllesmereUI.GetSoundCatalog()
+    local path = paths[key]
+    if not path then return end
+    local now = GetTime()
+    if (now - _lastPlay) < 0.3 then return end
+    _lastPlay = now
+    if EllesmereUI._PlayLSMSound then
+        EllesmereUI._PlayLSMSound(path)
+    else
+        PlaySoundFile(path, "Master")
+    end
+end
+
+-- Resynced (not fired) whenever the resolved config generation moves, so a
+-- profile/spec/threshold edit never causes a spurious cue.
+local _prevCur, _prevGen
+
+-- Settle window after a loading screen: a zone-in that lands above the
+-- threshold must not blare immediately.
+local _settleUntil = 0
+local settleFrame = CreateFrame("Frame")
+settleFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+settleFrame:SetScript("OnEvent", function()
+    _settleUntil = GetTime() + 2
+    _prevGen = nil
+end)
+
+-- entry:     resolved thresholdSpecs entry for the active spec (has
+--            thresholdSoundEnabled / thresholdSoundKey), or nil when the
+--            Threshold toggle itself is off
+-- cur:       current resource count (already resolved by the caller; must
+--            be a clean, comparable number -- never a secret value)
+-- useThresh: the pre-multi-band threshold boolean the caller already
+--            computed for this update
+function ns.EvalThresholdSound(entry, cur, useThresh)
+    if not entry or not entry.thresholdSoundEnabled then
+        _prevCur = cur
+        return
+    end
+    -- Sound is single-threshold only, mirroring the cog's own gating
+    -- (Threshold Sound is greyed out while Multi-band coloring is on).
+    if entry.multiBandEnabled then return end
+
+    if ns.CfgGen ~= _prevGen then
+        _prevGen = ns.CfgGen
+        _prevCur = cur
+        return
+    end
+    if GetTime() < _settleUntil then
+        _prevCur = cur
+        return
+    end
+
+    local gained = _prevCur ~= nil and cur > _prevCur
+    _prevCur = cur
+    if gained and useThresh then
+        PlaySoundKey(entry.thresholdSoundKey)
+    end
+end

--- a/EllesmereUIResourceBars/EUI_ResourceBars_ThresholdSound.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_ThresholdSound.lua
@@ -84,3 +84,75 @@ function ns.EvalThresholdSound(entry, cur, useThresh)
         PlaySoundKey(entry.thresholdSoundKey)
     end
 end
+
+-------------------------------------------------------------------------------
+-- Per-band alert sound (multi-band coloring): plays a distinct cue as the
+-- resource crosses into a HIGHER band on a gain -- same "gain, not every
+-- tick" spirit as EvalThresholdSound above, but keyed on which band matches
+-- instead of the raw count.
+--
+-- Rank, not raw count: bands[i] holds { to, r, g, b, a, soundKey }, sorted
+-- ascending by `to`. FindCountBand's matched index moves monotonically with
+-- `cur` in BOTH directions (forward scan for "Up to", backward scan for
+-- "From"), so tracking "which index matched" and firing when it INCREASES is
+-- a correct, direction-agnostic gain signal. A raw _prevCur comparison can't
+-- do this cleanly: FindCountBand returns nil on both sides of the band list,
+-- and nil means something different per direction (above the top band for
+-- "Up to", below the first band for "From") -- BandRank folds both cases into
+-- a single monotonic 0..#bands+1 scale so "rank increased" always means "cur
+-- moved toward the more severe end", regardless of direction.
+-------------------------------------------------------------------------------
+local function BandRank(bands, cur, reverse)
+    if not bands or #bands == 0 then return 0 end
+    local band = ns.FindCountBand and ns.FindCountBand(bands, cur, reverse)
+    if not band then
+        -- "Up to": no match = above every band (most severe, no sound to
+        -- play there -- nothing configured past the last band). "From": no
+        -- match = below every band (least severe, baseline).
+        return reverse and 0 or (#bands + 1)
+    end
+    for i = 1, #bands do
+        if bands[i] == band then return i end
+    end
+    return 0
+end
+
+local _prevRank
+
+-- bands:  the resolved band array for the active entry (already includes the
+--         sp.bands fallback the caller applied via ResolveBandConfig). The
+--         caller only invokes this from inside its own "band mode is on"
+--         branch (_tsBandOn/bandOn), so there is no separate enabled flag to
+--         re-check here -- unlike EvalThresholdSound's `entry`, which the
+--         caller passes unconditionally every tick and which can legitimately
+--         be nil (single threshold off) while band mode is independently on.
+-- cur:    current resource count -- same clean-value contract as
+--         EvalThresholdSound; never call this with a possibly-secret value
+-- reverse: the resolved band direction ("Up to"/false vs "From"/true)
+function ns.EvalBandSound(bands, cur, reverse)
+    if not bands or #bands == 0 then
+        _prevRank = nil
+        return
+    end
+    if ns.CfgGen ~= _prevGen then
+        _prevGen = ns.CfgGen
+        _prevRank = BandRank(bands, cur, reverse)
+        return
+    end
+    if GetTime() < _settleUntil then
+        _prevRank = BandRank(bands, cur, reverse)
+        return
+    end
+
+    local rank = BandRank(bands, cur, reverse)
+    local prevRank = _prevRank
+    _prevRank = rank
+    -- prevRank can still be nil on the very first call of a session (no
+    -- resync branch has run yet) -- just establish the baseline, no cue,
+    -- mirroring EvalThresholdSound's own resync-then-observe behavior.
+    if prevRank == nil then return end
+    if rank > prevRank and rank >= 1 and rank <= #bands then
+        local band = bands[rank]
+        if band and band.soundKey then PlaySoundKey(band.soundKey) end
+    end
+end

--- a/EllesmereUIResourceBars/EUI_ResourceBars_ThresholdSound.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_ThresholdSound.lua
@@ -118,6 +118,14 @@ local function BandRank(bands, cur, reverse)
 end
 
 local _prevRank
+-- Own generation tracker, NOT shared with EvalThresholdSound's _prevGen: the
+-- two are called back-to-back at every wiring site (threshold unconditionally,
+-- then band inside "if band mode on"). If they shared _prevGen, whichever
+-- runs first on the tick ns.CfgGen changes would consume the resync, and the
+-- other would compare against a stale baseline from before the edit instead
+-- of resyncing -- silently breaking the "no spurious cue after a
+-- profile/spec/threshold edit" guarantee for whichever call comes second.
+local _prevGenBand
 
 -- bands:  the resolved band array for the active entry (already includes the
 --         sp.bands fallback the caller applied via ResolveBandConfig). The
@@ -134,8 +142,8 @@ function ns.EvalBandSound(bands, cur, reverse)
         _prevRank = nil
         return
     end
-    if ns.CfgGen ~= _prevGen then
-        _prevGen = ns.CfgGen
+    if ns.CfgGen ~= _prevGenBand then
+        _prevGenBand = ns.CfgGen
         _prevRank = BandRank(bands, cur, reverse)
         return
     end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1235,7 +1235,7 @@ local DEFAULTS = {
             thresholdReverse = false,  -- bar-type only: threshold color below the value (spenders)
             thresholdR = 0x0c/255, thresholdG = 0xd2/255, thresholdB = 0x9d/255, thresholdA = 1,
             tickValues  = "",   -- comma-separated absolute resource values for tick marks (bar-type only)
-            thresholdSpecs = {},  -- per-spec threshold/hash entries: { specIDs={0}, hashValues="", thresholdCount=3, thresholdPartialOnly=false }
+            thresholdSpecs = {},  -- per-spec threshold/hash entries: { specIDs={0}, hashValues="", thresholdCount=3, thresholdPartialOnly=false, thresholdSoundEnabled=false, thresholdSoundKey="none" }
             thresholdTextInstead = false,
             -- Multi-band coloring
             multiBandEnabled = false,
@@ -5684,6 +5684,7 @@ local function UpdateSecondaryResource()
             -- Direction: "From" (>=, default) or "Up to" (<=, thresholdReverse).
             local useThresh = _tsEntry and ((_tsReverse and cur <= _tsThreshCount)
                 or ((not _tsReverse) and (cur >= _tsThreshCount or _enhRealCur >= _tsThreshCount)))
+            if ns.EvalThresholdSound then ns.EvalThresholdSound(_tsEntry, _enhRealCur, useThresh) end
             local tr, tg, tb = _tsR, _tsG, _tsB
             -- Multi-band: whole bar takes the color of the band containing `cur`.
             if _tsBandOn and not _enhFive then
@@ -5751,6 +5752,7 @@ local function UpdateSecondaryResource()
         -- Direction: "From" (>=, default) or "Up to" (<=, thresholdReverse).
         local useThresh = _tsEntry and ((_tsReverse and cur <= _tsThreshCount)
             or ((not _tsReverse) and cur >= _tsThreshCount))
+        if ns.EvalThresholdSound then ns.EvalThresholdSound(_tsEntry, cur, useThresh) end
         local tr, tg, tb = _tsR, _tsG, _tsB
         -- Multi-band
         if _tsBandOn then

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -4475,7 +4475,7 @@ local function UpdateIronfurBar()
     -- both single-threshold and multi-band match against `count`; multi wins when
     -- enabled with bands, else the single stack-count threshold (FindCountBand).
     local bandOn, bands, _bandMode, bandRev = ResolveBandConfig(sp, tsEntry)
-    if _buffActive and not (_activeBuffEntry and _activeBuffEntry.useAltThreshold) then
+    if _buffActive and not _activeBuffEntry.useAltThreshold then
         tsEntry = nil; bandOn = false
     end
     -- Active (threshold/band) color is computed separately from the base so it can

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -942,6 +942,9 @@ local function FindCountBand(bands, count, reverse)
     end
     return nil
 end
+-- Exposed so EUI_ResourceBars_ThresholdSound.lua can resolve the same match
+-- for its per-band sound rank, without re-deriving the boundary logic.
+ns.FindCountBand = FindCountBand
 
 -- Multi-stop step ColorCurve from band fractions. `stops` is ordered
 -- { frac=<0..1 upper boundary>, r, g, b, a }. Secret-safe: evaluated C-side by
@@ -4351,18 +4354,28 @@ local function PlayerHasBuff(spellID)
     return false
 end
 
--- Buff coloring for the class-resource bar
-local function ActiveBuffColor(entry)
+-- Resolves the active buffColors row for the class-resource bar (first
+-- match wins), or nil when no tracked buff is up. Shared by the color
+-- override below and by the alt-threshold override in UpdateSecondaryResource
+-- / UpdateIronfurBar, so the buff scan runs once per tick rather than twice.
+local function ActiveBuffEntry(entry)
     if not entry or not entry.buffColorEnabled then return nil end
     local list = entry.buffColors
     if not list then return nil end
     for i = 1, #list do
         local e = list[i]
         if e.spellID and PlayerHasBuff(e.spellID) then
-            return e.r, e.g, e.b, e.a
+            return e
         end
     end
     return nil
+end
+
+-- Buff coloring for the class-resource bar
+local function ActiveBuffColor(entry)
+    local e = ActiveBuffEntry(entry)
+    if not e then return nil end
+    return e.r, e.g, e.b, e.a
 end
 -- True when the current spec's resolved threshold entry tracks any buff (drives
 -- the aura poll / refresh so the bar recolors as buffs come and go).
@@ -4439,25 +4452,52 @@ local function UpdateIronfurBar()
         r, g, b, a = sp.fillR, sp.fillG, sp.fillB, 1
     end
     local tsEntry = ResolveThresholdSpecEntry(sp)
+    local _activeBuffEntry = ActiveBuffEntry(tsEntry)
+    -- A tracked buff can swap in an alternate trigger point instead of just
+    -- recoloring, mirroring UpdateSecondaryResource's alt-threshold override.
+    local _ifThreshCount = tsEntry and (tsEntry.thresholdCount or sp.thresholdCount or 3)
+    if tsEntry and _activeBuffEntry and _activeBuffEntry.useAltThreshold and _activeBuffEntry.altThresholdCount then
+        _ifThreshCount = _activeBuffEntry.altThresholdCount
+    end
     -- Capture "recolor text instead" BEFORE the buff nils tsEntry below so the flag
     -- survives (buff + text-instead => buff colors the count text, fill stays base).
     local _tiWanted = (tsEntry and tsEntry.thresholdTextInstead and sp.showText) and true or false
     -- Buff coloring wins: a tracked buff on this entry overrides the base color and
-    -- suppresses the stack-count threshold/bands below.
-    local _bfr, _bfg, _bfb, _bfa = ActiveBuffColor(tsEntry)
-    local _buffActive = _bfr ~= nil
+    -- suppresses the stack-count threshold/bands below, unless it defines an alt
+    -- threshold -- then the threshold stays live, just against the swapped count.
+    local _bfr, _bfg, _bfb, _bfa
+    if _activeBuffEntry then
+        _bfr, _bfg, _bfb, _bfa = _activeBuffEntry.r, _activeBuffEntry.g, _activeBuffEntry.b, _activeBuffEntry.a
+    end
+    local _buffActive = _activeBuffEntry ~= nil
     if _buffActive and not _tiWanted then r, g, b, a = _bfr or r, _bfg or g, _bfb or b, _bfa or a end
     -- Ironfur colors by active stack count, NOT the bar's duration fraction, so
     -- both single-threshold and multi-band match against `count`; multi wins when
     -- enabled with bands, else the single stack-count threshold (FindCountBand).
     local bandOn, bands, _bandMode, bandRev = ResolveBandConfig(sp, tsEntry)
-    if _buffActive then tsEntry = nil; bandOn = false end
+    if _buffActive and not (_activeBuffEntry and _activeBuffEntry.useAltThreshold) then
+        tsEntry = nil; bandOn = false
+    end
     -- Active (threshold/band) color is computed separately from the base so it can
     -- route to the fill or the count text. `triggered` = the stack count satisfies
     -- the threshold/band.
     local arR, arG, arB, arA = r, g, b, a
     local triggered = false
+    -- Single-threshold verdict, computed once regardless of band state: sound
+    -- always evaluates against the plain threshold (EvalThresholdSound itself
+    -- no-ops when multiBandEnabled is set), while band coloring below may
+    -- override `triggered`/the fill color for display only.
+    -- Direction: "From" (>=, default) or "Up to" (<=, thresholdReverse).
+    local threshOver = false
+    if tsEntry and tsEntry.thresholdEnabled ~= false then
+        local threshCount = _ifThreshCount or 3
+        local reverse = tsEntry.thresholdReverse
+        if reverse == nil then reverse = sp.thresholdReverse end
+        threshOver = (reverse and count <= threshCount) or ((not reverse) and count >= threshCount)
+    end
+    if ns.EvalThresholdSound then ns.EvalThresholdSound(tsEntry, count, threshOver) end
     if bandOn then
+        if ns.EvalBandSound then ns.EvalBandSound(bands, count, bandRev) end
         local band = FindCountBand(bands, count, bandRev)
         if band then
             arR = band.r or r
@@ -4466,15 +4506,12 @@ local function UpdateIronfurBar()
             arA = band.a or a
             triggered = true
         end
-    elseif tsEntry and tsEntry.thresholdEnabled ~= false then
-        local threshCount = tsEntry.thresholdCount or sp.thresholdCount or 3
-        if count >= threshCount then
-            arR = tsEntry.thresholdR or sp.thresholdR or r
-            arG = tsEntry.thresholdG or sp.thresholdG or g
-            arB = tsEntry.thresholdB or sp.thresholdB or b
-            arA = tsEntry.thresholdA or sp.thresholdA or a
-            triggered = true
-        end
+    elseif threshOver then
+        arR = tsEntry.thresholdR or sp.thresholdR or r
+        arG = tsEntry.thresholdG or sp.thresholdG or g
+        arB = tsEntry.thresholdB or sp.thresholdB or b
+        arA = tsEntry.thresholdA or sp.thresholdA or a
+        triggered = true
     end
     local _spTextInstead = _tiWanted
     local ft = secondaryBar:GetStatusBarTexture()
@@ -4490,8 +4527,10 @@ local function UpdateIronfurBar()
 
     if sp.showText and secondaryFrame and secondaryFrame._countText then
         secondaryFrame._countText:SetText(count > 0 and tostring(count) or "")
-        -- Buff + text-instead: use the buff color as the text base (there's no
-        -- stack-threshold trigger while a buff is up), so colorText paints it.
+        -- Buff + text-instead: use the buff color as the text base while
+        -- buffed and no alt threshold overrides it (triggered/arR already
+        -- reflect the swapped threshold when one is set), so colorText paints
+        -- whichever base is right.
         local _tbR, _tbG, _tbB = sp.textR or 1, sp.textG or 1, sp.textB or 1
         if _buffActive and _spTextInstead then _tbR, _tbG, _tbB = _bfr, _bfg, _bfb end
         colorText(_spTextInstead, triggered, arR, arG, arB, _tbR, _tbG, _tbB)
@@ -4747,11 +4786,21 @@ local function UpdateSecondaryResource()
     -- Per-spec threshold entry, resolved once per update
     local _tsEntry = ResolveThresholdSpecEntry(sp)
     local _buffEntry = _tsEntry
+    -- Resolved once, shared by the alt-threshold override below and the
+    -- fill-color override further down (was two separate PlayerHasBuff scans).
+    local _activeBuffEntry = ActiveBuffEntry(_buffEntry)
     -- Per-entry thresholdEnabled (absent field = true, for migrated entries)
     local _tsEnabled = _tsEntry and (_tsEntry.thresholdEnabled ~= false) or false
     local _tsBandOn, _tsBands, _tsBandMode, _tsBandReverse = ResolveBandConfig(sp, _tsEntry)
     if not _tsEnabled then _tsEntry = nil end
     local _tsThreshCount = _tsEntry and _tsEntry.thresholdCount or sp.thresholdCount
+    -- A tracked buff can swap in an alternate trigger point (e.g. alert
+    -- earlier while a proc is up) instead of just recoloring -- only when the
+    -- matched buffColors row opts in, so every existing profile (buff color
+    -- only, no alt threshold) is unaffected.
+    if _tsEntry and _activeBuffEntry and _activeBuffEntry.useAltThreshold and _activeBuffEntry.altThresholdCount then
+        _tsThreshCount = _activeBuffEntry.altThresholdCount
+    end
     -- Enhance Five Bar needs a threshold of at least 7 (5 pips + overflow). Clamp
     -- the value used this update, and persist a stale entry saved below 7 so it
     -- actually updates (Enhancement entry only).
@@ -4818,14 +4867,23 @@ local function UpdateSecondaryResource()
     -- A tracked buff overrides the fill (buff wins over threshold). With "recolor
     -- text instead" on, the buff colors the count TEXT (done at the end of this
     -- function) and fill/pips stay at their base color.
-    local _bfr, _bfg, _bfb, _bfa = ActiveBuffColor(_buffEntry)
-    local _buffActive = _bfr ~= nil
+    local _bfr, _bfg, _bfb, _bfa
+    if _activeBuffEntry then
+        _bfr, _bfg, _bfb, _bfa = _activeBuffEntry.r, _activeBuffEntry.g, _activeBuffEntry.b, _activeBuffEntry.a
+    end
+    local _buffActive = _activeBuffEntry ~= nil
     if _buffActive then
         if not _spTextInstead then
             r, g, b, a = _bfr or r, _bfg or g, _bfb or b, _bfa or a
         end
-        _tsEntry = nil
-        _tsBandOn = false
+        -- Threshold/band coloring is suppressed while buffed UNLESS the buff
+        -- carries an alt threshold, in which case _tsThreshCount was already
+        -- swapped above and every downstream branch should keep evaluating
+        -- against it (coloring, bands, and sound alike).
+        if not _activeBuffEntry.useAltThreshold then
+            _tsEntry = nil
+            _tsBandOn = false
+        end
     end
 
     -- Points: read once. A secret can't survive the comparison-based points
@@ -4856,11 +4914,15 @@ local function UpdateSecondaryResource()
             end
         end
 
-        -- Threshold: color ready runes differently when enough are available
-        local runeUseThresh = _tsEntry and readyN >= _tsThreshCount
+        -- Threshold: color ready runes differently when enough are available.
+        -- Direction: "From" (>=, default) or "Up to" (<=, thresholdReverse).
+        local runeUseThresh = _tsEntry and ((_tsReverse and readyN <= _tsThreshCount)
+            or ((not _tsReverse) and readyN >= _tsThreshCount))
+        if ns.EvalThresholdSound then ns.EvalThresholdSound(_tsEntry, readyN, runeUseThresh) end
         local tr, tg, tb = _tsR, _tsG, _tsB
         -- Multi-band threshold
         if _tsBandOn then
+            if ns.EvalBandSound then ns.EvalBandSound(_tsBands, readyN, _tsBandReverse) end
             local band = FindCountBand(_tsBands, readyN, _tsBandReverse)
             if band then
                 runeUseThresh = true
@@ -5106,6 +5168,16 @@ local function UpdateSecondaryResource()
                     -- if a rebuild reset the fill in that window.
                     staggerPct = secondaryBar._staggerPctCache
                 end
+                -- Threshold sound: computed unconditionally (theme/buff/band
+                -- state below only affects the FILL color) off the same
+                -- taint-safe staggerPct the color branch uses, so it survives
+                -- intermittent secrecy the same way.
+                if ns.EvalThresholdSound and _tsEntry and staggerPct then
+                    local _stOver
+                    if _tsReverse then _stOver = staggerPct <= (_tsThreshCount or 30)
+                    else _stOver = staggerPct >= (_tsThreshCount or 30) end
+                    ns.EvalThresholdSound(_tsEntry, staggerPct, _stOver)
+                end
                 if _buffActive then
                     local _sft = secondaryBar:GetStatusBarTexture()
                     if _sft then
@@ -5152,6 +5224,12 @@ local function UpdateSecondaryResource()
                 -- Prot Ignore Pain: total absorbs vs the IP cap (30% max health) --
                 -- the only readable source, since aura stack data is fully secret.
                 -- A secret absorb value flows into SetValue via the smooth target.
+                -- No threshold sound here: unlike Stagger, there is no persisted
+                -- clean-percent fallback for this resource, so no comparable value
+                -- is ever available to gate a gain check. (IP.value, populated by
+                -- a separate text-hook driver at a different cadence, is
+                -- occasionally clean but not a fit for EvalThresholdSound's
+                -- per-render-tick assumptions -- deliberately not used here.)
                 cur = UnitGetTotalAbsorbs("player") or 0
                 maxC = UnitHealthMax("player")
                 if (issecretvalue and issecretvalue(maxC)) or not maxC or maxC <= 0 then
@@ -5159,6 +5237,25 @@ local function UpdateSecondaryResource()
                 else
                     maxC = maxC * IP.CAP
                 end
+            end
+            -- Threshold sound for Maelstrom/Insanity/Focus/Lunar Power: unlike
+            -- their fill color (a ColorCurve evaluated C-side via
+            -- UnitPowerPercent specifically because cur/maxC can be secret in
+            -- combat), a sound decision needs a real Lua comparison. Best
+            -- effort: only evaluate on ticks where both are clean; stay silent
+            -- otherwise. This is a client limitation (the value is genuinely
+            -- unreadable), not something more guarding can fix.
+            if ns.EvalThresholdSound and _tsEntry
+               and (powerType == "MAELSTROM_BAR" or powerType == "INSANITY_BAR"
+                    or powerType == "FOCUS_BAR" or powerType == "LUNAR_POWER_BAR")
+               and not (issecretvalue and (issecretvalue(cur) or issecretvalue(maxC)))
+               and maxC and maxC > 0 then
+                local _bpPct = cur / maxC * 100
+                local _bpThresh = _tsThreshCount or 30
+                if _tsEntry.thresholdMode == "value" then _bpThresh = math.min(100, _bpThresh / maxC * 100) end
+                local _bpOver
+                if _tsReverse then _bpOver = _bpPct <= _bpThresh else _bpOver = _bpPct >= _bpThresh end
+                ns.EvalThresholdSound(_tsEntry, _bpPct, _bpOver)
             end
             -- Brewmaster stagger ceiling
             local barMax = maxC
@@ -5259,17 +5356,35 @@ local function UpdateSecondaryResource()
                         else
                             ft:SetVertexColor(r, g, b, a)
                         end
-                    elseif _tsEntry and powerType == "SOUL_FRAGMENTS_DEVOURER" then
-                        local threshVal = _tsThreshCount or 30
-                        if _tsEntry.thresholdMode ~= "value" and maxC and maxC > 0 then
-                            threshVal = maxC * threshVal / 100
+                    elseif (_tsEntry or _tsBandOn) and powerType == "SOUL_FRAGMENTS_DEVOURER" then
+                        -- cur is always a clean Lua number here (GetSoulFragments
+                        -- reads aura .applications, never UnitPower), so unlike
+                        -- the ColorCurve types above this can do a plain Lua
+                        -- comparison AND drive the threshold sound directly.
+                        local _tsThreshVal = _tsThreshCount or 30
+                        if _tsEntry and _tsEntry.thresholdMode ~= "value" and maxC and maxC > 0 then
+                            _tsThreshVal = maxC * _tsThreshVal / 100
+                        end
+                        local over = _tsEntry and ((_tsReverse and cur <= _tsThreshVal)
+                            or ((not _tsReverse) and cur >= _tsThreshVal))
+                        if ns.EvalThresholdSound then ns.EvalThresholdSound(_tsEntry, cur, over) end
+                        local tr, tg, tb = _tsR or 1, _tsG or 0.2, _tsB or 0.2
+                        if _tsBandOn then
+                            if ns.EvalBandSound then ns.EvalBandSound(_tsBands, cur, _tsBandReverse) end
+                            local band = FindCountBand(_tsBands, cur, _tsBandReverse)
+                            if band then
+                                over = true
+                                tr, tg, tb = band.r or tr, band.g or tg, band.b or tb
+                            else
+                                over = false
+                            end
                         end
                         if _spTextInstead then
                             -- Fill at base; tint the count text when at/over the threshold.
                             ft:SetVertexColor(r, g, b, a)
-                            colorText(true, cur >= threshVal, _tsR or 1, _tsG or 0.2, _tsB or 0.2, _spTextBaseR, _spTextBaseG, _spTextBaseB)
-                        elseif cur >= threshVal then
-                            ft:SetVertexColor(_tsR or 1, _tsG or 0.2, _tsB or 0.2, _tsA or 1)
+                            colorText(true, over, tr, tg, tb, _spTextBaseR, _spTextBaseG, _spTextBaseB)
+                        elseif over then
+                            ft:SetVertexColor(tr, tg, tb, _tsA or 1)
                         else
                             ft:SetVertexColor(r, g, b, a)
                         end
@@ -5688,6 +5803,7 @@ local function UpdateSecondaryResource()
             local tr, tg, tb = _tsR, _tsG, _tsB
             -- Multi-band: whole bar takes the color of the band containing `cur`.
             if _tsBandOn and not _enhFive then
+                if ns.EvalBandSound then ns.EvalBandSound(_tsBands, cur, _tsBandReverse) end
                 local band = FindCountBand(_tsBands, cur, _tsBandReverse)
                 if band then
                     useThresh = true
@@ -5756,6 +5872,7 @@ local function UpdateSecondaryResource()
         local tr, tg, tb = _tsR, _tsG, _tsB
         -- Multi-band
         if _tsBandOn then
+            if ns.EvalBandSound then ns.EvalBandSound(_tsBands, cur, _tsBandReverse) end
             local band = FindCountBand(_tsBands, cur, _tsBandReverse)
             if band then
                 useThresh = true

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.toc
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.toc
@@ -12,6 +12,7 @@
 # Main Luas
 EllesmereUIResourceBars.lua
 EUI_ResourceBars_EbonMight121.lua
+EUI_ResourceBars_ThresholdSound.lua
 
 # Options
 EUI_ResourceBars_Helpers.lua


### PR DESCRIPTION
## Summary

Adds a configurable alert sound, per threshold entry, that plays each time a
class resource gains a point while at/above (or, in reverse mode, at/below)
the configured threshold — alongside the existing color-band system.

- New `EUI_ResourceBars_ThresholdSound.lua`: owns sound state, gain detection
  via cur/prevCur comparison, a 0.3s throttle, and a login/zone settle
  window.
- Shared sound catalogue via `EllesmereUI.GetSoundCatalog()` (16 bundled
  sounds + LibSharedMedia entries, memoized on first call), replacing
  copy-pasted tables across Chat/CDM/QoL/RaidFrames.
- Per-band alert sound alongside the existing color bands.
- Full UI in the Threshold Options cog: Threshold Sound toggle, Sound
  dropdown with speaker-preview icon, disabled/greyed gating, Alt Threshold
  support.

## Fixes bundled in

Wiring the sound hook into every resource-bar render path surfaced a batch
of pre-existing bugs, fixed here:

- Threshold Sound never fired for Devourer, Runes, Ironfur, Brewmaster
  Stagger, or the Maelstrom/Insanity/Focus/Lunar Power bars — only the two
  pip-type render paths called `EvalThresholdSound`.
- Devourer, Runes and Ironfur hardcoded a `>=` comparison, ignoring the
  Direction ("Up to") toggle.
- Sound dropdown menus rendered behind their own popup and were unclickable
  (band Sound dropdown, and later the same bug in threshCog's Sound
  dropdown, twice).
- `EvalBandSound` needed its own generation tracker to avoid stale state.
- Assorted cleanup: redundant nil-check in Ironfur's alt-threshold gate,
  nil-popup indexing crash in threshCog's Sound-dropdown wiring.

Maelstrom/Insanity/Focus/Lunar Power's color is evaluated C-side because
`cur` can be a secret value in instanced combat (WoW 12.0); sound for those
is best-effort and silently skipped when `cur`/`maxC` aren't clean —
documented client limitation, not a bug. Ignore Pain stays unwired: no clean
comparable value exists for it.

## Test plan

- Verified in-game via the integration/dev branch (`local/all-features`,
  which has this feature merged and deployed to a live client) across
  multiple classes/specs: class resource pips, Devourer soul fragments,
  Runes, Ironfur, Brewmaster Stagger, and the ColorCurve-driven bars
  (Maelstrom/Insanity/Focus/Lunar Power).
- Confirmed threshold sound and per-band sound both fire correctly in
  normal and reverse ("Up to") direction modes, with Alt Threshold active.
- Confirmed Sound dropdown menus in the Threshold Options cog open, render
  in front of their popup, and are clickable for both band and threshold
  sound rows.