### PR TITLE
Feature(Myhtic+ Tools): Add interrupt awareness, range fade, and raid markers to Targeted Spell Bars

### DIFF
--- a/EllesmereUIMythicTimer/EUI_MythicTimer_TargetFocusBars.lua
+++ b/EllesmereUIMythicTimer/EUI_MythicTimer_TargetFocusBars.lua
@@ -200,15 +200,29 @@ local function BuildBar(which)
     SetFSFont(bar.timer, 11)
 
     -- 10Hz cast timer text (engine-slept between fires; self-stops when the
-    -- cast ends). Remaining time from the duration object only.
+    -- cast ends). Remaining time from the duration object only. bar.durKind
+    -- (set by ArmFill, which already knows which getter applies) picks the
+    -- one matching API instead of probing all three every tick; falls back to
+    -- the full chain on a transient miss or before any kind is cached.
     bar._timerTick = function(force)
         if not bar.isCasting and not force then return end
         local cfg = BarCfg(bar.which)
         if not cfg or cfg.showTimer == false then return true end
         if UnitCastingDuration then
-            local durObj = UnitCastingDuration(bar.unit)
-                or (UnitEmpoweredChannelDuration and UnitEmpoweredChannelDuration(bar.unit, true))
-                or (UnitChannelDuration and UnitChannelDuration(bar.unit))
+            local durObj
+            local kind = bar.durKind
+            if kind == "cast" then
+                durObj = UnitCastingDuration(bar.unit)
+            elseif kind == "empowered" then
+                durObj = UnitEmpoweredChannelDuration and UnitEmpoweredChannelDuration(bar.unit, true)
+            elseif kind == "channel" then
+                durObj = UnitChannelDuration and UnitChannelDuration(bar.unit)
+            end
+            if not durObj then
+                durObj = UnitCastingDuration(bar.unit)
+                    or (UnitEmpoweredChannelDuration and UnitEmpoweredChannelDuration(bar.unit, true))
+                    or (UnitChannelDuration and UnitChannelDuration(bar.unit))
+            end
             if durObj then
                 bar.timer:SetFormattedText("%.1f", durObj:GetRemainingDuration())
             else
@@ -599,12 +613,14 @@ local function ArmFill(bar, isChannel)
             local dirn = isEmp and Enum.StatusBarTimerDirection.ElapsedTime
                 or Enum.StatusBarTimerDirection.RemainingTime
             sb:SetTimerDuration(dur, nil, dirn)
+            bar.durKind = isEmp and "empowered" or "channel"
         end
     else
         dur = UnitCastingDuration(bar.unit)
         if dur then
             sb:SetReverseFill(false)
             sb:SetTimerDuration(dur, nil, Enum.StatusBarTimerDirection.ElapsedTime)
+            bar.durKind = "cast"
         end
     end
     return dur ~= nil, isEmp

--- a/EllesmereUIMythicTimer/EUI_MythicTimer_TargetedSpellBars.lua
+++ b/EllesmereUIMythicTimer/EUI_MythicTimer_TargetedSpellBars.lua
@@ -1,10 +1,12 @@
 if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_ClientGate.lua)
 --------------------------------------------------------------------------------
 --  EUI_MythicTimer_TargetedSpellBars.lua
---  Targeted Spell Bars (Mythic+ Tools): one movable group of plain cast bars,
---  one per enemy nameplate currently casting -- a replica of the nameplate
---  cast display (spell name, spell target, timer) collected in one place so
---  every active cast reads at a glance.
+--  Targeted Spell Bars (Mythic+ Tools): one movable group of cast bars, one per
+--  enemy nameplate currently casting -- a replica of the nameplate cast display
+--  (spell name, spell target, timer) collected in one place so every active
+--  cast reads at a glance. Optional interrupt awareness (kick-ready tint,
+--  uninterruptible wash, important-cast tint/glow), out-of-interrupt-range
+--  fade, and raid target markers, all opt-in and off by default.
 --
 --  Zero cost while disabled: no events are registered and no frames are built
 --  until the feature is enabled. All cast reads follow the nameplate module's
@@ -36,18 +38,97 @@ local function SetFSFont(fs, size)
 end
 
 --------------------------------------------------------------------------------
+--  Shared engines consumed read-only (core addon, loaded before this module).
+--------------------------------------------------------------------------------
+local GetActiveKickSpell = EllesmereUI.GetActiveKickSpell
+local ComputeCastBarTint = EllesmereUI.ComputeCastBarTint
+local Glows = EllesmereUI.Glows
+
+-- Raid marker sheet texcoords (4x4 grid), same layout as EllesmereUIRaidFrames.
+local RAID_MARKER_TEXCOORDS = {
+    [1] = { 0,    0.25, 0,    0.25 }, -- Star
+    [2] = { 0.25, 0.5,  0,    0.25 }, -- Circle
+    [3] = { 0.5,  0.75, 0,    0.25 }, -- Diamond
+    [4] = { 0.75, 1,    0,    0.25 }, -- Triangle
+    [5] = { 0,    0.25, 0.25, 0.5  }, -- Moon
+    [6] = { 0.25, 0.5,  0.25, 0.5  }, -- Square
+    [7] = { 0.5,  0.75, 0.25, 0.5  }, -- Cross
+    [8] = { 0.75, 1,    0.25, 0.5  }, -- Skull
+}
+
+--------------------------------------------------------------------------------
 --  State
 --------------------------------------------------------------------------------
 local container            -- anchor frame the unlock mover drags; built lazily
-local bars = {}            -- frame pool (holder frames, reused forever)
-local shown = {}           -- active entries in display order
-local unitEntry = {}       -- unit token -> entry while its bar is shown
-local plateUnits = {}      -- unit token -> true while its nameplate exists
-local active = false       -- events registered / feature live
-local previewOn = false    -- sample bars forced on (options eyeball / unlock)
-local timerTicker          -- shared 10Hz text ticker, self-stops when idle
+local bars = {}             -- frame pool (holder frames, reused forever)
+local shown = {}            -- active entries in display order
+local unitEntry = {}        -- unit token -> entry while its bar is shown
+local plateUnits = {}       -- unit token -> true while its nameplate exists
+local active = false        -- events registered / feature live
+local previewOn = false     -- sample bars forced on (options eyeball / unlock)
+local timerTicker           -- shared 10Hz text ticker, self-stops when idle
+local slowAccum = 0         -- 10Hz tick counter driving the 0.2s poll pass
+local styleGen = 0          -- bumped by TSB_Refresh; O3 restyle-on-stale stamp
+local anyCastDropped = false -- true only when the maxBars cap actually dropped a cast
+local whereActive = false   -- location/combat watcher registered (tied to cfg.enabled only)
 
 local DEFAULT_X, DEFAULT_Y = -340, 60
