### PR TITLE
Bar Glow taint error — "secret number value" arithmetic crash

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
@@ -307,10 +307,23 @@ local function UpdateOverlayVisuals()
 end
 ns.UpdateOverlayVisuals = UpdateOverlayVisuals
 
---- Rebuild overlays and force a visual update
-function ns.RequestBarGlowUpdate()
+-- Avoids scheduling more than one pending rebuild at a time.
+local _pendingGlowUpdate = false
+
+local function DoBarGlowUpdate()
+    _pendingGlowUpdate = false
     SetupOverlays()
     UpdateOverlayVisuals()
+end
+
+--- Rebuild overlays and force a visual update.
+--- Runs one frame later via C_Timer.After so it never executes on a
+--- tainted call stack, since reading a protected button's width/height
+--- while tainted can hand back a value later math can't be done on.
+function ns.RequestBarGlowUpdate()
+    if _pendingGlowUpdate then return end
+    _pendingGlowUpdate = true
+    C_Timer.After(0, DoBarGlowUpdate)
 end
 -- Alias for backward compatibility with options code
 ns.RequestUpdate = ns.RequestBarGlowUpdate


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540989165095620658

Issue: ns.RequestBarGlowUpdate() was running immediately, sometimes on the same call stack as a protected/secure hook (combat). Setting up the glow overlay reads a button's width/height, and doing that while tainted can return a value later code can't do math on — which then breaks when it hits arithmetic.

Fix: Delay the rebuild by one frame with C_Timer.After(0, ...) and a pending-flag guard so it never runs multiple times or on a tainted stack.