### PR TITLE
fix(Minimap) :  fix rectangular minimap positioning and edit mode behavior

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -3988,6 +3988,67 @@ function EBS._ApplyAddonCompartment()
     end
 end
 
+-- Rectangular mode moves a visible 4:3 child in unlock mode, but Blizzard's
+-- projection still lives on the square Minimap. Keep this adapter in the
+-- minimap module: broadening the shared mover contract would make every unlock
+-- element responsible for a second, hidden clamp geometry.
+function EBS._ClampMinimapCanvas(fromLayout, saveCorrection)
+    local minimap = Minimap
+    local p = EBS.db and EBS.db.profile.minimap
+    if not minimap or not p then return end
+
+    local data = GetFFD(minimap)
+    local layout = data.layoutFrame
+    local source = fromLayout and layout or minimap
+    if not source then return end
+
+    local uiScale = UIParent:GetEffectiveScale()
+    local sourceScale = source:GetEffectiveScale()
+    local canvasScale = minimap:GetEffectiveScale()
+    local cx, cy = source:GetCenter()
+    if not uiScale or uiScale == 0 or not sourceScale or not canvasScale
+       or not cx or not cy then return end
+
+    cx = cx * sourceScale / uiScale
+    cy = cy * sourceScale / uiScale
+    local uiW, uiH = UIParent:GetSize()
+    local position = p.position
+    if not fromLayout and position and position.point == "CENTER"
+       and (position.relPoint == "CENTER" or position.relPoint == nil)
+       and position.x and position.y then
+        -- SetClampedToScreen may already have shifted the live frame after a
+        -- size increase. Validate the saved intent so an invalid center does
+        -- not survive merely because Blizzard performed that visual clamp.
+        cx = uiW * 0.5 + position.x
+        cy = uiH * 0.5 + position.y
+    end
+    local canvasRatio = canvasScale / uiScale
+    local halfW = (minimap:GetWidth() or 0) * canvasRatio * 0.5
+    local halfH = (minimap:GetHeight() or 0) * canvasRatio * 0.5
+    local clampedX = math.max(halfW, math.min(uiW - halfW, cx))
+    local clampedY = math.max(halfH, math.min(uiH - halfH, cy))
+    local corrected = math.abs(clampedX - cx) > 0.01
+        or math.abs(clampedY - cy) > 0.01
+
+    if fromLayout or corrected then
+        local x = clampedX - uiW * 0.5
+        local y = clampedY - uiH * 0.5
+        minimap:ClearAllPoints()
+        minimap:SetPoint("CENTER", UIParent, "CENTER", x, y)
+        if saveCorrection and corrected then
+            p.position = { point = "CENTER", relPoint = "CENTER", x = x, y = y }
+        end
+    end
+
+    -- Unlock mode temporarily places the visible child on UIParent. Restore the
+    -- architectural relationship after consuming that proposed center.
+    if layout then
+        layout:ClearAllPoints()
+        layout:SetPoint("CENTER", minimap, "CENTER")
+    end
+    return corrected
+end
+
 local function ApplyMinimap()
     if TEMP_DISABLED.minimap then return end
     if InCombatLockdown() then QueueApplyAll(); return end
@@ -4188,9 +4249,13 @@ local function ApplyMinimap()
         -- healthy) -- which is why this presented as a border setting that would not
         -- survive a reload even though the stored value was never lost; anchoring only at
         -- creation made it permanent for the session, tracking how much else was loading
-        -- at login rather than the actual setting. Re-setting the points forces a layout recompute; harmless no-op otherwise.
+        -- at login rather than the actual setting. Give the host explicit dimensions:
+        -- SetAllPoints through the layout proxy can expose a transient invalid rect
+        -- during repeated slider updates, and ApplyBorderStyle correctly refuses to
+        -- draw against that rect until a later full rebuild.
         host:ClearAllPoints()
-        host:SetAllPoints(GetFFD(minimap).layoutFrame or minimap)
+        host:SetSize(mapSize, isRectangular and (mapSize * 192 / 256) or mapSize)
+        host:SetPoint("CENTER", GetFFD(minimap).layoutFrame or minimap, "CENTER")
         -- Same level as the minimap keeps the border under all child buttons; Show Behind drops it under the map surface for the Shadow style.
         host:SetFrameLevel(p.borderBehind and math.max(0, minimap:GetFrameLevel() - 1) or minimap:GetFrameLevel())
         host:SetAlpha(1)
@@ -4383,12 +4448,12 @@ local function ApplyMinimap()
     -- Shape changes do not fire a zone event. Reuse the existing housing detector
     -- so atlas/texture selection follows the new shape immediately.
     if GetFFD(minimap).checkHousing then GetFFD(minimap).checkHousing() end
-    -- Clamp to the visible shape. Rectangular mode keeps a square native canvas,
-    -- so allow only its hidden top/bottom strips beyond the screen bounds.
+    -- Clamp the native canvas, not the visible crop. Blizzard clips the map
+    -- render when any part of this square leaves the screen, even though the
+    -- rectangular mask hides its top and bottom strips.
     minimap:SetClampedToScreen(true)
     if isRectangular then
