### PR TITLE
Upgrade Calculator: live character sheet tab toggle and session snap

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -3838,8 +3838,6 @@ local function SkinCharacterSheet()
     -- Calc toggle tab: fake bottom tab on the right side of the character
     -- sheet, visually identical to the Blizzard Character/Rep/Currency tabs.
     do
-        local calcDb = EUIUpgCalc and EUIUpgCalc.GetOptsDB and EUIUpgCalc.GetOptsDB()
-        if calcDb and calcDb.showCalcButton then
             -- Match Blizzard tab dimensions from CharacterFrameTab1
             local refTab = _G["CharacterFrameTab1"]
             local tabW = refTab and refTab:GetWidth() or 80
@@ -3925,7 +3923,9 @@ local function SkinCharacterSheet()
             end
             GetFFD(frame).calcToggleBtn = calcTab
             GetFFD(frame).updateCalcBtnColor = RefreshCalcTab
-        end
+            if EllesmereUI.ApplyCharSheetCalcTab then
+                EllesmereUI.ApplyCharSheetCalcTab()
+            end
     end
 
     -- Left column slots (show itemlevel on right)
@@ -4775,6 +4775,19 @@ local function SkinCharacterSlot(slotName, slotID)
     end
 end
 
+-- Show/hide the Upgrades calc tab from upgradeCalcOpts.showCalcButton (live toggle).
+local function ApplyCharSheetCalcTab()
+    if not CharacterFrame then return end
+    local calcTab = GetFFD(CharacterFrame).calcToggleBtn
+    if not calcTab then return end
+    local show = false
+    if EUIUpgCalc and EUIUpgCalc.GetOptsDB then
+        local calcDb = EUIUpgCalc.GetOptsDB()
+        show = calcDb and calcDb.showCalcButton or false
+    end
+    calcTab:SetShown(show)
+end
+
 -- Entry point: apply the themed character sheet.
 local function ApplyThemedCharacterSheet()
     if EllesmereUIDB and (EllesmereUIDB.themedCharacterSheet == false or EllesmereUI.BlizzWindowSkinsKilled()) then
@@ -4788,6 +4801,7 @@ end
 
 if EllesmereUI then
     EllesmereUI.ApplyThemedCharacterSheet = ApplyThemedCharacterSheet
+    EllesmereUI.ApplyCharSheetCalcTab = ApplyCharSheetCalcTab
 
     -- Setup at PLAYER_LOGIN to register drag hooks early
     local initFrame = CreateFrame("Frame")

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -3835,97 +3835,9 @@ local function SkinCharacterSheet()
     -- Character tab is the default active view
     SetActiveTopButton(characterBtn)
 
