### PR TITLE
Cooldown Manager: let a bar-wide Threshold Text apply reach hosted buffs

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -639,7 +639,11 @@ end
                     pcall(ns.StyleOverlayCooldownText, cd, bd, ss, scale)
                 end
                 if ns.ApplyThresholdFormatter then
-                    pcall(ns.ApplyThresholdFormatter, cd, ThresholdFor(st.srcFrame, rule, ss))
+                    -- Resolve INSIDE the protection: an argument expression evaluates before pcall
+                    -- is entered, and a throw in this creation window takes the whole slot down
+                    -- (its swipe with it), not just the countdown text.
+                    local okT, ttB = pcall(ThresholdFor, st.srcFrame, rule, ss)
+                    pcall(ns.ApplyThresholdFormatter, cd, okT and ttB or ss)
                 end
                 if ns.ApplyShapeToOverlay and st.srcFrame then
                     pcall(ns.ApplyShapeToOverlay, st.srcFrame, tex, cd, bd)

--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -39,6 +39,7 @@ local C_SpellBook            = C_SpellBook
 local wipe                   = wipe
 local pcall                  = pcall
 local type                   = type
+local tonumber               = tonumber
 local RAID_CLASS_COLORS      = RAID_CLASS_COLORS
 local C_Container            = C_Container
 local GetInventoryItemCooldown = GetInventoryItemCooldown
@@ -292,6 +293,22 @@ IconTexture = function(iconFrame, o, rule)
     end
 end
 
+-- Threshold Text block for one rule's overlay countdown. Per-spell Threshold Text covers
+-- the ACTIVE STATE countdown as well as cooldown and recharge, but a USER rule's styling
+-- block is its customActiveStates entry, which carries threshold keys only when they were
+-- set from the preset/custom menu -- a threshold set on the SPELL lives in the family
+-- entry and would never reach these overlays. Fall through to the shared resolver, which
+-- reads family first then cas. Returns ss untouched when it already arms the feature, and
+-- when nobody uses it (session gate), so non-users pay nothing.
+local function ThresholdFor(frame, rule, ss)
+    if (tonumber(ss and ss.thresholdSeconds) or 0) > 0 then return ss end
+    if not (ns._cdmAnyThresholdText and ns.ResolveThresholdTextSettings) then return ss end
+    local fcT = frame and ns._ecmeFC and ns._ecmeFC[frame]
+    local bkT = fcT and fcT.barKey
+    return ns.ResolveThresholdTextSettings(frame, rule.spellID,
+        bkT and ns.GetBarSpellData and ns.GetBarSpellData(bkT), bkT)
+end
+
 -- ---------------------------------------------------------------------------
 --  Show / hide the overlay on a single icon frame.
 -- ---------------------------------------------------------------------------
@@ -349,7 +366,7 @@ ApplyToFrame = function(iconFrame, rule, win)
         -- only touches widgets it manages, and StyleOverlayCooldownText (above)
         -- already set the countdown numbers per the Duration Text state.
         if ns._cdmAnyThresholdText and ns.ApplyThresholdFormatter then
