### PR TITLE
fix: count Poison Cleansing Totem as a poison dispel for shamans

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -528,12 +528,19 @@ local GRADIENT_SHARP_TEXTURE = "Interface\\AddOns\\EllesmereUI\\media\\textures\
 -- Poison for a shaman whose poison removal is Poison Cleansing Totem (a talent).
 -- That slot keeps the plain filter in only-dispellable mode; its include-Poison
 -- candidate already narrows it to poison debuffs.
+-- The capability is CACHED: IsPlayerSpell can lag both addon load and the trait
+-- event that announces a change, so the shaman watcher on bmRegen (below)
+-- re-checks on trait and spellbook events and forces a reload on a flip.
+-- rfcTotemGen lets a button whose shells baked filters under the old value
+-- reconcile at finalize.
 local POISON_CLEANSING_TOTEM = 383013
 local _, rfcPlayerClass = UnitClass("player")
+local rfcTotemKnown = rfcPlayerClass == "SHAMAN"
+    and IsPlayerSpell(POISON_CLEANSING_TOTEM) or false
+local rfcTotemGen = 0
 
 local function TokenBlindDispel(token)
-    return token == "Poison" and rfcPlayerClass == "SHAMAN"
-        and IsPlayerSpell(POISON_CLEANSING_TOTEM)
+    return token == "Poison" and rfcTotemKnown
 end
 
 local function DispelSlotFilter(s, token)
@@ -543,12 +550,16 @@ local function DispelSlotFilter(s, token)
     return { "HARMFUL" }
 end
 
-local function DispelFilterFP(s)
+local function DispelSlotFilters(s)
     local parts = {}
     for i = 1, #DISPEL_SLOTS do
         parts[i] = AK.Filter(unpack(DispelSlotFilter(s, DISPEL_SLOTS[i].token)))
     end
-    return table.concat(parts, ";")
+    return parts
+end
+
+local function DispelFilterFP(s)
+    return table.concat(DispelSlotFilters(s), ";")
 end
 
 -- applyExtra for dispel slots. Per-button refs (health, slot definition) come from the
@@ -2859,6 +2870,7 @@ local function CreateButtonShells(button, health, d)
             -- NO unit yet: an unbound shell registers no events and parses
             -- nothing. The finish job binds the real unit.
             d.rfcDispelShell = c
+            d.rfcTotemGen = rfcTotemGen
         end
     end
 
@@ -3020,6 +3032,17 @@ local function QueueButtonGroups(button, health, d)
         local unit = button:GetAttribute("unit") or "player"
         CreateBmContainer(button, health, d, unit)
         d.rfcUnit = unit
+        -- Shells baked the dispel filters from rfcTotemKnown at build time; if a
+        -- totem flip landed mid-build, re-apply the current filters before the
+        -- fingerprint below is primed as current (which would otherwise latch the
+        -- stale filters as already-applied).
+        if d.rfcDispel and d.rfcTotemGen ~= rfcTotemGen then
+            local parts = DispelSlotFilters(ProxyFor(d) or s)
+            for i = 1, #DISPEL_SLOTS do
+                d.rfcDispel:SetAuraSlotFilterString(DISPEL_SLOTS[i].key, parts[i])
+            end
+        end
+        d.rfcTotemGen = nil
         -- Everything above was configured from current settings; prime the class
         -- fingerprints so the first reload doesn't re-drive it all (class resolved
         -- here, not at queue time -- party self button).
@@ -3288,10 +3311,11 @@ local function ComputeClassFlags(styleKey, s)
         AK.styles[dispelStyleKey] = BuildDispelStyle(s)
         AK.RestyleSoon(dispelStyleKey)
     end
-    local dispelFilter = DispelFilterFP(s)
+    local parts = DispelSlotFilters(s)
+    local dispelFilter = table.concat(parts, ";")
     if st.dispelFilter ~= dispelFilter then
         st.dispelFilter = dispelFilter
-        flags.dispelFilter = true
+        flags.dispelFilter = parts
     end
 
     return flags
