### PR TITLE
Fix chat disappearing inside the house editor

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -983,6 +983,10 @@ end
 -- with them. Follow the chat frames onto whichever host Blizzard picked, and
 -- back to UIParent when the editor closes. Every frame moved here is ours.
 local _panelHost = UIParent
+local function PanelHost()
+    return FCF_GetCurrentFullScreenFrame and FCF_GetCurrentFullScreenFrame() or UIParent
+end
+
 local function ReseatPanel(f, host)
     if not f then return end
     local p = f:GetParent()
@@ -992,7 +996,7 @@ local function ReseatPanel(f, host)
 end
 
 function ECHAT.ApplyPanelHost()
-    local host = FCF_GetCurrentFullScreenFrame and FCF_GetCurrentFullScreenFrame() or UIParent
+    local host = PanelHost()
     for i = 1, 20 do
         local cf = _G["ChatFrame" .. i]
         if cf then
@@ -1010,6 +1014,16 @@ function ECHAT.ApplyPanelHost()
     ReseatPanel(ns._sidebarSeparateBorder, host)
     ReseatPanel(ns._chatHoverOverlay, host)
     _panelHost = host
+end
+
+-- The on-demand popups are built the first time they are used and can be built
+-- on either side of an editor session, so they seat themselves on show instead
+-- of riding the pass above.
+function ECHAT.HostPopup(f)
+    local host = PanelHost()
+    if f:GetParent() ~= host then
+        FrameUtil.SetParentMaintainRenderLayering(f, host)
+    end
 end
 
 -- The main window ships with clamp-rect insets that extend its clamp box
@@ -2754,6 +2768,7 @@ function ECHAT.TogglePortalFlyout(anchorBtn)
             local bRight = anchorBtn:GetRight() * bs
             flyout:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", (bRight + 4) / fs, (bTop + 4) / fs)
         end
+        ECHAT.HostPopup(flyout)
         flyout:Show()
     end
 end
@@ -3685,6 +3700,7 @@ local function ShowCopyPopup(text)
     local popup = copyDimmer._popup
     popup._textBox:SetText(text)
     popup._editBox._readOnlyText = text
