### PR TITLE
Cooldown Manager reanchor bypasses throttle, trips script watchdog

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -9149,6 +9149,8 @@ function ns.SetupViewerHooks()
                 -- becomes active/inactive. Run a full reanchor so new/removed
                 -- icons get collected and centered. Batched via C_Timer to
                 -- collapse the spam (fires many times per frame).
+                -- Use the throttled queue here, not a direct call, so bursts
+                -- of state changes can't stack up multiple full reanchors.
                 if frame.OnActiveStateChanged then
                     local _asDeferFrame = CreateFrame("Frame")
                     _asDeferFrame:Hide()
@@ -9158,7 +9160,7 @@ function ns.SetupViewerHooks()
                         if _asDeferTicks < 2 then return end
                         self:Hide()
                         _activeStateReanchorPending = false
-                        CollectAndReanchor()
+                        QueueReanchor()
                     end)
                     hooksecurefunc(frame, "OnActiveStateChanged", function()
                         ReapplyPositions()


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541031427150188585

Issue: A per-icon OnActiveStateChanged handler called the full bar-rebuild routine (CollectAndReanchor) directly instead of going through the addon's existing throttled queue. When several icons changed state in quick succession (e.g. rapid buff/proc activity in combat), each one could trigger its own untamed full reanchor, and the stacked execution time crossed WoW's script watchdog limit — causing the "script ran too long" error.

Fix: Changed that one call site to use QueueReanchor() instead of CollectAndReanchor() directly, so it's coalesced through the same 0.2s-throttled queue every other trigger in the file already uses.