### PR TITLE
Improve assisted highlight

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -487,6 +487,13 @@ local defaults = {
         -- Positive pushes the blue swirl outward so it reads apart from a proc
         -- glow on the same edge; negative pulls it inward.
         assistGlowOutset = 0,
+        -- How the Assisted Highlight is drawn: 1 = Blizzard's glow ring only
+        -- (default, unchanged behavior), 2 = flat tint over the whole button
+        -- instead, 3 = both. The overlay leaves the button edge free for the
+        -- proc glow, which is the point of offering it.
+        assistGlowStyle = 1,
+        assistGlowOverlayColor = { r = 0.15, g = 0.5, b = 1 },
+        assistGlowOverlayAlpha = 30,
         useBlizzardStyle = false,
         showBlizzIconBg = false,
         blizzIconBgAlpha = 1,
@@ -10460,11 +10467,70 @@ do
         return hf
     end
 
-    local function AssistHide(btn)
+    -- Ring teardown alone. Split out of AssistHide because AssistShow also
+    -- needs it on its own: with the overlay style picked, or with Blizzard
+    -- painting its own ring on a hovered button, our ring must go while the
+    -- overlay stays up.
+    ns._AssistRingHide = function(btn)
         local hf = EFD(btn).assistHL
         if not hf then return end
         if hf.Flipbook and hf.Flipbook.Anim then hf.Flipbook.Anim:Stop() end
         hf:Hide()
+    end
+
+    -- Flat tint over the whole button -- the alternative (or companion) to the
+    -- ring. Its own child frame at btn+14, one below the ring, so it draws over
+    -- the icon and the cooldown swipe deterministically instead of racing
+    -- draw-layer sublevels against Blizzard's own button textures. No texture,
+    -- no animation, no driver entry: strictly cheaper than the flipbook ring.
+    -- Created lazily, so nobody on the ring-only default pays for it.
+    ns._AssistOverlay = function(btn, show)
+        local fd = EFD(btn)
+        local ov = fd.assistOverlay
+        if not show then
+            if ov then ov:Hide() end
+            return
+        end
+        if not ov then
+            ov = CreateFrame("Frame", nil, btn)
+            ov:SetAllPoints(btn)
+            ov.tex = ov:CreateTexture(nil, "OVERLAY")
+            ov.tex:SetAllPoints(ov)
+            fd.assistOverlay = ov
+        end
+        -- Re-assert: bar layout can change the button's frame level after create.
+        ov:SetFrameLevel(btn:GetFrameLevel() + 14)
+        local p = EAB.db and EAB.db.profile
+        local c = (p and p.assistGlowOverlayColor) or { r = 0.15, g = 0.5, b = 1 }
+        local a = (p and p.assistGlowOverlayAlpha) or 30
+        ov.tex:SetColorTexture(c.r or 0.15, c.g or 0.5, c.b or 1, a / 100)
+        -- Custom button shapes: follow the shape mask, else the tint is a
+        -- square sitting on a round icon. Keyed on the mask OBJECT, not a
+        -- boolean: a shape change swaps the mask, and the stale one must be
+        -- removed before the new one goes on.
+        local ofd = EFD(ov)
+        if fd.shapeMask and fd.shapeApplied then
+            if ofd.shapeMasked ~= fd.shapeMask then
+                if ofd.shapeMasked then UnmaskFrameTextures(ov, ofd.shapeMasked) end
+                MaskFrameTextures(ov, fd.shapeMask)
+                ofd.shapeMasked = fd.shapeMask
+            end
+        elseif ofd.shapeMasked then
+            UnmaskFrameTextures(ov, ofd.shapeMasked)
+            ofd.shapeMasked = nil
+        end
+        ov:Show()
+    end
+
+    -- Full teardown of everything we paint for one button. Also un-fades
+    -- Blizzard's own ring: the overlay-only style parks it at alpha 0, and a
+    -- button that stops being the suggestion (or the CVar going off) must not
+    -- leave it invisible for whoever shows it next.
+    local function AssistHide(btn)
+        ns._AssistRingHide(btn)
+        ns._AssistOverlay(btn, false)
+        local bf = btn.AssistedCombatHighlightFrame
+        if bf and bf:GetAlpha() ~= 1 then bf:SetAlpha(1) end
     end
 
     -- Scale that makes the 45px template art cover the button plus the user's
@@ -10484,8 +10550,40 @@ do
         return s
     end
 
+    -- Paint the suggestion on one button in whatever style the user picked.
+    -- Owns the "Blizzard already draws its own ring here" case too (it used to
+    -- live at the call site): the overlay is ours either way, so the two
+    -- decisions have to be made together.
     local function AssistShow(btn)
         local fd = EFD(btn)
+        local p = EAB.db and EAB.db.profile
+        local style = (p and p.assistGlowStyle) or 1
+
+        -- Tint: always ours, Blizzard never paints one.
+        ns._AssistOverlay(btn, style ~= 1)
+
+        -- Blizzard may show its own ring on a hovered button (candidate
+        -- re-add). Defer to it so two identical shines never stack, but keep it
+        -- scaled to our button size + outset. With the overlay-only style we
+        -- fade it rather than Hide() it: their manager re-shows it, so a Hide
+        -- would just be undone. Alpha is re-asserted on every pass, so it
+        -- self-corrects when the style changes back.
+        local bf = btn.AssistedCombatHighlightFrame
+        if bf and bf:IsShown() then
+            ns._AssistRingHide(btn)
+            bf:SetAlpha(style == 2 and 0 or 1)
+            if fd.squared then
+                local s = ns._AssistScale(btn)
+                if bf:GetScale() ~= s then bf:SetScale(s) end
+            end
+            return
+        end
+
+        if style == 2 then
+            ns._AssistRingHide(btn)
+            return
+        end
+
         local hf = fd.assistHL
         if not hf then
             hf = AssistCreate(btn)
@@ -10549,20 +10647,9 @@ do
                                         match = GetBaseSpell(sid) == suggestedBase
                                     end
                                     if match then
-                                        local bf = btn.AssistedCombatHighlightFrame
-                                        if bf and bf:IsShown() then
-                                            AssistHide(btn)  -- Blizzard's covers it
-                                            -- Scale Blizzard's lazily-created frame to
-                                            -- our button size + outset (change-guarded),
-                                            -- so a hovered button's shine does not jump
-                                            -- back to the un-outset size.
-                                            if EFD(btn).squared then
-                                                local s = ns._AssistScale(btn)
-                                                if bf:GetScale() ~= s then bf:SetScale(s) end
-                                            end
-                                        else
-                                            AssistShow(btn)
-                                        end
+                                        -- AssistShow owns the style decision and
+                                        -- the defer-to-Blizzard's-own-ring case.
+                                        AssistShow(btn)
                                         newSet[btn] = true
                                     end
                                 end

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -10478,46 +10478,66 @@ do
         hf:Hide()
     end
 
-    -- Flat tint over the whole button -- the alternative (or companion) to the
-    -- ring. Its own child frame at btn+14, one below the ring, so it draws over
-    -- the icon and the cooldown swipe deterministically instead of racing
-    -- draw-layer sublevels against Blizzard's own button textures. No texture,
-    -- no animation, no driver entry: strictly cheaper than the flipbook ring.
-    -- Created lazily, so nobody on the ring-only default pays for it.
-    ns._AssistOverlay = function(btn, show)
+    -- Flat tint over the button -- the alternative (or companion) to the ring.
+    -- Its own child frame at btn+14, one below the ring, so it draws over the
+    -- icon and the cooldown swipe deterministically instead of racing draw-layer
+    -- sublevels against Blizzard's own button textures. A color fill plus one
+    -- mask: no animation and no driver entry, so it is strictly cheaper than the
+    -- flipbook ring. Created lazily, so nobody on the ring-only default pays
+    -- for it.
+    -- style: nil/1 = hide, 2 = overlay only, 3 = overlay under the ring.
+    ns._AssistOverlay = function(btn, style)
         local fd = EFD(btn)
         local ov = fd.assistOverlay
-        if not show then
+        if not style or style == 1 then
             if ov then ov:Hide() end
             return
         end
+        local p = EAB.db and EAB.db.profile
         if not ov then
             ov = CreateFrame("Frame", nil, btn)
-            ov:SetAllPoints(btn)
             ov.tex = ov:CreateTexture(nil, "OVERLAY")
             ov.tex:SetAllPoints(ov)
+            -- Rounded corners: the addon's own Curved Square mask, so the tint
+            -- follows the button art instead of ending in hard 90-degree
+            -- corners. Only used when no button shape mask is in play -- that
+            -- one already defines the silhouette.
+            ov.roundMask = ov:CreateMaskTexture()
+            ov.roundMask:SetAllPoints(ov)
+            ov.roundMask:SetTexture(SHAPE_MASKS.csquare, "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
             fd.assistOverlay = ov
+        end
+        -- Footprint. Alone (style 2) the tint covers exactly the button. Under
+        -- the ring (style 3) it grows or shrinks with the ring's outset so the
+        -- two end flush -- the tint never sticks out past the ring, which is
+        -- what a negative outset would otherwise produce. Change-guarded: the
+        -- rescan runs several times a second while a suggestion is up.
+        local pad = (style == 3) and ((p and p.assistGlowOutset) or 0) or 0
+        local ofd = EFD(ov)
+        if ofd.pad ~= pad then
+            ofd.pad = pad
+            ov:ClearAllPoints()
+            ov:SetPoint("TOPLEFT", btn, "TOPLEFT", -pad, pad)
+            ov:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", pad, -pad)
         end
         -- Re-assert: bar layout can change the button's frame level after create.
         ov:SetFrameLevel(btn:GetFrameLevel() + 14)
-        local p = EAB.db and EAB.db.profile
         local c = (p and p.assistGlowOverlayColor) or { r = 0.15, g = 0.5, b = 1 }
         local a = (p and p.assistGlowOverlayAlpha) or 30
         ov.tex:SetColorTexture(c.r or 0.15, c.g or 0.5, c.b or 1, a / 100)
-        -- Custom button shapes: follow the shape mask, else the tint is a
-        -- square sitting on a round icon. Keyed on the mask OBJECT, not a
-        -- boolean: a shape change swaps the mask, and the stale one must be
-        -- removed before the new one goes on.
-        local ofd = EFD(ov)
-        if fd.shapeMask and fd.shapeApplied then
-            if ofd.shapeMasked ~= fd.shapeMask then
-                if ofd.shapeMasked then UnmaskFrameTextures(ov, ofd.shapeMasked) end
-                MaskFrameTextures(ov, fd.shapeMask)
-                ofd.shapeMasked = fd.shapeMask
+        -- Custom button shapes win over the rounded corners: a circle mask must
+        -- not end up as a rounded square. Keyed on the mask OBJECT, not a
+        -- boolean -- a shape change swaps the mask, and the stale one has to be
+        -- removed before the new one goes on. Applied to the tint texture
+        -- directly rather than via MaskFrameTextures: that walks GetRegions(),
+        -- which here would also hand the mask to our own roundMask region.
+        local want = (fd.shapeMask and fd.shapeApplied) and fd.shapeMask or ov.roundMask
+        if ofd.shapeMasked ~= want then
+            if ofd.shapeMasked then
+                pcall(ov.tex.RemoveMaskTexture, ov.tex, ofd.shapeMasked)
             end
-        elseif ofd.shapeMasked then
-            UnmaskFrameTextures(ov, ofd.shapeMasked)
-            ofd.shapeMasked = nil
+            pcall(ov.tex.AddMaskTexture, ov.tex, want)
+            ofd.shapeMasked = want
         end
         ov:Show()
     end
@@ -10528,7 +10548,7 @@ do
     -- leave it invisible for whoever shows it next.
     local function AssistHide(btn)
         ns._AssistRingHide(btn)
-        ns._AssistOverlay(btn, false)
+        ns._AssistOverlay(btn)
         local bf = btn.AssistedCombatHighlightFrame
         if bf and bf:GetAlpha() ~= 1 then bf:SetAlpha(1) end
     end
@@ -10560,7 +10580,7 @@ do
         local style = (p and p.assistGlowStyle) or 1
 
         -- Tint: always ours, Blizzard never paints one.
-        ns._AssistOverlay(btn, style ~= 1)
+        ns._AssistOverlay(btn, style)
 
         -- Blizzard may show its own ring on a hovered button (candidate
         -- re-add). Defer to it so two identical shines never stack, but keep it

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -482,6 +482,11 @@ local defaults = {
         procGlowUseClassColor = false,
         procGlowScale = 1.0,
         procGlowEnabled = false,
+        -- Assisted Highlight ring: extra pixels per side beyond the button
+        -- footprint. 0 = Blizzard's size (art sits exactly on the button).
+        -- Positive pushes the blue swirl outward so it reads apart from a proc
+        -- glow on the same edge; negative pulls it inward.
+        assistGlowOutset = 0,
         useBlizzardStyle = false,
         showBlizzIconBg = false,
         blizzIconBgAlpha = 1,
@@ -10462,6 +10467,23 @@ do
         hf:Hide()
     end
 
+    -- Scale that makes the 45px template art cover the button plus the user's
+    -- outset on every side. The frame is anchored CENTER, so scaling grows or
+    -- shrinks it symmetrically -- a positive outset pushes the blue swirl
+    -- outside the proc glow's edge, a negative one tucks it inside. Clamped
+    -- above zero: SetScale(0) is invalid, and a large negative outset on a
+    -- small button would otherwise reach it.
+    -- Stored on ns rather than as a local: this chunk is at the 200-local
+    -- ceiling (see _procState.GetButtonSpellID).
+    ns._AssistScale = function(btn)
+        local w = btn:GetWidth() or 45
+        local p = EAB.db and EAB.db.profile
+        local outset = (p and p.assistGlowOutset) or 0
+        local s = (w + outset * 2) / 45
+        if s < 0.05 then s = 0.05 end
+        return s
+    end
+
     local function AssistShow(btn)
         local fd = EFD(btn)
         local hf = fd.assistHL
@@ -10470,8 +10492,7 @@ do
             if not hf then return end
             fd.assistHL = hf
         end
-        local w = btn:GetWidth() or 45
-        hf:SetScale(w / 45)
+        hf:SetScale(ns._AssistScale(btn))
         -- Re-assert: bar layout can change the button's frame level after create.
         hf:SetFrameLevel(btn:GetFrameLevel() + 15)
         hf:Show()
@@ -10532,9 +10553,11 @@ do
                                         if bf and bf:IsShown() then
                                             AssistHide(btn)  -- Blizzard's covers it
                                             -- Scale Blizzard's lazily-created frame to
-                                            -- our button size (change-guarded).
+                                            -- our button size + outset (change-guarded),
+                                            -- so a hovered button's shine does not jump
+                                            -- back to the un-outset size.
                                             if EFD(btn).squared then
-                                                local s = (btn:GetWidth() or 45) / 45
+                                                local s = ns._AssistScale(btn)
                                                 if bf:GetScale() ~= s then bf:SetScale(s) end
                                             end
                                         else

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -5773,6 +5773,22 @@ initFrame:SetScript("OnEvent", function(self)
         end
         y = y - h
 
+        -- Assisted Highlight sits on the same button edge as the proc glow and
+        -- has no size control of its own; the outset pushes it clear so both
+        -- read as separate rings.
+        _, h = W:DualRow(parent, y,
+            { type="slider", text="Assisted Highlight Outset", min=-10, max=30, step=1,
+              tooltip="Moves Blizzard's blue Assisted Highlight ring outward (or inward at negative values) so it no longer overlaps the proc glow on the same button.",
+              disabled=function() return not (GetCVarBool and GetCVarBool("assistedCombatHighlight")) end,
+              disabledTooltip="This option requires Blizzard's Assisted Highlight to be enabled",
+              rawTooltip=true,
+              getValue=function() return p.assistGlowOutset or 0 end,
+              setValue=function(v)
+                  p.assistGlowOutset = v
+                  if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
+              end },
+            { type="spacer" });  y = y - h
+
         return math.abs(y)
     end
 

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -5829,7 +5829,7 @@ initFrame:SetScript("OnEvent", function(self)
 
         _, h = W:DualRow(parent, y,
             { type="slider", text="Assisted Highlight Outset", min=-10, max=30, step=1,
-              tooltip="Moves the blue Assisted Highlight ring outward (or inward at negative values) so it no longer overlaps the proc glow on the same button.",
+              tooltip="Moves the blue Assisted Highlight ring outward (or inward at negative values) so it no longer overlaps the proc glow on the same button. With Ring + Overlay the tint resizes along with it, so the two stay flush.",
               disabled=function() return AssistOff() or (p.assistGlowStyle or 1) == 2 end,
               disabledTooltip="This option requires a style that draws the glow ring",
               rawTooltip=true,

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -5773,14 +5773,65 @@ initFrame:SetScript("OnEvent", function(self)
         end
         y = y - h
 
-        -- Assisted Highlight sits on the same button edge as the proc glow and
-        -- has no size control of its own; the outset pushes it clear so both
-        -- read as separate rings.
+        -- Assisted Highlight. Blizzard's ring sits on the same button edge as
+        -- the proc glow and has no size control of its own, so we offer two
+        -- ways to tell them apart: push the ring clear with an outset, or drop
+        -- the ring for a flat tint that leaves the edge to the proc glow.
+        -- Values mirror p.assistGlowStyle: 1 = ring, 2 = overlay, 3 = both.
+        local function AssistOff()
+            return not (GetCVarBool and GetCVarBool("assistedCombatHighlight"))
+        end
+        local assistRow
+        assistRow, h = W:DualRow(parent, y,
+            { type="dropdown", text="Assisted Highlight",
+              values={ [1]="Glow Ring", [2]="Button Overlay", [3]="Ring + Overlay" },
+              order={ 1, 2, 3 },
+              tooltip="How Blizzard's next-spell suggestion is drawn on the button. Button Overlay replaces the blue ring with a flat tint, leaving the button edge free for the proc glow.",
+              disabled=AssistOff,
+              disabledTooltip="This option requires Blizzard's Assisted Highlight to be enabled",
+              rawTooltip=true,
+              getValue=function() return p.assistGlowStyle or 1 end,
+              setValue=function(v)
+                  p.assistGlowStyle = v
+                  if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
+                  -- Deferred like the proc-glow dropdown above: a synchronous
+                  -- rebuild tears the dropdown down inside its own click handler.
+                  C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
+              end },
+            { type="slider", text="Overlay Opacity", min=0, max=100, step=1,
+              tooltip="Opacity of the Button Overlay tint.",
+              disabled=function() return AssistOff() or (p.assistGlowStyle or 1) == 1 end,
+              disabledTooltip="This option requires the Button Overlay style",
+              rawTooltip=true,
+              getValue=function() return p.assistGlowOverlayAlpha or 30 end,
+              setValue=function(v)
+                  p.assistGlowOverlayAlpha = v
+                  if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
+              end });  y = y - h
+
+        -- Inline swatch: overlay tint color, next to the opacity slider it belongs to.
+        if not EllesmereUI._prebuilding then
+            EllesmereUI.BuildInlineSwatches(assistRow._rightRegion, {
+                { tooltip = "Button Overlay Color", hasAlpha = false,
+                  getValue = function()
+                      local c = p.assistGlowOverlayColor or { r = 0.15, g = 0.5, b = 1 }
+                      return c.r, c.g, c.b
+                  end,
+                  setValue = function(r, g, b)
+                      p.assistGlowOverlayColor = { r = r, g = g, b = b }
+                      if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
+                  end },
+            }, {
+                disabled = function() return AssistOff() or (p.assistGlowStyle or 1) == 1 end,
+                disabledTooltip = "This option requires the Button Overlay style",
+            })
+        end
+
         _, h = W:DualRow(parent, y,
             { type="slider", text="Assisted Highlight Outset", min=-10, max=30, step=1,
-              tooltip="Moves Blizzard's blue Assisted Highlight ring outward (or inward at negative values) so it no longer overlaps the proc glow on the same button.",
-              disabled=function() return not (GetCVarBool and GetCVarBool("assistedCombatHighlight")) end,
-              disabledTooltip="This option requires Blizzard's Assisted Highlight to be enabled",
+              tooltip="Moves the blue Assisted Highlight ring outward (or inward at negative values) so it no longer overlaps the proc glow on the same button.",
+              disabled=function() return AssistOff() or (p.assistGlowStyle or 1) == 2 end,
+              disabledTooltip="This option requires a style that draws the glow ring",
               rawTooltip=true,
               getValue=function() return p.assistGlowOutset or 0 end,
               setValue=function(v)


### PR DESCRIPTION
## What does this PR do?

Adds two options for the assisted highlight:

- outset in px of the blue glow
- Add overlay with custom color and alpha instead of additionally to the glow

## How was it tested?

Tested in 12.1 in combat and outside.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
