### PR TITLE
feat(resource bars): opt-in extended Brewmaster stagger bar

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -4653,6 +4653,10 @@ initFrame:SetScript("OnEvent", function(self)
                       setValue = function(v)
                           local p = DB(); if not p then return end
                           p.secondary.brewExtendedStaggerBar = v; RebuildClass()
+                          local tc = ns._thrCtx
+                          if tc and tc.page and tc.page:IsShown() and tc.refreshDetail then
+                              tc.refreshDetail()
+                          end
                           EllesmereUI:RefreshPage()
                       end },
                     { type = "slider", text = "Scale", min = ES_MIN, max = ES_MAX, step = 1,
@@ -4733,9 +4737,12 @@ initFrame:SetScript("OnEvent", function(self)
                 }
                 local esSwatches = {}
                 for i = 1, ES_MAX do
-                    esSwatches[i] = {
-                        tooltip = esStepTips[i], hasAlpha = false,
-                        disabled = function() return i > esScale() end,
+                    -- Lua 5.1 reuses the numeric-for control variable. Capture a
+                    -- per-iteration copy so every swatch keeps its own step index.
+                    local step = i
+                    esSwatches[step] = {
+                        tooltip = esStepTips[step], hasAlpha = false,
+                        disabled = function() return step > esScale() end,
                         -- Two reasons a swatch locks: the feature is off (standard
                         -- requirement wrapper) or the step is past the current Scale.
                         disabledTooltip = function()
@@ -4746,9 +4753,9 @@ initFrame:SetScript("OnEvent", function(self)
                         getValue = function()
                             local p = DB()
                             local t = p and p.secondary.brewExtendedStaggerColors
-                            local c = t and t[i]
+                            local c = t and t[step]
                             if c then return c.r or 1, c.g or 1, c.b or 1 end
-                            local d = _G._ERB_EXT_STAGGER_COLORS and _G._ERB_EXT_STAGGER_COLORS[i]
+                            local d = _G._ERB_EXT_STAGGER_COLORS and _G._ERB_EXT_STAGGER_COLORS[step]
                             if d then return d[1], d[2], d[3] end
                             return 1, 1, 1
                         end,
@@ -4756,7 +4763,7 @@ initFrame:SetScript("OnEvent", function(self)
                             local p = DB(); if not p then return end
                             local t = p.secondary.brewExtendedStaggerColors
                             if not t then t = {}; p.secondary.brewExtendedStaggerColors = t end
-                            t[i] = { r = r, g = g, b = b }
+                            t[step] = { r = r, g = g, b = b }
                             RefreshClass()
                         end,
                     }

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -4623,6 +4623,153 @@ initFrame:SetScript("OnEvent", function(self)
                     { type = "label", text = "" }
                 );  y = y - h
             end
+            local function _IsBrewmasterMonk()
+                if ctx.advanced then return ctx.specID == 268 end
+                local _, cf = UnitClass("player")
+                if cf ~= "MONK" then return false end
+                local s = GetSpecialization()
+                local sid = s and GetSpecializationInfo(s)
+                return sid == 268
+            end
+            if _IsBrewmasterMonk() then
+                local ES_LABEL = "Brewmaster Monk Extended Stagger Bar"
+                local ES_MIN = _G._ERB_EXT_STAGGER_MIN_SCALE or 2
+                local ES_MAX = _G._ERB_EXT_STAGGER_MAX_SCALE or 6
+                local esBarTip = "Lets the stagger bar run past 100% of your max health. The bar spans Scale steps of 100%, each step has its own fill color, and divider lines can mark the step boundaries. While this is on the step colors replace threshold and multi-band coloring, and Scale replaces \"Stagger Full %\" in Threshold Settings."
+                local esScaleTip = "How many 100% stagger steps the bar spans. Scale 4 fills the bar at 400% and puts divider lines at 100%, 200% and 300%."
+                local esColorsTip = "Fill color per 100% stagger step, from the lowest step to the highest. Steps above the current Scale are unused."
+                local function esOff() local p = DB(); return not (p and p.secondary.brewExtendedStaggerBar) end
+                local function esScale()
+                    local p = DB(); if not p then return 4 end
+                    local f = _G._ERB_ExtStaggerScale
+                    if f then return f(p.secondary) end
+                    return p.secondary.brewExtendedStaggerScale or 4
+                end
+                local esRow
+                esRow, h = W:DualRow(parent, y,
+                    { type = "toggle", text = ES_LABEL,
+                      tooltip = esBarTip,
+                      getValue = function() local p = DB(); return p and p.secondary.brewExtendedStaggerBar end,
+                      setValue = function(v)
+                          local p = DB(); if not p then return end
+                          p.secondary.brewExtendedStaggerBar = v; RebuildClass()
+                          EllesmereUI:RefreshPage()
+                      end },
+                    { type = "slider", text = "Scale", min = ES_MIN, max = ES_MAX, step = 1,
+                      tooltip = esScaleTip,
+                      disabled = esOff,
+                      disabledTooltip = ES_LABEL,
+                      getValue = esScale,
+                      setValue = function(v)
+                          local p = DB(); if not p then return end
+                          p.secondary.brewExtendedStaggerScale = v; RefreshClass()
+                          EllesmereUI:RefreshPage()
+                      end }
+                );  y = y - h
+                -- Divider lines sit in a cog on the Scale slider: they are positioned by
+                -- Scale, so they belong to the same slot.
+                if not EllesmereUI._prebuilding then
+                    local rgn = esRow._rightRegion
+                    local function divOff()
+                        local p = DB()
+                        return esOff() or not (p and p.secondary.brewExtendedStaggerDividers ~= false)
+                    end
+                    local _, cogShow = EllesmereUI.BuildCogPopup({
+                        title = "Scale Dividers",
+                        rows = {
+                            { type = "toggle", label = "Show Divider Lines",
+                              get = function() local p = DB(); return p and p.secondary.brewExtendedStaggerDividers ~= false end,
+                              set = function(v)
+                                  local p = DB(); if not p then return end
+                                  p.secondary.brewExtendedStaggerDividers = v; RefreshClass()
+                              end },
+                            { type = "slider", label = "Line Thickness", min = 1, max = 4, step = 1,
+                              disabled = divOff,
+                              disabledTooltip = "Show Divider Lines",
+                              get = function() local p = DB(); return p and p.secondary.brewExtendedStaggerDividerWidth or 1 end,
+                              set = function(v)
+                                  local p = DB(); if not p then return end
+                                  p.secondary.brewExtendedStaggerDividerWidth = v; RefreshClass()
+                              end },
+                            { type = "colorpicker", label = "Line Color", hasAlpha = true,
+                              disabled = divOff,
+                              disabledTooltip = "Show Divider Lines",
+                              get = function()
+                                  local p = DB(); if not p then return 0, 0, 0, 1 end
+                                  local c = p.secondary
+                                  return c.brewExtendedStaggerDividerR or 0, c.brewExtendedStaggerDividerG or 0,
+                                         c.brewExtendedStaggerDividerB or 0, c.brewExtendedStaggerDividerA or 1
+                              end,
+                              set = function(r, g, b, a)
+                                  local p = DB(); if not p then return end
+                                  local c = p.secondary
+                                  c.brewExtendedStaggerDividerR, c.brewExtendedStaggerDividerG = r, g
+                                  c.brewExtendedStaggerDividerB, c.brewExtendedStaggerDividerA = b, a
+                                  RefreshClass()
+                              end },
+                        },
+                    })
+                    local cogBtn = MakeCogBtn(rgn, cogShow)
+                    local cogDis = CreateFrame("Frame", nil, rgn)
+                    cogDis:SetAllPoints(cogBtn)
+                    cogDis:SetFrameLevel(cogBtn:GetFrameLevel() + 5)
+                    cogDis:EnableMouse(true)
+                    cogDis:SetScript("OnEnter", function()
+                        EllesmereUI.ShowWidgetTooltip(cogBtn, EllesmereUI.DisabledTooltip(ES_LABEL))
+                    end)
+                    cogDis:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                    local function UpdateEsCogDis()
+                        if esOff() then cogDis:Show() else cogDis:Hide() end
+                    end
+                    cogBtn:HookScript("OnShow", UpdateEsCogDis)
+                    EllesmereUI.RegisterWidgetRefresh(UpdateEsCogDis)
+                    UpdateEsCogDis()
+                end
+                -- One swatch per step; the ranges are fixed 100% bands, so the labels are
+                -- static and steps beyond the current Scale simply lock.
+                local esStepTips = {
+                    "Step 1: 0% - 100%", "Step 2: 100% - 200%", "Step 3: 200% - 300%",
+                    "Step 4: 300% - 400%", "Step 5: 400% - 500%", "Step 6: 500%+",
+                }
+                local esSwatches = {}
+                for i = 1, ES_MAX do
+                    esSwatches[i] = {
+                        tooltip = esStepTips[i], hasAlpha = false,
+                        disabled = function() return i > esScale() end,
+                        -- Two reasons a swatch locks: the feature is off (standard
+                        -- requirement wrapper) or the step is past the current Scale.
+                        disabledTooltip = function()
+                            if esOff() then return ES_LABEL end
+                            return "This step is above the current Scale."
+                        end,
+                        rawTooltip = function() return not esOff() end,
+                        getValue = function()
+                            local p = DB()
+                            local t = p and p.secondary.brewExtendedStaggerColors
+                            local c = t and t[i]
+                            if c then return c.r or 1, c.g or 1, c.b or 1 end
+                            local d = _G._ERB_EXT_STAGGER_COLORS and _G._ERB_EXT_STAGGER_COLORS[i]
+                            if d then return d[1], d[2], d[3] end
+                            return 1, 1, 1
+                        end,
+                        setValue = function(r, g, b)
+                            local p = DB(); if not p then return end
+                            local t = p.secondary.brewExtendedStaggerColors
+                            if not t then t = {}; p.secondary.brewExtendedStaggerColors = t end
+                            t[i] = { r = r, g = g, b = b }
+                            RefreshClass()
+                        end,
+                    }
+                end
+                _, h = W:DualRow(parent, y,
+                    { type = "multiSwatch", text = "Scale Colors",
+                      tooltip = esColorsTip,
+                      disabled = esOff,
+                      disabledTooltip = ES_LABEL,
+                      swatches = esSwatches },
+                    { type = "label", text = "" }
+                );  y = y - h
+            end
         end
 
         -- Row 1: Show Class Resource | Orientation
@@ -6519,6 +6666,20 @@ initFrame:SetScript("OnEvent", function(self)
 				ceilingInput:SetScript("OnEditFocusLost", CeilingCommit)
 				ceilingInput:SetScript("OnEnterPressed", function(self) self:ClearFocus() end)
 				ceilingInput:SetScript("OnEscapePressed", function(self) self._cancelCommit = true; self:ClearFocus(); ceilingSnap() end)
+				-- Extended Stagger derives the ceiling from its own Scale, so lock this input while it is on. The stored value is never overwritten and applies again once Extended Stagger goes off.
+				local ES_CEILING_TIP = "Extended Stagger is on; its Scale decides how far the bar fills. Turn Extended Stagger off in the Class Resource section to use Stagger Full % again."
+				local ceilingDis = CreateFrame("Frame", nil, ceilingRow)
+				ceilingDis:SetPoint("TOPLEFT", ceilingRow, "TOPLEFT", -2, 3)
+				ceilingDis:SetPoint("BOTTOMRIGHT", ceilingInput, "BOTTOMRIGHT", 3, -3)
+				ceilingDis:SetFrameLevel(ceilingRow:GetFrameLevel() + 6)
+				ceilingDis:EnableMouse(true)
+				local ceilingDisTex = ceilingDis:CreateTexture(nil, "OVERLAY")
+				ceilingDisTex:SetAllPoints()
+				ceilingDisTex:SetColorTexture(0.06, 0.08, 0.10, 0.7)
+				ceilingDis:SetScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(ceilingDis, EllesmereUI.L(ES_CEILING_TIP)) end)
+				ceilingDis:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+				ceilingDis:Hide()
+				ceilingRow._dis = ceilingDis
 
 				-- RefreshDetail: repaint the pane for the selected entry
 				RefreshDetail = function()
@@ -6686,7 +6847,13 @@ initFrame:SetScript("OnEvent", function(self)
 					place(buffRow)
 					-- Bar-wide text-instead toggle always gets a row (no visible effect for pip resources / Ignore Pain, whose render path keeps its own coloring)
 					place(textInsteadRow)
-					if isStagger then place(ceilingRow) end
+					if isStagger then
+						local _esPP = DB()
+						local _esOn = (_esPP and _esPP.secondary.brewExtendedStaggerBar) and true or false
+						ceilingRow._dis:SetShown(_esOn)
+						if ceilingRow._lbl then ceilingRow._lbl:SetAlpha(_esOn and 0.3 or 0.6) end
+						place(ceilingRow)
+					end
 				end
 				thrPage:Hide();
             end -- BuildFrame

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -7155,7 +7155,16 @@ initFrame:SetScript("OnEvent", function(self)
             local function ToggleFrame(anchor)
                 -- Nothing to configure with no config (Advanced, no spec selected/customised). The disabled overlay already blocks this, but the open path is guarded too.
                 if not DB() then return end
-                if not thrPage then BuildFrame({topY = _advTop, botY = y}) end
+                if not thrPage then
+                    BuildFrame({topY = _advTop, botY = y})
+                    -- BuildFrame lazily assigns the popup and detail refresher after
+                    -- _thrCtx was initially stamped below. Refresh the singleton so
+                    -- option toggles and spec events can update an already-open popup.
+                    if ns._thrCtx then
+                        ns._thrCtx.page = thrPage
+                        ns._thrCtx.refreshDetail = RefreshDetail
+                    end
+                end
 				if thrPage:IsShown() then
 					-- Unlock cycle: forces a correct redraw
 					if thrPage:GetLeft() ~= nil then

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -3049,15 +3049,24 @@ do
         local dg = sp.brewExtendedStaggerDividerG or 0
         local db = sp.brewExtendedStaggerDividerB or 0
         local da = sp.brewExtendedStaggerDividerA or 1
+        local oriSb = sb._sb or (sb.GetOrientation and sb)
+        local vert = (oriSb and oriSb.GetOrientation
+            and oriSb:GetOrientation() == "VERTICAL") or false
+        local revFill = (vert and oriSb.GetReverseFill
+            and oriSb:GetReverseFill()) or false
+        local pp = EllesmereUI and EllesmereUI.PP
+        local mult = (pp and pp.mult) or 1
         local st = sb._extStagDivState
         if st and st.scale == scale and st.dw == dw and st.r == dr and st.g == dg
-           and st.b == db and st.a == da and st.barW == barW and st.barH == barH then
+           and st.b == db and st.a == da and st.barW == barW and st.barH == barH
+           and st.vert == vert and st.rev == revFill and st.mult == mult then
             return
         end
         if not st then st = {}; sb._extStagDivState = st end
         st.scale, st.dw = scale, dw
         st.r, st.g, st.b, st.a = dr, dg, db, da
         st.barW, st.barH = barW, barH
+        st.vert, st.rev, st.mult = vert, revFill, mult
         ApplyResourceBarTicks(sb, 100, DividerPositions(scale), dividerTicks,
             dw, dr, dg, db, da, true)
     end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -1250,6 +1250,16 @@ local DEFAULTS = {
             bandReverse = false,
             bands = {},
             staggerCeilingPercent = 100,   -- % required for bar to fill up
+            -- Brewmaster Extended Stagger (opt-in, default off): the stagger bar spans
+            -- brewExtendedStaggerScale steps of 100% max health instead of stopping at
+            -- staggerCeilingPercent. While off nothing below is read, so stock behaviour
+            -- and the stored ceiling are untouched.
+            brewExtendedStaggerBar = false,
+            brewExtendedStaggerScale = 4,        -- 2-6; number of 100% stagger steps
+            brewExtendedStaggerColors = {},      -- per-step fill color {r,g,b} at index 1..6; empty entries fall back to EXT_STAGGER_COLORS
+            brewExtendedStaggerDividers = true,  -- draw a divider line at every 100% step
+            brewExtendedStaggerDividerWidth = 1,
+            brewExtendedStaggerDividerR = 0, brewExtendedStaggerDividerG = 0, brewExtendedStaggerDividerB = 0, brewExtendedStaggerDividerA = 1,
             guardianIronfurBar = true,     -- Guardian Druid: Ironfur duration bar (moving hash lines). New-user default; existing profiles pinned off by migration "resourcebars_guardian_ironfur_existing_off_v1".
             guardianShowHashLines = true,  -- Guardian Ironfur: draw the moving per-cast hash lines
             protIgnorePainBar = true,      -- Prot Warrior: Ignore Pain bar (absorbs vs the IP cap = 30% max health; aura stacks are secret). New-user default; existing profiles pinned off by migration "resourcebars_protwar_ignorepain_existing_off_v1".
@@ -2961,6 +2971,96 @@ function ns.ApplyHashLines(sb, cfg, getMaxFn)
     ApplyResourceBarTicks(sb, maxVal, cfg.hashValues, tickCache,
         cfg.hashWidth, cfg.hashColorR, cfg.hashColorG, cfg.hashColorB, cfg.hashColorA,
         isPercent, nil, vInset)
+end
+
+-- Brewmaster Extended Stagger (opt-in). The stagger bar spans brewExtendedStaggerScale
+-- steps of 100% max health; every step owns a fill color and, optionally, a divider line
+-- at its boundary. Everything here is a pure function of the config and is only reached
+-- from the BREWMASTER_STAGGER branch while the toggle is on -- off means no divider
+-- texture is ever created, no event is registered and no OnUpdate exists. Scoped in a
+-- block with ns entry points: the chunk is at the Lua local limit.
+do
+    local EXT_STAGGER_MIN_SCALE, EXT_STAGGER_MAX_SCALE = 2, 6
+    local EXT_STAGGER_COLORS = {
+        { 0.10, 0.80, 0.10 },
+        { 0.90, 0.90, 0.10 },
+        { 1.00, 0.50, 0.00 },
+        { 1.00, 0.00, 0.00 },
+        { 0.75, 0.00, 0.15 },
+        { 0.45, 0.00, 0.35 },
+    }
+    -- Options reads the same defaults and bounds for its swatches and Scale slider.
+    _G._ERB_EXT_STAGGER_COLORS = EXT_STAGGER_COLORS
+    _G._ERB_EXT_STAGGER_MIN_SCALE = EXT_STAGGER_MIN_SCALE
+    _G._ERB_EXT_STAGGER_MAX_SCALE = EXT_STAGGER_MAX_SCALE
+
+    function ns.ExtStaggerScale(sp)
+        local n = floor((tonumber(sp and sp.brewExtendedStaggerScale) or 4) + 0.5)
+        if n < EXT_STAGGER_MIN_SCALE then n = EXT_STAGGER_MIN_SCALE end
+        if n > EXT_STAGGER_MAX_SCALE then n = EXT_STAGGER_MAX_SCALE end
+        return n
+    end
+    _G._ERB_ExtStaggerScale = ns.ExtStaggerScale
+
+    -- Fill color for a stagger percentage of REAL max health (the same number the bar
+    -- text shows): step 1 covers 0-100%, step 2 covers 100-200%, up to the scale.
+    function ns.ExtStaggerColor(sp, staggerPct, scale)
+        local step = floor((staggerPct or 0) / 100) + 1
+        if step < 1 then step = 1 end
+        if step > scale then step = scale end
+        local c = sp.brewExtendedStaggerColors and sp.brewExtendedStaggerColors[step]
+        if c then return c.r or 1, c.g or 1, c.b or 1 end
+        c = EXT_STAGGER_COLORS[step] or EXT_STAGGER_COLORS[1]
+        return c[1], c[2], c[3]
+    end
+
+    -- Divider positions as percentages OF THE BAR, so they hold for any max health:
+    -- step k sits at k/scale of the bar's length. Cached per scale -- the string is also
+    -- ApplyResourceBarTicks' memo key, so it has to be stable.
+    local dividerTicks, dividerStr = {}, {}
+    local function DividerPositions(scale)
+        local s = dividerStr[scale]
+        if not s then
+            local parts = {}
+            for i = 1, scale - 1 do parts[i] = format("%.4f", i * 100 / scale) end
+            s = table.concat(parts, ",")
+            dividerStr[scale] = s
+        end
+        return s
+    end
+
+    -- Divider lines go through ApplyResourceBarTicks (reusing the bar's existing tick
+    -- overlay) with their own texture pool, so the user's own hash lines keep theirs and
+    -- their own color/width. The state memo is ours rather than the shared
+    -- sb._tickState: UNIT_POWER_FREQUENT drives the caller several times a second and
+    -- the hash-line call overwrites that memo, which would rebuild both pools nonstop.
+    function ns.ApplyExtStaggerDividers(sb, sp, active, scale)
+        if not (active and sp.brewExtendedStaggerDividers ~= false and scale > 1) then
+            if sb._extStagDivState then
+                sb._extStagDivState = nil
+                for i = 1, #dividerTicks do dividerTicks[i]:Hide() end
+            end
+            return
+        end
+        local barW, barH = sb:GetWidth(), sb:GetHeight()
+        if barW <= 0 then return end
+        local dw = sp.brewExtendedStaggerDividerWidth or 1
+        local dr = sp.brewExtendedStaggerDividerR or 0
+        local dg = sp.brewExtendedStaggerDividerG or 0
+        local db = sp.brewExtendedStaggerDividerB or 0
+        local da = sp.brewExtendedStaggerDividerA or 1
+        local st = sb._extStagDivState
+        if st and st.scale == scale and st.dw == dw and st.r == dr and st.g == dg
+           and st.b == db and st.a == da and st.barW == barW and st.barH == barH then
+            return
+        end
+        if not st then st = {}; sb._extStagDivState = st end
+        st.scale, st.dw = scale, dw
+        st.r, st.g, st.b, st.a = dr, dg, db, da
+        st.barW, st.barH = barW, barH
+        ApplyResourceBarTicks(sb, 100, DividerPositions(scale), dividerTicks,
+            dw, dr, dg, db, da, true)
+    end
 end
 
 -- Moving-hash overlay for the Guardian Ironfur bar, above the inner StatusBar fill so
@@ -5211,6 +5311,9 @@ local function UpdateSecondaryResource()
         -- Bar-style secondary (e.g. Devourer soul fragments, Elemental maelstrom, Brewmaster stagger)
         if secondaryBar then
             local cur, maxC = 0, maxPts
+            -- Brewmaster Extended Stagger: resolved once in the stagger branch below,
+            -- reused for the bar ceiling and the divider lines.
+            local _esActive, _esScale
             if powerType == "SOUL_FRAGMENTS_DEVOURER" and EllesmereUI and EllesmereUI.GetSoulFragments then
                 cur, maxC = EllesmereUI.GetSoulFragments()
                 if not maxC or maxC <= 0 then maxC = maxPts end
@@ -5237,6 +5340,10 @@ local function UpdateSecondaryResource()
             elseif powerType == "BREWMASTER_STAGGER" then
                 cur = UnitStagger("player") or 0
                 maxC = UnitHealthMax("player") or 1
+                if sp.brewExtendedStaggerBar then
+                    _esActive = true
+                    _esScale = ns.ExtStaggerScale(sp)
+                end
                 local curTainted = issecretvalue and issecretvalue(cur)
                 local maxTainted = issecretvalue and issecretvalue(maxC)
 				-- stagger thresholds
@@ -5259,7 +5366,12 @@ local function UpdateSecondaryResource()
                     end
                 elseif not sp.darkTheme and staggerPct then
                     local trig, tcr, tcg, tcb = false, r, g, b
-                    if _tsBandOn then
+                    if _esActive then
+                        -- Extended Stagger owns the color: one fixed step per 100% of
+                        -- max health, so threshold/band coloring does not apply.
+                        trig = true
+                        tcr, tcg, tcb = ns.ExtStaggerColor(sp, staggerPct, _esScale)
+                    elseif _tsBandOn then
                         local band = FindCountBand(_tsBands, staggerPct, _tsBandReverse)
                         if band then trig, tcr, tcg, tcb = true, band.r or r, band.g or g, band.b or b end
                     elseif _tsEntry then
@@ -5317,9 +5429,13 @@ local function UpdateSecondaryResource()
                     cur = IP.Active() and (UnitGetTotalAbsorbs("player") or 0) or 0
                 end
             end
-            -- Brewmaster stagger ceiling
+            -- Brewmaster stagger ceiling. Extended Stagger derives it from Scale
+            -- (scale * 100% of max health) and never writes staggerCeilingPercent, so
+            -- the stored ceiling applies again the moment the toggle goes off.
             local barMax = maxC
-            if powerType == "BREWMASTER_STAGGER" then
+            if _esActive then
+                barMax = maxC * _esScale
+            elseif powerType == "BREWMASTER_STAGGER" then
                 local ceil = sp.staggerCeilingPercent or 100
                 if ceil < 1 then ceil = 1 end
                 barMax = maxC * ceil / 100
@@ -5527,6 +5643,7 @@ local function UpdateSecondaryResource()
             else
                 secondaryBar:SetValue(cur, ns.EASE)
             end
+            ns.ApplyExtStaggerDividers(secondaryBar, sp, _esActive, _esScale or 0)
             if sp.showText and secondaryFrame._countText then
                 local ct = secondaryFrame._countText
                 local percentSuffix = (sp.showPercent == false) and "" or "%"


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in display mode for the Brewmaster stagger bar, off by default.

Stagger can already exceed 100% of max health, but the bar stops filling there, so everything above that point looks identical. With **Brewmaster Monk Extended Stagger Bar** enabled, the bar spans `Scale` steps of 100% max health (Scale 2-6, default 4). Each step gets its own fill color, and optional divider lines mark the step boundaries. The bar text still shows the real percentage of max health.

New rows in Class Resource (Brewmaster only):

- `Brewmaster Monk Extended Stagger Bar` toggle
- `Scale` slider (2-6), with a `Scale Dividers` cog for line visibility, thickness and color
- `Scale Colors` multi-swatch, one color per 100% step. Steps above the current `Scale` are locked.

Relationship to the existing `Stagger Full %` (`staggerCeilingPercent`): both decide how far the bar fills, so they must not fight each other. While Extended Stagger is on, `Scale` supplies the effective ceiling and `Stagger Full %` in Threshold Settings is locked with an explanatory tooltip. The stored value is never written to, and it applies again unchanged the moment the toggle goes off.

Interaction with existing stagger coloring while enabled: the step colors replace threshold and multi-band coloring, since the steps already define the color bands. Dark Theme behaves exactly as it does today.

## How was it tested?

Client 12.1.0.69587, EllesmereUI 9.1.6, Brewmaster Monk.

In game:

- Default off: bar, threshold coloring, `Stagger Full %` and hash lines behave exactly as before.
- On: Scale 2 / 4 / 6, divider count and positions, per-step colors, divider thickness and color, `Show Divider Lines` off.
- Horizontal, Vertical Up and Vertical Down orientation; UI scale change.
- `Stagger Full %` locks while on, unlocks live when the toggle flips with the Threshold Settings popup open, and its stored value is unchanged afterwards.
- Off after on: ceiling, threshold, band and hash behavior return unchanged.
- `/reload` and relog persistence.
- Dark Theme on and off.
- No Lua errors with `/console scriptErrors 1`.

## Screenshots

Options with the feature on at Scale 4. Steps 5 and 6 are locked because they sit above the current Scale:

<img width="990" height="320" alt="extended-stagger-options" src="https://github.com/user-attachments/assets/a4b61ab8-d8c0-4c17-9e12-bd86edd1f3f8" />

Bar at 260% of max health, Scale 4. The fill uses the 200-300% step color and the dividers sit at 100 / 200 / 300%:

<img width="920" height="128" alt="extended-stagger-bar-260" src="https://github.com/user-attachments/assets/31cb5922-bf6a-4630-b010-7f0e7af50458" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - `brewExtendedStaggerBar` defaults to `false`. With it off, the bar, `Stagger Full %`, threshold/band coloring and hash lines behave exactly as they do on 9.1.6.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - the runtime registers no event, adds no `OnUpdate` and no timer. The stagger branch reads one boolean; while it is false no divider texture is ever created and the color path is untouched.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
  The divider layout is memoized on scale, width, color, bar size, orientation, reverse fill and pixel multiplier, so `UNIT_POWER_FREQUENT` does not rebuild it. That memo is deliberately separate from the shared `sb._tickState`: the hash-line call overwrites that one, and both pools would otherwise rebuild several times a second. Divider textures use their own pool inside the existing tick overlay, so the user's hash lines keep their own color and width.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no Blizzard or secure frame is touched; every frame and texture here is EUI-owned. Secret values keep the existing handling: the step color reuses the same `staggerPct` the current threshold path already computes, including its last-known-good cache.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added.

The concept was discussed with Ellesmere on Discord beforehand.
