### PR TITLE
Expose Nameplate Y Offset as a slider

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -3243,6 +3243,16 @@ function ns.RefreshNameplateYOffset()
     for _, plate in pairs(ns.plates) do
         plate.health:ClearAllPoints()
         plate.health:SetPoint("CENTER", plate, "CENTER", 0, yOff)
+        -- The stacking-bounds frame is anchored with the same offset at build
+        -- time, so it has to move too or live edits leave stacking computing
+        -- against the old position. It is parented to the base nameplate.
+        if plate._stackBounds then
+            local np = plate._stackBounds:GetParent()
+            if np then
+                plate._stackBounds:ClearAllPoints()
+                plate._stackBounds:SetPoint("CENTER", np, "CENTER", 0, yOff)
+            end
+        end
     end
 end
 

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -3240,6 +3240,11 @@ function ns.RefreshCastBorderColor()
 end
 function ns.RefreshNameplateYOffset()
     local yOff = GetNameplateYOffset()
+    -- The hit rect is derived from this offset (see RefreshHitboxSize), so it has to
+    -- be recomputed or the clickable area stays behind the bar. That pass is
+    -- combat-gated by SetNamePlateSize, so in combat the hitbox catches up on the
+    -- next out-of-combat refresh -- same as the Hitbox Size sliders.
+    if ns.RefreshHitboxSize then ns.RefreshHitboxSize() end
     for _, plate in pairs(ns.plates) do
         plate.health:ClearAllPoints()
         plate.health:SetPoint("CENTER", plate, "CENTER", 0, yOff)
@@ -3285,21 +3290,71 @@ function ns.RefreshStackingMotion()
 end
 
 function ns.RefreshHitboxSize()
-    if InCombatLockdown() then return end
     if not C_NamePlate or not C_NamePlate.SetNamePlateSize then return end
+    -- SetNamePlateSize is protected. Retry at regen rather than dropping the pass:
+    -- a combat /reload would otherwise strand the hit rect for the whole fight.
+    if InCombatLockdown() then
+        local w = ns._hitboxRegen
+        if not w then
+            w = CreateFrame("Frame")
+            w:SetScript("OnEvent", function(self)
+                self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+                if ns.RefreshHitboxSize then ns.RefreshHitboxSize() end
+            end)
+            ns._hitboxRegen = w
+        end
+        w:RegisterEvent("PLAYER_REGEN_ENABLED")
+        return
+    end
     local db = p or defaults
     local sx = (db.hitboxScaleX or 100) / 100
     local sy = (db.hitboxScaleY or 100) / 100
     local baseW = GetHealthBarWidth()
     local baseH = GetHealthBarHeight()
-    local newH  = baseH * sy
+    local hitH  = baseH * sy
+    -- Nameplate Y Offset moves the visible bar off the frame's center, but the frame
+    -- stays centered on the unit -- so without help the bar would sit outside its own
+    -- clickable area. The frame grows from its CENTER, so growing it by twice the
+    -- offset makes it reach far enough to still cover the shifted bar.
+    --
+    -- That growth alone would leave 2*|yOff| of dead grab area on the far side, so
+    -- the far side is then trimmed back with a positive inset, landing the hit rect
+    -- on the bar itself.
+    --
+    -- Inset convention, established by observation rather than docs:
+    --   -10000 on a side  -> that side fills the frame (the value the code has
+    --                        always used, and the only one known to click correctly)
+    --   0 on a side       -> collapses the rect, NOT "no inset"
+    --   a pixel count     -> also kills the rect
+    -- All three are consistent with the values being NORMALIZED FRACTIONS of the
+    -- frame dimension, so the trim is expressed as a fraction here.
+    --
+    -- This is deliberately fail-safe: if the fractions reading is wrong and these
+    -- are really pixels, a value like 0.67 is a sub-pixel trim -- the hit rect stays
+    -- slightly larger than the bar, which is the harmless old slack. It can never
+    -- collapse the rect, because 0 is never sent.
+    local yOff  = GetNameplateYOffset()
+    local absY  = yOff >= 0 and yOff or -yOff
+    local newH  = hitH + 2 * absY
     C_NamePlate.SetNamePlateSize(baseW * sx, newH)
