### PR TITLE
fix(raidframes): localize the Debuff Manager "Select a Modifier" warning

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
@@ -1510,7 +1510,7 @@ local function BuildBaseDetailDM(frame, fontPath)
         -- Persistent red bubble above the cog while Shown on Modifier is
         -- selected with no key picked (the standard empty-selection warning);
         -- the hover tooltip above keeps the explanation.
-        EllesmereUI.AttachEmptyFilterWarn(leftRgn, tipModBtn, "Select a Modifier",
+        EllesmereUI.AttachEmptyFilterWarn(leftRgn, tipModBtn, L("Select a Modifier"),
             function()
                 return tipOff() or (p.debuffTooltipModifier or "none") ~= "none"
             end)


### PR DESCRIPTION
### Problem

On a non-English client the Debuff Manager's empty-selection warning is the
only untranslated thing on the page. Set Tooltips to `Shown on Modifier` and
leave Use Modifier at None: the red bubble that appears above the cog reads
"Select a Modifier" in English, sitting directly under a fully translated
dropdown, label and hover tooltip.

Cosmetic only - the warning fires and clears correctly, and English clients
see no difference at all.

Repro: Raid Frames -> Debuff Manager -> Tooltips -> Shown on Modifier, with
the Use Modifier cog left at None, on any non-English client.

### Cause

The bubble text is passed to `AttachEmptyFilterWarn` as a bare literal:

```lua
EllesmereUI.AttachEmptyFilterWarn(leftRgn, tipModBtn, "Select a Modifier", ...)
```

`AttachEmptyFilterWarn` does `fs:SetText(warnText)` and deliberately does not
localize on the caller's behalf, so every other call site wraps its own text.
The five that do - two in `EUI_UnitFrames_Options.lua`, two in
`EUI_PlayerAuraBars_ManagerPages.lua`, and the Debuff Manager's own filter
dropdown 290 lines above this one - all pass `L("...")`. This one call site
was the odd one out, so the string could never resolve no matter what a locale
file contained.

### Fix

Wrap it in the file's existing local `L()` helper, matching the five siblings.
That is the entire diff.

Localizing inside `AttachEmptyFilterWarn` instead would be the smaller-looking
change, but it would double-localize the five correct call sites: `L()` is an
exact table lookup, so a translated string passed back in returns itself, and
the bug would only resurface if a translation ever collided with an English
key. Fixing the outlier keeps one rule for all six.

### Notes

The zhTW string for this key ships separately in the locale PR, so on that
client the bubble stays English until both land. Every other locale falls back
to English exactly as it does today, which is the current behavior anyway.

Not touched: `SlotDisplay` in Quickdraw returns several labels assembled at
runtime (`"Target Marker: " .. MARKER_NAMES[id]`). Those do reach `L()` at the
draw site, so they are correct as written - noting it only because it looks
like the same pattern and is not.

### Testing

In-game, on live (12.1):

- Non-English client, Tooltips = Shown on Modifier, Use Modifier = None ->
  bubble shows the translated string.
- Same, with a modifier picked -> bubble hidden, unchanged.
- Tooltips = Hidden -> cog dims, blocking overlay still shows the requirement
  tooltip, unchanged.
- English client -> bubble reads "Select a Modifier" as before.

### Screenshots

Before/after of the bubble on a zhTW client - the only pixels that change are
the five characters inside it. Happy to attach shots if you want them in the
thread.

### Checklist

- [x] N/A - no new settings, no behavior change
- [x] N/A - no events, hooks or frames added
- [x] N/A - one table lookup on a string that was already being drawn
- [x] N/A - no Blizzard frames touched
- [x] Tested in-game on live (12.1); no version gates or pre-Midnight APIs added
