### PR TITLE
Fix "secret values" cooldown taint crash on action bar refresh

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -1054,7 +1054,7 @@ do
                 for i = 1, 6 do
                     local btn = _G["OverrideActionBarButton" .. i]
                     if btn then
-                        if btn.UpdateAction then btn:UpdateAction() end
+                        -- Cooldown-only refresh; avoids passing secret cooldown values through a tainted call.
                         ForceCooldownPaint(btn)
                         local hk = btn.HotKey
                         if hk then
@@ -2984,7 +2984,8 @@ local function SetupBar(info, skipProtected)
                     -- Force visual refresh; events are centrally dispatched
                     -- (per-button registration on 96 buttons caused mass
                     -- OnEvent->UpdateAction calls per tick -- screen blink).
-                    if btn.UpdateAction then btn:UpdateAction() end
+                    -- Taint-safe refresh; avoids passing secret cooldown values through a tainted call.
+                    EAB_VTABLE.ForceButtonRefresh(btn, slot)
                 end
                 if bindPrefix then
                     btn.commandName = bindPrefix .. i
@@ -4173,11 +4174,8 @@ do
                 local fd = EFD(btn)
                 if fd.lastIconTex ~= tex then
                     fd.lastIconTex = tex
-                    -- UpdateAction plus an explicit icon refresh: UpdateButtonArt is nooped, so texture alone would not repaint.
-                    if btn.UpdateAction then btn:UpdateAction() end
-                    if tex and btn.icon then
-                        btn.icon:SetTexture(tex)
-                    end
+                    -- Taint-safe refresh; avoids passing secret cooldown values through a tainted call.
+                    EAB_VTABLE.ForceButtonRefresh(btn, action)
                 end
             end
         end
@@ -5130,7 +5128,8 @@ do
                                 -- usable tri-state below can legitimately flip on a
                                 -- target swap, and it is memo-gated.
                                 if event ~= "PLAYER_TARGET_CHANGED" then
-                                    if btn.UpdateAction then btn:UpdateAction() end
+                                    -- Taint-safe refresh; avoids passing secret cooldown values through a tainted call.
+                                    EAB_VTABLE.ForceButtonRefresh(btn, btn:GetAttribute("action"))
                                     RefreshCooldownVisuals(btn)
                                 end
                                 local ufd = EFD(btn)
@@ -15151,7 +15150,7 @@ local function SetupBlizzardMovableFrame(barKey)
         local function RefreshExtraActionButton()
             local eab1 = ExtraActionButton1
             if not eab1 then return end
-            if eab1.UpdateAction then eab1:UpdateAction() end
+            -- Cooldown-only refresh below; avoids passing secret cooldown values through a tainted call.
             local hk = eab1.HotKey
             if hk then
                 local key1 = GetBindingKey("EXTRAACTIONBUTTON1")


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541099766799278142 

Issue: A game client update introduced "secret" cooldown values that a native cooldown-display function refuses to accept once the call stack is tainted. Five places in the code triggered a full button-update call from addon-driven contexts, tainting the stack and causing that native function to throw when it later tried to apply the cooldown.

Fix: Replaced each tainting call with a call already used elsewhere in the same file — either a cooldown-only paint helper or a full button-refresh helper — both of which set cooldowns through a secret-safe API instead of the native path.