### PR TITLE
RF: fix Group/Unit Growth in Merge Groups mode

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_Options.lua
@@ -4849,18 +4849,13 @@ initFrame:SetScript("OnEvent", function(self)
         -------------------------------------------------------------------
         _, h = W:SectionHeader(parent, "LAYOUT", y); y = y - h
 
-        -- Group Growth | Unit Growth both list all 4 directions. Separated groups
-        -- (Merge Groups off) support all 16 combinations -- the layout math steps
-        -- each group's own SetPoint along the literal groupGrowth axis. Merged
-        -- (Merge Groups on) goes through a single Blizzard flat header instead,
-        -- whose columnAnchorPoint can only be perpendicular to Unit Growth; a
-        -- same-axis pair there has no valid column direction, so KeepGrowthPerpendicular
-        -- bumps the other axis out of the way rather than letting the runtime
-        -- silently reinterpret it (see the colAnchor comment in EllesmereUIRaidFrames.lua).
-        -- Changing the base pair can also leave a per-tier override same-axis
-        -- (an override that only set ONE axis inherits the other from base, so
-        -- a base edit can silently break a tier that looked fine when it was
-        -- set) -- fix those up the same way the Merge Groups toggle does.
+        -- Group Growth | Unit Growth: separated groups (Merge Groups off) support all
+        -- 16 combinations, but merged mode's single Blizzard flat header can only make
+        -- its column direction perpendicular to Unit Growth, so a same-axis pair there
+        -- gets silently reinterpreted (see the colAnchor comment in EllesmereUIRaidFrames.lua)
+        -- -- KeepGrowthPerpendicular bumps the other axis instead. A base edit can also
+        -- leave a per-tier override same-axis (an override that only set one axis
+        -- inherits the other from base), so fix those up too.
         local function FixTierOverridesPerpendicular()
             local overrides = db.profile.raidSizeOverrides
             if type(overrides) ~= "table" then return end
@@ -4883,10 +4878,10 @@ initFrame:SetScript("OnEvent", function(self)
                           function() return SVal("unitGrowth", "DOWN") end,
                           function(nv) db.profile.unitGrowth = nv end)
                       FixTierOverridesPerpendicular()
+                      EllesmereUI:RefreshPage() -- the sibling dropdown may have just changed
                   end
                   if ns._BumpAbsorbGen then ns._BumpAbsorbGen() end
                   ReloadAndUpdate()
-                  EllesmereUI:RefreshPage()
               end },
             { type="dropdown", text="Unit Growth", values=growthValues, order=allGrowthOrder,
               getValue=function() return SVal("unitGrowth", "DOWN") end,
@@ -4897,10 +4892,10 @@ initFrame:SetScript("OnEvent", function(self)
                           function() return SVal("groupGrowth", "RIGHT") end,
                           function(nv) db.profile.groupGrowth = nv end)
                       FixTierOverridesPerpendicular()
+                      EllesmereUI:RefreshPage() -- the sibling dropdown may have just changed
                   end
                   if ns._BumpAbsorbGen then ns._BumpAbsorbGen() end
                   ReloadAndUpdate()
-                  EllesmereUI:RefreshPage()
               end });  y = y - h
 
         -- Row 4: Sort By (custom dropdown with drag-to-reorder roles) | Self Position
