### PR TITLE
Fix warband tab search not filtering by item type

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -1709,23 +1709,10 @@ function EUI_Bank:RefreshBank()
                 for slot = 1, tab.numSlots do
                     local info = C_Container.GetContainerItemInfo(tab.bagID, slot)
                     if info then used = used + 1 end
-                    if not hasSearch or info then
+                    -- use native search filter so type keywords work too
+                    if not hasSearch or (info and not info.isFiltered) then
                         visibleSlots[#visibleSlots + 1] = { slot = slot, _cachedInfo = info }
                     end
-                end
-                -- When searching, filter by name
-                if hasSearch then
-                    local filtered = {}
-                    for _, vs in ipairs(visibleSlots) do
-                        if vs._cachedInfo then
-                            local link = C_Container.GetContainerItemLink(tab.bagID, vs.slot)
-                            local itemName = link and GetItemInfo(link)
-                            if itemName and itemName:lower():find(searchQuery, 1, true) then
-                                filtered[#filtered + 1] = vs
-                            end
-                        end
-                    end
-                    visibleSlots = filtered
                 end
                 if not hasSearch or #visibleSlots > 0 then
                     headerIdx = headerIdx + 1
@@ -1796,14 +1783,11 @@ function EUI_Bank:RefreshBank()
             end
             local visibleSlots = allSlots
             if hasSearch then
+                -- use native search filter so type keywords work too
                 local filtered = {}
                 for _, vs in ipairs(allSlots) do
-                    if vs._cachedInfo then
-                        local link = C_Container.GetContainerItemLink(tab.bagID, vs.slot)
-                        local itemName = link and GetItemInfo(link)
-                        if itemName and itemName:lower():find(searchQuery, 1, true) then
-                            filtered[#filtered + 1] = vs
-                        end
+                    if vs._cachedInfo and not vs._cachedInfo.isFiltered then
+                        filtered[#filtered + 1] = vs
                     end
                 end
                 visibleSlots = filtered


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541074713621565552

The bank's flat "Bank"/"Warband Bank" views already used WoW's native item search (isFiltered), which understands type/slot keywords like "wrist". But the per-tab views ("All Bank Tabs," "All Warbank Tabs," and individual tab view) had their own separate filter that only matched item names as plain text — so a type keyword like "wrist" found nothing there, since no item is literally named "wrist."

Fix: Replaced the name-only substring match in those two per-tab code paths with the same native isFiltered check used elsewhere, so type/slot keyword search now works consistently across every bank view.