### PR TITLE
Fix(UnitFrames/Resources & Castbar) keep the power/castbar/gcd bar bar border anchored after a zero-height pass

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -6514,6 +6514,9 @@ BuildCastBar = function()
         -- "Show Behind": +5 in front of the bar, level-1 behind it.
         local pl = castBarFrame:GetFrameLevel()
         castBarFrame._border:SetFrameLevel(cb.borderBehind and math.max(0, pl - 1) or (pl + 5))
+        -- Same lost-rect recovery as MakePixelBorder:ApplyStyle -- re-anchoring the bar
+        -- stops this child's rect from resolving and the border silently vanishes.
+        if not castBarFrame._border:GetLeft() then castBarFrame._border:SetAllPoints(castBarFrame) end
         EllesmereUI.ApplyBorderStyle(castBarFrame._border, bs,
             cb.borderR or 0, cb.borderG or 0, cb.borderB or 0, cb.borderA or 1,
             texKey, cb.borderTextureOffset, cb.borderTextureOffsetY,
@@ -8207,6 +8210,8 @@ BuildGCDBar = function()
         local bs = g.borderSize or 0
         local pl = gcdBarFrame:GetFrameLevel()
         gcdBarFrame._border:SetFrameLevel(g.borderBehind and math.max(0, pl - 1) or (pl + 5))
+        -- Lost-rect recovery, see the cast bar border above.
+        if not gcdBarFrame._border:GetLeft() then gcdBarFrame._border:SetAllPoints(gcdBarFrame) end
         EllesmereUI.ApplyBorderStyle(gcdBarFrame._border, bs,
             g.borderR or 0, g.borderG or 0, g.borderB or 0, g.borderA or 1,
             g.borderTexture or "solid", g.borderTextureOffset, g.borderTextureOffsetY,

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -5585,10 +5585,16 @@ function ns.UpdatePowerBorder(power, settings)
         -- Nothing to render and nothing to hide: stay lazy.
         if not ((isDet or isAttached) and size > 0) then return end
         border = CreateFrame("Frame", nil, power)
-        PP.Point(border, "TOPLEFT", power, "TOPLEFT", 0, 0)
-        PP.Point(border, "BOTTOMRIGHT", power, "BOTTOMRIGHT", 0, 0)
         power._pbBorder = border
     end
+    -- Re-anchored every pass, not once at creation: a pass that lands while the power
+    -- bar is zero-height (Power Bar Height 0, e.g. before a Spec Override raises it)
+    -- leaves this frame with its anchor entries intact but NO resolved rect, and nothing
+    -- recomputes it afterwards -- the border then stays invisible until a reload rebuilds
+    -- it. Re-setting both points restores the rect.
+    border:ClearAllPoints()
+    PP.Point(border, "TOPLEFT", power, "TOPLEFT", 0, 0)
+    PP.Point(border, "BOTTOMRIGHT", power, "BOTTOMRIGHT", 0, 0)
     local c = settings.powerBorderColor or { r = 0, g = 0, b = 0 }
     local alpha = settings.powerBorderAlpha or 1
     -- Attached bars are always Solid; their unused edges are hidden below so only


### PR DESCRIPTION
## What does this PR do?

Fixes borders that disappear and only come back after a reload, on the Unit Frames power bar and on the Resource Bars cast bar and GCD bar. All three attach their border frame to the bar once, when it is created, and afterwards only update style, size and frame level. When the bar underneath is re-anchored or passes through zero height, the border frame keeps its anchor entries but loses its resolved rect, and nothing ever recomputes it: the border strips fall back to the plain texture's natural 8px on the dimension they take from anchors and the border silently vanishes. Resource Bars already guarded against this for the resource bars themselves in MakePixelBorder:ApplyStyle; this PR brings the two bars in that module that were missed in line with it, and fixes the Unit Frames power bar by re-anchoring its border on every pass.

The Unit Frames case is easy to reproduce with a profile whose Power Bar Height is 0 and a Spec Override that raises it: opening the options briefly puts the base value back on the live frame, the bar passes through zero height, and the power bar border is gone until the next reload.

There is no new setting and no behavior change for anyone who was not hitting this. The cost is one ClearAllPoints plus two SetPoint per settings-apply pass on the Unit Frames power bar, and a single GetLeft check on the Resource Bars path, all on frames the addon owns.

## How was it tested?

Tested in game on the live client. The broken state was traced on the live player frame: with the border missing, the border frame reported two valid anchor points to the power bar but no resolved rect at all, while the power bar itself had a correct rect, and the border strips measured exactly the 8px texture fallback. Re-setting the two anchor points made the border reappear immediately without a reload, which is what this change now does on every pass. Afterwards the border stays in place across opening and closing the options panel and across spec changes that swap the power bar height. The Resource Bars cast bar and GCD bar changes follow the recovery that the same file already applies to its other bars.

## Screenshots

Not included: the visual result is the border simply being present, which the description above covers.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting; the change only restores intended rendering
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- every frame touched here is created and owned by the addon
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added