### PR TITLE
Fix Mirror Key Presses not matching current-tier potions

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -10284,6 +10284,26 @@ do
         return false
     end
 
+    -- Reverse lookup: the primary itemID of the item preset that owns a given
+    -- alt/current-tier itemID (e.g. Concentrated Health Potion 271884 ->
+    -- 241304). Bar icons for these presets always key off the fixed primary
+    -- id (see silvermoon_health's itemID/altItemIDs split), but a press can
+    -- report any owned tier's itemID, so OnPress needs to resolve it back.
+    local _presetPrimaryByAltID
+    local function PresetPrimaryItemID(itemID)
+        if not _presetPrimaryByAltID then
+            _presetPrimaryByAltID = {}
+            for _, pr in ipairs(ns.CDM_ITEM_PRESETS or {}) do
+                if pr.altItemIDs then
+                    for _, alt in ipairs(pr.altItemIDs) do
+                        _presetPrimaryByAltID[alt] = pr.itemID
+                    end
+                end
+            end
+        end
+        return _presetPrimaryByAltID[itemID]
+    end
+
     local function IconSpellID(icon)
         local fc = _ecmeFC and _ecmeFC[icon]
         local sid = fc and fc.spellID
@@ -10402,6 +10422,8 @@ do
             -- Match both, plus the item's own on-use spell for the rarer case
             -- of it being tracked as a plain Custom Spell entry instead.
             pressedSet[-itemID] = true
+            local primaryItemID = PresetPrimaryItemID(itemID)
+            if primaryItemID then pressedSet[-primaryItemID] = true end
             for invSlot in pairs(ns.INV_SLOT_NAMES) do
                 if GetInventoryItemID("player", invSlot) == itemID then
                     pressedSet[-invSlot] = true


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541691517218066502

Issue: The "Mirror Key Presses" overlay never lit up when pressing a normal (current-tier) Health Potion, or any other potion in that family.

Root cause: CDM bar icons for pot presets are keyed to a fixed, pinned "primary" item ID (e.g. Health Potion's anchor is item 241304, an old/legacy ID kept only for identity purposes), while the actual potion players carry today is a newer variant listed in that preset's altItemIDs (e.g. 271884). When OnPress built its set of "what was just pressed," it only used the literal item ID from the action bar slot — never resolving it back to the preset's pinned primary ID — so it could never match the bar icon.

Fix: Added a small lookup in EllesmereUICdmHooks.lua that maps any potion variant's item ID back to its preset's primary ID, and used it in OnPress to also mark the primary ID as "pressed." This fixes Health Potion and the other affected pot families (Light's Potential, Potion of Recklessness, Liquid Luster, Lightfused Mana, Invisibility Potion). Healthstone was unaffected — it has no tier variants, so it already worked via the earlier fix.
