### PR TITLE
Provider raid-buff button fails with "requires a target" — missing unit attribute

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -2284,7 +2284,7 @@ function EABR.SyncProviderCastSpell()
         btn:SetAttribute("spell", spellID)
         btn:SetAttribute("item", nil)
         btn:SetAttribute("macrotext", nil)
-        btn:SetAttribute("unit", nil) -- raid buffs are self-cast, no unit needed
+        btn:SetAttribute("unit", "player") -- explicit unit so casting doesn't depend on your current target
         btn._icon:SetTexture(Tex(spellID) or 134400)
         btn._tooltipSpell = spellID
         btn._tooltipItem = nil


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540423447363194930

Issue: Clicking the raid-buff reminder icon for Power Word: Fortitude (and every other class's provider raid buff — Mark of the Wild, Battle Shout, Arcane Intellect, Skyfury, etc.) failed with "requires a target" when the player had no target selected. The secure button's unit attribute was explicitly set to nil based on the incorrect assumption that raid buffs are self-cast. In reality these are friendly-target spells, so without an explicit unit and without a target selected, WoW's secure spell casting has nothing to target.

Fix: In EABR.SyncProviderCastSpell(), changed the button's unit attribute from nil to "player", so the click always casts on yourself regardless of current target — matching the correct behavior already used elsewhere in the file (SetIconSpell).