### PR TITLE
fix(itemlevel): refresh overlays from item locations

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -146,6 +146,13 @@ local function IsGearItem(itemLink)
     local _, _, _, _, _, classID = GetItemInfoInstant(itemLink)
     return classID == ITEM_CLASS_WEAPON or classID == ITEM_CLASS_ARMOR
 end
+local function GetItemLevelAtLocation(loc, itemLink)
+    if loc and loc:IsValid() and C_Item.DoesItemExist(loc) then
+        local level = C_Item.GetCurrentItemLevel(loc)
+        if level and level > 0 then return level end
+    end
+    return itemLink and C_Item.GetDetailedItemLevelInfo(itemLink) or nil
+end
 local function GetFont() return (EUI.GetFontPath and EUI.GetFontPath("bags")) or "Fonts\\FRIZQT__.TTF" end
 local function GetOutline() return (EUI.GetFontOutlineFlag and EUI.GetFontOutlineFlag("bags")) or "" end
 local function SetBagFont(fs, size)
@@ -5050,17 +5057,19 @@ function EUI_Bags:RefreshInventory()
                 d.bag = bag; d.slot = slot; d.info = info; d.itemLink = itemLink
                 -- Pre-cache per-item data for RenderButton (zero API calls at render time)
                 if itemLink then
-                    local _, _, q, ilvl, _, _, _, _, _, _, _, _, _, bindType = GetItemInfo(itemLink)
+                    local _, _, q, _, _, _, _, _, _, _, _, _, _, bindType = GetItemInfo(itemLink)
+                    local loc = ItemLocation:CreateFromBagAndSlot(bag, slot)
                     -- Slot-grouping fields (_equipSlot/_classID/_subclassID) are NOT
                     -- pre-cached here: GetArmorySlotBucket fetches them lazily, only
                     -- for gear items and only while Group Armory by Slot is on, so the
                     -- feature costs nothing on the refresh path when disabled.
                     d._giQuality = q
-                    d._giIlvl = ilvl
                     d._giBindType = bindType
                     -- Track rank + cooldown: only for types that need them
                     local isGear = IsGearItem(itemLink)
                     d._isGear = isGear
+                    d._giIlvl = isGear and BP().showItemlevelInBags ~= false
+                        and GetItemLevelAtLocation(loc, itemLink) or nil
                     if isGear and GetUpgradeTrack then
                         local rankText, trackColor = GetUpgradeTrack(itemLink)
                         if rankText and rankText ~= "" then
@@ -5069,7 +5078,6 @@ function EUI_Bags:RefreshInventory()
                         end
                     end
                     -- Warbound check (warbank dim overlay) + WuE bind check (gear only, when bind-type text is enabled).
-                    local loc = ItemLocation:CreateFromBagAndSlot(bag, slot)
                     if loc and C_Item.DoesItemExist(loc) then
                         if C_Bank and C_Bank.IsItemAllowedInBankType then
                             d._isWarbound = C_Bank.IsItemAllowedInBankType(Enum.BankType.Account, loc)
@@ -6656,8 +6664,10 @@ function EUI_BagsReagent:RefreshInventory()
                 local showItemlevel = BP().showItemlevelInBags ~= false
                 if showItemlevel then
                     if itemLink then
-                        local _, _, quality, level = GetItemInfo(itemLink)
+                        local _, _, quality = GetItemInfo(itemLink)
                         if IsGearItem(itemLink) then
