### PR TITLE
Fix(unitframe): missing left border on Target Castbar when spell icon is disabled

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2840,6 +2840,19 @@ local function CastIconInWidth(unit, s)
     return s.showCastIcon ~= false and s.castbarIconInWidth ~= false
 end
 
+-- Whether the cast spell icon is shown at all. Independent of "part of the
+-- bar" (CastIconInWidth folds this in already for its own purposes, but
+-- LayoutCastbarIcon needs the shown state on its own to know whether a
+-- disabled icon should suppress the bar's facing border).
+local function CastIconShown(unit, s)
+    s = s or GetSettingsForUnit(unit)
+    if not s then return true end
+    if unit == "player" then
+        return s.showPlayerCastIcon ~= false
+    end
+    return s.showCastIcon ~= false
+end
+
 -- Whether the cast spell icon sits on the RIGHT of the bar instead of the
 -- default left. Independent of "part of the bar"; defaults off (left).
 local function CastIconOnRight(unit, s)
@@ -2872,7 +2885,7 @@ end
 -- at final height/scale). iconH is the configured cast bar height (castbarHeight/
 -- playerCastbarHeight), used only for the square WIDTH and matching fill inset so
 -- those stay deterministic; falls back to bg:GetHeight().
-local function LayoutCastbarIcon(castbar, inWidth, iconH, onRight, offX, offY)
+local function LayoutCastbarIcon(castbar, inWidth, iconH, onRight, offX, offY, iconShown)
     if not castbar then return end
     local bg = castbar:GetParent()
     if not bg then return end
@@ -2919,12 +2932,15 @@ local function LayoutCastbarIcon(castbar, inWidth, iconH, onRight, offX, offY)
     -- the facing edge on each side, same _hideLeft/_hideRight pattern as the
     -- health/power seam elsewhere in this file. Only when truly flush (no
     -- configured icon offset): with an offset there's a real gap, and hiding
-    -- both edges would leave it with no border on either side.
+    -- both edges would leave it with no border on either side. And only when
+    -- the icon is actually shown -- a disabled icon still owns a (hidden)
+    -- iconFrame, so blindly suppressing the bar's facing edge here left the
+    -- bar with no border at all on that side while the icon is off.
     if iconFrame then
         local iconEdges = PP.GetBorders(iconFrame)
         local barEdges = PP.GetBorders(castbar)
         if iconEdges and barEdges then
-            if offX == 0 and offY == 0 then
+            if iconShown and offX == 0 and offY == 0 then
                 iconEdges._hideRight = (not onRight) or nil
                 iconEdges._hideLeft  = onRight or nil
                 barEdges._hideLeft   = (not onRight) or nil
@@ -6693,7 +6709,10 @@ local function CreateCastBar(frame, unit, settings)
 
     -- Initial icon/fill layout (re-applied on every reload by the per-unit
     -- update paths and whenever the cast-bar height changes).
-    LayoutCastbarIcon(castbar, CastIconInWidth(unit, settings), cbHeight, CastIconOnRight(unit, settings), CastIconOffsets(unit, settings))
+    do
+        local offX, offY = CastIconOffsets(unit, settings)
+        LayoutCastbarIcon(castbar, CastIconInWidth(unit, settings), cbHeight, CastIconOnRight(unit, settings), offX, offY, CastIconShown(unit, settings))
+    end
 
     return castbar
 end
@@ -10280,7 +10299,8 @@ local function ReloadFrames()
                                     local cbg = settings.castBgColor
                                     castbarBg._bgTex:SetColorTexture(cbg and cbg.r or 0, cbg and cbg.g or 0, cbg and cbg.b or 0, settings.castBgAlpha or 0.5)
                                 end
-                                LayoutCastbarIcon(frame.Castbar, CastIconInWidth("player", settings), nil, CastIconOnRight("player", settings), CastIconOffsets("player", settings))
+                                local pIconOffX, pIconOffY = CastIconOffsets("player", settings)
+                                LayoutCastbarIcon(frame.Castbar, CastIconInWidth("player", settings), nil, CastIconOnRight("player", settings), pIconOffX, pIconOffY, CastIconShown("player", settings))
                                 -- Resize cast icon to match castbar height
                                 if frame.Castbar._iconFrame then
                                     PP.Size(frame.Castbar._iconFrame, cbH, cbH)
