### PR TITLE
Fix One Button Assist cooldown swipe flickering under a still icon

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -3910,6 +3910,17 @@ do
             local action = btn:GetAttribute("action")
             if not action or not HasAction(action) then return end
             local fd = EFD(btn)
+            -- Assist host: its slot cooldown mirrors whatever the engine is
+            -- suggesting at the instant it is read, so a slot-fed push here can
+            -- land on a different ability than the icon the assist ticker
+            -- painted -- the same split ns.PaintAssistCooldown closes. Every
+            -- cooldown event (any cast, any bar) reaches this function, so the
+            -- ticker's fix must own this path too. The spinner read keeps the
+            -- check a raw table lookup for every other button.
+            if fd.assistSpin and C_ActionBar.IsAssistedCombatAction
+               and C_ActionBar.IsAssistedCombatAction(action) then
+                return ns.PaintAssistCooldown(btn, ns._assistLastSuggest)
+            end
             local cd = btn.cooldown
             local durObj = gDur
             local cdInfo = ci or C_ActionBar.GetActionCooldown(action)
@@ -4134,7 +4145,14 @@ do
                         local ci = C_ActionBar.GetActionCooldown(action)
                         local cdReal = (ci and ci.isActive and not ci.isOnGCD) and true or false
                         if cdReal ~= (fd.cdWasReal or false) then
-                            ForceCooldownPaint(btn)
+                            -- Assist host: swipe follows the ticker's sample,
+                            -- never the slot (see PushButtonCooldown).
+                            if fd.assistSpin and C_ActionBar.IsAssistedCombatAction
+                               and C_ActionBar.IsAssistedCombatAction(action) then
+                                ns.PaintAssistCooldown(btn, ns._assistLastSuggest)
+                            else
+                                ForceCooldownPaint(btn)
+                            end
                             fd.cdWasReal = cdReal
                         end
                         local chargeCd = btn.chargeCooldown

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -840,6 +840,30 @@ local function ForceCooldownPaint(btn)
 end
 ns.ForceCooldownPaint = ForceCooldownPaint
 