@@ -4947,11 +4942,12 @@ initFrame:SetScript("OnEvent", function(self)
                 { type="toggle", text="Merge Groups",
                   getValue=function() return SVal("mergeGroups", false) end,
                   setValue=function(v)
-                      -- Fix up an already-saved same-axis Group/Unit Growth pair
-                      -- BEFORE flipping the mode, so the very first merged layout
-                      -- pass renders correctly instead of one frame behind. Covers
-                      -- both the base pair and every per-tier override, same as the
-                      -- per-tier cog dropdowns do while merge is already on.
+                      -- Fix up an already-saved same-axis Group/Unit Growth pair so the
+                      -- SAVED profile and the dropdowns stay honest about what's rendering
+                      -- (the runtime's own read-time backstop, ns._RFEffectiveGrowth, already
+                      -- makes the first merged render correct either way). Covers both the
+                      -- base pair and every per-tier override, same as the per-tier cog
+                      -- dropdowns do while merge is already on.
                       if v then
                           KeepGrowthPerpendicular(SVal("groupGrowth", "RIGHT"),
                               function() return SVal("unitGrowth", "DOWN") end,

--- a/EllesmereUIOptions/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_Options.lua
@@ -546,7 +546,9 @@ initFrame:SetScript("OnEvent", function(self)
     }
     local allGrowthOrder        = { "DOWN", "UP", "RIGHT", "LEFT" }
 
-    local function GrowthIsVertical(g) return g == "UP" or g == "DOWN" end
+    -- ns._RFGrowthIsVertical is the runtime module's single source of truth for
+    -- this check (EllesmereUIRaidFrames.lua); reuse it here rather than a second copy.
+    local GrowthIsVertical = ns._RFGrowthIsVertical
 
     -- Merge Groups renders through Blizzard's flat SecureGroupHeader, whose column
     -- axis (columnAnchorPoint) is always perpendicular to Unit Growth -- a same-axis
@@ -4855,6 +4857,22 @@ initFrame:SetScript("OnEvent", function(self)
         -- same-axis pair there has no valid column direction, so KeepGrowthPerpendicular
         -- bumps the other axis out of the way rather than letting the runtime
         -- silently reinterpret it (see the colAnchor comment in EllesmereUIRaidFrames.lua).
+        -- Changing the base pair can also leave a per-tier override same-axis
+        -- (an override that only set ONE axis inherits the other from base, so
+        -- a base edit can silently break a tier that looked fine when it was
+        -- set) -- fix those up the same way the Merge Groups toggle does.
+        local function FixTierOverridesPerpendicular()
+            local overrides = db.profile.raidSizeOverrides
+            if type(overrides) ~= "table" then return end
+            for _, ov in pairs(overrides) do
+                if type(ov) == "table" then
+                    KeepGrowthPerpendicular(ov.groupGrowth or SVal("groupGrowth", "RIGHT"),
+                        function() return ov.unitGrowth or SVal("unitGrowth", "DOWN") end,
+                        function(nv) ov.unitGrowth = nv end)
+                end
+            end
+        end
+
         _, h = W:DualRow(parent, y,
             { type="dropdown", text="Group Growth", values=growthValues, order=allGrowthOrder,
               getValue=function() return SVal("groupGrowth", "RIGHT") end,
@@ -4864,9 +4882,11 @@ initFrame:SetScript("OnEvent", function(self)
                       KeepGrowthPerpendicular(v,
                           function() return SVal("unitGrowth", "DOWN") end,
                           function(nv) db.profile.unitGrowth = nv end)
+                      FixTierOverridesPerpendicular()
                   end
                   if ns._BumpAbsorbGen then ns._BumpAbsorbGen() end
                   ReloadAndUpdate()
+                  EllesmereUI:RefreshPage()
               end },
             { type="dropdown", text="Unit Growth", values=growthValues, order=allGrowthOrder,
               getValue=function() return SVal("unitGrowth", "DOWN") end,
@@ -4876,9 +4896,11 @@ initFrame:SetScript("OnEvent", function(self)
                       KeepGrowthPerpendicular(v,
                           function() return SVal("groupGrowth", "RIGHT") end,
                           function(nv) db.profile.groupGrowth = nv end)
+                      FixTierOverridesPerpendicular()
                   end
                   if ns._BumpAbsorbGen then ns._BumpAbsorbGen() end
                   ReloadAndUpdate()
+                  EllesmereUI:RefreshPage()
               end });  y = y - h
 
         -- Row 4: Sort By (custom dropdown with drag-to-reorder roles) | Self Position
@@ -4934,16 +4956,7 @@ initFrame:SetScript("OnEvent", function(self)
                           KeepGrowthPerpendicular(SVal("groupGrowth", "RIGHT"),
                               function() return SVal("unitGrowth", "DOWN") end,
                               function(nv) db.profile.unitGrowth = nv end)
-                          local overrides = db.profile.raidSizeOverrides
-                          if type(overrides) == "table" then
-                              for _, ov in pairs(overrides) do
-                                  if type(ov) == "table" then
-                                      KeepGrowthPerpendicular(ov.groupGrowth or SVal("groupGrowth", "RIGHT"),
-                                          function() return ov.unitGrowth or SVal("unitGrowth", "DOWN") end,
-                                          function(nv) ov.unitGrowth = nv end)
-                                  end
-                              end
-                          end
+                          FixTierOverridesPerpendicular()
                       end
                       SSet("mergeGroups", v)
                       EllesmereUI:RefreshPage()

--- a/EllesmereUIOptions/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_Options.lua
@@ -4927,11 +4927,23 @@ initFrame:SetScript("OnEvent", function(self)
                   setValue=function(v)
                       -- Fix up an already-saved same-axis Group/Unit Growth pair
                       -- BEFORE flipping the mode, so the very first merged layout
-                      -- pass renders correctly instead of one frame behind.
+                      -- pass renders correctly instead of one frame behind. Covers
+                      -- both the base pair and every per-tier override, same as the
+                      -- per-tier cog dropdowns do while merge is already on.
                       if v then
                           KeepGrowthPerpendicular(SVal("groupGrowth", "RIGHT"),
                               function() return SVal("unitGrowth", "DOWN") end,
                               function(nv) db.profile.unitGrowth = nv end)
+                          local overrides = db.profile.raidSizeOverrides
+                          if type(overrides) == "table" then
+                              for _, ov in pairs(overrides) do
+                                  if type(ov) == "table" then
+                                      KeepGrowthPerpendicular(ov.groupGrowth or SVal("groupGrowth", "RIGHT"),
+                                          function() return ov.unitGrowth or SVal("unitGrowth", "DOWN") end,
+                                          function(nv) ov.unitGrowth = nv end)
+                                  end
+                              end
+                          end
                       end
                       SSet("mergeGroups", v)
                       EllesmereUI:RefreshPage()

--- a/EllesmereUIOptions/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_Options.lua
@@ -546,6 +546,21 @@ initFrame:SetScript("OnEvent", function(self)
     }
     local allGrowthOrder        = { "DOWN", "UP", "RIGHT", "LEFT" }
 
+    local function GrowthIsVertical(g) return g == "UP" or g == "DOWN" end
+
+    -- Merge Groups renders through Blizzard's flat SecureGroupHeader, whose column
+    -- axis (columnAnchorPoint) is always perpendicular to Unit Growth -- a same-axis
+    -- Group Growth has no valid column direction, so the runtime silently substitutes
+    -- an unrelated one instead of honoring it. Bump the OTHER axis to a perpendicular
+    -- value instead of letting an unrenderable pair through, mirroring the Spell
+    -- Name/Spell Target side-conflict rule used elsewhere in these options.
+    local function KeepGrowthPerpendicular(newVal, getOther, setOther)
+        local other = getOther()
+        if GrowthIsVertical(newVal) == GrowthIsVertical(other) then
+            setOther(GrowthIsVertical(newVal) and "RIGHT" or "DOWN")
+        end
+    end
+
     -- Every preview mode dropdown across tabs; all refresh when one changes.
     local pvModeDropdowns = {}
 
@@ -4501,10 +4516,17 @@ initFrame:SetScript("OnEvent", function(self)
                                       return ov and ov[tier] and ov[tier].groupGrowth or db.profile.groupGrowth or "RIGHT"
                                   end,
                                   set=function(v)
-                                      -- Every growth combination is allowed (see the
-                                      -- main LAYOUT dropdowns): same-axis = one
-                                      -- continuous line per tier.
-                                      EnsureTierOv().groupGrowth = v
+                                      -- Separated groups allow every combination (see
+                                      -- the main LAYOUT dropdowns); merged needs this
+                                      -- tier's effective Unit Growth kept perpendicular.
+                                      local ov = EnsureTierOv()
+                                      ov.groupGrowth = v
+                                      if SVal("mergeGroups", false) then
+                                          local ovs = db.profile.raidSizeOverrides
+                                          KeepGrowthPerpendicular(v,
+                                              function() return (ovs and ovs[tier] and ovs[tier].unitGrowth) or db.profile.unitGrowth or "DOWN" end,
+                                              function(nv) ov.unitGrowth = nv end)
+                                      end
                                       TierGrowthChanged()
                                   end },
                                 { type="dropdown", label="Unit Growth",
@@ -4516,6 +4538,12 @@ initFrame:SetScript("OnEvent", function(self)
                                   set=function(v)
                                       local ov = EnsureTierOv()
                                       ov.unitGrowth = v
+                                      if SVal("mergeGroups", false) then
+                                          local ovs = db.profile.raidSizeOverrides
+                                          KeepGrowthPerpendicular(v,
+                                              function() return (ovs and ovs[tier] and ovs[tier].groupGrowth) or db.profile.groupGrowth or "RIGHT" end,
+                                              function(nv) ov.groupGrowth = nv end)
+                                      end
                                       TierGrowthChanged()
                                   end },
                                 { type="slider", label="X Offset", min=-1000, max=1000, step=1,
@@ -4819,20 +4847,39 @@ initFrame:SetScript("OnEvent", function(self)
         -------------------------------------------------------------------
         _, h = W:SectionHeader(parent, "LAYOUT", y); y = y - h
 
-        -- Group Growth | Unit Growth both list all 4 directions, every combination
-        -- allowed. Same-axis (e.g. Up + Up) lays the groups end-to-end into one
-        -- continuous line -- the layout math derives the group stride from the
-        -- unit-growth bounding box, so all 16 combinations are geometrically
-        -- valid (the old perpendicular-only gate was a UI-side assumption; the
-        -- runtime never needed it, and users were hand-editing SavedVariables
-        -- to get single-line layouts).
+        -- Group Growth | Unit Growth both list all 4 directions. Separated groups
+        -- (Merge Groups off) support all 16 combinations -- the layout math steps
+        -- each group's own SetPoint along the literal groupGrowth axis. Merged
+        -- (Merge Groups on) goes through a single Blizzard flat header instead,
+        -- whose columnAnchorPoint can only be perpendicular to Unit Growth; a
+        -- same-axis pair there has no valid column direction, so KeepGrowthPerpendicular
+        -- bumps the other axis out of the way rather than letting the runtime
+        -- silently reinterpret it (see the colAnchor comment in EllesmereUIRaidFrames.lua).
         _, h = W:DualRow(parent, y,
             { type="dropdown", text="Group Growth", values=growthValues, order=allGrowthOrder,
               getValue=function() return SVal("groupGrowth", "RIGHT") end,
-              setValue=function(v) SSet("groupGrowth", v) end },
+              setValue=function(v)
+                  db.profile.groupGrowth = v
+                  if SVal("mergeGroups", false) then
+                      KeepGrowthPerpendicular(v,
+                          function() return SVal("unitGrowth", "DOWN") end,
+                          function(nv) db.profile.unitGrowth = nv end)
+                  end
+                  if ns._BumpAbsorbGen then ns._BumpAbsorbGen() end
+                  ReloadAndUpdate()
+              end },
             { type="dropdown", text="Unit Growth", values=growthValues, order=allGrowthOrder,
               getValue=function() return SVal("unitGrowth", "DOWN") end,
-              setValue=function(v) SSet("unitGrowth", v) end });  y = y - h
+              setValue=function(v)
+                  db.profile.unitGrowth = v
+                  if SVal("mergeGroups", false) then
+                      KeepGrowthPerpendicular(v,
+                          function() return SVal("groupGrowth", "RIGHT") end,
+                          function(nv) db.profile.groupGrowth = nv end)
+                  end
+                  if ns._BumpAbsorbGen then ns._BumpAbsorbGen() end
+                  ReloadAndUpdate()
+              end });  y = y - h
 
         -- Row 4: Sort By (custom dropdown with drag-to-reorder roles) | Self Position
         local sortRow
@@ -4877,7 +4924,18 @@ initFrame:SetScript("OnEvent", function(self)
                   setValue=function() end },
                 { type="toggle", text="Merge Groups",
                   getValue=function() return SVal("mergeGroups", false) end,
-                  setValue=function(v) SSet("mergeGroups", v); EllesmereUI:RefreshPage() end });  y = y - h
+                  setValue=function(v)
+                      -- Fix up an already-saved same-axis Group/Unit Growth pair
+                      -- BEFORE flipping the mode, so the very first merged layout
+                      -- pass renders correctly instead of one frame behind.
+                      if v then
+                          KeepGrowthPerpendicular(SVal("groupGrowth", "RIGHT"),
+                              function() return SVal("unitGrowth", "DOWN") end,
+                              function(nv) db.profile.unitGrowth = nv end)
+                      end
+                      SSet("mergeGroups", v)
+                      EllesmereUI:RefreshPage()
+                  end });  y = y - h
 
             -- Left dropdown becomes a checkbox dropdown for groups 1-8.
             if not EllesmereUI._prebuilding then

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -6735,8 +6735,14 @@ ns._LayoutGroupsImpl = function()
 
         -- Configure flat header layout attributes
         if ns._flatHeader then
+            -- Blizzard's header anchors its first button at the corner where
+            -- "point" and "columnAnchorPoint" meet, then grows away from it --
+            -- same corner ns._RFGrowthCorner names for separated headers. A
+            -- fixed TOPLEFT here left the rendered grid offset from the
+            -- container/mover box whenever growth pinned a different corner.
+            local hdrCorner = ns._RFGrowthCorner(unitGrowth, groupGrowth)
             ns._flatHeader:ClearAllPoints()
-            ns._flatHeader:SetPoint("TOPLEFT", containerFrame, "TOPLEFT", 0, 0)
+            ns._flatHeader:SetPoint(hdrCorner, containerFrame, hdrCorner, 0, 0)
             local layoutChanged = false
             -- While Self Position owns the merged header (whole-raid nameList,
             -- applied by ApplySortToHeaders at the end of this pass), a

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -6430,19 +6430,14 @@ ns._BuildHeaderSet = function(merge)
         self:SetHeight(%d)
     ]]):format(bw, bh)
 
-    -- Compute correct initial point/offset from saved growth direction
-    local initUnitGrowth = s.unitGrowth or "DOWN"
-    local initPoint, initXOff, initYOff
+    -- Compute correct initial point/offset from saved growth direction. Self-heal
+    -- a same-axis pair (see ns._RFEffectiveGrowth) before deriving anything from
+    -- it -- this bootstrap runs from the raw profile, ahead of _LayoutGroupsImpl's
+    -- own per-tier resolution and self-heal.
+    local initUnitGrowth, initGroupGrowth = ns._RFEffectiveGrowth(
+        s.unitGrowth or "DOWN", s.groupGrowth or "RIGHT", merge)
     local csInit = PixelSnap(s.cellSpacing or 2)
-    if initUnitGrowth == "DOWN" then
-        initPoint = "TOP";    initXOff = 0;    initYOff = -csInit
-    elseif initUnitGrowth == "UP" then
-        initPoint = "BOTTOM"; initXOff = 0;    initYOff = csInit
-    elseif initUnitGrowth == "RIGHT" then
-        initPoint = "LEFT";   initXOff = csInit; initYOff = 0
-    else -- LEFT
-        initPoint = "RIGHT";  initXOff = -csInit; initYOff = 0
-    end
+    local initPoint, initXOff, initYOff = ns._RFHeaderPoint(initUnitGrowth, csInit)
 
     if not merge then
         -----------------------------------------------------------
@@ -6507,23 +6502,7 @@ ns._BuildHeaderSet = function(merge)
         ns._flatHeader:SetAttribute("unitsPerColumn", 5)
         ns._flatHeader:SetAttribute("maxColumns", 8)
         ns._flatHeader:SetAttribute("columnSpacing", PixelSnap(s.groupSpacing or 8))
-        -- Compute correct initial columnAnchorPoint from saved growth directions
-        local initGroupGrowth = s.groupGrowth or "RIGHT"
-        local initColAnchor
-        if initGroupGrowth == "DOWN" or initGroupGrowth == "RIGHT" then
-            if initUnitGrowth == "DOWN" or initUnitGrowth == "UP" then
-                initColAnchor = "LEFT"
-            else
-                initColAnchor = "TOP"
-            end
-        else
-            if initUnitGrowth == "DOWN" or initUnitGrowth == "UP" then
-                initColAnchor = "RIGHT"
-            else
-                initColAnchor = "BOTTOM"
-            end
-        end
-        ns._flatHeader:SetAttribute("columnAnchorPoint", initColAnchor)
+        ns._flatHeader:SetAttribute("columnAnchorPoint", ns._RFColAnchor(initUnitGrowth, initGroupGrowth))
         ns._flatHeader:SetAttribute("sortMethod", "INDEX")
 
         -- Pre-create 40 buttons
@@ -6670,38 +6649,19 @@ ns._LayoutGroupsImpl = function()
         groupGrowth = activeOv.groupGrowth or groupGrowth
         unitGrowth  = activeOv.unitGrowth or unitGrowth
     end
+    -- Backstop: self-heal a same-axis pair that reached here without going
+    -- through a guarded write site (see ns._RFEffectiveGrowth).
+    unitGrowth, groupGrowth = ns._RFEffectiveGrowth(unitGrowth, groupGrowth, merged)
     local bw = PixelSnap(ns._activeSizeW or s.frameWidth or 72)
     local bh = PixelSnap(ns._activeSizeH or s.frameHeight or 46)
     local cs = PixelSnap(s.cellSpacing or 2)
     local gs = PixelSnap(s.groupSpacing or 8)
 
     -- Header attributes for unit growth direction
-    local hdrPoint, hdrXOff, hdrYOff
-    if unitGrowth == "DOWN" then
-        hdrPoint = "TOP";    hdrXOff = 0;   hdrYOff = -cs
-    elseif unitGrowth == "UP" then
-        hdrPoint = "BOTTOM"; hdrXOff = 0;   hdrYOff = cs
-    elseif unitGrowth == "RIGHT" then
-        hdrPoint = "LEFT";   hdrXOff = cs;  hdrYOff = 0
-    else -- LEFT
-        hdrPoint = "RIGHT";  hdrXOff = -cs; hdrYOff = 0
-    end
+    local hdrPoint, hdrXOff, hdrYOff = ns._RFHeaderPoint(unitGrowth, cs)
 
     -- Column anchor: where next column of 5 goes (perpendicular to unit growth)
-    local colAnchor
-    if groupGrowth == "DOWN" or groupGrowth == "RIGHT" then
-        if unitGrowth == "DOWN" or unitGrowth == "UP" then
-            colAnchor = "LEFT"
-        else
-            colAnchor = "TOP"
-        end
-    else -- UP or LEFT
-        if unitGrowth == "DOWN" or unitGrowth == "UP" then
-            colAnchor = "RIGHT"
-        else
-            colAnchor = "BOTTOM"
-        end
-    end
+    local colAnchor = ns._RFColAnchor(unitGrowth, groupGrowth)
 
     -- Group bounding box: size of one group along each axis
     local groupW, groupH
@@ -7326,7 +7286,11 @@ ns._RFPosTopLeft = function(pos, w, h)
     return ax - pfx * w, ay + (1 - pfy) * h
 end
 
--- Footprint of the 4-group mover box for a frame size and growth pair.
+-- Footprint of the 4-group mover box for a frame size and growth pair. Callers
+-- that also derive a corner from the same pair (ns._RFCornerTerms/_RFGrowthCorner)
+-- must self-heal (ns._RFEffectiveGrowth) BEFORE calling either, so the size and
+-- the corner agree -- this function does not self-heal internally to avoid a
+-- caller healing one but not the other.
 ns._RFFootprint = function(bw, bh, unitGrowth, groupGrowth, cs, gs)
     bw, bh = PixelSnap(bw), PixelSnap(bh)
     local groupW, groupH
@@ -7353,24 +7317,77 @@ ns._RFBaseTopLeft = function()
     if not pos then return nil end
     local cs = PixelSnap(s.cellSpacing or 2)
     local gs = PixelSnap(s.groupSpacing or 8)
-    local w, h = ns._RFFootprint(s.frameWidth or 72, s.frameHeight or 46,
-        s.unitGrowth or "DOWN", s.groupGrowth or "RIGHT", cs, gs)
+    local ug, gg = ns._RFEffectiveGrowth(s.unitGrowth or "DOWN", s.groupGrowth or "RIGHT", s.mergeGroups)
+    local w, h = ns._RFFootprint(s.frameWidth or 72, s.frameHeight or 46, ug, gg, cs, gs)
     local l, t = ns._RFPosTopLeft(pos, w, h)
     return l, t, w, h
 end
 
+-- Shared growth-direction helpers. A single source of truth for "is this
+-- direction vertical" and for deriving the flat header's point/xOffset/yOffset
+-- and columnAnchorPoint from a growth pair -- both _LayoutGroupsImpl and
+-- _BuildHeaderSet's header-creation bootstrap need the identical derivation,
+-- and previously hand-duplicated it.
+ns._RFGrowthIsVertical = function(g)
+    return g == "DOWN" or g == "UP"
+end
+
+-- First-button point/xOffset/yOffset for a header growing along unitGrowth.
+ns._RFHeaderPoint = function(unitGrowth, cs)
+    if unitGrowth == "DOWN" then
+        return "TOP", 0, -cs
+    elseif unitGrowth == "UP" then
+        return "BOTTOM", 0, cs
+    elseif unitGrowth == "RIGHT" then
+        return "LEFT", cs, 0
+    else -- LEFT
+        return "RIGHT", -cs, 0
+    end
+end
+
+-- Blizzard's flat header can only wrap into columns when columnAnchorPoint runs
+-- perpendicular to unitGrowth -- see ns._RFEffectiveGrowth below for why merged
+-- mode never actually reaches a same-axis pair here in practice.
+ns._RFColAnchor = function(unitGrowth, groupGrowth)
+    if groupGrowth == "DOWN" or groupGrowth == "RIGHT" then
+        if ns._RFGrowthIsVertical(unitGrowth) then return "LEFT" end
+        return "TOP"
+    else -- UP or LEFT
+        if ns._RFGrowthIsVertical(unitGrowth) then return "RIGHT" end
+        return "BOTTOM"
+    end
+end
+
+-- Self-heals a same-axis Group/Unit Growth pair when Merge Groups is on (see
+-- _RFColAnchor above) -- same rule as the options UI's write-time
+-- KeepGrowthPerpendicular (Group Growth wins), applied as a read-time backstop
+-- for a pair that reached here without a guarded write (a stale per-tier
+-- override, a spec override, hand-edited SavedVariables). No-op if not merged.
+ns._RFEffectiveGrowth = function(unitGrowth, groupGrowth, merged)
+    if not merged then return unitGrowth, groupGrowth end
+    if ns._RFGrowthIsVertical(unitGrowth) == ns._RFGrowthIsVertical(groupGrowth) then
+        unitGrowth = ns._RFGrowthIsVertical(unitGrowth) and "RIGHT" or "DOWN"
+    end
+    return unitGrowth, groupGrowth
+end
+
 -- Pinned screen corner implied by a growth pair: frames grow AWAY from this corner, so
--- it stays fixed when a tier's footprint differs from the base. Horizontal side = whichever
--- growth is horizontal (RIGHT pins LEFT edge, LEFT pins RIGHT edge); vertical side likewise
--- (DOWN pins TOP, UP pins BOTTOM). Separated groups still allow all 16 combinations,
--- so a same-axis pair resolves deterministically here too (UP beats BOTTOM, LEFT beats
--- RIGHT, default TOP+LEFT); merged mode's options UI keeps groupGrowth/unitGrowth
--- perpendicular (see the LAYOUT dropdowns), so this only ever sees a same-axis pair
--- there for a not-yet-migrated saved profile.
+-- it stays fixed when a tier's footprint differs from the base. Matches the exact corner
+-- Blizzard's header pins its first button to (the point where "point" and
+-- "columnAnchorPoint" meet -- see ns._RFHeaderPoint/_RFColAnchor above), for every
+-- growth pair including same-axis ones, not just an approximate tie-break -- separated
+-- mode legitimately reaches same-axis pairs (all 16 combinations are valid there), and
+-- merged mode's flat header anchor (ns._flatHeader's own SetPoint) relies on this
+-- matching exactly, not just landing on "a" corner.
 ns._RFGrowthCorner = function(unitGrowth, groupGrowth)
