### PR TITLE
Fix taint error from secret mouse-channel values during combat in raid

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -2941,7 +2941,9 @@ local function GetMouseChannels(f)
     local click
     if f.IsMouseClickEnabled then click = f:IsMouseClickEnabled()
     else click = f:IsMouseEnabled() end
+    if issecretvalue and issecretvalue(click) then click = false end
     local motion = f.IsMouseMotionEnabled and f:IsMouseMotionEnabled()
+    if issecretvalue and issecretvalue(motion) then motion = false end
     return click and true or false, motion and true or false
 end
 -- Forward declaration: the write helpers below arm it when a lockdown-


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1542262554330407066

Issue: Users in a raid were hitting a repeated Lua error while in combat — attempt to perform boolean test on local 'click' (a secret boolean value...) — thrown from EllesmereUIChat.lua's mouse-passthrough logic (the system that disables chat click-through when the panel fades out).

Root cause: GetMouseChannels read IsMouseClickEnabled()/IsMouseMotionEnabled() on chat frame widgets and immediately did a boolean test (click and true or false) on the raw result. Under WoW 12.1's secret-value system, those getters can return a "secret" boolean once execution is combat-tainted (which happens routinely in a raid), and testing a secret value directly throws — firing on every pass of the passthrough sweep during combat.

Fix: Sanitize each value with issecretvalue() before touching it, defaulting to false when secret — the same pattern already used elsewhere in this file for other secret booleans (focused, over). Confirmed fixed by the reporting user.