-    -- Calc toggle tab: fake bottom tab on the right side of the character
-    -- sheet, visually identical to the Blizzard Character/Rep/Currency tabs.
-    do
-            -- Match Blizzard tab dimensions from CharacterFrameTab1
-            local refTab = _G["CharacterFrameTab1"]
-            local tabW = refTab and refTab:GetWidth() or 80
-            local tabH = refTab and refTab:GetHeight() or 32
-
-            local calcTab = CreateFrame("Button", "EUI_CharSheet_CalcTab", frame)
-            calcTab:SetSize(tabW, tabH)
-            calcTab:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -10, -30)
-            calcTab:SetFrameLevel(frame:GetFrameLevel() + 5)
-            calcTab:EnableMouse(true)
-
-            -- Dark background (matches skinned Blizzard tabs)
-            local bg = calcTab:CreateTexture(nil, "BACKGROUND")
-            bg:SetAllPoints()
-            bg:SetColorTexture(0.068, 0.056, 0.052, 1)
-
-            -- Active highlight overlay
-            local activeHL = calcTab:CreateTexture(nil, "ARTWORK", nil, -6)
-            activeHL:SetAllPoints()
-            activeHL:SetColorTexture(1, 1, 1, 0.02)
-            activeHL:SetBlendMode("ADD")
-            activeHL:Hide()
-
-            local label = calcTab:CreateFontString(nil, "OVERLAY")
-            label:SetFont(fontPath, 9, "")
-            label:SetPoint("CENTER", calcTab, "CENTER", 0, 0)
-            label:SetJustifyH("CENTER")
-            label:SetText("Upgrades")
-
-            -- Accent underline (matches Blizzard tab underline)
-            local EG = EllesmereUI.ELLESMERE_GREEN or { r = 0.05, g = 0.82, b = 0.62 }
-            local underline = calcTab:CreateTexture(nil, "OVERLAY", nil, 6)
-            if PP and PP.DisablePixelSnap then
-                PP.DisablePixelSnap(underline)
-                underline:SetHeight(PP.mult or 1)
-            else
-                underline:SetHeight(1)
-            end
-            underline:SetPoint("BOTTOMLEFT", calcTab, "BOTTOMLEFT", 0, 0)
-            underline:SetPoint("BOTTOMRIGHT", calcTab, "BOTTOMRIGHT", 0, 0)
-            underline:SetColorTexture(EG.r, EG.g, EG.b, 1)
-            underline:Hide()
-            if EllesmereUI.RegAccent then
-                EllesmereUI.RegAccent({ type = "solid", obj = underline, a = 1 })
-            end
-
-            local function RefreshCalcTab()
-                local fr = _G["EUIUpgCalcFrame"]
-                local isOpen = fr and fr:IsShown()
-                label:SetTextColor(1, 1, 1, isOpen and 1 or 0.5)
-                underline:SetShown(isOpen)
-                activeHL:SetShown(isOpen)
-            end
-            RefreshCalcTab()
-
-            calcTab:SetScript("OnEnter", function()
-                label:SetTextColor(1, 1, 1, 1)
-            end)
-            calcTab:SetScript("OnLeave", function()
-                RefreshCalcTab()
-            end)
-            calcTab:SetScript("OnClick", function()
-                local fr = _G["EUIUpgCalcFrame"]
-                if fr then
-                    if fr:IsShown() then fr:Hide() else fr:Show() end
-                    RefreshCalcTab()
-                end
-            end)
-
-            frame:HookScript("OnShow", RefreshCalcTab)
-            -- Hook the calc frame so the tab tracks opens/closes from any source.
-            local function HookCalcFrame()
-                local fr = _G["EUIUpgCalcFrame"]
-                if not fr or GetFFD(calcTab)._calcHooked then return end
-                GetFFD(calcTab)._calcHooked = true
-                fr:HookScript("OnShow", RefreshCalcTab)
-                fr:HookScript("OnHide", RefreshCalcTab)
-            end
-            HookCalcFrame()
-            -- Deferred: calc frame may not exist yet at skin time
-            if not _G["EUIUpgCalcFrame"] then
-                C_Timer.After(1, HookCalcFrame)
-            end
-            GetFFD(frame).calcToggleBtn = calcTab
-            GetFFD(frame).updateCalcBtnColor = RefreshCalcTab
-            if EllesmereUI.ApplyCharSheetCalcTab then
-                EllesmereUI.ApplyCharSheetCalcTab()
-            end
+    -- Calc tab is created lazily by ApplyCharSheetCalcTab when showCalcButton is on.
+    if EllesmereUI.ApplyCharSheetCalcTab then
+        EllesmereUI.ApplyCharSheetCalcTab()
     end
 
     -- Left column slots (show itemlevel on right)
@@ -4775,17 +4687,109 @@ local function SkinCharacterSlot(slotName, slotID)
     end
 end
 