-    local h = (unitGrowth == "LEFT" or groupGrowth == "LEFT") and "RIGHT" or "LEFT"
-    local v = (unitGrowth == "UP" or groupGrowth == "UP") and "BOTTOM" or "TOP"
-    return v .. h
+    local uVert = ns._RFGrowthIsVertical(unitGrowth)
+    local gPinsHigh = (groupGrowth == "UP" or groupGrowth == "LEFT")
+    if uVert then
+        local v = (unitGrowth == "UP") and "BOTTOM" or "TOP"
+        return v .. (gPinsHigh and "RIGHT" or "LEFT")
+    end
+    local v = gPinsHigh and "BOTTOM" or "TOP"
+    return v .. ((unitGrowth == "LEFT") and "RIGHT" or "LEFT")
 end
 
 -- Signed corner terms: how far a tier footprint's TOPLEFT shifts from the base
@@ -7452,10 +7469,10 @@ ns._RFRebaseSavedCenter = function(cx, cy)
     if not ov then return cx, cy end
     local cs = PixelSnap(s.cellSpacing or 2)
     local gs = PixelSnap(s.groupSpacing or 8)
-    local bw, bh = ns._RFFootprint(s.frameWidth or 72, s.frameHeight or 46,
-        s.unitGrowth or "DOWN", s.groupGrowth or "RIGHT", cs, gs)
-    local ug = ov.unitGrowth or s.unitGrowth or "DOWN"
-    local gg = ov.groupGrowth or s.groupGrowth or "RIGHT"
+    local bug, bgg = ns._RFEffectiveGrowth(s.unitGrowth or "DOWN", s.groupGrowth or "RIGHT", s.mergeGroups)
+    local bw, bh = ns._RFFootprint(s.frameWidth or 72, s.frameHeight or 46, bug, bgg, cs, gs)
+    local ug, gg = ns._RFEffectiveGrowth(
+        ov.unitGrowth or s.unitGrowth or "DOWN", ov.groupGrowth or s.groupGrowth or "RIGHT", s.mergeGroups)
     local tw, th = ns._RFFootprint(ov.width or s.frameWidth or 72,
         ov.height or s.frameHeight or 46, ug, gg, cs, gs)
     local kx, ky = ns._RFCornerTerms(tw, th, bw, bh, ug, gg)
