### PR TITLE
Fix char sheet durability not refreshing after self-repair items

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -1401,8 +1401,14 @@ local function SkinCharacterSheet()
                 durEvents:SetScript("OnEvent", function() UpdateDurabilityDisplay() end)
             end
             durEvents:RegisterEvent("UPDATE_INVENTORY_DURABILITY")
+            -- Blizzard's own DurabilityFrame (the minimap alert icon) refreshes off this
+            -- event, not UPDATE_INVENTORY_DURABILITY: a self-repair item (e.g. a repair
+            -- hammer toy) recalculates alert status without firing the durability event,
+            -- so the sheet only caught the change on the next vendor-repair pass.
+            durEvents:RegisterEvent("UPDATE_INVENTORY_ALERTS")
         elseif durEvents then
             durEvents:UnregisterEvent("UPDATE_INVENTORY_DURABILITY")
+            durEvents:UnregisterEvent("UPDATE_INVENTORY_ALERTS")
         end
     end
 


### PR DESCRIPTION
Reported by <@200771375844032512> on 9.0.1. Durability shown on the character sheet doesn't update after repairing with a Thalassian Master Repair Hammer; only updates after a vendor repair.

**Cause:** the durability display only refreshed on `UPDATE_INVENTORY_DURABILITY`. Nothing in Blizzard's own retail UI actually handles that event; the minimap durability-alert icon refreshes off `UPDATE_INVENTORY_ALERTS` instead, which fires reliably on any durability change.

**Fix:** also register `UPDATE_INVENTORY_ALERTS` alongside the existing event.

**Test:** damage a piece of gear, use a self-repair item with the character sheet open, confirm the percent updates immediately without visiting a vendor.