+
+--------------------------------------------------------------------------------
+--  Where to Show: content-type gate (AuraBuffReminders convention). Runs
+--  independently of the nameplate-tracking lifecycle below -- entering or
+--  leaving a matching zone must be able to (de)activate the group even while
+--  the bucket the player is currently in is excluded, so this watcher stays
+--  armed for as long as the feature is enabled, never tied to `active`.
+--------------------------------------------------------------------------------
+local function CurrentWhereBucket()
+    if C_ChallengeMode and C_ChallengeMode.IsChallengeModeActive and C_ChallengeMode.IsChallengeModeActive() then
+        return "dungeon_mythic"
+    end
+    local _, iType, diffID = GetInstanceInfo()
+    diffID = tonumber(diffID) or 0
+    if iType == "party" then
+        if diffID == 23 or diffID == 8 then return "dungeon_mythic" end
+        if diffID == 2 or diffID == 1 or diffID == 205 then return "dungeon_nonmythic" end
+        if diffID == 24 then return "timewalking" end
+    elseif iType == "raid" then
+        if diffID == 16 or diffID == 233 then return "raid_mythic" end
+        if diffID == 15 or diffID == 6 then return "raid_heroic" end
+        if diffID == 14 or diffID == 3 or diffID == 4 or diffID == 5
+            or diffID == 17 or diffID == 7 then return "raid_normal_lfr" end
+        if diffID == 33 then return "timewalking" end
+    elseif iType == "scenario" then
+        if diffID == 208 then return "delve" end
+    end
+    if IsInInstance and not IsInInstance() then return "open_world" end
+    return nil -- unmapped (PvP/arena/etc.) -- always shows, matching AuraBuffReminders
+end
+
+local function WhereShows(whereToShow)
+    if not whereToShow then return true end
+    if whereToShow.in_combat == false and InCombatLockdown and InCombatLockdown() then return false end
+    local bucket = CurrentWhereBucket()
+    if not bucket then return true end
+    return whereToShow[bucket] ~= false
+end
+
+local whereEvt = CreateFrame("Frame")
+local WHERE_EVENTS = {
+    "PLAYER_ENTERING_WORLD", "CHALLENGE_MODE_START", "CHALLENGE_MODE_COMPLETED",
+    "ZONE_CHANGED_NEW_AREA", "PLAYER_REGEN_DISABLED", "PLAYER_REGEN_ENABLED",
+}
+whereEvt:SetScript("OnEvent", function() ns.TSB_Refresh() end)
+
+local function SetWhereWatcherActive(on)
+    on = on and true or false
+    if on == whereActive then return end
+    whereActive = on
+    if on then
+        for i = 1, #WHERE_EVENTS do whereEvt:RegisterEvent(WHERE_EVENTS[i]) end
+    else
+        whereEvt:UnregisterAllEvents()
+    end
+end
 
 --------------------------------------------------------------------------------
 --  Container + position (unlock interchange = raw UIParent-logical center
@@ -75,8 +156,9 @@ local function EnsureContainer()
 end
 
 --------------------------------------------------------------------------------
---  Bar construction: holder > bg + icon + StatusBar fill + text zones.
---  Built once per pool slot, restyled by ApplyStyle.
+--  Bar construction: holder > bg + icon + StatusBar fill + uninterruptible
+--  overlay + raid marker + text zones. Built once per pool slot, restyled by
+--  StyleBar.
 --------------------------------------------------------------------------------
 local function BuildBar()
     local holder = CreateFrame("Frame", nil, EnsureContainer())
@@ -93,14 +175,32 @@ local function BuildBar()
     holder.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
 
     holder.sb = CreateFrame("StatusBar", nil, holder)
+    -- Placeholder fill: a StatusBar has NO texture object until one is set, and
+    -- the fill-edge rider below (the uninterruptible overlay) would index nil
+    -- on a bar that never reached StyleBar (TargetFocusBars carries the same
+    -- guard, same reason).
+    holder.sb:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
     holder.sb:SetPoint("TOPLEFT", holder.iconFrame, "TOPRIGHT", 0, 0)
     holder.sb:SetPoint("BOTTOMRIGHT", holder, "BOTTOMRIGHT", 0, 0)
     holder.sb:SetMinMaxValues(0, 1)
     holder.sb:SetValue(0)
 
+    -- Uninterruptible grey wash: rides the fill texture, alpha-gated by the
+    -- (possibly secret) protection flag via SetAlphaFromBoolean.
+    holder.overlay = holder.sb:CreateTexture(nil, "ARTWORK", nil, 2)
+    holder.overlay:SetAllPoints(holder.sb:GetStatusBarTexture())
+    holder.overlay:SetTexture("Interface\\Buttons\\WHITE8x8")
+    holder.overlay:SetAlpha(0)
+
     -- Text zones ride a child frame so they draw above the fill and any border.
     holder.textFrame = CreateFrame("Frame", nil, holder.sb)
     holder.textFrame:SetAllPoints(holder.sb)
+
+    -- Raid target marker, left of the spell name; hidden until a cast paints it.
+    holder.marker = holder.textFrame:CreateTexture(nil, "OVERLAY")
+    holder.marker:SetTexture("Interface\\TargetingFrame\\UI-RaidTargetingIcons")
+    holder.marker:Hide()
+
     -- Fonts applied at BUILD as well as in StyleBar: SetText on a fontless
     -- FontString errors, and build/paint ordering must not be load-bearing.
     holder.name = holder.textFrame:CreateFontString(nil, "OVERLAY")
@@ -136,8 +236,24 @@ local function AcquireBarFrame()
 end
 
 --------------------------------------------------------------------------------
+--  Name anchoring: shared by StyleBar and the raid-marker paint pass, since
+--  the name has to shift right while a marker is shown.
+--------------------------------------------------------------------------------
+local function AnchorName(holder, cfg, markerShown)
+    local w = cfg.width or 240
+    local h = cfg.height or 20
+    local markerReserve = markerShown and ((cfg.raidMarkerSize or 14) + 2) or 0
+    holder.name:ClearAllPoints()
+    holder.name:SetPoint("LEFT", holder.sb, "LEFT", 4 + markerReserve + (cfg.nameX or 0), cfg.nameY or 0)
+    local nameWidth = (w - h) * 0.48 - markerReserve
+    if nameWidth < 1 then nameWidth = 1 end
+    holder.name:SetWidth(nameWidth)
+end
+
+--------------------------------------------------------------------------------
 --  Style pass: sizes, texture, colors, fonts, text layout. Runs on enable and
---  on any settings change (options call ns.TSB_Refresh). Cheap: <= pool size.
+--  on any settings change (options call ns.TSB_Refresh), and once per bar the
+--  first time it is used after a refresh (O3: StartCast skips this otherwise).
 --------------------------------------------------------------------------------
 local function StyleBar(holder, cfg)
     local w = cfg.width or 240
@@ -160,6 +276,13 @@ local function StyleBar(holder, cfg)
     if pp and pp.DisablePixelSnap then pp.DisablePixelSnap(holder.sb:GetStatusBarTexture()) end
     local c = cfg.barColor
     if c then holder.sb:SetStatusBarColor(c.r, c.g, c.b) end
+
+    -- Fill texture re-mint: SetStatusBarTexture creates a NEW texture object
+    -- every call, so the uninterruptible overlay must be re-pinned to it.
+    holder.overlay:ClearAllPoints()
+    holder.overlay:SetAllPoints(holder.sb:GetStatusBarTexture())
+    local un = cfg.uninterruptible
+    if un then holder.overlay:SetVertexColor(un.r, un.g, un.b) end
 
     -- Solid black border on the holder; size 0 removes it.
     local bsz = cfg.borderSize
@@ -184,9 +307,7 @@ local function StyleBar(holder, cfg)
 
     local showTimer = cfg.showTimer ~= false
     local timerReserve = showTimer and ((cfg.timerSize or 10) * 2.2) or 0
-    holder.name:ClearAllPoints()
-    holder.name:SetPoint("LEFT", holder.sb, "LEFT", 4 + (cfg.nameX or 0), cfg.nameY or 0)
-    holder.name:SetWidth((w - h) * 0.48)
+    AnchorName(holder, cfg, holder.marker:IsShown())
     holder.timer:ClearAllPoints()
     holder.timer:SetPoint("RIGHT", holder.sb, "RIGHT", -3 + (cfg.timerX or 0), cfg.timerY or 0)
     holder.target:ClearAllPoints()
@@ -194,9 +315,18 @@ local function StyleBar(holder, cfg)
         -3 - timerReserve + (cfg.targetX or 0), cfg.targetY or 0)
     holder.target:SetWidth((w - h) * 0.40)
 
+    -- Marker size/anchor; visibility and texcoords are per-cast (ApplyRaidMarker).
+    local msz = cfg.raidMarkerSize or 14
+    holder.marker:SetSize(msz, msz)
+    holder.marker:ClearAllPoints()
+    holder.marker:SetPoint("LEFT", holder.sb, "LEFT", 3, 0)
+
     holder.name:SetShown(cfg.showSpellName ~= false)
     holder.timer:SetShown(showTimer)
     -- target visibility is per-cast (hasTarget); the paint pass owns it
+
+    holder._glowDirty = true -- size may have changed; the glow geometry is size-dependent
+    holder._styleGen = styleGen
 end
 
 local function PositionBar(holder, slot, cfg)
@@ -218,33 +348,258 @@ local function Reflow()
 end
 
 --------------------------------------------------------------------------------