@@ -7526,10 +7543,11 @@ ns._NormalizeTierOffsetAnchors = function()
         if pos and bl then
             for _, o in pairs(ov) do
                 if type(o) == "table" then
-                    local tw, th = ns._RFFootprint(
-                        o.width or s.frameWidth or 72, o.height or s.frameHeight or 46,
+                    local ug, gg = ns._RFEffectiveGrowth(
                         o.unitGrowth or s.unitGrowth or "DOWN",
-                        o.groupGrowth or s.groupGrowth or "RIGHT", cs, gs)
+                        o.groupGrowth or s.groupGrowth or "RIGHT", s.mergeGroups)
+                    local tw, th = ns._RFFootprint(
+                        o.width or s.frameWidth or 72, o.height or s.frameHeight or 46, ug, gg, cs, gs)
                     local tl, tt = ns._RFPosTopLeft(pos, tw, th)
                     o.offsetX = math.floor((o.offsetX or 0) + (tl - bl) + 0.5)
                     o.offsetY = math.floor((o.offsetY or 0) + (tt - bt) + 0.5)
@@ -7542,11 +7560,11 @@ ns._NormalizeTierOffsetAnchors = function()
         if pos and bl then
             for _, o in pairs(ov) do
                 if type(o) == "table" then
-                    local ug = o.unitGrowth or s.unitGrowth or "DOWN"
-                    local gg = o.groupGrowth or s.groupGrowth or "RIGHT"
+                    local ug, gg = ns._RFEffectiveGrowth(
+                        o.unitGrowth or s.unitGrowth or "DOWN",
+                        o.groupGrowth or s.groupGrowth or "RIGHT", s.mergeGroups)
                     local tw, th = ns._RFFootprint(
-                        o.width or s.frameWidth or 72, o.height or s.frameHeight or 46,
-                        ug, gg, cs, gs)
+                        o.width or s.frameWidth or 72, o.height or s.frameHeight or 46, ug, gg, cs, gs)
                     local kx, ky = ns._RFCornerTerms(tw, th, bw, bh, ug, gg)
                     if kx ~= 0 then
                         o.offsetX = math.floor((o.offsetX or 0) - kx + 0.5)
