### PR TITLE
UF: keep name/hp text and raid marker above a raised cast bar strata

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -10007,19 +10007,26 @@ local function ReloadFrames()
             -- the frame's strata. Lift to HIGH so it never hides behind other MEDIUM-
             -- strata frames, unless "Raise Cast Bar Strata (All)" is off, in which case
             -- it's explicitly left at the frame's strata.
+            local cbStrata = strata
             if frame.Castbar and (unitKey == "player" or IsKickCastbarUnit(unitKey)) then
                 local cbg = frame.Castbar:GetParent()
                 if cbg then
                     if profile.raiseCastbarStrata ~= false then
-                        cbg:SetFrameStrata("HIGH")
-                    else
-                        cbg:SetFrameStrata(strata)
+                        cbStrata = "HIGH"
                     end
+                    cbg:SetFrameStrata(cbStrata)
                 end
             end
-            -- SetFrameStrata re-stacks children; lift the raid marker holder back
-            -- above the text overlay so the marker is never hidden behind name/health text.
+            -- SetFrameStrata re-stacks children; lift the text overlay (name/hp text)
+            -- to match the cast bar's strata too, so a raised cast bar doesn't draw in
+            -- front of its own frame's name/health text where they overlap, then lift
+            -- the raid marker holder back above the text overlay so the marker is never
+            -- hidden behind name/health text or the cast bar.
+            if frame._textOverlay then
+                frame._textOverlay:SetFrameStrata(cbStrata)
+            end
             if frame._raidMarkerHolder and frame._textOverlay then
+                frame._raidMarkerHolder:SetFrameStrata(cbStrata)
                 frame._raidMarkerHolder:SetFrameLevel(frame._textOverlay:GetFrameLevel() + 5)
             end
         end
@@ -13608,19 +13615,26 @@ function InitializeFrames()
             -- the frame's strata. Lift to HIGH so it never hides behind other MEDIUM-
             -- strata frames, unless "Raise Cast Bar Strata (All)" is off, in which case
             -- it's explicitly left at the frame's strata.
+            local cbStrata = strata
             if frame.Castbar and (unitKey == "player" or IsKickCastbarUnit(unitKey)) then
                 local cbg = frame.Castbar:GetParent()
                 if cbg then
                     if db.profile.raiseCastbarStrata ~= false then
-                        cbg:SetFrameStrata("HIGH")
-                    else
-                        cbg:SetFrameStrata(strata)
+                        cbStrata = "HIGH"
                     end
+                    cbg:SetFrameStrata(cbStrata)
                 end
             end
-            -- SetFrameStrata re-stacks children; lift the raid marker holder back
-            -- above the text overlay so the marker is never hidden behind name/health text.
+            -- SetFrameStrata re-stacks children; lift the text overlay (name/hp text)
+            -- to match the cast bar's strata too, so a raised cast bar doesn't draw in
+            -- front of its own frame's name/health text where they overlap, then lift
+            -- the raid marker holder back above the text overlay so the marker is never
+            -- hidden behind name/health text or the cast bar.
+            if frame._textOverlay then
+                frame._textOverlay:SetFrameStrata(cbStrata)
+            end
             if frame._raidMarkerHolder and frame._textOverlay then
+                frame._raidMarkerHolder:SetFrameStrata(cbStrata)
                 frame._raidMarkerHolder:SetFrameLevel(frame._textOverlay:GetFrameLevel() + 5)
             end
         end


### PR DESCRIPTION
Reported by @개굴이 on v9.0.1. Target/boss cast bar renders in front of its own frame's name/health text and raid marker.
**Cause:** "Raise Cast Bar Strata (All)" lifts the cast bar to HIGH strata, but the same update pass resets the frame's text overlay and raid marker back to the frame's normal strata every time, so the raised cast bar draws over them wherever they overlap.
**Fix:** Lift the text overlay and raid marker to match the cast bar's resolved strata in both strata-apply passes.
**Test:** Target/boss casting with default settings (Raise Cast Bar Strata on); name/health text and raid marker no longer disappear behind the cast bar. Confirmed fixed in-game.