### PR TITLE
Fix & Perf(Bags): stop the sort from thrashing the action bars

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -697,7 +697,29 @@ end
 local _dragState = { visible = false, strataCache = {} }
 
 -- Grid show/hide state (show empty slots during spell drag)
-local _gridState = { shown = false, visPending = false, spellsPending = false }
+local _gridState = { shown = false, visPending = false, spellsPending = false,
+    want = nil, settlePending = false, showFns = {}, hideFns = {} }
+
+-- Grid edges arrive in pairs from scripted cursor use: every
+-- PickupContainerItem fires ACTIONBAR_SHOWGRID and every place fires
+-- ACTIONBAR_HIDEGRID, hundreds of pairs per frame during a bag sort, and
+-- applying each edge re-walked every bar and flipped mouseover bars between
+-- alpha 1 and 0 (the visible blinking). Settle instead: a pair that nets back
+-- to the applied state (_gridState.shown, owned by the appliers) costs
+-- nothing, a real drag still surfaces the grid 50ms later. Appliers register
+-- into showFns/hideFns at their own definition sites.
+function ns.EABQueueGrid(show)
+    _gridState.want = show
+    if _gridState.settlePending then return end
+    _gridState.settlePending = true
+    C_Timer_After(0.05, function()
+        _gridState.settlePending = false
+        local want = _gridState.want
+        if want == _gridState.shown then return end
+        local list = want and _gridState.showFns or _gridState.hideFns
+        for i = 1, #list do list[i]() end
+    end)
+end
 local _quickKeybindState = { open = false, closePending = false, art = {}, FinishClose = nil }
 local EAB_UpdateQuickKeybindButtons -- forward-declared for early event hooks
 
@@ -11797,13 +11819,11 @@ end
 --  Grid Show/Hide (show empty slots during spell drag)
 -------------------------------------------------------------------------------
 
+-- Reached only on a real off -> on edge: ns.EABQueueGrid settles the event
+-- storm a bag sort produces (its old 0.1s throttle here could not, because
+-- every HIDEGRID in the storm reset _gridState.shown and re-armed it).
 local function OnGridChange()
     if InCombatLockdown() then return end
-    -- Throttle: bag addons fire ACTIONBAR_SHOWGRID hundreds of times
-    -- per sort pass via PickupContainerItem, causing "script ran too long".
-    local now = GetTime()
-    if _gridState.shown and _gridState._lastTime and (now - _gridState._lastTime) < 0.1 then return end
-    _gridState._lastTime = now
     _gridState.shown = true
 
     -- Propagate showgrid to the controller so the secure environment
@@ -13323,60 +13343,70 @@ function EAB:FinishSetup()
     end
 
     EAB._abcEvents = ns.TakeShell()
