### PR TITLE
Fix pet reminders not respecting delve visibility setting

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3671,7 +3671,7 @@ local function Refresh()
     ---------------------------------------------------------------------------
     if remindersOn and PET_CLASSES[playerClass] then
         local co = db.profile.consumables
-        if co and co.enabled and co.enabled.pet ~= false then
+        if co and co.enabled and co.enabled.pet ~= false and EABR.ConsumableShows(co, "pet", inInstance) then
             local suppress = false
             local petIcon = 132161
             local petLabel = "Pet"

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3671,7 +3671,7 @@ local function Refresh()
     ---------------------------------------------------------------------------
     if remindersOn and PET_CLASSES[playerClass] then
         local co = db.profile.consumables
-        if co and co.enabled and co.enabled.pet ~= false and EABR.ConsumableShows(co, "pet", inInstance) then
+        if co and co.enabled and co.enabled.pet ~= false and EABR.SectionShows(co.specialsWhereToShow, inInstance) then
             local suppress = false
             local petIcon = 132161
             local petLabel = "Pet"


### PR DESCRIPTION
Cause: Pet Reminders (Missing/Wrong/Passive Pet) never checked the zone "Where to Show" gate at all, unlike every other reminder section, so disabling delves had no effect on them.
Fix: Gate the Pet Reminders block on `EABR.SectionShows(co.specialsWhereToShow, inInstance)`, the same shared bucket class specials (Rogue Poisons/Paladin Rites/Shaman Imbues) already use, since it defaults to open-world-on and won't silently suppress pets outdoors like the bag-consumables filter would.
Test: On a pet class, open AuraBuff Reminders and toggle Delve off in any class-specials section's "Where to Show" cog (they share one setting). Enter a delve, confirm pet reminders no longer show there, and still show in other zones.

Reported by @allie.