+-- Paint the One Button Assist button's cooldown from the SUGGESTED spell rather
+-- than from its action slot. That button draws two things from two sources: the
+-- icon is the suggestion sampled on the assist ticker, while the slot's own
+-- cooldown mirrors whatever the engine is suggesting at the instant it is read.
+-- The suggestion moves faster than the 5 Hz tick, so consecutive reads land on
+-- different abilities and the swipe flips on and off under a still icon.
+-- spellID nil means no suggestion, where RepaintAssistIcons falls the icon back
+-- to the slot's own texture, so the swipe follows it there. isActive is
+-- NeverSecret and the duration object carries the timing: no secret is read.
+-- On ns, not a local: this file's main chunk is at the 200-local cap.
+ns.PaintAssistCooldown = function(btn, spellID)
+    if not spellID then return ForceCooldownPaint(btn) end
+    local cd = btn and btn.cooldown
+    if not cd then return end
+    local info = C_Spell and C_Spell.GetSpellCooldown and C_Spell.GetSpellCooldown(spellID)
+    local durObj = info and info.isActive and C_Spell.GetSpellCooldownDuration
+        and C_Spell.GetSpellCooldownDuration(spellID)
+    if durObj then
+        cd:SetCooldownFromDurationObject(durObj)
+    else
+        cd:Clear()
+    end
+end
+
 -- Stock bar frames to disable. Each entry carries flags for how to handle it:
 --   retainEvents  = true  -> do NOT unregister events (needed for override state)
 local STOCK_BAR_DISPOSAL = {
@@ -3114,10 +3138,15 @@ end
 -- OnUpdate poll drove Blizzard's re-stamp loop) NO event fires on suggestion
 -- changes -- the assist ticker below is the driver. Buttons are found via the
 -- spinner registry; the slot-spam event's id never matched our action attr anyway.
-function ns.RepaintAssistIcons()
+-- suggestedSpell: the ticker's single sample for this pass, so the icon and the
+-- swipe below describe the same ability. Callers without one read it themselves.
+function ns.RepaintAssistIcons(suggestedSpell)
     local found = 0
-    local nextSpell = C_AssistedCombat and C_AssistedCombat.GetNextCastSpell
-        and C_AssistedCombat.GetNextCastSpell()
+    local nextSpell = suggestedSpell
+    if nextSpell == nil then
+        nextSpell = C_AssistedCombat and C_AssistedCombat.GetNextCastSpell
+            and C_AssistedCombat.GetNextCastSpell()
+    end
     local tex = nextSpell and C_Spell and C_Spell.GetSpellTexture
         and C_Spell.GetSpellTexture(nextSpell)
     for _, info in ipairs(BAR_CONFIG) do
@@ -3145,7 +3174,9 @@ function ns.RepaintAssistIcons()
                             -- button only, so paint its swipe now (two C calls); the
                             -- next natural walk reconciles charges/desat -- never a
                             -- bar-wide invalidation (see ns._ArmAssistTicker).
-                            ns.ForceCooldownPaint(btn)
+                            -- Painted from the SAME spell whose texture just
+                            -- went on the icon, never from the slot.
+                            ns.PaintAssistCooldown(btn, nextSpell)
                         end
                     end
                 end
@@ -3167,15 +3198,18 @@ function ns._ArmAssistTicker()
         local Tick = EllesmereUI and EllesmereUI.Tick
         if not (Tick and Tick.NewAnimTicker) then return end
         t = Tick.NewAnimTicker(CreateFrame("Frame"), function()
+            -- ONE sample per tick, shared by the swipe and the icon: reading
+            -- the suggestion here and the slot's cooldown separately let the
+            -- two land on different abilities (see ns.PaintAssistCooldown).
+            local nextSpell = C_AssistedCombat and C_AssistedCombat.GetNextCastSpell
+                and C_AssistedCombat.GetNextCastSpell()
             -- Every tick, not just on suggestion change: the suggested
             -- spell's own cooldown can end/shorten while the suggestion
             -- holds steady, and nothing else repaints for that.
-            ns.RefreshAssistCooldowns()
-            local nextSpell = C_AssistedCombat and C_AssistedCombat.GetNextCastSpell
-                and C_AssistedCombat.GetNextCastSpell()
+            ns.RefreshAssistCooldowns(nextSpell)
             if nextSpell ~= ns._assistLastSuggest then
                 ns._assistLastSuggest = nextSpell
-                local n = ns.RepaintAssistIcons()
+                local n = ns.RepaintAssistIcons(nextSpell)
                 -- Suggestion moved: the shine may need to follow it too.
                 if ns.QueueAssistRescan then ns.QueueAssistRescan() end
                 -- The assist slot's cooldown mirrors the SUGGESTED spell, so a
@@ -3206,7 +3240,9 @@ end
 -- then three C calls for the one or two hosting buttons -- ~700 table
 -- reads/sec at the 0.2s ticker. Deliberately NOT a walk/memo-drop/dirty-bump:
 -- a one-button change never invalidates bar-wide (see ns._ArmAssistTicker).
-function ns.RefreshAssistCooldowns()
+-- suggestedSpell: paint from this spell rather than the slot, so the per-tick
+-- refresh cannot land on a different ability than the icon is showing.
+function ns.RefreshAssistCooldowns(suggestedSpell)
     for _, info in ipairs(BAR_CONFIG) do
         if not info.isStance and not info.isPetBar then
             local buttons = barButtons[info.key]
@@ -3219,7 +3255,7 @@ function ns.RefreshAssistCooldowns()
                         if action and HasAction(action) and C_ActionBar
                            and C_ActionBar.IsAssistedCombatAction
                            and C_ActionBar.IsAssistedCombatAction(action) then
-                            ns.ForceCooldownPaint(btn)
+                            ns.PaintAssistCooldown(btn, suggestedSpell)
                         end
                     end
                 end


### PR DESCRIPTION
**Cause:** The assist button's icon is painted from the suggested spell, but its cooldown swipe was repainted from the action slot, by the assist ticker and by the central cooldown dispatcher's pushes (tier passes, residual walk, probes, pressed-button ring, charge walk). The slot mirrors whatever the engine is suggesting at the instant it is read, so any cast on any bar landed a different ability's cooldown under a still icon, blinking the swipe on and off.

**Fix:** Sample the suggestion once per assist tick and feed both the icon and the swipe from it; every dispatcher path now delegates assist-hosting buttons to the same suggestion-fed paint instead of reading the slot. The check is a raw table read for all other buttons.

**Test:** Confirmed fixed in-game by the reporter (8.9.8-obrcd2): swipe stays locked to the shown ability while chain-casting from other bars.

<img width="330" height="427" alt="Excited American Horror Story GIF" src="https://github.com/user-attachments/assets/2406f5f7-a59b-417f-818f-ed9ac3f07688" />
