### PR TITLE
fix(cdm): never rebuild Blizzard's shared cooldown data on our stack

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -571,7 +571,7 @@ function ns.EnumerateCDMSettingsCatalog(wantSet)
 
     local result = {}
     for _, cdID in ipairs(ordered) do
-        local pInfo = infoByID[cdID]
+        local pInfo = _IsUsableSID(cdID) and infoByID[cdID]
         local category
         if type(pInfo) == "table" then category = pInfo.category end
         if category ~= nil and wantSet[category] then

--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -562,18 +562,18 @@ function ns.EnumerateCDMSettingsCatalog(wantSet)
     if not settings or type(settings.GetDataProvider) ~= "function" then return nil end
     local okP, provider = pcall(settings.GetDataProvider, settings)
     if not okP or type(provider) ~= "table" then return nil end
-    if type(provider.GetOrderedCooldownIDs) ~= "function"
-       or type(provider.GetCooldownInfoForID) ~= "function" then return nil end
-    local okO, ordered = pcall(provider.GetOrderedCooldownIDs, provider)
-    if not okO or type(ordered) ~= "table" then return nil end
+    -- Read the already-built display table, never the getters that would
+    -- build it (see ns.CDMGetProviderDisplayData, EllesmereUICooldownManager.lua).
+    local ordered, infoByID = ns.CDMGetProviderDisplayData(provider)
+    if not ordered then return nil end
     local gci = C_CooldownViewer and C_CooldownViewer.GetCooldownViewerCooldownInfo
     if not gci then return nil end
 
     local result = {}
     for _, cdID in ipairs(ordered) do
-        local okI, pInfo = pcall(provider.GetCooldownInfoForID, provider, cdID)
+        local pInfo = infoByID[cdID]
         local category
-        if okI and type(pInfo) == "table" then category = pInfo.category end
+        if type(pInfo) == "table" then category = pInfo.category end
         if category ~= nil and wantSet[category] then
             -- Same shape the migration and spell caches use. Prefer override
             -- only when the player actually has it -- CDM info can report a

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8463,6 +8463,26 @@ local function _IsUsableSID(id)
     return id > 0 and id == math.floor(id)
 end
 