+    ECHAT.HostPopup(copyDimmer)
     copyDimmer:Show()
     C_Timer.After(0.05, function()
         popup._editBox:SetFocus()
@@ -3807,6 +3823,8 @@ local function ShowUrlPopup(url)
     local cx, cy = GetCursorPosition()
     local scale = UIParent:GetEffectiveScale()
     urlPopup:SetPoint("BOTTOM", UIParent, "BOTTOMLEFT", cx / scale, cy / scale + 10)
+    ECHAT.HostPopup(urlBackdrop)
+    ECHAT.HostPopup(urlPopup)
     urlBackdrop:SetAlpha(0); urlBackdrop:Show(); urlBackdrop._fadeIn:Play()
     urlPopup:SetAlpha(0); urlPopup:Show(); urlPopup._fadeIn:Play()
     urlPopup._eb:SetFocus(); urlPopup._eb:HighlightText()
@@ -5617,6 +5635,9 @@ initFrame:SetScript("OnEvent", function(self)
         ECHAT.ApplyBackground()
         ECHAT.ApplyFonts()
         if ECHAT.RefreshVisibility then ECHAT.RefreshVisibility() end
+        -- The passes above can build panel chrome (borders, the tab-band
+        -- extension) that did not exist when the house editor opened.
+        ECHAT.ApplyPanelHost()
     end
 
     ---------------------------------------------------------------------------

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -2751,7 +2751,10 @@ end
 function ECHAT.TogglePortalFlyout(anchorBtn)
     if InCombatLockdown() then return end
     local flyout = CreatePortalFlyout()
-    if flyout:IsShown() then
+    -- Visibility, not the shown flag: leaving the house editor hides our host
+    -- out from under a flyout that is still flagged shown, and a stale flag
+    -- would eat the next click.
+    if flyout:IsVisible() then
         flyout:Hide()
     else
         -- Absolute screen position: a protected frame cannot anchor to a

--- a/EllesmereUIChat/EllesmereUIChat.lua
+++ b/EllesmereUIChat/EllesmereUIChat.lua
@@ -974,6 +974,44 @@ function ECHAT.PositionChatPanelsNow()
     -- The owned tab strip is anchored to the panel and follows for free.
 end
 
+-- Panel hosting. Blizzard's house editor is a full-screen UI panel: it hides
+-- UIParent and FCF_SetFullScreenFrame reparents the chat frames onto itself so
+-- chat stays readable while decorating. That helper only moves widgets whose
+-- parent is still UIParent, and our panel frames are UIParent children by design
+-- (see the bg creation note), so they stay behind on the hidden UIParent and the
+-- entire visible chat -- background, our message frames, tabs, sidebar -- goes
+-- with them. Follow the chat frames onto whichever host Blizzard picked, and
+-- back to UIParent when the editor closes. Every frame moved here is ours.
+local _panelHost = UIParent
+local function ReseatPanel(f, host)
+    if not f then return end
+    local p = f:GetParent()
+    if p ~= host and (p == UIParent or p == _panelHost) then
+        FrameUtil.SetParentMaintainRenderLayering(f, host)
+    end
+end
+
+function ECHAT.ApplyPanelHost()
+    local host = FCF_GetCurrentFullScreenFrame and FCF_GetCurrentFullScreenFrame() or UIParent
+    for i = 1, 20 do
+        local cf = _G["ChatFrame" .. i]
+        if cf then
+            local d = CFD(cf)
+            ReseatPanel(d.bg, host)
+            ReseatPanel(d.sidebar, host)
+            -- Moves only while it is seated on the chat panel; on the sidebar
+            -- seat it is a child of a frame this pass already moved.
+            ReseatPanel(d.scrollBtn, host)
+        end
+    end
+    ReseatPanel(ns._chatTabStrip, host)
+    ReseatPanel(ns._chatBgExt, host)
+    ReseatPanel(ns._chatPanelBorder, host)
+    ReseatPanel(ns._sidebarSeparateBorder, host)
+    ReseatPanel(ns._chatHoverOverlay, host)
+    _panelHost = host
+end
+
 -- The main window ships with clamp-rect insets that extend its clamp box
 -- ~25-60px past every edge (phantom room reserved for the stock tab strip
 -- and edit box). Our panel draws its own tabs and input INSIDE the window,
@@ -5062,6 +5100,9 @@ initFrame:SetScript("OnEvent", function(self)
             -- A frame integrated while the panel is fully hidden must join
             -- the passthrough set.
             RequestPassthroughSweep()
+            -- A window created while the house editor is open is born on the
+            -- hidden UIParent; seat it with the rest of the panel.
+            ECHAT.ApplyPanelHost()
         end)
     end
     ECHAT.QueueFullPass = QueueFullPass
@@ -5107,6 +5148,19 @@ initFrame:SetScript("OnEvent", function(self)
                 C_Timer.After(0, QueueEditModeTabStyle)
             end)
         end
+    end
+
+    -- House editor open/close: reseat the panel onto Blizzard's full-screen host
+    -- (see ApplyPanelHost). Our own event frame, deferred a tick so the reseat
+    -- runs after HouseEditorFrame's show/hide has set the full-screen frame --
+    -- never an EventRegistry callback or a hook, both of which would run our
+    -- body inside Blizzard's own execution.
+    if C_HouseEditor and C_HouseEditor.IsHouseEditorActive then
+        local houseEditorFrame = CreateFrame("Frame")
+        houseEditorFrame:RegisterEvent("HOUSE_EDITOR_MODE_CHANGED")
+        houseEditorFrame:SetScript("OnEvent", function()
+            C_Timer.After(0, ECHAT.ApplyPanelHost)
+        end)
     end
     -- Tab close is covered by the state watcher above. NEVER hook FCF_Close:
     -- "top-level user action" is the wrong test -- it is also reached from


### PR DESCRIPTION
**Bug:** Reported by kellymonster (8.9.8): chat is completely invisible inside the housing house editor. Every chat visibility setting was tried, and only disabling EllesmereUI brought it back.

**Issue:** `HouseEditorFrameMixin:OnShow` is a UI panel with area "full", so opening the editor hides `UIParent` and Blizzard calls `FCF_SetFullScreenFrame` to carry the chat frames onto the editor. Our chat visuals do not come along, so the entire visible chat (background, our message frames, tabs, sidebar) stays behind on the hidden `UIParent`.

**Root cause:** `ReparentFrame` inside `FCF_SetFullScreenFrame` moves a widget only if its current parent is the previous fullscreen frame. EUI's chat panel frames (the background that hosts our ScrollingMessageFrame, the sidebar, the tab strip, the panel border, the sidebar separator and the hover overlay) are `UIParent` children by design, because parenting them to a chat frame taints `ChatFrame.isLocked`, so Blizzard skips them. Blizzard's own reparented ChatFrame1 renders nothing in their place because we hold its FontStringContainer at alpha 0.

**Fix:** `ECHAT.ApplyPanelHost()` reseats our top level panel frames onto `FCF_GetCurrentFullScreenFrame()` through `FrameUtil.SetParentMaintainRenderLayering`, guarded the way Blizzard guards its own pass (move only frames whose parent is `UIParent` or the previous host), and back to `UIParent` when the editor closes. It is driven by our own `HOUSE_EDITOR_MODE_CHANGED` frame deferred one tick, never a hook or an EventRegistry callback, so none of our code runs inside Blizzard's execution. The on demand popups (URL copy, Copy Chat, portal flyout) seat themselves through `ECHAT.HostPopup` on show, since they can be built on either side of an editor session, and the full refresh pass ends with a host pass so chrome built late by a profile or spec swap is covered. The portal flyout toggle now keys off visibility rather than the shown flag, so a host hidden out from under an open flyout cannot eat the next click. With the editor closed the host is `UIParent`, every parent already matches and no `SetParent` calls are made, so the cost is zero.

Nothing here can taint: no hook, no EventRegistry callback, no Blizzard frame reparented or field written. The only Blizzard object touched is the host we parent to, and `HouseEditorFrame` is a plain `TopLevelParentScaleFrameTemplate`, so our frames do not inherit protection.

Known limitation, unchanged by this PR: EUI's own tooltip frame is a `UIParent` child, so no EUI tooltip shows anywhere in the editor. That is module wide rather than a chat issue.

**Testing:** confirmed fixed in game by kellymonster.
