### PR TITLE
Fix Show All on Mouseover triggering from non-Mouseover bars

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -8573,7 +8573,12 @@ function EAB_VTABLE.Hover.FadeIn(barKey, state)
     -- frame in lockstep. Cheap because FadeInOne routes hover fades through
     -- the shared manual fader (a table write) instead of a 0.7-4ms
     -- AnimationGroup start per bar. Iterative, not recursive: no reentrancy latch to get stuck.
-    if EAB.db.profile.mouseoverShowAll then
+    -- Gated on THIS bar being Mouseover itself -- AttachHoverHooks wires the
+    -- same OnEnter onto every bar regardless of its own visibility mode, so
+    -- without this check hovering an Always-visible bar broadcast the same
+    -- as hovering a real Mouseover one (tooltip promises the latter only).
+    local s = EAB_VTABLE.Hover.GetSettings(barKey)
+    if s and s.mouseoverEnabled and EAB.db.profile.mouseoverShowAll then
         local FadeInOne = EAB_VTABLE.Hover.FadeInOne
         for otherKey, otherState in pairs(hoverStates) do
             if otherKey ~= barKey then


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1542132572916547635

Issue: With "Show All on Mouseover" enabled, hovering any action bar — even one set to Always visible — made all Mouseover-visibility bars appear. The tooltip promises this should only happen when hovering a bar that's itself set to Mouseover.

Root cause: AttachHoverHooks wires the hover-fade handler onto every action bar unconditionally, regardless of that bar's own visibility setting. So FadeIn's "show all" broadcast fired on mouseoverShowAll alone, with no check on whether the bar actually being hovered was a Mouseover bar.

Fix: FadeIn now only broadcasts to the other bars when the entered bar itself has mouseoverEnabled set — matching the setting's documented behavior.