### PR TITLE
MacroFactory: use a locale-independent ping type in Ping Focus

### DIFF
--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -275,7 +275,12 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
                     lines[#lines + 1] = "/tm [@focus] ~" .. mark
                 end
                 if db.ping then
-                    lines[#lines + 1] = "/ping [@focus] onmyway"
+                    -- The ping type is a number, not a word: /ping matches the
+                    -- word forms against PING_TYPE_ON_MY_WAY and friends, which
+                    -- are localized, so a baked "onmyway" only resolves on an
+                    -- English client and sends a contextual ping everywhere
+                    -- else. 3 is on my way in every locale.
+                    lines[#lines + 1] = "/ping [@focus] 3"
                 end
                 if db.announce then
                     -- %f is the built-in chat substitution for the focus unit's


### PR DESCRIPTION
## What does this PR do?

Fixes the **Ping Focus** toggle on the Set Focus macro for non-English clients.

With the toggle on, the Macro Factory baked `/ping [@focus] onmyway` into
`EUI_Focus`. Blizzard's `/ping` handler resolves that word through
`PING_TYPE_ON_MY_WAY`, a localized global string, so on any client that is not
enUS it does not match and `C_Ping.SendMacroPing` sends a contextual ping
instead of On My Way.

Uses the numeric alias the same handler accepts - `3` is On My Way in every
locale:

```
-/ping [@focus] onmyway
+/ping [@focus] 3
```

No behavior change on an English client. Same bug as the Quickdraw Pings preset;
split into its own PR since it is a different module.

Macro bodies are baked when written, so an existing `EUI_Focus` keeps the old
text until a toggle rewrites it - inherent to the Macro Factory and already
noted in the surrounding comments, not something this PR changes.

## How was it tested?

Live 12.1 client, build 9.0.1.

- Toggled Ping Focus off and on to force a rewrite; confirmed the resulting
  `EUI_Focus` body ends in `/ping [@focus] 3`.
- With a focus set, fired the macro and confirmed an On My Way ping on the focus.
- With no focus, `/stopmacro [@focus,noexists]` still short-circuits and nothing
  is sent.

## Screenshots

Not a visual change - one line of baked macro text.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; Ping Focus already exists and already defaults off
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - unchanged; the line is only emitted when the toggle is on
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A, no frames touched
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
