### PR TITLE
[bugfix] Fix Vault font/icon coloring & Character Screen fonts

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -4276,6 +4276,23 @@ function EllesmereUI.ApplyIconTextFont(fs, fontPath, size, moduleKey)
     fs:SetFont(fontPath, size, flag)
 end
 
+-- fonts a string from the user's global/module font settings
+function EllesmereUI.ApplyTextFont(fs, moduleKey, size)
+    if not (fs and fs.SetFont) then return end
+
+    local font = EllesmereUI.GetFontPath(moduleKey)
+    if not size then
+        local _, cur = fs:GetFont()
+        size = cur or 12
+    end
+    local flag = EllesmereUI.GetFontOutlineFlag(moduleKey)
+
+    -- prime the shadow FontObject before SetFont (see PrimeFontShadow).
+    local useShadow = flag == "" and EllesmereUI.GetFontUseShadow(moduleKey)
+    EllesmereUI.PrimeFontShadow(fs, useShadow)
+    fs:SetFont(font, size, flag)
+end
+
 -- Build font dropdown values/order ("EUI Global Font" first) for W:DualRow configs.
 function EllesmereUI.BuildFontDropdownData()
     -- Glyph-restricted locales: bundled Latin fonts cannot render the script (and resolve to the

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -16,6 +16,10 @@ local function GetFFD(frame)
     return d
 end
 
+local function ApplyFont(fs, size)
+    EllesmereUI.ApplyTextFont(fs, "blizzardSkin", size)
+end
+
 -- Same reading as the Chat sidebar icon and the DataBars block: the LOWEST
 -- percent across equipped slots 1-18 (the weakest item), floored.
 local function GetDurabilityPercent()
@@ -751,7 +755,6 @@ local function SkinCharacterSheet()
         end)
     end
 
-    local fontPath = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("blizzardSkin") or STANDARD_TEXT_FONT
     local EG = EllesmereUI.ELLESMERE_GREEN or { r = 0.51, g = 0.784, b = 1 }
 
     do
@@ -763,13 +766,13 @@ local function SkinCharacterSheet()
             GetFFD(frame).durabilityOverlay = durOverlay
 
             local durabilityModelLabel = durOverlay:CreateFontString(nil, "OVERLAY")
-            durabilityModelLabel:SetFont(fontPath, 12, "")
+            ApplyFont(durabilityModelLabel, 12)
             durabilityModelLabel:SetPoint("TOP", modelScene, "TOP", 0, -8)
             GetFFD(frame).durabilityModelLabel = durabilityModelLabel
         end
         if not GetFFD(frame).durabilityFooterLabel then
             local durabilityFooterLabel = frame:CreateFontString(nil, "OVERLAY")
-            durabilityFooterLabel:SetFont(fontPath, 12, "")
+            ApplyFont(durabilityFooterLabel, 12)
             GetFFD(frame).durabilityFooterLabel = durabilityFooterLabel
         end
     end
@@ -818,7 +821,7 @@ local function SkinCharacterSheet()
 
             if not GetFFD(tab).label then
                 local label = tab:CreateFontString(nil, "OVERLAY")
-                label:SetFont(fontPath, 9, "")
+                ApplyFont(label, 9)
                 label:SetPoint("CENTER", tab, "CENTER", 0, 0)
                 label:SetJustifyH("CENTER")
                 label:SetText(labelText)
@@ -1301,7 +1304,7 @@ local function SkinCharacterSheet()
 
     -- M+ Score display (single inline FontString above itemlevel), colored via |cff...|r escapes based on score brackets.
     local mythicRatingLabel = statsPanel:CreateFontString(nil, "OVERLAY")
-    mythicRatingLabel:SetFont(fontPath, 12, "")
+    ApplyFont(mythicRatingLabel, 12)
     -- Positioned below iLvlText once that FontString exists (see below).
     mythicRatingLabel:SetTextColor(0.8, 0.8, 0.8, 1)
     mythicRatingLabel:SetText(L("M+ Score:"))
@@ -1335,14 +1338,14 @@ local function SkinCharacterSheet()
 
     -- Itemlevel display: sits just below the 3 tab buttons, inside the panel.
     local iLvlText = statsPanel:CreateFontString(nil, "OVERLAY")
-    iLvlText:SetFont(fontPath, 18, "")
+    ApplyFont(iLvlText, 18)
     iLvlText:SetPoint("TOP", statsPanel, "TOP", 0, -(25 + 3))  -- buttonHeight(25) + 3 gap
     iLvlText:SetTextColor(0.6, 0.2, 1, 1)
     GetFFD(frame).iLvlText = iLvlText  -- Store for tab visibility control
 
     -- PvP Item Level: sits directly below the iLvl text when enabled.
     local pvpIlvlText = statsPanel:CreateFontString(nil, "OVERLAY")
