### PR TITLE
Add MethodInternal nickname modes to frames and meters

### DIFF
--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -1040,6 +1040,90 @@ local function IsSecret(v)
     return issecretvalue ~= nil and issecretvalue(v)
 end
 
+-- Resolve a damage-meter source back to its live group unit when possible;
+-- MethodInternal's name-based surface API covers historical/off-roster sources.
+local function FindNicknameUnit(guid, isLocalPlayer)
+    if not IsSecret(isLocalPlayer) and isLocalPlayer == true then return "player" end
+
+    local cleanGuid = type(guid) == "string" and not IsSecret(guid) and guid or nil
+    if cleanGuid and UnitTokenFromGUID then
+        local unit = UnitTokenFromGUID(cleanGuid)
+        if unit and not IsSecret(unit) and UnitExists(unit)
+           and (UnitIsUnit(unit, "player") or UnitInParty(unit) or UnitInRaid(unit)) then
+            return unit
+        end
+    end
+end
+
+-- MethodInternal's surface choice is authoritative for known Method players;
+-- unhandled players keep their raw short character name.
+function ns.ResolvePlayerName(name, guid, isLocalPlayer)
+    local nameIsPlain = type(name) == "string" and not IsSecret(name) and name ~= ""
+    local unit = FindNicknameUnit(guid, isLocalPlayer)
+    local fullName = nameIsPlain and name or nil
+    local shortName = nameIsPlain and StripRealm(name) or nil
+    if unit then
+        local unitName = UnitName(unit)
+        if type(unitName) == "string" and not IsSecret(unitName) and unitName ~= "" then shortName = unitName end
+        local unitFullName = GetUnitName(unit, true)
+        if type(unitFullName) == "string" and not IsSecret(unitFullName) and unitFullName ~= "" then fullName = unitFullName end
+    end
+    local fallback = shortName or StripRealm(name)
+
+    -- MethodInternal owns the selected name for known Method players on this
+    -- surface. Character Name is authoritative even though it equals fallback.
+    if EasyNicknameAPI then
+        local ok, value, handled
+        if unit and EasyNicknameAPI.GetNicknameForUnitForSurface then
+            ok, value, handled = pcall(
+                EasyNicknameAPI.GetNicknameForUnitForSurface, unit, "damageMeters")
+        elseif fullName and EasyNicknameAPI.GetNicknameForCharacterNameForSurface then
+            ok, value, handled = pcall(
+                EasyNicknameAPI.GetNicknameForCharacterNameForSurface,
+                fullName, nil, "damageMeters")
+        end
+        if ok and handled == true then
+            if type(value) == "string" and not IsSecret(value) and value ~= "" then
+                return value
+            end
+            return fallback
+        end
+    end
+    return fallback
+end
+
+function ns.RefreshNicknameNames()
+    if ns._nicknameRefreshPending then return end
+    ns._nicknameRefreshPending = true
+    C_Timer.After(0, function()
+        ns._nicknameRefreshPending = nil
+        for _, window in ipairs(ns._windows or {}) do
+            window._stickyNameCache = nil
+            for _, bar in ipairs(window.rowPool or {}) do
+                bar._cachedSrcName = nil
+                bar._cachedDisplayName = nil
+            end
+            -- Combat already has the shared meter ticker; avoid an extra API fetch.
+            if not _inCombat and window.Refresh then window.Refresh() end
+        end
+    end)
+end
+
+-- Keep cached meter labels in sync with MethodInternal without adding work to
+-- the one-second damage-meter refresh hot path.
+do
+    local function RegisterMethodInternal()
+        if ns._dmMethodInternalSurfaceNickHooked then return end
+        if EasyNicknameAPI and EasyNicknameAPI.RegisterCallback then
+            EasyNicknameAPI.RegisterCallback(
+                "SurfaceNicknamesChanged", ns.RefreshNicknameNames, "EllesmereUIDamageMeters")
+            ns._dmMethodInternalSurfaceNickHooked = true
+        end
+    end
+
+    EventUtil.ContinueOnAddOnLoaded("MethodInternal", RegisterMethodInternal)
+end
+
 -- Is this bar the local player's? isLocalPlayer is documented NeverSecret, so
 -- the read is legal mid-combat -- but a doc being wrong must degrade to "not
 -- own" (the row stays blocked, today's behavior), never to a thrown compare.