-        local cropInset = mapSize * 32 / 256
-        minimap:SetClampRectInsets(0, 0, -cropInset, cropInset)
+        minimap:SetClampRectInsets(0, 0, 0, 0)
     else
         local bInset = isCircle and (p.borderSize or 1) or 0
         minimap:SetClampRectInsets(-bInset, bInset, bInset, -bInset)
@@ -5032,6 +5097,13 @@ local function ApplyMinimap()
         end
     end
 
+    -- Size changes can make a previously valid saved center place part of the
+    -- square canvas offscreen. Correct it in this same apply pass so the map
+    -- texture never waits for unlock mode to repair itself.
+    if isRectangular then
+        EBS._ClampMinimapCanvas(false, true)
+    end
+
     -- Mark module as active so persistent hooks know they can fire
     GetFFD(minimap).active = true
 
@@ -5403,11 +5475,22 @@ function EBS:OnEnable()
                 order = 500,
                 noResize = true,
                 noAnchorTo = true,
-                getFrame = function() return Minimap end,
-                getSize  = function()
+                -- The mover and anchor target use the visible crop. onLiveMove
+                -- translates that child frame's proposed center back onto the
+                -- square Blizzard canvas and clamps the full canvas onscreen.
+                getFrame = function()
+                    local m = MDB()
                     local layout = GetFFD(Minimap).layoutFrame
-                    if layout then return layout:GetWidth(), layout:GetHeight() end
-                    return Minimap:GetWidth(), Minimap:GetHeight()
+                    if m and m.shape == "rectangular" and layout then
+                        return layout
+                    end
+                    return Minimap
+                end,
+                onLiveMove = function()
+                    local m = MDB()
+                    if m and m.shape == "rectangular" then
+                        EBS._ClampMinimapCanvas(true, false)
+                    end
                 end,
                 isHidden = function()
                     local m = MDB()
@@ -5416,6 +5499,12 @@ function EBS:OnEnable()
                 savePos = function(_, point, relPoint, x, y)
                     local m = MDB(); if not m then return end
                     m.position = { point = point, relPoint = relPoint, x = x, y = y }
+                    if m.shape == "rectangular" then
+                        -- Keyboard nudges may retain their logical CENTER value
+                        -- even after onLiveMove clamps the visible frame. Validate
+                        -- the committed value against the square canvas as well.
+                        EBS._ClampMinimapCanvas(false, true)
+                    end
                     if not EllesmereUI._unlockActive then
                         ApplyMinimap()
                     end

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -4096,6 +4096,15 @@ local function ApplyMinimap()
             if needsReparent and minimap:GetParent() ~= UIParent then
                 minimap:SetParent(UIParent)
             end
+            -- Saved centers use UIParent coordinates. On reload the Minimap is
+            -- still under MinimapCluster until this taint-safe deferred reparent;
+            -- applying the rectangular clamp before it would resolve the same
+            -- offsets through the cluster's coordinate context, then shift when
+            -- SetParent completes. Reuse this existing deferral and correct only
+            -- after the final parent is in place.
+            if p.shape == "rectangular" and minimap:GetParent() == UIParent then
+                EBS._ClampMinimapCanvas(false, true)
+            end
             if needsClusterHide and MinimapCluster then
                 MinimapCluster:SetAlpha(0)
                 MinimapCluster:EnableMouse(false)
@@ -5127,7 +5136,7 @@ local function ApplyMinimap()
     -- Size changes can make a previously valid saved center place part of the
     -- square canvas offscreen. Correct it in this same apply pass so the map
     -- texture never waits for unlock mode to repair itself.
-    if isRectangular then
+    if isRectangular and minimap:GetParent() == UIParent then
         EBS._ClampMinimapCanvas(false, true)
     end
 

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -4029,10 +4029,10 @@ function EBS._ClampMinimapCanvas(fromLayout, saveCorrection)
     local clampedY = math.max(halfH, math.min(uiH - halfH, cy))
     local corrected = math.abs(clampedX - cx) > 0.01
         or math.abs(clampedY - cy) > 0.01
+    local x = clampedX - uiW * 0.5
+    local y = clampedY - uiH * 0.5
 
     if fromLayout or corrected then
-        local x = clampedX - uiW * 0.5
-        local y = clampedY - uiH * 0.5
         minimap:ClearAllPoints()
         minimap:SetPoint("CENTER", UIParent, "CENTER", x, y)
         if saveCorrection and corrected then
@@ -4040,11 +4040,18 @@ function EBS._ClampMinimapCanvas(fromLayout, saveCorrection)
         end
     end
 
-    -- Unlock mode temporarily places the visible child on UIParent. Restore the
-    -- architectural relationship after consuming that proposed center.
+    -- Keep the proxy in UIParent coordinates during unlock mode. Arrow-key
+    -- nudging reads its current point directly; restoring CENTER-to-Minimap here
+    -- would turn its valid screen position into a 0,0 relative offset and make
+    -- the next nudge jump to screen center. Normal applies restore the child
+    -- relationship outside unlock mode.
     if layout then
         layout:ClearAllPoints()