-    pvpIlvlText:SetFont(fontPath, 12, "")
+    ApplyFont(pvpIlvlText, 12)
     pvpIlvlText:SetTextColor(0.8, 0.8, 0.8, 1)
     pvpIlvlText:SetPoint("TOP", iLvlText, "BOTTOM", 0, -4)
     pvpIlvlText:Hide()
@@ -1352,7 +1355,7 @@ local function SkinCharacterSheet()
     mythicRatingLabel:SetPoint("TOP", pvpIlvlText, "BOTTOM", 0, -4)
 
     local durabilityHeaderLabel = statsPanel:CreateFontString(nil, "OVERLAY")
-    durabilityHeaderLabel:SetFont(fontPath, 12, "")
+    ApplyFont(durabilityHeaderLabel, 12)
     durabilityHeaderLabel:Hide()
     GetFFD(frame).durabilityHeaderLabel = durabilityHeaderLabel
 
@@ -2263,7 +2266,7 @@ local function SkinCharacterSheet()
         titleContainer:RegisterForClicks("LeftButtonUp")
 
         local sectionTitle = titleContainer:CreateFontString(nil, "OVERLAY")
-        sectionTitle:SetFont(fontPath, 11, "")
+        ApplyFont(sectionTitle, 11)
         sectionTitle:SetTextColor(section.color.r, section.color.g, section.color.b, 1)
         sectionTitle:SetPoint("CENTER", titleContainer, "CENTER", 0, 0)
         sectionTitle:SetText(L(section.title))
@@ -2332,13 +2335,13 @@ local function SkinCharacterSheet()
         for statIdx, stat in ipairs(section.stats) do
             if ShouldShowStat(stat.showWhen) and ShouldShowCrest(stat) then
                 local label = sectionContainer:CreateFontString(nil, "OVERLAY")
-                label:SetFont(fontPath, 10, "")
+                ApplyFont(label, 10)
                 label:SetTextColor(0.7, 0.7, 0.7, 0.8)
                 label:SetPoint("TOPLEFT", sectionContainer, "TOPLEFT", 0, statYOffset)
                 label:SetText(L(stat.name))
 
                 local value = sectionContainer:CreateFontString(nil, "OVERLAY")
-                value:SetFont(fontPath, 10, "")
+                ApplyFont(value, 10)
                 value:SetTextColor(section.color.r, section.color.g, section.color.b, 1)
                 value:SetPoint("TOPRIGHT", sectionContainer, "TOPRIGHT", 0, statYOffset)
                 value:SetJustifyH("RIGHT")
@@ -2907,7 +2910,7 @@ local function SkinCharacterSheet()
         btn:SetPoint("TOPLEFT", frame, "TOPLEFT", startX, startY)
 
         local text = btn:CreateFontString(nil, "OVERLAY")
-        text:SetFont(fontPath, 10, "")
+        ApplyFont(text, 10)
         -- Anchor TOP (not CENTER) so the text sits flush with the top of the panel
         -- section instead of floating ~12px down inside a tall button.
         text:SetPoint("TOP", btn, "TOP", 0, 0)
@@ -2961,11 +2964,11 @@ local function SkinCharacterSheet()
     searchBg:SetAllPoints()
 
     titlesSearchBox:SetTextColor(1, 1, 1, 1)
-    titlesSearchBox:SetFont(fontPath, 10, "")
+    ApplyFont(titlesSearchBox, 10)
     titlesSearchBox:SetTextInsets(4, 4, 0, 0)
 
     local hintText = titlesSearchBox:CreateFontString(nil, "OVERLAY")
-    hintText:SetFont(fontPath, 10, "")
+    ApplyFont(hintText, 10)
     hintText:SetText(L("Search titles..."))
     hintText:SetTextColor(0.6, 0.6, 0.6, 0.7)
     hintText:SetPoint("LEFT", titlesSearchBox, "LEFT", 4, 0)
@@ -2973,7 +2976,7 @@ local function SkinCharacterSheet()
     -- Clear "x" (visible only when the search box has text). Invisible click
     -- target sits on top of the glyph so it can be clicked to clear.
     local clearX = titlesSearchBox:CreateFontString(nil, "OVERLAY")
-    clearX:SetFont(fontPath, 11, "")
+    ApplyFont(clearX, 11)
     clearX:SetText("x")
     clearX:SetTextColor(0.7, 0.7, 0.7, 1)
     clearX:SetPoint("RIGHT", titlesSearchBox, "RIGHT", -4, 0)
