### PR TITLE
Fix: secret-value taint in Group Finder applicant list (PVEFrame refresh hook)

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
@@ -1344,8 +1344,14 @@ local _hooksInstalled = false
 local function InstallHooks()
     if _hooksInstalled or not PVEFrame then return end
     _hooksInstalled = true
-    hooksecurefunc(PVEFrame, "Show", RefreshAll)
-    if PVEFrame_ShowFrame then hooksecurefunc("PVEFrame_ShowFrame", function() RefreshAll(); UpdateTabVisuals() end) end
+    -- Deferred so this runs on its own tick, after the click that opened the
+    -- frame has finished, instead of inside that same execution chain.
+    hooksecurefunc(PVEFrame, "Show", function() C_Timer.After(0, RefreshAll) end)
+    if PVEFrame_ShowFrame then
+        hooksecurefunc("PVEFrame_ShowFrame", function()
+            C_Timer.After(0, function() RefreshAll(); UpdateTabVisuals() end)
+        end)
+    end
     if PVEFrame_TabOnClick then hooksecurefunc("PVEFrame_TabOnClick", function() RefreshAll(); UpdateTabVisuals() end) end
     if GroupFinderFrame_SelectGroupButton then
         hooksecurefunc("GroupFinderFrame_SelectGroupButton", function(index)


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540899327549898752

Issue: Opening the group finder (e.g. via the micro-menu) runs the addon's cosmetic refresh (RefreshAll/UpdateTabVisuals) synchronously inside the same execution chain as the click, via hooksecurefunc on PVEFrame:Show()/PVEFrame_ShowFrame. That taints everything downstream in the same chain, including Blizzard's own comparison of a "secret" (anti-automation) applicant number in LFGListApplicationViewer_UpdateInfo, which then errors outright. 

Fix: Defer the refresh with C_Timer.After(0, ...) so it runs on its own tick, after the click-triggered chain has finished, instead of inside it — preventing the taint from reaching Blizzard's secret-value comparison.