### PR TITLE
Fix and rework the Important Cast Glow on enemy nameplates

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -426,6 +426,10 @@ local defaults = {
     importantCastGlowSpeed = 4,
     importantCastGlowBackground = false,
     importantCastGlowBackgroundColor = { r = 0, g = 0, b = 0 },
+    -- Percent of bar height added around the glow frame. 0 puts the border on the
+    -- bar's edge; negative pulls the whole effect in tighter, which is the knob for
+    -- art whose halo reaches further out than you want.
+    importantCastGlowPad = 0,
     -- Core Positions: slot-based size + XY offsets
     topSlotSize = 26,        topSlotXOffset = 0,      topSlotYOffset = 0,      topSlotRaiseStrata = false,
     rightSlotSize = 24,      rightSlotXOffset = 0,    rightSlotYOffset = 0,    rightSlotRaiseStrata = false,
@@ -683,6 +687,42 @@ if EllesmereUI then EllesmereUI.NameplatePandemicGlowStyles = PANDEMIC_GLOW_STYL
 -- the two drift the first time a style is inserted into either one. On ns, not
 -- a file local: this chunk sits at the Lua 5.1 200-local cap.
 ns.NP_TO_SHARED_GLOW = { 1, 2, 3, 5, 6, 7 }
+
+-- Important Cast Glow gets one style the aura lists cannot use: Blizzard's own
+-- nameplate important-cast art (shared index 8). Every other style is action
+-- BUTTON art scaled onto whatever frame it lands on, which is what makes them
+-- smear across a long cast bar; that one is authored FOR a bar and stretches
+-- along its length by design. Meaningless on a square aura icon, so it is
+-- appended here instead of going into PANDEMIC_GLOW_STYLES. On ns for the same
+-- local-cap reason as the map above.
+-- Every action-button art style is dropped here -- Action Button Glow and the
+-- three FlipBook rings (GCD, Modern WoW, Classic WoW). All of them are square
+-- sprites scaled to the frame, which on a cast bar smears the corners and thins
+-- the side borders. They stay in PANDEMIC_GLOW_STYLES, where the frames are square
+-- aura icons and the art behaves. What is left is drawn per edge and holds its
+-- shape at any aspect: Pixel Glow, Auto-Cast Shine (which walks the perimeter in
+-- frame units), Blizzard's bar-authored art, and EUI's own edge glows. Filtered by
+-- NAME so the list survives reordering.
+ns.IMPORTANT_GLOW_STYLES, ns.IMPORTANT_TO_SHARED_GLOW = {}, {}
+for i = 1, #PANDEMIC_GLOW_STYLES do
+    local entry = PANDEMIC_GLOW_STYLES[i]
+    if entry.name ~= "Modern WoW Glow" and entry.name ~= "Classic WoW Glow"
+       and entry.name ~= "Action Button Glow" and entry.name ~= "GCD" then
+        local n = #ns.IMPORTANT_GLOW_STYLES + 1
+        ns.IMPORTANT_GLOW_STYLES[n] = entry
+        ns.IMPORTANT_TO_SHARED_GLOW[n] = ns.NP_TO_SHARED_GLOW[i]
+    end
+end
+ns.IMPORTANT_GLOW_STYLES[#ns.IMPORTANT_GLOW_STYLES + 1] = { name = "Blizzard Important Cast" }
+ns.IMPORTANT_TO_SHARED_GLOW[#ns.IMPORTANT_TO_SHARED_GLOW + 1] = 8
+-- EUI's own edge glows (shared 9 and 10). Drawn from primitives per edge rather
+-- than from a scaled sprite, so unlike every button-art style they hold their
+-- shape on a bar. Appended after Blizzard's so existing saved indices are
+-- untouched -- these two are additive, and need no migration.
+ns.IMPORTANT_GLOW_STYLES[#ns.IMPORTANT_GLOW_STYLES + 1] = { name = "Soft Bloom" }
+ns.IMPORTANT_TO_SHARED_GLOW[#ns.IMPORTANT_TO_SHARED_GLOW + 1] = 9
+ns.IMPORTANT_GLOW_STYLES[#ns.IMPORTANT_GLOW_STYLES + 1] = { name = "Pulse Border" }
+ns.IMPORTANT_TO_SHARED_GLOW[#ns.IMPORTANT_TO_SHARED_GLOW + 1] = 10
 
 local function GetPandemicGlowStyle()
     local raw = p and p.pandemicGlowStyle
@@ -7264,7 +7304,6 @@ function NameplateFrame:UpdateImportantCastGlow(spellID)
 
     if not self._importantCastOverlay then
         local ov = CreateFrame("Frame", nil, self.cast)
-        ov:SetAllPoints(self.cast)
         ov:SetFrameLevel(self.cast:GetFrameLevel() + 5)
         ov:EnableMouse(false)
         self._importantCastOverlay = ov
@@ -7274,7 +7313,7 @@ function NameplateFrame:UpdateImportantCastGlow(spellID)
     if not Glows then return end
 
     local style = cfg.importantCastGlowStyle or defaults.importantCastGlowStyle or 1
-    if type(style) ~= "number" or style < 1 or style > #PANDEMIC_GLOW_STYLES then style = 1 end
+    if type(style) ~= "number" or style < 1 or style > #ns.IMPORTANT_GLOW_STYLES then style = 1 end
     local c = cfg.importantCastGlowColor or defaults.importantCastGlowColor or { r = 1, g = 0.2, b = 0.2 }
     local bgColor = cfg.importantCastGlowBackgroundColor or defaults.importantCastGlowBackgroundColor or { r = 0, g = 0, b = 0 }
     local bgOn = cfg.importantCastGlowBackground == true
@@ -7287,22 +7326,90 @@ function NameplateFrame:UpdateImportantCastGlow(spellID)
         impPeriod = cfg.importantCastGlowSpeed or defaults.importantCastGlowSpeed or 4
     end
 
-    -- Ensure glow animation is running (idempotent if already active)
+    -- The spell icon hangs off the cast bar's outer edge. It is a CHILD of the cast
+    -- bar, so that is true in "Make Icon Part of the Bar" mode too -- that setting
+    -- narrows the BAR within the plate footprint, it does not tuck the icon inside
+    -- this frame. Anchoring the overlay to the bar alone therefore ran the glow's
+    -- side border straight down the icon's edge. Span both instead.
+    --
+    -- Vertical edges follow whichever frame is taller: the icon matches the bar at
+    -- scale 1, hangs BELOW it above that (top-aligned), and reaches UP to the health
+    -- bar's top when Full Sized. Taking the taller frame's top and bottom encloses
+    -- both in every one of those cases, where a fixed TOPLEFT/BOTTOMRIGHT pair would
+    -- clip the overhang.
+    local ov = self._importantCastOverlay
+    local icon = self.castIconFrame
+    local iconOut = icon and icon:IsShown()
+
+    local pW, pH = self.cast:GetWidth(), self.cast:GetHeight()
+    if pW < 5 then pW = 100 end
+    if pH < 5 then pH = 14 end
+
+    -- Pixel Glow draws its dashes INSIDE the wrapper: the strips are anchored to its
+    -- corners and sized inward, so an overlay flush with the bar paints the border on
+    -- top of the bar's own outermost pixels -- most obvious on the short left and
+    -- right edges. Push the overlay out by the dash thickness so the border rings the
+    -- bar instead of covering it. Every other style already draws beyond its frame
+    -- (baked padding, or Blizzard's own outset) and needs no room made for it.
+    --
+    -- Every style's art meets its frame edge, so a frame flush with the bar draws the
+    -- border across the bar's own outermost pixels. Stand the frame off. Horizontal
+    -- gets much the larger share: it is the edge that reads as wrong, and a stretched
+    -- texture's side border is its thinnest part, so it needs the most room to clear.
+    -- Both are multiples of the bar height, which keeps the standoff in proportion at
+    -- any bar size. Tune these two numbers if the glow sits too close or too far.
+    -- User-tunable, because the trade-off is a matter of taste and cannot be solved
+    -- from the art: each style's halo reaches a fixed fraction past the frame, so
+    -- sitting the border exactly on the bar edge is the same thing as accepting that
+    -- much bleed beyond it. Negative pad trades border placement for a tighter effect.
+    -- Vertical gets a third of the horizontal: bars are short, so the same pad reads
+    -- far heavier above and below than it does at the ends.
+    local pad = (cfg.importantCastGlowPad or defaults.importantCastGlowPad or 0) / 100
+    local barH = pH
+    local edge  = (style == 1) and (impTh or 2) or 0
+    local edgeX = edge + barH * pad
+    local edgeY = edge + barH * pad * 0.33
+
+    ov:ClearAllPoints()
+    if not iconOut then
+        ov:SetPoint("TOPLEFT", self.cast, "TOPLEFT", -edgeX, edgeY)
+        ov:SetPoint("BOTTOMRIGHT", self.cast, "BOTTOMRIGHT", edgeX, -edgeY)
+    else
+        local iScale = icon:GetScale() or 1
+        local iW = (icon:GetWidth() or 0) * iScale
+        local iH = (icon:GetHeight() or 0) * iScale
+        local tall = (iH > pH) and icon or self.cast
+        ov:SetPoint("TOP", tall, "TOP", 0, edgeY)
+        ov:SetPoint("BOTTOM", tall, "BOTTOM", 0, -edgeY)
+        if ns.GetCastIconOnRight() then
+            ov:SetPoint("LEFT", self.cast, "LEFT", -edgeX, 0)
+            ov:SetPoint("RIGHT", icon, "RIGHT", edgeX, 0)
+        else
+            ov:SetPoint("LEFT", icon, "LEFT", -edgeX, 0)
+            ov:SetPoint("RIGHT", self.cast, "RIGHT", edgeX, 0)
+        end
+        if iW > 0 then pW = pW + iW end
+        if iH > pH then pH = iH end
+    end
+    pW = pW + edgeX * 2
+    pH = pH + edgeY * 2
+
+    -- Ensure glow animation is running (idempotent if already active). The measured
+    -- size joins the key: the FlipBook and shine engines size themselves once at
+    -- start, so a bar or icon that changed dimensions has to restart them.
     if not self._importantGlowActive or self._importantGlowStyle ~= style
+       or self._importantGlowW ~= pW or self._importantGlowH ~= pH
        or self._importantGlowR ~= c.r or self._importantGlowG ~= c.g or self._importantGlowB ~= c.b
        or self._importantGlowBgOn ~= bgOn or self._importantGlowBgR ~= bgColor.r
        or self._importantGlowBgG ~= bgColor.g or self._importantGlowBgB ~= bgColor.b
        or self._importantGlowN ~= impN or self._importantGlowTh ~= impTh
        or self._importantGlowPeriod ~= impPeriod then
         Glows.StopAllGlows(self._importantCastOverlay)
-        local pW, pH = self.cast:GetWidth(), self.cast:GetHeight()
-        if pW < 5 then pW = 100 end
-        if pH < 5 then pH = 14 end
         -- StartGlow owns the per-style engine pick. Its Pixel Glow path reproduces
         -- the old direct call exactly: same lineLen formula, and an unset bg alpha
         -- resolves to 1 there, which is what omitting the argument used to do.
         local Start = StartGlow or Glows.StartGlow
-        Start(self._importantCastOverlay, ns.NP_TO_SHARED_GLOW[style] or 1, pW, c.r, c.g, c.b,
+        Start(self._importantCastOverlay, ns.IMPORTANT_TO_SHARED_GLOW[style] or 1, pW, c.r, c.g, c.b,
             style == 1 and {
                 N = impN, th = impTh, period = impPeriod,
                 bg = bgOn and { r = bgColor.r or 0, g = bgColor.g or 0, b = bgColor.b or 0 } or nil,
@@ -7313,6 +7420,7 @@ function NameplateFrame:UpdateImportantCastGlow(spellID)
         self._importantGlowBgOn = bgOn
         self._importantGlowBgR, self._importantGlowBgG, self._importantGlowBgB = bgColor.r, bgColor.g, bgColor.b
         self._importantGlowN, self._importantGlowTh, self._importantGlowPeriod = impN, impTh, impPeriod
+        self._importantGlowW, self._importantGlowH = pW, pH
     end
 
     -- SetAlphaFromBoolean handles the secret boolean taint-free.

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -198,6 +198,7 @@ initFrame:SetScript("OnEvent", function(self)
     local showClassificationPreview = false
     local showTargetGlowPreview = false
     local showAbsorbPreview = false
+    local showImportantGlowPreview = false
 
     -- Transient flags: force-show indicators during slider drag
     local _sliderDragShowRaidMarker = false
@@ -651,6 +652,14 @@ initFrame:SetScript("OnEvent", function(self)
         castParts.targetFS:SetWordWrap(false)
         castParts.targetFS:SetMaxLines(1)
         castParts.targetFS:SetText(UnitName("player") or EllesmereUI.L("Spell Target"))
+
+        -- Important Cast Glow host. The preview is otherwise a plain replica with no
+        -- added effects, but this one earns its place: the glow frames the cast bar
+        -- AND its icon, so no swatch beside the dropdown can show it honestly.
+        castParts.glow = CreateFrame("Frame", nil, cast)
+        castParts.glow:SetFrameLevel(cast:GetFrameLevel() + 6)
+        castParts.glow:EnableMouse(false)
+        castParts.glow:Hide()
 
         -- Class power pips (cosmetic preview queries live class/spec resource count); packed into a single table to stay under Lua's 60-upvalue limit.
         local CP = {
@@ -1187,6 +1196,81 @@ initFrame:SetScript("OnEvent", function(self)
             castParts.spark:SetHeight(castH)
             -- Show Spark (Cast Color cog): default on; explicit false hides it.
             castParts.spark:SetShown(DBVal("castBarSparkEnabled") ~= false)
+
+            -- Important Cast Glow, anchored exactly as the real one is: the union of
+            -- the cast bar and its icon, with the vertical edges following whichever
+            -- of the two is taller. Kept in step with UpdateImportantCastGlow.
+            do
+                local Glows = EllesmereUI.Glows
+                local g = castParts.glow
+                if g and Glows and Glows.StartGlow then
+                    Glows.StopAllGlows(g)
+                    local on = DBVal("importantCastGlow")
+                    if on == nil then on = defaults.importantCastGlow end
+                    -- On request only: a glow left running on the preview reads as part
+                    -- of the nameplate rather than as the effect being chosen.
+                    if not (on and showImportantGlowPreview) then
+                        g:Hide()
+                    else
+                        local styles = ns.IMPORTANT_GLOW_STYLES
+                        local st = DBVal("importantCastGlowStyle") or defaults.importantCastGlowStyle or 1
+                        if type(st) ~= "number" or st < 1 or st > #styles then st = 1 end
+
+                        local icon = castParts.iconFrame
+                        local pW, pH = cast:GetWidth(), castH
+                        if pW < 5 then pW = 100 end
+                        -- Pixel Glow's dashes are drawn inward from the wrapper edge, so
+                        -- the overlay stands off by their thickness (see the same edge
+                        -- calculation in UpdateImportantCastGlow).
+                        -- Same standoff maths as UpdateImportantCastGlow; keep in step.
+                        local gPad = (DBVal("importantCastGlowPad") or defaults.importantCastGlowPad or 0) / 100
+                        local gBarH = pH
+                        local gEdge = (st == 1)
+                            and (DBVal("importantCastGlowThickness") or defaults.importantCastGlowThickness or 2)
+                            or 0
+                        local gEdgeX = gEdge + gBarH * gPad
+                        local gEdgeY = gEdge + gBarH * gPad * 0.33
+                        g:ClearAllPoints()
+                        if showIcon and icon then
+                            local iW, iH = icon:GetWidth() or 0, icon:GetHeight() or 0
+                            local tall = (iH > pH) and icon or cast
+                            g:SetPoint("TOP", tall, "TOP", 0, gEdgeY)
+                            g:SetPoint("BOTTOM", tall, "BOTTOM", 0, -gEdgeY)
+                            if onRight then
+                                g:SetPoint("LEFT", cast, "LEFT", -gEdgeX, 0)
+                                g:SetPoint("RIGHT", icon, "RIGHT", gEdgeX, 0)
+                            else
+                                g:SetPoint("LEFT", icon, "LEFT", -gEdgeX, 0)
+                                g:SetPoint("RIGHT", cast, "RIGHT", gEdgeX, 0)
+                            end
+                            if iW > 0 then pW = pW + iW end
+                            if iH > pH then pH = iH end
+                        else
+                            g:SetPoint("TOPLEFT", cast, "TOPLEFT", -gEdgeX, gEdgeY)
+                            g:SetPoint("BOTTOMRIGHT", cast, "BOTTOMRIGHT", gEdgeX, -gEdgeY)
+                        end
+                        pW = pW + gEdgeX * 2
+                        pH = pH + gEdgeY * 2
+                        g:Show()
+
+                        local gc = (DB() and DB().importantCastGlowColor) or defaults.importantCastGlowColor
+                        local gOpts
+                        if st == 1 then
+                            local bgc = (DB() and DB().importantCastGlowBackgroundColor)
+                                or defaults.importantCastGlowBackgroundColor or { r = 0, g = 0, b = 0 }
+                            gOpts = {
+                                N      = DBVal("importantCastGlowLines") or defaults.importantCastGlowLines,
+                                th     = DBVal("importantCastGlowThickness") or defaults.importantCastGlowThickness,
+                                period = DBVal("importantCastGlowSpeed") or defaults.importantCastGlowSpeed,
+                                bg     = DBVal("importantCastGlowBackground") == true
+                                         and { r = bgc.r or 0, g = bgc.g or 0, b = bgc.b or 0 } or nil,
+                            }
+                        end
+                        Glows.StartGlow(g, ns.IMPORTANT_TO_SHARED_GLOW[st] or 1,
+                            pW, gc.r, gc.g, gc.b, gOpts, pH)
+                    end
+                end
+            end
 
             -- Name font + color + position (font size set per-slot below)
             local nameYOff = DBVal("nameYOffset") or defaults.nameYOffset
@@ -7221,21 +7305,17 @@ initFrame:SetScript("OnEvent", function(self)
                 if on == nil then on = defaults.importantCastGlow end
                 return not on
             end
-            -- Assigned once the preview frame exists, below. Forward-declared because
-            -- the dropdown, swatch and cog handlers are all built before that point
-            -- and every one of them re-renders the preview.
-            local RefreshImpCastPreview = function() end
-
             local function impCastAntsOff()
                 if impCastOff() then return true end
                 local raw = DB().importantCastGlowStyle or defaults.importantCastGlowStyle
                 return type(raw) ~= "number" or raw ~= 1
             end
 
-            -- Same list, same indices as the Pandemic Glow dropdown above.
+            -- Pandemic Glow's list plus the Blizzard bar style, which only makes
+            -- sense on a cast bar (see IMPORTANT_GLOW_STYLES in the module).
             local impGlowValues = { [0] = "None" }
             local impGlowOrder = { 0 }
-            for i, entry in ipairs(ns.PANDEMIC_GLOW_STYLES) do
+            for i, entry in ipairs(ns.IMPORTANT_GLOW_STYLES) do
                 impGlowValues[i] = entry.name
                 impGlowOrder[#impGlowOrder + 1] = i
             end
@@ -7248,7 +7328,7 @@ initFrame:SetScript("OnEvent", function(self)
                     if impCastOff() then return 0 end
                     local raw = DB().importantCastGlowStyle or defaults.importantCastGlowStyle or 1
                     if type(raw) ~= "number" then return 1 end
-                    if raw < 1 or raw > #ns.PANDEMIC_GLOW_STYLES then return 1 end
+                    if raw < 1 or raw > #ns.IMPORTANT_GLOW_STYLES then return 1 end
                     return raw
                   end,
                   setValue=function(v)
@@ -7259,7 +7339,7 @@ initFrame:SetScript("OnEvent", function(self)
                         DB().importantCastGlowStyle = v
                     end
                     RefreshAllPlates()
-                    RefreshImpCastPreview()
+                    UpdatePreview()
                     C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
                   end,
                   tooltip="Show a glow on the cast bar when the enemy is casting a spell Blizzard marks as important." },
@@ -7285,7 +7365,7 @@ initFrame:SetScript("OnEvent", function(self)
                         function(r, g, b)
                             DB().importantCastGlowColor = { r = r, g = g, b = b }
                             RefreshAllPlates()
-                            RefreshImpCastPreview()
+                            UpdatePreview()
                         end, nil, 20)
                     PP.Point(swatch, "RIGHT", ctrl, "LEFT", -12, 0)
                     leftRgn._lastInline = swatch
@@ -7303,27 +7383,39 @@ initFrame:SetScript("OnEvent", function(self)
             -- Cog popup for Pixel Glow settings.
             if not EllesmereUI._prebuilding then
                 local _, ShowImpCastGlowPopup = EllesmereUI.BuildCogPopup({
-                    title = "Pixel Glow Settings",
+                    title = "Important Cast Glow Settings",
                     rows = {
+                        -- Applies to every style; the rest of this popup is Pixel Glow's.
+                        { type = "slider", label = "Glow Size", min = -50, max = 100, step = 5,
+                          get = function() return DB().importantCastGlowPad or defaults.importantCastGlowPad or 0 end,
+                          set = function(v) DB().importantCastGlowPad = v; RefreshAllPlates(); UpdatePreview() end },
                         { type = "slider", label = "Lines", min = 2, max = 16, step = 1,
+                          disabled = function() return impCastAntsOff() end,
+                          disabledTooltip = "Pixel Glow only",
                           get = function() return DB().importantCastGlowLines or defaults.importantCastGlowLines or 8 end,
-                          set = function(v) DB().importantCastGlowLines = v; RefreshAllPlates(); RefreshImpCastPreview() end },
-                        { type = "slider", label = "Thickness", min = 1, max = 4, step = 1,
+                          set = function(v) DB().importantCastGlowLines = v; RefreshAllPlates(); UpdatePreview() end },
+                        { type = "slider", label = "Thickness",
+                          disabled = function() return impCastAntsOff() end,
+                          disabledTooltip = "Pixel Glow only", min = 1, max = 4, step = 1,
                           get = function() return DB().importantCastGlowThickness or defaults.importantCastGlowThickness or 2 end,
-                          set = function(v) DB().importantCastGlowThickness = v; RefreshAllPlates(); RefreshImpCastPreview() end },
-                        { type = "slider", label = "Speed", min = 1, max = 8, step = 1,
+                          set = function(v) DB().importantCastGlowThickness = v; RefreshAllPlates(); UpdatePreview() end },
+                        { type = "slider", label = "Speed",
+                          disabled = function() return impCastAntsOff() end,
+                          disabledTooltip = "Pixel Glow only", min = 1, max = 8, step = 1,
                           get = function() local s = DB().importantCastGlowSpeed or defaults.importantCastGlowSpeed or 4; return 9 - s end,
-                          set = function(v) DB().importantCastGlowSpeed = 9 - v; RefreshAllPlates(); RefreshImpCastPreview() end },
+                          set = function(v) DB().importantCastGlowSpeed = 9 - v; RefreshAllPlates(); UpdatePreview() end },
                         { type = "toggle", label = "Background",
+                          disabled = function() return impCastAntsOff() end,
+                          disabledTooltip = "Pixel Glow only",
                           get = function() return DB().importantCastGlowBackground == true end,
-                          set = function(v) DB().importantCastGlowBackground = v and true or nil; RefreshAllPlates(); RefreshImpCastPreview() end },
+                          set = function(v) DB().importantCastGlowBackground = v and true or nil; RefreshAllPlates(); UpdatePreview() end },
                         { type = "colorpicker", label = "Background Color",
                           get = function()
                               local c = DB().importantCastGlowBackgroundColor or defaults.importantCastGlowBackgroundColor or { r = 0, g = 0, b = 0 }
                               return c.r or 0, c.g or 0, c.b or 0
                           end,
-                          set = function(r, g, b) DB().importantCastGlowBackgroundColor = { r = r, g = g, b = b }; RefreshAllPlates(); RefreshImpCastPreview() end,
-                          disabled = function() return DB().importantCastGlowBackground ~= true end,
+                          set = function(r, g, b) DB().importantCastGlowBackgroundColor = { r = r, g = g, b = b }; RefreshAllPlates(); UpdatePreview() end,
+                          disabled = function() return impCastAntsOff() or DB().importantCastGlowBackground ~= true end,
                           disabledTooltip = "Pixel Glow Background" },
                     },
                 })
@@ -7345,7 +7437,7 @@ initFrame:SetScript("OnEvent", function(self)
                 cogBtn:SetScript("OnClick", function(self) ShowImpCastGlowPopup(self) end)
                 cogBtn:SetScript("OnEnter", function(self)
                     self:SetAlpha(1)
-                    EllesmereUI.ShowWidgetTooltip(self, "Pixel Glow Settings")
+                    EllesmereUI.ShowWidgetTooltip(self, "Important Cast Glow Settings")
                 end)
                 cogBtn:SetScript("OnLeave", function(self)
                     self:SetAlpha(0.4)
@@ -7353,67 +7445,51 @@ initFrame:SetScript("OnEvent", function(self)
                 end)
                 -- Disable cog when not using pixel glow
                 EllesmereUI.RegisterWidgetRefresh(function()
-                    local off = impCastAntsOff()
+                    local off = impCastOff()
                     cogBtn:SetAlpha(off and 0.15 or 0.4)
                     cogBtn:EnableMouse(not off)
                 end)
-                cogBtn:SetAlpha(impCastAntsOff() and 0.15 or 0.4)
-                cogBtn:EnableMouse(not impCastAntsOff())
+                cogBtn:SetAlpha(impCastOff() and 0.15 or 0.4)
+                cogBtn:EnableMouse(not impCastOff())
 
-                -- Glow preview. The Pandemic Glow row hosts its preview in the row's
-                -- right half; here that half is a real setting, so the preview joins
-                -- the inline chain instead and sits to the left of the cog.
-                local IMP_PREVIEW_SIZE = 26
-                local previewFrame = CreateFrame("Frame", nil, leftRgn)
-                PP.Size(previewFrame, IMP_PREVIEW_SIZE, IMP_PREVIEW_SIZE)
-                -- -12 rather than the chain's usual -6: the widest FlipBook styles
-                -- draw roughly 8px past the icon edge on each side.
-                PP.Point(previewFrame, "RIGHT", cogBtn, "LEFT", -12, 0)
-                previewFrame:SetFrameLevel(leftRgn:GetFrameLevel() + 5)
-
-                local previewTex = previewFrame:CreateTexture(nil, "ARTWORK")
-                previewTex:SetAllPoints()
-                previewTex:SetTexCoord(0.08, 0.92, 0.08, 0.92)
-                PP.CreateBorder(previewFrame, 0, 0, 0, 1, 1, "OVERLAY", 7)
-
-                -- Leftmost inline item on this half; the row label is bounded against
-                -- it (region._lastInline, see EllesmereUI_Widgets.lua).
-                leftRgn._lastInline = previewFrame
-
-                -- Renders through the SAME dispatcher, style list and stored options
-                -- the nameplate itself uses, so the preview cannot drift from the real
-                -- cast bar. Assigns the forward-declared local from the top of the block.
-                RefreshImpCastPreview = function()
-                    ns.StopAllGlows(previewFrame)
-                    previewTex:SetTexture(displayCastIcons[_previewCastIconIdx or 1])
-
+                -- Eye: play the chosen glow on the nameplate preview on demand. Anchored
+                -- to the cog explicitly, not to _lastInline, which still points at the
+                -- colour swatch the cog sits beside.
+                local EYE_VISIBLE   = EllesmereUI.EYE_VISIBLE_ICON
+                local EYE_INVISIBLE = EllesmereUI.EYE_INVISIBLE_ICON
+                local eyeBtn = CreateFrame("Button", nil, leftRgn)
+                eyeBtn:SetSize(26, 26)
+                PP.Point(eyeBtn, "RIGHT", cogBtn, "LEFT", -6, 0)
+                -- Leftmost inline item now, so the row label is bounded against it.
+                leftRgn._lastInline = eyeBtn
+                eyeBtn:SetFrameLevel(leftRgn:GetFrameLevel() + 5)
+                local eyeTex = eyeBtn:CreateTexture(nil, "OVERLAY")
+                eyeTex:SetAllPoints()
+                if eyeTex.SetSnapToPixelGrid then eyeTex:SetSnapToPixelGrid(false); eyeTex:SetTexelSnappingBias(0) end
+                local function RefreshImpEye()
+                    eyeTex:SetTexture(showImportantGlowPreview and EYE_INVISIBLE or EYE_VISIBLE)
                     local off = impCastOff()
-                    previewFrame:SetAlpha(off and 0.3 or 1)
-                    if off then return end
-
-                    local styles = ns.PANDEMIC_GLOW_STYLES
-                    local style = DB().importantCastGlowStyle or defaults.importantCastGlowStyle or 1
-                    if type(style) ~= "number" or style < 1 or style > #styles then style = 1 end
-
-                    local c = DB().importantCastGlowColor or defaults.importantCastGlowColor
-                    local opts
-                    if style == 1 then
-                        local bgc = DB().importantCastGlowBackgroundColor
-                            or defaults.importantCastGlowBackgroundColor or { r = 0, g = 0, b = 0 }
-                        opts = {
-                            N      = DB().importantCastGlowLines or defaults.importantCastGlowLines,
-                            th     = DB().importantCastGlowThickness or defaults.importantCastGlowThickness,
-                            period = DB().importantCastGlowSpeed or defaults.importantCastGlowSpeed,
-                            bg     = DB().importantCastGlowBackground == true
-                                     and { r = bgc.r or 0, g = bgc.g or 0, b = bgc.b or 0 } or nil,
-                        }
-                    end
-                    ns.StartGlow(previewFrame, ns.NP_TO_SHARED_GLOW[style] or 1,
-                        IMP_PREVIEW_SIZE, c.r, c.g, c.b, opts, IMP_PREVIEW_SIZE)
+                    eyeBtn:SetAlpha(off and 0.15 or 0.4)
+                    eyeBtn:EnableMouse(not off)
                 end
-
-                EllesmereUI.RegisterWidgetRefresh(RefreshImpCastPreview)
-                RefreshImpCastPreview()
+                eyeBtn:SetScript("OnClick", function()
+                    showImportantGlowPreview = not showImportantGlowPreview
+                    RefreshImpEye()
+                    UpdatePreview()
+                end)
+                eyeBtn:SetScript("OnEnter", function(self)
+                    if impCastOff() then return end
+                    self:SetAlpha(0.7)
+                    EllesmereUI.ShowWidgetTooltip(self, showImportantGlowPreview
+                        and "Hide the glow on the preview"
+                        or  "Show the glow on the preview")
+                end)
+                eyeBtn:SetScript("OnLeave", function(self)
+                    self:SetAlpha(impCastOff() and 0.15 or 0.4)
+                    EllesmereUI.HideWidgetTooltip()
+                end)
+                EllesmereUI.RegisterWidgetRefresh(RefreshImpEye)
+                RefreshImpEye()
             end
         end
 

--- a/EllesmereUI_Glows.lua
+++ b/EllesmereUI_Glows.lua
@@ -11,6 +11,7 @@ if EllesmereUI.Glows then return end  -- already loaded by another addon
 
 local floor = math.floor
 local min   = math.min
+local max   = math.max
 local ceil  = math.ceil
 local sin   = math.sin
 
@@ -36,6 +37,26 @@ local GLOW_STYLES = {
       -- backwards stutter. 22 matches what the Action Button Glow uses.
       rows = 5, columns = 5, frames = 22, duration = 0.3,
       frameW = 48, frameH = 48, texPadding = 1.25 },
+    -- Blizzard's own nameplate important-cast highlight. Unlike every style above
+    -- it is BAR art, not button art, so it belongs only on elongated frames --
+    -- see the barAtlas engine below.
+    -- Blizzard's own outsets from Blizzard_NamePlateCastingBar.lua, in the pixels
+    -- they are written in. Do NOT convert these to ratios of the frame: that was
+    -- tried on the theory that the art's baked border has to land at a fixed
+    -- fraction of texture width, and it is wrong. Blizzard applies these offsets
+    -- UNSCALED to a bar whose width IS scaled by horizontalScale, so no such
+    -- alignment exists to preserve -- the offsets are simply how much glow room the
+    -- art wants. As ratios the frame came out short and the side border sat on the
+    -- bar; doubled, it left a gap. In pixels it sits right.
+    --
+    -- Glow Size in the options remains the per-user trim, since it widens the frame
+    -- these hang off.
+    { name = "Blizzard Important Cast", barAtlas = "ui-hud-nameplates-importantcast",
+      outL = 26, outR = 25, outY = 3, pulse = 0.4 },
+    -- Built from primitives rather than art, so there is nothing to stretch: see
+    -- the edge-glow engine below. Correct at any aspect ratio by construction.
+    { name = "Soft Bloom",   edgeGlow = true, rings = 8, outline = 1, pulse = 0.5 },
+    { name = "Pulse Border", edgeGlow = true, rings = 1, outline = 2, pulse = 0.45 },
 }
 
 -------------------------------------------------------------------------------
@@ -760,6 +781,183 @@ local function StartFlipBookGlow(wrapper, szOrW, entry, cr, cg, cb, szH)
     wrapper:SetScript("OnUpdate", nil)
 end
 
+-------------------------------------------------------------------------------
+--  Bar-atlas glow
+--
+--  Every other engine here draws art authored for a square action button, which
+--  is why they smear when scaled onto a cast bar. This one draws art authored FOR
+--  a bar: Blizzard's own ImportantCastIndicator. It is meant to stretch along its
+--  length, so it needs no slicing, and the halo baked into its ends is why the
+--  outset is far wider than it is tall.
+--
+--  The outsets are Blizzard's own pixel values; the style entry records why they
+--  must stay pixels rather than become ratios of the frame.
+--
+--  The pulse mirrors their ImportantCastFlashAnim: alpha 0->1 then 1->0, looping,
+--  though quicker than their one second per half. C-side, so it animates
+--  identically under the restricted contexts where driver-ticked engines freeze.
+-------------------------------------------------------------------------------
+local function StartBarGlow(wrapper, entry, cr, cg, cb)
+    -- Blizzard art, so it can move between builds. Bail cleanly rather than
+    -- leaving an invisible texture playing an animation nobody can see.
+    if C_Texture and C_Texture.GetAtlasInfo and not C_Texture.GetAtlasInfo(entry.barAtlas) then
+        return
+    end
+    local d = wrapper._euiBarGlow
+    if not d then
+        local tex = wrapper:CreateTexture(nil, "OVERLAY", nil, 7)
+        local ag = tex:CreateAnimationGroup()
+        ag:SetLooping("REPEAT")
+        local up = ag:CreateAnimation("Alpha")
+        up:SetOrder(1); up:SetFromAlpha(0); up:SetToAlpha(1)
+        local down = ag:CreateAnimation("Alpha")
+        down:SetOrder(2); down:SetFromAlpha(1); down:SetToAlpha(0)
+        d = { tex = tex, ag = ag, up = up, down = down }
+        wrapper._euiBarGlow = d
+    end
+
+    -- Set every call, not at creation: the duration belongs to the STYLE, and one
+    -- wrapper outlives any single style choice.
+    local half = entry.pulse or 1
+    d.up:SetDuration(half)
+    d.down:SetDuration(half)
+
+    local outL = entry.outL or 26
+    local outR = entry.outR or 25
+    local outY = entry.outY or 3
+    d.tex:ClearAllPoints()
+    d.tex:SetPoint("TOPLEFT", wrapper, "TOPLEFT", -outL, outY)
+    d.tex:SetPoint("BOTTOMRIGHT", wrapper, "BOTTOMRIGHT", outR, -outY)
+    d.tex:SetAtlas(entry.barAtlas)
+    if cr then
+        d.tex:SetDesaturated(true)
+        d.tex:SetVertexColor(cr, cg, cb)
+    else
+        d.tex:SetDesaturated(false)
+        d.tex:SetVertexColor(1, 1, 1)
+    end
+    d.tex:Show()
+    if d.ag:IsPlaying() then d.ag:Stop() end
+    d.ag:Play()
+end
+
+-------------------------------------------------------------------------------
+--  Edge glow (EUI's own)
+--
+--  Every art-based engine here has the same flaw on a cast bar: a sprite authored
+--  for a square button, scaled onto a long frame, smears its corners and thins its
+--  side borders. This one uses no art. It draws NESTED RECTANGLE OUTLINES, each one
+--  pixel further out than the last and dimmer, so a stack of them reads as a glow
+--  that fades outward. Every ring is a closed rectangle built from four strips
+--  sized per edge, so it is correct at any aspect ratio and has no corner case:
+--  the sides run between the two horizontal strips, covering each corner exactly
+--  once rather than double-exposing it.
+--
+--  Rings rather than gradient bands on purpose. Bands fading outward from each edge
+--  have to decide what to do where two of them meet, and any answer leaves the
+--  corners either lit as a block or notched out -- visible as boxy shadows at the
+--  four corners. Concentric outlines have no seam to get wrong.
+--
+--  All rings sit on one host frame and the pulse animates THAT frame's alpha, so a
+--  single C-side AnimationGroup drives everything in lockstep -- no per-texture
+--  groups to drift, and nothing that freezes under restriction.
+-------------------------------------------------------------------------------
+local EDGE_RING_MAX = 12
+
+local function StartEdgeGlow(wrapper, entry, cr, cg, cb)
+    cr = cr or 1; cg = cg or 1; cb = cb or 1
+    local th    = max(1, entry.outline or 1)
+    local rings = max(1, min(entry.rings or 1, EDGE_RING_MAX))
+
+    local d = wrapper._euiEdgeGlow
+    if not d then
+        local host = CreateFrame("Frame", nil, wrapper)
+        host:SetAllPoints(wrapper)
+        local ag = host:CreateAnimationGroup()
+        ag:SetLooping("REPEAT")
+        local up = ag:CreateAnimation("Alpha")
+        up:SetOrder(1); up:SetFromAlpha(0.35); up:SetToAlpha(1)
+        local down = ag:CreateAnimation("Alpha")
+        down:SetOrder(2); down:SetFromAlpha(1); down:SetToAlpha(0.35)
+        d = { host = host, ag = ag, up = up, down = down, ring = {} }
+        wrapper._euiEdgeGlow = d
+    end
+
+    d.up:SetDuration(entry.pulse or 0.5)
+    d.down:SetDuration(entry.pulse or 0.5)
+
+    for i = 1, EDGE_RING_MAX do
+        local r = d.ring[i]
+        if i <= rings then
+            if not r then
+                r = {}
+                for k = 1, 4 do
+                    r[k] = d.host:CreateTexture(nil, "OVERLAY", nil, 7)
+                    r[k]:SetColorTexture(1, 1, 1, 1)
+                end
+                d.ring[i] = r
+            end
+
+            local off = (i - 1) * th
+            -- Squared falloff: linear reads as a flat slab with a hard outer step,
+            -- squared lands most of the brightness on the innermost ring and trails
+            -- off, which is what actually looks like a glow.
+            local a = 1 - (i - 1) / rings
+            a = a * a
+
+            r[1]:ClearAllPoints()
+            r[1]:SetPoint("TOPLEFT",  d.host, "TOPLEFT",  -off,  off)
+            r[1]:SetPoint("TOPRIGHT", d.host, "TOPRIGHT",  off,  off)
+            r[1]:SetHeight(th)
+
+            r[2]:ClearAllPoints()
+            r[2]:SetPoint("BOTTOMLEFT",  d.host, "BOTTOMLEFT",  -off, -off)
+            r[2]:SetPoint("BOTTOMRIGHT", d.host, "BOTTOMRIGHT",  off, -off)
+            r[2]:SetHeight(th)
+
+            -- Sides run BETWEEN the two horizontal strips rather than the full
+            -- height, so the corners are covered exactly once. Overlapping them
+            -- would double the alpha on four pixels of every ring, which is the
+            -- corner artifact this design exists to avoid.
+            r[3]:ClearAllPoints()
+            r[3]:SetPoint("TOPLEFT",    r[1], "BOTTOMLEFT", 0, 0)
+            r[3]:SetPoint("BOTTOMLEFT", r[2], "TOPLEFT",    0, 0)
+            r[3]:SetWidth(th)
+
+            r[4]:ClearAllPoints()
+            r[4]:SetPoint("TOPRIGHT",    r[1], "BOTTOMRIGHT", 0, 0)
+            r[4]:SetPoint("BOTTOMRIGHT", r[2], "TOPRIGHT",    0, 0)
+            r[4]:SetWidth(th)
+
+            for k = 1, 4 do
+                r[k]:SetVertexColor(cr, cg, cb, a)
+                r[k]:Show()
+            end
+        elseif r then
+            for k = 1, 4 do r[k]:Hide() end
+        end
+    end
+
+    d.host:SetAlpha(1)
+    d.host:Show()
+    if d.ag:IsPlaying() then d.ag:Stop() end
+    d.ag:Play()
+end
+
+local function StopEdgeGlow(wrapper)
+    local d = wrapper._euiEdgeGlow
+    if not d then return end
+    if d.ag then d.ag:Stop() end
+    d.host:Hide()
+end
+
+local function StopBarGlow(wrapper)
+    local d = wrapper._euiBarGlow
+    if not d then return end
+    if d.ag then d.ag:Stop() end
+    d.tex:Hide()
+end
+
 local function StopFlipBookGlow(wrapper)
     if wrapper._euiFlipData then
         wrapper._euiFlipData.tex:Hide()
@@ -788,6 +986,8 @@ local function StopAllGlows(wrapper)
     StopProceduralAnts(wrapper)
     StopButtonGlow(wrapper)
     StopAutoCastShine(wrapper)
+    StopBarGlow(wrapper)
+    StopEdgeGlow(wrapper)
     StopShapeGlow(wrapper)
     StopFlipBookGlow(wrapper)
     StopAnimatedAnts(wrapper)
@@ -841,6 +1041,12 @@ local function StartGlow(wrapper, styleIdx, szOrW, cr, cg, cb, opts, szH)
 
     elseif entry.shapeGlow then
         StartShapeGlow(wrapper, w, cr, cg, cb, 1.20, opts)
+
+    elseif entry.barAtlas then
+        StartBarGlow(wrapper, entry, cr, cg, cb)
+
+    elseif entry.edgeGlow then
+        StartEdgeGlow(wrapper, entry, cr, cg, cb)
 
     else
         -- FlipBook mode (GCD, Modern WoW Glow, Classic WoW Glow, etc.)

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -4106,3 +4106,48 @@ EllesmereUI.RegisterMigration({
         end
     end,
 })
+
+-- Important Cast Glow lost every style built from square action-button art:
+-- Action Button Glow itself and the three FlipBook rings (GCD, Modern WoW,
+-- Classic WoW). All of them are sprites scaled to the frame, which on a cast bar
+-- smears the corners and thins the side borders. They remain in the nameplate
+-- AURA lists, where the frames are square icons and the art behaves.
+--
+-- Removing entries from the middle renumbers everything after them, so the saved
+-- index has to be re-pointed or a user silently ends up on a different style. The
+-- map is written out rather than derived: three source indices collapse onto one
+-- target, so no arithmetic covers it.
+--
+--   1 Pixel Glow          -> 1 Pixel Glow          (kept)
+--   2 Action Button Glow  -> 1 Pixel Glow          (nearest survivor that is a border)
+--   3 Auto-Cast Shine     -> 2 Auto-Cast Shine     (kept)
+--   4 GCD                 -> 4 Soft Bloom          (a soft animated ring, like GCD)
+--   5 Modern WoW Glow     -> 4 Soft Bloom
+--   6 Classic WoW Glow    -> 4 Soft Bloom
+--
+-- Source numbering is what 9.0.7 shipped, i.e. after
+-- np_important_cast_glow_style_reindex_v1 has run. Blizzard Important Cast, Soft
+-- Bloom and Pulse Border are new here and sit after the survivors, so no shipped
+-- index ever referred to them.
+--
+-- Guarded by a stored version, not by the runner's flag alone: a renumbering is
+-- not self-idempotent -- a second pass would read an already migrated 2 as Action
+-- Button and move it again -- so the version key is what makes the body safe if
+-- the flag is ever lost, as rule (2) requires.
+EllesmereUI.RegisterMigration({
+    id          = "np_important_cast_glow_drop_button_art_v1",
+    scope       = "profile",
+    description = "Re-point Important Cast Glow styles removed in the cast-bar pass (Action Button Glow, GCD, Modern WoW Glow, Classic WoW Glow) onto the nearest surviving style.",
+    body        = function(ctx)
+        local np = ctx.profile.addons and ctx.profile.addons.EllesmereUINameplates
+        if type(np) ~= "table" then return end
+        if np.importantCastGlowStyleVer then return end
+
+        local remap = { [1] = 1, [2] = 1, [3] = 2, [4] = 4, [5] = 4, [6] = 4 }
+        local s = np.importantCastGlowStyle
+        if type(s) == "number" and remap[s] then
+            np.importantCastGlowStyle = remap[s]
+        end
+        np.importantCastGlowStyleVer = 2
+    end,
+})


### PR DESCRIPTION
Follow up PR after https://github.com/EllesmereGaming/EllesmereUI/pull/1779

## What does this PR do?

**1. Glow border cut through the cast spell icon.** The overlay was
`SetAllPoints(self.cast)`, but the icon is a child of the bar anchored outside its
edge. It now spans the union of bar + icon, vertical edges following whichever is
taller. Measured size joins the restart cache key (FlipBook/Auto-Cast size
themselves once at start).

**2. Square action-button art smears on a long bar.** The list now offers only
styles that hold their shape at any aspect: Pixel Glow, Auto-Cast Shine,
Blizzard's own bar art, and two new EUI edge glows. Action Button Glow, GCD,
Modern WoW Glow and Classic WoW Glow are dropped from **this list only** — they
stay in the aura lists, where frames are square.

**3. New styles.** *Blizzard Important Cast* draws
`ui-hud-nameplates-importantcast` with Blizzard's own outsets and a quicker
`ImportantCastFlashAnim`. *Soft Bloom* / *Pulse Border* use no art: nested
rectangle outlines under a squared falloff, correct at any aspect by construction,
one C-side AnimationGroup driving the pulse.

**4. Glow Size** (cog) trims the effect in or out — border placement and halo
bleed are the same dial pulled opposite ways, and the right end depends on bar
width. Default 0 = no change. The cog now opens for every style, Pixel-only rows
greying out.

**Preview** moves from a 26px swatch onto the nameplate preview, behind an eye
toggle matching the absorb/target-glow previews on this page. It renders through
the same union rule and stored options as the real plate.

**Migration** `np_important_cast_glow_drop_button_art_v1` re-points saved styles —
removing mid-list entries renumbers what follows, so without it anyone on
Auto-Cast Shine silently becomes Pixel Glow. Action Button → Pixel Glow; GCD,
Modern, Classic → Soft Bloom. Version-guarded, as renumbering is not
self-idempotent.

Two calls worth your view: this relaxes the preview's documented "no glow, no
added effects" rule, and it removes four styles from a shipped list. Happy to
revert either.

## How was it tested?

Client 12.1.0.69497.

Offline: migration run against real SavedVariables and
(version guard holds). Style indices verified to resolve to the correctly named
engine entry. Parse clean, ASCII only, `_keys.txt` unch

## Screenshots


https://github.com/user-attachments/assets/8f0c446f-9111-40ab-b219-34497dd4b698



## Checklist

- [x] New settings default **OFF** — Glow Size defaults
      Pixel Glow; new styles appended after the survivors.
- [x] Zero cost while disabled — unchanged early-out; pe
      LoD panel open.
- [x] Cheap while enabled — re-anchor on cast start onl
      AnimationGroups. No OnUpdate, events, hooks or timers.
- [x] No writes onto Blizzard-owned frames — EUI overla
- [ ] Tested in-game on live — no version gates or pre-Midnight APIs; tick after
      the passes above.
