### PR TITLE
Add gold amount abbreviation option to Databars

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -221,7 +221,7 @@ ns.BLOCK_DEFAULTS = {
     -- which the options page pulses about.
     location   = { showIcon = true, showSubZone = true },
     coords     = { showIcon = true, precision = 0, hideInInstance = true },
-    gold       = { showIcons = true, showBagSpace = false, showSmall = false, coinIcons = false, abbreviate = false },
+    gold       = { showIcons = true, showBagSpace = false, showSmall = false, coinIcons = false, abbreviate = false, forceEnglishUnits = false },
     durability = { showIcon = true },
     combat     = { onlyInCombat = false },
     xprep      = { mode = "auto" },
@@ -368,27 +368,34 @@ local CJK_GOLD = ({
     koKR = { wan = "만" },
 })[GetLocale()]
 
-local _goldAbbrevCfg
-if CreateAbbreviateConfig then
-    local opts
-    if CJK_GOLD then
-        opts = {
+local function BuildGoldAbbrevOpts(forceEnglish)
+    if CJK_GOLD and not forceEnglish then
+        return {
             { breakpoint = 10000, abbreviation = CJK_GOLD.wan, significandDivisor = 100, fractionDivisor = 100, abbreviationIsGlobal = false },
             { breakpoint = 1,     abbreviation = "",           significandDivisor = 1,   fractionDivisor = 1,   abbreviationIsGlobal = false },
         }
-    else
-        opts = {
-            { breakpoint = 1000000, abbreviation = "M", significandDivisor = 10000, fractionDivisor = 100, abbreviationIsGlobal = false },
-            { breakpoint = 1000,    abbreviation = "K", significandDivisor = 100,   fractionDivisor = 10,  abbreviationIsGlobal = false },
-            { breakpoint = 1,       abbreviation = "",  significandDivisor = 1,     fractionDivisor = 1,   abbreviationIsGlobal = false },
-        }
     end
-    _goldAbbrevCfg = { config = CreateAbbreviateConfig(opts) }
+    return {
+        { breakpoint = 1000000, abbreviation = "M", significandDivisor = 10000, fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 1000,    abbreviation = "K", significandDivisor = 100,   fractionDivisor = 10,  abbreviationIsGlobal = false },
+        { breakpoint = 1,       abbreviation = "",  significandDivisor = 1,     fractionDivisor = 1,   abbreviationIsGlobal = false },
+    }
+end
+
+-- Two cached configs: the locale's own (CJK 万/萬/만, or K/M if not CJK) and
+-- the English-forced one (Force English Units option). Non-CJK clients never
+-- differ between the two, so the second build is skipped for them.
+local _goldAbbrevCfgLocal, _goldAbbrevCfgEnglish
+if CreateAbbreviateConfig then
+    _goldAbbrevCfgLocal = { config = CreateAbbreviateConfig(BuildGoldAbbrevOpts(false)) }
+    _goldAbbrevCfgEnglish = CJK_GOLD
+        and { config = CreateAbbreviateConfig(BuildGoldAbbrevOpts(true)) }
+        or _goldAbbrevCfgLocal
 end
 
 -- Fallback for clients missing AbbreviateNumbers/CreateAbbreviateConfig.
-local function AbbrevGoldFallback(gold)
-    if CJK_GOLD then
+local function AbbrevGoldFallback(gold, forceEnglish)
+    if CJK_GOLD and not forceEnglish then
         if gold >= 1e4 then return format("%.2f%s", gold / 1e4, CJK_GOLD.wan)
         else return tostring(gold) end
     end
@@ -397,15 +404,16 @@ local function AbbrevGoldFallback(gold)
     else return tostring(gold) end
 end
 
-local function AbbrevGold(gold)
+local function AbbrevGold(gold, forceEnglish)
     if AbbreviateNumbers then
-        return AbbreviateNumbers(gold, _goldAbbrevCfg) or tostring(gold)
+        local cfg = forceEnglish and _goldAbbrevCfgEnglish or _goldAbbrevCfgLocal
+        return AbbreviateNumbers(gold, cfg) or tostring(gold)
     end
-    return AbbrevGoldFallback(gold)
+    return AbbrevGoldFallback(gold, forceEnglish)
 end
 
-local function GoldDisplay(val, abbreviate)
-    if abbreviate then return AbbrevGold(val) end
+local function GoldDisplay(val, abbreviate, forceEnglish)
+    if abbreviate then return AbbrevGold(val, forceEnglish) end
     return BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
 end
 
@@ -416,11 +424,11 @@ end
 -- Tip_AddColumns copies it, so one buffer serves all rows.
 local _moneyTokens = {}
 
-function ns.MoneyTokens(amount, showSmall, coinIcons, coloured, abbreviate)
+function ns.MoneyTokens(amount, showSmall, coinIcons, coloured, abbreviate, forceEnglish)
     amount = floor(abs(amount or 0))
     wipe(_moneyTokens)
     local gold = floor(amount / DENOMINATIONS[1].divisor)
-    _moneyTokens[1] = GoldDisplay(gold, abbreviate) .. CoinMarker(1, coinIcons, coloured)
+    _moneyTokens[1] = GoldDisplay(gold, abbreviate, forceEnglish) .. CoinMarker(1, coinIcons, coloured)
     if showSmall ~= false then
         local silver = floor((amount % DENOMINATIONS[1].divisor) / DENOMINATIONS[2].divisor)
         _moneyTokens[2] = silver .. CoinMarker(2, coinIcons, coloured)
@@ -429,7 +437,7 @@ function ns.MoneyTokens(amount, showSmall, coinIcons, coloured, abbreviate)
     return _moneyTokens
 end
 
-function ns.FormatMoneyPlain(amount, showSmall, coinIcons, abbreviate)
+function ns.FormatMoneyPlain(amount, showSmall, coinIcons, abbreviate, forceEnglish)
     amount = floor(abs(amount or 0))
     local parts, foundGold = {}, false
     for i, denom in ipairs(DENOMINATIONS) do
@@ -437,7 +445,7 @@ function ns.FormatMoneyPlain(amount, showSmall, coinIcons, abbreviate)
         amount = amount % denom.divisor
         if i == 1 and val > 0 then
             foundGold = true
-            parts[#parts + 1] = GoldDisplay(val, abbreviate) .. CoinMarker(i, coinIcons, false)
+            parts[#parts + 1] = GoldDisplay(val, abbreviate, forceEnglish) .. CoinMarker(i, coinIcons, false)
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
             parts[#parts + 1] = val .. CoinMarker(i, coinIcons, false)
         end
@@ -446,7 +454,7 @@ function ns.FormatMoneyPlain(amount, showSmall, coinIcons, abbreviate)
     return "0" .. CoinMarker(3, coinIcons, false)
 end
 
-function ns.FormatMoney(amount, useColors, showSmall, coinIcons, abbreviate)
+function ns.FormatMoney(amount, useColors, showSmall, coinIcons, abbreviate, forceEnglish)
     amount = floor(abs(amount or 0))
     local coloured = useColors ~= false
     local parts, foundGold = {}, false
@@ -455,7 +463,7 @@ function ns.FormatMoney(amount, useColors, showSmall, coinIcons, abbreviate)
         amount = amount % denom.divisor
         if i == 1 and val > 0 then
             foundGold = true
-            parts[#parts + 1] = GoldDisplay(val, abbreviate) .. CoinMarker(i, coinIcons, coloured)
+            parts[#parts + 1] = GoldDisplay(val, abbreviate, forceEnglish) .. CoinMarker(i, coinIcons, coloured)
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
             parts[#parts + 1] = val .. CoinMarker(i, coinIcons, coloured)
         end

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -221,7 +221,7 @@ ns.BLOCK_DEFAULTS = {
     -- which the options page pulses about.
     location   = { showIcon = true, showSubZone = true },
     coords     = { showIcon = true, precision = 0, hideInInstance = true },
-    gold       = { showIcons = true, showBagSpace = false, showSmall = false, coinIcons = false },
+    gold       = { showIcons = true, showBagSpace = false, showSmall = false, coinIcons = false, abbreviate = false },
     durability = { showIcon = true },
     combat     = { onlyInCombat = false },
     xprep      = { mode = "auto" },
@@ -357,6 +357,58 @@ local function CoinMarker(i, coinIcons, coloured)
     return d.symbol
 end
 
+-- Gold abbreviation (SI units): 284208 -> "284.2K". CJK clients group by
+-- 万 (萬, 만) instead of K/M, matching EllesmereUIDamageMeters' number
+-- formatting so the addon reads consistently across modules. The gold cap is
+-- 99,999,999 -- under the M/亿 rollover for a full 9-digit value, so there's
+-- no "B"/亿 breakpoint to carry.
+local CJK_GOLD = ({
+    zhCN = { wan = "万" },
+    zhTW = { wan = "萬" },
+    koKR = { wan = "만" },
+})[GetLocale()]
+
+local _goldAbbrevCfg
+if CreateAbbreviateConfig then
+    local opts
+    if CJK_GOLD then
+        opts = {
+            { breakpoint = 10000, abbreviation = CJK_GOLD.wan, significandDivisor = 100, fractionDivisor = 100, abbreviationIsGlobal = false },
+            { breakpoint = 1,     abbreviation = "",           significandDivisor = 1,   fractionDivisor = 1,   abbreviationIsGlobal = false },
+        }
+    else
+        opts = {
+            { breakpoint = 1000000, abbreviation = "M", significandDivisor = 10000, fractionDivisor = 100, abbreviationIsGlobal = false },
+            { breakpoint = 1000,    abbreviation = "K", significandDivisor = 100,   fractionDivisor = 10,  abbreviationIsGlobal = false },
+            { breakpoint = 1,       abbreviation = "",  significandDivisor = 1,     fractionDivisor = 1,   abbreviationIsGlobal = false },
+        }
+    end
+    _goldAbbrevCfg = { config = CreateAbbreviateConfig(opts) }
+end
+
+-- Fallback for clients missing AbbreviateNumbers/CreateAbbreviateConfig.
+local function AbbrevGoldFallback(gold)
+    if CJK_GOLD then
+        if gold >= 1e4 then return format("%.2f%s", gold / 1e4, CJK_GOLD.wan)
+        else return tostring(gold) end
+    end
+    if gold >= 1e6 then return format("%.2fM", gold / 1e6)
+    elseif gold >= 1e3 then return format("%.1fK", gold / 1e3)
+    else return tostring(gold) end
+end
+
+local function AbbrevGold(gold)
+    if AbbreviateNumbers then
+        return AbbreviateNumbers(gold, _goldAbbrevCfg) or tostring(gold)
+    end
+    return AbbrevGoldFallback(gold)
+end
+
+local function GoldDisplay(val, abbreviate)
+    if abbreviate then return AbbrevGold(val) end
+    return BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
+end
+
 -- Money split per denomination: one token per coin, so callers can align them
 -- in columns (tooltip) or separate lines (vertical bar) -- a single formatted
 -- string can't, since the proportional font makes "9g" and "1 234g" different
@@ -364,12 +416,11 @@ end
 -- Tip_AddColumns copies it, so one buffer serves all rows.
 local _moneyTokens = {}
 
-function ns.MoneyTokens(amount, showSmall, coinIcons, coloured)
+function ns.MoneyTokens(amount, showSmall, coinIcons, coloured, abbreviate)
     amount = floor(abs(amount or 0))
     wipe(_moneyTokens)
     local gold = floor(amount / DENOMINATIONS[1].divisor)
-    local gStr = BreakUpLargeNumbers and BreakUpLargeNumbers(gold) or tostring(gold)
-    _moneyTokens[1] = gStr .. CoinMarker(1, coinIcons, coloured)
+    _moneyTokens[1] = GoldDisplay(gold, abbreviate) .. CoinMarker(1, coinIcons, coloured)
     if showSmall ~= false then
         local silver = floor((amount % DENOMINATIONS[1].divisor) / DENOMINATIONS[2].divisor)
         _moneyTokens[2] = silver .. CoinMarker(2, coinIcons, coloured)
@@ -378,7 +429,7 @@ function ns.MoneyTokens(amount, showSmall, coinIcons, coloured)
     return _moneyTokens
 end
 
-function ns.FormatMoneyPlain(amount, showSmall, coinIcons)
+function ns.FormatMoneyPlain(amount, showSmall, coinIcons, abbreviate)
     amount = floor(abs(amount or 0))
     local parts, foundGold = {}, false
     for i, denom in ipairs(DENOMINATIONS) do
@@ -386,8 +437,7 @@ function ns.FormatMoneyPlain(amount, showSmall, coinIcons)
         amount = amount % denom.divisor
         if i == 1 and val > 0 then
             foundGold = true
-            local display = BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
-            parts[#parts + 1] = display .. CoinMarker(i, coinIcons, false)
+            parts[#parts + 1] = GoldDisplay(val, abbreviate) .. CoinMarker(i, coinIcons, false)
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
             parts[#parts + 1] = val .. CoinMarker(i, coinIcons, false)
         end
@@ -396,7 +446,7 @@ function ns.FormatMoneyPlain(amount, showSmall, coinIcons)
     return "0" .. CoinMarker(3, coinIcons, false)
 end
 
-function ns.FormatMoney(amount, useColors, showSmall, coinIcons)
+function ns.FormatMoney(amount, useColors, showSmall, coinIcons, abbreviate)
     amount = floor(abs(amount or 0))
     local coloured = useColors ~= false
     local parts, foundGold = {}, false
@@ -405,8 +455,7 @@ function ns.FormatMoney(amount, useColors, showSmall, coinIcons)
         amount = amount % denom.divisor
         if i == 1 and val > 0 then
             foundGold = true
-            local display = BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
-            parts[#parts + 1] = display .. CoinMarker(i, coinIcons, coloured)
+            parts[#parts + 1] = GoldDisplay(val, abbreviate) .. CoinMarker(i, coinIcons, coloured)
         elseif i > 1 and (not foundGold or showSmall ~= false) and (val > 0 or (i == 3 and #parts == 0)) then
             parts[#parts + 1] = val .. CoinMarker(i, coinIcons, coloured)
         end

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -2006,13 +2006,14 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         local money = GetMoney()
         local ci = dg.coinIcons == true
         local ab = dg.abbreviate == true
+        local fe = dg.forceEnglishUnits == true
         if isSide then
             local slotW = VSlotW(inst)
             local innerW = max(30, slotW - 8)
             -- One token per coin, one coin per line. Coin Colored tints the suffix letters
             -- (nothing to tint once Coin Icons is on, so the two compose); hovering drops it so the accent wash reads.
             local lines = ns.MoneyTokens(money, dg.showSmall == true, ci,
-                blockCfg.useCoinColor == true and not mouseOver, ab)
+                blockCfg.useCoinColor == true and not mouseOver, ab, fe)
             local startSize = min(fontSize, max(10, floor(CONTENT_BASE * 0.52 + 0.5)))
             local goldFontSize = startSize
             ns.SetFont(goldText, goldFontSize, barCfg)
@@ -2023,11 +2024,11 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             else r, g, b = BlockColorOf(blockCfg) end
             goldText:SetTextColor(r, g, b, 1)
         elseif mouseOver then
-            goldText:SetText(ns.FormatMoneyPlain(money, dg.showSmall == true, ci, ab))
+            goldText:SetText(ns.FormatMoneyPlain(money, dg.showSmall == true, ci, ab, fe))
             local r, g, b = ns.GetAccent()
             goldText:SetTextColor(r, g, b, 1)
         else
-            goldText:SetText(ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci, ab))
+            goldText:SetText(ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci, ab, fe))
             if blockCfg.useCoinColor then
                 goldText:SetTextColor(1, 1, 1, 1)
             else
@@ -2094,8 +2095,8 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         else
             local slotW = HBudget(inst, 100)
             -- Fit against BOTH money formats so font/icon size and frame width stay identical hovered or not; otherwise it resizes on mouseover.
-            local plainText = ns.FormatMoneyPlain(money, dg.showSmall == true, ci, ab)
-            local fancyText = ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci, ab)
+            local plainText = ns.FormatMoneyPlain(money, dg.showSmall == true, ci, ab, fe)
+            local fancyText = ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci, ab, fe)
             local moneyText
             if mouseOver then moneyText = plainText else moneyText = fancyText end
             local bagTextValue = ""

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -2005,13 +2005,14 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
 
         local money = GetMoney()
         local ci = dg.coinIcons == true
+        local ab = dg.abbreviate == true
         if isSide then
             local slotW = VSlotW(inst)
             local innerW = max(30, slotW - 8)
             -- One token per coin, one coin per line. Coin Colored tints the suffix letters
             -- (nothing to tint once Coin Icons is on, so the two compose); hovering drops it so the accent wash reads.
             local lines = ns.MoneyTokens(money, dg.showSmall == true, ci,
-                blockCfg.useCoinColor == true and not mouseOver)
+                blockCfg.useCoinColor == true and not mouseOver, ab)
             local startSize = min(fontSize, max(10, floor(CONTENT_BASE * 0.52 + 0.5)))
             local goldFontSize = startSize
             ns.SetFont(goldText, goldFontSize, barCfg)
@@ -2022,11 +2023,11 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
             else r, g, b = BlockColorOf(blockCfg) end
             goldText:SetTextColor(r, g, b, 1)
         elseif mouseOver then
-            goldText:SetText(ns.FormatMoneyPlain(money, dg.showSmall == true, ci))
+            goldText:SetText(ns.FormatMoneyPlain(money, dg.showSmall == true, ci, ab))
             local r, g, b = ns.GetAccent()
             goldText:SetTextColor(r, g, b, 1)
         else
-            goldText:SetText(ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci))
+            goldText:SetText(ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci, ab))
             if blockCfg.useCoinColor then
                 goldText:SetTextColor(1, 1, 1, 1)
             else
@@ -2093,8 +2094,8 @@ ns.BlockFactories.gold = function(blockCfg, slot, content, barCtx)
         else
             local slotW = HBudget(inst, 100)
             -- Fit against BOTH money formats so font/icon size and frame width stay identical hovered or not; otherwise it resizes on mouseover.
-            local plainText = ns.FormatMoneyPlain(money, dg.showSmall == true, ci)
-            local fancyText = ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci)
+            local plainText = ns.FormatMoneyPlain(money, dg.showSmall == true, ci, ab)
+            local fancyText = ns.FormatMoney(money, blockCfg.useCoinColor == true, dg.showSmall == true, ci, ab)
             local moneyText
             if mouseOver then moneyText = plainText else moneyText = fancyText end
             local bagTextValue = ""

--- a/EllesmereUILocales/ptBR.lua
+++ b/EllesmereUILocales/ptBR.lua
@@ -6606,3 +6606,9 @@ L["World Marker: Skull"] = "Marcador de Mundo: Caveira"
 L["World Marker: Square"] = "Marcador de Mundo: Quadrado"
 L["World Marker: Star"] = "Marcador de Mundo: Estrela"
 L["World Marker: Triangle"] = "Marcador de Mundo: Triângulo"
+
+-- == Data Bars / Gold ===========================================================
+L["Abbreviate Amount"] = "Abreviar Quantidade"
+L["Always use K/M instead of localized units."] = "Sempre usar K/M em vez de unidades localizadas."
+L["Force English Units (K/M)"] = "Forçar unidades em inglês (K/M)"
+L["Shows large amounts using K/M suffixes (284,208g becomes 284.2Kg) instead of the full grouped number. The tooltip always shows the exact amount."] = "Mostra grandes quantidades usando sufixos K/M (284.208 vira 284,2K) em vez do número completo agrupado. A dica sempre mostra a quantia exata."

--- a/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
@@ -2899,6 +2899,8 @@ initFrame:SetScript("OnEvent", function(self)
                       values = { __placeholder = "..." }, order = { "__placeholder" },
                       getValue = function() return "__placeholder" end,
                       setValue = function() end },
+                    MkToggle("Abbreviate Amount", "abbreviate",
+                        "Shows large amounts using K/M suffixes (284,208g becomes 284.2Kg) instead of the full grouped number. The tooltip always shows the exact amount."),
                 }
             elseif b.type == "xprep" then
                 typeRows = {

--- a/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
@@ -2902,6 +2902,17 @@ initFrame:SetScript("OnEvent", function(self)
                     MkToggle("Abbreviate Amount", "abbreviate",
                         "Shows large amounts using K/M suffixes (284,208g becomes 284.2Kg) instead of the full grouped number. The tooltip always shows the exact amount."),
                 }
+                -- Force English Units: CJK clients only (zhCN/zhTW/koKR group
+                -- numbers by 万/亿 instead of K/M); every other locale already
+                -- gets K/M, so the toggle would be a no-op there. Mirrors the
+                -- Damage Meters options row (EUI_DamageMeters_Options.lua).
+                do
+                    local clientLocale = GetLocale()
+                    if clientLocale == "zhCN" or clientLocale == "zhTW" or clientLocale == "koKR" then
+                        typeRows[#typeRows + 1] = MkToggle("Force English Units (K/M)", "forceEnglishUnits",
+                            "Always use K/M instead of localized units.")
+                    end
+                end
             elseif b.type == "xprep" then
                 typeRows = {
                     { type = "dropdown", text = "Mode",


### PR DESCRIPTION
## Summary
- Adds an "Abbreviate Amount" toggle to the Databars Gold block, showing large balances with K/M suffixes (e.g. `284,208g` → `284.2Kg`) instead of the fully grouped number. The gold tooltip breakdown (session earned/spent, per-character list, warbank, total) always keeps full precision regardless of this setting.
- CJK clients (zhCN/zhTW/koKR) group by 万/萬/만 instead of K/M, matching how the client's own number formatting reads for those locales. There's no "B"/亿 tier since the gold cap (99,999,999) never reaches it.

The CJK abbreviation table/config-building approach is copied from the existing pattern in `EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua` (`BuildAbbrevOpts`/`RebuildAbbrevCfg`/`AbbrevNumber`, around line 960 onward), reused here in a simplified, gold-specific form so both modules format abbreviated numbers consistently.

## Test plan
- [x] In-game: toggle "Abbreviate Amount" on the Gold block and confirm the bar shows `284.2Kg`-style text while hovering still shows the exact amount.
- [x] Confirm the gold tooltip (session/characters/warbank/total) still shows full precision with the toggle on.
- [x] Confirm vertical bar layout (side bar) also abbreviates correctly.
- [x] Switch client locale to a CJK locale (or `/console locale koKR`-style test) and confirm 万/萬/만 grouping appears instead of K/M.