@@ -3059,7 +3062,7 @@ local function SkinCharacterSheet()
         btn._hover:Hide()
 
         btn._text = btn:CreateFontString(nil, "OVERLAY")
-        btn._text:SetFont(fontPath, 11, "")
+        ApplyFont(btn._text, 11)
         btn._text:SetTextColor(1, 1, 1, 1)
         btn._text:SetPoint("LEFT", btn, "LEFT", 10, 0)
 
@@ -3261,7 +3264,7 @@ local function SkinCharacterSheet()
     setsHeaderFrame:SetPoint("TOPRIGHT", equipScrollChild, "TOPRIGHT", -5, -30)
 
     local setsHeaderText = setsHeaderFrame:CreateFontString(nil, "OVERLAY")
-    setsHeaderText:SetFont(fontPath, 11, "")
+    ApplyFont(setsHeaderText, 11)
     setsHeaderText:SetText(L("Gear Sets"))
     setsHeaderText:SetTextColor(0.047, 0.824, 0.616, 1)
     setsHeaderText:SetPoint("CENTER", setsHeaderFrame, "CENTER", 0, 0)
@@ -3296,7 +3299,7 @@ local function SkinCharacterSheet()
     local function MakeTextLink(parent, label, onClick)
         local btn = CreateFrame("Button", nil, parent)
         local fs = btn:CreateFontString(nil, "OVERLAY")
-        fs:SetFont(fontPath, 10, "")
+        ApplyFont(fs, 10)
         fs:SetText(label)
         fs:SetTextColor(1, 1, 1, 0.7)
         fs:SetPoint("CENTER", btn, "CENTER", 0, 0)
@@ -3488,7 +3491,7 @@ local function SkinCharacterSheet()
             tile._hover:Hide()
 
             tile._text = tile:CreateFontString(nil, "OVERLAY")
-            tile._text:SetFont(fontPath, 10, "")
+            ApplyFont(tile._text, 10)
             tile._text:SetPoint("LEFT", tile, "LEFT", 10, 0)
 
             tile._specIcon = tile:CreateTexture(nil, "OVERLAY")
@@ -3570,7 +3573,7 @@ local function SkinCharacterSheet()
             local delTxt = del:CreateFontString(nil, "OVERLAY")
             -- 12pt "x" nudged up 1px; larger sizes overflow the 14x14 button and
             -- render as a giant X.
-            delTxt:SetFont(fontPath, 12, "")
+            ApplyFont(delTxt, 12)
             delTxt:SetText("x")
             delTxt:SetTextColor(1, 1, 1, 0.8)
             delTxt:SetPoint("CENTER", del, "CENTER", 0, 1)
@@ -3854,7 +3857,6 @@ local function SkinCharacterSheet()
         "CharacterTrinket0Slot", "CharacterTrinket1Slot"
     }
 
-    local fontPath = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("blizzardSkin") or STANDARD_TEXT_FONT
 
     local globalSocketContainer = CreateFrame("Frame", "EUI_CharSheet_SocketContainer", frame)
     globalSocketContainer:SetFrameLevel(100)
@@ -3919,7 +3921,7 @@ local function SkinCharacterSheet()
         if slot and not GetFFD(slot).itemLevelLabel and not skipLabels then
             local itemLevelSize = EllesmereUIDB and EllesmereUIDB.charSheetItemLevelSize or 11
             local label = textOverlayFrame:CreateFontString(nil, "OVERLAY")
-            label:SetFont(fontPath, itemLevelSize, "")
+            ApplyFont(label, itemLevelSize)
             label:SetTextColor(1, 1, 1, 0.8)
             label:SetJustifyH("CENTER")
 
@@ -3941,7 +3943,7 @@ local function SkinCharacterSheet()
         if slot and not GetFFD(slot).enchantLabel and not skipLabels then
             local enchantSize = EllesmereUIDB and EllesmereUIDB.charSheetEnchantSize or 9
             local enchantLabel = textOverlayFrame:CreateFontString(nil, "OVERLAY")
-            enchantLabel:SetFont(fontPath, enchantSize, "")
+            ApplyFont(enchantLabel, enchantSize)
             enchantLabel:SetTextColor(1, 1, 1, 0.8)
 
             -- Below the itemlevel, justified toward the icon so a width-capped
