### PR TITLE
Nameplates: recognise Rogue Shiv as an Enrage dispel (fixes #1299)

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -724,6 +724,7 @@ do
         { 19505,  "Magic",  "WARLOCK" },  -- Devour Magic (Felhunter)
         { 19801,  "Both",   nil       },  -- Tranquilizing Shot (Hunter)
         { 2908,   "Enrage", nil       },  -- Soothe (Druid)
+        { 5938,   "Enrage", nil       },  -- Shiv (Rogue)
         { 30449,  "Magic",  nil       },  -- Spellsteal (Mage)
         { 115078, "Enrage", "MONK", 450432 },  -- Paralysis (w/ Pressure Points talent)
     }


### PR DESCRIPTION
## What does this PR do?

Rogues now get the enemy-nameplate dispel indicator on removable Enrage effects.
Previously a Rogue saw no dispel glow on an Enrage, and with "Show All Enemy Buffs"
off the buff was filtered out of the nameplate entirely, because the addon did not
consider Shiv an Enrage removal.

Shiv (5938) carries a Dispel (Enrage) effect but was absent from
`OFFENSIVE_DISPEL_SPELLS`, so `canDispelEnrage` stayed false for every Rogue. One
table entry.

Note on the third field: it is left `nil` rather than `"ROGUE"`. A non-nil third
field with no fourth routes the lookup to the pet spellbook (what Devour Magic
needs), so `"ROGUE"` would search the pet bank and never resolve. The player-bank
lookup is already class-safe, since no other class knows 5938 - the same shape
Soothe, Purge and Spellsteal use.

Both consumers read this table through `ns.GetOffensiveDispelTypes`, so the
capability-based aura path and the aura-container purge glow are fixed together.

Separately, and deliberately not changed here: the table's header comment documents
field 3 as `requiredClass or nil`, which does not describe the pet-bank behavior.
That mismatch is what led the issue reporter to suggest `"ROGUE"`. Might be worth a
comment fix in a separate pass.

Fixes #1299

## How was it tested?

Live 12.1 client, deployed over the installed build. Verified on a Rogue with Shiv
that a removable Enrage on an enemy now shows on the nameplate and carries the
configured dispel glow, with Dispel Glow on and Show All Enemy Buffs off. Confirmed
working in game before opening this PR.

## Screenshots

Before:
<img width="400" height="272" alt="image" src="https://github.com/user-attachments/assets/0b104111-f681-4079-a516-4f64d6439f88" />

After:
<img width="357" height="272" alt="image" src="https://github.com/user-attachments/assets/d291b162-f2c3-4bf6-907a-732a35283034" />


## Checklist

- [x] New settings default **OFF** - N/A, no new setting
- [x] Zero cost while disabled - N/A, one entry in an existing table; no new events,
      hooks, frames or allocations
- [x] Cheap while enabled - the table is walked only on the existing
      SPELLS_CHANGED / UNIT_PET / TRAIT_CONFIG_UPDATED rebuild
- [x] No writes onto Blizzard-owned frames - N/A, no frame interaction
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
