### PR TITLE
Fix Roll the Bones tracking bar losing its binding after a re-roll

### DIFF
--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -2679,6 +2679,25 @@ initFrame:SetScript("OnEvent", function(self)
                     if info and info.spellID and info.spellID > 0 and info.spellID ~= sp.spellID then
                         barCfg.baseSpellID = info.spellID
                     end
+                    -- Roll the Bones only: its tracked slot cycles through several
+                    -- mutually exclusive outcome buffs (whichever roll is currently
+                    -- up), told apart live via linkedSpellIDs rather than a
+                    -- hardcoded outcome list (names/ids shift across reworks --
+                    -- e.g. Midnight's). Without this, the bar only ever matched
+                    -- whichever single outcome happened to be active at add time
+                    -- (field report: name froze on that outcome and the bar
+                    -- eventually lost its binding and disappeared once a
+                    -- different outcome rolled). Capturing the live family here
+                    -- lets CfgWantsSID recognize every outcome from the start.
+                    if info and type(info.linkedSpellIDs) == "table" and #info.linkedSpellIDs >= 2
+                       and sp.name and sp.name:find("Roll the Bones", 1, true) then
+                        local ids = {}
+                        for i = 1, #info.linkedSpellIDs do
+                            local lid = info.linkedSpellIDs[i]
+                            if type(lid) == "number" and lid > 0 then ids[#ids + 1] = lid end
+                        end
+                        if #ids >= 2 then barCfg.spellIDs = ids end
+                    end
                 end
                 Refresh()
                 ns.BuildTrackedBuffBars()


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541652764495716373

Issue: A "Tracking Bars" entry for Roll the Bones would stop updating its name to match whichever buff was actually rolled (e.g. One of a Kind, Jackpot), and would eventually disappear entirely — even with Always Visible enabled. Blizzard's own default Cooldown Manager handled it correctly, confirming this was an EllesmereUI-side bug, not a game/data restriction.

Root cause: When Roll the Bones was added to a Tracking Bar, the addon only captured the ID of whichever single outcome buff happened to be active at that exact moment — not the full set of possible outcomes. The matching logic that's supposed to recognize "any Roll the Bones outcome" never actually had a full list to check against, so as soon as a different outcome rolled, nothing matched anymore — the bar's binding to Blizzard's live tracking frame was lost, which is why both the name froze and the bar eventually vanished.

Fix: When adding Roll the Bones specifically, the addon now reads Blizzard's own live outcome list for that ability at add-time and stores the full set, so every possible roll is recognized from the start — not just whichever one was up when it was added. No outcome names/IDs are hardcoded, so it stays correct if the ability's outcomes are renamed or reworked again in the future. Scoped narrowly to Roll the Bones by name, so no other ability's behavior is affected.