### PR TITLE
fix(raidframes): fix absorb texture tiling

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -1143,6 +1143,19 @@ function ns.ResolveAbsorbStyleTex(style, fallback)
         or fallback
 end
 
+-- SetStatusBarTexture leaves the texture's wrap mode set to CLAMP. SetHorizTile and SetVertTile require the corresponding dimension's wrap mode to be REPEAT for tiling to work.
+-- As a workaround, we reset the texture directly with the appropriate wrap mode.
+function ns.ApplyStatusBarTextureTiling(barTexture, mode)
+    if mode then
+        local wrapModeHorizontal = (mode == "BOTH" or mode == "HORIZ") and "REPEAT" or "CLAMP"
+        local wrapModeVertical = (mode == "BOTH" or mode == "VERT")  and "REPEAT" or "CLAMP"
+
+        barTexture:SetTexture(barTexture:GetTexture(), wrapModeHorizontal, wrapModeVertical)
+    end
+    barTexture:SetHorizTile(mode == "BOTH" or mode == "HORIZ")
+    barTexture:SetVertTile(mode == "BOTH" or mode == "VERT")
+end
+
 -------------------------------------------------------------------------------
 --  Power bar visibility (derived from role flags)
 -------------------------------------------------------------------------------
@@ -1936,8 +1949,7 @@ ns.ApplyModernAbsorbBar = function(bar, mask)
     local fill = bar:GetStatusBarTexture()
     if fill then
         fill:SetDrawLayer("ARTWORK", 1)
-        fill:SetHorizTile(true)
-        fill:SetVertTile(true)
+        ns.ApplyStatusBarTextureTiling(fill, "BOTH")
         if mask then fill:AddMaskTexture(mask) end
         local base = bar._modernBase
         if base then base:SetAllPoints(fill); base:Show() end
@@ -1984,8 +1996,7 @@ local function ApplyAbsorbStyle(absorbBar, style, settings)
     local fill = absorbBar:GetStatusBarTexture()
     if fill then
         fill:SetDrawLayer("ARTWORK", 1)
-        fill:SetHorizTile(tiled)
-        fill:SetVertTile(tiled)
+        ns.ApplyStatusBarTextureTiling(fill, tiled and "BOTH")
         if mask then fill:AddMaskTexture(mask) end
     end
     -- New fill object + new tiling state: re-derive rotation.
@@ -1996,8 +2007,7 @@ local function ApplyAbsorbStyle(absorbBar, style, settings)
         local fwFill = fw:GetStatusBarTexture()
         if fwFill then
             fwFill:SetDrawLayer("ARTWORK", 1)
-            fwFill:SetHorizTile(tiled)
-            fwFill:SetVertTile(tiled)
+            ns.ApplyStatusBarTextureTiling(fwFill, tiled and "BOTH")
             if mask then fwFill:AddMaskTexture(mask) end
         end
         ns.RF_ApplyFillRotation(fw)
@@ -2018,8 +2028,7 @@ ns.ApplyHealAbsorbStyle = function(haBar, style, settings)
     local fill = haBar:GetStatusBarTexture()
     if fill then
         fill:SetDrawLayer("ARTWORK", 2)
-        fill:SetHorizTile(tiled)
-        fill:SetVertTile(tiled)
+        ns.ApplyStatusBarTextureTiling(fill, tiled and "BOTH")
         if mask then fill:AddMaskTexture(mask) end
     end
     ns.RF_ApplyFillRotation(haBar)
@@ -2047,8 +2056,7 @@ ns.ApplyMaxHealthStyle = function(bar, style, settings)
     local fill = bar:GetStatusBarTexture()
     if fill then
         fill:SetDrawLayer("ARTWORK", 3)
-        fill:SetHorizTile(tiled)
-        fill:SetVertTile(tiled)
+        ns.ApplyStatusBarTextureTiling(fill, tiled and "BOTH")
     end
     ns.RF_ApplyFillRotation(bar)
 end
@@ -2474,7 +2482,7 @@ local function CreateAbsorbBar(button, healthBar)
     local rmhFill = reducedBar:GetStatusBarTexture()
     if rmhFill then
         rmhFill:SetDrawLayer("ARTWORK", 3)