---  Shared 10Hz timer text: one ticker for the whole group, armed while any
---  bar is live, self-stops when the last releases (engine sleeps between
---  fires). Remaining time comes from the duration object -- cast start/end
---  times are secret and unusable in arithmetic.
+--  Important-cast glow: routed through Glows.StartEngineGlow (the C-side
+--  AnimationGroup path built for the 12.1 forbidden aura partition), so it
+--  costs ZERO per-frame Lua regardless of how many bars glow -- unlike the
+--  driver-ticked engines the nameplate module uses. Only styles with a
+--  genuine C-side twin are offered (1/2/5/6/7); styles 3/4 silently remap
+--  inside the engine and are left off the options dropdown.
+--------------------------------------------------------------------------------
+local function EnsureGlowOverlay(holder)
+    if holder._glow then return holder._glow end
+    local ov = CreateFrame("Frame", nil, holder.sb)
+    ov:SetAllPoints(holder.sb)
+    ov:SetFrameLevel(holder.sb:GetFrameLevel() + 5)
+    ov:EnableMouse(false)
+    holder._glow = ov
+    return ov
+end
+
+local function ClearImportantGlow(holder)
+    if holder._glowActive and holder._glow then
+        if Glows then Glows.StopAllGlows(holder._glow) end
+        holder._glow:SetAlpha(0)
+        holder._glow:Hide()
+        holder._glowActive = false
+        holder._glowStyle = nil
+    end
+end
+
+local function StartImportantGlowAnim(holder, cfg)
+    local ov = EnsureGlowOverlay(holder)
+    local style = cfg.importantGlowStyle or 1
+    local c = cfg.importantGlowColor or { r = 1, g = 0.2, b = 0.2 }
+    local n = cfg.importantGlowLines or 8
+    local th = cfg.importantGlowThickness or 2
+    local period = cfg.importantGlowSpeed or 4
+
+    -- Dirty-check so the animation is not restarted on every cast event; only
+    -- a real style/color/param/size change tears it down and re-plays it.
+    if not holder._glowActive or holder._glowStyle ~= style
+        or holder._glowR ~= c.r or holder._glowG ~= c.g or holder._glowB ~= c.b
+        or holder._glowN ~= n or holder._glowTh ~= th or holder._glowPeriod ~= period
+        or holder._glowDirty then
+        holder._glowDirty = nil
+        Glows.StopAllGlows(ov)
+        local pW, pH = holder.sb:GetWidth(), holder.sb:GetHeight()
+        if pW < 5 then pW = 100 end
+        if pH < 5 then pH = 14 end
+        Glows.StartEngineGlow(ov, style, pW, c.r, c.g, c.b, { N = n, th = th, period = period }, pH)
+        holder._glowActive = true
+        holder._glowStyle = style
+        holder._glowR, holder._glowG, holder._glowB = c.r, c.g, c.b
+        holder._glowN, holder._glowTh, holder._glowPeriod = n, th, period
+    end
+    ov:Show()
+    return ov
+end
+
+-- e._important may be true / false / a SECRET boolean (C_Spell.IsSpellImportant
+-- can return secret under restricted execution) -- only the issecretvalue()
+-- branch below is allowed to touch it without deciding what it IS.
+local function ApplyImportantGlow(e, cfg)
+    local holder = e.bar
+    if not (cfg.importantGlow and Glows and Glows.StartEngineGlow) then
+        ClearImportantGlow(holder)
+        return
+    end
+    local imp = e._important
+    if type(imp) == "nil" then
+        ClearImportantGlow(holder)
+        return
+    end
+    if issecretvalue and issecretvalue(imp) then
+        -- Must run the animation regardless; only its alpha carries the answer.
+        -- StartEngineGlow forces alpha 1 on (re)start, so the boolean alpha
+        -- assignment always runs AFTER the start call, never before.
+        local ov = StartImportantGlowAnim(holder, cfg)
+        ov:SetAlphaFromBoolean(imp)
+        return
+    end
+    -- Known, non-secret boolean: safe to branch directly.
+    if imp then
+        local ov = StartImportantGlowAnim(holder, cfg)
+        ov:SetAlpha(1)
+    else
+        ClearImportantGlow(holder)
+    end
+end
+
+--------------------------------------------------------------------------------
+--  Cast color: kick-ready tint and uninterruptible wash always apply (Cast
+--  Colors has no off switch); the important-cast tint blends in on top only
+--  when enabled. All secret combines ride C_CurveUtil boolean curves or
+--  SetAlphaFromBoolean; nothing branches on a secret.
+--------------------------------------------------------------------------------
+local impScratch = {}
+local function ApplyCastColor(e, cfg)
+    local holder = e.bar
+    holder.overlay:SetAlphaFromBoolean(e._kickProtected)
+    local base = cfg.barColor or { r = 0.70, g = 0.40, b = 0.90 }
+    if cfg.importantEnabled and C_CurveUtil and C_CurveUtil.EvaluateColorValueFromBoolean then
+        local imp = e._important
+        if type(imp) == "nil" then imp = false end
+        local ic = cfg.importantColor or { r = 1, g = 0.2, b = 0.2 }
+        local ev = C_CurveUtil.EvaluateColorValueFromBoolean
+        impScratch.r = ev(imp, ic.r, base.r)
+        impScratch.g = ev(imp, ic.g, base.g)
+        impScratch.b = ev(imp, ic.b, base.b)
+        base = impScratch
+    end
+    local cr, cg, cb = base.r, base.g, base.b
+    if ComputeCastBarTint then
+        local ready = cfg.interruptReady or { r = 0.92, g = 0.35, b = 0.20 }
+        cr, cg, cb = ComputeCastBarTint(ready, base)
+    end
+    holder.sb:GetStatusBarTexture():SetVertexColor(cr, cg, cb)
+end
+
+--------------------------------------------------------------------------------
+--  Raid target marker: left of the spell name. Deliberately NOT
+--  SetRaidTargetIconTexture -- that helper derives texcoords with Lua
+--  arithmetic on the index, which throws on a secret number.
+--  GetRaidTargetIndex is a known secret-prone call.
+--------------------------------------------------------------------------------
+local function ApplyRaidMarker(e, cfg)
+    local holder = e.bar
+    if not cfg.showRaidMarker then
+        if holder.marker:IsShown() then
+            holder.marker:Hide()
+            AnchorName(holder, cfg, false)
+        end
+        return
+    end
+    local idx = GetRaidTargetIndex and GetRaidTargetIndex(e.unit)
+    if type(idx) == "nil" then -- type() is the taint-safe existence check
+        if holder.marker:IsShown() then
+            holder.marker:Hide()
+            AnchorName(holder, cfg, false)
+        end
+        return
+    end
+    if issecretvalue and issecretvalue(idx) then
+        if holder.marker.SetSpriteSheetCell then
+            pcall(holder.marker.SetSpriteSheetCell, holder.marker, idx, 4, 4, 64, 64)
+        end
+    else
+        local tc = RAID_MARKER_TEXCOORDS[idx]
+        if tc then holder.marker:SetTexCoord(tc[1], tc[2], tc[3], tc[4]) end
+    end
+    holder.marker:Show()
+    AnchorName(holder, cfg, true)
+end
+
+--------------------------------------------------------------------------------
+--  Out-of-interrupt-range fade: dims the whole bar (icon, texts, marker, glow
+--  together) when the unit is beyond the player's active interrupt spell's
+--  range. Secret-safe idiom: issecretvalue() runs BEFORE the ~= nil check so
+--  the comparison never touches a secret value.
+--------------------------------------------------------------------------------
+local function ApplyRangeAlpha(e, cfg)
+    local holder = e.bar
+    if not (cfg.oorEnabled and GetActiveKickSpell and GetActiveKickSpell()
+        and C_Spell and C_Spell.IsSpellInRange) then
+        if e._oorApplied then
+            holder:SetAlpha(1)
+            e._oorApplied = nil
+        end
+        return
+    end
+    local inRange = C_Spell.IsSpellInRange(GetActiveKickSpell(), e.unit)
+    if (issecretvalue and issecretvalue(inRange)) or inRange ~= nil then
+        holder:SetAlphaFromBoolean(inRange, 1, cfg.oorAlpha or 0.45)
+    else
+        holder:SetAlpha(1)
+    end
+    e._oorApplied = true
+end
+
+--------------------------------------------------------------------------------
+--  Duration lookup: ArmFill already knows which getter applies (it picks the
+--  fill direction), so the timer text reuses that instead of trying all three
+--  duration APIs every tick (O2). Falls back to the full chain on a transient
+--  miss or before any kind has been cached, so behaviour never regresses.
+--------------------------------------------------------------------------------
+local function GetDurationObj(e)
+    local kind = e.durKind
+    if kind == "cast" then
+        local d = UnitCastingDuration(e.unit)
+        if d then return d end
+    elseif kind == "empowered" then
+        local d = UnitEmpoweredChannelDuration and UnitEmpoweredChannelDuration(e.unit, true)
+        if d then return d end
+    elseif kind == "channel" then
+        local d = UnitChannelDuration and UnitChannelDuration(e.unit)
+        if d then return d end
+    end
+    return UnitCastingDuration(e.unit)
+        or (UnitEmpoweredChannelDuration and UnitEmpoweredChannelDuration(e.unit, true))
+        or (UnitChannelDuration and UnitChannelDuration(e.unit))
+end
+
+--------------------------------------------------------------------------------
+--  Shared 10Hz timer text: one ticker for the whole group, armed only while
+--  needed (O1), self-stops when the last bar releases. Remaining time comes
+--  from the duration object only -- cast start/end times are secret and
+--  unusable in arithmetic. Also drives a 0.2s slow pass (every 2nd fire) for
+--  kick-ready repaint and range fade, since neither reliably fires a naming
+--  event (a kick coming off cooldown, or walking back into range).
 --------------------------------------------------------------------------------
 local function TimerBody()
     local n = #shown
     if n == 0 then return false end
