### PR TITLE
Fix action bars staying hidden through combat after a mount-triggered hide condition (Druid forms + Skyriding Mount)

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12786,13 +12786,21 @@ function EllesmereUI.CheckVisibilityOptionsNonMacro(opts, skipMountAxis)
 
     -- Skyriding-mount axis (glide capability, ground included -- NOT the airborne
     -- show_dragonriding / show_not_dragonriding mode pair, which additionally
-    -- requires IsFlying; see EllesmereUI.IsAirborneSkyriding).
+    -- requires IsFlying; see EllesmereUI.IsAirborneSkyriding). No secure macro
+    -- token can express "ground included" (the airborne-only [advflyable,flying]
+    -- pair used elsewhere is a different check), so this stays Lua-only for
+    -- every caller. Returns "mountaxis" instead of a plain true so a secure-driver
+    -- caller (Action Bars) can recognize it needs a [combat] show escape hatch
+    -- baked into whatever it writes -- root-caused 2026-08-27: a bare "hide" from
+    -- this branch froze the bar hidden through an entire fight after a skyriding
+    -- dismount-into-combat, because InCombatLockdown() defers the next Lua pass
+    -- that would otherwise re-evaluate it. Still truthy for every other caller.
     if opts.visHideDragonriding then
-        if EllesmereUI.IsPlayerSkyriding and EllesmereUI.IsPlayerSkyriding() then return true end
+        if EllesmereUI.IsPlayerSkyriding and EllesmereUI.IsPlayerSkyriding() then return "mountaxis" end
     end
 
     if opts.visOnlySkyriding then
-        if not (EllesmereUI.IsPlayerSkyriding and EllesmereUI.IsPlayerSkyriding()) then return true end
+        if not (EllesmereUI.IsPlayerSkyriding and EllesmereUI.IsPlayerSkyriding()) then return "mountaxis" end
     end
 
     return false

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -9738,15 +9738,20 @@ function EAB:UpdateHousingVisibility()
             if s.visHideMounted then
                 -- Regular mounts are handled entirely by the secure "[mounted] hide"
                 -- clause, which self-updates even in combat, so the bar reappears the
-                -- instant the player is dazed off a mount. Clobbering the driver with a
-                -- literal "hide" here would freeze it hidden until combat ends: this
-                -- handler bails during InCombatLockdown and
-                -- PLAYER_MOUNT_DISPLAY_CHANGED can't re-evaluate a dead constant
-                -- string. Only shapeshift travel/flight forms need this non-secure
-                -- fallback, since [mounted] doesn't match them.
+                -- instant the player is dazed off a mount. Druid travel/flight forms
+                -- don't match [mounted], so they fall back to this non-secure clobber --
+                -- but a bare "hide" is a dead constant once written: shifting out of
+                -- form to attack fires UPDATE_SHAPESHIFT_FORM into combat almost
+                -- immediately, this handler's deferred callback bails on
+                -- InCombatLockdown(), and nothing re-evaluates the literal string until
+                -- combat ends (root-caused 2026-08-27: bars stayed hidden for a whole
+                -- fight after dropping out of Flight Form onto an enemy). Returning this
+                -- marker instead of a plain true lets the write site bake a "[combat]
+                -- show" escape hatch into the string itself, so the engine can
+                -- self-correct in combat exactly like the real-mount case does.
                 if not (IsMounted and IsMounted())
                     and EllesmereUI and EllesmereUI.IsPlayerMountedLike and EllesmereUI.IsPlayerMountedLike() then