@@ -7604,8 +7622,9 @@ ns._ApplyTierOffset = function()
     local gs = PixelSnap(s.groupSpacing or 8)
     local fw = (ov and ov.width) or s.frameWidth or 72
     local fh = (ov and ov.height) or s.frameHeight or 46
-    local ug = (ov and ov.unitGrowth) or s.unitGrowth or "DOWN"
-    local gg = (ov and ov.groupGrowth) or s.groupGrowth or "RIGHT"
+    local ug, gg = ns._RFEffectiveGrowth(
+        (ov and ov.unitGrowth) or s.unitGrowth or "DOWN",
+        (ov and ov.groupGrowth) or s.groupGrowth or "RIGHT", s.mergeGroups)
     local tw, th = ns._RFFootprint(fw, fh, ug, gg, cs, gs)
     local x, y = ns._RFTierTopLeft(tw, th, ug, gg,
         (ov and ov.offsetX) or 0, (ov and ov.offsetY) or 0)
@@ -13701,8 +13720,8 @@ ns._ShowSizePreview = function(tier)
     local bh = PixelSnap(ov.height or s.frameHeight or 60)
     local cs = PixelSnap(s.cellSpacing or 2)
     local gs = PixelSnap(s.groupSpacing or 8)
-    local unitGrowth  = ov.unitGrowth or s.unitGrowth or "DOWN"
-    local groupGrowth = ov.groupGrowth or s.groupGrowth or "RIGHT"
+    local unitGrowth, groupGrowth = ns._RFEffectiveGrowth(
+        ov.unitGrowth or s.unitGrowth or "DOWN", ov.groupGrowth or s.groupGrowth or "RIGHT", s.mergeGroups)
     local frameCount  = tier
     local perGroup    = 5
     local numGroups   = math.ceil(frameCount / perGroup)

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -7356,9 +7356,11 @@ end
 -- Pinned screen corner implied by a growth pair: frames grow AWAY from this corner, so
 -- it stays fixed when a tier's footprint differs from the base. Horizontal side = whichever
 -- growth is horizontal (RIGHT pins LEFT edge, LEFT pins RIGHT edge); vertical side likewise
