### PR TITLE
Guard Instance Reset Announce against secret CHAT_MSG_SYSTEM text

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -1617,6 +1617,10 @@ qolFrame:SetScript("OnEvent", function(self)
 
         local resetAnnounceFrame = CreateFrame("Frame")
         resetAnnounceFrame:SetScript("OnEvent", function(self, event, msg)
+            -- CHAT_MSG_SYSTEM fires for every system message all session (this frame
+            -- stays registered while the toggle is on, not just around /reset), and some
+            -- carry secret text in protected content. Bail before touching msg at all.
+            if issecretvalue and issecretvalue(msg) then return end
             if not (EllesmereUIDB and EllesmereUIDB.instanceResetAnnounce) then return end
 
             -- Instance group only: LE_PARTY_CATEGORY_INSTANCE covers party/raid; IsInGroup() is the older-API fallback.


### PR DESCRIPTION
Reported by @Karambos on 8.9.8. New/empty whisper windows and Report Player cleanup both threw a chat taint error blamed on EllesmereUI/EllesmereUIQoL.
**Cause:** Instance Reset Announce's CHAT_MSG_SYSTEM watcher stays registered all session (not just around /reset) and touched `msg` without an `issecretvalue` check; some system messages carry secret text in protected content, tainting the handler.
**Fix:** Bail on `issecretvalue(msg)` before anything else in the handler runs.
**Taint:** Guard is the first line; no remaining code path in the closure operates on `msg` unchecked.
**Left alone:** Diagnosis is correlation-based (reporter confirmed disabling the toggle stopped the error), not confirmed via taint.log.
**Test:** UNTESTED in-game — reproduce with the toggle on during raid content, confirm chat no longer taints on whisper/report actions.