### PR TITLE
feat(charsheet): highlight equipped items granting a hovered secondary/tertiary stat

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -255,6 +255,8 @@ do
             showCharSheetDurability      = false,
             charSheetDurabilityLocation  = "model",
             charSheetDurabilityShowLabel = true,
+            highlightSecondaryItems      = false,
+            highlightTertiaryItems       = false,
         }
         for k, v in pairs(defaults) do
             if EllesmereUIDB[k] == nil then
@@ -2037,6 +2039,74 @@ local function SkinCharacterSheet()
         return defaultOrder
     end
 
+    -- Per stat hover highlighters (reuse Glows system to match the socket panel).
+    -- Keyed by the exact ITEM_MOD_* token GetItemStats returns -- these are fixed
+    -- Blizzard identifiers, not localized text, so matching is locale-independent
+    -- (see the same convention in EllesmereUIBlizzardSkin_SocketPanel.lua's GetGemStatText).
+    local STAT_NAME_TO_ITEM_MOD = {
+        -- Secondary stats
+        ["Critical Strike"] = { ITEM_MOD_CRIT_RATING_SHORT = true },
+        ["Haste"]           = { ITEM_MOD_HASTE_RATING_SHORT = true },
+        ["Mastery"]         = { ITEM_MOD_MASTERY_RATING_SHORT = true },
+        ["Versatility"]     = { ITEM_MOD_VERSATILITY = true, ITEM_MOD_VERSATILITY_2 = true },
+        -- Tertiary stats
+        ["Leech"]           = { ITEM_MOD_CR_LIFESTEAL_SHORT = true },
+        ["Avoidance"]       = { ITEM_MOD_CR_AVOIDANCE_SHORT = true },
+        ["Speed"]           = { ITEM_MOD_CR_SPEED_SHORT = true },
+    }
+    local _statHighlighters = {}
+    local function StartStatHighlights(statName)
+        if not (EllesmereUI and EllesmereUI.Glows and EllesmereUI.Glows.StartGlow) then return end
+        local wantedMods = statName and STAT_NAME_TO_ITEM_MOD[statName]
+        if not wantedMods then return end
+        local G = EllesmereUI.Glows
+        for _, slotName in ipairs(EUI_GEAR_SLOTS) do
+            local slot = _G[slotName]
+            if slot and slot.GetID then
+                local slotID = slot:GetID()
+                local link = GetInventoryItemLink("player", slotID)
+                if link and C_Item and C_Item.GetItemStats then
+                    local stats = C_Item.GetItemStats(link)
+                    if stats then
+                        for key, val in pairs(stats) do
+                            if type(val) == "number" and val > 0 and wantedMods[key] then
+                                if not _statHighlighters[slotID] then
+                                    local slotBtn = slot
+                                    local f = CreateFrame("Frame", nil, CharacterFrame)
+                                    f:ClearAllPoints()
+                                    f:SetAllPoints(slotBtn)
+                                    f:SetFrameStrata(slotBtn:GetFrameStrata())
+                                    f:SetFrameLevel(slotBtn:GetFrameLevel() + 5)
+                                    f:Show()
+                                    local w, h = slotBtn:GetWidth(), slotBtn:GetHeight()
+                                    if not w or w < 1 then w = 37 end
+                                    if not h or h < 1 then h = w end
+                                    G.StartGlow(f, 6, w, 1, 1, 1, nil, h)
+                                    _statHighlighters[slotID] = f
+                                end
+                                break
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    local function StopStatHighlights()
+        if not (EllesmereUI and EllesmereUI.Glows) then
+            _statHighlighters = {}
+            return
+        end
+        local G = EllesmereUI.Glows
+        for id, f in pairs(_statHighlighters) do
+            if f then
+                G.StopGlow(f)
+                f:Hide()
+            end
+            _statHighlighters[id] = nil
+        end
+    end
+
     local statSections = GetStatSectionsOrder()
 
     GetFFD(frame).statsPanel = statsPanel
@@ -2174,6 +2244,9 @@ local function SkinCharacterSheet()
                 EllesmereUI._updateStatCategoryVisibility()
             end
         end)
+    end)
+    frame:HookScript("OnHide", function()
+        StopStatHighlights()
     end)
 
     -- Show/hide whole stat categories per their DB setting.
@@ -2564,10 +2637,21 @@ local function SkinCharacterSheet()
                     end
 
                     GameTooltip:Show()
