### PR TITLE
Fix: Modifier-key tooltip peek tainting action bars

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2894,23 +2894,38 @@ do
     -- every frame under the cursor and walk up parents. Nameplates' clickable
     -- frame has an OnEnter that builds nothing (its tip comes from the engine's
     -- mouseover unit on a real hover), so fall back to driving the unit tooltip directly when one is up.
+    -- Skip forbidden frames entirely; touching them taints secure code.
+    local function IsFrameForbidden(frame)
+        return frame and frame.IsForbidden and frame:IsForbidden()
+    end
+    -- Skip protected frames too; their OnEnter can call protected functions.
+    local function IsFrameProtected(frame)
+        return frame and frame.IsProtected and frame:IsProtected()
+    end
     local function FireHoveredOnEnter()
         local foci = (GetMouseFoci and GetMouseFoci()) or (GetMouseFocus and { GetMouseFocus() })
         local anchorFrame = foci and foci[1]
+        if IsFrameForbidden(anchorFrame) then anchorFrame = nil end
         if foci then
             for _, focus in ipairs(foci) do
                 local frame = focus
                 while frame and frame ~= WorldFrame and frame ~= UIParent do
-                    if frame.GetScript then
-                        local onEnter = frame:GetScript("OnEnter")
-                        if onEnter then
+                    if IsFrameForbidden(frame) then
+                        break
+                    end
+                    if not IsFrameProtected(frame) and frame.GetScript then
+                        local ok, onEnter = pcall(frame.GetScript, frame, "OnEnter")
+                        if ok and onEnter then
                             pcall(onEnter, frame)
                             if GameTooltip:IsShown() then return end
                             anchorFrame = frame
                             break
                         end
                     end
-                    frame = frame.GetParent and frame:GetParent()
+                    if not frame.GetParent then break end
+                    local okParent, parent = pcall(frame.GetParent, frame)
+                    if not okParent or IsFrameForbidden(parent) then break end
+                    frame = parent
                 end
             end
         end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540175858306785410

Issue: The tooltip peek feature works by walking up the frame chain under the mouse and manually re-firing each frame's OnEnter handler. Two of WoW's frame types break this:

Forbidden frames (certain secure Blizzard widgets) throw an error the instant you even touch them with GetScript/GetParent.
Protected frames (action buttons, etc.) run protected calls like SetAttribute inside their OnEnter — calling that manually from addon code gets hard-blocked (ADDON_ACTION_BLOCKED), and the block cascades into further action-bar errors.

Fix: Before touching any frame in the walk, check IsForbidden()/IsProtected() and skip it — forbidden frames stop the walk entirely, protected frames are just skipped over (their parent is still checked). These frames already tooltip correctly on a real hover, so nothing is lost; the peek logic is only needed for ordinary addon-drawn frames.