### PR TITLE
Add opt-in Combat Only visibility toggle for cursor, GCD, and cast circles

### DIFF
--- a/EllesmereUIOptions/EUI_QoL_Cursor_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_Cursor_Options.lua
@@ -297,6 +297,19 @@ initFrame:SetScript("OnEvent", function(self)
                 if _G._ECL_ApplyOnlyWhenHidden then _G._ECL_ApplyOnlyWhenHidden() end
               end }
         );  y = y - h
+                
+        -- Combat Only
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Combat Only",
+              tooltip="Only shows the cursor circle while you are in combat.",
+              getValue=function() local p = DB(); return p and p.combatOnly or false end,
+              setValue=function(v)
+                local p = DB(); if not p then return end
+                p.combatOnly = v
+                if _G._ECL_UpdateVisibility then _G._ECL_UpdateVisibility() end
+              end },
+            { type="label", text="" }
+        );  y = y - h
         end   -- close Cursor Circle hidden-while-disabled gate
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
@@ -438,7 +451,7 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        -- Only Show in Instances
+        -- Only Show in Instances ---- Combat Only
         _, h = W:DualRow(parent, y,
             { type="toggle", text="Only Show in Instances",
               getValue=function() return GCD_DB().instanceOnly or false end,
@@ -446,7 +459,13 @@ initFrame:SetScript("OnEvent", function(self)
                 GCD_DB().instanceOnly = v
                 if _G._ECL_UpdateVisibility then _G._ECL_UpdateVisibility() end
               end },
-            { type="label", text="" }
+            { type="toggle", text="Combat Only",
+              tooltip="Only shows the GCD circle while you are in combat.",
+              getValue=function() return GCD_DB().combatOnly or false end,
+              setValue=function(v)
+                GCD_DB().combatOnly = v
+                if _G._ECL_UpdateVisibility then _G._ECL_UpdateVisibility() end
+              end }
         );  y = y - h
         end   -- close GCD Circle hidden-while-disabled gate
 
@@ -622,7 +641,7 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        -- Only Show in Instances
+        -- Only Show in Instances ---- Combat Only
         _, h = W:DualRow(parent, y,
             { type="toggle", text="Only Show in Instances",
               getValue=function() return Cast_DB().instanceOnly or false end,
@@ -630,7 +649,13 @@ initFrame:SetScript("OnEvent", function(self)
                 Cast_DB().instanceOnly = v
                 if _G._ECL_UpdateVisibility then _G._ECL_UpdateVisibility() end
               end },
-            { type="label", text="" }
+            { type="toggle", text="Combat Only",
+              tooltip="Only shows the cast bar circle while you are in combat.",
+              getValue=function() return Cast_DB().combatOnly or false end,
+              setValue=function(v)
+                Cast_DB().combatOnly = v
+                if _G._ECL_UpdateVisibility then _G._ECL_UpdateVisibility() end
+              end }
         );  y = y - h
         end   -- close Cast Bar Circle hidden-while-disabled gate
 

--- a/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
@@ -442,6 +442,7 @@ local function CreateGCDCircle()
         local g2 = GCD_DB()
         if not g2.enabled then return end
         if g2.instanceOnly and not InRealInstancedContent() then return end
+        if g2.combatOnly and not InCombatLockdown() then return end
         -- On cancelled/failed/interrupted casts the GCD resets stop the ring
         if event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_INTERRUPTED" or event == "UNIT_SPELLCAST_STOP" then
             local cdData = GetSpellCooldown(61304)
@@ -506,6 +507,10 @@ local function ApplyGCDCircle()
     if g.instanceOnly and not InRealInstancedContent() then
         gcdRoot:Hide()
     end
+    -- Respect combat-only: hide if not in combat
+    if g.combatOnly and not InCombatLockdown() then
+        gcdRoot:Hide()
+    end
     if attached and not EllesmereUI._unlockActive then
         -- When the cursor circle is visible, anchor directly to it.
         -- When the cursor circle is hidden (e.g. instance-only outside an instance),
@@ -558,6 +563,11 @@ UpdateVisibility = function()
     if shouldShow and p.instanceOnly then
         shouldShow = InRealInstancedContent()
     end
+    -- "Combat Only": only show while the player is in combat. Driven by the
+    -- PLAYER_REGEN_DISABLED / PLAYER_REGEN_ENABLED registrations in OnEnable.
+    if shouldShow and p.combatOnly then
+        shouldShow = InCombatLockdown() and true or false
+    end
     -- Standard visibility options (returns true if should HIDE)
     if shouldShow and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(p) then
         shouldShow = false
@@ -609,11 +619,12 @@ UpdateVisibility = function()
         HideTrailDots()
     end
 
-    -- GCD circle instance-only check
+    -- GCD circle instance-only / combat-only check
     if gcdRoot then
         local g = GCD_DB()
         if g.enabled then
-            if g.instanceOnly and not InRealInstancedContent() then
+            if (g.instanceOnly and not InRealInstancedContent())
+                or (g.combatOnly and not InCombatLockdown()) then
                 gcdRoot:Hide()
                 gcdRoot:SetScript("OnUpdate", nil)
             else
@@ -638,11 +649,12 @@ UpdateVisibility = function()
         end
     end
 
-    -- Cast circle instance-only check
+    -- GCD circle instance-only / combat-only check
     if castRoot then
         local c = Cast_DB()
         if c.enabled then
-            if c.instanceOnly and not InRealInstancedContent() then
+            if (c.instanceOnly and not InRealInstancedContent())
+                or (c.combatOnly and not InCombatLockdown()) then
                 castRoot:Hide()
                 castRoot:SetScript("OnUpdate", nil)
             else
@@ -823,6 +835,7 @@ local function CreateCastCircle()
         local c2 = Cast_DB()
         if not c2.enabled then return end
         if c2.instanceOnly and not InRealInstancedContent() then return end
+        if c2.combatOnly and not InCombatLockdown() then return end
 
         if event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_DELAYED" then
             local name, _, _, startMS, endMS, _, cID = UnitCastingInfo("player")
@@ -944,6 +957,10 @@ local function ApplyCastCircle()
     castRoot:Show()
     -- Respect instance-only: hide if not in instance
     if c.instanceOnly and not InRealInstancedContent() then
+        castRoot:Hide()
+    end
+    -- Respect combat-only: hide if not in combat
+    if c.combatOnly and not InCombatLockdown() then
         castRoot:Hide()
     end
     if attached and not EllesmereUI._unlockActive then
@@ -1174,6 +1191,7 @@ function ECL:OnInitialize()
                 enabled = true,
                 instanceOnly = false,
                 onlyWhenHidden = false,
+                combatOnly = false,
                 useClassColor = true,
                 hex = "0CD29D",
                 texture = "ring_normal",
@@ -1189,6 +1207,7 @@ function ECL:OnInitialize()
                     alpha = 80,
                     useClassColor = false,
                     instanceOnly = false,
+                    combatOnly = false,
                 },
                 castCircle = {
                     enabled = false,
@@ -1202,6 +1221,7 @@ function ECL:OnInitialize()
                     sparkHex = nil,
                     useClassColor = true,
                     instanceOnly = false,
+                    combatOnly = false,
                 },
                 trail = false,
                 visibility       = "always",
@@ -1307,4 +1327,6 @@ function ECL:OnEnable()
 
     self:RegisterEvent("PLAYER_ENTERING_WORLD", UpdateVisibility)
     self:RegisterEvent("ZONE_CHANGED_NEW_AREA", UpdateVisibility)
+    self:RegisterEvent("PLAYER_REGEN_DISABLED", UpdateVisibility)
+    self:RegisterEvent("PLAYER_REGEN_ENABLED", UpdateVisibility)
 end


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in **Combat Only** toggle to the cursor circle, the GCD circle, and
the cast bar circle. When enabled, that element is shown only while the player
is in combat. Defaults off for all three, so nothing changes for existing users
until they turn it on.

Implementation follows the existing `instanceOnly` pattern rather than
introducing a new one:

* New `combatOnly` boolean in each of the three defaults tables, all `false`.
* Cursor circle: gated in `UpdateVisibility` alongside the existing
  `instanceOnly` check.
* GCD and cast circles: checked in their `UNIT_SPELLCAST_*` handlers, in
  `ApplyGCDCircle` / `ApplyCastCircle`, and folded into the existing hide
  branches in `UpdateVisibility`.
* Combat state is read via `InCombatLockdown()`, a native API, so there is no
  dependency on another module's load or event order.

`PLAYER_REGEN_DISABLED` and `PLAYER_REGEN_ENABLED` are registered so the cursor
circle re-evaluates on combat transitions. The GCD and cast circles are already
event-driven off `UNIT_SPELLCAST_*` and needed no new registrations.

In the options page, the GCD and cast toggles fill the empty right slot that
already existed on their "Only Show in Instances" rows, so neither section gains
a mid-section gap. The cursor section gets a new final row with an empty right
slot.

**One thing to flag on criterion 1:** the two `PLAYER_REGEN_*` registrations are
currently unconditional, so a user who never enables Combat Only still has them
registered. `UpdateVisibility` is cheap (no allocations, no loops) and the module
already registers `PLAYER_ENTERING_WORLD` and `ZONE_CHANGED_NEW_AREA` the same
way, so I judged this consistent with the existing pattern rather than a new
cost. If you would rather have them registered lazily on first enable and
unregistered when all three toggles are off, say the word and I will add that.

## How was it tested?

Live client, Midnight 12.1. Tested each of the three toggles independently and in
combination: entering and leaving combat, in open world and in instanced content,
with the toggle flipped both while in and out of combat. Verified the existing
"Only Show in Instances" and "Only Show When Hidden" behavior is unchanged when
Combat Only is off, and that the two options interact correctly when both are on.
Also confirmed both files compile clean under `luac5.1 -p` and that all added
lines are ASCII only.

## Screenshots

<img width="1461" height="1090" alt="image" src="https://github.com/user-attachments/assets/aba58732-6f5e-4c38-99c5-0d920bad7d47" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
  <br>Mostly yes: no frames, no hooks, no polling, no work in any handler while
  disabled. Not fully: two `PLAYER_REGEN_*` events are registered
  unconditionally. See the note above, happy to gate them lazily if preferred.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] N/A. No Blizzard frames are touched. No `SetScript` on Blizzard frames, no hooks added.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added