### PR TITLE
fix(qol) Fix target distance text frame strata

### DIFF
--- a/EllesmereUIOptions/EUI_QoL_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_Options.lua
@@ -2104,6 +2104,18 @@ initFrame:SetScript("OnEvent", function(self)
                         EllesmereUIDB.targetDistanceTextSize = v
                         if EllesmereUI._applyTargetDistanceFrame then EllesmereUI._applyTargetDistanceFrame() end
                       end },
+                    { type="dropdown", label="Frame Strata",
+                      tooltip="Controls the order that overlapping elements display in. Set higher to show above other elements.",
+                      values = EllesmereUI.FRAME_STRATA_LABELS,
+                      order = EllesmereUI.FRAME_STRATA_ORDER_BASE,
+                      get=function()
+                        return (EllesmereUIDB and EllesmereUIDB.targetDistanceStrata) or "MEDIUM"
+                      end,
+                      set=function(v)
+                        if not EllesmereUIDB then EllesmereUIDB = {} end
+                        EllesmereUIDB.targetDistanceStrata = v
+                        if EllesmereUI._applyTargetDistanceFrame then EllesmereUI._applyTargetDistanceFrame() end
+                      end },
                 },
                 footer = { unlockKey = "EUI_TargetDistance" },
             })

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -4143,11 +4143,13 @@ do
             outline = (outline == "") and "OUTLINE" or (outline .. ", OUTLINE")
         end
         local size = (EllesmereUIDB and EllesmereUIDB.targetDistanceTextSize) or DEFAULT_TEXT_SIZE
+        local strata = (EllesmereUIDB and EllesmereUIDB.targetDistanceStrata) or "MEDIUM"
         local align = GetAlign()
         distFrame._text:SetFont(fontPath, size, outline)
         distFrame._text:SetJustifyH(align)
         distFrame._text:ClearAllPoints()
         distFrame._text:SetPoint(align, distFrame, align, 0, 0)
+        distFrame:SetFrameStrata(strata)
         distFrame:SetSize(size * 5, size + 10)
 
         -- Unlock Mode owns anchors while dragging, or when Anchor-to is linked.
@@ -4169,7 +4171,6 @@ do
         if distFrame then return end
         distFrame = CreateFrame("Frame", nil, UIParent)
         distFrame:SetSize(100, 28)
-        distFrame:SetFrameStrata("HIGH")
         distFrame:SetFrameLevel(55)
         distFrame:EnableMouse(false)
         distFrame:SetMouseClickEnabled(false)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

The Target Distance Text is always set to HIGH, which it displays over the Bank UI element.
Add Frame Strata to the Target Distance Text Cog so that the user can set the frame strata by themselves

<!-- User-facing description: what changes for the player? -->

## How was it tested?

Tested in-game

<!-- Client build, what you tested in game, etc. -->

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

Before
<img width="1780" height="1225" alt="before" src="https://github.com/user-attachments/assets/95dccf4d-5224-46aa-bec1-56b8149301e5" />

After
<img width="3010" height="1216" alt="after" src="https://github.com/user-attachments/assets/c8ace7dc-b2be-4dbc-bf46-be84c6b2e072" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