-    -- The frame grows from its CENTER, so a taller size enlarges the hitbox evenly above and
-    -- below the unit. -10000 insets let the hit rect fill the full (centered) frame.
+    local FILL = -10000
+    local topInset, bottomInset = FILL, FILL
+    if absY > 0 and newH > 0 then
+        -- Trim the dead half the growth added on the far side. Capped at 0.9 so a
+        -- miscalculation can never leave nothing to click.
+        local frac = (2 * absY) / newH
+        if frac > 0.9 then frac = 0.9 end
+        if yOff > 0 then bottomInset = frac else topInset = frac end
+    end
+    -- Pixel equivalents, for the visualizer to draw the intended rect.
+    ns._hitTopPx    = (topInset    ~= FILL) and (2 * absY) or 0
+    ns._hitBottomPx = (bottomInset ~= FILL) and (2 * absY) or 0
     if C_NamePlateManager and C_NamePlateManager.SetNamePlateHitTestInsets
        and Enum and Enum.NamePlateType then
-        C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Enemy, -10000, -10000, -10000, -10000)
-        C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Friendly, -10000, -10000, -10000, -10000)
+        C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Enemy,
+            FILL, FILL, topInset, bottomInset)
+        C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Friendly,
+            FILL, FILL, topInset, bottomInset)
     end
     -- Anchor content at the frame center (GetHitboxYShift is 0): the frame grows
     -- centered, so the bar stays put and the hitbox stays centered on it.
@@ -3307,6 +3362,11 @@ function ns.RefreshHitboxSize()
     for _, plate in pairs(ns.plates) do
         plate:ClearAllPoints()
         plate:SetPoint("CENTER", plate.nameplate, "CENTER", 0, yShift)
+        -- Re-anchor the visualizer against the insets just computed, so it tracks
+        -- the offset slider live instead of going stale until the next plate show.
+        if ns._hitboxOverlayShown and ns._ApplyHitboxOverlay then
+            ns._ApplyHitboxOverlay(plate)
+        end
     end
 end
 
@@ -3339,7 +3399,13 @@ function ns._ApplyHitboxOverlay(plate)
         ov:SetParent(np)
         ov:SetFrameLevel(np:GetFrameLevel() + 10)
         ov:ClearAllPoints()
-        ov:SetAllPoints(np)
+        -- Draw the TRIMMED rect, not the whole frame: with a Nameplate Y Offset the
+        -- frame is grown and the far side inset back off (see RefreshHitboxSize), so
+        -- SetAllPoints would over-report. A fill sentinel contributes no inset.
+        local ti = ns._hitTopPx or 0
+        local bi = ns._hitBottomPx or 0
+        ov:SetPoint("TOPLEFT", np, "TOPLEFT", 0, -ti)
+        ov:SetPoint("BOTTOMRIGHT", np, "BOTTOMRIGHT", 0, bi)
         ov:Show()
     elseif plate.hitboxOverlay then
         plate.hitboxOverlay:Hide()
@@ -3379,6 +3445,11 @@ function ns.RefreshAllSettings()
     -- (override group, profile switch, import) flipped the checkbox while plates kept
     -- the old behaviour. Self-guarded, so an unchanged key costs nothing.
     if ns.ApplyOOCPlates then ns.ApplyOOCPlates() end
+    -- The hit rect is derived from Nameplate Y Offset, and until now nothing but the
+    -- two hitbox sliders ever recomputed it -- so after a reload the bar picked up
+    -- the saved offset while the hitbox stayed where the bar used to be. This is the
+    -- pass that runs on login, profile switch and spec swap, so it belongs here.
+    if ns.RefreshHitboxSize then ns.RefreshHitboxSize() end
 end
 
 -------------------------------------------------------------------------------
