### PR TITLE
Chat font selection ignored for the client's native CJK alphabet

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat_Engine.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Engine.lua
@@ -377,8 +377,14 @@ function ECHAT.EngineFontFamily(id, font, size, flags)
         -- CJK renders +2px: ideographs at latin point sizes read visibly
         -- smaller (dense glyphs, no ascender/descender whitespace). Not on the
         -- client's own alphabet -- see CJKHeight.
+        
+        -- Client's own CJK alphabet uses the chosen font, not the stock
+        -- file, since most chat text renders through it. Other CJK
+        -- alphabets keep the stock file as a tofu fallback.
         for alphabet, file in pairs(CJK_FILES) do
-            members[#members + 1] = { alphabet = alphabet, file = file, height = CJKHeight(alphabet, size), flags = flags }
+            local memberFile = (alphabet == CJK_CLIENT_ALPHABET) and font or file
+            members[#members + 1] = { alphabet = alphabet, file = memberFile, height = CJKHeight(alphabet, size), flags = flags }
+         end
         end
         local ok, created = pcall(CreateFontFamily, "EUIChatFontFamily" .. id, members)
         if not ok or not created then FAMS[id] = false; return nil end
@@ -389,8 +395,9 @@ function ECHAT.EngineFontFamily(id, font, size, flags)
         fam:GetFontObjectForAlphabet("roman"):SetFont(font, size, flags)
         fam:GetFontObjectForAlphabet("russian"):SetFont(font, size, flags)
         for alphabet, file in pairs(CJK_FILES) do
+            local memberFile = (alphabet == CJK_CLIENT_ALPHABET) and font or file
             local member = fam:GetFontObjectForAlphabet(alphabet)
-            member:SetFont(file, CJKHeight(alphabet, size), flags)
+            member:SetFont(memberFile, CJKHeight(alphabet, size), flags)
             member:SetSpacing(CJK_SPACING[alphabet] or 0)
         end
     end)


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540235406463860776

Issue: ECHAT.EngineFontFamily() built a per-alphabet font family for chat text, but hardcoded all three CJK alphabets (korean/simplifiedchinese/traditionalchinese) to fixed stock font files via CJK_FILES, ignoring the user's font selection. On a zhTW client, nearly all chat renders through the traditionalchinese member, so the font option had almost no visible effect — only the rarely-used roman/russian members respected it.

Fix: When an alphabet matches the client's own locale (CJK_CLIENT_ALPHABET), use the user-selected font instead of the stock file. The other two (non-native) CJK alphabets still fall back to the stock files, preserving the original tofu-prevention behavior for foreign-script text that occasionally shows up in the log.