### PR TITLE
Fix(CDM): housing-hide default resetting on the three built-in bars

### DIFF
--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -16428,6 +16428,11 @@ initFrame:SetScript("OnEvent", function(self)
         local visRow, visH = EllesmereUI.BuildVisibilityRow(W, parent, y,
             { getStore = BD, legacyKey = "barVisibility",
               caps = { partyIncludesRaid = false, noMouseover = true, luaDragonriding = true },
+              -- The three built-in bars ship visHideHousing = true in DEFAULTS, so an
+              -- explicit uncheck must persist false or DeepMergeDefaults re-fills it to
+              -- true on next login. Harmless for other bars: they never go through that
+              -- merge, so the checkbox reads store[k] == true either way.
+              trueDefaultOpts = { visHideHousing = true },
               onChanged = function()
                   ns.CDMApplyVisibility()
               end,

--- a/EllesmereUIOptions/EllesmereUI_Widgets.lua
+++ b/EllesmereUIOptions/EllesmereUI_Widgets.lua
@@ -8426,6 +8426,10 @@ end
 --      applyScalarFn       = optional fn(store, mode) for scalar side effects
 --      getOption/setOption = optional fn(key)/fn(key, value) when option booleans live
 --                            outside getStore() (Resource Bars writes three stores)
+--      trueDefaultOpts     = optional set { [visOptKey] = true, ... } for opt-axis keys whose
+--                            shipped DEFAULTS value is true; unchecking such a key persists an
+--                            explicit false instead of nil, so DeepMergeDefaults on next login
+--                            does not re-fill it back to true (CDM housing-hide, 2026-08-28)
 --      onChanged/onOptionChanged = fired after a mode / option write (latter falls back)
 --      extraItems          = { { key, label, tooltip, get, set }, ... } single-lane rows
 --      label/width/tooltip/disabledFn/disabledTooltip/rawTooltip/refreshPageArg
@@ -8556,9 +8560,20 @@ function EllesmereUI.AttachVisibilityChecklist(region, opts)
     end
 
     local function SetOpt(k, v)
-        if opts.setOption then opts.setOption(k, v or nil); return end
+        -- Uncheck normally persists as nil ("never set"), which is correct for every
+        -- shipped-off key. A key whose DEFAULTS entry is true needs an explicit false
+        -- instead, or DeepMergeDefaults re-fills the nil back to true on next login.
+        local storedValue
+        if v then
+            storedValue = true
+        elseif opts.trueDefaultOpts and opts.trueDefaultOpts[k] then
+            storedValue = false
+        else
+            storedValue = nil
+        end
+        if opts.setOption then opts.setOption(k, storedValue); return end
         local store = opts.getStore()
-        if store then store[k] = v or nil end
+        if store then store[k] = storedValue end
     end
 
     -- A Show-lane option axis narrows showing to a subset, which is precisely what Always


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Fixes the "Hide in Housing" visibility checkbox resetting itself back to checked after every `/reload` on the three built-in Cooldown Manager bars (Cooldowns, Utility, Buffs). Unchecking the box previously persisted as `nil` rather than an explicit `false`, and since the shipped default for `visHideHousing` on those three bars is `true`, the login-time defaults merge silently filled the `nil` back in and re-enabled housing-hide even though the player had turned it off. Custom bars were never affected, since they live outside the array the defaults merge walks. The shared visibility checklist widget now supports an opt-in list of keys whose default is `true`, so an explicit uncheck on one of those keys persists as `false` instead of `nil` and survives the merge; the Cooldown Manager options wire this up for `visHideHousing`.

## How was it tested?

Tested in-game on live.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting added; this fixes persistence of an existing checkbox
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A, no new events/hooks/frames
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- adds one table lookup on checkbox toggle, no per-frame cost
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, no frame writes involved
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
