### PR TITLE
fix(cdm): arm the lust preset again after a death

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -5740,6 +5740,16 @@ function ns.BuildTrackedBuffBars()
             local namePos2 = cfg.namePosition or ((cfg.showName ~= false) and "left" or "none")
             if namePos2 ~= "none" and bar._nameText then
                 local displayName = cfg.name
+                -- Preset bars take the live label the same way the icon does above:
+                -- the copy saved at pick time can name the other faction's lust.
+                if cfg.popularKey then
+                    for _, pe in ipairs(TBB_POPULAR_BUFFS) do
+                        if pe.key == cfg.popularKey then
+                            displayName = pe.name or displayName
+                            break
+                        end
+                    end
+                end
                 if (not displayName or displayName == "") and cfg.spellID and cfg.spellID > 0 then
                     local spInfo = C_Spell and C_Spell.GetSpellInfo and C_Spell.GetSpellInfo(cfg.spellID)
                     displayName = spInfo and spInfo.name

--- a/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBuffBars.lua
@@ -3895,8 +3895,16 @@ local function _ensureLustListener(enable)
                     _lustZoneGuard = GetTime() + 1.5
                     return
                 end
-                -- Sated lasts 10 minutes and nothing lifts it early, so a rise this
-                -- listener armed on pins the debuff for the next 590s: skip the
+                if event == "PLAYER_DEAD" or event == "PLAYER_ALIVE" then
+                    -- Death strips the lockout debuff, so the 590s pin below has to be
+                    -- released here: a wipe followed by a fresh lust would otherwise be
+                    -- swallowed for the rest of the window the pin was stamped for.
+                    _satedPresent = _playerHasSated()
+                    _satedSince = nil
+                    return
+                end
+                -- Nothing but death lifts the lockout early (handled above), so a rise
+                -- this listener armed on pins the debuff for the next 590s: skip the
                 -- (allocating) aura probe until it can possibly have dropped.
                 if _satedPresent and _satedSince and GetTime() < _satedSince + 590 then return end
                 local present = _playerHasSated()
@@ -3931,6 +3939,8 @@ local function _ensureLustListener(enable)
             _satedSince = nil
             _lustListener:RegisterUnitEvent("UNIT_AURA", "player")
             _lustListener:RegisterEvent("PLAYER_ENTERING_WORLD")
+            _lustListener:RegisterEvent("PLAYER_DEAD")
+            _lustListener:RegisterEvent("PLAYER_ALIVE")
             _lustListenerActive = true
         end
     elseif _lustListener and _lustListenerActive then

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -4938,7 +4938,8 @@ local function GetOrCreateCustomBuffFrame(barKey, sid)
             if ns.QueueCustomBuffUpdate then C_Timer.After(0, ns.QueueCustomBuffUpdate) end
             if ns.QueueReanchor then C_Timer.After(0, ns.QueueReanchor) end
         end)
-        local spInfo = C_Spell and C_Spell.GetSpellInfo and C_Spell.GetSpellInfo(sid)
+        local iconSID = ns.LustPresetIconSpellID and ns.LustPresetIconSpellID(sid) or sid
+        local spInfo = C_Spell and C_Spell.GetSpellInfo and C_Spell.GetSpellInfo(iconSID)
         if spInfo and spInfo.iconID and f._tex then f._tex:SetTexture(spInfo.iconID) end
         _presetFrames[fkey] = f
         _injectedCustomBuffFrames[f] = true
@@ -8849,7 +8850,9 @@ local function UpdateCustomBuffBars()
                                     cd:HookScript("OnCooldownDone", function()
                                         C_Timer.After(0, QueueCustomBuffUpdate)
                                     end)
-                                    local spInfo = C_Spell and C_Spell.GetSpellInfo and C_Spell.GetSpellInfo(sid)
+                                    local iconSID = ns.LustPresetIconSpellID
+                                        and ns.LustPresetIconSpellID(sid) or sid
+                                    local spInfo = C_Spell and C_Spell.GetSpellInfo and C_Spell.GetSpellInfo(iconSID)
                                     if spInfo and spInfo.iconID and f._tex then f._tex:SetTexture(spInfo.iconID) end
                                 end
                                 if isActive and timer then

--- a/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmSpellPicker.lua
@@ -1674,6 +1674,22 @@ function ns.AddPresetToBar(barKey, preset)
     return true
 end
 