-    if not UnitCastingDuration then return false end
-    for i = 1, n do
-        local e = shown[i]
-        if not e.preview then
-            local fs = e.bar.timer
-            local durObj = UnitCastingDuration(e.unit)
-                or (UnitEmpoweredChannelDuration and UnitEmpoweredChannelDuration(e.unit, true))
-                or (UnitChannelDuration and UnitChannelDuration(e.unit))
-            if durObj then
-                fs:SetFormattedText("%.1f", durObj:GetRemainingDuration())
-            else
-                fs:SetText("")
+    local cfg = Cfg()
+    local showTimer = UnitCastingDuration and cfg and cfg.showTimer ~= false
+    if showTimer then
+        for i = 1, n do
+            local e = shown[i]
+            if not e.preview then
+                local fs = e.bar.timer
+                local durObj = GetDurationObj(e)
+                if durObj then
+                    fs:SetFormattedText("%.1f", durObj:GetRemainingDuration())
+                else
+                    fs:SetText("")
+                end
             end
         end
     end
+
+    local wantColor = cfg and GetActiveKickSpell and GetActiveKickSpell()
+    local wantRange = cfg and cfg.oorEnabled
+    if wantColor or wantRange then
+        slowAccum = slowAccum + 1
+        if slowAccum >= 2 then
+            slowAccum = 0
+            for i = 1, n do
+                local e = shown[i]
+                if not e.preview then
+                    if wantColor then ApplyCastColor(e, cfg) end
+                    if wantRange then ApplyRangeAlpha(e, cfg) end
+                end
+            end
+        end
+    end
+
     return true
 end
 
 local function ArmTimerTicker()
+    local cfg = Cfg()
+    -- O1: don't arm the ticker at all unless something needs its 10Hz tick --
+    -- the timer text, or one of the polling features.
+    local needed = cfg and (cfg.showTimer ~= false or cfg.oorEnabled or (GetActiveKickSpell and GetActiveKickSpell()))
+    if not needed then return end
     if not timerTicker and EllesmereUI.Tick and EllesmereUI.Tick.NewAnimTicker then
         timerTicker = EllesmereUI.Tick.NewAnimTicker(EnsureContainer(), TimerBody, 0.1)
     end
@@ -273,12 +628,14 @@ local function ArmFill(e, isChannel)
             local dirn = isEmp and Enum.StatusBarTimerDirection.ElapsedTime
                 or Enum.StatusBarTimerDirection.RemainingTime
             sb:SetTimerDuration(dur, nil, dirn)
+            e.durKind = isEmp and "empowered" or "channel"
         end
     else
         dur = UnitCastingDuration(e.unit)
         if dur then
             sb:SetReverseFill(false)
             sb:SetTimerDuration(dur, nil, Enum.StatusBarTimerDirection.ElapsedTime)
+            e.durKind = "cast"
         end
     end
 end
@@ -326,8 +683,16 @@ local function Release(unit)
             break
         end
     end
-    e.bar._tsbInUse = nil
-    e.bar:Hide()
+    -- Bars are pooled and reused forever: every piece of per-cast visual state
+    -- set by the new features must be cleared here, or the next occupant
+    -- inherits it.
+    local holder = e.bar
+    ClearImportantGlow(holder)
+    holder:SetAlpha(1)
+    holder.overlay:SetAlpha(0)
+    holder.marker:Hide()
+    holder._tsbInUse = nil
+    holder:Hide()
     Reflow()
 end
 
@@ -347,10 +712,10 @@ local PromoteWaiting -- forward: StartCast <-> PromoteWaiting recursion
 local function StartCast(unit)
     local cfg = Cfg()
     if not cfg then return end
-    local name, _, texture, _, _, _, _, _, castSpellID = UnitCastingInfo(unit)
+    local name, _, texture, _, _, _, _, kickProtected, castSpellID = UnitCastingInfo(unit)
     local isChannel = false
     if type(name) == "nil" then
-        name, _, texture, _, _, _, _, castSpellID = UnitChannelInfo(unit)
+        name, _, texture, _, _, _, kickProtected, castSpellID = UnitChannelInfo(unit)
         isChannel = true
     end
     if type(name) == "nil" then
@@ -361,16 +726,35 @@ local function StartCast(unit)
     if not IsTrackableUnit(unit) then return end
 
     local e = unitEntry[unit]
+    local isNew = false
     if not e then