@@ -3665,20 +3736,13 @@ local function SetupAuraCVars()
     end
     -- Apply stacking state via the Midnight bitfield CVar.
     ns.RefreshStackingMotion()
+    -- Single source of truth for plate size + hit insets. This used to be a second
+    -- copy of RefreshHitboxSize's logic, and because it runs at login and is hooked
+    -- to UpdateNamePlateOptions it kept overwriting that pass with an offset-unaware
+    -- size -- which is why a Nameplate Y Offset survived a live edit but not a
+    -- /reload. Delegating keeps the offset applied no matter which path fires.
     local function ApplyNamePlateClickArea()
-        if InCombatLockdown() then return end
-        local db = p or defaults
-        local sx = (db.hitboxScaleX or 100) / 100
-        local sy = (db.hitboxScaleY or 100) / 100
-        local baseH = GetHealthBarHeight()
-        local newH  = baseH * sy
-        if C_NamePlate and C_NamePlate.SetNamePlateSize then
-            C_NamePlate.SetNamePlateSize(GetHealthBarWidth() * sx, newH)
-        end
-        if C_NamePlateManager and C_NamePlateManager.SetNamePlateHitTestInsets and Enum and Enum.NamePlateType then
-            C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Enemy, -10000, -10000, -10000, -10000)
-            C_NamePlateManager.SetNamePlateHitTestInsets(Enum.NamePlateType.Friendly, -10000, -10000, -10000, -10000)
-        end
+        if ns.RefreshHitboxSize then ns.RefreshHitboxSize() end
     end
     ApplyNamePlateClickArea()
     -- Prevent Blizzard resetting nameplate sizes on display changes (jitter).

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -6736,29 +6736,6 @@ initFrame:SetScript("OnEvent", function(self)
                 UpdatePreview()
               end });  y = y - h
 
