### PR TITLE
Add Fill Color and Dynamic Color settings in Korean

### DIFF
--- a/EllesmereUILocales/koKR.lua
+++ b/EllesmereUILocales/koKR.lua
@@ -7021,6 +7021,8 @@ L["UNIT FRAME AURA FILTERS"] = "유닛 프레임 오라 필터"
 L["Target Tracked Auras"] = "대상 추적 오라"
 L["Copy Included/Excluded Spells From:"] = "포함/제외된 주문 복사 대상:"
 L["Debuffs Blizzard flags as important"] = "블리자드가 중요하다고 지정한 약화 효과"
+L["Fill Color Settings"] = "채우기 색상 설정"
+L["Dynamic Color"] = "동적 색상"
 
 -- 전체 설정 - 글꼴 
 L["Fonts"] = "글꼴"


### PR DESCRIPTION

## What does this PR do?

- Added Korean localization for `Fill Color Settings` and `Dynamic Color`.
- Players using the Korean client can now see these options in their native language.

## How was it tested?

- Tested in-game using the Korean retail client.
- Verified that the localized text displays correctly in the configuration UI.

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added