### PR TITLE
RB: give Moonkin its own per-form bucket, separate from Caster

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -1050,7 +1050,8 @@ initFrame:SetScript("OnEvent", function(self)
         tooltip = tooltip or EllesmereUI.L(title)
         local FORMS = { { key = "mana", label = "Caster" },
                         { key = "rage", label = "Bear" },
-                        { key = "energy", label = "Cat" } }
+                        { key = "energy", label = "Cat" },
+                        { key = "moonkin", label = "Moonkin" } }
         local rows = {}
         for _, f in ipairs(FORMS) do
             local key = f.key
@@ -1859,14 +1860,16 @@ initFrame:SetScript("OnEvent", function(self)
         -- Druid "form specific" (Advanced mode only): a threshold per resource type, keyed by form
         local _playerClassFile = select(2, UnitClass("player"))
         local hasFormToggle = cfg.formCapable and cfg.singleSpec and _playerClassFile == "DRUID"
-        local FORM_LABEL = { mana = "Caster", rage = "Bear", energy = "Cat" }
+        local FORM_LABEL = { mana = "Caster", rage = "Bear", energy = "Cat", moonkin = "Moonkin" }
         local function DefaultFormEntries()
             return {
-                { formKey = "mana",   thresholdEnabled = true, thresholdPct = 30, thresholdPartialOnly = true,
+                { formKey = "mana",    thresholdEnabled = true, thresholdPct = 30, thresholdPartialOnly = true,
                   thresholdR = defR, thresholdG = defG, thresholdB = defB, thresholdA = defA },
-                { formKey = "rage",   thresholdEnabled = true, thresholdPct = 30, thresholdPartialOnly = false,
+                { formKey = "rage",    thresholdEnabled = true, thresholdPct = 30, thresholdPartialOnly = false,
                   thresholdR = defR, thresholdG = defG, thresholdB = defB, thresholdA = defA },
-                { formKey = "energy", thresholdEnabled = true, thresholdPct = 30, thresholdPartialOnly = true,
+                { formKey = "energy",  thresholdEnabled = true, thresholdPct = 30, thresholdPartialOnly = true,
+                  thresholdR = defR, thresholdG = defG, thresholdB = defB, thresholdA = defA },
+                { formKey = "moonkin", thresholdEnabled = true, thresholdPct = 30, thresholdPartialOnly = true,
                   thresholdR = defR, thresholdG = defG, thresholdB = defB, thresholdA = defA },
             }
         end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -784,8 +784,12 @@ ResolveThresholdSpecEntry = function(sp)
     if not entries or #entries == 0 then return nil end
 
     -- Form-specific mode (druid power bar): pick the entry matching the current
+    -- form. Moonkin (31/35) is checked directly by form ID since it shares
+    -- Mana with Caster on GetPrimaryPowerType() and would otherwise collide
+    -- with the "mana" bucket.
     if sp.thresholdFormMode then
-        local key = FORM_THRESHOLD_KEY[GetPrimaryPowerType()]
+        local form = GetShapeshiftFormID()
+        local key = (form == 31 or form == 35) and "moonkin" or FORM_THRESHOLD_KEY[GetPrimaryPowerType()]
         if not key then return nil end
         for _, entry in ipairs(entries) do
             if entry.formKey == key then return entry end
@@ -1053,14 +1057,15 @@ end
 local _, playerClassFile = UnitClass("player")
 
 -- Druid "hide bar text per form". isClassResource: Moonkin (31/35) is exempt on
--- the class resource bar (shows Astral there); power/health keep it in "Caster".
+-- the class resource bar (shows Astral there); power/health get their own
+-- "Moonkin" bucket, separate from "Caster" (no form).
 _G._ERB_TextHiddenByForm = function(cfg, isClassResource)
     if playerClassFile ~= "DRUID" then return false end
     local df = cfg and cfg.textDisabledForms
     if not df then return false end
     local f = GetShapeshiftFormID()
     if isClassResource and (f == 31 or f == 35) then return false end
-    local key = (f == 1) and "energy" or (f == 5) and "rage" or "mana"
+    local key = (f == 1) and "energy" or (f == 5) and "rage" or (f == 31 or f == 35) and "moonkin" or "mana"
     return df[key] and true or false
 end
 -- Druid "hide whole bar per form": same buckets/isClassResource rule as above,
@@ -1071,7 +1076,7 @@ _G._ERB_BarHiddenByForm = function(cfg, isClassResource)
     if not df then return false end
     local f = GetShapeshiftFormID()
     if isClassResource and (f == 31 or f == 35) then return false end
-    local key = (f == 1) and "energy" or (f == 5) and "rage" or "mana"
+    local key = (f == 1) and "energy" or (f == 5) and "rage" or (f == 31 or f == 35) and "moonkin" or "mana"
     return df[key] and true or false
 end
 -- Static neutral defaults for custom fill colors; used only as the initial custom

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -3962,3 +3962,61 @@ EllesmereUI.RegisterMigration({
         end
     end,
 })
+
+--------------------------------------------------------------------------------
+--  Power Bar's per-form threshold mode used to resolve Moonkin into the same
+--  "mana" entry as Caster (both report PT.MANA from GetPrimaryPowerType()).
+--  Now that Moonkin is checked by form ID and gets its own "moonkin" bucket,
+--  seed it as a copy of the existing "mana" entry so upgrading users see the
+--  same threshold behavior in Moonkin they had before, with a separate entry
+--  to customize going forward.
+--------------------------------------------------------------------------------
+EllesmereUI.RegisterMigration({
+    id          = "erb_power_form_mode_moonkin_bucket_v1",
+    scope       = "profile",
+    description = "Give the Power Bar's per-form threshold mode its own Moonkin entry instead of sharing Caster's.",
+    body        = function(ctx)
+        local erb = ctx.profile.addons and ctx.profile.addons.EllesmereUIResourceBars
+        local pri = erb and erb.primary
+        if not pri or not pri.thresholdFormMode then return end
+        local entries = pri.thresholdSpecs
+        if type(entries) ~= "table" or #entries == 0 then return end
+        local manaEntry
+        for _, entry in ipairs(entries) do
+            if type(entry) == "table" then
+                if entry.formKey == "moonkin" then return end  -- already migrated
+                if entry.formKey == "mana" then manaEntry = entry end
+            end
+        end
+        if not manaEntry then return end
+        local moonkinEntry = EllesmereUI.Lite.DeepCopy(manaEntry)
+        moonkinEntry.formKey = "moonkin"
+        entries[#entries + 1] = moonkinEntry
+    end,
+})
+
+-- Same split for the Health/Power "hide bar/text per form" popups: Moonkin
+-- used to share the "mana"/Caster bucket, so disabling Caster there also hid
+-- Moonkin. Seed moonkin=true wherever mana=true so that choice survives.
+-- Class Resource is skipped: it exempts Moonkin from this system entirely.
+EllesmereUI.RegisterMigration({
+    id          = "erb_moonkin_form_bucket_v1",
+    scope       = "profile",
+    description = "Preserve existing Moonkin bar/text visibility now that Moonkin has its own per-form bucket separate from Caster.",
+    body        = function(ctx)
+        local erb = ctx.profile.addons and ctx.profile.addons.EllesmereUIResourceBars
+        if not erb then return end
+        local function SeedMoonkin(sectionKey)
+            local sec = erb[sectionKey]
+            if not sec then return end
+            for _, field in ipairs({ "textDisabledForms", "barDisabledForms" }) do
+                local df = sec[field]
+                if type(df) == "table" and df.mana and df.moonkin == nil then
+                    df.moonkin = true
+                end
+            end
+        end
+        SeedMoonkin("health")
+        SeedMoonkin("primary")
+    end,
+})


### PR DESCRIPTION
\`\`\`
Cause: Moonkin form reports PT.MANA, same as no-form Caster, so the Health/
Power "hide per form" popups and the Power Bar's per-form threshold mode
both lumped Moonkin into the Caster bucket with no way to configure it
separately (reported by @nday, confirmed by another user wanting to hide
the mana bar only in Moonkin).

Fix: Check Moonkin by shapeshift form ID (31/35) directly and give it its
own bucket in both systems. Class Resource bar is unaffected: it already
exempts Moonkin to keep Astral Power visible. Migrations seed the new
bucket from the existing Caster entry so upgrading profiles keep current
behavior until edited.

Test: Verified in-game on a Balance druid, both the bar/text per-form
popup and the Advanced per-form threshold mode.
\`\`\`

<img width="480" height="480" alt="Legion GIF by eUnited" src="https://github.com/user-attachments/assets/32b3bbc5-18be-45c2-8f75-2c1c95b24553" />