-    EAB._abcEvents:SetScript("OnEvent", function(_, event, arg1)
-        if event == "ACTIONBAR_SHOWGRID" then
-            -- Cancel any pending restore (swap case: drop + immediate pickup)
-            _gridRestorePending = false
-            if not InCombatLockdown() then
-                for btn in pairs(_controllerButtons) do
-                    SetShowGridInsecure(btn, true, SHOWGRID.GAME_EVENT)
-                end
-                -- Temporarily surface bars hidden by conditional visibility
-                -- (combat-only, target-only, etc.) so the user can place spells.
-                for _, info in ipairs(BAR_CONFIG) do
-                    if not info.isStance and not info.isPetBar then
-                        local s = EAB.db.profile.bars[info.key]
-                        local frame = barFrames[info.key]
-                        if s and frame and not s.alwaysHidden then
-                            local vis = s.barVisibility or "always"
-                            local hasCondition = vis ~= "always" and vis ~= "never"
-                                or s.visHideNoTarget or s.visHideNoEnemy
-                                or s.visHideMounted or s.visOnlyMounted or s.visOnlyInstances
-                            if hasCondition then
-                                _gridSurfacedBars[info.key] = true
-                                RegisterAttributeDriver(frame, "state-visibility", "show")
-                                -- Keep the cache in sync with the stomp (same
-                                -- class as the QuickKeybind surface fix): a
-                                -- stale cache holding the real string makes
-                                -- every later refresh compare equal and skip
-                                -- re-registering, leaving the bar stuck on
-                                -- "show" until a settings toggle or /reload.
-                                frame._eabLastVisStr = "show"
-                                frame:Show()
-                            end
-                            -- Mouseover bars: force alpha to 1 during drag
-                            if s.mouseoverEnabled then
-                                _gridSurfacedBars[info.key] = true
-                                StopFade(frame)
-                                frame:SetAlpha(1)
-                            end
+
+    -- Controller-side grid appliers, run from the settle in ns.EABQueueGrid.
+    _gridState.showFns[#_gridState.showFns + 1] = function()
+        -- Cancel any pending restore (swap case: drop + immediate pickup)
+        _gridRestorePending = false
+        if not InCombatLockdown() then
+            for btn in pairs(_controllerButtons) do
+                SetShowGridInsecure(btn, true, SHOWGRID.GAME_EVENT)
+            end
+            -- Temporarily surface bars hidden by conditional visibility
+            -- (combat-only, target-only, etc.) so the user can place spells.
+            for _, info in ipairs(BAR_CONFIG) do
+                if not info.isStance and not info.isPetBar then
+                    local s = EAB.db.profile.bars[info.key]
+                    local frame = barFrames[info.key]
+                    if s and frame and not s.alwaysHidden then
+                        local vis = s.barVisibility or "always"
+                        local hasCondition = vis ~= "always" and vis ~= "never"
+                            or s.visHideNoTarget or s.visHideNoEnemy
+                            or s.visHideMounted or s.visOnlyMounted or s.visOnlyInstances
+                        if hasCondition then
+                            _gridSurfacedBars[info.key] = true
+                            RegisterAttributeDriver(frame, "state-visibility", "show")
+                            -- Keep the cache in sync with the stomp (same
+                            -- class as the QuickKeybind surface fix): a
+                            -- stale cache holding the real string makes
+                            -- every later refresh compare equal and skip
+                            -- re-registering, leaving the bar stuck on
+                            -- "show" until a settings toggle or /reload.
+                            frame._eabLastVisStr = "show"
+                            frame:Show()
+                        end
+                        -- Mouseover bars: force alpha to 1 during drag
+                        if s.mouseoverEnabled then
+                            _gridSurfacedBars[info.key] = true
+                            StopFade(frame)
+                            frame:SetAlpha(1)
                         end
                     end
                 end
             end
-        elseif event == "ACTIONBAR_HIDEGRID" or event == "PET_BAR_HIDEGRID" then
-            if not InCombatLockdown() then
-                for btn in pairs(_controllerButtons) do
-                    SetShowGridInsecure(btn, false, SHOWGRID.GAME_EVENT)
-                end
-                -- Defer restore: spell swaps fire HIDEGRID then SHOWGRID
-                -- in rapid succession. Deferring lets the next SHOWGRID
-                -- cancel the restore so bars stay visible.
-                if next(_gridSurfacedBars) then
-                    _gridRestorePending = true
-                    C_Timer_After(0, RestoreGridSurfacedBars)
-                end
+        end
+    end
+
+    _gridState.hideFns[#_gridState.hideFns + 1] = function()
+        if not InCombatLockdown() then
+            for btn in pairs(_controllerButtons) do
+                SetShowGridInsecure(btn, false, SHOWGRID.GAME_EVENT)
             end
+            -- Defer restore: spell swaps fire HIDEGRID then SHOWGRID
+            -- in rapid succession. Deferring lets the next SHOWGRID
+            -- cancel the restore so bars stay visible.
+            if next(_gridSurfacedBars) then
+                _gridRestorePending = true
+                C_Timer_After(0, RestoreGridSurfacedBars)
+            end
+        end
+    end
+
+    EAB._abcEvents:SetScript("OnEvent", function(_, event, arg1)
+        if event == "ACTIONBAR_SHOWGRID" then
+            ns.EABQueueGrid(true)
+        elseif event == "ACTIONBAR_HIDEGRID" or event == "PET_BAR_HIDEGRID" then
+            ns.EABQueueGrid(false)
         elseif event == "CVAR_UPDATE" then
             -- Name-filtered: CVAR_UPDATE fires for every cvar, dozens of times
             -- at login. Only the lock matters to the drag wrapper.
@@ -13512,9 +13542,10 @@ function EAB:FinishSetup()
         self:ApplyFonts()
     end)
 
-    self:RegisterEvent("ACTIONBAR_SHOWGRID", OnGridChange)
+    _gridState.showFns[#_gridState.showFns + 1] = OnGridChange
+    self:RegisterEvent("ACTIONBAR_SHOWGRID", function() ns.EABQueueGrid(true) end)
     -- Pet actions fire their own grid events when dragging pet spells
-    self:RegisterEvent("PET_BAR_SHOWGRID", OnGridChange)
+    self:RegisterEvent("PET_BAR_SHOWGRID", function() ns.EABQueueGrid(true) end)
 
     -- Re-apply useOnKeyDown when the "Press and Hold Casting" CVar changes.
     self:RegisterEvent("CVAR_UPDATE", function(_, cvarName)
@@ -13616,9 +13647,11 @@ function EAB:FinishSetup()
         if cursorType then
             if DRAG_TYPES[cursorType] then
                 SetDragVisible(true)
-                if not _gridState.shown then
-                    OnGridChange()
-                end
+                -- Through the queue, never straight into OnGridChange: a
+                -- direct call flips _gridState.shown, and this drag's own
+                -- ACTIONBAR_SHOWGRID would then settle as a no-op and skip
+                -- the controller-side applier.
+                ns.EABQueueGrid(true)
                 -- Force mouseover bars visible during real cursor drags
                 _gridState._mouseoverForced = true
                 for _, info in ipairs(BAR_CONFIG) do
@@ -13661,17 +13694,11 @@ function EAB:FinishSetup()
         else
             SetDragVisible(false)
             EAB._RestoreDragNeverBars()
-            if _gridState.shown then
-                _gridState.shown = false
-                C_Timer_After(0, function()
-                    -- Drag force-showed grids: the stamps no longer reflect
-                    -- button state, so every bar must re-assert.
-                    if ns._asbStamp then wipe(ns._asbStamp) end
-                    for _, info in ipairs(BAR_CONFIG) do
-                        self:ApplyAlwaysShowButtons(info.key)
-                    end
-                end)
-            end
+            -- Fallback for a cursor cleared without a HIDEGRID; the queue
+            -- dedupes when both arrive. OnGridHide owns the state flip and
+            -- the re-assert, so this must not clear _gridState.shown itself
+            -- (that would make the settle skip the hide appliers).
+            if _gridState.shown then ns.EABQueueGrid(false) end
         end
     end)
 
@@ -13934,6 +13961,9 @@ function EAB:FinishSetup()
         -- causing the button to be hidden as empty.
         C_Timer.After(0, function()
             if InCombatLockdown() then return end
+            -- The grid show force-showed buttons, so the stamps no longer
+            -- reflect button state and every bar must re-assert.
+            if ns._asbStamp then wipe(ns._asbStamp) end
             for _, info2 in ipairs(BAR_CONFIG) do
                 self:ApplyAlwaysShowButtons(info2.key)
             end
@@ -13957,8 +13987,9 @@ function EAB:FinishSetup()
         -- Re-hide Never bars surfaced by Show All During Drag.
         EAB._RestoreDragNeverBars()
     end
-    self:RegisterEvent("ACTIONBAR_HIDEGRID", OnGridHide)
-    self:RegisterEvent("PET_BAR_HIDEGRID", OnGridHide)
+    _gridState.hideFns[#_gridState.hideFns + 1] = OnGridHide
+    self:RegisterEvent("ACTIONBAR_HIDEGRID", function() ns.EABQueueGrid(false) end)
+    self:RegisterEvent("PET_BAR_HIDEGRID", function() ns.EABQueueGrid(false) end)
 
     -- Spell updates: refresh button icons and visibility
     -- Also re-layout the stance bar since GetNumShapeshiftForms() may have changed

--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -317,23 +317,46 @@ local function SetItemPanelOpen(key, open)
     return true
 end
 
--- Pre-cache sort fields onto item data tables to avoid API calls in comparator
-local function PreCacheSortFields(items)
-    for _, d in ipairs(items) do
-        if d.itemLink and not d._sortCached then
-            local name, _, quality, ilvl, _, itemType = GetItemInfo(d.itemLink)
-            d._sortName = name or ""
-            d._sortQuality = quality or 0
-            d._sortIlvl = ilvl or 0
-            d._sortType = itemType or ""
-            if GetUpgradeTrack and _trackRank then
-                local _, color = GetUpgradeTrack(d.itemLink)
-                d._sortTrackRank = color and _trackRank[color] or 0
-            else
-                d._sortTrackRank = 0
+-- Pre-cache sort fields onto item data tables to avoid API calls in comparator.
+-- The per-table _sortCached flag only covers repeats within one pass: every
+-- physical-sort retry builds fresh item tables, so it re-ran GetItemInfo and
+-- GetItemUpgradeInfo for every item on every pass. All five fields are pure
+-- functions of the item link, so memo them on the link instead. Incomplete
+-- item data (nil name) is never stored and still resolves on a later pass.
+-- _sortGear stays per item: it follows the category, not the link.
+local PreCacheSortFields
+do
+    local cache = {}
+    local cacheCount = 0
+    PreCacheSortFields = function(items)
+        for _, d in ipairs(items) do
+            if d.itemLink and not d._sortCached then
+                local c = cache[d.itemLink]
+                if not c then
+                    local name, _, quality, ilvl, _, itemType = GetItemInfo(d.itemLink)
+                    local rank = 0
+                    if GetUpgradeTrack and _trackRank then
+                        local _, color = GetUpgradeTrack(d.itemLink)
+                        rank = color and _trackRank[color] or 0
+                    end
+                    c = { name = name or "", quality = quality or 0, ilvl = ilvl or 0,
+                          itemType = itemType or "", rank = rank, complete = name ~= nil }
+                    if c.complete then
+                        -- Links are per-item-instance, so the table would grow
+                        -- with every distinct item seen in a session.
+                        if cacheCount >= 4000 then wipe(cache); cacheCount = 0 end
+                        cache[d.itemLink] = c
+                        cacheCount = cacheCount + 1
+                    end
+                end
+                d._sortName = c.name
+                d._sortQuality = c.quality
+                d._sortIlvl = c.ilvl
+                d._sortType = c.itemType
+                d._sortTrackRank = c.rank
+                d._sortGear = d.categoryIndex and IsGearCategory(d.categoryIndex) or false
+                if c.complete then d._sortCached = true end
             end
-            d._sortGear = d.categoryIndex and IsGearCategory(d.categoryIndex) or false
-            if name then d._sortCached = true end
         end
     end
 end
@@ -944,6 +967,13 @@ local function CreateHeader()
     end)
 
     local sortLocked = false
+    -- One reusable BAG_UPDATE listener per role. Both phases are strictly
+    -- sequential, and a fresh CreateFrame per round leaked frames per click
+    -- (frames are never collected). The run token keeps a second sort from
+    -- inheriting the first one's callbacks: EndDragDrop can unlock the button
+    -- mid-run, and a stale callback clearing the live chain's OnEvent would
+    -- strand it with refreshEnabled false (bags frozen until reload).
+    local consolidateFrame, retryFrame
     local function LockSort()
         sortLocked = true
         sort:EnableMouse(false)
@@ -978,6 +1008,13 @@ local function CreateHeader()
         --  Phase 1: consolidate partial stacks (smallest onto largest of the same itemID; the engine performs the combine).
         -----------------------------------------------------------------------
         local function ConsolidateStacks(onDone)
+            -- Max stack size is a static per-itemID fact, but it was re-read
+            -- through GetItemInfo for every occupied slot on every pass (up to
+            -- 30 passes over six bags). Memo it for the run instead; the
+            -- ItemLocation + DoesItemExist guard it used to sit behind is
+            -- redundant, GetContainerItemInfo just returned the item.
+            local maxStackByID = {}
+            local function ByCount(a, b) return a.count < b.count end
             local function DoOnePass()
                 local stacks = {}  -- itemID -> { {bag,slot,count}, ... }
                 for bag = 0, 5 do
@@ -985,10 +1022,13 @@ local function CreateHeader()
                     for slot = 1, numSlots do
                         local info = C_Container.GetContainerItemInfo(bag, slot)
                         if info and info.itemID and info.stackCount then
-                            local maxStack = info.stackCount
-                            local loc = ItemLocation:CreateFromBagAndSlot(bag, slot)
-                            if C_Item.DoesItemExist(loc) then
-                                maxStack = select(8, C_Item.GetItemInfo(info.itemID)) or 1
+                            local maxStack = maxStackByID[info.itemID]
+                            if not maxStack then
+                                maxStack = select(8, C_Item.GetItemInfo(info.itemID))
+                                -- Uncached item data: don't memo the fallback,
+                                -- a later pass can still resolve it.
+                                if maxStack then maxStackByID[info.itemID] = maxStack
+                                else maxStack = 1 end
                             end
                             if maxStack > 1 and info.stackCount < maxStack then
                                 if not stacks[info.itemID] then stacks[info.itemID] = {} end
@@ -999,24 +1039,20 @@ local function CreateHeader()
                         end
                     end
                 end
-                -- One smallest->largest pair per itemID per pass; distinct itemIDs occupy distinct slots
-                -- so all merges fire same-frame, then wait one BAG_UPDATE and repeat -- converges in max-partials-per-item rounds, not one per merge.
+                -- Emptiest partial merges into fullest, second-emptiest into
+                -- second-fullest, and so on: every slot is touched at most
+                -- once, so all pairs of this pass still fire same-frame -- but
+                -- an item with 2n partial stacks now converges in log rounds
+                -- instead of n BAG_UPDATE round trips. Overflow waits for a
+                -- later pass, same as before.
                 local merged = false
                 for _, partials in pairs(stacks) do
-                    if #partials >= 2 then
-                        -- Emptiest partial merges into fullest via one scan (no sort); overflow waits for a later pass.
-                        local target = partials[1]
-                        for i = 2, #partials do
-                            if partials[i].count > target.count then target = partials[i] end
-                        end
-                        local source
-                        for i = 1, #partials do
-                            local pr = partials[i]
-                            if pr ~= target and (not source or pr.count < source.count) then
-                                source = pr
-                            end
-                        end
-                        if source then
+                    local n = #partials
+                    if n >= 2 then
+                        table.sort(partials, ByCount)
+                        local lo, hi = 1, n
+                        while lo < hi do
+                            local source, target = partials[lo], partials[hi]
                             local srcLoc = ItemLocation:CreateFromBagAndSlot(source.bag, source.slot)
                             local dstLoc = ItemLocation:CreateFromBagAndSlot(target.bag, target.slot)
                             if not C_Item.IsLocked(srcLoc) and not C_Item.IsLocked(dstLoc) then
@@ -1025,6 +1061,8 @@ local function CreateHeader()
                                 ClearCursor()
                                 merged = true
                             end
+                            lo = lo + 1
+                            hi = hi - 1
                         end
                     end
                 end
@@ -1037,12 +1075,16 @@ local function CreateHeader()
             end
 
             local consolidateRetry = 0
-            local consolidateFrame = CreateFrame("Frame")
+            if not consolidateFrame then consolidateFrame = CreateFrame("Frame") end
+            local runToken = {}
+            consolidateFrame._runToken = runToken
             consolidateFrame:RegisterEvent("BAG_UPDATE")
             consolidateFrame:SetScript("OnEvent", function(self)
+                if self._runToken ~= runToken then return end
                 self:UnregisterAllEvents()
                 consolidateRetry = consolidateRetry + 1
                 C_Timer.After(0.15, function()
+                    if consolidateFrame._runToken ~= runToken then return end
                     if consolidateRetry < 30 and DoOnePass() then
                         self:RegisterEvent("BAG_UPDATE")
                     else
@@ -1177,12 +1219,16 @@ local function CreateHeader()
             if not moved then onDone(); return end
 
             local retryCount = 0
-            local retryFrame = CreateFrame("Frame")
+            if not retryFrame then retryFrame = CreateFrame("Frame") end
+            local runToken = {}
+            retryFrame._runToken = runToken
             retryFrame:RegisterEvent("BAG_UPDATE")
             retryFrame:SetScript("OnEvent", function(self)
+                if self._runToken ~= runToken then return end
                 self:UnregisterAllEvents()
                 retryCount = retryCount + 1
                 C_Timer.After(0.15, function()
+                    if retryFrame._runToken ~= runToken then return end
                     local moved = ComputeAndExecute(bagMin, bagMax)
                     if moved and retryCount < 15 then
                         self:RegisterEvent("BAG_UPDATE")


### PR DESCRIPTION
## What does this PR do?

Clicking Sort in EllesmereUI Bags made the game stutter and made mouseover action bars blink for the whole duration of the sort. Root cause is on the Action Bars side: every `C_Container.PickupContainerItem` fires `ACTIONBAR_SHOWGRID` and every place fires `ACTIONBAR_HIDEGRID`, so a sort of full bags produces hundreds of event pairs inside a single frame. Each edge was applied the moment it arrived, which force-showed empty slots across every bar, re-registered attribute drivers on conditionally hidden bars, and flipped mouseover bars between alpha 1 and alpha 0. That alpha flip is the blinking, and the repeated full button walks are most of the stutter. The 0.1s throttle that already existed in `OnGridChange` could never help, because every `ACTIONBAR_HIDEGRID` in the storm reset the very state the throttle was gated on.

Grid edges now go through a small settle instead of being applied on arrival. An edge records the wanted state and resolves once 50ms later; if the wanted state equals the state that is currently applied, nothing runs at all. A scripted pickup/place pair nets back to the applied state and therefore costs nothing, while a real cursor drag holds the cursor across frames and still surfaces the grid, 50ms later than before. The two former inline handler bodies are now appliers registered into `showFns`/`hideFns`, so the controller-side work and the bar-side work stay in their previous order. Two follow-on defects that the restructure would otherwise have introduced are handled in the same change: the drag-start path no longer calls `OnGridChange` directly (a direct call flips the applied-state flag and would make that drag's own `ACTIONBAR_SHOWGRID` settle as a no-op, skipping the controller-side applier), and the cursor-cleared fallback no longer clears the flag itself but queues the hide, so the controller bits and any surfaced bars are always released. The `_asbStamp` wipe that the cursor path used to own moved into the post-grid-hide re-assert, where it covers every grid hide rather than only cursor drags.

The sort itself is also cheaper on the Bags side. Sort fields (name, quality, item level, type, upgrade track) are pure functions of the item link, but the cache flag lived on the item tables, which every retry pass allocates fresh, so `GetItemInfo` and `GetItemUpgradeInfo` ran for every item on every pass; they now memo on the link, with incomplete item data deliberately not stored so it still resolves on a later pass. Stack consolidation memos max stack size per itemID instead of re-reading it through `GetItemInfo` for every occupied slot on every one of up to 30 passes, and the `ItemLocation` plus `DoesItemExist` guard that call used to sit behind is gone, since `GetContainerItemInfo` had just returned the item. Partial stacks now merge as emptiest-into-fullest, second-emptiest into second-fullest and so on: every slot is still touched at most once so all pairs of a pass fire in the same frame, but an item with n partial stacks converges in log rounds instead of n `BAG_UPDATE` round trips. The retry listeners are reused rather than leaking a frame per round, guarded by a run token so a second sort started while the first is still running cannot inherit the first one's callbacks and strand the live chain with refreshes disabled.

One deliberate side effect worth calling out for review: `PET_BAR_SHOWGRID` now runs the same applier list as `ACTIONBAR_SHOWGRID`, so a pet-spell drag also surfaces conditionally hidden and mouseover bars. Previously only the hide side was wired to both handlers, which looked like an oversight rather than intent.

## How was it tested?

Tested in game on live: sorting full bags with mouseover action bars active, and normal spell drag and drop onto mouseover bars and onto conditionally hidden bars afterwards to confirm the grid reveal and the restore still behave.

## Screenshots

Not applicable: the change removes unintended visual churn over time (bars blinking during a sort), which a still image cannot show. No intentional visual change.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new settings. The behavior change is the bug fix itself, plus the pet-bar grid symmetry noted above.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A, no new feature to disable; no new event registrations, and the Bags change reuses existing listeners instead of creating them per round.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - still fully event-driven. The 50ms settle is a coalescer on an event edge, not a logic gate or a poll, and follows the same pattern as the existing hover fade-out coalescing in this file. Net effect is a large reduction in work and allocations.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no write target changed; `SetScript` is used only on frames this addon creates.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added - no new API surface at all.