### PR TITLE
RF: repair dropped aura-container unit binding on roster rebuild

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -4497,6 +4497,14 @@ local function RebuildUnitMap()
                 -- Cache class token for power border (avoids UnitClass in hot path)
                 local _, classToken = UnitClass(u)
                 d.classToken = classToken
+                -- Repair a container binding the OnAttributeChanged hook dropped because
+                -- UnitExists(u) was false at the moment the header assigned it (roster still
+                -- streaming in on a zone/group transition). Nothing else re-drives this once
+                -- the header stops re-asserting the same token, so aura containers can stay
+                -- bound to a stale unit indefinitely.
+                if d.rfcUnit ~= u and UnitExists(u) and ns.RFC_OnUnitAssigned then
+                    ns.RFC_OnUnitAssigned(btn, d, u)
+                end
             end
         end
     end


### PR DESCRIPTION
Reported by @VOODOO on 9.0.1. Riptide (and other single-target heals) cast on the tank never showed on the tank's Party Frame; casting on self sometimes falsely showed on the tank's frame instead.

**Cause:** the aura-container unit binding is only re-pointed from the `OnAttributeChanged("unit")` hook, gated behind `UnitExists(u)`. A reassignment landing before the new unit resolves gets silently dropped, and nothing else ever re-drives it, so the container stays bound to a stale unit.

**Fix:** `RebuildUnitMap` now re-drives `RFC_OnUnitAssigned` for any button whose live unit doesn't match the container's recorded unit, self-healing the dropped binding.

**Test:** confirmed fixed in-game by the reporter and independently by a second reporter (Resto Druid, single-target HoTs) on the same build.