-        if #shown >= (cfg.maxBars or 5) then return end -- promoted when a slot frees
+        if #shown >= (cfg.maxBars or 5) then
+            anyCastDropped = true -- promoted when a slot frees (O4)
+            return
+        end
         e = { unit = unit, bar = AcquireBarFrame() }
         unitEntry[unit] = e
         shown[#shown + 1] = e
-        StyleBar(e.bar, cfg)
+        isNew = true
         PositionBar(e.bar, #shown, cfg)
+    end
+    -- O3: a bar only needs a full restyle once per settings generation, not on
+    -- every cast -- new/reused-from-pool bars never carry the current stamp.
+    if isNew or e.bar._styleGen ~= styleGen then
+        StyleBar(e.bar, cfg)
     end
     e.isChannel = isChannel
     e.preview = nil
+
+    if type(kickProtected) == "nil" then kickProtected = false end
+    e._kickProtected = kickProtected
+    -- Important flag may be SECRET: stored raw, fed only to color curves and
+    -- SetAlphaFromBoolean, never branched on directly.
+    e._important = false
+    if C_Spell and C_Spell.IsSpellImportant then
+        local impOK, imp = pcall(C_Spell.IsSpellImportant, castSpellID or 0)
+        if impOK then e._important = imp end
+    end
 
     -- Icon and name MUST describe the SAME cast: both come from this
     -- snapshot. The live texture may be SECRET -- SetTexture accepts it.
@@ -392,18 +776,26 @@ local function StartCast(unit)
         e.bar.name:SetText(name)
     end
     PaintTarget(e, cfg)
+    ApplyRaidMarker(e, cfg)
+    ApplyCastColor(e, cfg)
+    ApplyImportantGlow(e, cfg)
     e.bar.timer:SetText("")
     ArmFill(e, isChannel)
+    ApplyRangeAlpha(e, cfg)
     e.bar:Show()
     ArmTimerTicker()
 end
 
 -- Fill freed slots from plates that were casting while the group was full.
--- Bounded: runs only on release-while-full, over the live plate set.
+-- O4: only scans plateUnits when a cast was actually dropped at the cap --
+-- with nothing ever dropped, every release is a free no-op instead of a full
+-- plate walk.
 PromoteWaiting = function()
+    if not anyCastDropped then return end
     local cfg = Cfg()
     if not cfg then return end
     if #shown >= (cfg.maxBars or 5) then return end
+    anyCastDropped = false
     for unit in pairs(plateUnits) do
         if not unitEntry[unit] then
             local nm = UnitCastingInfo(unit)
@@ -413,6 +805,37 @@ PromoteWaiting = function()
                 if #shown >= (cfg.maxBars or 5) then return end
             end
         end
+    end
+end
+
+-- Mid-cast interruptibility flips: re-read protection once, store, repaint.
+-- Port of the TargetFocusBars KickProtectionChanged pattern.
+local function RefreshKickProtection(unit)
+    local cfg = Cfg()
+    if not cfg then return end
+    local e = unitEntry[unit]
+    if not e then return end
+    local kickProtected
+    local sName, _, _, _, _, _, _, kp = UnitCastingInfo(unit)
+    if type(sName) ~= "nil" then
+        kickProtected = kp
+    else
+        local cName
+        cName, _, _, _, _, _, kp = UnitChannelInfo(unit)
+        if type(cName) == "nil" then return end
+        kickProtected = kp
+    end
+    if type(kickProtected) == "nil" then kickProtected = false end
+    e._kickProtected = kickProtected
+    ApplyCastColor(e, cfg)
+end
+
+local function RefreshAllRaidMarkers()
+    local cfg = Cfg()
+    if not cfg then return end
+    for i = 1, #shown do
+        local e = shown[i]
+        if not e.preview then ApplyRaidMarker(e, cfg) end
     end
 end
 
@@ -466,6 +889,10 @@ evt:SetScript("OnEvent", function(_, event, unit)
         end
         return
     end
+    if event == "RAID_TARGET_UPDATE" then
+        RefreshAllRaidMarkers()
+        return
+    end
     -- Spellcast family: nameplate units only.
     if not unit or not plateUnits[unit] then return end
     if START_EVENTS[event] then
@@ -478,6 +905,8 @@ evt:SetScript("OnEvent", function(_, event, unit)
     elseif RELEASE_EVENTS[event] then
         Release(unit)
         PromoteWaiting()
+    elseif event == "UNIT_SPELLCAST_INTERRUPTIBLE" or event == "UNIT_SPELLCAST_NOT_INTERRUPTIBLE" then
+        RefreshKickProtection(unit)
     end
 end)
 
@@ -489,14 +918,21 @@ local ALL_EVENTS = {
     "UNIT_SPELLCAST_STOP", "UNIT_SPELLCAST_FAILED",
     "UNIT_SPELLCAST_EMPOWER_STOP", "UNIT_SPELLCAST_CHANNEL_STOP",
     "UNIT_SPELLCAST_INTERRUPTED",
+    "UNIT_SPELLCAST_INTERRUPTIBLE", "UNIT_SPELLCAST_NOT_INTERRUPTIBLE",
+    "RAID_TARGET_UPDATE",
 }
 
 local function ReleaseAll()
     for i = #shown, 1, -1 do
         local e = shown[i]
         unitEntry[e.unit] = nil
-        e.bar._tsbInUse = nil
-        e.bar:Hide()
+        local holder = e.bar
+        ClearImportantGlow(holder)
+        holder:SetAlpha(1)
+        holder.overlay:SetAlpha(0)
+        holder.marker:Hide()
+        holder._tsbInUse = nil
+        holder:Hide()
         shown[i] = nil
     end
 end
@@ -536,11 +972,12 @@ end
 --------------------------------------------------------------------------------
 --  Preview: sample bars for options / unlock placement. Static content --
 --  plain SetValue (cancels timer mode) so nothing animates or reads units.
+--  Every new feature gets one sample row so it is visible while configuring.
 --------------------------------------------------------------------------------
 local PREVIEW_ROWS = {
-    { name = "Shadow Bolt",   fill = 0.65, timer = "1.2" },
-    { name = "Mending",       fill = 0.35, timer = "2.4" },
-    { name = "Terrifying Roar", fill = 0.85, timer = "0.6" },
+    { name = "Shadow Bolt",     fill = 0.65, timer = "1.2" },
+    { name = "Mending",         fill = 0.35, timer = "2.4", uninterruptible = true },
+    { name = "Terrifying Roar", fill = 0.85, timer = "0.6", marker = 8, important = true },
 }
 
 local function ShowPreview()
@@ -555,6 +992,7 @@ local function ShowPreview()
         shown[#shown + 1] = e
         StyleBar(e.bar, cfg)
         PositionBar(e.bar, i, cfg)
+        e.bar:SetAlpha(1)
         e.bar.icon:SetTexture(134400)
         if cfg.showSpellName ~= false then e.bar.name:SetText(sample.name) end
         if cfg.showTarget ~= false then
@@ -573,6 +1011,42 @@ local function ShowPreview()
         end
         e.bar.timer:SetText(cfg.showTimer ~= false and sample.timer or "")
         e.bar.sb:SetValue(sample.fill)
+
+        -- Uninterruptible / kick-ready sample: static, no live unit involved.
+        if sample.uninterruptible then
+            e.bar.overlay:SetAlpha(1)
+            local un = cfg.uninterruptible or { r = 0.45, g = 0.45, b = 0.45 }
+            e.bar.sb:GetStatusBarTexture():SetVertexColor(un.r, un.g, un.b)
+        else
+            e.bar.overlay:SetAlpha(0)
+            local c = cfg.barColor
+            if c then e.bar.sb:GetStatusBarTexture():SetVertexColor(c.r, c.g, c.b) end
+        end
+
+        -- Raid marker sample: static, non-secret index.
+        if cfg.showRaidMarker and sample.marker then
+            local tc = RAID_MARKER_TEXCOORDS[sample.marker]
+            if tc then e.bar.marker:SetTexCoord(tc[1], tc[2], tc[3], tc[4]) end
+            e.bar.marker:Show()
+            AnchorName(e.bar, cfg, true)
+        else
+            e.bar.marker:Hide()
+            AnchorName(e.bar, cfg, false)
+        end
+
+        -- Important sample: tint and/or glow, both driven by a plain (never
+        -- secret) boolean here.
+        e._important = sample.important == true
+        if cfg.importantEnabled and sample.important then
+            local ic = cfg.importantColor or { r = 1, g = 0.2, b = 0.2 }
+            e.bar.sb:GetStatusBarTexture():SetVertexColor(ic.r, ic.g, ic.b)
+        end
+        if cfg.importantGlow and sample.important then
+            ApplyImportantGlow(e, cfg)
+        else
+            ClearImportantGlow(e.bar)
+        end
+
         e.bar:Show()
     end
 end
@@ -597,7 +1071,8 @@ end
 --------------------------------------------------------------------------------
 function ns.TSB_Refresh()
     local cfg = Cfg()
-    local want = cfg and cfg.enabled == true
+    SetWhereWatcherActive(cfg and cfg.enabled == true)
+    local want = cfg and cfg.enabled == true and WhereShows(cfg.whereToShow)
     if want and not active then
         Activate()
     elseif not want and active then
@@ -605,6 +1080,7 @@ function ns.TSB_Refresh()
         previewOn = false
     end
     if not cfg then return end
+    styleGen = styleGen + 1 -- O3: invalidate every bar's cached style stamp
     if container then
         container:SetSize(cfg.width or 240, cfg.height or 20)
         ApplyContainerPosition()
@@ -618,14 +1094,27 @@ function ns.TSB_Refresh()
     for i = #shown, maxBars + 1, -1 do
         local e = shown[i]
         unitEntry[e.unit] = nil
-        e.bar._tsbInUse = nil
-        e.bar:Hide()
+        local holder = e.bar
+        ClearImportantGlow(holder)
+        holder:SetAlpha(1)
+        holder.overlay:SetAlpha(0)
+        holder.marker:Hide()
+        holder._tsbInUse = nil
+        holder:Hide()
         shown[i] = nil
     end
     for i = 1, #shown do
-        StyleBar(shown[i].bar, cfg)
-        PositionBar(shown[i].bar, i, cfg)
+        local e = shown[i]
+        StyleBar(e.bar, cfg)
+        PositionBar(e.bar, i, cfg)
+        if not e.preview then
+            ApplyRaidMarker(e, cfg)
+            ApplyCastColor(e, cfg)
+            ApplyImportantGlow(e, cfg)
+            ApplyRangeAlpha(e, cfg)
+        end
     end
+    ArmTimerTicker()
 end
 
 --------------------------------------------------------------------------------

--- a/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
+++ b/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
@@ -215,6 +215,32 @@ local DB_DEFAULTS = {
             timerSize        = 10,
             timerX           = 0,
             timerY           = 0,
+            -- Interrupt awareness and visibility. Cast Colors (kick-ready
+            -- tint + uninterruptible wash) always applies, no off switch;
+            -- the rest is opt-in and off by default: important-cast
+            -- tint/glow, out-of-interrupt-range fade, raid target marker.
+            interruptReady    = { r = 0.92, g = 0.35, b = 0.20 },
+            uninterruptible   = { r = 0.45, g = 0.45, b = 0.45 },
+            importantEnabled  = false,
+            importantColor    = { r = 1, g = 0.2, b = 0.2 },
+            importantGlow     = false,
+            importantGlowStyle = 1,
+            importantGlowColor = { r = 1, g = 0.2, b = 0.2 },
+            importantGlowLines = 8,
+            importantGlowThickness = 2,
+            importantGlowSpeed = 4,
+            oorEnabled       = false,
+            oorAlpha         = 0.45,
+            showRaidMarker   = false,
+            raidMarkerSize   = 14,
+            -- Where to Show: a key is present only when explicitly unchecked
+            -- (AuraBuffReminders convention). Default: Mythic Dungeons and
+            -- In Combat only -- every other bucket starts unchecked.
+            whereToShow      = {
+                open_world = false, raid_mythic = false, raid_heroic = false,
+                raid_normal_lfr = false, dungeon_nonmythic = false,
+                timewalking = false, delve = false,
+            },
         },
         -- Target/Focus standalone cast bars (Mythic+ Tools tab): unlock-mode
         -- placeable cast bars carrying the nameplate interrupt color/effects

--- a/EllesmereUIOptions/EUI_MythicTimer_Options.lua
+++ b/EllesmereUIOptions/EUI_MythicTimer_Options.lua
@@ -976,6 +976,34 @@ initFrame:SetScript("OnEvent", function(self)
         if ns.TFB_Refresh then ns.TFB_Refresh() end
     end
 
+    -- Where to Show: same content-type list and multi-select checkbox
+    -- dropdown (EllesmereUI.BuildVisOptsCBDropdown) as AuraBuffReminders.
+    local TSB_WHERE_ITEMS = {
+        { key="open_world",        label="Open World" },
+        { key="raid_mythic",       label="Mythic Raid" },
+        { key="raid_heroic",       label="Heroic Raid" },
+        { key="raid_normal_lfr",   label="Normal/LFR Raid" },
+        { key="dungeon_mythic",    label="Mythic Dungeons" },
+        { key="dungeon_nonmythic", label="Non-Mythic Dungeons" },
+        { key="timewalking",       label="Timewalking" },
+        { key="delve",             label="Delve" },
+        { key="in_combat",         label="In Combat" },
+    }
+    local function TSBWhere()
+        local c = TSB(); if not c then return nil end
+        c.whereToShow = c.whereToShow or {}
+        return c.whereToShow
+    end
+    local function TSBWhereGet(k)
+        local t = TSBWhere()
+        return not (t and t[k] == false)
+    end
+    local function TSBWhereSet(k, v)
+        local t = TSBWhere(); if not t then return end
+        t[k] = v and true or false
+        TSBRefresh()
+    end
+
     -- Auto-disable the cast-bar previews when the options window closes so
     -- sample bars never linger (same contract as the timer preview).
     local function _installCastPreviewAutoOff()
@@ -1073,6 +1101,29 @@ initFrame:SetScript("OnEvent", function(self)
                   c.enabled = v and true or false
                   TSBRefresh(); EllesmereUI:RefreshPage()
               end },
+            { type="dropdown", text="Where to Show",
+              values={ _placeholder="..." }, order={ "_placeholder" },
+              getValue=function() return "_placeholder" end, setValue=function() end });  y = y - h
+        if not EllesmereUI._prebuilding then
+            MakeEye(row._leftRegion,
+                function() return ns.TSB_IsPreview and ns.TSB_IsPreview() or false end,
+                function(v)
+                    if Off() then return end
+                    if ns.TSB_SetPreview then ns.TSB_SetPreview(v) end
+                end)
+
+            local rrgn = row._rightRegion
+            if rrgn._control then rrgn._control:Hide() end
+            local whereDD, whereRefresh = EllesmereUI.BuildVisOptsCBDropdown(
+                rrgn, 220, rrgn:GetFrameLevel() + 2, TSB_WHERE_ITEMS,
+                TSBWhereGet, TSBWhereSet)
+            EllesmereUI.PP.Point(whereDD, "RIGHT", rrgn, "RIGHT", -20, 0)
+            rrgn._control = whereDD
+            rrgn._lastInline = nil
+            EllesmereUI.RegisterWidgetRefresh(whereRefresh)
+        end
+
+        _, h = W:DualRow(parent, y,
             { type="dropdown", text="Grow Direction",
               disabled=Off, disabledTooltip=REQ,
               tooltip="Which way new bars stack as more enemies start casting.",
@@ -1085,58 +1136,39 @@ initFrame:SetScript("OnEvent", function(self)
                   local c = TSB(); if not c then return end
                   c.growUp = v == "UP"
                   TSBRefresh()
-              end });  y = y - h
-        if not EllesmereUI._prebuilding then
-            MakeEye(row._leftRegion,
-                function() return ns.TSB_IsPreview and ns.TSB_IsPreview() or false end,
-                function(v)
-                    if Off() then return end
-                    if ns.TSB_SetPreview then ns.TSB_SetPreview(v) end
-                end)
-        end
-
-        _, h = W:DualRow(parent, y,
+              end },
             { type="slider", text="Width", min=80, max=600, step=1, pixel=true,
               disabled=Off, disabledTooltip=REQ,
               getValue=function() local c = TSB(); return (c and c.width) or 240 end,
-              setValue=function(v) local c = TSB(); if c then c.width = v; TSBRefresh() end end },
+              setValue=function(v) local c = TSB(); if c then c.width = v; TSBRefresh() end end });  y = y - h
+
+        _, h = W:DualRow(parent, y,
             { type="slider", text="Height", min=6, max=60, step=1, pixel=true,
               disabled=Off, disabledTooltip=REQ,
               getValue=function() local c = TSB(); return (c and c.height) or 20 end,
-              setValue=function(v) local c = TSB(); if c then c.height = v; TSBRefresh() end end });  y = y - h
-
-        _, h = W:DualRow(parent, y,
+              setValue=function(v) local c = TSB(); if c then c.height = v; TSBRefresh() end end },
             { type="slider", text="Bar Spacing", min=0, max=20, step=1, pixel=true,
               disabled=Off, disabledTooltip=REQ,
               getValue=function() local c = TSB(); return (c and c.spacing) or 4 end,
-              setValue=function(v) local c = TSB(); if c then c.spacing = v; TSBRefresh() end end },
+              setValue=function(v) local c = TSB(); if c then c.spacing = v; TSBRefresh() end end });  y = y - h
+
+        local texValues, texOrder = BuildBarTexDropdown()
+        _, h = W:DualRow(parent, y,
             { type="slider", text="Max Bars", min=1, max=10, step=1,
               disabled=Off, disabledTooltip=REQ,
               tooltip="The most cast bars shown at once. Extra casters take a bar as soon as one frees up.",
               getValue=function() local c = TSB(); return (c and c.maxBars) or 5 end,
-              setValue=function(v) local c = TSB(); if c then c.maxBars = v; TSBRefresh() end end });  y = y - h
-
-        local texValues, texOrder = BuildBarTexDropdown()
-        _, h = W:DualRow(parent, y,
+              setValue=function(v) local c = TSB(); if c then c.maxBars = v; TSBRefresh() end end },
             { type="dropdown", text="Bar Texture",
               disabled=Off, disabledTooltip=REQ,
               values=texValues, order=texOrder,
               getValue=function() local c = TSB(); return (c and c.texture) or "none" end,
-              setValue=function(v) local c = TSB(); if c then c.texture = v; TSBRefresh() end end },
-            { type="multiSwatch", text="Colors",
+              setValue=function(v) local c = TSB(); if c then c.texture = v; TSBRefresh() end end });  y = y - h
+
+        _, h = W:DualRow(parent, y,
+            { type="multiSwatch", text="Background Color",
               disabled=Off, disabledTooltip=REQ,
               swatches = {
-                { tooltip = "Bar Color",
-                  getValue = function()
-                      local c = TSB()
-                      local col = c and c.barColor
-                      return (col and col.r) or 0.70, (col and col.g) or 0.40, (col and col.b) or 0.90
-                  end,
-                  setValue = function(r, g, b)
-                      local c = TSB(); if not c then return end
-                      c.barColor = { r = r, g = g, b = b }
-                      TSBRefresh()
-                  end },
                 { tooltip = "Background Color", hasAlpha = true,
                   getValue = function()
                       local c = TSB()
@@ -1148,9 +1180,7 @@ initFrame:SetScript("OnEvent", function(self)
                       c.bgColor = { r = r, g = g, b = b, a = a }
                       TSBRefresh()
                   end },
-              } });  y = y - h
-
-        _, h = W:DualRow(parent, y,
+              } },
             { type="slider", text="Border Size", min=0, max=5, step=1, pixel=true,
               disabled=Off, disabledTooltip=REQ,
               getValue=function()
@@ -1159,21 +1189,17 @@ initFrame:SetScript("OnEvent", function(self)
                   if v == nil then v = 1 end
                   return v
               end,
-              setValue=function(v) local c = TSB(); if c then c.borderSize = v; TSBRefresh() end end },
+              setValue=function(v) local c = TSB(); if c then c.borderSize = v; TSBRefresh() end end });  y = y - h
+
+        row, h = W:DualRow(parent, y,
             { type="toggle", text="Show Icon",
               disabled=Off, disabledTooltip=REQ,
               getValue=function() local c = TSB(); return not c or c.showIcon ~= false end,
-              setValue=function(v) local c = TSB(); if c then c.showIcon = v and true or false; TSBRefresh() end end });  y = y - h
-
-        row, h = W:DualRow(parent, y,
+              setValue=function(v) local c = TSB(); if c then c.showIcon = v and true or false; TSBRefresh() end end },
             { type="toggle", text="Show Spell Name",
               disabled=Off, disabledTooltip=REQ,
               getValue=function() local c = TSB(); return not c or c.showSpellName ~= false end,
-              setValue=function(v) local c = TSB(); if c then c.showSpellName = v and true or false; TSBRefresh() end end },
-            { type="toggle", text="Show Cast Timer",
-              disabled=Off, disabledTooltip=REQ,
-              getValue=function() local c = TSB(); return not c or c.showTimer ~= false end,
-              setValue=function(v) local c = TSB(); if c then c.showTimer = v and true or false; TSBRefresh() end end });  y = y - h
+              setValue=function(v) local c = TSB(); if c then c.showSpellName = v and true or false; TSBRefresh() end end });  y = y - h
         if not EllesmereUI._prebuilding then
             local _, showNameCog = EllesmereUI.BuildCogPopup({
                 title = "Spell Name",
@@ -1189,7 +1215,20 @@ initFrame:SetScript("OnEvent", function(self)
                       set=function(v) local c = TSB(); if c then c.nameY = v; TSBRefresh() end end },
                 },
             })
