### PR TITLE
"Disable Right Click" and the Left+Right-Click Move Forward Conflict

### DIFF
--- a/EllesmereUIOptions/EUI_QoL_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_Options.lua
@@ -1388,7 +1388,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUI:RefreshPage()
               end },
             { type="dropdown", text="Disable Right Click",
-              tooltip="Suppresses right click targeting. Enemies applies everywhere. Allies In Combat only suppresses friendly targets while you are in combat, so you can still right click vendors and NPCs out of combat.",
+              tooltip="Suppresses right click targeting. Enemies applies everywhere. Allies In Combat only suppresses friendly targets while you are in combat, so you can still right click vendors and NPCs out of combat.\n\nNote: while this is active, holding Left+Right click to move forward won't work if your cursor is over a suppressed nameplate/unit, since this feature has to take over the right mouse button entirely to block targeting.",
               values={ ["_placeholder"]="..." }, order={ "_placeholder" },
               getValue=function() return "_placeholder" end,
               setValue=function() end }


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540456120441643078

The issue: With "Disable Right Click" set to Enemies, hovering an enemy nameplate makes the addon fully rebind your right mouse button (BUTTON2) to a custom mouselook action instead of its default WoW action. Holding Left+Right to move forward is a hardcoded client behavior that requires both mouse buttons to be firing their default bindings together — so once right-click is rebound, that combo breaks. There's no way for the addon to selectively block just the targeting part, since it's the same underlying binding, and the restricted environment the addon runs in doesn't expose a way to check "is the other button also held" before deciding to remap. So it's a genuine trade-off of the feature, not a bug.

Updated tooltip:

Suppresses right click targeting. Enemies applies everywhere. Allies In Combat only suppresses friendly targets while you are in combat, so you can still right click vendors and NPCs out of combat.

Note: while this is active, holding Left+Right click to move forward won't work if your cursor is over a suppressed nameplate/unit, since this feature has to take over the right mouse button entirely to block targeting.