### PR TITLE
Nameplates: fix per-module outline override not applying to cast bar text

### DIFF
--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -9,7 +9,7 @@ if not ns then return end  -- module disabled: no options page
 
 local function GetNPOptOutline()
     -- Body-text preview flag, already slug-gated at the source (GetFontOutlineFlag).
-    return EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag() or ""
+    return EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("nameplates") or ""
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -828,7 +828,7 @@ initFrame:SetScript("OnEvent", function(self)
         pf.Update = function(self)
             local fontPath   = (EllesmereUI and EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("nameplates")) or DBVal("font")
             -- Body-text outline, already slug-gated at the source (GetFontOutlineFlag).
-            local npOutline  = (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag()) or "OUTLINE, SLUG"
+            local npOutline  = (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("nameplates")) or "OUTLINE, SLUG"
             local barH       = Snap(DBVal("healthBarHeight"))
             local rawBarW    = BAR_W + DBVal("healthBarWidth")
             local barW       = IsDragging() and rawBarW or Snap(rawBarW)


### PR DESCRIPTION
```
Cause: GetNPOptOutline() and the header preview's cast-bar/name/hp text
in EUI_Nameplates_Options.lua called GetFontOutlineFlag() with no
addonKey, so both always fell through to the account-wide Global
Outline Mode instead of reading the per-module Nameplates override.
Real in-game nameplates were unaffected -- only the options preview.

Fix: pass "nameplates" as the addonKey at both call sites, matching
every other module's options page.

Test: tested in-game, module outline override now applies to the
nameplate cast bar text as expected.

Reported by @MunG.
```