-            MakeCog(row._leftRegion, showNameCog, "Spell Name Settings")
+            MakeCog(row._rightRegion, showNameCog, "Spell Name Settings")
+        end
+
+        row, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Cast Timer",
+              disabled=Off, disabledTooltip=REQ,
+              getValue=function() local c = TSB(); return not c or c.showTimer ~= false end,
+              setValue=function(v) local c = TSB(); if c then c.showTimer = v and true or false; TSBRefresh() end end },
+            { type="toggle", text="Show Spell Target",
+              disabled=Off, disabledTooltip=REQ,
+              tooltip="Show who each spell is being cast on, exactly like the nameplate cast bars.",
+              getValue=function() local c = TSB(); return not c or c.showTarget ~= false end,
+              setValue=function(v) local c = TSB(); if c then c.showTarget = v and true or false; TSBRefresh() end end });  y = y - h
+        if not EllesmereUI._prebuilding then
             local _, showTimerCog = EllesmereUI.BuildCogPopup({
                 title = "Cast Timer",
                 rows = {
@@ -1204,17 +1243,7 @@ initFrame:SetScript("OnEvent", function(self)
                       set=function(v) local c = TSB(); if c then c.timerY = v; TSBRefresh() end end },
                 },
             })
-            MakeCog(row._rightRegion, showTimerCog, "Cast Timer Settings")
-        end
-
-        row, h = W:DualRow(parent, y,
-            { type="toggle", text="Show Spell Target",
-              disabled=Off, disabledTooltip=REQ,
-              tooltip="Show who each spell is being cast on, exactly like the nameplate cast bars.",
-              getValue=function() local c = TSB(); return not c or c.showTarget ~= false end,
-              setValue=function(v) local c = TSB(); if c then c.showTarget = v and true or false; TSBRefresh() end end },
-            { type="label", text="" });  y = y - h
-        if not EllesmereUI._prebuilding then
+            MakeCog(row._leftRegion, showTimerCog, "Cast Timer Settings")
             local _, showTargetCog = EllesmereUI.BuildCogPopup({
                 title = "Spell Target",
                 rows = {
@@ -1245,7 +1274,210 @@ initFrame:SetScript("OnEvent", function(self)
                       end },
                 },
             })