-        layout:SetPoint("CENTER", minimap, "CENTER")
+        if EllesmereUI._unlockActive then
+            layout:SetPoint("CENTER", UIParent, "CENTER", x, y)
+        else
+            layout:SetPoint("CENTER", minimap, "CENTER")
+        end
     end
     return corrected
 end
@@ -4220,6 +4227,26 @@ local function ApplyMinimap()
         if layout then
             layout:SetSize(mapSize, isRectangular and (mapSize * 192 / 256) or mapSize)
             layout:SetFrameLevel(minimap:GetFrameLevel())
+            if not isRectangular then
+                layout:ClearAllPoints()
+                layout:SetPoint("CENTER", minimap, "CENTER")
+            end
+        end
+    end
+    -- Reuse the existing unlock lifecycle instead of teaching the shared mover
+    -- about a second frame. Register only while rectangular mode is active, so
+    -- every other shape pays no callback or hook cost.
+    if EllesmereUI.RegisterUnlockModeListener and EllesmereUI.UnregisterUnlockModeListener then
+        if isRectangular and not GetFFD(minimap).rectUnlockListener then
+            GetFFD(minimap).rectUnlockListener = true
+            EllesmereUI:RegisterUnlockModeListener("EBS_RectMinimap", function(active)
+                local mp = EBS.db and EBS.db.profile.minimap
+                if not mp or mp.shape ~= "rectangular" then return end
+                EBS._ClampMinimapCanvas(active, false)
+            end)
+        elseif not isRectangular and GetFFD(minimap).rectUnlockListener then
+            GetFFD(minimap).rectUnlockListener = nil
+            EllesmereUI:UnregisterUnlockModeListener("EBS_RectMinimap")
         end
     end
     do

--- a/EllesmereUIOptions/EUI_Minimap_Options.lua
+++ b/EllesmereUIOptions/EUI_Minimap_Options.lua
@@ -193,7 +193,21 @@ initFrame:SetScript("OnEvent", function(self)
         local shapeRow
         shapeRow, h = W:DualRow(parent, y,
             { type="dropdown", text="Shape",
-              values = { square = "Square", rectangular = "Rectangular", circle = "Circle", textured_circle = "Textured Circle" },
+              values = {
+                  square = "Square", rectangular = "Rectangular",
+                  circle = "Circle", textured_circle = "Textured Circle",
+                  _menuOpts = {
+                      onItemHover = function(key, item)
+                          if key == "rectangular" then
+                              EllesmereUI.ShowWidgetTooltip(item,
+                                  "Rectangular mode cannot be placed flush against the top or bottom screen edge.")
+                          end
+                      end,
+                      onItemLeave = function(key)
+                          if key == "rectangular" then EllesmereUI.HideWidgetTooltip() end
+                      end,
+                  },
+              },
               order  = { "square", "rectangular", "circle", "textured_circle" },
               getValue=function() local m = MinimapDB(); return m and m.shape or "square" end,
               setValue=function(v)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

**What is the issue:**

The latest rectangular minimap changes fixed the misplaced player arrow, but made it impossible to place the minimap flush against the top or bottom of the screen. The preview in unlock mode was therefore kept square to prevent users from placing the minimap flush against those edges.

However, this made it difficult to anchor other elements to the visible minimap. You had to use Shift + Right Click to hide the minimap from unlock mode and then approximately place the anchored elements in the correct location.

Also, increasing the size of the minimap in rectangular mode could cause the square canvas to extend beyond the top edge of the screen, leaving the top of the map blank, and you could also nudge the minimap out of the border.

**How it was fixed:**

In unlock mode, the preview and highlight for the rectangular minimap are now rectangular. However, this minimap shape is now clamped so that the hidden square canvas cannot extend beyond the screen edges.

Because this behavior may be confusing, a disclaimer was added to the tooltip shown when hovering over the Rectangular option in the shape dropdown. It explains that the minimap cannot be placed flush against the top or bottom of the screen while using this shape.

Resizing the minimap in rectangular mode now correctly updates its position so that the complete square canvas remains within the screen edges, and nudging up or down no longer works when the square canvas is already at the limit.

## How was it tested?

Tested on live retail:

* Changing shapes works correctly, including while in housing.
* When anchoring an element to the minimap, the element is correctly placed against the edge of the visible minimap.
* Tested every minimap option in rectangular mode.
* The other shapes behave as before.
* The height match option in unlock mode clones the visible height of the minimap

## Screenshots

**Before:** The cropped parts of the minimap block access to the clock data bar under the minimap.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/f5960fea-5c2e-4692-8759-ae1bf6c639c6" />

##

**After:** The clock data bar is now easily accessible and can be anchored correctly to the visible minimap instead of the cropped square canvas.

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/303b1e9c-9f1c-4117-8c97-cea719b037e3" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

* [x] N/A - No new setting is added; this bug fix only affects users who have already selected the rectangular minimap shape.
* [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
* [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
* [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
* [x] Tested in-game on live; no version gates or pre-Midnight APIs added