+-- Reads the ALREADY-BUILT display table, never the getters that would build
+-- it: provider:GetOrderedCooldownIDs()/GetCooldownInfoForID() run
+-- CheckBuildDisplayData first, which rebuilds Blizzard's shared cooldown
+-- tables when the provider is dirty -- and a PvP match boundary (talents
+-- (de)activating) marks it dirty right when EUI reads it, poisoning
+-- Blizzard's own state until reload. GetDisplayData is a plain field read,
+-- so this can only observe what Blizzard already built; callers already
+-- treat nil as "not ready" and fall back to keep-all/live-pool.
+function ns.CDMGetProviderDisplayData(provider)
+    if type(provider) ~= "table" or type(provider.GetDisplayData) ~= "function" then
+        return nil, nil
+    end
+    local ok, displayData = pcall(provider.GetDisplayData, provider)
+    if not ok or type(displayData) ~= "table" then return nil, nil end
+    local ordered = displayData.orderedCooldownIDs
+    local infoByID = displayData.cooldownInfoByID
+    if type(ordered) ~= "table" or type(infoByID) ~= "table" then return nil, nil end
+    return ordered, infoByID
+end
+
 -- Active BLIZZARD CDM layout id (the user's "preset"), not to be confused with
 -- ns.GetActiveLayoutName (EUI's own account-wide spell-layout system). Used to
 -- scope the automatic-reseed session gate by layout as well as spec: a spell
@@ -8533,9 +8553,9 @@ function ns.CDMEntryHiddenOrRemoved(cdID, mergedInfo, rawInfo, liveSetLookup)
     if mergedInfo == nil then
         local provider = CooldownViewerSettings and CooldownViewerSettings.GetDataProvider
                           and CooldownViewerSettings:GetDataProvider()
-        if provider and provider.GetCooldownInfoForID then
-            local ok, info = pcall(provider.GetCooldownInfoForID, provider, cdID)
-            if ok then mergedInfo = info end
+        if provider then
+            local _, infoByID = ns.CDMGetProviderDisplayData(provider)
+            if infoByID then mergedInfo = infoByID[cdID] end
         end
     end
 
@@ -8636,10 +8656,10 @@ local function BuildBuffFamilyPresentSet()
     if not settings or type(settings.GetDataProvider) ~= "function" then return nil end
     local okP, provider = pcall(settings.GetDataProvider, settings)
     if not okP or type(provider) ~= "table" then return nil end
-    if type(provider.GetOrderedCooldownIDs) ~= "function"
-       or type(provider.GetCooldownInfoForID) ~= "function" then return nil end
-    local okO, ordered = pcall(provider.GetOrderedCooldownIDs, provider)
-    if not okO or type(ordered) ~= "table" then return nil end
+    -- Read the already-built display table, never the getters that would
+    -- build it (see ns.CDMGetProviderDisplayData).
+    local ordered, infoByID = ns.CDMGetProviderDisplayData(provider)
+    if not ordered then return nil end
     local gci = C_CooldownViewer and C_CooldownViewer.GetCooldownViewerCooldownInfo
     if not gci then return nil end
     local evc = Enum and Enum.CooldownViewerCategory
@@ -8663,8 +8683,8 @@ local function BuildBuffFamilyPresentSet()
 
     local present, sawEntry = {}, false
     for _, cdID in ipairs(ordered) do
-        local okI, mergedInfo = pcall(provider.GetCooldownInfoForID, provider, cdID)
-        local category = okI and type(mergedInfo) == "table" and mergedInfo.category
+        local mergedInfo = infoByID[cdID]
+        local category = type(mergedInfo) == "table" and mergedInfo.category
         if category ~= nil and wantCats[category] then
             sawEntry = true
             local rawInfo = gci(cdID)

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -8683,7 +8683,7 @@ local function BuildBuffFamilyPresentSet()
 
     local present, sawEntry = {}, false
     for _, cdID in ipairs(ordered) do
-        local mergedInfo = infoByID[cdID]
+        local mergedInfo = _IsUsableSID(cdID) and infoByID[cdID]
         local category = type(mergedInfo) == "table" and mergedInfo.category
         if category ~= nil and wantCats[category] then
             sawEntry = true


### PR DESCRIPTION
Bug: reported by Factor in EllesmereUI-helper Discord (8/5 - 8/15)

Issue: After leaving queued content such as a battleground or arena, the Cooldown Manager disappears and stays gone until a full /reload. It fires intermittently with no obvious trigger, which is why it has been hard to pin down. First reported on 8.7.6 and retested still broken on 8.8.8+.

Root cause: EUI read Blizzard's CDM settings provider through provider:GetOrderedCooldownIDs() and provider:GetCooldownInfoForID(). Both of those run CheckBuildDisplayData() as their first step, which rebuilds Blizzard's shared cooldownInfoByID and orderedCooldownIDs tables whenever the provider is marked dirty, and can write back into the active layout and fire reentrant OnDataChanged notifications while doing it. Building the client's own shared state inside addon execution poisons it for the client's later use. The provider is marked dirty by talents activating and deactivating, which is exactly what a PvP match boundary does, so the viewer bricks on leaving a match with no apparent trigger and only a reload clears it. A diagnostic run while broken showed every item frame still IsShown() with a plausible on-screen position, which rules out a pool-release or claim-loss bug and points at the viewer's own build path instead.

Fix: added ns.CDMGetProviderDisplayData, which reads provider:GetDisplayData() instead. That is a plain field read returning what Blizzard already built, so it can never trigger a rebuild. It replaces the unsafe pattern at all three call sites that had it: EnumerateCDMSettingsCatalog in EllesmereUICdmSpellPicker.lua, plus CDMEntryHiddenOrRemoved and BuildBuffFamilyPresentSet in EllesmereUICooldownManager.lua. All three already treat an unavailable provider as "not ready" and fall back to keep-all or live-pool behaviour, so nothing changes on the happy path. Kept the provider read rather than switching to the C API, because the C API gives neither the user's arranged order nor Hidden handling.

The second commit restores a per-entry guard the first one dropped: swapping the pcall-wrapped getter for a direct infoByID[cdID] index removed an error boundary that the hidden-channel reader documents ("every provider read here is pcall-degraded, so the drop pass this feeds never over-drops on a bad read"). Both loops now gate on _IsUsableSID before keying the table, matching what the third call site already did.

Tested in-game by the original reporter across several battleground and arena queues: the Cooldown Manager now survives the match boundary with no reload needed.