-            MakeCog(row._leftRegion, showTargetCog, "Spell Target Settings")
+            MakeCog(row._rightRegion, showTargetCog, "Spell Target Settings")
+        end
+
+        ---------------------------------------------------------------------
+        --  Interrupt awareness and visibility
+        ---------------------------------------------------------------------
+        _, h = W:SectionHeader(parent, "INTERRUPT AND VISIBILITY", y); y = y - h
+
+        -- Only styles with a genuine C-side twin via StartEngineGlow are
+        -- offered: Pixel/Action Button/GCD/Modern/Classic. Auto-Cast Shine and
+        -- Shape Glow have no C-side equivalent and silently remap inside the
+        -- engine, so a user picking them would see a different effect than
+        -- the name promises.
+        local impGlowValues, impGlowOrder = { [0] = "None" }, { 0 }
+        do
+            local ENGINE_SAFE_STYLES = { 1, 2, 5, 6, 7 }
+            local styles = EllesmereUI.Glows and EllesmereUI.Glows.STYLES
+            for _, idx in ipairs(ENGINE_SAFE_STYLES) do
+                local entry = styles and styles[idx]
+                impGlowValues[idx] = entry and entry.name or ("Style " .. idx)
+                impGlowOrder[#impGlowOrder + 1] = idx
+            end
+        end
+
+        -- Row: Cast Colors (always-on kick-ready/uninterruptible tints, no
+        -- off switch; 4 swatches + cog for the separate opt-in Important
+        -- Cast tint) | Important Cast Glow (dropdown-as-enable + inline
+        -- glow-color swatch + cog, same layout as the Nameplates module).
+        row, h = W:DualRow(parent, y,
+            { type="multiSwatch", text="Cast Colors",
+              disabled=Off, disabledTooltip=REQ,
+              swatches = {
+                { tooltip = "Interruptible Cast",
+                  getValue = function()
+                      local c = TSB()
+                      local col = c and c.barColor
+                      return (col and col.r) or 0.70, (col and col.g) or 0.40, (col and col.b) or 0.90
+                  end,
+                  setValue = function(r, g, b)
+                      local c = TSB(); if not c then return end
+                      c.barColor = { r = r, g = g, b = b }
+                      TSBRefresh()
+                  end },
+                { tooltip = "Interrupt on CD",
+                  getValue = function()
+                      local c = TSB()
+                      local col = c and c.interruptReady
+                      return (col and col.r) or 0.92, (col and col.g) or 0.35, (col and col.b) or 0.20
+                  end,
+                  setValue = function(r, g, b)
+                      local c = TSB(); if not c then return end
+                      c.interruptReady = { r = r, g = g, b = b }
+                      TSBRefresh()
+                  end },
+                { tooltip = "Uninterruptible Cast",
+                  getValue = function()
+                      local c = TSB()
+                      local col = c and c.uninterruptible
+                      return (col and col.r) or 0.45, (col and col.g) or 0.45, (col and col.b) or 0.45
+                  end,
+                  setValue = function(r, g, b)
+                      local c = TSB(); if not c then return end
+                      c.uninterruptible = { r = r, g = g, b = b }
+                      TSBRefresh()
+                  end },
+                { tooltip = "Important Cast",
+                  disabled = function() local c = TSB(); return not (c and c.importantEnabled == true) end,
+                  disabledTooltip = "Important Cast Color",
+                  getValue = function()
+                      local c = TSB()
+                      local col = c and c.importantColor
+                      return (col and col.r) or 1, (col and col.g) or 0.2, (col and col.b) or 0.2
+                  end,
+                  setValue = function(r, g, b)
+                      local c = TSB(); if not c then return end
+                      c.importantColor = { r = r, g = g, b = b }
+                      TSBRefresh()
+                  end },
+              } },
+            { type="dropdown", text="Important Cast Glow",
+              disabled=Off, disabledTooltip=REQ,
+              values=impGlowValues, order=impGlowOrder,
+              tooltip="Glow the bar when the enemy casts a spell Blizzard flags as important.",
+              getValue=function()
+                  local c = TSB()
+                  if not (c and c.importantGlow == true) then return 0 end
+                  return c.importantGlowStyle or 1
+              end,
+              setValue=function(v)
+                  local c = TSB(); if not c then return end
+                  if v == 0 then
+                      c.importantGlow = false
+                  else
+                      c.importantGlow = true
+                      c.importantGlowStyle = v
+                  end
+                  TSBRefresh(); EllesmereUI:RefreshPage()
+              end });  y = y - h
+
+        if not EllesmereUI._prebuilding then
+            local _, importantColorCog = EllesmereUI.BuildCogPopup({
+                title = "Important Cast Color",
+                rows = {
+                    { type="toggle", label="Important Cast Color",
+                      tooltip="Tint the bar with the Important colour when the enemy casts a spell the game flags as important.",
+                      get=function() local c = TSB(); return c and c.importantEnabled == true end,
+                      set=function(v)
+                          local c = TSB(); if not c then return end
+                          c.importantEnabled = v and true or false
+                          TSBRefresh(); EllesmereUI:RefreshPage()
+                      end },
+                },
+            })
+            MakeCog(row._leftRegion, importantColorCog, "Important Cast Color")
+
+            local rightRgn = row._rightRegion
+            local ctrl = rightRgn and rightRgn._control
+            if ctrl and EllesmereUI.BuildColorSwatch then
+                local PP = EllesmereUI.PP
+                local function GlowOff()
+                    local c = TSB()
+                    return Off() or not (c and c.importantGlow == true)
+                end
+                local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
+                    rightRgn, row:GetFrameLevel() + 3,
+                    function()
+                        local c = TSB()
+                        local col = c and c.importantGlowColor
+                        return (col and col.r) or 1, (col and col.g) or 0.2, (col and col.b) or 0.2
+                    end,
+                    function(r, g, b)
+                        local c = TSB(); if not c then return end
+                        c.importantGlowColor = { r = r, g = g, b = b }
+                        TSBRefresh()
+                    end, nil, 20)
+                PP.Point(swatch, "RIGHT", ctrl, "LEFT", -12, 0)
+                rightRgn._lastInline = swatch
+                EllesmereUI.RegisterWidgetRefresh(function()
+                    local off = GlowOff()
+                    swatch:SetAlpha(off and 0.15 or 1)
+                    swatch:EnableMouse(not off)
+                    updateSwatch()
+                end)
+                swatch:SetAlpha(GlowOff() and 0.15 or 1)
+                swatch:EnableMouse(not GlowOff())
+            end
+
+            local _, glowCog = EllesmereUI.BuildCogPopup({
+                title = "Important Cast Glow Settings",
+                rows = {
+                    { type="slider", label="Lines", min=2, max=16, step=1,
+                      get=function() local c = TSB(); return (c and c.importantGlowLines) or 8 end,
+                      set=function(v) local c = TSB(); if c then c.importantGlowLines = v; TSBRefresh() end end },
+                    { type="slider", label="Thickness", min=1, max=4, step=1,
+                      get=function() local c = TSB(); return (c and c.importantGlowThickness) or 2 end,
+                      set=function(v) local c = TSB(); if c then c.importantGlowThickness = v; TSBRefresh() end end },
+                    { type="slider", label="Speed", min=1, max=8, step=1,
+                      get=function() local c = TSB(); local s = (c and c.importantGlowSpeed) or 4; return 9 - s end,
+                      set=function(v) local c = TSB(); if c then c.importantGlowSpeed = 9 - v; TSBRefresh() end end },
+                },
+            })
+            MakeCog(row._rightRegion, glowCog, "Important Cast Glow Settings")
+        end
+
+        -- Row: Fade Out of Interrupt Range | Show Raid Target Marker.
+        row, h = W:DualRow(parent, y,
+            { type="toggle", text="Fade Out of Interrupt Range",
+              disabled=Off, disabledTooltip=REQ,
+              tooltip="Fade a bar when the enemy is beyond your active interrupt spell's range. Has no effect for specs without an interrupt.",
+              getValue=function() local c = TSB(); return c and c.oorEnabled == true end,
+              setValue=function(v)
+                  local c = TSB(); if not c then return end
+                  c.oorEnabled = v and true or false
+                  TSBRefresh()
+              end },
+            { type="toggle", text="Show Raid Target Marker",
+              disabled=Off, disabledTooltip=REQ,
+              tooltip="Show the enemy's raid target marker to the left of the spell name.",
+              getValue=function() local c = TSB(); return c and c.showRaidMarker == true end,
+              setValue=function(v)
+                  local c = TSB(); if not c then return end
+                  c.showRaidMarker = v and true or false
+                  TSBRefresh()
+              end });  y = y - h
+
+        if not EllesmereUI._prebuilding then
+            local _, oorCog = EllesmereUI.BuildCogPopup({
+                title = "Fade Out of Interrupt Range",
+                rows = {
+                    { type="slider", label="Opacity", min=0, max=100, step=5,
+                      get=function() local c = TSB(); return math.floor(((c and c.oorAlpha) or 0.45) * 100 + 0.5) end,
+                      set=function(v) local c = TSB(); if c then c.oorAlpha = v / 100; TSBRefresh() end end },
+                },
+            })
+            MakeCog(row._leftRegion, oorCog, "Range Fade Settings")
+            local _, markerCog = EllesmereUI.BuildCogPopup({
+                title = "Raid Target Marker",
+                rows = {
+                    { type="slider", label="Marker Size", min=6, max=30, step=1, pixel=true,
+                      get=function() local c = TSB(); return (c and c.raidMarkerSize) or 14 end,
+                      set=function(v) local c = TSB(); if c then c.raidMarkerSize = v; TSBRefresh() end end },
+                },
+            })
+            MakeCog(row._rightRegion, markerCog, "Raid Marker Settings")
         end
 
         _, h = W:Spacer(parent, y, 20); y = y - h


