### PR TITLE
task(macrofactory): added new 12.1 hp pots

### DIFF
--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -208,7 +208,7 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
             icon = "Interface\\Icons\\inv_potion_131",
             label = "Health / Recuperate (Combat Based)",
             spells = {1231418}, -- Recuperate (universal campfire self-heal)
-            fixedBody = "/stopcasting\n/cast [nocombat] {1}\n/use [combat] item:271884\n/use [combat] item:271883\n/use [combat] item:241304\n/use [combat] item:241305",
+            fixedBody = "/stopcasting\n/cast [nocombat] {1}\n/use [combat] item:271883\n/use [combat] item:271884\n/use [combat] item:241304\n/use [combat] item:241305",
             fixedTooltip = "item:271884",
         },
         {

--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -208,8 +208,8 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
             icon = "Interface\\Icons\\inv_potion_131",
             label = "Health / Recuperate (Combat Based)",
             spells = {1231418}, -- Recuperate (universal campfire self-heal)
-            fixedBody = "/stopcasting\n/cast [nocombat] {1}\n/use [combat] item:241304\n/use [combat] item:241305",
-            fixedTooltip = "item:241304",
+            fixedBody = "/stopcasting\n/cast [nocombat] {1}\n/use [combat] item:271884\n/use [combat] item:271883\n/use [combat] item:241304\n/use [combat] item:241305",
+            fixedTooltip = "item:271884",
         },
         {
             name = "EUI_Food",


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Added spell ids for r1 and r2 health pots added in 12.1 (Concentrated Silvermoon Health Potion) to the MacroFactory.

Still works with old health potions

## How was it tested?

Delete old macro and created macro under Quality of Life > General Macro Factory > Health / Recuperate

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->
<img width="396" height="255" alt="image" src="https://github.com/user-attachments/assets/0abefb05-9c9a-434a-b481-43ca3aee3896" />


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
Old macro would need to be delete for changes to take effect.
- [n/a] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [n/a] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [n/a] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
