### PR TITLE
Fix(Visiblity Options): Never and Always interplay with the visibility option axes

### DIFF
--- a/EllesmereUIOptions/EllesmereUI_Widgets.lua
+++ b/EllesmereUIOptions/EllesmereUI_Widgets.lua
@@ -8561,6 +8561,17 @@ function EllesmereUI.AttachVisibilityChecklist(region, opts)
         if store then store[k] = v or nil end
     end
 
+    -- A Show-lane option axis narrows showing to a subset, which is precisely what Always
+    -- claims not to do, so the two must never read as checked together. Mode and group rows
+    -- drop always from the selection itself; the option axes live outside it, so the
+    -- contradiction is reconciled in GetChecked/SetChecked instead.
+    local function AnyShowOptActive()
+        for _, d in pairs(defs) do
+            if d.axis == "opt" and GetOpt(d.show) then return true end
+        end
+        return false
+    end
+
     local cbDD, cbDDRefresh
     local pendingRefresh = false
 
@@ -8568,12 +8579,18 @@ function EllesmereUI.AttachVisibilityChecklist(region, opts)
     -- REBUILD waits for menu close: rebuilding under the open menu destroys the button
     -- it is anchored to, and the point of a checklist is setting several axes in one
     -- visit. Terminal picks (Never/Always, orphans) close the menu themselves.
-    local function AfterChange(closeMenu, isOption)
-        if isOption and opts.onOptionChanged then
-            opts.onOptionChanged()
-        elseif opts.onChanged then
-            opts.onChanged()
-        end
+    -- alsoOther: this click wrote a mode AND an option (an option axis that had to clear
+    -- Never, or Always clearing the Show lanes), so both chains run. Neither is a subset of
+    -- the other -- Action Bars' option chain recompiles the housing driver its mode chain
+    -- never touches, and its mode chain rebuilds the page on a Never flip.
+    local function AfterChange(closeMenu, isOption, alsoOther)
+        local optionFn = (isOption or alsoOther) and opts.onOptionChanged
+        local modeFn = ((not isOption) or alsoOther) and opts.onChanged
+        if optionFn then optionFn() end
+        if modeFn then modeFn() end
+        -- Fallback kept from before: an option write on a caller that only supplies
+        -- onChanged still gets that chain rather than nothing.
+        if not optionFn and not modeFn and opts.onChanged then opts.onChanged() end
         pendingRefresh = true
         if closeMenu and cbDD and cbDD._ddMenu then cbDD._ddMenu:Hide() end
     end
@@ -8596,6 +8613,7 @@ function EllesmereUI.AttachVisibilityChecklist(region, opts)
             end
             return true
         end
+        if k == "always" then return sel.always == true and not AnyShowOptActive() end
         return sel[k] == true
     end
 
@@ -8614,7 +8632,21 @@ function EllesmereUI.AttachVisibilityChecklist(region, opts)
             if neg then lane, other = def.hide, def.show end
             SetOpt(lane, checked)
             if checked then SetOpt(other, false) end
-            AfterChange(false, true)
+            -- Switching a lane on while Never is picked would be a no-op, so the click leaves
+            -- Never: the selection empties and WriteSel's never-empty invariant lands on
+            -- Always, which is the base a Hide lane needs and the one a Show lane then narrows
+            -- (GetChecked unchecks Always for it). Unchecking a lane leaves Never alone --
+            -- clearing a condition is not a request to start showing.
+            local clearedNever = false
+            if checked then
+                local sel, store = Sel()
+                if store and sel.never then
+                    sel.never = nil
+                    WriteSel(sel, store)
+                    clearedNever = true
+                end
+            end
+            AfterChange(false, true, clearedNever)
             return
         end
 
@@ -8664,12 +8696,24 @@ function EllesmereUI.AttachVisibilityChecklist(region, opts)
         end
 
         if k == "never" or k == "always" then
-            -- Exclusive and terminal, like a plain single-select. Deliberately does NOT
-            -- clear the option axes: they are separate constraints, same as before.
+            -- Exclusive and terminal, like a plain single-select.
             for key in pairs(sel) do sel[key] = nil end
             if checked then sel[k] = true end
             WriteSel(sel, store)
-            AfterChange(true)
+            -- Always is the unrestricted state, so it clears the Show lanes that would
+            -- otherwise keep its own box unchecked (GetChecked) and make this click a no-op.
+            -- Hide lanes are exceptions on top of showing and survive, as do both lanes under
+            -- Never: picking Never suppresses the option axes, it does not reset them.
+            local clearedOpts = false
+            if k == "always" and checked then
+                for _, d in pairs(defs) do
+                    if d.axis == "opt" and GetOpt(d.show) then
+                        SetOpt(d.show, false)
+                        clearedOpts = true
+                    end
+                end
+            end
+            AfterChange(true, false, clearedOpts)
             return
         end
 


### PR DESCRIPTION
## What does this PR do?

Fixes two clicks in the Visibility checklist that silently did nothing, and a row state that could contradict what the element actually did. The option axes (Skyriding Mount, Instances, Housing, Mounted, Target, Enemy Target) are stored as their own booleans rather than as part of the mode selection, so Never and Always were never reconciled against them.

Checking an option axis while Never was selected had no effect whatsoever, because Never hides the element before any option is consulted. That click now leaves Never behind: picking a Hide lane lands you on Always plus that Hide option, and picking a Show lane lands you on just that Show option, which is the base state each of them needs in order to mean anything. Unchecking a lane still leaves Never alone, since clearing a condition is not a request to start showing.

Always and a Show lane could also read as checked at the same time, which is a contradiction: Always claims the element is unrestricted, while a Show lane narrows it to a subset. Always now reads unchecked while any Show lane is active, so the row reflects what the element really does, and clicking Always clears those lanes instead of being a second no-op click. Hide lanes are exceptions layered on top of showing, so they survive both Never and Always. The collapsed dropdown summary follows the same rule and now reads "Mounted" where it previously read the self-contradictory "Always, Mounted".

Because both of those cases write a mode and an option in a single click, the row now runs both module callback chains rather than one. Neither is a subset of the other: Action Bars recompiles its housing driver only in the option chain and rebuilds the options page on a Never flip only in the mode chain, so running just one of them left the element stale until something else happened to refresh it.

No evaluation code is touched. The change is confined to the options row builder in EllesmereUIOptions/EllesmereUI_Widgets.lua, so nothing changes for a user who does not open the options, and no stored setting is migrated or rewritten other than by an actual click. One consequence worth calling out for review: a profile that already stored Always together with a Show lane now shows Always unchecked, and clicking Always to "restore" it will clear that Show lane. That combination was always contradictory in evaluation, but the click that resolves it is new.

## How was it tested?

Tested in game on live.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A: no new settings. This is a bug fix to existing controls, which criterion 2 exempts from the opt-in rule; what it changes is two clicks that previously did nothing at all.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A: nothing is built, registered or hooked. The diff only changes how an existing options row reads and writes settings that already exist.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - the added work is two short loops over the row definition table, run only on a click or an options-menu refresh. No events, no timers, no per-frame work, nothing outside the options UI.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A: no Blizzard frames are involved. The rows are addon-owned widget frames.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added