### PR TITLE
fix(dispels): anchor the Fill Overlay to the fill on both axes

### DIFF
--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -3318,8 +3318,7 @@ initFrame:SetScript("OnEvent", function(self)
                             or "Interface\\AddOns\\EllesmereUI\\media\\textures\\gradient-tb.tga")
                         dispelOverlayPreview:SetVertexColor(c.r, c.g, c.b, alpha)
                     else
-                        dispelOverlayPreview:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
-                        dispelOverlayPreview:SetPoint("BOTTOMRIGHT", healthFill, "BOTTOMRIGHT", 0, 0)
+                        dispelOverlayPreview:SetAllPoints(healthFill)
                         dispelOverlayPreview:SetColorTexture(c.r, c.g, c.b, alpha)
                     end
                     dispelOverlayPreview:Show()

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -639,11 +639,12 @@ local function ApplyRFDispelSlot(button, dd, style)
     else -- "fill"
         tex:Show()
         local fillTex = health.GetStatusBarTexture and health:GetStatusBarTexture()
-        tex:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
+        -- Both corners come off the fill texture: a TOPLEFT-of-bar pair only tracks a
+        -- left-to-right bar, so a vertical fill spanned the whole frame like "full".
         if fillTex then
-            tex:SetPoint("BOTTOMRIGHT", fillTex, "BOTTOMRIGHT", 0, 0)
+            tex:SetAllPoints(fillTex)
         else
-            tex:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+            tex:SetAllPoints(health)
         end
         tex:SetColorTexture(r, g, b, alpha)
         tex:SetVertexColor(1, 1, 1, 1)

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -13110,8 +13110,7 @@ local function ApplyPreviewData(f, index)
             if olMode == "fill" then
                 local fillTex = f._health:GetStatusBarTexture()
                 if fillTex then
-                    olTex:SetPoint("TOPLEFT", f._health, "TOPLEFT", 0, 0)
-                    olTex:SetPoint("BOTTOMRIGHT", fillTex, "BOTTOMRIGHT", 0, 0)
+                    olTex:SetAllPoints(fillTex)
                 else
                     olTex:SetAllPoints(f._health)
                 end

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_AuraContainers.lua
@@ -1520,11 +1520,12 @@ local function ApplyDispelSlotStyle(button, d, style)
         tex:SetVertexColor(c.r, c.g, c.b, alpha)
     elseif style.mode == "fill" then
         local fillTex = health.GetStatusBarTexture and health:GetStatusBarTexture()
-        tex:SetPoint("TOPLEFT", health, "TOPLEFT", 0, 0)
+        -- Both corners come off the fill texture so the overlay follows vertical and
+        -- reverse fills; anchoring TOPLEFT to the bar only tracks left-to-right.
         if fillTex then
-            tex:SetPoint("BOTTOMRIGHT", fillTex, "BOTTOMRIGHT", 0, 0)
+            tex:SetAllPoints(fillTex)
         else
-            tex:SetPoint("BOTTOMRIGHT", health, "BOTTOMRIGHT", 0, 0)
+            tex:SetAllPoints(health)
         end
         tex:SetColorTexture(c.r, c.g, c.b, alpha)
         tex:SetVertexColor(1, 1, 1, 1)


### PR DESCRIPTION
Bug: reported by Clandestin in EllesmereUI-helper Discord (2026-08-26), Party Frames, version 9.0.6.

Issue: with Vertical Fill health bars turned on, the Dispels "Fill Overlay" stops tracking the health fill and paints the entire frame, which is what "Full Overlay" is supposed to look like. Clandestin hit this while working through the settings after switching Raid and Party Frames to vertical bars, and swapping back to horizontal made the overlay behave correctly again, so the setting itself reads as if it silently changed meaning. The type colour, opacity and priority ordering are all correct; the only thing wrong is how far the tint reaches.

Root cause: the fill-mode overlay was anchored with a mismatched corner pair, TOPLEFT to the health bar and BOTTOMRIGHT to the bar's fill texture. That describes a left-to-right bar and nothing else. SetOrientation("VERTICAL") makes the fill texture keep the bar's full width and its BOTTOMRIGHT corner, moving only its top edge, so the pair resolves to the whole health bar and the overlay covers everything. The same two lines exist in ApplyRFDispelSlot for live raid and party frames, in ApplyDispelSlotStyle for unit frames, and in both option previews, so the preview agreed with the broken live frame and gave no hint that anything was off.

Fix: both corners now come off the fill texture, which is axis-agnostic and reverse-agnostic, so the overlay follows the filled region whichever way the bar grows. Unit frames are included because they carry the identical anchor pair and additionally expose Reverse Fill, where the old code left the overlay pinned to the left edge while the bar filled right-to-left; raid frames have no reverse-fill key, so vertical was the only broken axis there. Non-reverse horizontal bars resolve to exactly the same rect as before and are unchanged. Nothing new runs per frame or per tick, the absorb and heal-prediction paths were already axis-aware and are untouched, and no secure or aura-slot access pattern changes: anchor-derived geometry is the same route the existing code used, which keeps it legal on the aura-slot subtrees while auras are secret.
