### PR TITLE
Fix Auto Open Containers opening Warbound Until Equipped items

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -259,7 +259,19 @@ qolFrame:SetScript("OnEvent", function(self)
             -- re-checks once the data lands) so a warbound container is never
             -- opened just because its bind type was not known yet.
             if not bindType then return true end
-            return WARBOUND_BIND_TYPES[bindType] == true
+            if WARBOUND_BIND_TYPES[bindType] == true then return true end
+            -- Warbound Until Equipped containers report bindType == OnEquip, same as
+            -- an ordinary BoE item (no dedicated GetItemInfo enum value -- see
+            -- EUI_Bags.SetBindTypeText's "WuE items report bindType == OnEquip"), so
+            -- ToBnetAccountUntilEquipped above never actually matches one. The item's
+            -- own bound-until-equip flag is the only reliable signal.
+            if bindType == Enum.ItemBind.OnEquip and ItemLocation and C_Item.IsBoundToAccountUntilEquip then
+                local loc = ItemLocation:CreateFromBagAndSlot(bag, slot)
+                if loc and C_Item.DoesItemExist(loc) then
+                    return C_Item.IsBoundToAccountUntilEquip(loc) == true
+                end
+            end
+            return false
         end
         local SLOTS_PER_FRAME = 3  -- check 3 slots per OnUpdate tick
 


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1538994455875555484
https://discord.com/channels/585577383847788554/1541856960561811546

Issue: Auto Open Containers' "Exclude Warbound Containers" toggle was supposed to hold back Warbound items so they wouldn't get auto-opened, but items that are specifically Warbound Until Equipped (e.g. Cache of Void-Touched Armaments) slipped through and got opened anyway — causing item/currency losses for users.

Root cause: the exclusion check matched the item's bindType against three known "warbound" enum values. But Warbound Until Equipped items report bindType == OnEquip — the same value as an ordinary Bind-on-Equip item — so none of the three checks ever matched, and the exclusion silently did nothing for this category.

Fix: when an item's bind type is OnEquip, additionally check C_Item.IsBoundToAccountUntilEquip on its bag/slot location — the same API the Bags module already relies on elsewhere to detect WuE gear — and exclude it if true. Verified in-game against a real Cache of Void-Touched drop with the toggle on: it's now held instead of opened.