### PR TITLE
Expose a public unit-to-frame accessor for raid frames

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -4775,6 +4775,16 @@ end
 -------------------------------------------------------------------------------
 --  Unit-to-button mapping
 -------------------------------------------------------------------------------
+-- Public accessor: unitToButton/ns._partyUnitToButton stay private otherwise (every
+-- other reader in this file is a raid-frame-internal event handler), but another
+-- addon in the suite (NaowhUI_SmartReminders' raid-frame glow reminder) needs a way
+-- to find the actual button for a unit without reaching into this file's own locals.
+-- Same combined-lookup shape every internal reader already uses.
+function EllesmereUI.RaidFrames_GetFrameForUnit(unit)
+    if not unit then return nil end
+    return unitToButton[unit] or ns._partyUnitToButton[unit]
+end
+
 local function RebuildUnitMap()
     wipe(unitToButton)
     for _, btn in ipairs(allButtons) do


### PR DESCRIPTION
```
Adds `EllesmereUI.RaidFrames_GetFrameForUnit(unit)`, a small public accessor
that returns the actual button for a given unit token on our own raid
frames.

Context: EllesmereUIRaidFrames keeps its unit->button map (`unitToButton`,
`ns._partyUnitToButton`) private -- every existing reader is an internal
event handler in this same file. A companion addon (NaowhUI_SmartReminders,
part of the same suite) wants to highlight a specific raider's raid-frame
button for a new "raid-frame glow" reminder type, and needs a way to find
that button without reaching into this file's own locals.

The new function is a one-line combined lookup, the same shape every
internal reader in this file already uses (`unitToButton[unit] or
ns._partyUnitToButton[unit]`). No existing behavior changes -- purely
additive, zero cost unless called.
```