### PR TITLE
Fix Sense Power not tracked, and its options-menu name collision

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
@@ -3954,7 +3954,8 @@ function ns.BMP_ShowFilterEditor()
                 local onFilter = (f.spells and f.spells[id] ~= nil)
                     or (f.custom and f.custom[id])
                 if not onFilter then
-                    local nm = C_Spell.GetSpellName and C_Spell.GetSpellName(id)
+                    local nm = (ns.SPELL_NAME_BY_ID and ns.SPELL_NAME_BY_ID[id])
+                        or (C_Spell.GetSpellName and C_Spell.GetSpellName(id))
                     out[#out + 1] = {
                         key = id, label = nm or tostring(id), noCheck = true,
                         icon = C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(id),
@@ -4031,7 +4032,8 @@ function ns.BMP_ShowFilterEditor()
     end
     -- Alphabetical by spell name (id tiebreak for identical names).
     local function NameOf(id)
-        return (C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id)) or tostring(id)
+        return (ns.SPELL_NAME_BY_ID and ns.SPELL_NAME_BY_ID[id])
+            or (C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id)) or tostring(id)
     end
     local function ByName(a, b)
         local na, nb = NameOf(a), NameOf(b)
@@ -4069,7 +4071,8 @@ function ns.BMP_ShowFilterEditor()
         local tex = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(id)
         if tex then ico:SetTexture(tex) end
         ico:SetTexCoord(0.08, 0.92, 0.08, 0.92)
-        local name = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id)
+        local name = (ns.SPELL_NAME_BY_ID and ns.SPELL_NAME_BY_ID[id])
+            or (C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id))
         local lr, lg2, lb2 = 1, 1, 1
         if classColor then lr, lg2, lb2 = classColor.r, classColor.g, classColor.b end
         local lbl = EllesmereUI.MakeFont(srow, 13, nil, lr, lg2, lb2)
@@ -4289,7 +4292,8 @@ function ns.BMP_BuildAssignedFilters(parent, sy, ind, fontPath)
         -- (adding them as extras would be redundant); direct picks always show under
         -- Selected so they can be unchecked.
         local function SpellEntry(id)
-            local name = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id)
+            local name = (ns.SPELL_NAME_BY_ID and ns.SPELL_NAME_BY_ID[id])
+                or (C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id))
             return { key = id, label = (name or ("Spell " .. tostring(id))),
                 icon = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(id) }
         end
@@ -4420,7 +4424,8 @@ function ns.BMP_BuildAssignedFilters(parent, sy, ind, fontPath)
                 local present, seen, out = {}, {}, {}
                 for i = 1, #resolved do present[resolved[i]] = true end
                 local function Add(id)
-                    local nm = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id)
+                    local nm = (ns.SPELL_NAME_BY_ID and ns.SPELL_NAME_BY_ID[id])
+                        or (C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id))
                     out[#out + 1] = { key = id, label = nm or ("Spell " .. tostring(id)) }
                 end
                 local so = ind.spellOrder

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -266,7 +266,13 @@ local HEALER_SPECS = {
             { id = 410686, name = "Symbiotic Bloom" },
             { id = 395152, name = "Ebon Might" },
             { id = 369459, name = "Source of Magic" },
-            { id = 361022, name = "Sense Power", secret = true, sig = "0:1:0:0" },
+            { id = 361021, name = "Sense Power" },
+            -- 361021 is the caster's own permanent toggle buff; 361022 is the
+            -- effect that lands on whichever ally triggers Sense Power's
+            -- "powerful ability" detection. Distinct spell IDs, same client
+            -- display name -- kept as separate entries so both are
+            -- selectable (see SPELL_NAME_BY_ID for how the UI tells them apart).
+            { id = 361022, name = "Sense Power (Ally)" },
         },
     },
 }
@@ -362,6 +368,11 @@ local SPELL_NAME_BY_ID = setmetatable({}, {
         return C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id)
     end,
 })
+-- Shared with EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua (same ns):
+-- the Filter Editor and its dropdowns build spell row labels off this too, so
+-- curated names (e.g. distinguishing two client-side-identical spell names)
+-- apply there as well, not just in this file's own dropdowns.
+ns.SPELL_NAME_BY_ID = SPELL_NAME_BY_ID
 
 local SPEC_DD_VALUES = {}
 local SPEC_DD_ORDER = {}
