### PR TITLE
Raid Frames: fix absorb coalescer stutter from 9.0.1

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -2965,19 +2965,30 @@ ns._ABSORB_FLUSH_BUDGET = 20
 ns._abFlush = CreateFrame("Frame")
 ns._abFlush:Hide()
 ns._abFlush:SetScript("OnUpdate", function(self)
-    local n = 0
-    for button, unit in pairs(ns._abDirty) do
-        ns._abDirty[button] = nil
-        UpdateAbsorb(button, unit)
+    local dirty = ns._abDirty
+    local budget = ns._ABSORB_FLUSH_BUDGET
+    local n, hitBudget = 0, false
+    for button in pairs(dirty) do
+        dirty[button] = nil
+        -- Re-read the button's CURRENT unit instead of trusting a token captured
+        -- at mark time: a roster reassignment mid-drain would otherwise repaint
+        -- the button with a stale occupant's absorb data.
+        local unit = button:GetAttribute("unit")
+        if unit then UpdateAbsorb(button, unit) end
         n = n + 1
-        if n >= ns._ABSORB_FLUSH_BUDGET then break end
+        if n >= budget then
+            hitBudget = true
+            break
+        end
     end
-    if not next(ns._abDirty) then
+    if not hitBudget then
         self:Hide()
     end
 end)
+-- unit is accepted for caller convenience but not stored -- the flush re-reads
+-- the button's current unit itself (see above).
 function ns._MarkAbsorbDirty(button, unit)
-    ns._abDirty[button] = unit
+    ns._abDirty[button] = true
     ns._abFlush:Show()
 end
 
@@ -2989,24 +3000,26 @@ end
 -- stale (event-active members are skipped by the stamp compare), and the
 -- ticker cancels itself when the armed set empties. Zero event registrations,
 -- zero cost with no shields anywhere.
--- Staleness margin needs real slack above the 0.5s ticker period: UpdateAbsorb
+-- Staleness margin needs real slack above the ticker period: UpdateAbsorb
 -- stamps _paintAt unconditionally, including on paints the belt itself just
 -- triggered, so a margin at or below one tick period re-qualifies every armed
 -- button as stale on the very next tick and the belt never stops sweeping the
--- whole armed set. 1.5s (three ticks) keeps this an occasional catch, not a
--- steady-state resweep.
+-- whole armed set. Margin is derived from the period (three ticks) rather than
+-- a second independent literal, so the two can't drift back out of sync.
 ns._abArmed = ns._abArmed or {}
+ns._ABSORB_BELT_PERIOD = 0.5
+ns._ABSORB_BELT_MARGIN = ns._ABSORB_BELT_PERIOD * 3
 function ns._AbArm(button, unit, d)
     d._absActive = true
     ns._abArmed[button] = unit
     if not ns._abBelt and C_Timer then
-        ns._abBelt = C_Timer.NewTicker(0.5, function()
+        ns._abBelt = C_Timer.NewTicker(ns._ABSORB_BELT_PERIOD, function()
             local now = GetTime()
             local any = false
             for btn, u in pairs(ns._abArmed) do
                 any = true
                 local ab = GetFFD(btn).absorbBar
-                if not ab or (now - (ab._paintAt or 0)) > 1.5 then
+                if not ab or (now - (ab._paintAt or 0)) > ns._ABSORB_BELT_MARGIN then
                     ns._MarkAbsorbDirty(btn, u)
                 end
             end

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -2981,7 +2981,7 @@ ns._abFlush:SetScript("OnUpdate", function(self)
             break
         end
     end
-    if not hitBudget then
+    if not (hitBudget and next(dirty)) then
         self:Hide()
     end
 end)

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -2954,19 +2954,27 @@ end
 -------------------------------------------------------------------------------
 -- Absorb paint coalescer (Blizzard's own CompactUnitFrame model: absorb /
 -- heal-prediction repaints are "frequent and expensive, update once per frame
--- at most"). Event branches MARK; one flush paints each dirty button once per
--- render frame -- server batches land several absorb-family events per button
--- in one frame at raid scale, and only the last paint renders. The flush
--- frame is hidden whenever the set is empty. On ns (200-local cap).
+-- at most"). Event branches MARK; the flush paints dirty buttons off a fixed
+-- per-frame budget -- server batches land several absorb-family events per
+-- button in one frame at raid scale, and only the last paint renders. A
+-- budget (not "drain everything") caps worst-case single-frame cost at raid
+-- size; any leftover keeps the frame shown so it drains over the following
+-- frames instead of spiking one of them. On ns (200-local cap).
 ns._abDirty = {}
+ns._ABSORB_FLUSH_BUDGET = 20
 ns._abFlush = CreateFrame("Frame")
 ns._abFlush:Hide()
 ns._abFlush:SetScript("OnUpdate", function(self)
+    local n = 0
     for button, unit in pairs(ns._abDirty) do
+        ns._abDirty[button] = nil
         UpdateAbsorb(button, unit)
+        n = n + 1
+        if n >= ns._ABSORB_FLUSH_BUDGET then break end
     end
-    table.wipe(ns._abDirty)
-    self:Hide()
+    if not next(ns._abDirty) then
+        self:Hide()
+    end
 end)
 function ns._MarkAbsorbDirty(button, unit)
     ns._abDirty[button] = unit
@@ -2981,6 +2989,12 @@ end
 -- stale (event-active members are skipped by the stamp compare), and the
 -- ticker cancels itself when the armed set empties. Zero event registrations,
 -- zero cost with no shields anywhere.
+-- Staleness margin needs real slack above the 0.5s ticker period: UpdateAbsorb
+-- stamps _paintAt unconditionally, including on paints the belt itself just
+-- triggered, so a margin at or below one tick period re-qualifies every armed
+-- button as stale on the very next tick and the belt never stops sweeping the
+-- whole armed set. 1.5s (three ticks) keeps this an occasional catch, not a
+-- steady-state resweep.
 ns._abArmed = ns._abArmed or {}
 function ns._AbArm(button, unit, d)
     d._absActive = true
@@ -2992,7 +3006,7 @@ function ns._AbArm(button, unit, d)
             for btn, u in pairs(ns._abArmed) do
                 any = true
                 local ab = GetFFD(btn).absorbBar
-                if not ab or (now - (ab._paintAt or 0)) > 0.45 then
+                if not ab or (now - (ab._paintAt or 0)) > 1.5 then
                     ns._MarkAbsorbDirty(btn, u)
                 end
             end


### PR DESCRIPTION
```
Cause: the 9.0.1 absorb paint coalescer had a staleness margin (0.45s)
shorter than its own belt ticker period (0.5s), so any shielded raid
member was resweept on nearly every tick instead of the rare no-event
case it was built for, and the flush drained the whole dirty set in
one uncapped frame -- exactly the "Raid, zero events, 128ms" pattern
in the report.

Fix: bound the flush to a per-frame budget, derive the belt's margin
from its ticker period instead of two independent constants, and
re-read each button's current unit at flush time instead of trusting
a token captured at mark time (closes a roster-reassignment race the
multi-frame drain would otherwise widen).

Test: tested in-game in raid, stutter no longer reproduces.

Reported by @Nenpo.
```