--- (DOWN pins TOP, UP pins BOTTOM). The UI no longer restricts groupGrowth/unitGrowth to
--- perpendicular pairs, so a same-axis combination resolves deterministically here too
--- (UP beats BOTTOM, LEFT beats RIGHT, default TOP+LEFT).
+-- (DOWN pins TOP, UP pins BOTTOM). Separated groups still allow all 16 combinations,
+-- so a same-axis pair resolves deterministically here too (UP beats BOTTOM, LEFT beats
+-- RIGHT, default TOP+LEFT); merged mode's options UI keeps groupGrowth/unitGrowth
+-- perpendicular (see the LAYOUT dropdowns), so this only ever sees a same-axis pair
+-- there for a not-yet-migrated saved profile.
 ns._RFGrowthCorner = function(unitGrowth, groupGrowth)
     local h = (unitGrowth == "LEFT" or groupGrowth == "LEFT") and "RIGHT" or "LEFT"
     local v = (unitGrowth == "UP" or groupGrowth == "UP") and "BOTTOM" or "TOP"

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -6869,14 +6869,31 @@ ns._LayoutGroupsImpl = function()
     -- Apply sort after all headers are positioned
     ApplySortToHeaders()
 
-    -- Container size based on 4 groups for unlock mode mover
+    -- Container size based on 4 groups for unlock mode mover. Merged mode's
+    -- columnAnchorPoint is always perpendicular to unitGrowth (colAnchor above),
+    -- so its actual render axis follows unitGrowth, not the literal groupGrowth
+    -- (which can share unitGrowth's axis; Blizzard's header can't express that as
+    -- a column direction). Keying the box off groupGrowth there mismatches the
+    -- box against what merged mode really renders. Separated mode has no such
+    -- header constraint and renders along groupGrowth literally, so it keeps the
+    -- original formula.
     local totalW, totalH