+                            local loc = ItemLocation:CreateFromBagAndSlot(data.bag, data.slot)
+                            local level = GetItemLevelAtLocation(loc, itemLink)
                             local fs = BP().itemlevelFontSize or 12
                             btn.ItemLevelText:SetFont(STANDARD_TEXT_FONT, fs, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
                             btn.ItemLevelText:SetText(level or "")

--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -60,6 +60,13 @@ local function IsGearItem(itemLink)
     local _, _, _, _, _, classID = GetItemInfoInstant(itemLink)
     return classID == ITEM_CLASS_WEAPON or classID == ITEM_CLASS_ARMOR
 end
+local function GetItemLevelAtLocation(loc, itemLink)
+    if loc and loc:IsValid() and C_Item.DoesItemExist(loc) then
+        local level = C_Item.GetCurrentItemLevel(loc)
+        if level and level > 0 then return level end
+    end
+    return itemLink and C_Item.GetDetailedItemLevelInfo(itemLink) or nil
+end
 local function GetAccentRGB()
     if EUI.GetAccentColor then return EUI.GetAccentColor() end
     return 0.05, 0.82, 0.62
@@ -1909,16 +1916,18 @@ function EUI_Bank:RefreshBank()
             local showBindType = isGear and not info.isBound and BP().bagDisplayBindType
             local showIlvl = isGear and BP().showItemlevelInBags ~= false
             local giIlvl, giBindType
+            local loc
             if showBindType or showIlvl then
-                local _, _, _, i4, _, _, _, _, _, _, _, _, _, b14 = GetItemInfo(itemLink)
-                giIlvl, giBindType = i4, b14
+                local _, _, _, _, _, _, _, _, _, _, _, _, _, b14 = GetItemInfo(itemLink)
+                loc = ItemLocation:CreateFromBagAndSlot(bagID, slot)
+                giIlvl = showIlvl and GetItemLevelAtLocation(loc, itemLink) or nil
+                giBindType = b14
             end
 
             -- Bind Type : BoE / WuE bottom-left (gear only)
             if btn.BindTypeText then
                 if showBindType then
                     local isWuE = false
-                    local loc = ItemLocation:CreateFromBagAndSlot(bagID, slot)
                     if loc and C_Item.DoesItemExist(loc) then
                         isWuE = C_Item.IsBoundToAccountUntilEquip(loc)
                     end

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -4449,7 +4449,7 @@ end
 --  Equipment Flyout item levels -- Blizzard's gear flyout (hover a character-
 --  sheet slot -> popup of same-slot bag/equipped items) only shows icons; when
 --  enabled, overlays each button with the item's level, coloured by quality. Hooks
---  EquipmentFlyout_DisplayButton (fires per button on populate) and reads EllesmereUIDB
+--  EquipmentFlyout_UpdateItems (after every flyout shape is populated) and reads EllesmereUIDB
 --  live, so the toggle applies to the next flyout with no reload. Toggle: EllesmereUIDB.flyoutItemLevels (Quality of Life -> UI).
 -------------------------------------------------------------------------------
 do
@@ -4472,7 +4472,13 @@ do
             end
             return
         end
-        -- Equipped / bank inventory slot.
+        -- Equipped inventory slot.
+        if ItemLocation then
+            local loc = ItemLocation:CreateFromEquipmentSlot(slot)
+            if loc and loc:IsValid() and C_Item.DoesItemExist(loc) then
+                return C_Item.GetCurrentItemLevel(loc), C_Item.GetItemQuality(loc), C_Item.GetItemLink(loc)
+            end
+        end
         local link = GetInventoryItemLink("player", slot)
         if link then
             local quality = GetInventoryItemQuality and GetInventoryItemQuality("player", slot)
@@ -4483,8 +4489,8 @@ do
     -- Item level + quality + link for a flyout button. Handles all three flyout
     -- shapes: modern buttons storing an ItemLocation object; retail packed location
     -- via EquipmentManager_GetLocationData; older clients via EquipmentManager_UnpackLocation.
-    local function ButtonItemInfo(button)
-        if button.GetItemLocation then
+    local function ButtonItemInfo(button, useItemLocation)
+        if useItemLocation and button.GetItemLocation then
             local ok, loc = pcall(button.GetItemLocation, button)
             if ok and loc and loc.IsValid and loc:IsValid() and C_Item.DoesItemExist(loc) then
                 return C_Item.GetCurrentItemLevel(loc), C_Item.GetItemQuality(loc), C_Item.GetItemLink(loc)
@@ -4531,35 +4537,54 @@ do
         return fs
     end
 
