### PR TITLE
Fix Dynamic Health Color not updating per health tick since 9.0.1

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2047,9 +2047,17 @@ do
         -- Color inputs (class/reaction/dark/disconnect/tap) change via their
         -- own events or identity repaints -- a pure health tick re-runs the
         -- color chain only for modes whose color follows health/combat state
-        -- per tick (dynamic curve, threat, tap coloring).
-        if event ~= "UNIT_HEALTH" or element.colorSmooth
-           or element.colorThreat or element.colorTapping then
+        -- per tick (dynamic curve, threat, tap coloring). element.colorSmooth/
+        -- colorThreat/colorTapping are oUF's own flags and this addon never
+        -- sets them -- Dynamic/Class Reactive Health Color is EllesmereUI's
+        -- own PostUpdateColor path (ns.UF_DynamicHealthColor), gated by the
+        -- unit's healthColorMode setting instead, so check that directly or
+        -- a dynamic-colored bar stops tracking health value after every tick.
+        local unitKey = element._euiUnitKey
+        local unitColorMode = unitKey and db.profile[unitKey]
+        unitColorMode = unitColorMode and unitColorMode.healthColorMode
+        if event ~= "UNIT_HEALTH" or element.colorSmooth or element.colorThreat
+           or element.colorTapping or (unitColorMode and unitColorMode ~= "none") then
             UF_SecretSafeHealthColor(frame, event, unit)
         end
     end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541582176901009489

Issue: Player Dynamic Health Color stopped updating after the 9.0.1 update (worked fine on 9.0.0), and it's still broken on the current 9.0.2 release. The health bar's color would freeze instead of tracking health percentage as it changed.

Root cause: 9.0.1 added a performance optimization that skips the health-color recompute on plain health-value-change events, unless certain flags were set on the frame. But those flags belong to a different (unused) coloring system — this addon's actual Dynamic Color feature is driven by its own separate mechanism, gated by a per-frame color-mode setting that the new optimization never checked. So the gate always skipped the recompute on the very event that represents health changing, freezing the color.

Fix: Added a direct check of that per-frame color-mode setting to the gate, so the color recompute still runs on every health change when Dynamic/Class Reactive coloring is enabled — restoring the old behavior for that case while keeping the performance benefit for frames that don't use it.