### PR TITLE
Fix(CDM): Suppress GCD leaving the GCD sweep visible on Hide Active State States

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2901,23 +2901,27 @@ local function DecorateFrame(frame, barData)
                     -- pushes a GCD via SetCooldown, whose geometry the PERSISTENT
                     -- black colour sweeps as a visible bar (SetCooldown changes
                     -- geometry, not colour, so nothing re-hides it). Paint fully
-                    -- transparent for exactly that case. Gated on Suppress GCD; normal
-                    -- hide-active spells and transforms whose proc is on its own real
-                    -- CD keep the black swipe, and a charge proc mid-recharge is
-                    -- carved out (its swipe IS the recharge).
+                    -- transparent for exactly that case, and also for a plain
+                    -- hide-active spell whose swipe color never zeroes out
+                    -- (e.g. Prismatic Barrier), which pins fd._hideActiveOverriding
+                    -- and otherwise leaks a bare GCD once charges max out. Gated
+                    -- on Suppress GCD; a spell genuinely on its own real CD keeps
+                    -- the black swipe, and a charge proc mid-recharge is carved
+                    -- out (its swipe IS the recharge).
                     local hideActiveAlpha = barData.swipeAlpha or 0.7
                     if ((bd2 and bd2.suppressGCD) or (ss2 and ss2.suppressGCD)) and sid2
                        and C_SpellBook and C_SpellBook.FindSpellOverrideByID
                        and C_Spell and C_Spell.GetSpellCooldown then
-                        local ovrID = C_SpellBook.FindSpellOverrideByID(sid2)
-                        if ovrID and ovrID > 0 and ovrID ~= sid2 then
-                            local chargeRecharging = false
-                            do
-                                local ci = CdmChargeInfoFor(frame, sid2)
-                                chargeRecharging = (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true) or false
-                            end
-                            local oc = C_Spell.GetSpellCooldown(ovrID)
-                            if not chargeRecharging and oc and not (oc.isActive and not oc.isOnGCD) then
+                        local chargeRecharging = false
+                        do
+                            local ci = CdmChargeInfoFor(frame, sid2)
+                            chargeRecharging = (ci and (ci.maxCharges or 0) > 1 and ci.isActive == true) or false
+                        end
+                        if not chargeRecharging then
+                            local ovrID = C_SpellBook.FindSpellOverrideByID(sid2)
+                            local checkID = (ovrID and ovrID > 0 and ovrID ~= sid2) and ovrID or sid2
+                            local oc = C_Spell.GetSpellCooldown(checkID)
+                            if oc and not (oc.isActive and not oc.isOnGCD) then
                                 hideActiveAlpha = 0
                             end
                         end


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Fixes Suppress GCD in Cooldown Manager leaving the shared GCD sweep visible on some spells once a charge fully replenishes, most easily reproduced on the mage spell Prismatic Barrier: use one of two charges, keep casting other spells, and the GCD sweep reappears on the Barrier icon as soon as the charge finishes recharging back to max, even though Suppress GCD is enabled and the recharge itself was correctly suppressed the whole time it was in progress.

The root cause is that spells with Hide Active State enabled whose swipe color never reads back to zero (Prismatic Barrier is one of these) permanently pin an internal "hide-active override" flag true, which by design blocks the primary Suppress GCD suppression path so a genuinely in-progress recharge display never gets blanked. The Hide Active State branch has its own separate Suppress GCD carve-out for exactly this situation, but that carve-out only checked a spell's hero-talent transform override cooldown, so a plain spell without an override (like Prismatic Barrier) never got suppressed once its charges maxed out and all that remained to draw was a bare GCD. This PR makes that carve-out fall back to the spell's own cooldown when there is no transform override, so the bare-GCD case gets suppressed the same way the transform case already was.

## How was it tested?

Tested in-game on live.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting; this only changes behavior for spells that already have Suppress GCD enabled
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- adds one extra cooldown lookup only for the specific case that was previously unhandled
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
