### PR TITLE
feat(mythictimer): add strict comparison mode for split compare

### DIFF
--- a/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
+++ b/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
@@ -151,6 +151,7 @@ local DB_DEFAULTS = {
         showCompletedMilliseconds = true,
         objectiveCompareMode = "NONE",
         objectiveCompareDeltaOnly = false,
+        objectiveCompareStrict = false,
         showUpcomingSplitTargets = false,
         frameWidth        = 260,
         barWidth          = 210,
@@ -508,8 +509,15 @@ local function GetReferenceObjectiveTime(run, objectiveIndex, mode)
 
     -- Try exact scope first, then fall back to broader scopes.
     -- LEVEL_AFFIX -> LEVEL -> DUNGEON
+    -- Strict mode drops the fallback so a run is only ever measured against a
+    -- previous run at the same scope. Without it, the first run at a new key
+    -- level has no same-scope record and silently borrows the dungeon-wide
+    -- best (set at any level), which reads as a slower split every time.
+    -- COMPARE_DUNGEON is already the broadest scope, so strict is a no-op there.
     local tryOrder
-    if mode == COMPARE_LEVEL_AFFIX then
+    if db.profile.objectiveCompareStrict == true then
+        tryOrder = { mode }
+    elseif mode == COMPARE_LEVEL_AFFIX then
         tryOrder = { COMPARE_LEVEL_AFFIX, COMPARE_LEVEL, COMPARE_DUNGEON }
     elseif mode == COMPARE_LEVEL then
         tryOrder = { COMPARE_LEVEL, COMPARE_DUNGEON }

--- a/EllesmereUIOptions/EUI_MythicTimer_Options.lua
+++ b/EllesmereUIOptions/EUI_MythicTimer_Options.lua
@@ -947,6 +947,21 @@ initFrame:SetScript("OnEvent", function(self)
               order=compareModeOrder,
               getValue=function() return Cfg("objectiveCompareMode") or "NONE" end,
               setValue=function(v) Set("objectiveCompareMode", v); Refresh() end })
+        -- Cog on Split Compare: strict scoping. Only meaningful for the level
+        -- scopes, since Per Dungeon is itself the fallback the switch removes.
+        if not EllesmereUI._prebuilding then
+        _AttachPopupButton(row._rightRegion, EllesmereUI.COGS_ICON, "Split Compare", {
+            { type="toggle", label="Strict Comparison Mode",
+              tooltip="Compares same key level splits only. When off, new key level splits compare against your dungeon best.",
+              disabled=function()
+                  local mode = Cfg("objectiveCompareMode") or "NONE"
+                  return mode ~= "LEVEL" and mode ~= "LEVEL_AFFIX"
+              end,
+              disabledTooltip="This option requires Split Compare to include a key level",
+              get=function() return Cfg("objectiveCompareStrict") == true end,
+              set=function(v) Set("objectiveCompareStrict", v); Refresh() end },
+        }, function() return Cfg("enabled") == false or Cfg("showObjectives") == false end)
+        end
         y = y - h
 
         _, h = W:Spacer(parent, y, 20); y = y - h


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->

Mythic+ split comparisons will compare only when a key level matches. New behavior is behind a cog switch, so old functionality stays the same (new key levels compare against dungeon best).

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
12.1

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game, works on live retail; no load errors on the 12.1 PTR client
