### PR TITLE
Wind Shear icon missing in Elemental Shaman Macro Factory

### DIFF
--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -509,7 +509,7 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
 
     -- Shaman (262=Elemental, 263=Enhancement, 264=Restoration)
     local SHAMAN_GEN = {
-        { name="EUI_WindShear", icon="Interface\\Icons\\spell_nature_cyclonestrikes", label="Wind Shear\n(Focus)", spells={57994}, fixedBody="/cast [@focus,harm,nodead][] {1}", fixedTooltip="{1}" }, -- Wind Shear
+        { name="EUI_WindShear", icon="Interface\\Icons\\spell_nature_cyclone", label="Wind Shear\n(Focus)", spells={57994}, fixedBody="/cast [@focus,harm,nodead][] {1}", fixedTooltip="{1}" }, -- Wind Shear
         { name="EUI_Purge", icon="Interface\\Icons\\spell_nature_purge", label="Purge\n(Focus)", spells={370}, fixedBody="/cast [@focus,harm,nodead][] {1}", fixedTooltip="{1}" }, -- Purge
         { name="EUI_CleanseSpirit", icon="Interface\\Icons\\ability_shaman_cleansespirit", label="Cleanse Spirit\n(Focus)", spells={51886}, fixedBody="/cast [@focus,help,nodead][] {1}", fixedTooltip="{1}" }, -- Cleanse Spirit
         { name="EUI_WindrushTotem", icon="Interface\\Icons\\ability_shaman_windwalktotem", label="Windrush Totem\n(Cursor)", spells={192077}, fixedBody="/cast [@cursor] {1}", fixedTooltip="{1}" }, -- Wind Rush Totem


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540865564300542094

Issue: The Wind Shear macro entry in EUI_MacroFactory.lua referenced a non-existent icon texture, spell_nature_cyclonestrikes, so the game couldn't render it and left a blank square in the picker. The macro itself worked fine since the icon path is cosmetic and separate from the spell/cast logic.

Fix: Corrected the texture path to the real Wind Shear icon, spell_nature_cyclone