### PR TITLE
Fix(Nameplates): Friendly Name Size not surviving reload in Nameplates

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -311,13 +311,33 @@ local function _OnNameWidthChanged(self)
     _nameFixGuard = false
 end
 
+-- Blizzard's NamePlateUnitFrameMixin:ApplyFrameOptions stamps a PER-INSTANCE
+-- height onto the name FontString (name:SetTextHeight(healthBarFontHeight))
+-- right after assigning the shared font object. A per-instance height beats the
+-- shared SystemFont_NamePlate size, so the font-object override alone is lost on
+-- every plate setup -- which is why the configured size did not survive a reload
+-- (every plate is built fresh) while a live slider change still looked correct.
+-- Re-assert the configured height per FontString, and again whenever Blizzard
+-- re-stamps it. Guarded because our own write re-enters the hook.
+local _nameHeightGuard = false
+local function ApplyNameTextHeight(nameFS)
+    if _nameHeightGuard then return end
+    if not (nameFS and nameFS.SetTextHeight) then return end
+    if not IsNameOnlyMode() then return end
+    _nameHeightGuard = true
+    pcall(nameFS.SetTextHeight, nameFS, GetFriendlyNameSize())
+    _nameHeightGuard = false
+end
+
 local function EnsureNameUnconstrained(nameFS)
     if not nameFS then return end
     FixNameSizing(nameFS)
+    ApplyNameTextHeight(nameFS)
     if hookedNameFonts[nameFS] then return end
     hookedNameFonts[nameFS] = true
     hooksecurefunc(nameFS, "SetWidth", _OnNameWidthChanged)
     if nameFS.SetSize then hooksecurefunc(nameFS, "SetSize", _OnNameWidthChanged) end
+    if nameFS.SetTextHeight then hooksecurefunc(nameFS, "SetTextHeight", ApplyNameTextHeight) end
 end
 
 local function ApplyFontToNameplate(nameplate)
@@ -331,6 +351,9 @@ ns.ApplyFontToNameplate = ApplyFontToNameplate
 function ns.RefreshFriendlyNameSize()
     if IsNameOnlyMode() then
         ApplyFriendlyFontOverride()
+        -- Blizzard's per-instance name height overrides the font object, so the
+        -- visible plates need the new size stamped on directly.
+        if ReanchorAllPlayerNames then ReanchorAllPlayerNames() end
         -- The guild line hangs half a name-height below the plate centre, so
         -- a new name size moves it (ns lookup: defined later in this file).
         if ns.RefreshFriendlyBelowName then ns.RefreshFriendlyBelowName() end
@@ -720,7 +743,10 @@ function ReanchorAllPlayerNames()
     for unit, nameplate in pairs(pending) do
         if UnitIsPlayer(unit) and not UnitCanAttack("player", unit) and not UnitIsUnit(unit, "player") then
             local uf = nameplate.UnitFrame
-            if uf and uf.name then FixNameSizing(uf.name) end
+            if uf and uf.name then
+                FixNameSizing(uf.name)
+                ApplyNameTextHeight(uf.name)
+            end
         end
     end
 end


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1541791608947875890

## What does this PR do?

Fixes the Friendly Name Size slider (Nameplates, Name Only mode) not surviving a `/reload`. Blizzard's own nameplate setup (`NamePlateUnitFrameMixin:ApplyFrameOptions`) assigns the shared `SystemFont_NamePlate` font object and then stamps a per-instance text height onto each name FontString, which overrides the shared font object's size. Since the addon only wrote the configured size onto the shared font object, that override was silently lost every time nameplates were rebuilt from scratch (login/reload) - a live slider change looked correct because it restyled FontStrings already on screen, but the size reverted on the next reload. The fix re-asserts the configured height directly on each name FontString (piggybacking on the existing per-plate setup path) and re-corrects it whenever Blizzard re-stamps it.

## How was it tested?

Tested in-game on live.

## Screenshots

N/A - not a visual/layout change, same rendered result, only reload-persistence is fixed.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; existing slider now applies correctly.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - the added hook/logic only runs while Name Only mode is active, same gating as the existing font-override code.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - one extra `SetTextHeight` write per plate setup and a `hooksecurefunc` reassertion, no timers or polling added.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - only `hooksecurefunc` is used; the new `SetTextHeight` write is a cosmetic display sink on the same FontString the module already writes to, same pattern as the existing `SetWidth`/`SetSize` hooks.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
