### PR TITLE
fix(databars): use season-earned total for capped currency tooltips

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -5241,6 +5241,11 @@ ns.BlockFactories.currency = function(blockCfg, slot, content, barCtx)
         return nil
     end
 
+    local function Num(v)
+        if BreakUpLargeNumbers then return BreakUpLargeNumbers(v or 0) end
+        return tostring(v or 0)
+    end
+
     function inst:Refresh()
         local s = D()
         local barCfg = BC()
@@ -5369,12 +5374,17 @@ ns.BlockFactories.currency = function(blockCfg, slot, content, barCtx)
             ns.Tip_AddWrappedLine(info.description, 280, 0.8, 0.8, 0.8)
         end
         ns.Tip_AddLine(" ")
-        local qty
-        if BreakUpLargeNumbers then qty = BreakUpLargeNumbers(info.quantity or 0) else qty = tostring(info.quantity or 0) end
-        if info.maxQuantity and info.maxQuantity > 0 then
-            local maxQty
-            if BreakUpLargeNumbers then maxQty = BreakUpLargeNumbers(info.maxQuantity) else maxQty = tostring(info.maxQuantity) end
-            ns.Tip_AddDouble(L["TOTAL"], qty .. " / " .. maxQty, 0.6, 0.6, 0.6, 1, 1, 1)
+        local qty = Num(info.quantity)
+        local cap = info.maxQuantity
+        if cap and cap > 0 then
+            -- useTotalEarnedForMaxQty currencies (crests) cap what you EARNED this
+            -- season, not what you hold, so the wallet total is the wrong numerator.
+            if info.useTotalEarnedForMaxQty then
+                ns.Tip_AddDouble(L["TOTAL"], qty .. " |cffaaaaaa(" .. Num(info.totalEarned) .. "/" .. Num(cap) .. ")|r",
+                    0.6, 0.6, 0.6, 1, 1, 1)
+            else
+                ns.Tip_AddDouble(L["TOTAL"], qty .. " / " .. Num(cap), 0.6, 0.6, 0.6, 1, 1, 1)
+            end
         else
             ns.Tip_AddDouble(L["TOTAL"], qty, 0.6, 0.6, 0.6, 1, 1, 1)
         end


### PR DESCRIPTION
Bug: reported by Zaughon in EllesmereUI-helper Discord (2026-08-25), Data Bars, version 9.0.5.

Issue: the Currency data bar block's tooltip overstates how close you are to a seasonal cap. Zaughon was holding 99 Myth Mistcrests while sitting at 49/100 for the season, and the tooltip read "Total: 99 / 100", implying one more crest would cap him out when he was barely halfway. It reads like a refresh or rounding problem but is neither: the figure is stable, survives a reload, and is simply the wrong number. It only appears on currencies that carry a seasonal earn cap, so most entries in the currency picker look correct, and the Crests block sitting on the same bar reports the real figure, which is what made the two surfaces appear to contradict each other.

Root cause: C_CurrencyInfo.GetCurrencyInfo returns both quantity (what is in the wallet) and totalEarned (what you have earned this season), plus a useTotalEarnedForMaxQty flag saying which of the two maxQuantity actually bounds. For crests that flag is set and the cap applies to totalEarned, so the wallet total is the wrong numerator, and the two diverge the moment you spend a crest or carry one over from a previous season. ShowCurrencyTooltip in EllesmereUIDataBars_Blocks.lua composed the line as quantity / maxQuantity unconditionally. The Crests block in the same file already branches on the flag in its AmountText and TooltipAmount helpers, so the generic Currency block was the one surface that never picked it up.

Fix: the tooltip now branches on useTotalEarnedForMaxQty the same way Blizzard's own WillCurrencyRewardOverflow does, rendering the wallet total followed by season progress dimmed in parentheses, so Zaughon's example reads "Total: 99 (49/100)". Currencies whose cap genuinely bounds the wallet keep the existing qty / max form, and uncapped currencies are untouched. The bar text never showed a cap and is unchanged, and nothing here runs outside the hover handler. Verified in game against Blizzard's own currency tooltip on a capped crest, on an uncapped currency, and against the Crests block, with all three now agreeing.

<img width="260" height="195" alt="adorable cuteness GIF" src="https://github.com/user-attachments/assets/44ddc953-a323-4b58-8d9f-40d48c12a95a" />