+-- Fake bottom tab on the character sheet, visually identical to the Blizzard
+-- Character/Rep/Currency tabs. Built on first enable only (zero cost while off).
+local function EnsureCalcTab(frame)
+    local existing = GetFFD(frame).calcToggleBtn
+    if existing then return existing end
+
+    local fontPath = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("blizzardSkin") or STANDARD_TEXT_FONT
+    local PP = EllesmereUI and (EllesmereUI.PanelPP or EllesmereUI.PP)
+
+    local refTab = _G["CharacterFrameTab1"]
+    local tabW = refTab and refTab:GetWidth() or 80
+    local tabH = refTab and refTab:GetHeight() or 32
+
+    local calcTab = CreateFrame("Button", "EUI_CharSheet_CalcTab", frame)
+    calcTab:SetSize(tabW, tabH)
+    calcTab:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -10, -30)
+    calcTab:SetFrameLevel(frame:GetFrameLevel() + 5)
+    calcTab:EnableMouse(true)
+
+    local bg = calcTab:CreateTexture(nil, "BACKGROUND")
+    bg:SetAllPoints()
+    bg:SetColorTexture(0.068, 0.056, 0.052, 1)
+
+    local activeHL = calcTab:CreateTexture(nil, "ARTWORK", nil, -6)
+    activeHL:SetAllPoints()
+    activeHL:SetColorTexture(1, 1, 1, 0.02)
+    activeHL:SetBlendMode("ADD")
+    activeHL:Hide()
+
+    local label = calcTab:CreateFontString(nil, "OVERLAY")
+    label:SetFont(fontPath, 9, "")
+    label:SetPoint("CENTER", calcTab, "CENTER", 0, 0)
+    label:SetJustifyH("CENTER")
+    label:SetText("Upgrades")
+
+    local EG = EllesmereUI.ELLESMERE_GREEN or { r = 0.05, g = 0.82, b = 0.62 }
+    local underline = calcTab:CreateTexture(nil, "OVERLAY", nil, 6)
+    if PP and PP.DisablePixelSnap then
+        PP.DisablePixelSnap(underline)
+        underline:SetHeight(PP.mult or 1)
+    else
+        underline:SetHeight(1)
+    end
+    underline:SetPoint("BOTTOMLEFT", calcTab, "BOTTOMLEFT", 0, 0)
+    underline:SetPoint("BOTTOMRIGHT", calcTab, "BOTTOMRIGHT", 0, 0)
+    underline:SetColorTexture(EG.r, EG.g, EG.b, 1)
+    underline:Hide()
+    if EllesmereUI.RegAccent then
+        EllesmereUI.RegAccent({ type = "solid", obj = underline, a = 1 })
+    end
+
+    local function RefreshCalcTab()
+        local fr = _G["EUIUpgCalcFrame"]
+        if fr and not GetFFD(calcTab)._calcHooked then
+            GetFFD(calcTab)._calcHooked = true
+            fr:HookScript("OnShow", RefreshCalcTab)
+            fr:HookScript("OnHide", RefreshCalcTab)
+        end
+        local isOpen = fr and fr:IsShown()
+        label:SetTextColor(1, 1, 1, isOpen and 1 or 0.5)
+        underline:SetShown(isOpen)
+        activeHL:SetShown(isOpen)
+    end
+    RefreshCalcTab()
+
+    calcTab:SetScript("OnEnter", function()
+        label:SetTextColor(1, 1, 1, 1)
+    end)
+    calcTab:SetScript("OnLeave", function()
+        RefreshCalcTab()
+    end)
+    calcTab:SetScript("OnClick", function()
+        local fr = _G["EUIUpgCalcFrame"]
+        if fr then
+            if fr:IsShown() then fr:Hide() else fr:Show() end
+            RefreshCalcTab()
+        end
+    end)
+
+    frame:HookScript("OnShow", RefreshCalcTab)
+    GetFFD(frame).calcToggleBtn = calcTab
+    GetFFD(frame).updateCalcBtnColor = RefreshCalcTab
+    return calcTab
+end
+
 -- Show/hide the Upgrades calc tab from upgradeCalcOpts.showCalcButton (live toggle).
 local function ApplyCharSheetCalcTab()
     if not CharacterFrame then return end
-    local calcTab = GetFFD(CharacterFrame).calcToggleBtn
-    if not calcTab then return end
+    if not skinned then return end
+    if EllesmereUIDB and (EllesmereUIDB.themedCharacterSheet == false or EllesmereUI.BlizzWindowSkinsKilled()) then
+        return
+    end
     local show = false
     if EUIUpgCalc and EUIUpgCalc.GetOptsDB then
         local calcDb = EUIUpgCalc.GetOptsDB()
         show = calcDb and calcDb.showCalcButton or false
     end
-    calcTab:SetShown(show)
+    if show then
+        EnsureCalcTab(CharacterFrame):SetShown(true)
+    else
+        local calcTab = GetFFD(CharacterFrame).calcToggleBtn
+        if calcTab then calcTab:SetShown(false) end
+    end
 end
 
 -- Entry point: apply the themed character sheet.