@@ -3368,9 +3392,8 @@ function ns.RFC_ReloadAll()
                 if d.rfcDispel then
                     if flags.dispelFilter then
                         for j = 1, #DISPEL_SLOTS do
-                            local def = DISPEL_SLOTS[j]
-                            d.rfcDispel:SetAuraSlotFilterString(def.key,
-                                AK.Filter(unpack(DispelSlotFilter(s, def.token))))
+                            d.rfcDispel:SetAuraSlotFilterString(DISPEL_SLOTS[j].key,
+                                flags.dispelFilter[j])
                         end
                     end
                     d.rfcDispel:SetShown(d.rfcAssist ~= false and DispelVisible(s))
@@ -3408,16 +3431,34 @@ bmRegen:RegisterEvent("PLAYER_REGEN_ENABLED")
 bmRegen:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 bmRegen:RegisterEvent("PLAYER_ENTERING_WORLD")
 -- The poison dispel-slot filter depends on Poison Cleansing Totem being talented
--- (see DispelSlotFilter); talent edits fire no spec event, so shamans re-drive
--- the fingerprinted reload on trait apply.
-if rfcPlayerClass == "SHAMAN" then bmRegen:RegisterEvent("TRAIT_CONFIG_UPDATED") end
+-- (see DispelSlotFilter). Talent edits fire no spec event, and IsPlayerSpell can
+-- lag the trait event itself (the spellbook grant lands with SPELLS_CHANGED), so
+-- shamans re-check on both; the reload runs only on an actual flip, and a flip
+-- seen in combat latches for the regen branch below.
+local function RecheckTotem()
+    local known = rfcPlayerClass == "SHAMAN"
+        and IsPlayerSpell(POISON_CLEANSING_TOTEM) or false
+    if known == rfcTotemKnown then return end
+    if InCombatLockdown() then ns._rfcTotemDirty = true; return end
+    ns._rfcTotemDirty = nil
+    rfcTotemKnown = known
+    rfcTotemGen = rfcTotemGen + 1
+    -- Stale by construction now: force the next compare to re-apply the slot
+    -- filters instead of trusting a fingerprint stamped under the old value.
+    for _, st in pairs(classFP) do st.dispelFilter = nil end
+    ns.RFC_ReloadAll()
+end
+if rfcPlayerClass == "SHAMAN" then
+    bmRegen:RegisterEvent("TRAIT_CONFIG_UPDATED")
+    bmRegen:RegisterEvent("SPELLS_CHANGED")
+end
 bmRegen:SetScript("OnEvent", function(_, event, arg1)
     if event == "PLAYER_SPECIALIZATION_CHANGED" then
         if arg1 == "player" and not InCombatLockdown() then ns.RFC_ReloadAll() end
         return
     end
-    if event == "TRAIT_CONFIG_UPDATED" then
-        if not InCombatLockdown() then ns.RFC_ReloadAll() end
+    if event == "TRAIT_CONFIG_UPDATED" or event == "SPELLS_CHANGED" then
+        RecheckTotem()
         return
     end
     if event == "PLAYER_ENTERING_WORLD" then
@@ -3427,6 +3468,7 @@ bmRegen:SetScript("OnEvent", function(_, event, arg1)
         AssistSweep()
         return
     end
+    if ns._rfcTotemDirty then RecheckTotem() end
     local any = false
     for i = 1, #registry do
         local d = ns.GetFFD and ns.GetFFD(registry[i])

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -524,11 +524,31 @@ end
 local GRADIENT_TEXTURE = "Interface\\AddOns\\EllesmereUI\\media\\textures\\gradient-tb.tga"
 local GRADIENT_SHARP_TEXTURE = "Interface\\AddOns\\EllesmereUI\\media\\textures\\gradient-sharp.tga"
 
-local function DispelSlotFilter(s)
-    if s.dispelShowAll == false then
+-- RAID_PLAYER_DISPELLABLE knows class and spec dispels only, so it never matches
+-- Poison for a shaman whose poison removal is Poison Cleansing Totem (a talent).
+-- That slot keeps the plain filter in only-dispellable mode; its include-Poison
+-- candidate already narrows it to poison debuffs.
+local POISON_CLEANSING_TOTEM = 383013
+local _, rfcPlayerClass = UnitClass("player")
+
+local function TokenBlindDispel(token)
+    return token == "Poison" and rfcPlayerClass == "SHAMAN"
+        and IsPlayerSpell(POISON_CLEANSING_TOTEM)
+end
+
+local function DispelSlotFilter(s, token)
+    if s.dispelShowAll == false and not TokenBlindDispel(token) then
         return { "HARMFUL", "RAID_PLAYER_DISPELLABLE" }
     end
     return { "HARMFUL" }
+end
+
+local function DispelFilterFP(s)
+    local parts = {}
+    for i = 1, #DISPEL_SLOTS do
+        parts[i] = AK.Filter(unpack(DispelSlotFilter(s, DISPEL_SLOTS[i].token)))
+    end
+    return table.concat(parts, ";")
 end
 
 -- applyExtra for dispel slots. Per-button refs (health, slot definition) come from the
@@ -744,7 +764,7 @@ local function PrimeClassFP(styleKey, s)
     st.dispLocStyle = DispLocStyleFP(s, font)
     st.dispLocCfg = DispLocCfgFP(s)
     st.dispelStyle = DispelStyleFP(s)
-    st.dispelFilter = AK.Filter(unpack(DispelSlotFilter(s)))
+    st.dispelFilter = DispelFilterFP(s)
 end
 
 local function ApplyDebuffConfig(container, d, s)
@@ -2818,12 +2838,11 @@ local function CreateButtonShells(button, health, d)
             local dispelStyleKey = StyleKeyFor(d):gsub("debuff", "dispel")
             AK.styles[dispelStyleKey] = AK.styles[dispelStyleKey] or BuildDispelStyle(s)
             local c = AK.CreateContainerShell(button, { point = { "CENTER", health, "CENTER" } })
-            local dispelFilter = DispelSlotFilter(s)
             for i = 1, #DISPEL_SLOTS do
                 local def = DISPEL_SLOTS[i]
                 AK.AddSlotToContainer(c, {
                     key = def.key,
-                    filter = dispelFilter,
+                    filter = DispelSlotFilter(s, def.token),
                     candidateFilters = { includeDispelTypes = { [def.token] = true } },
                     style = dispelStyleKey,
                     extraInit = function(slotButton, dd)
@@ -3269,10 +3288,10 @@ local function ComputeClassFlags(styleKey, s)
         AK.styles[dispelStyleKey] = BuildDispelStyle(s)
         AK.RestyleSoon(dispelStyleKey)
     end
-    local dispelFilter = AK.Filter(unpack(DispelSlotFilter(s)))
+    local dispelFilter = DispelFilterFP(s)
     if st.dispelFilter ~= dispelFilter then
         st.dispelFilter = dispelFilter
-        flags.dispelFilter = dispelFilter
+        flags.dispelFilter = true
     end
 
     return flags
@@ -3349,7 +3368,9 @@ function ns.RFC_ReloadAll()
                 if d.rfcDispel then
                     if flags.dispelFilter then
                         for j = 1, #DISPEL_SLOTS do
-                            d.rfcDispel:SetAuraSlotFilterString(DISPEL_SLOTS[j].key, flags.dispelFilter)
+                            local def = DISPEL_SLOTS[j]
+                            d.rfcDispel:SetAuraSlotFilterString(def.key,
+                                AK.Filter(unpack(DispelSlotFilter(s, def.token))))
                         end
                     end
                     d.rfcDispel:SetShown(d.rfcAssist ~= false and DispelVisible(s))
@@ -3386,9 +3407,17 @@ local bmRegen = CreateFrame("Frame")
 bmRegen:RegisterEvent("PLAYER_REGEN_ENABLED")
 bmRegen:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 bmRegen:RegisterEvent("PLAYER_ENTERING_WORLD")
+-- The poison dispel-slot filter depends on Poison Cleansing Totem being talented
+-- (see DispelSlotFilter); talent edits fire no spec event, so shamans re-drive
+-- the fingerprinted reload on trait apply.
+if rfcPlayerClass == "SHAMAN" then bmRegen:RegisterEvent("TRAIT_CONFIG_UPDATED") end
 bmRegen:SetScript("OnEvent", function(_, event, arg1)
     if event == "PLAYER_SPECIALIZATION_CHANGED" then
         if arg1 == "player" and not InCombatLockdown() then ns.RFC_ReloadAll() end
+        return
+    end
+    if event == "TRAIT_CONFIG_UPDATED" then
+        if not InCombatLockdown() then ns.RFC_ReloadAll() end
         return
     end
     if event == "PLAYER_ENTERING_WORLD" then

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
@@ -1405,15 +1405,16 @@ local DISPEL_SLOTS = {
 }
 local DISPEL_TYPE_TOKENS = { magic = "Magic", curse = "Curse", disease = "Disease", poison = "Poison", bleed = "Bleed" }
 
--- A dispel type only the player's RACE can clear (bleeds, via Stoneform) is
--- rejected by RAID_PLAYER_DISPELLABLE, which knows class and spec dispels
--- only. Handled here by keeping the PLAIN slot lit for such a type rather than
--- giving the by-me twin a filter that would match it: two slots declaring one
--- filter string share a single engine parse batch (see AK.Filter) and both are
--- not guaranteed to receive the aura. The rule itself lives with the legacy
--- overlay in EllesmereUIUnitFrames.lua, which needs the same answer.
-local function RacialCoversDispelSlot(slotKey)
-    return ns.UF_RacialClearsDispel ~= nil and ns.UF_RacialClearsDispel(slotKey)
+-- A dispel type RAID_PLAYER_DISPELLABLE can never match (bleeds via the dwarf
+-- racial, poison on a shaman via Poison Cleansing Totem -- the token knows class
+-- and spec dispels only) is handled here by keeping the PLAIN slot lit for such
+-- a type rather than giving the by-me twin a filter that would match it: two
+-- slots declaring one filter string share a single engine parse batch (see
+-- AK.Filter) and both are not guaranteed to receive the aura. The rule itself
+-- lives with the legacy overlay in EllesmereUIUnitFrames.lua, which needs the
+-- same answer.
+local function TokenBlindDispelSlot(slotKey)
+    return ns.UF_TokenBlindDispel ~= nil and ns.UF_TokenBlindDispel(slotKey)
 end
 local GRADIENT_TEXTURE = "Interface\\AddOns\\EllesmereUI\\media\\textures\\gradient-tb.tga"
 local GRADIENT_SHARP_TEXTURE = "Interface\\AddOns\\EllesmereUI\\media\\textures\\gradient-sharp.tga"
@@ -1486,10 +1487,10 @@ local function BuildDispelStyles(frame)
     local op = p.dispelOverlayOpacity or 100
     for i = 1, #DISPEL_SLOTS do
         local slot = DISPEL_SLOTS[i]
-        -- A type only the player's RACE can clear keeps using the PLAIN slot in
-        -- "by me" mode: the engine token can never match it, so its by-me twin
-        -- stays dark and would swallow the setting entirely.
-        local racial = RacialCoversDispelSlot(slot.key)
+        -- A type the engine token can never match keeps using the PLAIN slot in
+        -- "by me" mode: its by-me twin stays dark and would swallow the setting
+        -- entirely.
+        local tokenBlind = TokenBlindDispelSlot(slot.key)
         local col = p[slot.colorKey]
         local color = { r = col and col.r or slot.fallback[1], g = col and col.g or slot.fallback[2], b = col and col.b or slot.fallback[3] }
         AK.styles[DispelStyleKey(slot.key)] = {
@@ -1497,7 +1498,7 @@ local function BuildDispelStyles(frame)
             noRegions = true,
             mode = mode,
             color = color,
-            opacity = (byMe and not racial) and 0 or op,
+            opacity = (byMe and not tokenBlind) and 0 or op,
             level = slot.level,
             healthFrame = frame.Health,
             applyExtra = ApplyDispelSlotStyle,
@@ -1507,7 +1508,7 @@ local function BuildDispelStyles(frame)
             noRegions = true,
             mode = mode,
             color = color,
-            opacity = (byMe and not racial) and op or 0,
+            opacity = (byMe and not tokenBlind) and op or 0,
             level = slot.level,
             healthFrame = frame.Health,
             applyExtra = ApplyDispelSlotStyle,
@@ -1575,7 +1576,10 @@ local function CreateDispelSlots(frame, entry)
 end
 
 local function DispelFP(p)
+    -- The poison capability is a talent (Poison Cleansing Totem), so it rides
+    -- the fingerprint; race can't change mid-session.
     return FP(p.dispelOverlay, p.dispelOverlayOpacity, p.dispelOverlayByMe == true,
+        TokenBlindDispelSlot("poison") and 1 or 0,
         CK(p.dispelColorMagic), CK(p.dispelColorCurse),
         CK(p.dispelColorDisease), CK(p.dispelColorPoison), CK(p.dispelColorBleed))
 end
@@ -1603,6 +1607,18 @@ function ns.UF_ReloadPlayerDispelSlots()
     local entry = registry.player
     if entry and entry.frame and not entry.building then
         ReloadDispelSlots(entry.frame, entry)
+    end
+end
+
+-- The poison capability behind UF_TokenBlindDispel is a talent (Poison
+-- Cleansing Totem); talent edits fire no spec event, so shamans re-drive the
+-- fingerprinted reload on trait apply.
+do
+    local _, class = UnitClass("player")
+    if class == "SHAMAN" then
+        local ev = CreateFrame("Frame")
+        ev:RegisterEvent("TRAIT_CONFIG_UPDATED")
+        ev:SetScript("OnEvent", function() ns.UF_ReloadPlayerDispelSlots() end)
     end
 end
 

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
@@ -1611,14 +1611,22 @@ function ns.UF_ReloadPlayerDispelSlots()
 end
 
 -- The poison capability behind UF_TokenBlindDispel is a talent (Poison
--- Cleansing Totem); talent edits fire no spec event, so shamans re-drive the
--- fingerprinted reload on trait apply.
+-- Cleansing Totem). Talent edits fire no spec event, and IsPlayerSpell can lag
+-- the trait event itself (the spellbook grant lands with SPELLS_CHANGED), so
+-- shamans re-check on both; the reload runs only when the cached capability
+-- actually flips. No combat gate: the restyle routes through AK.RestyleSoon,
+-- whose worker defers secrecy-denied writes to the restriction-lift re-queue.
 do
     local _, class = UnitClass("player")
     if class == "SHAMAN" then
         local ev = CreateFrame("Frame")
         ev:RegisterEvent("TRAIT_CONFIG_UPDATED")
-        ev:SetScript("OnEvent", function() ns.UF_ReloadPlayerDispelSlots() end)
+        ev:RegisterEvent("SPELLS_CHANGED")
+        ev:SetScript("OnEvent", function()
+            if ns.UF_RefreshPoisonTotem and ns.UF_RefreshPoisonTotem() then
+                ns.UF_ReloadPlayerDispelSlots()
+            end
+        end)
     end
 end
 

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -15523,7 +15523,21 @@ do
     -- The token is equally blind to talent dispels: a shaman's poison removal is
     -- Poison Cleansing Totem, so Poison never passes for them. Raid Frames applies
     -- the same rule to its group-wide dispel slots (EUI_RaidFrames_AuraContainers.lua).
+    -- Cached: IsPlayerSpell can lag both addon load and the trait event that
+    -- announces a change; the shaman watcher in EUI_UnitFrames_AuraContainers.lua
+    -- calls UF_RefreshPoisonTotem on trait and spellbook events and reloads the
+    -- dispel slots when it reports a flip.
     local POISON_CLEANSING_TOTEM = 383013
+    local _, ufPlayerClass = UnitClass("player")
+    local poisonTotemKnown = ufPlayerClass == "SHAMAN"
+        and IsPlayerSpell(POISON_CLEANSING_TOTEM) or false
+    function ns.UF_RefreshPoisonTotem()
+        local known = ufPlayerClass == "SHAMAN"
+            and IsPlayerSpell(POISON_CLEANSING_TOTEM) or false
+        if known == poisonTotemKnown then return false end
+        poisonTotemKnown = known
+        return true
+    end
     -- Shared with the 12.1 container slots (EUI_UnitFrames_AuraContainers.lua),
     -- which apply the same rule by choosing which slot style stays visible.
     function ns.UF_TokenBlindDispel(typeKey)
@@ -15533,8 +15547,7 @@ do
             return raceToken ~= nil and races[raceToken] == true
         end
         if typeKey == "poison" then
-            local _, class = UnitClass("player")
-            return class == "SHAMAN" and IsPlayerSpell(POISON_CLEANSING_TOTEM)
+            return poisonTotemKnown
         end
         return false
     end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -15520,13 +15520,23 @@ do
     local RACIAL_DISPEL_TYPES = {
         bleed = { Dwarf = true },  -- Stoneform
     }
+    -- The token is equally blind to talent dispels: a shaman's poison removal is
+    -- Poison Cleansing Totem, so Poison never passes for them. Raid Frames applies
+    -- the same rule to its group-wide dispel slots (EUI_RaidFrames_AuraContainers.lua).
+    local POISON_CLEANSING_TOTEM = 383013
     -- Shared with the 12.1 container slots (EUI_UnitFrames_AuraContainers.lua),
     -- which apply the same rule by choosing which slot style stays visible.
-    function ns.UF_RacialClearsDispel(typeKey)
+    function ns.UF_TokenBlindDispel(typeKey)
         local races = RACIAL_DISPEL_TYPES[typeKey]
-        if not races then return false end
-        local _, raceToken = UnitRace("player")
-        return raceToken ~= nil and races[raceToken] == true
+        if races then
+            local _, raceToken = UnitRace("player")
+            return raceToken ~= nil and races[raceToken] == true
+        end
+        if typeKey == "poison" then
+            local _, class = UnitClass("player")
+            return class == "SHAMAN" and IsPlayerSpell(POISON_CLEANSING_TOTEM)
+        end
+        return false
     end
 
     local function RebuildCurve()


### PR DESCRIPTION
Reported by Bags and Diamedes on Discord. Poison Cleansing Totem doesn't count as a dispel for shamans.
**Cause:** the `RAID_PLAYER_DISPELLABLE` token only recognizes class/spec dispels, so it's blind to talent dispels like Poison Cleansing Totem — poison never routed to a Dispellable-only filter for shamans.
**Fix:** RF and UF aura containers now give the Poison slot a plain `HARMFUL` filter (narrowed by the include-Poison candidate) when shaman+totem in only-dispellable mode, instead of relying on the token. Capability is cached per addon and re-checked on `TRAIT_CONFIG_UPDATED`/`SPELLS_CHANGED` since the spellbook grant can lag the trait event.
**Left alone:** Debuff Manager's "Dispellable" tile/preset in "you" mode still rides the bare token (declined for scope, see comments).
**Test:** talent Poison Cleansing Totem on a shaman, apply a poison debuff with only-Dispellable filtering active on Raid Frames/Unit Frames, confirm the icon shows. Tester confirmed fixed on EllesmereUI-8.9.8-poisontotem2.

<img width="480" height="480" alt="Vibe Vibing GIF by VeeFriends" src="https://github.com/user-attachments/assets/983bd8bc-d5d2-4fad-92f6-a799e1fa820a" />
