### PR TITLE
fix(raidframes): respect status text setting in preview mode

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -13587,7 +13587,10 @@ local function ApplyPreviewData(f, index)
         else
             f._statusText:SetPoint("CENTER", stHost, "CENTER", stOX, stOY)
         end
-        if isRezCorpse then
+        if stPos == "none" then
+            -- Status text display is turned off
+            f._statusText:Hide()
+        elseif isRezCorpse then
             -- Being resurrected: the rez icon takes this spot, so no DEAD text.
             f._statusText:Hide()
         elseif isDead then
@@ -13600,6 +13603,7 @@ local function ApplyPreviewData(f, index)
             f._statusText:SetText(EllesmereUI.L("AFK"))
             f._statusText:Show()
         else
+            -- No status to show
             f._statusText:Hide()
         end
     end


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where the **Status Text** setting was not respected in preview mode. Status text was still displayed even when the setting was disabled.

## How was it tested?

Tested on the live 12.1 client, build 9.0.7.

* Checked that disabling **Status Text** also hides the status text in preview mode.

## Checklist

- [n/a] New settings default **OFF** (no behavior change without opt-in)
- [n/a] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [n/a] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [n/a] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added