@@ -3986,7 +3988,7 @@ local function SkinCharacterSheet()
         if slot and not GetFFD(slot).upgradeTrackLabel and GetFFD(slot).itemLevelLabel then
             local upgradeTrackSize = EllesmereUIDB and EllesmereUIDB.charSheetUpgradeTrackSize or 11
             local upgradeTrackLabel = textOverlayFrame:CreateFontString(nil, "OVERLAY")
-            upgradeTrackLabel:SetFont(fontPath, upgradeTrackSize, "")
+            ApplyFont(upgradeTrackLabel, upgradeTrackSize)
             upgradeTrackLabel:SetTextColor(1, 1, 1, 0.6)
             upgradeTrackLabel:SetJustifyH("CENTER")
 
@@ -4500,8 +4502,7 @@ local function SkinCharacterSheet()
                 GetFFD(slot).enchantLabel:SetText(labelText)
                 local enchFontSize = (EllesmereUIDB and EllesmereUIDB.charSheetEnchantSize) or 9
                 if useName then
-                    -- Names always render OUTLINE, SLUG for legibility over the model.
-                    GetFFD(slot).enchantLabel:SetFont(fontPath, enchFontSize, "OUTLINE, SLUG")
+                    ApplyFont(GetFFD(slot).enchantLabel, enchFontSize)
                     -- Item-level color, blended 50% toward white so the name reads
                     -- softer than the ilvl number.
                     GetFFD(slot).enchantLabel:SetTextColor(
@@ -4521,10 +4522,9 @@ local function SkinCharacterSheet()
                     GetFFD(slot).enchantLabel:SetWordWrap(false)
                     GetFFD(slot).enchantLabel:SetWidth(maxW or 0)
                 else
-                    -- Icon mode: no outline (the label's creation default), white
-                    -- tint so a prior name-mode color never bleeds onto the atlas
-                    -- icons, and clear the width cap.
-                    GetFFD(slot).enchantLabel:SetFont(fontPath, enchFontSize, "")
+                    -- icon mode: white tint so a prior name color never bleeds onto
+                    -- the atlas icons, and clear the width cap.
+                    ApplyFont(GetFFD(slot).enchantLabel, enchFontSize)
                     GetFFD(slot).enchantLabel:SetTextColor(1, 1, 1, 0.8)
                     GetFFD(slot).enchantLabel:SetWidth(0)
                 end
@@ -4693,7 +4693,6 @@ local function EnsureCalcTab(frame)
     local existing = GetFFD(frame).calcToggleBtn
     if existing then return existing end
 
-    local fontPath = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("blizzardSkin") or STANDARD_TEXT_FONT
     local PP = EllesmereUI and EllesmereUI.PP
 
     local refTab = _G["CharacterFrameTab1"]
@@ -4717,7 +4716,7 @@ local function EnsureCalcTab(frame)
     activeHL:Hide()
 
     local label = calcTab:CreateFontString(nil, "OVERLAY")
-    label:SetFont(fontPath, 9, "")
+    ApplyFont(label, 9)
     label:SetPoint("CENTER", calcTab, "CENTER", 0, 0)
     label:SetJustifyH("CENTER")
     label:SetText("Upgrades")
@@ -4985,7 +4984,7 @@ if EllesmereUI then
     end)
 end
 
--- Apply the char-sheet label size / outline / shadow settings.
+-- gear-label sizes; outline follows the module/global font choice.
 function EllesmereUI._applyCharSheetTextSizes()
     if not CharacterFrame then return end
 
@@ -4993,43 +4992,19 @@ function EllesmereUI._applyCharSheetTextSizes()
     local upgradeTrackSize = EllesmereUIDB and EllesmereUIDB.charSheetUpgradeTrackSize or 11
     local enchantSize = EllesmereUIDB and EllesmereUIDB.charSheetEnchantSize or 9
 
-    local itemLevelShadow = EllesmereUIDB and EllesmereUIDB.charSheetItemLevelShadow or false
-    local itemLevelOutline = EllesmereUIDB and EllesmereUIDB.charSheetItemLevelOutline or false
-    local upgradeTrackShadow = EllesmereUIDB and EllesmereUIDB.charSheetUpgradeTrackShadow or false
-    local upgradeTrackOutline = EllesmereUIDB and EllesmereUIDB.charSheetUpgradeTrackOutline or false
-    local enchantShadow = EllesmereUIDB and EllesmereUIDB.charSheetEnchantShadow or false
-    local enchantOutline = EllesmereUIDB and EllesmereUIDB.charSheetEnchantOutline or false
-
-    local fontPath = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("blizzardSkin") or STANDARD_TEXT_FONT
-
     local itemSlots = EUI_GEAR_SLOTS
 
     for _, slotName in ipairs(itemSlots) do
         local slot = _G[slotName]
         if slot then
             if GetFFD(slot).itemLevelLabel then
-                local flags = ""
-                if itemLevelOutline then
-                    flags = "OUTLINE, SLUG"
-                end
-                if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(GetFFD(slot).itemLevelLabel, itemLevelShadow) end
-                GetFFD(slot).itemLevelLabel:SetFont(fontPath, itemLevelSize, flags)
+                ApplyFont(GetFFD(slot).itemLevelLabel, itemLevelSize)
             end
             if GetFFD(slot).upgradeTrackLabel then
-                local flags = ""
-                if upgradeTrackOutline then
-                    flags = "OUTLINE, SLUG"
-                end
-                if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(GetFFD(slot).upgradeTrackLabel, upgradeTrackShadow) end
-                GetFFD(slot).upgradeTrackLabel:SetFont(fontPath, upgradeTrackSize, flags)
+                ApplyFont(GetFFD(slot).upgradeTrackLabel, upgradeTrackSize)
             end
             if GetFFD(slot).enchantLabel then
-                local flags = ""
-                if enchantOutline then
-                    flags = "OUTLINE, SLUG"
-                end
-                if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(GetFFD(slot).enchantLabel, enchantShadow) end
-                GetFFD(slot).enchantLabel:SetFont(fontPath, enchantSize, flags)
+                ApplyFont(GetFFD(slot).enchantLabel, enchantSize)
             end
         end
     end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GreatVault.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GreatVault.lua
@@ -451,7 +451,8 @@ local function RefreshTypeFrameState(frame, theme)
     if not frame then return end
     if frame.Name then
         local c = STYLE.colors.typeName
-        frame.Name:SetTextColor(c.r, c.g, c.b, 1)
+        -- nil size keeps Blizzard's native size
+        ApplyFont(frame.Name, nil, c.r, c.g, c.b, 1)
 
         local d = GetFFD(frame)
         if not d.nameRaised then

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GreatVault.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GreatVault.lua
@@ -28,7 +28,6 @@ local STYLE = {
         inset = 3,
         activityCard = 4,
         concessionCard = 6,
-        icon = 2,
     },
     sizes = {
         itemName = 10,
@@ -99,7 +98,7 @@ end
 
 local function SetBorderColor(frame, theme, color, alpha)
     local pp = theme and theme.borderAPI
-    if pp and pp.SetBorderColor and frame and frame._ppBorders and color then
+    if pp and pp.SetBorderColor and frame and color then
         pp.SetBorderColor(frame, color.r or 1, color.g or 1, color.b or 1, alpha or color.a or 1)
     end
 end
@@ -261,13 +260,32 @@ local function EnsureLockIcon(frame, anchorFrame)
     return lock
 end
 
+local function ValidLink(link)
+    if type(link) == "string" and link ~= "" then
+        return link
+    end
+    return nil
+end
+
 local function ResolveWeeklyRewardItemLink(activityFrame, itemFrame)
+    -- reward lands on displayedItem*, not itemLink/itemDBID
     if itemFrame then
-        if itemFrame.itemLink then
-            return itemFrame.itemLink
+        local link = ValidLink(itemFrame.displayedItemLink)
+        if link then
+            return link
         end
-        if itemFrame.itemHyperlink then
-            return itemFrame.itemHyperlink
+        if itemFrame.displayedItemDBID and C_WeeklyRewards and C_WeeklyRewards.GetItemHyperlink then
+            local ok, itemLink = pcall(C_WeeklyRewards.GetItemHyperlink, itemFrame.displayedItemDBID)
+            if ok then
+                link = ValidLink(itemLink)
+                if link then
+                    return link
+                end
+            end
+        end
+        link = ValidLink(itemFrame.itemLink) or ValidLink(itemFrame.itemHyperlink)
+        if link then
+            return link
         end
         if itemFrame.itemDBID and C_WeeklyRewards and C_WeeklyRewards.GetItemHyperlink then
             local itemLink = C_WeeklyRewards.GetItemHyperlink(itemFrame.itemDBID)
@@ -278,17 +296,27 @@ local function ResolveWeeklyRewardItemLink(activityFrame, itemFrame)
     end
 
     local info = activityFrame and activityFrame.info
-    local rewards = info and info.rewards
-    if type(rewards) ~= "table" then
+    if not info then
         return nil
     end
 
-    for _, reward in ipairs(rewards) do
-        if reward and reward.itemDBID and C_WeeklyRewards and C_WeeklyRewards.GetItemHyperlink then
-            local itemLink = C_WeeklyRewards.GetItemHyperlink(reward.itemDBID)
-            if itemLink then
-                return itemLink
+    local rewards = info.rewards
+    if type(rewards) == "table" then
+        for _, reward in ipairs(rewards) do
+            if reward and reward.itemDBID and C_WeeklyRewards and C_WeeklyRewards.GetItemHyperlink then
+                local ok, itemLink = pcall(C_WeeklyRewards.GetItemHyperlink, reward.itemDBID)
+                if ok and ValidLink(itemLink) then
+                    return itemLink
+                end
             end
+        end
+    end
+
+    -- returns "" not nil when there's no preview
+    if info.id and C_WeeklyRewards and C_WeeklyRewards.GetExampleRewardItemHyperlinks then
+        local ok, itemLink = pcall(C_WeeklyRewards.GetExampleRewardItemHyperlinks, info.id)
+        if ok and ValidLink(itemLink) then
+            return itemLink
         end
     end
 
@@ -300,13 +328,10 @@ local function ResolveItemBorderColor(itemLink)
         return STYLE.colors.itemDefaultBorder
     end
 
-    local quality
-    if C_Item and C_Item.GetItemQualityByID then
+    -- GetItemInfo reads the link -  GetItemQualityByID only the base item
+    local _, _, quality = GetItemInfo(itemLink)
+    if not quality and C_Item and C_Item.GetItemQualityByID then
         quality = C_Item.GetItemQualityByID(itemLink)
-    end
-    if not quality then
-        local _, _, itemQuality = GetItemInfo(itemLink)
-        quality = itemQuality
     end
 
     if quality then
@@ -328,35 +353,48 @@ local function EnsureIconChrome(itemFrame, theme, borderColor)
     if not itemFrame or not itemFrame.Icon then return end
 
     local icon = itemFrame.Icon
-    local pad = STYLE.paddings.icon
     local pp = theme.borderAPI
     local d = GetFFD(itemFrame)
+
+    if not d.iconBg then
+        d.iconBg = itemFrame._euiIconBg
+    end
 
     if not d.iconBg then
         local bg = itemFrame:CreateTexture(nil, "BACKGROUND", nil, -6)
         bg._euiOwned = true
         d.iconBg = bg
+        itemFrame._euiIconBg = bg
     end
 
+    -- flush: inset left a grey ring reading as a second border
     d.iconBg:ClearAllPoints()
-    d.iconBg:SetPoint("TOPLEFT", icon, "TOPLEFT", -pad, pad)
-    d.iconBg:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT", pad, -pad)
+    d.iconBg:SetAllPoints(icon)
     ApplyColorTexture(d.iconBg, STYLE.colors.itemSlotBackground)
+
+    -- also on the frame: FFD is weak and these frames are pooled
+    if not d.iconBorder then
+        d.iconBorder = itemFrame._euiIconBorderHost
+    end
 
     if not d.iconBorder then
         local borderHost = CreateFrame("Frame", nil, itemFrame)
         d.iconBorder = borderHost
+        itemFrame._euiIconBorderHost = borderHost
 
         if pp and pp.CreateBorder then
-            pp.CreateBorder(borderHost, 1, 1, 1, 1, 2, "OVERLAY", 7)
+            pp.CreateBorder(borderHost, 1, 1, 1, 1, 1, "OVERLAY", 7)
         end
     end
 
+    -- flush: inset left a gap showing the card background
     local borderHost = d.iconBorder
     borderHost:ClearAllPoints()
-    borderHost:SetPoint("TOPLEFT", icon, "TOPLEFT", -pad, pad)
-    borderHost:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT", pad, -pad)
+    borderHost:SetAllPoints(icon)
     borderHost:SetFrameLevel(itemFrame:GetFrameLevel() + 1)
+    if pp and pp.SetBorderSize then
+        pp.SetBorderSize(borderHost, 1)
+    end
     SetBorderColor(borderHost, theme, borderColor or STYLE.colors.itemDefaultBorder, 1)
 
     return borderHost
@@ -478,6 +516,17 @@ local function RefreshActivityItemState(itemFrame, activityFrame, theme)
     local borderColor = ResolveItemBorderColor(itemLink)
     EnsureIconChrome(itemFrame, theme, borderColor)
 
+    -- reward swaps after Refresh, so recolor from the item frame
+    local d = GetFFD(itemFrame)
+    if not d.displayHooked and itemFrame.SetDisplayedItem then
+        d.displayHooked = true
+        hooksecurefunc(itemFrame, "SetDisplayedItem", function(self)
+            local parent = self:GetParent()
+            local link = ResolveWeeklyRewardItemLink(parent, self)
+            EnsureIconChrome(self, BuildThemeContext(), ResolveItemBorderColor(link))
+        end)
+    end
+
     if itemFrame.Name then
         ApplyFont(itemFrame.Name, STYLE.sizes.itemName, 1, 1, 1, STYLE.alpha.itemName)
     end
@@ -535,11 +584,8 @@ local function RefreshSelectableCardState(theme, skinFrame, glow, state)
 
     if not skinFrame then return end
 
-    if state.isSelected then
-        SetBorderColor(skinFrame, theme, theme.accent, STYLE.alpha.selectedBorder)
-    else
-        SetBorderColor(skinFrame, theme, state.borderColor or STYLE.colors.white, state.borderAlpha)
-    end
+    -- keep the faint edge from EnsureInsetBackdrop; rarity lives on the icon
+    SetBorderColor(skinFrame, theme, STYLE.colors.white, theme.reskin.BRD_ALPHA)
 end
 
 local function RefreshActivityVisualState(frame, selectedActivity, theme)
@@ -916,6 +962,15 @@ local function HookGreatVault()
             ScheduleGreatVaultRefresh(self)
         end)
     end
+
+    -- links are uncached on first pass; recolor as they arrive
+    local itemInfoFrame = CreateFrame("Frame")
+    itemInfoFrame:RegisterEvent("GET_ITEM_INFO_RECEIVED")
+    itemInfoFrame:SetScript("OnEvent", function()
+        if frame:IsShown() then
+            ScheduleGreatVaultRefresh(frame)
+        end
+    end)
 end
 
 do

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GreatVault.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GreatVault.lua
@@ -85,7 +85,6 @@ local function BuildThemeContext()
     return {
         accent = { r = r, g = g, b = b },
         borderAPI = EllesmereUI.PP or EllesmereUI.PanelPP,
-        fontPath = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("blizzardSkin") or STANDARD_TEXT_FONT,
         reskin = EllesmereUI.RESKIN or DEFAULT_RESKIN,
     }
 end
@@ -128,11 +127,10 @@ local function SuppressTexture(texture)
     end
 end
 
-local function ApplyFont(fontString, theme, size, r, g, b, a, flags)
+local function ApplyFont(fontString, size, r, g, b, a)
     if not fontString then return end
 
-    if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fontString, true) end
-    fontString:SetFont((theme and theme.fontPath) or STANDARD_TEXT_FONT, size, flags or "")
+    EllesmereUI.ApplyTextFont(fontString, "blizzardSkin", size)
     fontString:SetTextColor(r or 1, g or 1, b or 1, a or 1)
 end
 
