### PR TITLE
Fix spec data bar swap confirmation racing unrelated trait updates

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -3968,8 +3968,13 @@ ns.BlockFactories.spec = function(blockCfg, slot, content, barCtx)
         end
     end)
 
-    inst.eventFrame = MakeEventFrame(inst, function(self, event)
-        if pendingSwapConfigID then
+    inst.eventFrame = MakeEventFrame(inst, function(self, event, eventConfigID)
+        -- Both events carry the configID they're actually about; a raid/dungeon's
+        -- background trait churn (other loadouts syncing, hero-talent updates)
+        -- fires TRAIT_CONFIG_UPDATED for configs that are not our pending swap far
+        -- more often than solo open-world play, and an unmatched one was being
+        -- read as "commit landed", writing the pointer to a still-uncommitted swap.
+        if pendingSwapConfigID and eventConfigID == pendingSwapConfigID then
             if event == "TRAIT_CONFIG_UPDATED" then
                 -- Commit landed: write the pointer now (the write hook refreshes).
                 local specId, configID = pendingSwapSpecId, pendingSwapConfigID


### PR DESCRIPTION
Bug: reported by Tephrite in EllesmereUI-helper Discord (2026-08-24); Higans confirmed the dungeon/raid-specific persistence in the same thread (2026-08-27).

Issue: The spec/talent data bar on Data Bars shows the new loadout name after a talent-loadout swap gets interrupted by combat, even though the swap never actually committed server-side. Testing showed the bar reverts correctly in open-world play but keeps sticking to the uncommitted loadout in dungeons and raids.

Root cause: ns.BlockFactories.spec's pending-swap resolver in EllesmereUIDataBars_Blocks.lua treats any TRAIT_CONFIG_UPDATED event as proof the tracked swap landed, without checking which config the event is actually about. Group content generates far more background trait-config churn than solo play (other saved loadouts syncing, hero-talent data), so an unrelated update was routinely mistaken for commit confirmation while the real swap sat stuck behind combat.

Fix: match the event's configID payload against the pending swap before treating TRAIT_CONFIG_UPDATED or CONFIG_COMMIT_FAILED as resolving it. Verified in-game in dungeons and raids.