@@ -1475,7 +1559,7 @@ local function PopulatePreview(bar, curSession, curSessionID, curDMType)
         -- Reverse to oldest-first
         local reversed = {}
         for ri = #raw, 1, -1 do reversed[#reversed + 1] = raw[ri] end
-        ApplyTTHeader(StripRealm(bar._src.name) or "Unknown", EllesmereUI.L("Death Recap"))
+        ApplyTTHeader(ns.ResolvePlayerName(bar._src.name, bar._srcGUID, bar._src.isLocalPlayer), EllesmereUI.L("Death Recap"))
         local texPath, texKey = GetBreakdownBarTexturePath()
         local deathTime = reversed[#reversed] and reversed[#reversed].timestamp
         if IsSecret(deathTime) then deathTime = nil end
@@ -1599,7 +1683,7 @@ local function PopulatePreview(bar, curSession, curSessionID, curDMType)
                 if cc then b.fill:SetStatusBarColor(cc.r, cc.g, cc.b)
                 else b.fill:SetStatusBarColor(0x33/255, 0x33/255, 0x33/255) end
                 b.label:SetTextColor(1, 1, 1); b.amount:SetTextColor(1, 1, 1)
-                b.label:SetText(StripRealm(p.name))
+                b.label:SetText(ns.ResolvePlayerName(p.name))
                 b.amount:SetText(FormatBarValue(p.total, p.amountPerSecond, numFmt))
                 b.row:Show()
             else b.row:Hide() end
@@ -1630,7 +1714,7 @@ local function PopulatePreview(bar, curSession, curSessionID, curDMType)
     end
     if not srcData or not srcData.combatSpells or #srcData.combatSpells == 0 then return false end
 
-    ApplyTTHeader(StripRealm(bar._src.name) or "Unknown", L(DM_TYPE_NAMES[curDMType] or "Damage Done"))
+    ApplyTTHeader(ns.ResolvePlayerName(bar._src.name, bar._srcGUID, bar._src.isLocalPlayer), L(DM_TYPE_NAMES[curDMType] or "Damage Done"))
 
     wipe(_ttSorted)
     for _, spell in ipairs(srcData.combatSpells) do
@@ -2256,7 +2340,7 @@ local function CreateDMWindow(winIdx)
                 end
                 if not hasRecap then
                     EnsureTooltipFrame()
-                    local playerName = StripRealm(bar._src.name) or "Unknown"
+                    local playerName = ns.ResolvePlayerName(bar._src.name, bar._srcGUID, bar._src.isLocalPlayer)
                     _ttFrame._hdrText:SetText(EllesmereUI.Lf("%1$s's Death Recap", playerName))
                     local cfg2 = DB()
                     local hc = cfg2.hdrBgColor; local hR = hc and hc.r or 0x1B/255; local hG = hc and hc.g or 0x1B/255; local hB = hc and hc.b or 0x1B/255
@@ -2281,7 +2365,9 @@ local function CreateDMWindow(winIdx)
                and W.curDMType ~= Enum.DamageMeterType.Deaths then
                 EnsureTooltipFrame()
                 -- Show header with player name + type
-                local playerName = StripRealm(bar._src and bar._src.name) or "Unknown"
+                local playerName = W.curDMType == Enum.DamageMeterType.EnemyDamageTaken
+                    and StripRealm(bar._src and bar._src.name)
+                    or ns.ResolvePlayerName(bar._src and bar._src.name, bar._srcGUID, bar._src and bar._src.isLocalPlayer)
                 local typeName = L(DM_TYPE_NAMES[W.curDMType] or "Damage Done")
                 _ttFrame._hdrText:SetText(EllesmereUI.Lf("%1$s's %2$s Breakdown", playerName, typeName))
                 local cfg2 = DB()
@@ -3363,11 +3449,11 @@ local function CreateDMWindow(winIdx)
         -- Name: only when source name changes (guard secret values)
         local srcName = src.name
         if issecretvalue and issecretvalue(srcName) then
-            bar.label:SetText(StripRealm(srcName) or "You")
+            bar.label:SetText(ns.ResolvePlayerName(srcName, src.sourceGUID, src.isLocalPlayer) or "You")
             W._stickyNameCache = nil
         elseif srcName ~= W._stickyNameCache then
             W._stickyNameCache = srcName
-            bar.label:SetText(StripRealm(srcName) or "You")
+            bar.label:SetText(ns.ResolvePlayerName(srcName, src.sourceGUID, src.isLocalPlayer) or "You")
         end
         if isDeaths then
             local isOverall = (not W.curSessionID and W.curSession == Enum.DamageMeterSessionType.Overall)
@@ -3540,11 +3626,13 @@ local function CreateDMWindow(winIdx)
                         -- Name
                         local srcName = src.name
                         if isSecret and issecretvalue(srcName) then
-                            bar.label:SetText(StripRealm(srcName))
+                            bar.label:SetText(W.curDMType == Enum.DamageMeterType.EnemyDamageTaken
+                                and StripRealm(srcName) or ns.ResolvePlayerName(srcName, src.sourceGUID, src.isLocalPlayer))
                             bar._cachedSrcName = nil
                         elseif srcName ~= bar._cachedSrcName then
                             bar._cachedSrcName = srcName
-                            bar._cachedDisplayName = StripRealm(srcName)
+                            bar._cachedDisplayName = W.curDMType == Enum.DamageMeterType.EnemyDamageTaken
+                                and StripRealm(srcName) or ns.ResolvePlayerName(srcName, src.sourceGUID, src.isLocalPlayer)
                             bar.label:SetText(bar._cachedDisplayName)
                         end
 
@@ -3832,7 +3920,7 @@ local function CreateDMWindow(winIdx)
                     else local ar2, ag2, ab2 = GetAccentRGB(); bar.fill:SetStatusBarColor(ar2, ag2, ab2) end
                     SetDMFont(bar.label, leftFS); SetDMFont(bar.amount, rightFS)
                     bar.label:SetTextColor(1, 1, 1); bar.amount:SetTextColor(1, 1, 1)
-                    bar.label:SetText(StripRealm(p.name))
+                    bar.label:SetText(ns.ResolvePlayerName(p.name))
                     bar.amount:SetText(FormatBarValue(p.total, p.amountPerSecond, c.numberFormat or 2)); bar._spellID = nil
                 else bar.row:Hide(); bar._spellID = nil end
             end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2350,9 +2350,10 @@ end
 -- On ns for the Lua 5.1 200-local ceiling.
 ns.NICK_ADDON = addonName:find("Standalone") and addonName or "EllesmereUI"
 
--- Resolve a unit's display name via nickname providers in order: NSAPI ->
--- EasyNicknameAPI -> TimelineReminders -> LiquidAPI, then the raw unit name. Each is
--- pcall-wrapped so a misbehaving external API can never break names.
+-- Resolve a unit's display name through MethodInternal's authoritative surface
+-- choice for known Method players, then the normal provider order: NSAPI ->
+-- TimelineReminders -> LiquidAPI, then the raw unit name. Each
+-- external call is pcall-wrapped so a misbehaving API can never break names.
 --
 -- SECRET-SAFE: an enemy unit's UnitName is secret in protected content and any Lua op
 -- on it (==, .., format) throws. Nicknames only apply to your own group, so: non-players
@@ -2364,22 +2365,30 @@ ns.NICK_ADDON = addonName:find("Standalone") and addonName or "EllesmereUI"
 function ns.ResolveUnitNickname(unit)
     local name = UnitName(unit)
     if not name then return "" end
-    -- Master toggle (Unit Frames > main frames > Display, default OFF): when off,
-    -- skip every provider lookup and show the raw unit name (display-safe).
-    if not (db and db.profile and db.profile.showNicknames) then return name end
     -- Nicknames are player-only; NPCs (bosses, etc.) keep their name.
     if not UnitIsPlayer(unit) then return name end
     local nameSecret = issecretvalue and issecretvalue(name)
     local display
-    if not nameSecret and NSAPI and NSAPI.GetName then
-        local ok, dn = pcall(NSAPI.GetName, NSAPI, name, "EUI")
-        if ok and type(dn) == "string"
-           and not (issecretvalue and issecretvalue(dn)) and dn ~= "" and dn ~= name then
-            display = dn
+    -- MethodInternal's surface choice is authoritative for known Method players,
+    -- including Character Name (which deliberately equals the raw name). It sits
+    -- ahead of the EUI master toggle so the MethodInternal-owned setting works on
+    -- its selected surface; unknown players continue through EUI's normal chain.
+    if EasyNicknameAPI and EasyNicknameAPI.GetNicknameForUnitForSurface then
+        local ok, dn, handled = pcall(
+            EasyNicknameAPI.GetNicknameForUnitForSurface, unit, "unitFrames")
+        if ok and handled == true then
+            if type(dn) == "string"
+               and not (issecretvalue and issecretvalue(dn)) and dn ~= "" then
+                return dn
+            end
+            return name
         end
     end
-    if not display and not nameSecret and EasyNicknameAPI and EasyNicknameAPI.GetNicknameForUnit then
-        local ok, dn = pcall(EasyNicknameAPI.GetNicknameForUnit, unit)
+    -- Master toggle (Unit Frames > main frames > Display, default OFF): when off,
+    -- skip the remaining provider lookups and show the raw unit name (display-safe).
+    if not (db and db.profile and db.profile.showNicknames) then return name end
+    if not nameSecret and NSAPI and NSAPI.GetName then
+        local ok, dn = pcall(NSAPI.GetName, NSAPI, name, "EUI")
         if ok and type(dn) == "string"
            and not (issecretvalue and issecretvalue(dn)) and dn ~= "" and dn ~= name then
             display = dn
@@ -2464,13 +2473,21 @@ do
     end)
 end
 
