### PR TITLE
Fix Mirror Key Presses not matching item-based actions

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -10283,6 +10283,14 @@ do
         local actionType, id, subType = GetActionInfo(slot)
         if actionType == "spell" then
             return id
+        elseif actionType == "item" then
+            -- On-use trinkets/potions/healthstones placed directly on the
+            -- action bar: hand back the itemID as a second return. Bar icons
+            -- for these track by NEGATIVE identity (-itemID for item presets,
+            -- -invSlot for "whatever's equipped in slot X" -- see
+            -- ns.INV_SLOT_NAMES / the <= -100 item-preset branch above), not a
+            -- resolved spellID, so the caller builds the matching keys itself.
+            return nil, id
         elseif actionType == "macro" then
             if subType == "spell" then
                 return id
@@ -10309,10 +10317,27 @@ do
     local function OnPress(btn, bindCmd)
         if not btn or not _anyPressMirror then return end
         local slot = btn.action or (btn.GetAttribute and btn:GetAttribute("action"))
-        local sid = SlotSpellID(slot)
-        if not sid then return end
+        local sid, itemID = SlotSpellID(slot)
+        if not sid and not itemID then return end
 
-        local pressedSet = SpellIdSet(sid)
+        local pressedSet = sid and SpellIdSet(sid) or {}
+        if itemID then
+            -- Item-preset icons (potions, healthstones, custom item ids) key
+            -- off -itemID; equipment-slot icons (trinkets -13/-14, or any
+            -- user-added slot) key off -invSlot for whatever's equipped there.
+            -- Match both, plus the item's own on-use spell for the rarer case
+            -- of it being tracked as a plain Custom Spell entry instead.
+            pressedSet[-itemID] = true
+            for invSlot in pairs(ns.INV_SLOT_NAMES) do
+                if GetInventoryItemID("player", invSlot) == itemID then
+                    pressedSet[-invSlot] = true
+                end
+            end
+            local _, useSpellID = C_Item.GetItemSpell(itemID)
+            if useSpellID then
+                for k in pairs(SpellIdSet(useSpellID)) do pressedSet[k] = true end
+            end
+        end
         local overlays
         if cdmBarIcons then
             for barKey, list in pairs(cdmBarIcons) do


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541691517218066502

Issue: "Mirror Key Presses" on a custom Cooldown Manager bar wasn't flashing the mirror overlay for trinkets, potions, or healthstones — the actual keybind still fired the item fine, just no visual mirror. Toggling other bar settings had no effect because the bug wasn't a settings issue at all.

Root cause: The press-mirror code (SlotSpellID in EllesmereUICdmHooks.lua) only knew how to resolve action bar slots holding a spell or macro. Any slot holding an item directly (trinket, potion, healthstone) reports actionType == "item", which fell through to nil — silently killing the mirror for every item-tracked icon.

Fix: OnPress now also resolves item-type presses and matches them against how this addon actually keys item-based bar icons — a negative identity (-itemID for potions/healthstones/custom items, -invSlot for equipped-slot tracking like trinkets' -13/-14) — plus the item's on-use spell ID as a fallback for the rarer case where it's tracked as a raw Custom Spell entry.