### PR TITLE
Fix Raid Tools marker buttons when ActionButtonUseKeyDown is 0

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL_RaidTools.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_RaidTools.lua
@@ -518,8 +518,12 @@ local function MakeMarkerButton(parent, index, kind)
     local b = CreateFrame("Button", nil, parent, "SecureActionButtonTemplate")
     b:SetSize(MARKER_SZ, MARKER_SZ)
     -- One phase only: the "!" prefix toggles the marker, so firing on both the
-    -- down and the up would set it and immediately clear it again.
+    -- down and the up would set it and immediately clear it again. useOnKeyDown
+    -- is pinned because left unset it follows the ActionButtonUseKeyDown CVar,
+    -- and at 0 the secure handler acts on the up phase we never register --
+    -- every marker button goes dead.
     b:RegisterForClicks("AnyDown")
+    b:SetAttribute("useOnKeyDown", true)
 
     local icon = b:CreateTexture(nil, "ARTWORK")
     icon:SetAllPoints()


### PR DESCRIPTION
**Cause:** The Raid Tools marker grid registers its SecureActionButtonTemplate buttons for AnyDown only. With the useOnKeyDown attribute unset, SecureActionButton_OnClick follows the ActionButtonUseKeyDown CVar: at 0 it acts on the up phase, which the buttons never receive, so every world/target marker click is silently discarded.

**Fix:** Pin useOnKeyDown true at build, matching the existing DataBars/Quickdraw pattern, so the registered down-click is always honored. CVar=1 behavior is unchanged.

**Test:** Reporter reproduced with CVar=0 and confirmed the test build fixes it; markers verified working at both CVar values, no double-fire.