### PR TITLE
Add missing Avenging Wrath buff tracking

### DIFF
--- a/EllesmereUI_BuffPresets.lua
+++ b/EllesmereUI_BuffPresets.lua
@@ -260,6 +260,7 @@ spells = {
         [190319] = { class = "MAGE" },
         [365350] = { class = "MAGE", alts = { 365362 } },
         [1249625] = { class = "MONK" },
+        [31884] = { class = "PALADIN" },
         [10060] = { class = "PRIEST" },
         [114050] = { class = "SHAMAN", alts = { 114051, 114052, 1219480 } },
         [107574] = { class = "WARRIOR" },


### PR DESCRIPTION
## What does this PR do?

In the buff presets, Paladins are not included in the offensive CDs section. This PR adds Avenging Wrath as one of the possible spells to be tracked. I have not investigated if more spells are missing here.

## How was it tested?

Tested in game; the buff is displayed as expected.

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [N/A] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [N/A] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [N/A] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
