### PR TITLE
Fix gamepad keybinds showing raw button names instead of controller icons

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -821,9 +821,14 @@ ns.ResolveBorderThickness = ResolveBorderThickness
 local function FormatHotkeyText(text)
     if not text or text == "" then return "" end
     -- GetBindingKey hands back a gamepad button's raw id (PADDUP); only
-    -- GetBindingText resolves it to the controller's icon markup.
-    if IsBindingForGamePad(text) then
-        return GetBindingText(text, 1) or ""
+    -- GetBindingText resolves it to the controller's icon markup. Adopted just
+    -- when markup came back, so keyboard binds keep the raw token names the
+    -- substitutions below are written against. Those still run over a resolved
+    -- chord to condense its modifier -- no gamepad atlas name contains one of
+    -- their search strings.
+    local resolved = GetBindingText(text, 1)
+    if resolved and resolved:find("|A:", 1, true) then
+        text = resolved
     end
     text = text:gsub("CTRL%-", "C")
     text = text:gsub("ALT%-", "A")

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -820,6 +820,11 @@ ns.ResolveBorderThickness = ResolveBorderThickness
 -- Condense keybind text (CTRL-2 C2, Mouse Button 4 M4, etc.)
 local function FormatHotkeyText(text)
     if not text or text == "" then return "" end
+    -- GetBindingKey hands back a gamepad button's raw id (PADDUP); only
+    -- GetBindingText resolves it to the controller's icon markup.
+    if IsBindingForGamePad(text) then
+        return GetBindingText(text, 1) or ""
+    end
     text = text:gsub("CTRL%-", "C")
     text = text:gsub("ALT%-", "A")
     text = text:gsub("SHIFT%-", "S")

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7096,10 +7096,14 @@ local _stableMode = false
 local function FormatKeybindKey(key)
     if not key or key == "" then return nil end
     -- GetBindingKey hands back a gamepad button's raw id (PADDUP); only
-    -- GetBindingText resolves it to the controller's icon markup.
-    if IsBindingForGamePad(key) then
-        local text = GetBindingText(key, 1)
-        return text ~= "" and text or nil
+    -- GetBindingText resolves it to the controller's icon markup. Adopted just
+    -- when markup came back, so keyboard binds keep the raw token names the
+    -- substitutions below are written against. Those still run over a resolved
+    -- chord to condense its modifier -- no gamepad atlas name contains one of
+    -- their search strings.
+    local resolved = GetBindingText(key, 1)
+    if resolved and resolved:find("|A:", 1, true) then
+        key = resolved
     end
     key = key:gsub("SHIFT%-", "S")
     key = key:gsub("CTRL%-",  "C")

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7095,6 +7095,12 @@ local _stableMode = false
 
 local function FormatKeybindKey(key)
     if not key or key == "" then return nil end
+    -- GetBindingKey hands back a gamepad button's raw id (PADDUP); only
+    -- GetBindingText resolves it to the controller's icon markup.
+    if IsBindingForGamePad(key) then
+        local text = GetBindingText(key, 1)
+        return text ~= "" and text or nil
+    end
     key = key:gsub("SHIFT%-", "S")
     key = key:gsub("CTRL%-",  "C")
     key = key:gsub("ALT%-",   "A")


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1542203148544778270

Issue: with a DualSense controller connected, action bar buttons show raw binding names like PADUP where Blizzard's default bars draw the controller's own glyph. Cooldown Manager icon keybinds carry the same text.

Root cause: GetBindingKey returns a gamepad bind as its raw id, and only GetBindingText resolves that id to the icon markup Blizzard builds in SharedConstants.lua. FormatHotkeyText in EllesmereUIActionBars.lua and FormatKeybindKey in EllesmereUICooldownManager.lua never called it, so the raw id fell through their keyboard condensing substitutions untouched.

Fix: both now take GetBindingText's answer whenever it comes back carrying icon markup, then run the existing substitutions over it. Keyboard binds have no markup to match and are unchanged, and no gamepad atlas name contains one of those search strings, so a shoulder-modifier chord like SHIFT-PAD4 condenses its modifier and keeps its glyph.