--- Provider callbacks. NSAPI and TimelineReminders may load after us, so registration
--- retries on PLAYER_LOGIN/PLAYER_ENTERING_WORLD until it sticks. Registrant key MUST
+-- Provider callbacks. MethodInternal uses the addon-loaded callback; NSAPI and
+-- TimelineReminders retry on PLAYER_LOGIN/PLAYER_ENTERING_WORLD. Registrant key MUST
 -- be "EllesmereUIUnitFrames", not "EllesmereUI": Raid Frames owns that key and
 -- CallbackHandler keys registrations by it, so reuse would clobber one module. The
 -- provider CHECKBOX key stays shared (ns.NICK_ADDON/"EUI") so one toggle drives raid AND unit frames.
 do
     local function RefreshNames() if ns.RefreshAllUnitNames then ns.RefreshAllUnitNames() end end
+    local function RegisterMethodInternal()
+        if ns._methodInternalSurfaceNickHooked then return end
+        if EasyNicknameAPI and EasyNicknameAPI.RegisterCallback then
+            EasyNicknameAPI.RegisterCallback(
+                "SurfaceNicknamesChanged", RefreshNames, "EllesmereUIUnitFrames")
+            ns._methodInternalSurfaceNickHooked = true
+        end
+    end
     local function RegisterNSRT()
         if ns._nsrtNickHooked then return true end
         if NSAPI and NSAPI.RegisterCallback then
@@ -2506,6 +2523,7 @@ do
             if (a and b) or event == "PLAYER_ENTERING_WORLD" then self:UnregisterAllEvents() end
         end)
     end
+    EventUtil.ContinueOnAddOnLoaded("MethodInternal", RegisterMethodInternal)
 end
 
 -- "Name > Target" is built from FOUR tags so the (possibly SECRET) target name is never


### PR DESCRIPTION
## Summary
- use MethodInternal's surface-specific nickname choice for Unit Frames
- apply MethodInternal display names to player entries and breakdowns in Damage Meters
- refresh cached labels when MethodInternal reports a surface nickname change