### PR TITLE
Add all six glow styles plus a live preview to Important Cast Glow

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
@@ -289,9 +289,9 @@ function NPB.GroupGlow(idx)
     return magic == true, "magic"
 end
 
--- PANDEMIC_GLOW_STYLES index -> shared EllesmereUI.Glows.STYLES index (the
--- NP list has no Shape Glow, so the flipbook entries sit one lower there).
-local NP_TO_SHARED_GLOW = { 1, 2, 3, 5, 6, 7 }
+-- PANDEMIC_GLOW_STYLES index -> shared EllesmereUI.Glows.STYLES index. Defined
+-- beside PANDEMIC_GLOW_STYLES in EllesmereUINameplates.lua (loaded before us).
+local NP_TO_SHARED_GLOW = ns.NP_TO_SHARED_GLOW
 
 local function ApplyNPBuffExtra(button, d, style)
     ApplyNPText(button, d, style)

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -677,6 +677,13 @@ ns.PANDEMIC_GLOW_STYLES = PANDEMIC_GLOW_STYLES
 -- never raw index: this list omits "Custom Shape Glow", so the same index differs per side.
 if EllesmereUI then EllesmereUI.NameplatePandemicGlowStyles = PANDEMIC_GLOW_STYLES end
 
+-- PANDEMIC_GLOW_STYLES index -> shared EllesmereUI.Glows.STYLES index. The NP
+-- list omits Shape Glow (shared index 4), so every flipbook entry sits one lower
+-- here. Lives beside the list it translates FROM on purpose: a second copy is how
+-- the two drift the first time a style is inserted into either one.
+local NP_TO_SHARED_GLOW = { 1, 2, 3, 5, 6, 7 }
+ns.NP_TO_SHARED_GLOW = NP_TO_SHARED_GLOW
+
 local function GetPandemicGlowStyle()
     local raw = p and p.pandemicGlowStyle
     if raw == nil then return defaults.pandemicGlowStyle end
@@ -1485,12 +1492,16 @@ local StartButtonGlow     = _G_Glows.StartButtonGlow
 local StopButtonGlow      = _G_Glows.StopButtonGlow
 local StartAutoCastShine  = _G_Glows.StartAutoCastShine
 local StopAutoCastShine   = _G_Glows.StopAutoCastShine
+local StartGlow           = _G_Glows.StartGlow
+local StopAllGlows        = _G_Glows.StopAllGlows
 ns.StartProceduralAnts = StartProceduralAnts
 ns.StopProceduralAnts  = StopProceduralAnts
 ns.StartButtonGlow     = StartButtonGlow
 ns.StopButtonGlow      = StopButtonGlow
 ns.StartAutoCastShine  = StartAutoCastShine
 ns.StopAutoCastShine   = StopAutoCastShine
+ns.StartGlow           = StartGlow
+ns.StopAllGlows        = StopAllGlows
 
 -------------------------------------------------------------------------------
 --  Dispellable buff glow: highlights enemy buffs the player can purge/soothe
@@ -7263,12 +7274,14 @@ function NameplateFrame:UpdateImportantCastGlow(spellID)
     if not Glows then return end
 
     local style = cfg.importantCastGlowStyle or defaults.importantCastGlowStyle or 1
-    if style ~= 1 and style ~= 4 then style = 1 end
+    if type(style) ~= "number" or style < 1 or style > #PANDEMIC_GLOW_STYLES then style = 1 end
     local c = cfg.importantCastGlowColor or defaults.importantCastGlowColor or { r = 1, g = 0.2, b = 0.2 }
     local bgColor = cfg.importantCastGlowBackgroundColor or defaults.importantCastGlowBackgroundColor or { r = 0, g = 0, b = 0 }
     local bgOn = cfg.importantCastGlowBackground == true
+    -- Lines/thickness/speed and the background are Pixel Glow's own knobs; every
+    -- other style ignores them, so they stay nil and out of the cache key below.
     local impN, impTh, impPeriod
-    if style ~= 4 then
+    if style == 1 then
         impN = cfg.importantCastGlowLines or defaults.importantCastGlowLines or 8
         impTh = cfg.importantCastGlowThickness or defaults.importantCastGlowThickness or 2
         impPeriod = cfg.importantCastGlowSpeed or defaults.importantCastGlowSpeed or 4
@@ -7285,15 +7298,15 @@ function NameplateFrame:UpdateImportantCastGlow(spellID)
         local pW, pH = self.cast:GetWidth(), self.cast:GetHeight()
         if pW < 5 then pW = 100 end
         if pH < 5 then pH = 14 end
