### PR TITLE
Fix blank names on Extra Frames after login while in group

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -6267,6 +6267,22 @@ function ns.XF_Apply()
             d.classToken = classToken
             b:SetAttribute("unit", unit)
             ns._xfUnitToButton[unit] = b
+            -- Safeguard: right after a reconnect mid-raid, the client can still be
+            -- streaming in roster data, so UnitName(unit) may not be cached yet at
+            -- this first paint -- ResolveDisplayName then commits a blank nameText
+            -- that no later event reliably corrects (field report: stayed blank
+            -- until a manual /reload). One short delayed retry closes that gap;
+            -- a no-op in the normal case where the name already resolved. Guarded
+            -- by a live re-check of both the unit's name AND this slot's current
+            -- assignment, so a stale timer from a fast reassignment can't repaint
+            -- the wrong unit's data over a different occupant.
+            if not UnitName(unit) then
+                C_Timer.After(2, function()
+                    if b:GetAttribute("unit") == unit and UnitName(unit) then
+                        UpdateButton(b)
+                    end
+                end)
+            end
             for _, ev in ipairs(XF.EVENTS) do
                 t:RegisterUnitEvent(ev, unit)
             end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541525492933337228

Issue: After a mid-raid reconnect (crash/disconnect), the "Extra Frames" tank duplicates (pinned tank frames shown separately from the main raid grid) would come up with blank name text — health bars and percentages displayed fine, but no name. It stayed blank for the rest of the session; only a /reload fixed it.

Root cause: Right after reconnecting, the client can still be streaming in roster data, so UnitName(unit) returns nil the moment Extra Frames first paints a duplicate slot. That blank result gets committed to the name text, and nothing during normal play reliably forces a repaint afterward — only a fresh /reload (by which point the name is cached) fixed it.

Fix: When a tank duplicate slot is assigned and the name isn't resolvable yet, schedule one 2-second delayed retry to repaint it — but only if that slot is still showing the same unit by then, so a fast reassignment can't paint the wrong occupant's name. No-op in the normal case where the name resolves immediately.