### PR DESCRIPTION
Feature Request: https://discord.com/channels/585577383847788554/1540382407302053969

## What does this PR do?

Adds interrupt awareness to Targeted Spell Bars (Mythic+ Tools), the one cast-bar surface in the suite that previously discarded the notInterruptible flag on every cast read and had no interrupt-related visuals at all.

Cast Colors (kick-ready tint on the bar plus a grey wash while the cast cannot be interrupted) is ported from Target/Focus Bars and always applies once Targeted Spell Bars itself is enabled, with no separate toggle: this is the one deliberate exception to "new settings default off" in this PR, since it mirrors the always-on Target/Focus Bars behavior and was chosen as the default rather than adding another switch.

Everything else added is opt-in and off by default: an Important Cast tint and a separate Important Cast Glow (offered in five styles that route through Glows.StartEngineGlow, its C-side AnimationGroup path, so the glow costs zero per-frame Lua no matter how many bars are glowing at once), a fade when the target is out of the player's interrupt range, and a raid target marker to the left of the spell name.

Also adds a Where to Show content-type filter (Open World, Mythic/Heroic/Normal-LFR Raid, Mythic/Non-Mythic Dungeons, Timewalking, Delve, In Combat), matching the same multi-select dropdown and bucket-detection convention already used by AuraBuffReminders, defaulting to Mythic Dungeons and In Combat only. It runs its own small zone/combat watcher, decoupled from the nameplate-tracking event set, so entering or leaving a matching zone (de)activates the group immediately without needing to reopen the options page.

Options page reorganized to fit: Enable Targeted Spell Bars now sits next to the new Where to Show control, the remaining rows shifted down to absorb it, and the Interrupt and Visibility section groups Cast Colors with Important Cast Glow on one row and Fade Out of Interrupt Range with Show Raid Target Marker on the other.

Beyond the new features, this also fixes a latent nil-texture trap in the bar builder (a StatusBar has no texture object until one is explicitly assigned, which every new fill-edge rider would have indexed into) and applies four behavior-preserving optimizations to the existing code: the shared 10Hz ticker no longer does work that cannot be seen, the duration lookup no longer probes three APIs when the active one is already known, a bar only restyles when its settings generation is stale instead of on every single cast, and releasing a bar only triggers a full nameplate scan when a cast was actually dropped at the bar cap. The duration-lookup fix also applies to Target/Focus Bars, which had the identical three-API probe.

## How was it tested?

Tested in-game on live.

## Screenshots
<img width="1296" height="943" alt="grafik" src="https://github.com/user-attachments/assets/d8d16f3a-b85f-44fb-b340-c8bfccd0241e" />
<img width="342" height="108" alt="grafik" src="https://github.com/user-attachments/assets/3afc1d30-efe7-4f37-bcc1-ffc3764713b4" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - true for every setting except Cast Colors, which is intentionally always-on once Targeted Spell Bars is enabled (see description above); everything else defaults off.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - the one exception is the existing shared 10Hz ticker (present before this PR for the cast timer text), extended with a 0.2s slow pass for kick-ready repaint and range fade, since neither has a push event in the API; this matches the same polling pattern already shipped in Nameplates and Target/Focus Bars for the identical reason.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added