-    if groupGrowth == "DOWN" or groupGrowth == "UP" then
-        totalW = groupW
-        totalH = MOVER_GROUPS * groupH + (MOVER_GROUPS - 1) * gs
+    if merged then
+        if unitGrowth == "DOWN" or unitGrowth == "UP" then
+            totalW = MOVER_GROUPS * groupW + (MOVER_GROUPS - 1) * gs
+            totalH = groupH
+        else
+            totalW = groupW
+            totalH = MOVER_GROUPS * groupH + (MOVER_GROUPS - 1) * gs
+        end
     else
-        totalW = MOVER_GROUPS * groupW + (MOVER_GROUPS - 1) * gs
-        totalH = groupH
+        if groupGrowth == "DOWN" or groupGrowth == "UP" then
+            totalW = groupW
+            totalH = MOVER_GROUPS * groupH + (MOVER_GROUPS - 1) * gs
+        else
+            totalW = MOVER_GROUPS * groupW + (MOVER_GROUPS - 1) * gs
+            totalH = groupH
+        end
     end
     containerFrame:SetSize(PixelSnap(totalW), PixelSnap(totalH))
 
@@ -7339,9 +7356,9 @@ end
 -- Pinned screen corner implied by a growth pair: frames grow AWAY from this corner, so
 -- it stays fixed when a tier's footprint differs from the base. Horizontal side = whichever
 -- growth is horizontal (RIGHT pins LEFT edge, LEFT pins RIGHT edge); vertical side likewise
--- (DOWN pins TOP, UP pins BOTTOM). Growths are perpendicular (UI-enforced); degenerate
--- imported data still resolves deterministically (UP beats BOTTOM, LEFT beats RIGHT,
--- default TOP+LEFT). Merged-groups fills from the same corner, no special case.
+-- (DOWN pins TOP, UP pins BOTTOM). The UI no longer restricts groupGrowth/unitGrowth to
+-- perpendicular pairs, so a same-axis combination resolves deterministically here too
+-- (UP beats BOTTOM, LEFT beats RIGHT, default TOP+LEFT).
 ns._RFGrowthCorner = function(unitGrowth, groupGrowth)
     local h = (unitGrowth == "LEFT" or groupGrowth == "LEFT") and "RIGHT" or "LEFT"
     local v = (unitGrowth == "UP" or groupGrowth == "UP") and "BOTTOM" or "TOP"

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -7359,10 +7359,12 @@ ns._RFColAnchor = function(unitGrowth, groupGrowth)
 end
 
 -- Self-heals a same-axis Group/Unit Growth pair when Merge Groups is on (see
--- _RFColAnchor above) -- same rule as the options UI's write-time
--- KeepGrowthPerpendicular (Group Growth wins), applied as a read-time backstop
--- for a pair that reached here without a guarded write (a stale per-tier
--- override, a spec override, hand-edited SavedVariables). No-op if not merged.
+-- _RFColAnchor above), applied as a read-time backstop for a pair that reached
+-- here without a guarded write (a stale per-tier override, a spec override,
+-- hand-edited SavedVariables). Group Growth wins here; the options UI's
+-- write-time KeepGrowthPerpendicular uses the same resolution EXCEPT its Unit
+-- Growth dropdown, which deliberately lets Unit Growth win instead. No-op if
+-- not merged.
 ns._RFEffectiveGrowth = function(unitGrowth, groupGrowth, merged)
     if not merged then return unitGrowth, groupGrowth end
     if ns._RFGrowthIsVertical(unitGrowth) == ns._RFGrowthIsVertical(groupGrowth) then