-    local function InstallHook()
-        if not EquipmentFlyout_DisplayButton then return end
-        hooksecurefunc("EquipmentFlyout_DisplayButton", function(button)
-            local fs = _flyoutFS[button]
-            if not FlyoutEnabled() then
-                if fs then fs:SetText("") end
-                return
-            end
+    local function PaintButton(button, useItemLocation)
+        local fs = _flyoutFS[button]
+        if not FlyoutEnabled() or not button:IsShown() then
+            if fs then fs:SetText("") end
+            return
+        end
 
-            local ilvl, quality, link = ButtonItemInfo(button)
-            fs = EnsureText(button)
-            if ilvl and ilvl > 0 then
-                fs:SetText(ilvl)
-                -- Match the character sheet: custom color > upgrade track > rarity.
-                local c
-                if EllesmereUI.GetItemLevelColor then
-                    c = EllesmereUI.GetItemLevelColor(link, quality)
-                elseif quality and ITEM_QUALITY_COLORS then
-                    c = ITEM_QUALITY_COLORS[quality]
-                end
-                if c then
-                    fs:SetTextColor(c.r, c.g, c.b, 1)
-                else
-                    fs:SetTextColor(1, 1, 1, 1)
-                end
-            else
-                fs:SetText("")
+        local ilvl, quality, link = ButtonItemInfo(button, useItemLocation)
+        fs = EnsureText(button)
+        if ilvl and ilvl > 0 then
+            fs:SetText(ilvl)
+            -- Match the character sheet: custom color > upgrade track > rarity.
+            local c
+            if EllesmereUI.GetItemLevelColor then
+                c = EllesmereUI.GetItemLevelColor(link, quality)
+            elseif quality and ITEM_QUALITY_COLORS then
+                c = ITEM_QUALITY_COLORS[quality]
             end
-        end)
+            if c then
+                fs:SetTextColor(c.r, c.g, c.b, 1)
+            else
+                fs:SetTextColor(1, 1, 1, 1)
+            end
+        else
+            fs:SetText("")
+        end
+    end
+
+    local function RefreshFlyoutItemLevels()
+        local flyout = EquipmentFlyoutFrame
+        if not flyout or not flyout.buttons then return end
+        local source = flyout.button
+        local parent = source and source:GetParent()
+        local settings = parent and parent.flyoutSettings
+        local useItemLocation = settings and settings.useItemLocation == true
+        for _, button in ipairs(flyout.buttons) do
+            PaintButton(button, useItemLocation)
+        end
+    end
+
+    local function InstallHook()
+        if not EquipmentFlyout_UpdateItems then return end
+        -- Item-upgrade flyouts use ItemLocation objects and bypass
+        -- EquipmentFlyout_DisplayButton entirely. They also leave that ItemLocation
+        -- on pooled buttons when an ordinary numeric-location flyout reuses them.
+        -- Refresh after the shared update and follow the active flyout's mode, so
+        -- both paths repaint instead of inheriting the other's item or overlay.
+        hooksecurefunc("EquipmentFlyout_UpdateItems", RefreshFlyoutItemLevels)
     end
 
     local f = CreateFrame("Frame")


### PR DESCRIPTION
## What does this PR do?

Fixes stale or incorrect item-level overlays after opening the item-upgrade flyout.

- Bags and bank now read the exact item instance through `ItemLocation` / `C_Item.GetCurrentItemLevel`, with the item-link API retained only as a fallback.
- Equipment flyout overlays now refresh after the shared `EquipmentFlyout_UpdateItems` path, which covers both the ordinary character-sheet flyout and the item-upgrade flyout.
- The repaint follows the active flyout's `useItemLocation` mode. This prevents pooled buttons from reusing the previous flyout's `ItemLocation` or overlay text.
- Hidden or disabled flyout buttons clear their old item-level text.

No new setting is added. This only corrects the existing opt-in bag/bank and gear-flyout item-level features.

## How was it tested?

- Tested in game on Retail 12.1 with EllesmereUI 8.9.6:
  - bag item levels remain correct after opening the item-upgrade selector;
  - character-sheet Alt gear flyout item levels remain correct;
  - item-upgrade candidate flyout item levels are correct;
  - repeatedly switching between the two flyout modes does not carry stale values.
- Verified against Blizzard UI source for 12.1.0 build 69404: item-upgrade flyouts set `useItemLocation = true` and bypass `EquipmentFlyout_DisplayButton`.
- Lua 5.1 syntax checks passed for all three changed files.
- Targeted mocks cover exact `ItemLocation` precedence, both flyout modes, pooled-button reuse, hidden buttons, and the disabled setting.

## Screenshots

The incorrect overlay is visible as stale item-level numbers on pooled item buttons; the fix changes only the numbers, not layout or styling.

## Checklist

- [x] New settings default **OFF** (N/A: no new setting)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built (existing shared hook performs only the existing enabled check and clears previously-created text)
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern retained); `hooksecurefunc` only
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added