### PR TITLE
Title: Devourer (DH) flagged for Attack Power buffs instead of Arcane Intellect

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -835,6 +835,7 @@ local BUFF_BENEFICIARIES = {
     intellect = {
         MAGE = true, WARLOCK = true, PRIEST = true, DRUID = true,
         SHAMAN = true, MONK = true, EVOKER = true, PALADIN = true,
+        DEMONHUNTER = true, -- Devourer (1480) is Intellect; Havoc/Vengeance are not
     },
     attackPower = {
         WARRIOR = true, ROGUE = true, HUNTER = true, DEATHKNIGHT = true,
@@ -887,13 +888,14 @@ EABR.SPEC_BENEFITS = {
         [262]=true, [264]=true,                   -- Shaman: Elemental, Restoration
         [270]=true,                               -- Monk: Mistweaver
         [65]=true,                                -- Paladin: Holy
+        [1480]=true,                               -- Demon Hunter: Devourer (Intellect, not Agility)
     },
     attackPower = {
         [71]=true, [72]=true, [73]=true,          -- Warrior
         [259]=true, [260]=true, [261]=true,       -- Rogue
         [253]=true, [254]=true, [255]=true,       -- Hunter
         [250]=true, [251]=true, [252]=true,       -- Death Knight
-        [577]=true, [581]=true, [1480]=true,      -- Demon Hunter (incl. Devourer)
+        [577]=true, [581]=true,                   -- Demon Hunter: Havoc, Vengeance
         [103]=true, [104]=true,                   -- Druid: Feral, Guardian
         [66]=true, [70]=true,                     -- Paladin: Protection, Retribution
         [268]=true, [269]=true,                   -- Monk: Brewmaster, Windwalker


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540755478760521892

Summary: The buff-reminder module hardcoded Demon Hunter's new hero spec, Devourer (spec ID 1480), under the Attack Power benefit set — left over from when all DH specs were Agility-based. Devourer actually uses Intellect as its primary stat (its warglaives convert to Intellect for that spec), so it was never counted as wanting Arcane Intellect, and instead fell back to the DEMONHUNTER class-level entry, which only existed under Attack Power — causing it to ask for Battle Shout-type buffs instead.

Fix: Moved spec 1480 from the attackPower spec-benefit table to intellect, and added DEMONHUNTER to the class-level intellect fallback table (while keeping it under attackPower too, since Havoc/Vengeance are still Agility-based).