-        rmhFill:SetHorizTile(true); rmhFill:SetVertTile(true)
+        ns.ApplyStatusBarTextureTiling(rmhFill, "BOTH")
     end
     reducedBar:SetStatusBarColor(0.7, 0.1, 0.1, 1)
     reducedBar:SetReverseFill(true)
@@ -11508,7 +11516,7 @@ local function CreatePreviewFrame(index)
         local rmhFill = rmh:GetStatusBarTexture()
         if rmhFill then
             rmhFill:SetDrawLayer("ARTWORK", 3)
-            rmhFill:SetHorizTile(true); rmhFill:SetVertTile(true)
+            ns.ApplyStatusBarTextureTiling(rmhFill, "BOTH")
         end
         rmh:SetStatusBarColor(0.7, 0.1, 0.1, 1)
         rmh:SetReverseFill(true)
@@ -12296,8 +12304,7 @@ local function ApplyPreviewData(f, index)
                 local bfFill = f._absorbBar:GetStatusBarTexture()
                 if bfFill then
                     bfFill:SetDrawLayer("ARTWORK", 1)
-                    bfFill:SetHorizTile(tiled)
-                    bfFill:SetVertTile(tiled)
+                    ns.ApplyStatusBarTextureTiling(bfFill, tiled and "BOTH")
                     if mask then bfFill:AddMaskTexture(mask) end
                 end
 
@@ -12308,8 +12315,7 @@ local function ApplyPreviewData(f, index)
                     local fwFill = fw:GetStatusBarTexture()
                     if fwFill then
                         fwFill:SetDrawLayer("ARTWORK", 1)
-                        fwFill:SetHorizTile(tiled)
-                        fwFill:SetVertTile(tiled)
+                        ns.ApplyStatusBarTextureTiling(fwFill, tiled and "BOTH")
                         if mask then fwFill:AddMaskTexture(mask) end
                     end
                 end
@@ -12534,8 +12540,7 @@ local function ApplyPreviewData(f, index)
             local haFillPv = f._healAbsorbBar:GetStatusBarTexture()
             if haFillPv then
                 haFillPv:SetDrawLayer("ARTWORK", 2)
-                haFillPv:SetHorizTile(tiled)
-                haFillPv:SetVertTile(tiled)
+                ns.ApplyStatusBarTextureTiling(haFillPv, tiled and "BOTH")
                 if mask then haFillPv:AddMaskTexture(mask) end
             end
             f._healAbsorbBar:SetMinMaxValues(0, 100)


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where absorb texture tiling does not work as expected. The texture is stretched instead of being repeated.

The easiest way to reproduce this is to replace `striped-thick.png` with a smaller 32×32 version for testing:

<img width="32" height="32" alt="striped-thick" src="https://github.com/user-attachments/assets/4e12751c-ad3c-467c-a3f7-428f21100e1c" />

The result is:

<img width="149" height="71" alt="tiling_not_working" src="https://github.com/user-attachments/assets/30515826-9c21-4d9c-9ff0-37c24eac54a0" />

This apparently happens because `StatusBar:SetStatusBarTexture` does not set the texture's wrap mode to `CLAMP`. However, `TextureBase:SetHorizTile` and `TextureBase:SetVertTile` require the corresponding dimension's wrap mode to be `REPEAT` for tiling to work.

This PR introduces a helper function to work around this limitation. The function calls `TextureBase:SetTexture` with the appropriate wrap mode on the status bar's texture before calling `TextureBase:SetHorizTile` and `TextureBase:SetVertTile`.

Interestingly, this issue does **not** occur on unit frames, and I don't know why. No corresponding fix is required there.

## How was it tested?

Tested on the live 12.1 client, build 9.0.7.

* Checked that tiling works with the replaced `striped-thick.png` texture.
* Checked that non-tiling textures continue to work as expected.

## Checklist

- [n/a] New settings default **OFF** (no behavior change without opt-in)
- [n/a] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [n/a] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [n/a] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
