### PR TITLE
Fix item-usability red-tint false positives/negatives for recipes and level-scaled gear

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -71,7 +71,7 @@ local function BagsItemUnusable(bagID, slot, itemLink, itemID)
                     break
                 end
                 local rc = row.rightColor
-                if rc and rc.r == 1 and rc.g < 0.2 and rc.b < 0.2 then
+                if rc and rc.r > 0.9 and rc.g < 0.2 and rc.b < 0.2 then
                     unusable = true
                     break
                 end

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -27,21 +27,43 @@ local SLOT_SIZE, SPACING = 34, 4
 -- the real item, never GetItemByID: scaling gear's bonus IDs lower its required level, but
 -- GetItemByID shows the unscaled base item's level (reads red). Prefer bag slot > link > ID; cache by link, wipe on level-up.
 local _canUseCache = {}
+local ITEM_CLASS_RECIPE = Enum.ItemClass.Recipe
 local function BagsItemUnusable(bagID, slot, itemLink, itemID)
     local item = itemLink or itemID
     if not item then return false end
     local cached = _canUseCache[item]
     if cached ~= nil then return cached end
     local unusable = false
+
+-- Recipes also have a spell (the teach effect), so they'd hit the tooltip scan
+    -- below. Skip that: the scan can see red from the crafted item's own preview
+    -- stats, not just from the recipe's learn requirements. Use the usable check
+    -- instead, which reflects skill/known state directly.
+    local _, _, _, _, _, classID = GetItemInfoInstant(item)
+    if classID == ITEM_CLASS_RECIPE then
+        local usable = C_Item.IsUsableItem(item)
+        unusable = not usable
+        _canUseCache[item] = unusable
+        return unusable
+    end
+    
     if IsEquippableItem(item) or C_Item.GetItemSpell(item) then
-        local tip
-        if bagID and slot then tip = C_TooltipInfo.GetBagItem(bagID, slot) end
-        if not tip and itemLink then tip = C_TooltipInfo.GetHyperlink(itemLink) end
-        if not tip and itemID then tip = C_TooltipInfo.GetItemByID(itemID) end
+        -- Only use a tooltip from the real bag slot or real item link; both carry
+        -- bonus IDs, which set the item's true required level. A bare itemID lacks
+        -- those and can read the wrong level requirement either way.
+        local tip, reliable
+        if bagID and slot then
+            tip = C_TooltipInfo.GetBagItem(bagID, slot)
+            reliable = true
+        elseif itemLink then
+            tip = C_TooltipInfo.GetHyperlink(itemLink)
+            reliable = true
+        end
         if tip and tip.lines then
             for _, row in ipairs(tip.lines) do
                 local lc = row.leftColor
-                if lc and lc.r == 1 and lc.g < 0.2 and lc.b < 0.2
+                -- Tolerance, not exact equality: rounding can put red just under r=1.
+                if lc and lc.r > 0.9 and lc.g < 0.2 and lc.b < 0.2
                    and row.leftText ~= ITEM_SCRAPABLE_NOT
                    and row.leftText ~= CANNOT_UNEQUIP_COMBAT
                    and row.leftText ~= ITEM_DISENCHANT_NOT_DISENCHANTABLE then
@@ -54,6 +76,11 @@ local function BagsItemUnusable(bagID, slot, itemLink, itemID)
                     break
                 end
             end
+        end
+        if not reliable then
+            -- No bag slot or link yet, so don't cache a guess. A later call with
+            -- real data will compute and cache the right answer.
+            return unusable
         end
     end
     _canUseCache[item] = unusable


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1508291854762774528

Summary:

The bag/bank "unusable" (red-tint) check scanned every tooltip line for red text, which caused three related bugs:

Recipes flagged as unusable even when learnable. Recipes carry a "teach" spell, so they went through the same red-line scan as gear. Their tooltip embeds the crafted item's own preview (level, stats, etc.), and red text in that preview — unrelated to whether the recipe itself can be learned — was misread as "can't use." Fixed by giving recipes their own check based on skill/known state instead of the tooltip scan.
Low-level-appropriate items falsely flagged unusable. When no reliable tooltip source (bag slot or item link) was available, the code fell back to a generic item-ID lookup, which ignores bonus IDs and can show a higher, unscaled level requirement than the item actually has once scaled down.
Too-high-level items not flagged. Same fallback, opposite direction — the generic lookup can also miss a level requirement that only exists on the scaled instance, so an item a character truly can't use showed as fine.

Fixed by dropping the unreliable generic-ID fallback (only bag slot / real item link are trusted now), not caching a result when neither is available yet, and loosening an exact color-equality check to a small tolerance so borderline red isn't missed.