+--- Is any member of this preset already on the bar? The inverse of the "exists"
+--- guard above, so the picker greys exactly what an add would reject: a preset
+--- with variant ids (the invisibility potions, the two faction lust ids) counts
+--- as present no matter which member is stored.
+function ns.IsPresetOnBar(barKey, preset)
+    local sd = ns.GetBarSpellData(barKey)
+    local spellList = sd and sd.assignedSpells
+    if not spellList or type(preset.spellIDs) ~= "table" then return false end
+    for _, sid in ipairs(preset.spellIDs) do
+        for _, existing in ipairs(spellList) do
+            if existing == sid then return true end
+        end
+    end
+    return false
+end
+
 --- Add a tracked spell (spellID) to a bar. Picker-driven add: always treated
 --- as "claim this spell for the target bar" -- auto-removed from EVERY other
 --- bar in the same family (default + custom + matching ghost) first. One

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -375,11 +375,13 @@ end
 -- (special-case "timespiral"); warlock pets are excluded (no usable detection).
 local BUFF_BAR_PRESETS = {
     {
-        -- Horde form; ns.RefreshLustPresetFaction rewrites it for Alliance below.
+        -- Horde order; ns.RefreshLustPresetFaction flips it for Alliance below.
+        -- BOTH ids are listed so the "already on this bar" tests recognise a lust
+        -- icon added by the other faction on a shared profile.
         key      = "bloodlust",
         name     = "Bloodlust",
         icon     = "Interface\\Icons\\spell_nature_bloodlust",
-        spellIDs = { 2825 },
+        spellIDs = { 2825, 32182 },
         duration = 40,
         tbbOnly  = true,  -- not a cooldown-usable preset (kept out of the CD/utility picker)
         customAuraToo = true,  -- but allowed on Custom Auras (icon) bars; debuff-driven 40s window
@@ -432,7 +434,10 @@ function ns.RefreshLustPresetFaction()
     for _, p in ipairs(BUFF_BAR_PRESETS) do
         if p.key == "bloodlust" then
             p.name, p.icon = name, icon
+            -- This character's id leads: everything that stores a preset takes
+            -- spellIDs[1], while the membership tests read the whole list.
             p.spellIDs[1] = ns._lustPresetSpellID
+            p.spellIDs[2] = alliance and 2825 or 32182
             break
         end
     end
@@ -447,7 +452,9 @@ ns.RefreshLustPresetFaction()
 -- A profile shared between a Horde and an Alliance character keeps whichever lust
 -- id was stored first, so icon art resolves through here instead of off that id.
 function ns.LustPresetIconSpellID(sid)
-    if sid == 2825 or sid == 32182 then return ns._lustPresetSpellID or sid end
+    if ns.IsLustPresetSpell and ns.IsLustPresetSpell(sid) then
+        return ns._lustPresetSpellID or sid
+    end
     return sid
 end
 

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -375,13 +375,11 @@ end
 -- (special-case "timespiral"); warlock pets are excluded (no usable detection).
 local BUFF_BAR_PRESETS = {
     {
-        -- Faction label: Horde = Bloodlust (2825), Alliance = Heroism (32182).
+        -- Horde form; ns.RefreshLustPresetFaction rewrites it for Alliance below.
         key      = "bloodlust",
-        name     = (UnitFactionGroup("player") == "Horde") and "Bloodlust" or "Heroism",
-        icon     = (UnitFactionGroup("player") == "Horde")
-                       and "Interface\\Icons\\spell_nature_bloodlust"
-                       or  "Interface\\Icons\\ability_shaman_heroism",
-        spellIDs = { (UnitFactionGroup("player") == "Horde") and 2825 or 32182 },
+        name     = "Bloodlust",
+        icon     = "Interface\\Icons\\spell_nature_bloodlust",
+        spellIDs = { 2825 },
         duration = 40,
         tbbOnly  = true,  -- not a cooldown-usable preset (kept out of the CD/utility picker)
         customAuraToo = true,  -- but allowed on Custom Auras (icon) bars; debuff-driven 40s window
@@ -420,6 +418,38 @@ local BUFF_BAR_PRESETS = {
     },
 }
 ns.BUFF_BAR_PRESETS = BUFF_BAR_PRESETS
+
+-- Horde casts Bloodlust (2825), Alliance casts Heroism (32182). UnitFactionGroup
+-- can read nil this early in a client session, and a wrong read baked into the
+-- table would stick for the whole session (a Horde player got the Heroism name,
+-- icon and id in the picker), so OnEnable calls this again once the player loads.
+function ns.RefreshLustPresetFaction()
+    local alliance = UnitFactionGroup("player") == "Alliance"
+    local name = alliance and "Heroism" or "Bloodlust"
+    local icon = alliance and "Interface\\Icons\\ability_shaman_heroism"
+                          or  "Interface\\Icons\\spell_nature_bloodlust"
+    ns._lustPresetSpellID = alliance and 32182 or 2825
+    for _, p in ipairs(BUFF_BAR_PRESETS) do
+        if p.key == "bloodlust" then
+            p.name, p.icon = name, icon
+            p.spellIDs[1] = ns._lustPresetSpellID
+            break
+        end
+    end
+    -- The Tracking Bar list copies name/icon by value at load (spellIDs is the
+    -- same table), and is built after this file, so it is absent on the first call.
+    for _, e in ipairs(ns.TBB_POPULAR_BUFFS or {}) do
+        if e.key == "bloodlust" then e.name, e.icon = name, icon; break end
+    end
+end
+ns.RefreshLustPresetFaction()
+
+-- A profile shared between a Horde and an Alliance character keeps whichever lust
+-- id was stored first, so icon art resolves through here instead of off that id.
+function ns.LustPresetIconSpellID(sid)
+    if sid == 2825 or sid == 32182 then return ns._lustPresetSpellID or sid end
+    return sid
+end
 
 -- Item presets for CD/utility bars (potions that track cooldowns). displayOrder is a
 -- dynamic-display priority list, newest tier first: the icon resolves to the FIRST id
@@ -9353,6 +9383,7 @@ function ECME:OnEnable()
     ns._playerRace = _playerRace
     ns._playerClass = _playerClass
     ns._myRacialsSet = _myRacialsSet
+    ns.RefreshLustPresetFaction()
 
     -- Build cached racial spell list for this character (used for render-time substitution)
     table.wipe(_myRacials)

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -7473,17 +7473,11 @@ initFrame:SetScript("OnEvent", function(self)
         -- custom buffs via AddPresetToBar; the buff phase injects an own-frame so
         -- they render alongside Blizzard-tracked buffs.
         do
-            local alreadyTracked = {}
-            local sdPS = ns.GetBarSpellData(targetBarKey)
-            if sdPS and sdPS.assignedSpells then
-                for _, sid in ipairs(sdPS.assignedSpells) do alreadyTracked[sid] = true end
-            end
             local _, _pClass = UnitClass("player")
             for _, preset in ipairs(ns.BUFF_BAR_PRESETS or {}) do
                 if (not preset.class or preset.class == _pClass)
                    and (not preset.tbbOnly or preset.customAuraToo) then
-                    local primaryID = preset.spellIDs and preset.spellIDs[1]
-                    local isAdded = primaryID and alreadyTracked[primaryID]
+                    local isAdded = ns.IsPresetOnBar(targetBarKey, preset)
                     local si = CreateFrame("Button", nil, inner)
                     si:SetHeight(ITEM_H)
                     si:SetPoint("TOPLEFT", inner, "TOPLEFT", 1, -mH)
@@ -13165,12 +13159,6 @@ initFrame:SetScript("OnEvent", function(self)
 
         -- Presets (Heroism, potions, etc.) -- flat list in custom buff bar picker
         if isCustomBuff then
-            local alreadyTracked = {}
-            local sdPS = bd and ns.GetBarSpellData(bd.key)
-            if sdPS and sdPS.assignedSpells then
-                for _, sid in ipairs(sdPS.assignedSpells) do alreadyTracked[sid] = true end
-            end
-
             -- Divider before presets
             local psDiv = inner:CreateTexture(nil, "ARTWORK")
             psDiv:SetHeight(1)
@@ -13186,8 +13174,7 @@ initFrame:SetScript("OnEvent", function(self)
                 -- self-timed icon, armed off the Sated edge instead of a cast).
                 if (not preset.class or preset.class == _pClass)
                     and (not preset.tbbOnly or preset.customAuraToo) then
-                    local primaryID = preset.spellIDs and preset.spellIDs[1]
-                    local isAdded = primaryID and alreadyTracked[primaryID]
+                    local isAdded = ns.IsPresetOnBar(barKey, preset)
 
                     local si = CreateFrame("Button", nil, inner)
                     si:SetHeight(ITEM_H)

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -6410,6 +6410,7 @@ initFrame:SetScript("OnEvent", function(self)
     -- Only the art moves; identity stays untouched.
     local function ResolveIconArt(sid, cdID)
         if not sid or sid <= 0 then return sid end
+        if ns.LustPresetIconSpellID then sid = ns.LustPresetIconSpellID(sid) end
         if ns.ResolvePlaceholderIconSID then
             local live = ns.ResolvePlaceholderIconSID(sid, cdID)
             if type(live) == "number" and live > 0 then return live end


### PR DESCRIPTION
Bug: reported by @Denis in the EllesmereUI-helper Discord (2026-08-26), on v9.0.5.

Issue: the Bloodlust preset on a Cooldown Manager Buffs bar tracks some lusts and not others: the reporter, a mage raiding beside a second mage, saw his own Time Warp track but not the other mage's.

Root cause: not the caster. The Sated listener in EllesmereUICdmBuffBars stamps the lockout on the edge it arms on, then skips the aura probe for 590 seconds because nothing lifts it early. Death does, which is why a wipe frees a raid to lust again: the cached presence flag stays true, so the next lust produces no edge. Two lusters make it systematic, the second landing minutes after the first.

Fix: re-read presence and drop the stamp on PLAYER_DEAD/PLAYER_ALIVE. The preset also read its faction at file load, where UnitFactionGroup can return nil, showing a Horde player the Heroism form; it now re-resolves in OnEnable, both faction ids counting as one preset. Confirmed by the reporter on a test build: lusting, dying, taking a battle rez in place and lusting again inside ten minutes now arms the bar.