@@ -480,7 +478,7 @@ local function RefreshActivityItemState(itemFrame, activityFrame, theme)
     EnsureIconChrome(itemFrame, theme, borderColor)
 
     if itemFrame.Name then
-        ApplyFont(itemFrame.Name, theme, STYLE.sizes.itemName, 1, 1, 1, STYLE.alpha.itemName)
+        ApplyFont(itemFrame.Name, STYLE.sizes.itemName, 1, 1, 1, STYLE.alpha.itemName)
     end
 end
 
@@ -648,7 +646,7 @@ local function RefreshActivityVisualState(frame, selectedActivity, theme)
 
     if frame.Threshold then
         local thresholdAlpha = activityState.isComplete and STYLE.alpha.thresholdUnlocked or STYLE.alpha.thresholdLocked
-        ApplyFont(frame.Threshold, theme, STYLE.sizes.threshold, 1, 1, 1, thresholdAlpha)
+        ApplyFont(frame.Threshold, STYLE.sizes.threshold, 1, 1, 1, thresholdAlpha)
     end
 
     if frame.Progress then
@@ -657,7 +655,7 @@ local function RefreshActivityVisualState(frame, selectedActivity, theme)
             -- we already modified it on a prior pass so it stays current.
             local rawText = frame.Progress:GetText() or ""
             local diffText = rawText:match("^%d+%s*%((.+)%)$") or rawText
