### PR TITLE
Refresh CDM charge counter on SPELL_UPDATE_CHARGES

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2152,6 +2152,52 @@ function ns.WatchZeroChargeTextIfEnabled(frame)
 end
 
 -------------------------------------------------------------------------------
+--  Charge counter on SPELL_UPDATE_CHARGES. Blizzard_CooldownViewer (12.1.0)
+--  does not register the event, so a proc that hands charges to a chargeless
+--  spell reaches the icon only at its next RefreshData, seconds later. Mirrors
+--  RefreshSpellChargeInfo's charge branch (maxCharges > 1, NeverSecret) from
+--  the frame's own GetSpellChargeInfo; SetText takes a secret count. Not
+--  routed through RefreshSpellChargeInfo: SetCachedChargeValues compares
+--  currentCharges, secret while cooldowns are restricted. Show() is
+--  unconditional because the counter's shown aspect is secret once Blizzard
+--  set it from a secret cast count. Frames this wrote are hidden again when
+--  maxCharges drops back; the rest stays with Blizzard. No payload.
+-------------------------------------------------------------------------------
+do
+    local wrote = setmetatable({}, { __mode = "k" })
+
+    local function WriteChargeCount(frame)
+        local cc = frame.ChargeCount
+        local fs = cc and cc.Current
+        if not fs then return end
+        local ci = CdmChargeInfoFor(frame, nil)
+        if ci and (ci.maxCharges or 0) > 1 then
+            fs:SetText(ci.currentCharges)
+            cc:Show()
+            wrote[frame] = true
+        elseif wrote[frame] then
+            wrote[frame] = nil
+            cc:Hide()
+        end
+    end
+
+    local ef = ns.TakeShell()
+    ef:RegisterEvent("SPELL_UPDATE_CHARGES")
+    ef:SetScript("OnEvent", function()
+        if IsCDMSettingsOpen() then return end
+        for vi = 1, 2 do
+            local viewer = GetViewerFrame(vi)
+            local pool = viewer and viewer.itemFramePool
+            if pool and pool.EnumerateActive then
+                for frame in pool:EnumerateActive() do
+                    WriteChargeCount(frame)
+                end
+            end
+        end
+    end)
+end
+
+-------------------------------------------------------------------------------
 --  Cooldown State Effect -- charge-aware readiness for Hidden (CD Ready)
 --  For a CHARGE spell "CD Ready" must mean AT MAX CHARGES, not "a charge in
 --  hand": GetSpellCooldown().isActive is false with a charge left, so a plain


### PR DESCRIPTION
## What does this PR do?

Fixes a stale charge count on the Cooldown Manager. Example: Mistweaver's S2 4-piece tier set procs give Rushing Wind Kick an extra charge, and the spell normally has none. The action bar shows the "1" as soon as the proc lands; the CDM icon usually does not show the charge for a few seconds.

The cause is in Blizzard's viewer: Blizzard_CooldownViewer never registers `SPELL_UPDATE_CHARGES`. It only rewrites the counter inside `RefreshData` (a `SPELL_UPDATE_COOLDOWN` for that spell or a nil-spell wave) or on a matching `SPELL_UPDATE_USES`, and a charge grant fires neither. In my trace the charge arrived 0.1 s after the cast and the counter caught up 6.7 s later on an unrelated refresh.

This adds one `SPELL_UPDATE_CHARGES` listener in `EllesmereUICdmHooks.lua`. On each event it walks the Essential and Utility viewer pools and, for any icon whose frame reports `maxCharges > 1`, writes `currentCharges` into Blizzard's `ChargeCount.Current` and shows it, mirroring `RefreshSpellChargeInfo`. When `maxCharges` drops back to 1 on an icon the addon wrote, it hides the counter again so no stale number is left behind. Everything else stays with Blizzard.

Things a reviewer will want to know:

- Charges are read from the frame's own `GetSpellChargeInfo` (via the existing `CdmChargeInfoFor`), the same source Blizzard's text uses. `C_Spell.GetSpellCharges` on the cached spell id gives different answers for override spells.
- It does not call `RefreshSpellChargeInfo` because `SetCachedChargeValues` compares `currentCharges`, which is secret while cooldowns are restricted, and a tainted compare throws. `maxCharges` is NeverSecret and `SetText` accepts a secret count.
- `Show()` runs unconditionally. `IsShown()` returns a secret once Blizzard has set the counter from a secret cast count, so it can't be tested. `ChargeCount` is an unprotected child region nothing secure reads, and Blizzard's next refresh overwrites it; the file already does the same with `SpellActivationAlert:Hide()`.
- No setting, always on. A gate that skips non-charge spells would skip exactly the icons this fixes, and the event has no payload. Cost per event is one `GetSpellCharges` call per active cd/utility icon; nothing runs between events, and the per-frame flag lives in a weak table. The event coalesces to once per frame and only fires when a player spell's charge count changes: about once every three seconds in my open-world trace, a few times a second in combat on charge-heavy specs. Blizzard's own `RefreshData` on every cast wave costs more, more often.
- Only the number is fixed. The recharge swipe for the granted charge still waits for Blizzard's next refresh.

## How was it tested?

Live 12.1.0 (69299), Mistweaver Monk with the S2 4-piece, open world. I hooked the icon's `SetText`/`SetShown`/`RefreshSpellChargeInfo` and logged events to confirm the cause, then with the fix confirmed the CDM "1" lands in the same frame as the action bar's, the "2" follows on the second charge, and the counter clears once the proc is used. luacheck is clean. Not yet run in instanced content; the secret-value paths were checked against the API docs.

## Screenshots

Not visual beyond the counter appearing on time.

## Checklist

- [x] New settings default OFF: N/A, no setting. This is a bug fix and changes behavior for everyone: the counter updates when the charge arrives instead of seconds later.
- [ ] Zero cost while disabled: there is no disabled state. One event registration at load; work only when `SPELL_UPDATE_CHARGES` fires (see above).
- [x] Cheap while enabled: event-driven, no polling, no timers, no per-frame allocations.
- [x] No writes onto Blizzard-owned frames (weak table used); hooks only. It does call `SetText` and `Show`/`Hide` on Blizzard's `ChargeCount` region, see above.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk48VAuhEo5o3VRo3awowh