+                    -- Highlight equipped items that grant this secondary stat (opt-in)
+                    if section and (section.settingKey == "SecondaryStats")
+                       and EllesmereUIDB and EllesmereUIDB.highlightSecondaryItems then
+                        StartStatHighlights(stat.name)
+                    end
+                    -- Tertiary highlight opt-in
+                    if section and (section.settingKey == "Tertiary")
+                       and EllesmereUIDB and EllesmereUIDB.highlightTertiaryItems then
+                        StartStatHighlights(stat.name)
+                    end
                 end)
 
                 valueButton:SetScript("OnLeave", function()
                     GameTooltip:Hide()
+                    StopStatHighlights()
                 end)
 
                 table.insert(GetFFD(frame).statsValues, {

--- a/EllesmereUIOptions/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIOptions/EUI_BlizzardSkin_Options.lua
@@ -1232,6 +1232,13 @@ initFrame:SetScript("OnEvent", function(self)
                       if v then EllesmereUIDB.showSecondaryRaw = false end
                       if EllesmereUI._refreshStatFormats then EllesmereUI._refreshStatFormats() end
                   end },
+                { type="toggle", label="Highlight Items",
+                  tooltip="When hovering a secondary stat, highlight equipped items that grant it.",
+                  get=function() return EllesmereUIDB and EllesmereUIDB.highlightSecondaryItems or false end,
+                  set=function(v)
+                      if not EllesmereUIDB then EllesmereUIDB = {} end
+                      EllesmereUIDB.highlightSecondaryItems = v
+                  end },
             },
         }
         local tertiaryCogOpts = {
@@ -1252,6 +1259,13 @@ initFrame:SetScript("OnEvent", function(self)
                       EllesmereUIDB.showTertiaryBoth = v
                       if v then EllesmereUIDB.showTertiaryRaw = false end
                       if EllesmereUI._refreshStatFormats then EllesmereUI._refreshStatFormats() end
+                  end },
+                { type="toggle", label="Highlight Tertiary Items",
+                  tooltip="When hovering a tertiary stat, highlight equipped items that grant it.",
+                  get=function() return EllesmereUIDB and EllesmereUIDB.highlightTertiaryItems or false end,
+                  set=function(v)
+                      if not EllesmereUIDB then EllesmereUIDB = {} end
+                      EllesmereUIDB.highlightTertiaryItems = v
                   end },
             },
         }


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds an opt-in hover highlight on the character sheet: hovering a secondary
stat (Critical Strike, Haste, Mastery, Versatility) or tertiary stat (Leech,
Avoidance, Speed) row now glows the equipped item slots that are actually
granting that stat, using the same Glows highlight already used to spotlight
a slot from the socket panel. Two new toggles are added under Stat Display
settings (Secondary Stats / Tertiary Stats cog popups): "Highlight Items"
and "Highlight Tertiary Items" -- both default OFF.

## How was it tested?

Tested in-game on live: toggled both settings on/off, hovered each secondary
and tertiary stat with a mix of geared/ungeared slots, confirmed the correct
slots glow and clear on mouse-leave, and confirmed closing the character
sheet mid-hover clears the glow instead of leaking it.

## Screenshots

Without highlighting:
<img width="1315" height="786" alt="image" src="https://github.com/user-attachments/assets/f2a94c3b-c7b3-4c55-abe7-a2fc5c01589c" />

With:
<img width="935" height="565" alt="image" src="https://github.com/user-attachments/assets/5a33f610-497a-4cc9-b7ff-6b1c7f322947" />

And on tertiary:
<img width="977" height="562" alt="image" src="https://github.com/user-attachments/assets/df855fe2-7adf-4e2f-831b-2c5627e12590" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) --
      `highlightSecondaryItems` / `highlightTertiaryItems` both default `false`;
      existing users and fresh installs alike see no change until enabled.
- [x] Zero cost while disabled: no events registered, no polling, no hooks
      doing work, no frames built -- the highlight frames are created lazily,
      only the first time a matching stat is hovered while the setting is on.
      The one unconditional `OnHide` hook is a cheap no-op while disabled
      (iterates an empty table).
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic,
      no per-frame allocations) -- driven entirely by existing `OnEnter`/
      `OnLeave` tooltip handlers on the stat rows; a small bounded loop over
      the 16 gear slots runs once per hover, not per frame.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used);
      `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard
      frames -- the highlight overlay is our own `CreateFrame`, anchored to
      the Blizzard slot button via `SetAllPoints` but never scripting it;
      the character-sheet `OnHide` cleanup uses `HookScript`, not `SetScript`.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added --
      uses `C_Item.GetItemStats`, `GetInventoryItemLink`, and the existing
      `EllesmereUI.Glows` module only.
