### PR TITLE
Blistering Scales reminder gets stuck showing after the first pull in M+

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -4760,12 +4760,13 @@ mainFrame:SetScript("OnEvent", function(_, e, arg1, arg2, arg3)
         -- set our combat flag, so HideAllIcons guards on InCombatLockdown itself.
         HideAllIcons()
         HideCursorIcons()
-        _eabrInCombat = true
         -- Re-snapshots only if ENCOUNTER_START didn't just do it (fires ms before REGEN_DISABLED, producing a cleaner snapshot since the aura API is fully available pre-lockdown).
+        -- Must snapshot before marking combat, or the group-buff lookup treats itself as restricted and reports nothing found.
         if not _encounterSnapshotTime or (GetTime() - _encounterSnapshotTime) > 1 then
             SnapshotPlayerAuras()
             if _isEvokerOwnOnRaid then SnapshotOwnOnRaidBuffs() end
         end
+        _eabrInCombat = true
         _encounterSnapshotTime = nil
         RequestRefresh()
         return


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541059126074023946

Issue: The pull-start handler flips the internal combat flag before it snapshots which raid members already have your group buff (Blistering Scales, Source of Magic) applied. Since the buff-lookup function refuses to check other group members once it thinks combat is active, the snapshot always comes back empty — so on every trash pull the reminder resets to "missing" regardless of whether the buff is actually still up, and can stay stuck that way even after recasting.

Fix: Reorder two lines so the snapshot runs while still out of combat, then the flag is set. One-line change, single function.