### PR TITLE
Clamp resource bar hash tick offset to the bar's own span

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -2890,7 +2890,7 @@ local function ApplyResourceBarTicks(sb, maxVal, tickStr, tickCache, hashWidth, 
             t:ClearAllPoints()
             if vert then
                 local off = PP and PP.Scale(barH * frac) or (barH * frac)
-                off = math.max(0, math.min(off, barH - pxW))
+                off = math.max(0, math.min(off, PP and PP.Scale(barH - pxW) or (barH - pxW)))
                 t:SetSize(barW - vI * 2, pxW)
                 if revFill then
                     t:SetPoint("TOPLEFT", sb, "TOPLEFT", vI, -off)
@@ -2899,7 +2899,7 @@ local function ApplyResourceBarTicks(sb, maxVal, tickStr, tickCache, hashWidth, 
                 end
             else
                 local off = PP and PP.Scale(barW * frac) or (barW * frac)
-                off = math.max(0, math.min(off, barW - pxW))
+                off = math.max(0, math.min(off, PP and PP.Scale(barW - pxW) or (barW - pxW)))
                 t:SetSize(pxW, tickH)
                 t:SetPoint("TOPLEFT", sb, "TOPLEFT", off, -vI)
             end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -2890,6 +2890,7 @@ local function ApplyResourceBarTicks(sb, maxVal, tickStr, tickCache, hashWidth, 
             t:ClearAllPoints()
             if vert then
                 local off = PP and PP.Scale(barH * frac) or (barH * frac)
+                off = math.max(0, math.min(off, barH - pxW))
                 t:SetSize(barW - vI * 2, pxW)
                 if revFill then
                     t:SetPoint("TOPLEFT", sb, "TOPLEFT", vI, -off)
@@ -2898,6 +2899,7 @@ local function ApplyResourceBarTicks(sb, maxVal, tickStr, tickCache, hashWidth, 
                 end
             else
                 local off = PP and PP.Scale(barW * frac) or (barW * frac)
+                off = math.max(0, math.min(off, barW - pxW))
                 t:SetSize(pxW, tickH)
                 t:SetPoint("TOPLEFT", sb, "TOPLEFT", off, -vI)
             end


### PR DESCRIPTION
```
Cause: Hash/threshold tick marks on resource bars anchored their leading
corner at the raw fill offset with no upper bound, so a tick configured
at the max value (100% / cap) sat flush at the bar's far edge and let its
full stroke width render past it, unclipped.

Fix: Clamp the tick offset to the bar's own span in the shared
ApplyResourceBarTicks function, routing the clamped bound through
PP.Scale() so it stays on the same pixel grid as every other tick.
Covers health, class power, and secondary/pip-strip bars.

Test: Verified in-game - hash lines at max value now sit flush with the
bar edge instead of overflowing, on both horizontal and vertical bars.

Reported by @Math.
```