### PR TITLE
Feature(Mythic+ Tools): add Icon on Right / Show Icon Divider to Targeted Spell Bars

### DIFF
--- a/EllesmereUIMythicTimer/EUI_MythicTimer_TargetedSpellBars.lua
+++ b/EllesmereUIMythicTimer/EUI_MythicTimer_TargetedSpellBars.lua
@@ -197,6 +197,19 @@ local function BuildBar()
     holder.icon:SetAllPoints(holder.iconFrame)
     holder.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
 
+    -- Optional icon/bar seam divider (opt-in "Show Icon Divider"), same seam
+    -- treatment as the resource bars cast bar's iconOnRight/showIconDivider pair.
+    -- Parented to a dedicated overlay frame raised well above holder.sb (a
+    -- child frame, which defaults to holder's own level + 1): a texture drawn
+    -- directly on holder renders at holder's frame level, which sits BELOW
+    -- holder.sb -- it would be invisible under it regardless of draw layer,
+    -- since draw layer only orders content within the SAME frame.
+    holder.overlayFrame = CreateFrame("Frame", nil, holder)
+    holder.overlayFrame:SetAllPoints(holder)
+    holder.overlayFrame:SetFrameLevel(holder:GetFrameLevel() + 5)
+    holder.iconDivider = holder.overlayFrame:CreateTexture(nil, "OVERLAY", nil, 7)
+    holder.iconDivider:Hide()
+
     holder.sb = CreateFrame("StatusBar", nil, holder)
     -- Placeholder fill: a StatusBar has NO texture object until one is set, and
     -- the fill-edge rider below (the uninterruptible overlay) would index nil
@@ -288,8 +301,26 @@ local function StyleBar(holder, cfg)
     else holder.bg:SetColorTexture(0, 0, 0, 0.45) end
 
     local showIcon = cfg.showIcon ~= false
+    local iconOnRight = cfg.iconOnRight
+    holder.iconFrame:ClearAllPoints()
+    if iconOnRight then
+        holder.iconFrame:SetPoint("TOPRIGHT", holder, "TOPRIGHT", 0, 0)
+        holder.iconFrame:SetPoint("BOTTOMRIGHT", holder, "BOTTOMRIGHT", 0, 0)
+    else
+        holder.iconFrame:SetPoint("TOPLEFT", holder, "TOPLEFT", 0, 0)
+        holder.iconFrame:SetPoint("BOTTOMLEFT", holder, "BOTTOMLEFT", 0, 0)
+    end
     holder.iconFrame:SetWidth(showIcon and h or 0.001)
     holder.iconFrame:SetShown(showIcon)
+
+    holder.sb:ClearAllPoints()
+    if showIcon and iconOnRight then
+        holder.sb:SetPoint("TOPLEFT", holder, "TOPLEFT", 0, 0)
+        holder.sb:SetPoint("BOTTOMRIGHT", holder.iconFrame, "BOTTOMLEFT", 0, 0)
+    else
+        holder.sb:SetPoint("TOPLEFT", holder.iconFrame, "TOPRIGHT", 0, 0)
+        holder.sb:SetPoint("BOTTOMRIGHT", holder, "BOTTOMRIGHT", 0, 0)
+    end
 
     local texPath = EllesmereUI.ResolveTexturePath
         and EllesmereUI.ResolveTexturePath(ns.barTextures, cfg.texture or "none", "Interface\\Buttons\\WHITE8x8")
@@ -322,6 +353,27 @@ local function StyleBar(holder, cfg)
         elseif holder._tsbBorder and pp.HideBorder then
             pp.HideBorder(holder)
         end
+    end
+
+    -- Optional icon/bar seam divider (opt-in "Show Icon Divider"), matching
+    -- the border color so it reads as part of the same frame.
+    if showIcon and cfg.showIconDivider then
+        local des = holder:GetEffectiveScale()
+        local onePixel = (pp and des > 0) and (pp.perfect / des) or ((pp and pp.mult) or 1)
+        local dbs = bsz > 0 and bsz or 1
+        holder.iconDivider:ClearAllPoints()
+        holder.iconDivider:SetWidth(math.max(onePixel, math.floor(dbs + 0.5) * onePixel))
+        if iconOnRight then
+            holder.iconDivider:SetPoint("TOPRIGHT", holder.iconFrame, "TOPLEFT", 0, 0)
+            holder.iconDivider:SetPoint("BOTTOMRIGHT", holder.iconFrame, "BOTTOMLEFT", 0, 0)
+        else
+            holder.iconDivider:SetPoint("TOPLEFT", holder.iconFrame, "TOPRIGHT", 0, 0)
+            holder.iconDivider:SetPoint("BOTTOMLEFT", holder.iconFrame, "BOTTOMRIGHT", 0, 0)
+        end
+        holder.iconDivider:SetColorTexture(0, 0, 0, 1)
+        holder.iconDivider:Show()
+    else
+        holder.iconDivider:Hide()
     end
 
     SetFSFont(holder.name, cfg.nameSize or 10)

--- a/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
+++ b/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
@@ -201,6 +201,8 @@ local DB_DEFAULTS = {
             bgColor          = { r = 0, g = 0, b = 0, a = 0.45 },
             borderSize       = 1,
             showIcon         = true,
+            iconOnRight      = false,  -- attach the spell icon to the right of the bar instead of the left
+            showIconDivider  = false,  -- draw a 1px divider at the icon/bar seam
             showSpellName    = true,
             nameSize         = 10,
             nameX            = 0,

--- a/EllesmereUIOptions/EUI_MythicTimer_Options.lua
+++ b/EllesmereUIOptions/EUI_MythicTimer_Options.lua
@@ -1225,6 +1225,20 @@ initFrame:SetScript("OnEvent", function(self)
               getValue=function() local c = TSB(); return not c or c.showSpellName ~= false end,
               setValue=function(v) local c = TSB(); if c then c.showSpellName = v and true or false; TSBRefresh() end end });  y = y - h
         if not EllesmereUI._prebuilding then
+            local _, showIconCog = EllesmereUI.BuildCogPopup({
+                title = "Spell Icon Settings",
+                rows = {
+                    { type="toggle", label="Icon on Right",
+                      tooltip = "Attach the spell icon to the right of the cast bar instead of the left.",
+                      get=function() local c = TSB(); return c and c.iconOnRight end,
+                      set=function(v) local c = TSB(); if c then c.iconOnRight = v; TSBRefresh() end end },
+                    { type="toggle", label="Show Icon Divider",
+                      tooltip = "Draw a 1px divider between the spell icon and the cast bar, matching the border color.",
+                      get=function() local c = TSB(); return c and c.showIconDivider end,
+                      set=function(v) local c = TSB(); if c then c.showIconDivider = v; TSBRefresh() end end },
+                },
+            })
+            MakeCog(row._leftRegion, showIconCog, "Spell Icon Settings")
             local _, showNameCog = EllesmereUI.BuildCogPopup({
                 title = "Spell Name",
                 rows = {


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds a cog popup to the Show Icon setting in Mythic+ Tools -> Targeted Spell Bars, matching the one already on the resource bars cast bar's Show Spell Icon setting: Icon on Right, to attach the spell icon to the right side of the bar instead of the left, and Show Icon Divider, to draw a 1px divider at the icon/bar seam matching the border color. Both are off by default, so existing bars are unaffected until a player opts in.

## How was it tested?

Tested in-game on live.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added