### PR TITLE
fix(qol): hide the FPS Counter mover when Show FPS Counter is off

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -2525,9 +2525,12 @@ do
                 label = "FPS Counter",
                 group = "General",
                 order = 700,
-                -- Dragged by the Secondary Stats element while attached. Read
-                -- live, so detaching restores the mover without re-registering.
-                isHidden = IsAttached,
+                -- Off, or dragged by the Secondary Stats element while
+                -- attached. Read live, so enabling or detaching restores the
+                -- mover without re-registering.
+                isHidden = function()
+                    return not EllesmereUI.QoLExtrasGet("showFPS") or IsAttached()
+                end,
                 getFrame = function()
                     if not fpsFrame then CreateFPSCounter() end
                     return fpsFrame

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -2510,15 +2510,22 @@ do
         end
     end
 
+    local RegisterFPSUnlockElement  -- forward: defined below
+
     -- A settings change can move the readout between its two owners, so every
     -- FPS option writes through here rather than calling one side directly.
     EllesmereUI._applyFPSDisplay = function()
         if EllesmereUI._applyFPSCounter then EllesmereUI._applyFPSCounter() end
         if EllesmereUI._applySecondaryStats then EllesmereUI._applySecondaryStats() end
+        -- Re-registering is how an open unlock session gains or loses a mover,
+        -- so a showFPS flip (options toggle or the keybind, both of which land
+        -- here) takes effect without leaving and re-entering.
+        if EllesmereUI._unlockActive then RegisterFPSUnlockElement() end
     end
 
-    C_Timer.After(2, function()
+    RegisterFPSUnlockElement = function()
         local MK = EllesmereUI.MakeUnlockElement
+        if not MK then return end
         EllesmereUI:RegisterUnlockElements({
             MK({
                 key = "EUI_FPS",
@@ -2526,8 +2533,8 @@ do
                 group = "General",
                 order = 700,
                 -- Off, or dragged by the Secondary Stats element while
-                -- attached. Read live, so enabling or detaching restores the
-                -- mover without re-registering.
+                -- attached. Read live, so detaching restores the mover without
+                -- re-registering.
                 isHidden = function()
                     return not EllesmereUI.QoLExtrasGet("showFPS") or IsAttached()
                 end,
@@ -2564,7 +2571,8 @@ do
                 end,
             }),
         })
-    end)
+    end
+    C_Timer.After(2, RegisterFPSUnlockElement)
 
     C_Timer.After(2.5, function()
         local MK = EllesmereUI.MakeUnlockElement


### PR DESCRIPTION
Bug: reported by Scalyskin in EllesmereUI-helper Discord (2026-08-26), QoL, version 9.0.6.

Issue: with "Show FPS Counter" turned off in QoL, the FPS Counter still appears as a draggable element in Unlock Mode. Scalyskin re-enabled and disabled the toggle to try to clear it, with no effect. The counter itself is correctly hidden during play, so the only thing wrong is that Unlock Mode offers a mover for a feature that is switched off, which reads as if the toggle failed to take.

Root cause: the EUI_FPS unlock element declared isHidden = IsAttached, which only reports hidden while the readout is being drawn as extra rows inside the Secondary Stats block. It never consulted showFPS at all. Its getFrame calls CreateFPSCounter() unconditionally, so CreateMover always received a real (if hidden) frame and built a mover for it. Secondary Stats sits directly beside it and avoids the same fault by accident rather than by design: its getFrame runs ApplySecondaryStats, which early-returns while disabled and leaves the frame nil, so CreateMover has nothing to attach to and bails.

Fix: isHidden now returns true when showFPS is off, keeping IsAttached as the second clause so the attach case is unchanged. The predicate is read live in CreateMover, in mover:Sync and in the late-registration retry ticker, so all three paths agree. The element registration is also lifted into a named local that _applyFPSDisplay calls back into while a session is open, matching the ns._RFRegisterUnlock seam Raid Frames uses for its Healer Mana Display: re-registration is what lets an open Unlock Mode session gain or lose a mover, so flipping the toggle now takes effect in both directions without leaving and re-entering. Both writers of showFPS, the options toggle and the FPS keybind, already route through _applyFPSDisplay, so one seam covers them. Registration is idempotent and the size hooks it installs are guarded against duplicates, and the call is gated on _unlockActive so nothing extra runs during normal play. No new frames, timers or events, and no secure or restricted access changes.
