### PR TITLE
Resource Bars: fix left-corner border sliver on bar-type class resource

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -3743,9 +3743,11 @@ local function BuildBars()
         if secondaryBar and secondaryBar._fillOpApplied and secondaryBar:IsShown() then
             -- Bar-type Fill Opacity active: the full-bar backdrop must retreat to
             -- the empty portion too, or it tints the translucent fill from behind
-            -- and defeats the world-show-through.
+            -- and defeats the world-show-through. Anchor to secondaryBar's own
+            -- inset inner StatusBar (_sb), not the uninset outer secondaryFrame,
+            -- or a halfPx sliver of _barBg peeks out past the fill's clipped edge.
             ns.AnchorBgToFillEdge(secondaryFrame._barBg, secondaryBar:GetStatusBarTexture(),
-                secondaryFrame, sp.pipOrientation or "HORIZONTAL")
+                secondaryBar._sb, sp.pipOrientation or "HORIZONTAL")
             secondaryFrame._barBg:Show()
         elseif (sp.fillOpacity or 100) < 100 then
             -- Pip/rune-type Fill Opacity active: a full-frame backdrop cannot hole
@@ -3753,7 +3755,14 @@ local function BuildBars()
             -- fill. Hide it; ApplyGapFills draws the gap strips in the bar-bg color
             -- and inactive pips keep their own per-pip background.
             secondaryFrame._barBg:Hide()
+        elseif isBarType then
+            -- Bar-type: anchor to secondaryBar's inset inner StatusBar (_sb) so
+            -- _barBg doesn't extend a halfPx past the fill/bg's own clipped edge.
+            secondaryFrame._barBg:SetAllPoints(secondaryBar._sb)
+            secondaryFrame._barBg:Show()
         else
+            -- Pip/rune-type: flush to secondaryFrame so this shows through the
+            -- gaps between pips (see comment above).
             secondaryFrame._barBg:SetAllPoints(secondaryFrame)
             secondaryFrame._barBg:Show()
         end


### PR DESCRIPTION
```
Reported by @Zer0: with a Solid border and thickness 0, a stray 1-2px sliver of
border color still shows at a corner of the class resource bar (bar-type/continuous
fill, not pips), regardless of border style.

Cause: secondaryFrame._barBg (the full-bar backdrop) was anchored flush to the
outer frame edge, while the fill it sits behind is inset by half a pixel for its
clip rect. That halfPx gap let _barBg's own color peek out around the edge.

Fix: anchor _barBg to secondaryBar's own inset inner StatusBar instead of the
outer frame, for bar-type resources. Pip/rune-type resources are unchanged (that
backdrop still needs to be flush to show through pip gaps).

Test: confirmed in-game.
```
<img width="260" height="195" alt="Cuteness Cute Animals GIF" src="https://github.com/user-attachments/assets/d7e8f180-b9b2-4e30-85bc-d96fc088e5d8" />
