### PR TITLE
fix(locale): show module outline tooltips and video guide popups in the client language

### DIFF
--- a/EllesmereUIOptions/EUI_Fonts_Options.lua
+++ b/EllesmereUIOptions/EUI_Fonts_Options.lua
@@ -89,7 +89,11 @@ local MODULE_OUTLINE_ORDER = { "__global", "none", "outline", "thick" }
 -- Per-module outline row config (left slot of each card's first row).
 local function ModuleOutlineCfg(folder, display)
     return { type = "dropdown", text = "Module Outline",
-        tooltip = "Outline style override for all " .. display .. " text. EUI Global Outline follows the global Outline Mode setting above.",
+        -- Lf, not a ".." chain: see DisabledNote below for why a concatenated
+        -- sentence can never be keyed.
+        tooltip = EllesmereUI.Lf(
+            "Outline style override for all %1$s text. EUI Global Outline follows the global Outline Mode setting above.",
+            EllesmereUI.L(display)),
         values = MODULE_OUTLINE_VALUES, order = MODULE_OUTLINE_ORDER,
         getValue = function()
             local entry = FindModuleFontEntry(folder)
@@ -156,6 +160,15 @@ local function NoteRow(parent, y, text)
     return y - ROW_H
 end
 
+-- The note every disabled card shows. Lf with a placeholder rather than a ".."
+-- chain: L() is an exact lookup, so "Enable " .. display .. " ..." can never be
+-- keyed and the note would stay English on every localized client. The card
+-- header tooltip below already does it this way.
+local function DisabledNote(parent, y, tile)
+    return NoteRow(parent, y, EllesmereUI.Lf(
+        "Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+end
+
 -------------------------------------------------------------------------------
 --  Per-module card content builders
 --
@@ -197,7 +210,7 @@ local function TileActionBars(parent, y, W, tile)
             tile.folder, "Bar Display", "TEXT", "Keybind Text Size")
     else
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        y = NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        y = DisabledNote(parent, y, tile)
     end
     return y
 end
@@ -207,7 +220,7 @@ local function TileNameplates(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db() return ns.db and ns.db.profile end
     local DEF = ns.defaults or {}
@@ -281,7 +294,7 @@ local function TileUnitFrames(parent, y, W, tile)
         y = LinkRow(parent, y, "Player Aura Bars Text (per bar)",
             tile.folder, "Player Aura Bars", nil)
     else
-        y = NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        y = DisabledNote(parent, y, tile)
     end
     return y
 end
@@ -291,7 +304,7 @@ local function TileRaidFrames(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db() return ns.db and ns.db.profile end
     local function RFApply()
@@ -351,7 +364,7 @@ local function TileCooldownManager(parent, y, W, tile)
         y = LinkRow(parent, y, "Tracking Bar Name, Timer & Stacks Text (per bar)",
             tile.folder, "Tracking Bars", "BAR LAYOUT")
     else
-        y = NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        y = DisabledNote(parent, y, tile)
     end
     return y
 end
@@ -361,7 +374,7 @@ local function TileResourceBars(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db() return _G._ERB_AceDB and _G._ERB_AceDB.profile end
     local function RBApply() if _G._ERB_Apply then _G._ERB_Apply() end end
@@ -398,7 +411,7 @@ local function TileAuraBuffReminders(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db() return _G._EABR_AceDB and _G._EABR_AceDB.profile end
     _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display),
@@ -441,7 +454,7 @@ local function TileQoL(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     -- Flat EllesmereUIDB keys with a parent-published apply fn.
     local function gsize(label, key, minV, maxV, def, applyName)
@@ -581,7 +594,7 @@ local function TileChat(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local ECHAT = ns.ECHAT
     local function db()
@@ -705,7 +718,7 @@ local function TileMythicTimer(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db() return _G._EMT_AceDB and _G._EMT_AceDB.profile end
     local function MTApply() if _G._EMT_Apply then _G._EMT_Apply() end end
@@ -786,7 +799,7 @@ local function TileDamageMeters(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db()
         return _G._EDM_DB and _G._EDM_DB.profile and _G._EDM_DB.profile.dm
@@ -847,7 +860,7 @@ local function TileBags(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db()
         return EllesmereUI._bagsDB and EllesmereUI._bagsDB.profile
@@ -886,7 +899,7 @@ local function TileMinimap(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db()
         return _G._EMM_DB and _G._EMM_DB.profile and _G._EMM_DB.profile.minimap
@@ -936,7 +949,7 @@ local function TileQuestTracker(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     local function db()
         return _G._EQT_DB and _G._EQT_DB.profile and _G._EQT_DB.profile.questTracker
@@ -988,7 +1001,7 @@ local function TileBlizzardSkin(parent, y, W, tile)
     local _, h
     if not ns then
         _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
-        return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        return DisabledNote(parent, y, tile)
     end
     _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display),
         { type = "slider", text = "Tooltip Font Size Scale", min = 0.7, max = 1.5, step = 0.05,
@@ -1033,7 +1046,7 @@ local function TileDataBars(parent, y, W, tile)
         y = LinkRow(parent, y, "Text Scale (per data bar)",
             tile.folder, "DataBars", "BAR SETTINGS", "Text Scale")
     else
-        y = NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
+        y = DisabledNote(parent, y, tile)
     end
     return y
 end

--- a/EllesmereUIOptions/EUI_Textures_Options.lua
+++ b/EllesmereUIOptions/EUI_Textures_Options.lua
@@ -134,6 +134,10 @@ local function NoteRow(parent, y, text)
     return y - ROW_H
 end
 
+-- Lf with a placeholder rather than a ".." chain: L() is an exact lookup, so
+-- "Enable " .. display .. " ..." can never be keyed and the note would stay
+-- English on every localized client. The card header tooltip below already
+-- does it this way ("Enable %1$s to edit these settings.").
 local function DisabledTile(parent, y, W, tile)
     return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its texture settings.", EllesmereUI.L(tile.display)))
 end

--- a/EllesmereUI_VideoGuides.lua
+++ b/EllesmereUI_VideoGuides.lua
@@ -36,6 +36,15 @@ if IS_STANDALONE then return end
 local PP = EllesmereUI.PanelPP
 local MakeBorder = EllesmereUI.MakeBorder
 
+-- Register() parks each guide's def table verbatim, so nothing localizes the
+-- strings on the way in. They are localized here instead, at the single place
+-- the engine puts one on screen (SetGuide) -- resolved per Show, so a locale
+-- loaded after this file still applies. L() is identity on a missing key, so
+-- an untranslated guide keeps its English.
+local function L(s)
+    return (s and EllesmereUI.L and EllesmereUI.L(s)) or s
+end
+
 -- The override system's gold (used by guide art, exposed via ctx).
 local GOLD = { r = 1, g = 0.82, b = 0.30 }
 
@@ -282,7 +291,7 @@ local function BuildShell()
     eb:SetScript("OnEnterPressed", function(self) Dismiss() end)
     eb:SetScript("OnKeyDown", function(self, key)
         if key == "C" and IsControlKeyDown() then
-            hint:SetText("Link copied - paste it into your browser")
+            hint:SetText(L("Link copied - paste it into your browser"))
             hint:SetTextColor(cur.r, cur.g, cur.b, 0.9)
         end
     end)
@@ -300,7 +309,7 @@ local function BuildShell()
     local okLbl = okBtn:CreateFontString(nil, "OVERLAY")
     okLbl:SetFont(FONT, 15, "")
     PP.Point(okLbl, "CENTER", okBtn, "CENTER", 0, 0)
-    okLbl:SetText("Okay")
+    okLbl:SetText(L("Okay"))
     ui.okLbl = okLbl
     ui.okBtn = okBtn
     okBtn:SetScript("OnEnter", function()
@@ -376,7 +385,7 @@ local function SetGuide(id, def)
     ui.blurb:SetWidth(w - 80)
     ui.footnote:SetWidth(w - 80)
     PP.Size(ui.urlWell, def.urlWidth or 350, 34)
-    ui.okLbl:SetText(def.okText or "Okay")
+    ui.okLbl:SetText(L(def.okText or "Okay"))
     ui._onDismiss = def.onDismiss
 
     -- Bullet rows: accent-dotted short labels, up to two centered lines; the
@@ -388,7 +397,7 @@ local function SetGuide(id, def)
         local function Line(items)
             local parts = {}
             for i = 1, #items do
-                parts[i] = "|cff" .. hex .. "\226\128\162|r " .. items[i]
+                parts[i] = "|cff" .. hex .. "\226\128\162|r " .. L(items[i])
             end
             return table.concat(parts, "    ")
         end
@@ -408,17 +417,17 @@ local function SetGuide(id, def)
         PP.Point(ui.urlWell, "TOP", ui.blurb, "BOTTOM", 0, -(gUrl or 18))
     end
 
-    ui.eyebrow:SetText(def.eyebrow or "VIDEO GUIDE")
+    ui.eyebrow:SetText(L(def.eyebrow or "VIDEO GUIDE"))
     ui.eyebrow:SetTextColor(accent.r, accent.g, accent.b, 0.9)
     ui.tri:SetColorTexture(accent.r, accent.g, accent.b, 0.9)
     ui.rule:SetColorTexture(accent.r, accent.g, accent.b, 0.35)
-    ui.title:SetText(def.title or "")
-    ui.blurb:SetText(def.blurb or "")
-    ui.hint:SetText("Ctrl+C to copy, Escape to close")
+    ui.title:SetText(L(def.title) or "")
+    ui.blurb:SetText(L(def.blurb) or "")
+    ui.hint:SetText(L("Ctrl+C to copy, Escape to close"))
     ui.hint:SetTextColor(1, 1, 1, 0.45)
     ui.okLbl:SetTextColor(accent.r, accent.g, accent.b, 0.9)
     ui.okBrd:SetColor(accent.r, accent.g, accent.b, 0.9)
-    ui.footnote:SetText(def.footnote or "")
+    ui.footnote:SetText(L(def.footnote) or "")
 
     ui.eb._readOnly = def.url or ""
     ui.eb:SetText(def.url or "")


### PR DESCRIPTION
### Problem

On a non-English client two groups of strings always render in English, even
when the locale file already has a translation for them. English clients are
unaffected -- `EllesmereUILocales` never loads there.

- The **Module Outline** dropdown tooltip on every Fonts card (`Outline style
  override for all <Module> text. ...`).
- Every video guide popup, in full: eyebrow, title, blurb, bullets, footnote
  and the confirm button. That covers the 12.1 launch announcement, the
  Settings Overrides warning, the Unlock Mode and Cooldown Manager guides, and
  the presets-website popup.

Repro: run a localized client, open Global Settings > Fonts, hover **Module
Outline** on any card -- the tooltip is English while the rest of the page is
translated.

(The disabled-card notes on Fonts/Textures had the same root cause and were
part of this PR originally, but #1640's disabled-tile fix landed first via a
parallel PR and already covers that half -- see Notes.)

### Cause

`EllesmereUI.L()` is an exact table lookup on the English string.

**1. Concatenation.** The outline tooltip is assembled with `..`:

```lua
tooltip = "Outline style override for all " .. display .. " text. ...",
```

What reaches `L()` is the finished sentence, so a locale file could only match
it by carrying one entry per module. The disabled-card note right below it
already uses the `Lf("...%1$s...")` pattern for the same reason.

**2. No `L()` at all.** `VideoGuides.Register()` parks each guide's def table
verbatim (`guides[id] = def`) and `SetGuide()` calls `SetText(def.title)`,
`SetText(def.blurb)` and so on directly. No guide popup has ever been
translatable. `zhTW.lua` already carries translations for `Settings
Overrides`, `Unlock Mode`, `Everything New in 12.1`, `Got It`, `Okay` and
`Ctrl+C to copy, Escape to close` that could never be reached.

### Fix

- `EUI_Fonts_Options.lua`: `ModuleOutlineCfg`'s tooltip becomes
  `Lf("...%1$s...", L(display))`. A local `DisabledNote(parent, y, tile)`
  also replaces the 16 identical `NoteRow` calls the disabled-card fix left
  behind, so the note text lives in one place.
- `EllesmereUI_VideoGuides.lua`: a local `L(s)` wrapper localizes the def
  fields at `SetGuide()`, the single place the engine puts a guide on screen.

Localizing at render rather than inside `Register()` is deliberate: guides
register at file load, before the locale catalog is guaranteed to be built.
Resolving per `Show` is correct whatever the load order, and costs nothing --
a popup is built at most once per session.

### Notes

- Nothing here changes behavior on an English client: `L()` is identity on a
  missing key, so an untranslated guide keeps its English text.
- `EllesmereUILocales/_keys.txt` is unchanged and stays current: that list is
  literals passed directly to `EllesmereUI.L(...)` on the call line, and these
  strings reach the catalog either through a wrapped `Lf(` call or through the
  module-local `L()` wrapper. The in-game `/euiloc` harvester picks all of
  them up, which is what `CONTRIBUTING_TRANSLATIONS.md` points translators at
  for the complete set.
- `def.bullets` items are localized too. The 12.1 guide's bullets are module
  names, three of which had no key yet (`Aura Filtering`, `Buff Reminders`,
  `Chat Rewrite`).
- Deliberately left alone: the `print()` in the video-guide reset path (a
  developer/reset command, not popup UI), and the `12.1|r EUI Guide` wordmark
  drawn inside that guide's art band (artwork, not copy).
- The disabled-card notes on Fonts/Textures (`Enable <Module> to edit its
  text/texture settings.`) are no longer part of this diff: they had the
  exact same concatenation bug and were originally fixed here too, but a
  parallel fix landed on `main` first and already resolves them. Rebased on
  top of that rather than re-doing the same fix two ways.
- No new settings, no new events, no frames created, no Blizzard frames
  touched.

### Testing

In-game, on live:

- zhTW client, Global Settings > Fonts, hovering **Module Outline** on any
  card -> tooltip renders in Chinese with the module name substituted.
- Each video guide popup opened in turn -> eyebrow, title, blurb, bullets,
  footnote and the confirm button all render in Chinese.
- enUS client -> every one of the above still reads exactly as before.

### Checklist

- [x] N/A - no new settings
- [x] N/A - no events, hooks or frames added; the change is one table lookup per
      string that was already being rendered
- [x] Cheap while enabled: lookups happen at page/popup build time only
- [x] N/A - no Blizzard frames touched
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
