### PR TITLE
Fix Ebon Might bar text going blank when engine overlay isn't confirmed live

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_EbonMight121.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_EbonMight121.lua
@@ -203,6 +203,17 @@ local function EnsureBuilt()
     end, "erb:emb121-shell")
 end
 
+-- True once the engine overlay's countdown text is confirmed live: false
+-- while the (async, one-shot) build is still queued, and false if the build
+-- ran but its FontString creation hit the pcall guard in Build() (armored
+-- because an uncaught error there kills the whole slot). Callers use this to
+-- fall back to the legacy numeric text instead of leaving the bar
+-- permanently blank for the rest of the session (S.built never gets a second
+-- attempt once set -- only a /reload resets it).
+function ns.EMB121_TextOk()
+    return S.built and not S.fsErr
+end
+
 -- Called from UpdatePrimaryBar whenever the primary power type resolves:
 -- parks the overlay the moment the bar stops being Ebon Might (spec swap).
 function ns.EMB121_Gate(isEbon)

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -4074,8 +4074,14 @@ local function UpdatePrimaryBar()
             end
             primaryBar:SetMinMaxValues(0, EBON_MIGHT_DURATION)
             primaryBar:SetValue(0)
-            primaryBar._text:Hide()
-            return
+            if ns.EMB121_TextOk and ns.EMB121_TextOk() then
+                primaryBar._text:Hide()
+                return
+            end
+            -- Engine text isn't confirmed live yet (build still queued, or its
+            -- one-shot FontString attempt failed and won't retry this session)
+            -- -- fall through and render the legacy numeric text below instead
+            -- of leaving the bar permanently blank.
         end
         local aura = C_UnitAuras.GetPlayerAuraBySpellID(EBON_MIGHT_SPELL_ID)
         -- Ebon Might is secret-flagged: under aura restriction the query returns
@@ -4084,19 +4090,21 @@ local function UpdatePrimaryBar()
         if aura and issecretvalue(aura.expirationTime) then aura = nil end
         _ebonMightExpiry = (aura and aura.expirationTime) or 0
         local remaining = (_ebonMightExpiry > 0) and max(0, _ebonMightExpiry - GetTime()) or 0
-        primaryBar:SetMinMaxValues(0, EBON_MIGHT_DURATION)
-        primaryBar:SetValue(remaining)
-        -- Color: custom > power color (same priority as standard)
-        local ft = primaryBar:GetStatusBarTexture()
-        if not pp.customColored then
-            local pc = POWER_COLORS["EBON_MIGHT"]
-            local r, g, b = 1, 1, 1
-            if pc then r, g, b = pc[1], pc[2], pc[3] end
-            if pp.gradientEnabled then
-                ApplyBarGradient(ft, pp.gradientDir or "HORIZONTAL", r, g, b, 1,
-                    pp.gradientR, pp.gradientG, pp.gradientB, pp.gradientA)
-            else
-                ApplyBarFlat(ft, r, g, b, 1)
+        if not ns.EMB121_Owns then
+            primaryBar:SetMinMaxValues(0, EBON_MIGHT_DURATION)
+            primaryBar:SetValue(remaining)
+            -- Color: custom > power color (same priority as standard)
+            local ft = primaryBar:GetStatusBarTexture()
+            if not pp.customColored then
+                local pc = POWER_COLORS["EBON_MIGHT"]
+                local r, g, b = 1, 1, 1
+                if pc then r, g, b = pc[1], pc[2], pc[3] end
+                if pp.gradientEnabled then
+                    ApplyBarGradient(ft, pp.gradientDir or "HORIZONTAL", r, g, b, 1,
+                        pp.gradientR, pp.gradientG, pp.gradientB, pp.gradientA)
+                else
+                    ApplyBarFlat(ft, r, g, b, 1)
+                end
             end
         end
         if pp.textFormat and pp.textFormat ~= "none" then


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1537154239560941580

Issue: The Ebon Might resource bar's countdown text could go permanently blank for the rest of a session. UpdatePrimaryBar unconditionally hid the legacy numeric text as soon as the newer EMB121 engine overlay took ownership of the bar — but that overlay builds asynchronously and creates its FontString only once, guarded by a pcall. If the build was still queued, or the one-shot FontString creation silently failed inside that pcall, the overlay's text never appeared, and since S.built never gets a second attempt (only a /reload resets it), the bar stayed blank indefinitely.

Fix: Added a check for whether the overlay's text is confirmed live before hiding the legacy text. If it isn't confirmed live, the code now falls through and renders the legacy numeric text/color path instead, so the bar always shows a number.