--- a/EllesmereUIOptions/EUI_UpgradeCalc_Options.lua
+++ b/EllesmereUIOptions/EUI_UpgradeCalc_Options.lua
@@ -211,7 +211,12 @@ local function BuildUpgradeCalcPage(pageName, parent, yOffset)
         { type = "toggle", text = "Show Calc Button on Character Sheet",
           tooltip = "Adds a Calc toggle button to the character sheet that opens and closes the Upgrade Calculator.",
           getValue = function() return GetAddonDB().showCalcButton or false end,
-          setValue = function(v) GetAddonDB().showCalcButton = v end },
+          setValue = function(v)
+              GetAddonDB().showCalcButton = v
+              if EllesmereUI and EllesmereUI.ApplyCharSheetCalcTab then
+                  EllesmereUI.ApplyCharSheetCalcTab()
+              end
+          end },
         { type = "toggle", text = "Open with Crest Upgrader",
           tooltip = "Automatically opens the Upgrade Calculator when the Crest Upgrade NPC window is opened.",
           getValue = function() return GetAddonDB().openWithUpgrader or false end,

--- a/EllesmereUIQoL/EUI_UpgradeCalc.lua
+++ b/EllesmereUIQoL/EUI_UpgradeCalc.lua
@@ -639,9 +639,7 @@ local function DockToCharacterFrame()
     local leftFits = leftRoom >= minRoom
     local rightFits = rightRoom >= minRoom
     local dockLeft
-    if leftFits and rightFits then
-        dockLeft = false
-    elseif rightFits then
+    if rightFits then
         dockLeft = false
     elseif leftFits then
         dockLeft = true
@@ -1754,6 +1752,7 @@ f:SetScript("OnShow", function()
     if IsLocked() then f:Hide(); return end
     Calc.ApplyBgOpacity()
     Calc.ApplyScale()
+    InstallCharacterFrameSnapHooks()
     TrySnapToCharacterFrame()
     -- Reload persisted crest manual-add offsets each time the frame opens,
     -- so that values the user set before logging out are visible immediately.
@@ -1930,7 +1929,6 @@ local function HookCharacterSheet()
     if _charSheetHooked then return end
     if not CharacterFrame then return end
     _charSheetHooked = true
-    InstallCharacterFrameSnapHooks()
     CharacterFrame:HookScript("OnShow", function()
         if Opts().openWithCharSheet then
             local fr = _G["EUIUpgCalcFrame"]
@@ -1950,5 +1948,4 @@ loginFrame:RegisterEvent("PLAYER_LOGIN")
 loginFrame:SetScript("OnEvent", function(self)
     self:UnregisterEvent("PLAYER_LOGIN")
     HookCharacterSheet()
-    InstallCharacterFrameSnapHooks()
 end)

--- a/EllesmereUIQoL/EUI_UpgradeCalc.lua
+++ b/EllesmereUIQoL/EUI_UpgradeCalc.lua
@@ -614,7 +614,72 @@ f:SetFrameStrata("DIALOG")
 f:SetMovable(true)
 f:EnableMouse(true)
 f:RegisterForDrag("LeftButton")
-f:SetScript("OnDragStart", function(self) self:StartMoving() end)
+
+-- Session snap: dock beside CharacterFrame on each open until the user drags.
+local _sessionUnpinned = false
+local _cfSnapHooked = false
+
+local function ShouldSnapToCharacterFrame()
+    if _sessionUnpinned then return false end
+    local cf = _G.CharacterFrame
+    return cf ~= nil and cf:IsShown()
+end
+
+local function DockToCharacterFrame()
+    local cf = _G.CharacterFrame
+    if not cf or not cf:IsShown() then return end
+    local margin = 4
+    local cs = cf:GetEffectiveScale() or 1
+    local es = f:GetEffectiveScale() or 1
+    local ues = UIParent:GetEffectiveScale() or 1
+    local wAbs = (f:GetWidth() or 0) * es
+    local leftRoom = (cf:GetLeft() or 0) * cs
+    local rightRoom = (GetScreenWidth() or 0) * ues - (cf:GetRight() or 0) * cs
+    local minRoom = wAbs + margin * es
+    local leftFits = leftRoom >= minRoom
+    local rightFits = rightRoom >= minRoom
+    local dockLeft
+    if leftFits and rightFits then
+        dockLeft = false
+    elseif rightFits then
+        dockLeft = false
+    elseif leftFits then
+        dockLeft = true
+    else
+        dockLeft = leftRoom >= rightRoom
+    end
+    f:ClearAllPoints()
+    if dockLeft then
+        f:SetPoint("TOPRIGHT", cf, "TOPLEFT", -margin, 0)
+    else
+        f:SetPoint("TOPLEFT", cf, "TOPRIGHT", margin, 0)
+    end
+end
+
+local function TrySnapToCharacterFrame()
+    if f:IsShown() and ShouldSnapToCharacterFrame() then
+        DockToCharacterFrame()
+    end
+end
+
+local function InstallCharacterFrameSnapHooks()
+    if _cfSnapHooked then return end
+    local cf = _G.CharacterFrame
+    if not cf then return end
+    _cfSnapHooked = true
+    cf:HookScript("OnShow", TrySnapToCharacterFrame)
+    hooksecurefunc(cf, "SetPoint", function()
+        TrySnapToCharacterFrame()
+    end)
+    hooksecurefunc(cf, "SetScale", function()
+        TrySnapToCharacterFrame()
+    end)
+end
+
+f:SetScript("OnDragStart", function(self)
+    _sessionUnpinned = true
+    self:StartMoving()
+end)
 f:SetScript("OnDragStop",  function(self) self:StopMovingOrSizing() end)
 f:Hide()
 
@@ -1689,6 +1754,7 @@ f:SetScript("OnShow", function()
     if IsLocked() then f:Hide(); return end
     Calc.ApplyBgOpacity()
     Calc.ApplyScale()
+    TrySnapToCharacterFrame()
     -- Reload persisted crest manual-add offsets each time the frame opens,
     -- so that values the user set before logging out are visible immediately.
     local dbAdds = DB().crestManualAdds
@@ -1701,6 +1767,7 @@ f:SetScript("OnShow", function()
 end)
 f:SetScript("OnHide", function()
     equipListener:UnregisterAllEvents()
+    _sessionUnpinned = false
     -- Cancel any pending equipment-change debounce.
     if _equipDebounce then _equipDebounce:Cancel(); _equipDebounce = nil end
     -- If hidden mid-scan (e.g. combat, /reload), unblock future scans.
@@ -1863,6 +1930,7 @@ local function HookCharacterSheet()
     if _charSheetHooked then return end
     if not CharacterFrame then return end
     _charSheetHooked = true
+    InstallCharacterFrameSnapHooks()
     CharacterFrame:HookScript("OnShow", function()
         if Opts().openWithCharSheet then
             local fr = _G["EUIUpgCalcFrame"]
@@ -1882,4 +1950,5 @@ loginFrame:RegisterEvent("PLAYER_LOGIN")
 loginFrame:SetScript("OnEvent", function(self)
     self:UnregisterEvent("PLAYER_LOGIN")
     HookCharacterSheet()
+    InstallCharacterFrameSnapHooks()
 end)


### PR DESCRIPTION
## Summary
- Fix "Show Calc Button on Character Sheet" not appearing until `/reload` by always creating the tab at skin time and applying visibility live via `ApplyCharSheetCalcTab()`.
- Snap the Upgrade Calculator beside the character sheet on each open, keeping it pinned while the sheet moves until the user manually drags it during that session.

## Test plan
- [ ] Enable "Show Calc Button on Character Sheet" with character sheet open — Upgrades tab appears without reload
- [ ] Disable the toggle — tab hides immediately
- [ ] Click Upgrades tab — calculator opens docked beside character sheet (prefers right side)
- [ ] Move character sheet (e.g. Shifter) while calc is open and unpinned=false — calculator follows
- [ ] Drag calculator — it stays where dropped for remainder of that open
- [ ] Close and reopen calculator — snaps beside sheet again
- [ ] Open calculator via `/euic` with character sheet closed — uses default position (no snap)