### PR TITLE
Quickdraw: use locale-independent ping types in the Pings preset

### DIFF
--- a/EllesmereUIOptions/EUI_Quickdraw_Options.lua
+++ b/EllesmereUIOptions/EUI_Quickdraw_Options.lua
@@ -1680,36 +1680,42 @@ initFrame:SetScript("OnEvent", function(self)
         return out
     end
 
+    -- The ping type is given as a number, not a word. /ping matches the word
+    -- forms against PING_TYPE_ATTACK and friends, which are localized, so a
+    -- baked "/ping attack" only resolves on an English client and silently
+    -- sends a contextual ping everywhere else. The numeric aliases
+    -- (1 attack, 2 warning, 3 on my way, 4 assist, 5 look) are the same in
+    -- every locale.
     local function PingSlots()
         return {
             {
                 kind = "macrotext",
                 name = "Look",
-                macrotext = "/ping look",
+                macrotext = "/ping 5",
                 icon = { atlas = "Ping_Marker_Icon_NonThreat" },
             },
             {
                 kind = "macrotext",
                 name = "Assist",
-                macrotext = "/ping assist",
+                macrotext = "/ping 4",
                 icon = { atlas = "Ping_Marker_Icon_Assist" },
             },
             {
                 kind = "macrotext",
                 name = "Attack",
-                macrotext = "/ping attack",
+                macrotext = "/ping 1",
                 icon = { atlas = "Ping_Marker_Icon_Attack" },
             },
             {
                 kind = "macrotext",
                 name = "Warning",
-                macrotext = "/ping warning",
+                macrotext = "/ping 2",
                 icon = { atlas = "Ping_Marker_Icon_Warning" },
             },
             {
                 kind = "macrotext",
                 name = "On My Way",
-                macrotext = "/ping onmyway",
+                macrotext = "/ping 3",
                 icon = { atlas = "Ping_Marker_Icon_OnMyWay" },
             },
         }


### PR DESCRIPTION
## What does this PR do?

Fixes the Quickdraw **Pings** palette preset on non-English clients.

The preset seeded its five slots with the word forms of the ping types -
`/ping look`, `/ping assist`, `/ping attack`, `/ping warning`, `/ping onmyway`.
Blizzard's `/ping` handler resolves those words through a table built from
`PING_TYPE_ATTACK`, `PING_TYPE_WARNING` and friends, which are localized global
strings. On any client that is not enUS the word does not match, `pingType`
comes back nil, and `C_Ping.SendMacroPing` falls back to a contextual ping based
on whatever is under the cursor. The slot fires, so nothing looks broken - it
just sends the wrong ping, and never the one the slot's icon promises.

The same handler accepts numeric aliases, which are identical in every locale.
The preset now uses those:

| Slot | Before | After |
|---|---|---|
| Look | `/ping look` | `/ping 5` |
| Assist | `/ping assist` | `/ping 4` |
| Attack | `/ping attack` | `/ping 1` |
| Warning | `/ping warning` | `/ping 2` |
| On My Way | `/ping onmyway` | `/ping 3` |

Slot order, icons and names are untouched. No behavior change on an English
client - the same five pings fire as before.

Note the alias numbers are not the `PingSubjectType` enum: the enum orders
Assist before OnMyWay and AlertThreat before AlertNotThreat, while the slash
aliases swap both pairs. They are taken from the alias table directly rather
than derived.

### Known limitation

`AddPalette` copies preset slots into saved variables at seed time, so palettes
created before this change keep the old text. Re-seeding the preset into a new
palette picks up the fix. I did not add a migration - rewriting saved user data
seemed out of proportion to the bug, but happy to add one if you would prefer it.

## How was it tested?

Live 12.1 client, build 9.0.1.

- Seeded a fresh palette from the Pings preset and dumped the saved slots:
  all five stored the numeric form.
- Fired all five from the ring; each produced its own marker, matching the slot
  icon (Attack, Warning, On My Way, Assist, Look).
- Confirmed a palette created before the change is unaffected, as described above.

Only reachable path is the preset builder, so there is nothing to test with the
feature disabled.

## Screenshots

Not a visual change - the diff only alters the macro text baked into a preset
slot. Icons, layout and slot order are unchanged.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; this is a bug fix to an existing preset
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A, no new runtime code; five string literals changed
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A, no frames touched
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
