### PR TITLE
Fix: Class power ignore group members' spec events & optimization

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -4411,6 +4411,11 @@ local function EnableClassPowerWatcher()
         end
         classPowerWatcher:SetScript("OnEvent", function(_, event, ...)
             if event == "PLAYER_SPECIALIZATION_CHANGED" then
+                -- The event carries a unit and is delivered for GROUP MEMBERS too, so
+                -- without this filter a raid full of spec swaps rebuilds the watcher
+                -- (and every pip on the personal plate) over and over for nothing.
+                local specUnit = ...
+                if specUnit ~= "player" then return end
                 -- Spec changed: tear down and rebuild (spec may no longer have this resource)
                 DisableClassPowerWatcher()
                 ApplyClassPowerSetting()
@@ -4475,8 +4480,11 @@ local function EnableClassPowerWatcher()
         if classPowerType == Enum.PowerType.Runes then
             classPowerWatcher:RegisterEvent("RUNE_POWER_UPDATE")
         end
-        classPowerWatcher:SetScript("OnEvent", function(_, event)
+        classPowerWatcher:SetScript("OnEvent", function(_, event, unit)
             if event == "PLAYER_SPECIALIZATION_CHANGED" then
+                -- Group members' spec events land here too; see the filter note in the
+                -- string-resource branch above.
+                if unit ~= "player" then return end
                 DisableClassPowerWatcher()
                 ApplyClassPowerSetting()
             elseif event == "PLAYER_TARGET_CHANGED" or event == "UPDATE_SHAPESHIFT_FORM" then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -9630,8 +9630,13 @@ local function CreateCustomClassPower(playerFrame, style)
         end
 
         eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
-        eventFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
-
+        -- PLAYER_SPECIALIZATION_CHANGED is deliberately NOT registered here. It is owned
+        -- by cpSpecWatcher (see InitializeFrames), which lives OUTSIDE the container,
+        -- filters unit == "player", and rebuilds after tearing down. A copy of that
+        -- handler on this driver could only ever destroy WITHOUT rebuilding (the
+        -- teardown unregisters the driver mid-dispatch), and -- lacking the unit filter
+        -- -- would fire on any GROUP MEMBER's spec event, silently killing the bar until
+        -- the next /reload.
         if needsAura then
             eventFrame:RegisterUnitEvent("UNIT_AURA", "player")
         end
@@ -9645,14 +9650,7 @@ local function CreateCustomClassPower(playerFrame, style)
         end
 
         eventFrame:SetScript("OnEvent", function(_, event, ...)
-            if event == "PLAYER_SPECIALIZATION_CHANGED" then
-                DestroyCustomClassPower()
-                frames._classPowerBar = nil
-                -- Don't call ReloadFrames here: the profile system handles the full
-                -- rebuild via RefreshAllAddons -> _EUF_ReloadFrames. Width/height
-                -- matches re-apply after CDM clears _specProfileSwitching in ProcessSpecChange.
-                return
-            elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+            if event == "UNIT_SPELLCAST_SUCCEEDED" then
                 if not _G._ERB_AceDB and EllesmereUI then
                     local unit, castGUID, spellID = ...
                     if unit == "player" then


### PR DESCRIPTION
## What does this PR do?

PLAYER_SPECIALIZATION_CHANGED carries a unit and is delivered for group members too, which two class power handlers did not account for.

Unit Frames: the container's own event driver registered the event without a unit filter and only tore the bar down, leaving the rebuild to RefreshAllAddons -- which never runs on a shared profile. Any teammate's spec change killed the bar until the next /reload, and the strip reserved by ResizeFrameForClassPower stayed behind as an empty, tickless bar. cpSpecWatcher already owns this event correctly (outside the container, unit-filtered, rebuilding after teardown), so drop the duplicate handler. Affects custom-resource specs only (Arms, Fury, Enhancement, Survival, Frost Mage, Vengeance/Devourer DH, Brewmaster).

Nameplates: same missing filter, but harmless -- ApplyClassPowerSetting rebuilds synchronously. Filter anyway so a raid full of spec swaps stops rebuilding the watcher and every pip on the personal plate for nothing.

## How was it tested?

Tested on an arms warrior in a +8 Delve (12.1 retail)

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
