### PR TITLE
Fix nameplate cast bar outline requiring a reload to apply

### DIFF
--- a/EllesmereUIOptions/EUI_Fonts_Options.lua
+++ b/EllesmereUIOptions/EUI_Fonts_Options.lua
@@ -33,6 +33,11 @@ local _ftExpanded = {}
 -- new value is already live in the DB.
 local function FontReload()
     EllesmereUI.InvalidateFontCache()
+    if EllesmereUI._ModuleNS then
+        for _, mns in pairs(EllesmereUI._ModuleNS) do
+            if mns.RefreshAllSettings then mns.RefreshAllSettings() end
+        end
+    end
     EllesmereUI:ShowConfirmPopup({
         title       = "Reload Required",
         message     = "Font changed. A UI reload is needed to apply the new font.",


### PR DESCRIPTION
```
Reported by @MunG: changing the cast bar outline (Global Outline Mode or the Nameplates
Module Outline override) had no visible effect on already-shown nameplates.

Cause: FontReload() only invalidated the font cache and prompted for a reload, it never
repainted visible plates. Nameplate cast bar text only re-fonts on ns.RefreshAllSettings(),
which FontReload() never called, unlike other Nameplates font controls.

Fix: FontReload() now also calls RefreshAllSettings() on every module that has one, so the
outline change applies live instead of requiring a reload.

Test: confirmed in-game, outline now updates immediately on an active enemy cast bar.
```