### PR TITLE
Fix watchdog error building nameplate pool after reconnecting mid-M+

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
@@ -1739,7 +1739,15 @@ function QueueBundleBuild() -- forward-declared local (pool growth + login build
             NPF_EnsureRecords(nb)
             pool[#pool + 1] = nb
             built = built + 1
-            ServiceWaiting()
+            -- Queued rather than called inline: ServiceWaiting attaches a real plate
+            -- (NPC_AttachPlate populates its aura containers from scratch), and
+            -- bundling that cost into this same non-resumable atom is what blew past
+            -- the client watchdog after reconnecting mid-pull in an M+ (root-caused
+            -- 2026-08-27: every enemy nameplate is waiting simultaneously the instant
+            -- the pool starts producing bundles, none of the normal caches are warm,
+            -- and retrying re-runs the identical combined cost from scratch every
+            -- time). Its own job gets its own watchdog-protected budget/retry slot.
+            AK.QueueBuildJob(ServiceWaiting, "np:service")
             if built == POOL_SIZE then ns.NPC_ReloadAll() end
         end, "np:cc+pool")
     end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1542618416761016351

Issue: After reconnecting from a disconnect mid-Mythic+, users hit a repeated Lua error — script ran too long — from EllesmereUI_AuraKit.lua, tied to a nameplate build job labeled np:cc+pool.

Root cause: Nameplate containers build incrementally through a paced, watchdog-protected job queue specifically to avoid long synchronous bursts. But ServiceWaiting() — which attaches a real waiting nameplate and populates its aura containers from scratch — was called inline inside that same job rather than through the queue. Normally that's cheap (one plate attached per new bundle). Reconnecting mid-pull breaks that assumption: every enemy nameplate is waiting simultaneously the instant the pool starts producing bundles, and none of the normal caches are warm, so the combined build-plus-attach cost blew past the client's script watchdog. The system already retries a watchdogged job up to 3 times, but since each retry re-ran the exact same combined work from scratch, all 3 attempts failed identically and the error surfaced.

Fix: ServiceWaiting() now runs as its own queued job instead of inline, so it gets its own independent watchdog-protected budget rather than compounding with the container build. Note: hard to reproduce on demand (needs a live disconnect mid-pull)