-            ApplyFont(frame.Progress, theme, STYLE.sizes.progress, complete.r, complete.g, complete.b, 1)
+            ApplyFont(frame.Progress, STYLE.sizes.progress, complete.r, complete.g, complete.b, 1)
 
             local info = frame.info
             local ilvl
@@ -674,7 +672,6 @@ local function RefreshActivityVisualState(frame, selectedActivity, theme)
             local progressColor = activityState.progressColor
             ApplyFont(
                 frame.Progress,
-                theme,
                 STYLE.sizes.progress,
                 progressColor.r,
                 progressColor.g,
@@ -726,10 +723,10 @@ local function RefreshConcessionVisualState(frame, selectedActivity, theme)
 
     if frame.RewardsFrame then
         if frame.RewardsFrame.Label then
-            ApplyFont(frame.RewardsFrame.Label, theme, STYLE.sizes.itemName, 1, 1, 1, STYLE.alpha.rewardsLabel)
+            ApplyFont(frame.RewardsFrame.Label, STYLE.sizes.itemName, 1, 1, 1, STYLE.alpha.rewardsLabel)
         end
         if frame.RewardsFrame.Text then
-            ApplyFont(frame.RewardsFrame.Text, theme, STYLE.sizes.itemName, theme.accent.r, theme.accent.g, theme.accent.b, 1)
+            ApplyFont(frame.RewardsFrame.Text, STYLE.sizes.itemName, theme.accent.r, theme.accent.g, theme.accent.b, 1)
         end
     end
 end
@@ -742,10 +739,10 @@ local function RefreshOverlayState(overlay, theme)
     if overlay.NineSlice then overlay.NineSlice:SetAlpha(0) end
 
     if overlay.Title then
-        ApplyFont(overlay.Title, theme, STYLE.sizes.overlayTitle, theme.accent.r, theme.accent.g, theme.accent.b, 1)
+        ApplyFont(overlay.Title, STYLE.sizes.overlayTitle, theme.accent.r, theme.accent.g, theme.accent.b, 1)
     end
     if overlay.Text then
-        ApplyFont(overlay.Text, theme, STYLE.sizes.overlayText, 1, 1, 1, STYLE.alpha.overlayText)
+        ApplyFont(overlay.Text, STYLE.sizes.overlayText, 1, 1, 1, STYLE.alpha.overlayText)
     end
 end
 
@@ -758,7 +755,7 @@ local function RefreshWarningDialogState(frame, theme)
         frame.WarningIcon:SetDesaturated(true)
     end
     if frame.Description then
-        ApplyFont(frame.Description, theme, STYLE.sizes.warningText, 1, 1, 1, STYLE.alpha.warningText)
+        ApplyFont(frame.Description, STYLE.sizes.warningText, 1, 1, 1, STYLE.alpha.warningText)
     end
     -- Any standard buttons on the dialog get the engine treatment too
     -- (depth-capped, no-op when there are none).
@@ -840,7 +837,7 @@ RefreshGreatVaultFrame = function(frame)
                     hf.Text:ClearAllPoints()
                     hf.Text:SetPoint(point, rel, relPoint, x, (y or 0) + 30)
                 end
-                hf.Text:SetFont(theme.fontPath, STYLE.sizes.headerTitle, "")
+                EllesmereUI.ApplyTextFont(hf.Text, "blizzardSkin", STYLE.sizes.headerTitle)
             end
 
             if hf.HeaderDivider then


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Applies global/module settings to Character Sheet and Great Vault window skins
Also fixes the coloration of the default "white" on the icon borders of great vault items to their rarity

## How was it tested?

Live on 12.1.0.69497

## Screenshots
Settings:
<img width="943" height="250" alt="image" src="https://github.com/user-attachments/assets/a9ff5db8-bcba-482b-a9eb-c1e786372fb7" />

### Character Sheet
Before:
<img width="751" height="632" alt="image" src="https://github.com/user-attachments/assets/972c180f-e5a3-4492-a8d4-f4f32745e889" />

After:
<img width="747" height="633" alt="image" src="https://github.com/user-attachments/assets/6221a141-fa27-49d4-98ec-7248d085c0a0" />


### Great Vault
Before:
<img width="1407" height="912" alt="image" src="https://github.com/user-attachments/assets/c4b2a8c8-fc15-4b44-90ba-47665cbd992c" />

After:
<img width="1431" height="937" alt="image" src="https://github.com/user-attachments/assets/4ea6e625-df7e-487b-9bb3-7ce1c2617282" />


### Different settings
Settings:
<img width="957" height="92" alt="image" src="https://github.com/user-attachments/assets/e1ad98e5-8627-48a2-a5c7-07fc6be652e0" />
<img width="746" height="647" alt="image" src="https://github.com/user-attachments/assets/759b3c60-514c-46bf-acdb-3ea886a7a984" />
<img width="1427" height="913" alt="image" src="https://github.com/user-attachments/assets/3aa1b77c-b82a-4d9f-a988-21b589580067" />

item coloration fix:
<img width="845" height="577" alt="image" src="https://github.com/user-attachments/assets/edd3dd37-b428-42fc-b617-bfbf1be48e76" />




## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
