### PR TITLE
Fix xp/rep databar showing 0% for friendship reputations

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -2216,8 +2216,29 @@ ns.BlockFactories.xprep = function(blockCfg, slot, content, barCtx)
                 r = 0.5, g = 0.5, b = 0.5, rested = 0,
             }
         end
+        -- Friendship factions (Captain Tokka, Cursed Angler ranks, etc.): the
+        -- watched-faction payload returns EQUAL reaction thresholds for these,
+        -- which collapsed the range to zero and rendered a permanent 0% with a
+        -- nonsense "8,400 / 8,401" tooltip (field report 2026-08-22). The
+        -- friendship API carries the real rank window -- same handling as the
+        -- Action Bars RepBar. Checked before renown, matching that code path.
+        local isFriendship = false
+        if factionID and C_GossipInfo and C_GossipInfo.GetFriendshipReputation then
+            local fi = C_GossipInfo.GetFriendshipReputation(factionID)
+            if fi and fi.friendshipFactionID and fi.friendshipFactionID > 0 then
+                isFriendship = true
+                minV = fi.reactionThreshold or 0
+                curV = fi.standing or minV
+                if fi.nextThreshold and fi.nextThreshold > minV then
+                    maxV = fi.nextThreshold
+                else
+                    -- Maxed friendship rank: render a full bar.
+                    minV, maxV, curV = 0, 1, 1
+                end
+            end
+        end
         -- Major Factions (renown progress)
-        if factionID and C_MajorFactions and C_MajorFactions.GetMajorFactionData then
+        if not isFriendship and factionID and C_MajorFactions and C_MajorFactions.GetMajorFactionData then
             local mfd = C_MajorFactions.GetMajorFactionData(factionID)
             if mfd and type(mfd.renownLevelThreshold) == "number" and mfd.renownLevelThreshold > 0 then
                 minV = 0; maxV = mfd.renownLevelThreshold; curV = mfd.renownReputationEarned or 0


### PR DESCRIPTION
For friendship factions (Captain Tokka, etc.) the watched reputation does not display correctly, 0% with 8400/8401.

<img width="352" height="154" alt="image" src="https://github.com/user-attachments/assets/7dbef84e-dd30-4cf0-aa53-570e25ed5c66" />

## What does this PR do?
Before rendering, check if the tracked reputation is a friendship rep, and use the standing/friendship rank thresholds if true.

## How was it tested?
Screenshots below, tested by switching tracked factions

## Screenshots

<img width="969" height="700" alt="image" src="https://github.com/user-attachments/assets/8860054b-d207-4c6c-a489-584d5b8c246a" />
<img width="918" height="704" alt="image" src="https://github.com/user-attachments/assets/0c1d360a-173e-4e2f-b08a-c125c3c8a066" />

## Checklist

Pure bugfix, one additional API call added to identify the reputation type, and one to retrieve the standing/thresholds if needed.

- N/A: New settings default **OFF** (no behavior change without opt-in)
- N/A: Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- N/A: Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- N/A: No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