-                    return true
+                    return "formhide"
                 end
             end
             -- Every other Lua-only option (both instance lanes, both housing lanes, both
@@ -9796,10 +9801,15 @@ function EAB:UpdateHousingVisibility()
                         end
                     elseif shouldHide then
                         if isSecure then
-                            if frame._eabLastVisStr ~= "hide" then
+                            -- "formhide" (druid mount-like form) bakes a [combat] show
+                            -- escape hatch into the string so the secure engine can
+                            -- un-hide on its own if combat starts before this handler
+                            -- gets to run again (see ShouldHideNonMacro above).
+                            local hideStr = (shouldHide == "formhide") and "[combat] show; hide" or "hide"
+                            if frame._eabLastVisStr ~= hideStr then
 
-                                frame._eabLastVisStr = "hide"
-                                RegisterAttributeDriver(frame, "state-visibility", "hide")
+                                frame._eabLastVisStr = hideStr
+                                RegisterAttributeDriver(frame, "state-visibility", hideStr)
                             end
                         elseif info.blizzOwnedVisibility then
                             local bf = _G[info.frameName]

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -9751,7 +9751,7 @@ function EAB:UpdateHousingVisibility()
                 -- self-correct in combat exactly like the real-mount case does.
                 if not (IsMounted and IsMounted())
                     and EllesmereUI and EllesmereUI.IsPlayerMountedLike and EllesmereUI.IsPlayerMountedLike() then
-                    return "formhide"
+                    return "combathide"
                 end
             end
             -- Every other Lua-only option (both instance lanes, both housing lanes, both
@@ -9759,10 +9759,16 @@ function EAB:UpdateHousingVisibility()
             -- there is live here too instead of silently going stale on the next zone or
             -- mount edge. skipMountAxis keeps the driver's [mounted]/[nomounted] clauses
             -- authoritative, leaving the narrower shapeshift check above as the only
-            -- mount handling on this path.
-            if EllesmereUI and EllesmereUI.CheckVisibilityOptionsNonMacro
-                and EllesmereUI.CheckVisibilityOptionsNonMacro(s, true) then
-                return true
+            -- mount handling on this path. The skyriding-mount lanes are exactly as
+            -- combat-race-prone as the druid-form case above (root-caused 2026-08-27
+            -- alongside it: no secure macro token can express their "ground included"
+            -- semantics, so they hit the same bare-"hide"-freezes-through-combat bug
+            -- after a skyriding dismount), so the shared evaluator flags them with the
+            -- same "mountaxis" marker rather than a plain true.
+            if EllesmereUI and EllesmereUI.CheckVisibilityOptionsNonMacro then
+                local nonMacro = EllesmereUI.CheckVisibilityOptionsNonMacro(s, true)
+                if nonMacro == "mountaxis" then return "combathide" end
+                if nonMacro then return true end
             end
             return false
         end
@@ -9801,11 +9807,12 @@ function EAB:UpdateHousingVisibility()
                         end
                     elseif shouldHide then
                         if isSecure then
-                            -- "formhide" (druid mount-like form) bakes a [combat] show
-                            -- escape hatch into the string so the secure engine can
-                            -- un-hide on its own if combat starts before this handler
-                            -- gets to run again (see ShouldHideNonMacro above).
-                            local hideStr = (shouldHide == "formhide") and "[combat] show; hide" or "hide"
+                            -- "combathide" (druid mount-like form, or the skyriding-mount
+                            -- lanes) bakes a [combat] show escape hatch into the string so
+                            -- the secure engine can un-hide on its own if combat starts
+                            -- before this handler gets to run again (see ShouldHideNonMacro
+                            -- above).
+                            local hideStr = (shouldHide == "combathide") and "[combat] show; hide" or "hide"
                             if frame._eabLastVisStr ~= hideStr then
 
                                 frame._eabLastVisStr = hideStr


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1542555648451940466

Summary:

Issue: With Action Bars set to "Show Always" plus a mount-related hide condition, bars would stay hidden for an entire fight after dropping into combat directly from a mount (e.g. diving onto an enemy), only reappearing once combat ended. Two separate causes turned out to be involved.

Root cause (shared pattern): Mount-state hide conditions are meant to be handled by a secure macro conditional (like [mounted]) baked into the action bar's driver string, which the game engine re-evaluates natively — even mid-combat, no addon code needed. But two specific cases had no native equivalent and fell back to a non-secure Lua check instead: that fallback writes a plain "hide" string, which — unlike a native macro token — can't self-correct. If combat starts in the same instant the fallback needs to re-run, the addon's own combat-lockdown guard defers that re-run, and the bar stays frozen hidden until combat ends.

Druid Travel/Flight Form (fixed first commit): not a real mount, so [mounted] never matches it.
"Hide - Skyriding Mount" (fixed second commit): deliberately fires "on the ground too," a distinction no native macro token can express — so it was Lua-only for every class, not just Druids.
Fix: Both cases now get flagged with a marker instead of a plain true/hide, letting the write site bake a [combat] show escape hatch directly into the driver string — so the engine can self-correct in combat exactly like the native [mounted] case always could. Confirmed fixed on Druid (original repro) and on a regular mount with matching toggles.