@@ -543,8 +554,6 @@ local SECRET_SPELL_ICONS = {
     [431381] = 5927633,  -- Dawnlight
     [357170] = 4630500,  -- Time Dilation
     [363534] = 4630498,  -- Rewind
-    [361022] = 132160,   -- Sense Power
-
 }
 
 -------------------------------------------------------------------------------
@@ -692,7 +701,7 @@ local DEFAULT_INDICATORS = {
     },
     EVOKER_AUGMENTATION = {
         { pos = "TOPLEFT",  spells = { 410089, 360827, 369459 } },             -- Prescience, Blistering Scales, Source of Magic
-        { pos = "TOPRIGHT", spells = { 413984, 410263, 410686, 395152, 361022 } }, -- Shifting Sands, Infernos Blessing, Symbiotic Bloom, Ebon Might, Sense Power
+        { pos = "TOPRIGHT", spells = { 413984, 410263, 410686, 395152, 361021 } }, -- Shifting Sands, Infernos Blessing, Symbiotic Bloom, Ebon Might, Sense Power
     },
 }
 
@@ -1304,7 +1313,7 @@ local previewSpellIcons = {}
 local function GetSpellIcon(spellID)
     if previewSpellIcons[spellID] then return previewSpellIcons[spellID] end
     local info = C_Spell and C_Spell.GetSpellInfo and C_Spell.GetSpellInfo(spellID)
-    -- Secret auras (e.g. Sense Power) often lack a resolvable spell-info icon; fall back to the known fingerprint icon before the generic question mark.
+    -- Secret auras (e.g. Ironbark) often lack a resolvable spell-info icon; fall back to the known fingerprint icon before the generic question mark.
     local icon = (info and info.iconID) or SECRET_SPELL_ICONS[spellID] or 136243
     previewSpellIcons[spellID] = icon
     return icon
@@ -3293,7 +3302,11 @@ function ns.BM_BuildPage(pageName, parent, yOffset)
                         popup._fltDD = fltDD
 
                         local function SpellEntry(id)
-                            local name = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id)
+                            -- Curated name first (distinguishes variants the client
+                            -- API can't, e.g. two spell IDs both named "Sense Power"
+                            -- by Blizzard); SPELL_NAME_BY_ID already falls back to
+                            -- the live API internally when no curated name exists.
+                            local name = SPELL_NAME_BY_ID[id]
                             return { key = id, label = (name or ("Spell " .. tostring(id))),
                                 icon = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(id) }
                         end

--- a/EllesmereUI_BuffPresets.lua
+++ b/EllesmereUI_BuffPresets.lua
@@ -244,6 +244,8 @@ spells = {
         [413984] = { class = "EVOKER", disabled = true },
         [369459] = { class = "EVOKER", disabled = true },
         [406732] = { class = "EVOKER", disabled = true },
+        [361021] = { class = "EVOKER", disabled = true },
+        [361022] = { class = "EVOKER", disabled = true },
     },
     offensive = {
         [1249658] = { class = "DEATHKNIGHT", alts = { 152279 } },


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1541393067930558534

Issue: Sense Power never appeared as a trackable buff in the Augmentation Evoker options. It was keyed to spell ID 361022 with a secret-aura fingerprint (sig = "0:1:0:0"), and that fingerprint never matched in practice, so the option was invisible everywhere it should have been selectable.

Fix: Track 361021 instead — the caster's own confirmed, non-secret buff — as the primary "Sense Power" entry, and keep 361022 alongside it as a separate "Sense Power (Ally)" entry (both registered in the shared buff presets, off by default). Since Blizzard's client reports the identical display name for both spell IDs, every UI spot that built a label straight from GetSpellName (the Buff Manager's spell picker, the Filter Editor, its Search Spells and spell-order dropdowns) showed two indistinguishable "Sense Power" rows. All of them now route through the addon's existing curated-name lookup instead, which was already used elsewhere in the codebase for exactly this class of problem but wasn't being applied here — that lookup is also exported so the separate options-page file sharing this same logic benefits too, rather than duplicating the fix.