-            ns.ApplyThresholdFormatter(o.cd, ss)
+            ns.ApplyThresholdFormatter(o.cd, ThresholdFor(iconFrame, rule, ss))
         end
         -- Feed the active glow + border the underlying icon's shape / border so
         -- Shape Glow masks to the shape (it reads the shape from its glow frame's
@@ -491,7 +508,7 @@ end
                     pcall(ns.StyleOverlayCooldownText, st.cd, bd, ss, iconFrame:GetScale())
                 end
                 if ns._cdmAnyThresholdText and ns.ApplyThresholdFormatter then
-                    pcall(ns.ApplyThresholdFormatter, st.cd, ss)
+                    pcall(ns.ApplyThresholdFormatter, st.cd, ThresholdFor(iconFrame, rule, ss))
                 end
             else
                 st.cdLocked = true
@@ -622,7 +639,7 @@ end
                     pcall(ns.StyleOverlayCooldownText, cd, bd, ss, scale)
                 end
                 if ns.ApplyThresholdFormatter then
-                    pcall(ns.ApplyThresholdFormatter, cd, ss)
+                    pcall(ns.ApplyThresholdFormatter, cd, ThresholdFor(st.srcFrame, rule, ss))
                 end
                 if ns.ApplyShapeToOverlay and st.srcFrame then
                     pcall(ns.ApplyShapeToOverlay, st.srcFrame, tex, cd, bd)

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -8633,15 +8633,16 @@ initFrame:SetScript("OnEvent", function(self)
                                        and type(b2.assignedSpells) == "table" then
                                         for _, sid2 in ipairs(b2.assignedSpells) do
                                             claimed[sid2] = true
+                                            -- A cd-claimed member is listed by its MARKER but stores
+                                            -- its settings under "c"..cooldownID; claim both or this
+                                            -- bar's entry reads as unclaimed and gets wiped.
+                                            local cdID2 = ns.CdClaimMarkerToCdID and ns.CdClaimMarkerToCdID(sid2)
+                                            if cdID2 then claimed["c" .. cdID2] = true end
                                         end
                                     end
                                     -- Also exclude HOSTED buffs (on cd/util bars): removed from Apply-to-Bar,
                                     -- so a default-buffs-bar apply must not treat their buff-store entry as unclaimed and wipe it.
-                                    if type(b2) == "table" and type(b2.hostedBuffSpellIDs) == "table" then
-                                        for hsid in pairs(b2.hostedBuffSpellIDs) do
-                                            claimed[hsid] = true
-                                        end
-                                    end
+                                    AB.ForEachHostedKey(b2, function(hkey) claimed[hkey] = true end)
                                 end
                             end
                             for sid2, e in pairs(st) do
@@ -8743,24 +8744,53 @@ initFrame:SetScript("OnEvent", function(self)
                         end
                         return true
                     end
+                    -- Every BUFF-store key the bar's hosted buffs use. Two shapes: a plain spell id
+                    -- from hostedBuffSpellIDs, and "c"..cooldownID for a CD-CLAIMED slot, whose
+                    -- marker lives in assignedSpells while hostedBuffSpellIDs carries only the
+                    -- existence sentinel AddHostedBuffByCdID sets. That sentinel doubles as the
+                    -- gate: a buff-family bar never sets it, so its own cd-claim markers (ordinary
+                    -- members via AddTrackedBuffByCdID, not hosted) are never read as hosted slots.
+                    AB.ForEachHostedKey = function(bsX, fn)
+                        if type(bsX) ~= "table" or type(bsX.hostedBuffSpellIDs) ~= "table" then return end
+                        for hsid in pairs(bsX.hostedBuffSpellIDs) do fn(hsid) end
+                        if type(bsX.assignedSpells) == "table" and ns.CdClaimMarkerToCdID then
+                            for _, sid2 in ipairs(bsX.assignedSpells) do
+                                local cdID = ns.CdClaimMarkerToCdID(sid2)
+                                if cdID then fn("c" .. cdID) end
+                            end
+                        end
+                    end
                     -- Stamp one spec profile's hosted buffs on this bar. Blocking-false has nothing
                     -- to block here (hosted entries chain to no tier), so an "off" apply clears the
                     -- keys instead, and an entry left empty is dropped.
-                    AB.StampHostedBuffs = function(prof, bsX, applyWrite, val)
-                        local hosted = bsX and bsX.hostedBuffSpellIDs
-                        if type(hosted) ~= "table" then return end
-                        local st = ns.GetSpellSettingsStoreForProf
-                            and ns.GetSpellSettingsStoreForProf(prof, AB.hostedFamKey, true)
-                        if not st then return end
-                        for hsid in pairs(hosted) do
-                            local e = st[hsid]
-                            if not e then e = {}; st[hsid] = e end
+                    AB.StampHostedBuffs = function(prof, bsX, applyWrite, val, keys)
+                        local st
+                        local mintedCdKey = false
+                        AB.ForEachHostedKey(bsX, function(hkey)
+                            -- Resolved on the first hosted key, not up front: an All Specs apply on
+                            -- a bar with no hosted buffs would otherwise mint an empty family store
+                            -- in every spec profile.
+                            st = st or (ns.GetSpellSettingsStoreForProf
+                                and ns.GetSpellSettingsStoreForProf(prof, AB.hostedFamKey, true))
+                            if not st then return end
+                            local e, fresh = st[hkey], false
+                            if not e then e = {}; st[hkey] = e; fresh = true end
                             applyWrite(e, val)
-                            for k in pairs(AB.HOSTED_KEYS) do
+                            -- Only the keys this apply wrote: reaching across the whole set would
+                            -- drop blocking-false values the apply never touched, and the un-stamp
+                            -- walks `keys` too, so it could not put them back.
+                            for _, k in ipairs(keys) do
                                 if rawget(e, k) == false then e[k] = nil end
                             end
-                            if next(e) == nil then st[hsid] = nil end
-                        end
+                            if next(e) == nil then
+                                st[hkey] = nil
+                            elseif fresh and type(hkey) == "string" then
+                                mintedCdKey = true
+                            end
+                        end)
+                        -- A newly minted "c"..cooldownID entry stays invisible to the runtime until
+                        -- the buff-family cd-key gate flips, the same call the menu's EnsureSS makes.
+                        if mintedCdKey and ns.MarkBuffFamHasCdKey then ns.MarkBuffFamHasCdKey() end
                     end
                     AB.StampMemberCas = function(bsX, applyWrite, val, keys)
                         if not (bsX and type(bsX.assignedSpells) == "table") then return end
@@ -8869,15 +8899,15 @@ initFrame:SetScript("OnEvent", function(self)
                                 end
                             end
                             -- Hosted buffs stamp their own entries (StampHostedBuffs), under the same blocking-false normalization the cas stamps use.
-                            if touchesHosted and bsX and type(bsX.hostedBuffSpellIDs) == "table" then
+                            if touchesHosted then
                                 local st = prof[AB.hostedFamKey]
                                 if st then
-                                    for hsid in pairs(bsX.hostedBuffSpellIDs) do
-                                        local e = st[hsid]
+                                    AB.ForEachHostedKey(bsX, function(hkey)
+                                        local e = st[hkey]
                                         if type(e) == "table" and entryLoses(e, true) then
                                             count = count + 1
                                         end
-                                    end
+                                    end)
                                 end
                             end
                         end
@@ -8925,7 +8955,7 @@ initFrame:SetScript("OnEvent", function(self)
                                 AB.StampMemberCas(bsX, applyWrite, val, keys)
                             end
                             if touchesHosted then
-                                AB.StampHostedBuffs(prof, bsX, applyWrite, val)
+                                AB.StampHostedBuffs(prof, bsX, applyWrite, val, keys)
                             end
                         end
                         if allSpecs then
@@ -9052,12 +9082,16 @@ initFrame:SetScript("OnEvent", function(self)
                                 end
                             end
                             local function unstamp(prof, bsX)
-                                if touchesHosted and bsX and type(bsX.hostedBuffSpellIDs) == "table" then
+                                if touchesHosted then
                                     local st = prof and prof[AB.hostedFamKey]
                                     if st then
-                                        for hsid in pairs(bsX.hostedBuffSpellIDs) do
-                                            unstampEntry(st[hsid])
-                                        end
+                                        AB.ForEachHostedKey(bsX, function(hkey)
+                                            local e = st[hkey]
+                                            if not e then return end
+                                            unstampEntry(e)
+                                            -- Mirror the stamp: an entry the un-stamp empties is dropped, so it cannot linger and defeat the resolver's empty-store shortcut.
+                                            if next(e) == nil then st[hkey] = nil end
+                                        end)
                                     end
                                 end
                                 if not (bsX and type(bsX.assignedSpells) == "table") then return end

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -8723,6 +8723,45 @@ initFrame:SetScript("OnEvent", function(self)
                         thresholdColorEnabled = true, thresholdColorR = true,
                         thresholdColorG = true, thresholdColorB = true,
                     }
+                    -- Keys a bar apply also stamps onto the bar's HOSTED buffs. A hosted buff
+                    -- never chains to the bar tiers -- the tier carries cd-bar meaning for shared
+                    -- keys (Duration Text, Border) and its entry is the same one the spell uses on
+                    -- a buffs bar -- so a bar apply otherwise skips it entirely. These keys read
+                    -- the same on any icon, so they stamp directly, like preset icons do through
+                    -- StampMemberCas. Only rows whose keys are ALL in here stamp.
+                    AB.HOSTED_KEYS = {
+                        thresholdSeconds = true, thresholdDecimals = true,
+                        thresholdColorEnabled = true, thresholdColorR = true,
+                        thresholdColorG = true, thresholdColorB = true,
+                    }
+                    -- Hosted buffs keep their entries in the BUFF family store whatever family the host bar belongs to.
+                    AB.hostedFamKey = ns.SettingsFamilyKey("buffs")
+                    AB.TouchesHosted = function(keys)
+                        if not keys or #keys == 0 then return false end
+                        for _, k in ipairs(keys) do
+                            if not AB.HOSTED_KEYS[k] then return false end
+                        end
+                        return true
+                    end
+                    -- Stamp one spec profile's hosted buffs on this bar. Blocking-false has nothing
+                    -- to block here (hosted entries chain to no tier), so an "off" apply clears the
+                    -- keys instead, and an entry left empty is dropped.
+                    AB.StampHostedBuffs = function(prof, bsX, applyWrite, val)
+                        local hosted = bsX and bsX.hostedBuffSpellIDs
+                        if type(hosted) ~= "table" then return end
+                        local st = ns.GetSpellSettingsStoreForProf
+                            and ns.GetSpellSettingsStoreForProf(prof, AB.hostedFamKey, true)
+                        if not st then return end
+                        for hsid in pairs(hosted) do
+                            local e = st[hsid]
+                            if not e then e = {}; st[hsid] = e end
+                            applyWrite(e, val)
+                            for k in pairs(AB.HOSTED_KEYS) do
+                                if rawget(e, k) == false then e[k] = nil end
+                            end
+                            if next(e) == nil then st[hsid] = nil end
+                        end
+                    end
                     AB.StampMemberCas = function(bsX, applyWrite, val, keys)
                         if not (bsX and type(bsX.assignedSpells) == "table") then return end
                         if not (ns.GetCustomActiveState and ns.ResolveCustomActiveKey) then return end
@@ -8783,6 +8822,7 @@ initFrame:SetScript("OnEvent", function(self)
                         for _, k in ipairs(keys) do
                             if AB.CAS_KEYS[k] then touchesCas = true; break end
                         end
+                        local touchesHosted = AB.TouchesHosted(keys)
                         local count = 0
                         local CAS_FALSE_STRIPPED = {
                             cdStateEffect = true, thresholdSeconds = true,
@@ -8828,6 +8868,18 @@ initFrame:SetScript("OnEvent", function(self)
                                     end
                                 end
                             end
+                            -- Hosted buffs stamp their own entries (StampHostedBuffs), under the same blocking-false normalization the cas stamps use.
+                            if touchesHosted and bsX and type(bsX.hostedBuffSpellIDs) == "table" then
+                                local st = prof[AB.hostedFamKey]
+                                if st then
+                                    for hsid in pairs(bsX.hostedBuffSpellIDs) do
+                                        local e = st[hsid]
+                                        if type(e) == "table" and entryLoses(e, true) then
+                                            count = count + 1
+                                        end
+                                    end
+                                end
+                            end
                         end
                         local spAll = ns.GetActiveSpecProfiles and ns.GetActiveSpecProfiles()
                         if allSpecs then
@@ -8852,6 +8904,7 @@ initFrame:SetScript("OnEvent", function(self)
                         for _, k in ipairs(keys) do
                             if AB.CAS_KEYS[k] then touchesCas = true; break end
                         end
+                        local touchesHosted = AB.TouchesHosted(keys)
                         local function sweepProf(prof)
                             if type(prof) ~= "table" then return end
                             -- Sweeps can delete emptied member entries and the per-spec tier: retire memoized resolution results.
@@ -8870,6 +8923,9 @@ initFrame:SetScript("OnEvent", function(self)
                             end)
                             if touchesCas then
                                 AB.StampMemberCas(bsX, applyWrite, val, keys)
+                            end
+                            if touchesHosted then
+                                AB.StampHostedBuffs(prof, bsX, applyWrite, val)
                             end
                         end
                         if allSpecs then
@@ -8967,6 +9023,7 @@ initFrame:SetScript("OnEvent", function(self)
                             removed[k] = rawget(t, k)
                             rawset(t, k, nil)
                         end
+                        local touchesHosted = AB.TouchesHosted(keys)
                         if next(t) == nil then
                             if allSpecs then
                                 if bdSel then bdSel.barSpellSettings = nil end
@@ -8994,7 +9051,15 @@ initFrame:SetScript("OnEvent", function(self)
                                     if rv ~= nil and rawget(e, k) == rv then e[k] = nil end
                                 end
                             end
-                            local function unstamp(bsX)
+                            local function unstamp(prof, bsX)
+                                if touchesHosted and bsX and type(bsX.hostedBuffSpellIDs) == "table" then
+                                    local st = prof and prof[AB.hostedFamKey]
+                                    if st then
+                                        for hsid in pairs(bsX.hostedBuffSpellIDs) do
+                                            unstampEntry(st[hsid])
+                                        end
+                                    end
+                                end
                                 if not (bsX and type(bsX.assignedSpells) == "table") then return end
                                 for _, sid2 in ipairs(bsX.assignedSpells) do
                                     local isInj = ((type(sid2) == "number" and sid2 < 0)
@@ -9021,14 +9086,14 @@ initFrame:SetScript("OnEvent", function(self)
                                 if spAll then
                                     for _, prof in pairs(spAll) do
                                         if type(prof) == "table" then
-                                            unstamp(prof.barSpells and prof.barSpells[barKey])
+                                            unstamp(prof, prof.barSpells and prof.barSpells[barKey])
                                         end
                                     end
                                 end
                             else
                                 local specKeyA = ns.GetActiveSpecKey and ns.GetActiveSpecKey()
                                 local prof = spAll and specKeyA and spAll[specKeyA]
-                                if prof then unstamp(prof.barSpells and prof.barSpells[barKey]) end
+                                if prof then unstamp(prof, prof.barSpells and prof.barSpells[barKey]) end
                             end
                             if ns.FakeActive_Rearm then ns.FakeActive_Rearm() end
                         end


### PR DESCRIPTION
**Cause:** A hosted buff (a buff placed on a cd/utility bar) is excluded from the Apply-to-Bar machinery in three places: the options effective-read passes nil for the bar tiers, the runtime resolver strips them, and the member sweep skips them. Threshold Text set on a normal spell had no path to reach one, in any spec.

**Fix:** Stamp the Threshold Text keys onto each hosted buff's own buff-store entry during a bar apply, the way preset icons are already handled by `StampMemberCas`. Covers both hosted shapes, including cd-claimed slots keyed `"c"..cooldownID`. Also honours the per-spell Threshold Text on a user rule's active-state countdown, which the row already documents.

**Test:** Threshold Text applied bar-wide from a normal spell now reaches hosted buffs and carries across specs; un-apply clears them. Verified in game by the reporter.
