### PR TITLE
Update MailBox Interaction Check

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -229,7 +229,10 @@ qolFrame:SetScript("OnEvent", function(self)
             return (MailFrame and MailFrame:IsShown()) and true or false
         end
         local function BankOpen()
-            return (BankFrame and BankFrame:IsShown()) and true or false
+            -- return (BankFrame and BankFrame:IsShown()) and true or false
+            -- Changed to checking interaction state instead of framestate for wider
+            -- compatability with other addons.
+            return C_PlayerInteractionManager.IsInteractingWithNpcOfType(Enum.PlayerInteractionType.MailInfo) and true or false
         end
         -- "Exclude Warbound Containers": checks the item's own bind type
         -- instead of asking the bank if it would accept a deposit right now --


### PR DESCRIPTION
Fixed QOL Auto-Open to suspend when mailbox is being interacted with instead of checking for the frame visibility.  This widens support to any mail addon instead of just native.

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Suspend Auto-Open when users are interacting with mailbox but not using stock UI.

## How was it tested?

Tested off v8.9.8 codebase and tested in game with Stock UI and TSM.

## Checklist

- [X] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [X] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [X] Tested in-game on live; no version gates or pre-Midnight APIs added
