### PR TITLE
Bags: Bag and Bank Columns sliders, and fix Window Scale not rescaling an open bank

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags_Bank.lua
+++ b/EllesmereUIBags/EllesmereUIBags_Bank.lua
@@ -1612,6 +1612,7 @@ end
 --  Refresh
 -------------------------------------------------------------------------------
 function EUI_Bank:RefreshBank()
+    COLUMNS = BP().bankColumns or 14
     if not EUI_Bank:IsVisible() then return end
     NotifyBankTypeForTSM()
 
@@ -2386,6 +2387,7 @@ eventFrame:SetScript("OnEvent", function(_, event)
             end
         end
         -- Set initial size so frame is visible immediately
+        COLUMNS = BP().bankColumns or 14
         local gridW = COLUMNS * (SLOT_SIZE + SPACING)
         EUI_Bank:SetWidth(GetBankSidebarWidth() + gridW + 10 * 2 + SCROLLBAR_HIT_W + 2)
         EUI_Bank:SetHeight(FIXED_H)

--- a/EllesmereUIBags/EllesmereUIBags_DB.lua
+++ b/EllesmereUIBags/EllesmereUIBags_DB.lua
@@ -12,6 +12,7 @@ local BAGS_DEFAULTS = {
         bagScale              = 1,
         bagItemIconZoom       = 0.08,
         bagColumns            = 12,
+        bankColumns           = 14,
         bagAutoSize           = false,
         bagCatTitleSize       = 11,
         bagCountFontSize      = 11,

--- a/EllesmereUIOptions/EUI_Bags_Options.lua
+++ b/EllesmereUIOptions/EUI_Bags_Options.lua
@@ -81,7 +81,7 @@ initFrame:SetScript("OnEvent", function(self)
                       if _G.EUI_Bags then _G.EUI_Bags:SetScale(s) end
                       if _G.EUI_BagsReagent then _G.EUI_BagsReagent:SetScale(s) end
                       if _G.EUI_BagsWindow then _G.EUI_BagsWindow:SetScale(s) end
-                      if _G.EUI_Bank and _G.EUI_Bank:IsVisible() then _G.EUI_Bank:SetScale(s) end
+                      if _G.EUI_BankFrame and _G.EUI_BankFrame:IsVisible() then _G.EUI_BankFrame:SetScale(s) end
                   end },
                 { type="slider", text="Icon Zoom", min=0, max=0.20, step=0.01,
                   tooltip="Crops the border of every item icon in bags and bank. 0 shows the full icon.",
@@ -91,6 +91,26 @@ initFrame:SetScript("OnEvent", function(self)
                       if _G.EUI_Bags and _G.EUI_Bags.RefreshIconZoom then _G.EUI_Bags:RefreshIconZoom() end
                       local bank = _G.EUI_BankFrame
                       if bank and bank.RefreshIconZoom then bank:RefreshIconZoom() end
+                  end }
+            ); y = y - h
+
+            -- Bag Columns | Bank Columns (grid width of each window; the bank
+            -- keeps its own count because its frame is a different shape)
+            _, h = W:DualRow(parent, y,
+                { type="slider", text="Bag Columns", min=8, max=24, step=1,
+                  tooltip="Number of item columns in the bag window. With Auto-Size to Fit on this acts as a minimum: Auto-Size adds columns past it to fit the active tab, and never drops below it.",
+                  getValue=function() return db.profile.bagColumns or 12 end,
+                  setValue=function(v)
+                      db.profile.bagColumns = v
+                      ResetAndRefreshBagLayout()
+                  end },
+                { type="slider", text="Bank Columns", min=8, max=24, step=1,
+                  tooltip="Number of item columns in the bank window.",
+                  getValue=function() return db.profile.bankColumns or 14 end,
+                  setValue=function(v)
+                      db.profile.bankColumns = v
+                      local bank = _G.EUI_BankFrame
+                      if bank and bank.RefreshBank then bank:RefreshBank() end
                   end }
             ); y = y - h
 

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -2305,7 +2305,7 @@ EllesmereUI.RegisterMigration({
         end
 
         local PROFILE_KEYS = {
-            "bagScale", "bagColumns", "bagCatTitleSize", "bagCountFontSize",
+            "bagScale", "bagColumns", "bankColumns", "bagCatTitleSize", "bagCountFontSize",
             "itemlevelFontSize", "showItemlevelInBags", "showUpgradeIndicator",
             "bagShowTrackRank", "itemlevelUseCustomColor", "itemlevelCustomColor",
             "bagHideEmptyCategories", "bagSidebarCollapsed", "bankSidebarCollapsed",


### PR DESCRIPTION
## What does this PR do?

Two changes in the Bags module.

**Bag Columns / Bank Columns sliders.** Adds one options row exposing the grid width of the bag and bank windows. `bagColumns` already existed in the profile at `12` but was not reachable from the options page. `bankColumns` is new and defaults to `14`, the value `COLUMNS` has always been hardcoded to in `EllesmereUIBags/EllesmereUIBags_Bank.lua`. Both windows therefore look exactly as they did until a slider is moved. The warband bank follows Bank Columns. `bankColumns` is added to the migration profile key list in `EllesmereUI_Migration.lua` so it carries across profiles and presets.

**Window Scale on an open bank.** The Window Scale setter guarded on `_G.EUI_Bank`, which is always `nil`: `EUI_Bank` is a file local, and the frame's global name is `EUI_BankFrame` (`EllesmereUIBags/EllesmereUIBags_Bank.lua:209`). The guard never passed, so dragging Window Scale while the bank was open did nothing. The bank already applies the same `bagScale` value on open (`EllesmereUIBags/EllesmereUIBags_Bank.lua:2374`), so only the live update was affected; closing and reopening the bank picked the new scale up. The fix uses the real global.

Closes #1175.

## How was it tested?

Live on `12.1.0` (client `120100`), running a package of this branch built from `v9.0.0`.

- Bags, bank and warband bank at default and raised column counts
- Window Scale dragged with the bank already open, before and after the fix
- `/console scriptErrors 1` for the whole session, no errors
- Auto-Size to Fit on: Bag Columns behaves as the minimum its tooltip describes, with Auto-Size adding columns past it and never dropping below it
- Settings survive `/reload`
- `bankColumns` carries across a profile switch
- Bank Columns changed while the bank is closed applies on the next open

## Screenshots

Before, on stock `v9.0.0`:

**1.** Bank open, Window Scale `100`.

![before, Window Scale 100](https://github.com/user-attachments/assets/f2061be9-bd19-44b4-bf53-1d8be7923887)

**2.** Window Scale `130`. The inventory rescales; the bank, already open, does not.

![before, Window Scale 130, bank unchanged](https://github.com/user-attachments/assets/e017e1c6-b021-4ac6-94f2-472fdb5a98d7)

After, on this branch. Each step changes one thing:

**3.** Defaults, Bag Columns `12` and Bank Columns `14`.

![after, columns 12 and 14](https://github.com/user-attachments/assets/72553504-8be4-458a-b49b-31a89e05be97)

**4.** Bag Columns `16` and Bank Columns `18`, Window Scale unchanged.

![after, columns 16 and 18](https://github.com/user-attachments/assets/3ec50f19-be43-4ab7-a8a3-1e9e025317c5)

**5.** Window Scale `125`, columns unchanged. The bank now rescales.

![after, Window Scale 125, bank rescales](https://github.com/user-attachments/assets/e79a4be5-f938-4cc4-86a5-bff14d5d6710)

**6.** The new options row at its defaults.

![new options row](https://github.com/user-attachments/assets/94fbeb54-5e60-40c1-90d7-76951b5888d6)

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) — not applicable as written, these are sliders rather than toggles. They default to the values already in use, `12` for bags and `14` for the bank, so nothing changes for anyone who does not move them.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built — none of those are added. The bank reads `bankColumns` inside its existing refresh path.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) — one upvalue assignment per bank refresh.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames — not applicable, only EllesmereUI's own frames are touched.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added.