-        if style == 4 then
-            (StartAutoCastShine or Glows.StartAutoCastShine)(self._importantCastOverlay, pW, c.r, c.g, c.b, 1.0, pH)
-        else
-            local lineLen = math.floor((pW + pH) * (2 / impN - 0.1))
-            lineLen = math.min(lineLen, math.min(pW, pH))
-            if lineLen < 1 then lineLen = 1 end
-            (StartProceduralAnts or Glows.StartProceduralAnts)(self._importantCastOverlay, impN, impTh, impPeriod, lineLen, c.r, c.g, c.b, pW, pH,
-                bgOn and (bgColor.r or 0) or nil, bgColor.g or 0, bgColor.b or 0)
-        end
+        -- StartGlow owns the per-style engine pick. Its Pixel Glow path reproduces
+        -- the old direct call exactly: same lineLen formula, and an unset bg alpha
+        -- resolves to 1 there, which is what omitting the argument used to do.
+        local Start = StartGlow or Glows.StartGlow
+        Start(self._importantCastOverlay, NP_TO_SHARED_GLOW[style] or 1, pW, c.r, c.g, c.b,
+            style == 1 and {
+                N = impN, th = impTh, period = impPeriod,
+                bg = bgOn and { r = bgColor.r or 0, g = bgColor.g or 0, b = bgColor.b or 0 } or nil,
+            } or nil, pH)
         self._importantGlowActive = true
         self._importantGlowStyle = style
         self._importantGlowR, self._importantGlowG, self._importantGlowB = c.r, c.g, c.b

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -7221,14 +7221,24 @@ initFrame:SetScript("OnEvent", function(self)
                 if on == nil then on = defaults.importantCastGlow end
                 return not on
             end
+            -- Assigned once the preview frame exists, below. Forward-declared because
+            -- the dropdown, swatch and cog handlers are all built before that point
+            -- and every one of them re-renders the preview.
+            local RefreshImpCastPreview = function() end
+
             local function impCastAntsOff()
                 if impCastOff() then return true end
                 local raw = DB().importantCastGlowStyle or defaults.importantCastGlowStyle
                 return type(raw) ~= "number" or raw ~= 1
             end
 
-            local impGlowValues = { [0] = "None", [1] = "Pixel Glow", [4] = "Auto-Cast Shine" }
-            local impGlowOrder = { 0, 1, 4 }
+            -- Same list, same indices as the Pandemic Glow dropdown above.
+            local impGlowValues = { [0] = "None" }
+            local impGlowOrder = { 0 }
+            for i, entry in ipairs(ns.PANDEMIC_GLOW_STYLES) do
+                impGlowValues[i] = entry.name
+                impGlowOrder[#impGlowOrder + 1] = i
+            end
 
             local impGlowRow
             impGlowRow, h = W:DualRow(parent, y,
@@ -7236,7 +7246,10 @@ initFrame:SetScript("OnEvent", function(self)
                   values=impGlowValues, order=impGlowOrder,
                   getValue=function()
                     if impCastOff() then return 0 end
-                    return DB().importantCastGlowStyle or defaults.importantCastGlowStyle or 1
+                    local raw = DB().importantCastGlowStyle or defaults.importantCastGlowStyle or 1
+                    if type(raw) ~= "number" then return 1 end
+                    if raw < 1 or raw > #ns.PANDEMIC_GLOW_STYLES then return 1 end
+                    return raw
                   end,
                   setValue=function(v)
                     if v == 0 then
@@ -7246,6 +7259,7 @@ initFrame:SetScript("OnEvent", function(self)
                         DB().importantCastGlowStyle = v
                     end
                     RefreshAllPlates()
+                    RefreshImpCastPreview()
                     C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
                   end,
                   tooltip="Show a glow on the cast bar when the enemy is casting a spell Blizzard marks as important." },
@@ -7271,6 +7285,7 @@ initFrame:SetScript("OnEvent", function(self)
                         function(r, g, b)
                             DB().importantCastGlowColor = { r = r, g = g, b = b }
                             RefreshAllPlates()
+                            RefreshImpCastPreview()
                         end, nil, 20)
                     PP.Point(swatch, "RIGHT", ctrl, "LEFT", -12, 0)
                     leftRgn._lastInline = swatch
@@ -7292,22 +7307,22 @@ initFrame:SetScript("OnEvent", function(self)
                     rows = {
                         { type = "slider", label = "Lines", min = 2, max = 16, step = 1,
                           get = function() return DB().importantCastGlowLines or defaults.importantCastGlowLines or 8 end,
-                          set = function(v) DB().importantCastGlowLines = v; RefreshAllPlates() end },
+                          set = function(v) DB().importantCastGlowLines = v; RefreshAllPlates(); RefreshImpCastPreview() end },
                         { type = "slider", label = "Thickness", min = 1, max = 4, step = 1,
                           get = function() return DB().importantCastGlowThickness or defaults.importantCastGlowThickness or 2 end,
-                          set = function(v) DB().importantCastGlowThickness = v; RefreshAllPlates() end },
+                          set = function(v) DB().importantCastGlowThickness = v; RefreshAllPlates(); RefreshImpCastPreview() end },
                         { type = "slider", label = "Speed", min = 1, max = 8, step = 1,
                           get = function() local s = DB().importantCastGlowSpeed or defaults.importantCastGlowSpeed or 4; return 9 - s end,
-                          set = function(v) DB().importantCastGlowSpeed = 9 - v; RefreshAllPlates() end },
+                          set = function(v) DB().importantCastGlowSpeed = 9 - v; RefreshAllPlates(); RefreshImpCastPreview() end },
                         { type = "toggle", label = "Background",
                           get = function() return DB().importantCastGlowBackground == true end,
-                          set = function(v) DB().importantCastGlowBackground = v and true or nil; RefreshAllPlates() end },
+                          set = function(v) DB().importantCastGlowBackground = v and true or nil; RefreshAllPlates(); RefreshImpCastPreview() end },
                         { type = "colorpicker", label = "Background Color",
                           get = function()
                               local c = DB().importantCastGlowBackgroundColor or defaults.importantCastGlowBackgroundColor or { r = 0, g = 0, b = 0 }
                               return c.r or 0, c.g or 0, c.b or 0
                           end,
-                          set = function(r, g, b) DB().importantCastGlowBackgroundColor = { r = r, g = g, b = b }; RefreshAllPlates() end,
+                          set = function(r, g, b) DB().importantCastGlowBackgroundColor = { r = r, g = g, b = b }; RefreshAllPlates(); RefreshImpCastPreview() end,
                           disabled = function() return DB().importantCastGlowBackground ~= true end,
                           disabledTooltip = "Pixel Glow Background" },
                     },
@@ -7344,6 +7359,61 @@ initFrame:SetScript("OnEvent", function(self)
                 end)
                 cogBtn:SetAlpha(impCastAntsOff() and 0.15 or 0.4)
                 cogBtn:EnableMouse(not impCastAntsOff())
+
+                -- Glow preview. The Pandemic Glow row hosts its preview in the row's
+                -- right half; here that half is a real setting, so the preview joins
+                -- the inline chain instead and sits to the left of the cog.
+                local IMP_PREVIEW_SIZE = 26
+                local previewFrame = CreateFrame("Frame", nil, leftRgn)
+                PP.Size(previewFrame, IMP_PREVIEW_SIZE, IMP_PREVIEW_SIZE)
+                -- -12 rather than the chain's usual -6: the widest FlipBook styles
+                -- draw roughly 8px past the icon edge on each side.
+                PP.Point(previewFrame, "RIGHT", cogBtn, "LEFT", -12, 0)
+                previewFrame:SetFrameLevel(leftRgn:GetFrameLevel() + 5)
+
+                local previewTex = previewFrame:CreateTexture(nil, "ARTWORK")
+                previewTex:SetAllPoints()
+                previewTex:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+                PP.CreateBorder(previewFrame, 0, 0, 0, 1, 1, "OVERLAY", 7)
+
+                -- Leftmost inline item on this half; the row label is bounded against
+                -- it (region._lastInline, see EllesmereUI_Widgets.lua).
+                leftRgn._lastInline = previewFrame
+
+                -- Renders through the SAME dispatcher, style list and stored options
+                -- the nameplate itself uses, so the preview cannot drift from the real
+                -- cast bar. Assigns the forward-declared local from the top of the block.
+                RefreshImpCastPreview = function()
+                    ns.StopAllGlows(previewFrame)
+                    previewTex:SetTexture(displayCastIcons[_previewCastIconIdx or 1])
+
+                    local off = impCastOff()
+                    previewFrame:SetAlpha(off and 0.3 or 1)
+                    if off then return end
+
+                    local styles = ns.PANDEMIC_GLOW_STYLES
+                    local style = DB().importantCastGlowStyle or defaults.importantCastGlowStyle or 1
+                    if type(style) ~= "number" or style < 1 or style > #styles then style = 1 end
+
+                    local c = DB().importantCastGlowColor or defaults.importantCastGlowColor
+                    local opts
+                    if style == 1 then
+                        local bgc = DB().importantCastGlowBackgroundColor
+                            or defaults.importantCastGlowBackgroundColor or { r = 0, g = 0, b = 0 }
+                        opts = {
+                            N      = DB().importantCastGlowLines or defaults.importantCastGlowLines,
+                            th     = DB().importantCastGlowThickness or defaults.importantCastGlowThickness,
+                            period = DB().importantCastGlowSpeed or defaults.importantCastGlowSpeed,
+                            bg     = DB().importantCastGlowBackground == true
+                                     and { r = bgc.r or 0, g = bgc.g or 0, b = bgc.b or 0 } or nil,
+                        }
+                    end
+                    ns.StartGlow(previewFrame, ns.NP_TO_SHARED_GLOW[style] or 1,
+                        IMP_PREVIEW_SIZE, c.r, c.g, c.b, opts, IMP_PREVIEW_SIZE)
+                end
+
+                EllesmereUI.RegisterWidgetRefresh(RefreshImpCastPreview)
+                RefreshImpCastPreview()
             end
         end
 

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -4053,3 +4053,25 @@ EllesmereUI.RegisterMigration({
         end
     end,
 })
+
+-- The Important Cast Glow menu used to offer exactly two engines under an ad-hoc
+-- numbering: 1 = Pixel Glow, 4 = Auto-Cast Shine. It now offers the whole
+-- PANDEMIC_GLOW_STYLES list, where 3 is Auto-Cast Shine and 4 is GCD -- so a saved
+-- 4 would silently become a different glow. Re-point it.
+--
+-- 4 is the only value that can be stale: 1 means Pixel Glow in both numberings and
+-- nothing else was reachable from the old menu. Runs per profile and the flag rides
+-- on the profile data, so a profile IMPORTED from an older build is fixed up on the
+-- pass after it lands rather than staying wrong forever.
+EllesmereUI.RegisterMigration({
+    id          = "np_important_cast_glow_style_reindex_v1",
+    scope       = "profile",
+    description = "Re-point the saved Important Cast Glow style from the old two-entry numbering (4 = Auto-Cast Shine) onto the PANDEMIC_GLOW_STYLES index (3).",
+    body = function(ctx)
+        local np = ctx.profile.addons and ctx.profile.addons.EllesmereUINameplates
+        if type(np) ~= "table" then return end
+        if np.importantCastGlowStyle == 4 then
+            np.importantCastGlowStyle = 3
+        end
+    end,
+})


### PR DESCRIPTION
## What does this PR do?

Important Cast Glow on enemy nameplates offered 2 styles. It now offers the
same 6 as Pandemic Glow (Pixel, Action Button, Auto-Cast Shine, GCD, Modern
WoW, Classic WoW), plus a live preview icon in the row so you can see the glow
while picking it.

`UpdateImportantCastGlow` hardcoded two engines behind an ad-hoc numbering
(1 and 4); it now renders through `Glows.StartGlow` like the pandemic glow
does. Pixel Glow output is unchanged. `NP_TO_SHARED_GLOW` moves next to
`PANDEMIC_GLOW_STYLES` so the aura containers and the cast glow share one copy.

Old saved value `4` meant Auto-Cast Shine but means GCD in the new numbering,
so `np_important_cast_glow_style_reindex_v1` re-points it to `3`. Nothing
changes for existing users.

## How was it tested?

Client 12.1.0.69497.

<!-- CONFIRM --> Cycled all 6 styles on an enemy important cast; colour swatch
and the Pixel Glow cog settings update plate + preview live; "None" clears it.
Set Auto-Cast Shine on the old build, updated, confirmed it stayed.

Offline: verified the index translation by name against all three style tables;
ran the migration body against real SavedVariables (idempotent, no-ops on
profiles without the key).

 ## Screenshots

<img width="600" alt="glow-ingame-2" src="https://github.com/user-attachments/assets/e4084449-dc15-4744-a316-7c9f77d17e74" />
 
<img width="600" alt="glow-ingame-4" src="https://github.com/user-attachments/assets/f12ef259-1f54-410e-a67c-308e389b82ac" />

## Settings


https://github.com/user-attachments/assets/f4e5fb76-b1ad-4383-ac78-04246762b3b3



## Checklist

- [x] New settings default **OFF** — N/A, no new setting. `importantCastGlow`
      (true) and `importantCastGlowStyle` (1) are pre-existing defaults, untouched.
- [x] Zero cost while disabled — returns before building the overlay when off;
      preview only exists while the LoD options panel is open.
- [x] Cheap while enabled — no new events/hooks/timers; uses the existing shared
      Glows driver. The 3 FlipBook styles are C-side, cheaper than what was there.
- [x] No writes onto Blizzard-owned frames — EUI-owned overlay on the EUI cast bar.
- [ ] Tested in-game on live — no version gates or pre-Midnight APIs; tick after
      the in-game pass.