### PR TITLE
CDM: make the shift and bar-offset sliders pixel units

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8993,6 +8993,14 @@ RegisterCDMUnlockElements = function()
                     local ox = (bd3 and bd3.addOffsetX) or 0
                     local oy = (bd3 and bd3.addOffsetY) or 0
                     if ox == 0 and oy == 0 then return nil end
+                    -- The offset is STORED in coordinate units but the options
+                    -- slider reads and writes physical pixels, so report pixels
+                    -- here too -- otherwise the tooltip prints the raw fraction
+                    -- (0.5007... instead of 1) and disagrees with the slider.
+                    local PPt = EllesmereUI.PP
+                    if PPt and PPt.ToPixels then
+                        ox, oy = PPt.ToPixels(ox), PPt.ToPixels(oy)
+                    end
                     return EllesmereUI.Lf(
                         "This bar has an Additional Bar Offset (X %1$s, Y %2$s) set in its options. Unlock mode shows the base position; the offset re-applies when you exit.",
                         ox, oy)

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -19017,11 +19017,11 @@ initFrame:SetScript("OnEvent", function(self)
                 Refresh()
             end
             _, h = W:DualRow(parent, y,
-                { type = "slider", text = "Offset X", min = -500, max = 500, step = 1, trackWidth = 120,
+                { type = "slider", pixel = true, text = "Offset X", min = -500, max = 500, step = 1, trackWidth = 120,
                   tooltip = "Extra horizontal shift stacked on top of this bar's normal position. Unlock mode shows the base position; the offset re-applies when you exit.",
                   getValue = function() local b = BD(); return (b and b.addOffsetX) or 0 end,
                   setValue = function(v) SetAddOffset("addOffsetX", v) end },
-                { type = "slider", text = "Offset Y", min = -500, max = 500, step = 1, trackWidth = 120,
+                { type = "slider", pixel = true, text = "Offset Y", min = -500, max = 500, step = 1, trackWidth = 120,
                   tooltip = "Extra vertical shift stacked on top of this bar's normal position. Unlock mode shows the base position; the offset re-applies when you exit.",
                   getValue = function() local b = BD(); return (b and b.addOffsetY) or 0 end,
                   setValue = function(v) SetAddOffset("addOffsetY", v) end }

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -4611,7 +4611,7 @@ initFrame:SetScript("OnEvent", function(self)
                 local _, cogShow = EllesmereUI.BuildCogPopup({
                     title = "Shift Offset",
                     rows = {
-                        { type = "slider", label = "Extra Y Offset", min = -50, max = 50, step = 1,
+                        { type = "slider", pixel = true, label = "Extra Y Offset", min = -50, max = 50, step = 1,
                           get = function()
                               local e = GlobalEntry()
                               return (e and e.shiftNoBarExtraY) or 0


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1585, which fixed the two ResourceBars Extra Y Offset sliders. The same unit problem remains on three Cooldown Manager sliders -- they are stored and consumed as UIParent coordinate units, so their granularity follows the UI scale instead of the screen. At 4K with uiScale 0.71 one coordinate unit is ~1.997 physical pixels, so an offset of 1 moves things **2 px** and odd pixel offsets can't be reached at all:

- Tracking Bars > Global Group -- "Shift Elements If No Bars" > Extra Y Offset
- bar > ADDITIONAL BAR OFFSET -- Offset X
- bar > ADDITIONAL BAR OFFSET -- Offset Y

All three are marked `pixel = true`, matching #1585 and every other spacing/offset slider: the value is entered and displayed in physical pixels and converted to coordinate units on write, so 1 means 1 pixel at any resolution and UI scale. The unlock-mode mover tooltip that prints the Additional Bar Offset is converted to pixels too, so it agrees with the slider instead of showing the raw fraction.

No behavioural change for anyone already on a pixel-perfect scale -- there 1 coordinate unit == 1 px, so the conversion is the identity.

## Why the fix reaches the screen

I traced every consumer before touching anything. Both features feed positions that are snapped to the **physical pixel grid** (`PP.SnapForES` / `PP.SnapCenterForDim`, `onePixel = PP.perfect / es`), and CDM bars are scale-1 children of UIParent, so every path snaps against UIParent's own grid -- the same grid `PP.mult` and `FromPixels` are defined against, with no scale conversion involved.

**Shift Elements If No Bars** takes the same path #1585 fixed: the entry is pushed into `EllesmereUI._anchorShiftProviders`, dispatched by `_GetAnchorTargetShiftDir`, and `ApplyAnchorPosition` folds it into the UIParent-space centre (`cy = cy + dir * ((tT - tB) + (extraY or 0))`) before the snap. Snapping is equivariant under whole-pixel translation, so the stored fraction survives.

**The Additional Bar Offset** reaches the screen through eight paths in two orderings, and both preserve an exact whole-pixel value:

- *pre-snap add, then snap* -- `ApplyBarPositionCentered`; the party, player and ERB anchor branches; `ApplyCenterPosition`; the non-CENTER format branch.
- *snap, then post-snap add* -- `ApplyAnchorPosition`'s two placement branches, via the `_anchorExtraOffset` registry. Adding an exact whole number of physical pixels to an already-snapped value keeps the result on the grid; today's 1-coordinate-unit offset lands it 0.0031 px off.

`SaveCDMBarPosition` subtracts the offset to recover the base position; with exact-pixel offsets that round-trip is exact, where integer coordinate units drift up to 0.0094 px per save. The remaining readers are `~= 0` tests, which a fraction satisfies unchanged.

I swept the rest of the family while here: with #1585 merged those are the last three sliders of this kind, and the fourth registered shift provider (the CDM additional-offset lifecycle hooks) has `dir = 0` and no magnitude, so it is unaffected.

## How was it tested?

- In game on live retail at 3840x2160 / uiScale 0.71: an offset of -1 moved things 2 px before the change and exactly 1 px after; odd pixel offsets are now reachable. Checked on the Tracking Bars global-group shift and on a bar's Additional Bar Offset in all three placement states (free-standing, party-anchored, unlock-anchored), since those take different paths.
- Offline against the real `PP` helpers (Lua 5.1), reproducing each ordering found in the code:
  - shift path: snap equivariance across 1500 cases (5 child scales x 5 frame heights including odd pixel dims x 5 base positions x +/-1..3 px x both snap functions)
  - Additional Bar Offset: 900 cases across both orderings (5 frame dims including odd pixel heights x 5 base positions x +/-1..3 px x `SnapForES` and `SnapCenterForDim`) -- movement is exactly the requested pixel count, the post-snap result stays exactly on the grid, and the save round-trip has zero drift (0.0094 px before)
  - display round-trips px -> coordinate units -> px exactly for +/-1..500, so the slider and the mover tooltip agree
- `luac -p` clean on both touched files; added code is ASCII-only; `Locales/_keys.txt` unchanged (no new strings).

## Migration note

Saved values keep their meaning -- an existing offset of 1 was always ~2 px on a 0.71 scale, and now simply reads as "2" in the slider and the mover tooltip. Nothing moves on upgrade; only the number shown becomes honest.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A: no new setting. The change is a unit correction on three existing sliders, and it is the identity at pixel-perfect UI scales
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- options-layer only, plus one conversion in a tooltip that is built on demand
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- arithmetic conversions in the existing accessors
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- nothing here touches a frame
- [x] Tested in-game, works on live retail