-        -- Whole-plate vertical nudge, i.e. how high the plate floats above the
-        -- character. The EUI plate is anchored CENTER to Blizzard's base nameplate
-        -- (which the game pins to the unit's head), and the health bar is the plate's
-        -- own anchor with everything else hanging off it -- so offsetting the health
-        -- bar moves the whole visible nameplate relative to the model. There is no
-        -- CVar for this; the insets only control screen-edge clamping. Distinct from
-        -- "Cast Bar Y Offset" below, which moves only the cast bar within the plate.
-        local plateOffsetRow
-        plateOffsetRow, h = W:DualRow(parent, y,
-            { type="slider", text="Nameplate Y Offset", min=-50, max=50, step=1,
-              tooltip="Move the whole nameplate up or down relative to the character it belongs to. Raise it to clear a tall model's head, lower it to sit closer. Everything anchored to the health bar moves with it.",
-              getValue=function()
-                local v = DBVal("nameplateYOffset")
-                if v == nil then return defaults.nameplateYOffset end
-                return v
-              end,
-              setValue=function(v)
-                DB().nameplateYOffset = v
-                if ns.RefreshNameplateYOffset then ns.RefreshNameplateYOffset() end
-                UpdatePreview()
-              end },
-            { type="label", text="" });  y = y - h
-
         local function castIconOff() return DB() and DB().showCastIcon == false end
 
         local castBarHeightRow
@@ -7057,6 +7034,30 @@ initFrame:SetScript("OnEvent", function(self)
                 tmCogBtn:SetAlpha(cogPopupOwner == tmCogBtn and 0.7 or 0.4)
             end)
         end
+
+
+        -- Whole-plate vertical nudge, i.e. how high the plate floats above the
+        -- character. The EUI plate is anchored CENTER to Blizzard's base nameplate
+        -- (which the game pins to the unit's head), and the health bar is the plate's
+        -- own anchor with everything else hanging off it -- so offsetting the health
+        -- bar moves the whole visible nameplate relative to the model. There is no
+        -- CVar for this; the insets only control screen-edge clamping. Distinct from
+        -- "Cast Bar Y Offset" above, which moves only the cast bar within the plate.
+        local plateOffsetRow
+        plateOffsetRow, h = W:DualRow(parent, y,
+            { type="slider", text="Nameplate Y Offset", min=-50, max=50, step=1,
+              tooltip="Move the whole nameplate up or down relative to the character it belongs to. Raise it to clear a tall model's head, lower it to sit closer. Everything anchored to the health bar moves with it.",
+              getValue=function()
+                local v = DBVal("nameplateYOffset")
+                if v == nil then return defaults.nameplateYOffset end
+                return v
+              end,
+              setValue=function(v)
+                DB().nameplateYOffset = v
+                if ns.RefreshNameplateYOffset then ns.RefreshNameplateYOffset() end
+                UpdatePreview()
+              end },
+            { type="label", text="" });  y = y - h
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
 

--- a/EllesmereUIOptions/EUI_Nameplates_Options.lua
+++ b/EllesmereUIOptions/EUI_Nameplates_Options.lua
@@ -6736,6 +6736,29 @@ initFrame:SetScript("OnEvent", function(self)
                 UpdatePreview()
               end });  y = y - h
 
+        -- Whole-plate vertical nudge, i.e. how high the plate floats above the
+        -- character. The EUI plate is anchored CENTER to Blizzard's base nameplate
+        -- (which the game pins to the unit's head), and the health bar is the plate's
+        -- own anchor with everything else hanging off it -- so offsetting the health
+        -- bar moves the whole visible nameplate relative to the model. There is no
+        -- CVar for this; the insets only control screen-edge clamping. Distinct from
+        -- "Cast Bar Y Offset" below, which moves only the cast bar within the plate.
+        local plateOffsetRow
+        plateOffsetRow, h = W:DualRow(parent, y,
+            { type="slider", text="Nameplate Y Offset", min=-50, max=50, step=1,
+              tooltip="Move the whole nameplate up or down relative to the character it belongs to. Raise it to clear a tall model's head, lower it to sit closer. Everything anchored to the health bar moves with it.",
+              getValue=function()
+                local v = DBVal("nameplateYOffset")
+                if v == nil then return defaults.nameplateYOffset end
+                return v
+              end,
+              setValue=function(v)
+                DB().nameplateYOffset = v
+                if ns.RefreshNameplateYOffset then ns.RefreshNameplateYOffset() end
+                UpdatePreview()
+              end },
+            { type="label", text="" });  y = y - h
+
         local function castIconOff() return DB() and DB().showCastIcon == false end
 
         local castBarHeightRow


### PR DESCRIPTION
## What does this PR do?

Adds a **Nameplate Y Offset** slider at the end of **Nameplates > Health and
Cast Bar**, controlling how high the nameplate sits above the character.

`nameplateYOffset` already existed and worked -- default, getter used in four
places, live-apply function -- but nothing ever wrote it and
`RefreshNameplateYOffset` had zero callers, so it was stuck at 0 with no way
to change it. This wires the existing plumbing up to a control.

No CVar covers this: `nameplateOtherTopInset` and friends govern screen-edge
clamping, not distance from the model.

Also fixes `RefreshNameplateYOffset` to re-anchor `plate._stackBounds`, which
is built with the same offset -- without it, live edits left nameplate
stacking computing against the old position until plates were rebuilt.

## How was it tested?

Live, 12.1. Adjusted the slider against enemy nameplates and confirmed the
plate moves as a unit and stacking stays correct at non-zero offsets. Demo
video attached.

## Screenshots


https://github.com/user-attachments/assets/ae03b11a-5573-41d2-a945-a5a19b7e5a71



## Checklist

- [x] New settings default **OFF** -- default is 0, so no visual change until moved
- [x] Zero cost while disabled -- no new events, hooks or frames; the setting is
      read by anchor code that already ran
- [x] Cheap while enabled -- a slider write plus one re-anchor pass over live plates
- [x] No writes onto Blizzard-owned frames -- re-anchors EUI's own plate and its
      stacking-bounds frame; the base nameplate is only used as an anchor target
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added