### PR TITLE
Nameplate border stuck oversized/white on wrong (non-target) mob in packs

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -6223,9 +6223,16 @@ function NameplateFrame:UpdateHealthValues()
                 self._castLockout = nil
                 if ns.NPC_UpdateLockout then ns.NPC_UpdateLockout(self) end
             end
+            -- Unit changed without a full add/remove cycle: clear old
+            -- target/hover border state and re-check it for the new unit.
+            self._targetBorderSized = nil
+            self._hoverBorderSized = nil
+            self._hoverFxOn = nil
             self:UpdateName()
             self._castDirtyFull = true
             self:UpdateCast()
+            self:ApplyTarget()
+            self:ApplyMouseover()
         end
     end
 


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540213541301125160

Issue: When Blizzard silently reassigns a live nameplate frame from one mob to another (a "token swap," common in packs as mobs die and plates get re-stacked), the addon updated the name/cast display but never re-checked target/hover border state. If the previous occupant was the player's target (Border Size + white Border Color applied), those flags stayed stuck on the frame, so a completely different, non-target mob would inherit the oversized white border until something unrelated happened to touch that plate again.

Fix: In the token-swap branch of UpdateHealthValues, clear the stale target/hover border flags and call ApplyTarget()/ApplyMouseover() immediately after the unit reassignment, so the border size/color get freshly evaluated against the mob the plate now actually represents.