### PR TITLE
Minimap: stop the hidden difficulty flag from answering mouseover

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -3313,11 +3313,12 @@ local function LayoutIndicatorFrames(minimap, p, circleMode)
         diffFrame:ClearAllPoints()
         diffFrame:SetPoint("TOPRIGHT", minimap, "TOPRIGHT", 2, 1)
         -- Text mode overrides Show Blizzard Elements: the flag is always suppressed.
-        if p.hideRaidDifficulty or p.diffTextEnabled then
-            diffFrame:SetAlpha(0)
-        else
-            diffFrame:SetAlpha(1)
-        end
+        -- Alpha leaves the hit region live, so a suppressed flag still answers mouseover
+        -- with Blizzard's difficulty tooltip at the top-right corner.
+        local suppressed = p.hideRaidDifficulty or p.diffTextEnabled
+        diffFrame:SetAlpha(suppressed and 0 or 1)
+        diffFrame:EnableMouse(not suppressed)
+        if diffFrame.Guild then diffFrame.Guild:EnableMouse(not suppressed) end
     end
     if not minimap.Layout then minimap.Layout = function() end end
 

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -3317,8 +3317,8 @@ local function LayoutIndicatorFrames(minimap, p, circleMode)
         -- with Blizzard's difficulty tooltip at the top-right corner.
         local suppressed = p.hideRaidDifficulty or p.diffTextEnabled
         diffFrame:SetAlpha(suppressed and 0 or 1)
-        diffFrame:EnableMouse(not suppressed)
-        if diffFrame.Guild then diffFrame.Guild:EnableMouse(not suppressed) end
+        diffFrame:EnableMouseMotion(not suppressed)
+        if diffFrame.Guild then diffFrame.Guild:EnableMouseMotion(not suppressed) end
     end
     if not minimap.Layout then minimap.Layout = function() end end
 


### PR DESCRIPTION
Reported by @Elandura: hovering just below the minimap's mail icon pops the instance difficulty tooltip, while the Difficulty as Text readout sits wherever the user placed it.

**Cause:** the difficulty banner is suppressed with `SetAlpha(0)`, which leaves its hit region live, so the invisible frame still answers mouseover at its top-right anchor.

**Fix:** disable mouse motion on the banner and on its guild content frame (which owns its own tooltip) while it is suppressed. Motion only, so the click flag Blizzard set is untouched and the corner keeps answering ping / tracking / micro menu.

**Test:** with Difficulty as Text on, hover below the mail icon, no tooltip. Turn it off and re-enable the Blizzard difficulty element, tooltip works again. Checked in a guild group for the Guild banner path.