@@ -7372,22 +7374,18 @@ ns._RFEffectiveGrowth = function(unitGrowth, groupGrowth, merged)
 end
 
 -- Pinned screen corner implied by a growth pair: frames grow AWAY from this corner, so
--- it stays fixed when a tier's footprint differs from the base. Matches the exact corner
--- Blizzard's header pins its first button to (the point where "point" and
--- "columnAnchorPoint" meet -- see ns._RFHeaderPoint/_RFColAnchor above), for every
--- growth pair including same-axis ones, not just an approximate tie-break -- separated
--- mode legitimately reaches same-axis pairs (all 16 combinations are valid there), and
--- merged mode's flat header anchor (ns._flatHeader's own SetPoint) relies on this
--- matching exactly, not just landing on "a" corner.
+-- it stays fixed when a tier's footprint differs from the base. Horizontal side = whichever
+-- growth is horizontal (RIGHT pins LEFT edge, LEFT pins RIGHT edge); vertical side likewise
+-- (DOWN pins TOP, UP pins BOTTOM). Every ns._RFEffectiveGrowth caller heals a same-axis pair
+-- before reaching here whenever merged is true, so this only ever sees one for separated mode
+-- (merged=false is a no-op for _RFEffectiveGrowth), where all 16 combinations are legitimate
+-- and this tie-break (UP beats BOTTOM, LEFT beats RIGHT, default TOP+LEFT) is what existing
+-- per-tier offsets are calibrated against -- matching Blizzard's own same-axis corner instead
+-- would be dead code here for merged and a silent position-shift regression for separated.
 ns._RFGrowthCorner = function(unitGrowth, groupGrowth)
-    local uVert = ns._RFGrowthIsVertical(unitGrowth)
-    local gPinsHigh = (groupGrowth == "UP" or groupGrowth == "LEFT")
-    if uVert then
-        local v = (unitGrowth == "UP") and "BOTTOM" or "TOP"
-        return v .. (gPinsHigh and "RIGHT" or "LEFT")
-    end
-    local v = gPinsHigh and "BOTTOM" or "TOP"
-    return v .. ((unitGrowth == "LEFT") and "RIGHT" or "LEFT")
+    local h = (unitGrowth == "LEFT" or groupGrowth == "LEFT") and "RIGHT" or "LEFT"
+    local v = (unitGrowth == "UP" or groupGrowth == "UP") and "BOTTOM" or "TOP"
+    return v .. h
 end
 
 -- Signed corner terms: how far a tier footprint's TOPLEFT shifts from the base

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -4020,3 +4020,36 @@ EllesmereUI.RegisterMigration({
         SeedMoonkin("primary")
     end,
 })
+
+-- Merge Groups renders through one Blizzard flat SecureGroupHeader, whose column
+-- axis can only run perpendicular to Unit Growth -- a same-axis pair has no valid
+-- column direction, so the runtime silently substitutes one instead of honoring
+-- Group Growth. The options UI now prevents new conflicting pairs; this fixes up
+-- profiles that already saved one.
+EllesmereUI.RegisterMigration({
+    id          = "rf_merge_groups_growth_axis_v1",
+    scope       = "profile",
+    description = "For Raid Frames profiles with Merge Groups on, bump Unit Growth off Group Growth's axis (base and per-tier overrides) so the merged flat header has a valid column direction.",
+    body = function(ctx)
+        local rf = ctx.profile.addons and ctx.profile.addons.EllesmereUIRaidFrames
+        if type(rf) ~= "table" then return end
+        if not rf.mergeGroups then return end
+        local function isVert(g) return g == "UP" or g == "DOWN" end
+        local gg, ug = rf.groupGrowth or "RIGHT", rf.unitGrowth or "DOWN"
+        if isVert(gg) == isVert(ug) then
+            ug = isVert(gg) and "RIGHT" or "DOWN"
+            rf.unitGrowth = ug
+        end
+        local overrides = rf.raidSizeOverrides
+        if type(overrides) ~= "table" then return end
+        for _, ov in pairs(overrides) do
+            if type(ov) == "table" then
+                local ogg = ov.groupGrowth or gg
+                local oug = ov.unitGrowth or ug
+                if isVert(ogg) == isVert(oug) then
+                    ov.unitGrowth = isVert(ogg) and "RIGHT" or "DOWN"
+                end
+            end
+        end
+    end,
+})


### PR DESCRIPTION
Fixes Raid Frames layout bugs reported by a user testing Merge Groups + non-default Group/Unit Growth: same-axis growth collapsing merged mode into one line, the rendered grid landing offset from the mover box (blank first column), and several gaps a follow-up code review found in the same area (per-tier overrides not re-checked, a stale dropdown label, a wrong corner for same-axis pairs, and a read-time backstop so the fix holds even if a bad pair reaches the renderer some other way).

Cause: Blizzard's flat SecureGroupHeader can only wrap into columns when `columnAnchorPoint` is perpendicular to Unit Growth, and pins its first button at the corner where `point`/`columnAnchorPoint` meet -- the addon wasn't enforcing the first and was hardcoding the header's own anchor to TOPLEFT regardless of the second.

Fix: keep Group/Unit Growth perpendicular whenever Merge Groups is on (write-time, base + per-tier), anchor the flat header to its actual growth corner instead of a fixed one, and self-heal at render/mover time as a backstop.

Test: reproduced and confirmed fixed in a live raid by the reporting user across two rounds of the original bugs; code review findings verified by hand-tracing against Blizzard's actual header source, luac clean.

<img width="480" height="480" alt="Happy Good Vibes GIF by VeeFriends" src="https://github.com/user-attachments/assets/873a0c03-63c8-4d84-902a-2e4dbae1a868" />