@@ -10792,7 +10812,8 @@ local function ReloadFrames()
                                     local cbg = settings.castBgColor
                                     castbarBg._bgTex:SetColorTexture(cbg and cbg.r or 0, cbg and cbg.g or 0, cbg and cbg.b or 0, settings.castBgAlpha or 0.5)
                                 end
-                                LayoutCastbarIcon(frame.Castbar, CastIconInWidth("target", settings), nil, CastIconOnRight("target", settings), CastIconOffsets("target", settings))
+                                local tIconOffX, tIconOffY = CastIconOffsets("target", settings)
+                                LayoutCastbarIcon(frame.Castbar, CastIconInWidth("target", settings), nil, CastIconOnRight("target", settings), tIconOffX, tIconOffY, CastIconShown("target", settings))
                                 if frame.Castbar._iconFrame then
                                     PP.Size(frame.Castbar._iconFrame, cbH2, cbH2)
                                     if not frame.Castbar:IsShown() then
@@ -11206,7 +11227,8 @@ local function ReloadFrames()
                                 local cbg = settings.castBgColor
                                 castbarBg._bgTex:SetColorTexture(cbg and cbg.r or 0, cbg and cbg.g or 0, cbg and cbg.b or 0, settings.castBgAlpha or 0.5)
                             end
-                            LayoutCastbarIcon(frame.Castbar, CastIconInWidth("focus", settings), nil, CastIconOnRight("focus", settings), CastIconOffsets("focus", settings))
+                            local fIconOffX, fIconOffY = CastIconOffsets("focus", settings)
+                            LayoutCastbarIcon(frame.Castbar, CastIconInWidth("focus", settings), nil, CastIconOnRight("focus", settings), fIconOffX, fIconOffY, CastIconShown("focus", settings))
                             if frame.Castbar._iconFrame then
                                 PP.Size(frame.Castbar._iconFrame, cbH3, cbH3)
                                 if not frame.Castbar:IsShown() then
@@ -11582,7 +11604,8 @@ local function ReloadFrames()
                             local bCbW = settings.castbarWidth or 0
                             if bCbW > 0 and bCbW < 30 then bCbW = 30 end
                             PP.Size(castbarBg, bCbW > 0 and bCbW or totalWidth, settings.castbarHeight or 14)
-                            LayoutCastbarIcon(frame.Castbar, CastIconInWidth("boss1", settings), nil, CastIconOnRight("boss1", settings), CastIconOffsets("boss1", settings))
+                            local bIconOffX, bIconOffY = CastIconOffsets("boss1", settings)
+                            LayoutCastbarIcon(frame.Castbar, CastIconInWidth("boss1", settings), nil, CastIconOnRight("boss1", settings), bIconOffX, bIconOffY, CastIconShown("boss1", settings))
                             if frame.Castbar._iconFrame then
                                 local cbH = settings.castbarHeight or 14
                                 PP.Size(frame.Castbar._iconFrame, cbH, cbH)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Fixes the Target Castbar (and Player/Focus/Boss1 castbars, which share the same code path) losing its leftmost border when the cast spell icon is disabled. The icon frame and the cast bar are two separate frames that each draw their own 1px border, and when they sit flush against each other the code suppresses the facing edge on each side to avoid a doubled 2px seam. That suppression ran regardless of whether the icon was actually visible, so a disabled icon (which still keeps a hidden icon frame around) caused the bar's left border to be hidden with nothing there to cover the gap, leaving the bar without a visible edge on that side. The facing-edge suppression is now only applied when the icon is actually shown.

## How was it tested?

Tested in-game on live.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; this only fixes a border rendering bug for the existing icon-disabled state
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A, no new events, polling, or frames added
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- unchanged layout call, no new work added
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, no Blizzard frames touched
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
