### PR TITLE
Durability bar reads stale 100% until hover, then reverts

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -889,6 +889,22 @@ local function MakeStatBlock(blockCfg, slot, content, barCtx, opts)
         Tick()
     end
 
+    -- Lets a tooltip resync the bar text with what it just sampled.
+    function inst:ForceSample()
+        ForceTick()
+    end
+
+    -- A sample taken right when an event fires can catch the source before
+    -- it's populated. Resample once more after a short delay to catch that.
+    local function ForceTickChecked()
+        ForceTick()
+        if opts.retryDelay then
+            C_Timer.After(opts.retryDelay, function()
+                if not inst._dead then ForceTick() end
+            end)
+        end
+    end
+
     function inst:Enable()
         content:Show()
         lastVal = -1
@@ -897,10 +913,10 @@ local function MakeStatBlock(blockCfg, slot, content, barCtx, opts)
         if opts.events then
             if not self.eventFrame then
                 self.events = opts.events
-                self.eventFrame = MakeEventFrame(self, ForceTick)
+                self.eventFrame = MakeEventFrame(self, ForceTickChecked)
             end
             RegisterInstEvents(self)
-            ForceTick()
+            ForceTickChecked()
         else
             ns.RegisterHeartbeat(opts.hbPrefix .. ":" .. self.key, Tick)
         end
@@ -1181,7 +1197,9 @@ ns.BlockFactories.durability = function(blockCfg, slot, content, barCtx)
         return pct
     end
 
-    local function DurabilityTooltip()
+    local function DurabilityTooltip(inst)
+        -- Resync the bar text whenever the tooltip opens.
+        if inst then inst:ForceSample() end
         local ar, ag, ab = 1, 1, 1
         ns.Tip_Begin(content)
         ns.Tip_AddDouble("Durability", SampleDurability() .. "%",
@@ -1197,6 +1215,8 @@ ns.BlockFactories.durability = function(blockCfg, slot, content, barCtx)
         -- the block samples on those events alone -- no heartbeat, and with no
         -- other time-driven block enabled the 1s ticker never runs at all.
         events   = { "UPDATE_INVENTORY_DURABILITY", "PLAYER_ENTERING_WORLD" },
+        -- Retry each sample once, a moment later.
+        retryDelay = 2,
         sample   = SampleDurability,
         suffix   = function() return "%" end,
         tooltip  = DurabilityTooltip,


### PR DESCRIPTION
Bug:  https://discord.com/channels/585577383847788554/1539982765502505044

Summary:
The durability data bar only resamples on UPDATE_INVENTORY_DURABILITY / PLAYER_ENTERING_WORLD. A sample taken right as one of those events fires can catch the durability API before it's actually populated, silently locking in 100% — and since nothing else re-checks afterward, that stale value sticks. Hovering forced a fresh read in the tooltip, which is why it "corrected" there — but the fix wasn't wired to update the bar's own value, and worse, only the very first sample at load had any retry logic, so any later event (zoning, repairs, etc.) could re-introduce the same stale read with no way to recover.

Fix: every event-triggered sample now schedules one automatic re-check a couple seconds later, and opening the tooltip also forces the bar itself to resync — so a bad read can't get stuck, whether it happens at login or later in a play session.