### PR TITLE
Fix multi-state buffs dropping out of Player Aura Bars filters

### DIFF
--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -752,8 +752,16 @@ local function BuildAssignedBuffsFields(frame, fontPath, sy, cfg, apply, isDefau
                 if v then
                     if not HasDirect(k) then cfg.spells[#cfg.spells + 1] = k end
                 else
+                    -- Unchecking drops the whole curated family, not just this id:
+                    -- PAB_ResolveSpells expands a family from any member, so a
+                    -- differently-named sibling left in the list would keep the buff
+                    -- tracked behind an unchecked box. Same family = same table.
+                    local fam = ns.PAB_SPELL_FAMILY and ns.PAB_SPELL_FAMILY[k]
                     for i = #cfg.spells, 1, -1 do
-                        if cfg.spells[i] == k then table.remove(cfg.spells, i) end
+                        local id = cfg.spells[i]
+                        if id == k or (fam and ns.PAB_SPELL_FAMILY[id] == fam) then
+                            table.remove(cfg.spells, i)
+                        end
                     end
                 end
                 apply()

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -291,9 +291,10 @@ end
 --     ns.PAB_Filters() list order (map iteration via bar.filters alone is
 --     unordered -- would make the tile flicker between refreshes). If 3+
 --     filters are selected the 3rd shown name is truncated to its first 3
---     characters + "..." as an overflow hint. Falls back to the old
---     resolved-count phrasing when no filters are selected at all (e.g. a
---     bar with only Extra Spells and Show All Buffs off).
+--     characters + "..." as an overflow hint. Falls back to the Extra
+--     Spells count when no filters are selected at all (e.g. a bar with
+--     only Extra Spells and Show All Buffs off) -- the ASSIGNED count, not
+--     the resolved one, which expands curated spell families.
 local function TruncateFilterName(name)
     return (name or ""):sub(1, 3) .. "..."
 end
@@ -372,8 +373,7 @@ local function BuildBuffBarSubtitle(bar)
     end
 
     if #names == 0 then
-        local resolved = ns.PAB_ResolveSpells and ns.PAB_ResolveSpells(bar) or (bar.spells or {})
-        return tostring(#resolved) .. " " .. L("spells")
+        return tostring(extraCount) .. " " .. L("spells")
     end
 
     if totalSelected >= 3 then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -2993,6 +2993,22 @@ end
 -- Union of a buff-side cfg's direct spells (cfg.spells) and the enabled spells of
 -- every filter it references (cfg.filters), minus own-only tracking (see above).
 -- Sorted so the caller's signature diffing stays deterministic.
+--
+-- Curated FAMILIES (a primary plus its `alts`: rank/talent ids for one buff, and
+-- multi-state buffs like Aspect of Harmony whose aura swaps spell ID as it advances)
+-- expand here, as the Raid Frames Buff Manager does in BmIncludeMap. Not at write
+-- time: the Filter Editor and both spell dropdowns collapse a family into ONE
+-- same-named row, so only one member is ever reachable to add or toggle, and saved
+-- filters hold that member alone. An explicit `false` still wins, so unchecking a
+-- member whose name differs from its primary's (the only kind with its own row) sticks.
+local function ExpandFamily(set, id, blocked)
+    local fam = ns.PAB_SPELL_FAMILY and ns.PAB_SPELL_FAMILY[id]
+    if not fam then return end
+    for i = 1, #fam do
+        if not (blocked and blocked[fam[i]] == false) then set[fam[i]] = true end
+    end
+end
+
 function ns.PAB_ResolveSpells(cfg)
     local set = {}
     local direct
@@ -3002,6 +3018,8 @@ function ns.PAB_ResolveSpells(cfg)
         for i = 1, #spells do
             set[spells[i]] = true
             direct[spells[i]] = true
+            ExpandFamily(direct, spells[i])
+            ExpandFamily(set, spells[i])
         end
     end
     -- Under the broad modes (All Buffs / Has Duration) the hide-lane filters leave via
@@ -3015,20 +3033,30 @@ function ns.PAB_ResolveSpells(cfg)
             local f = ns.PAB_GetFilter(filterId)
             if f then
                 for id, on in pairs(f.spells) do
-                    if on then set[id] = true end
+                    if on then
+                        set[id] = true
+                        ExpandFamily(set, id, f.spells)
+                    end
                 end
             end
         end
     end
     local negFilters = addMode and cfg.negFilters or nil
     if negFilters then
+        local hide = {}
         for filterId in pairs(negFilters) do
             local f = ns.PAB_GetFilter(filterId)
             if f then
                 for id, on in pairs(f.spells) do
-                    if on and not (direct and direct[id]) then set[id] = nil end
+                    if on then
+                        hide[id] = true
+                        ExpandFamily(hide, id, f.spells)
+                    end
                 end
             end
+        end
+        for id in pairs(hide) do
+            if not (direct and direct[id]) then set[id] = nil end
         end
     end
     local out = {}
@@ -3222,6 +3250,16 @@ do
         BM2_FILTER_SEED[#BM2_FILTER_SEED + 1] =
             { name = def.name, enabled = enabled, disabled = disabled }
     end
+    -- Every member of a curated family (primary + its alternates) maps to the whole
+    -- member list, so PAB_ResolveSpells can expand from whichever id the user has.
+    -- Families are disjoint, so one carried by two preset filters rewrites an equal entry.
+    local fams = {}
+    for primary, alts in pairs(PRESET_ALTS) do
+        local fam = { primary }
+        for i = 1, #alts do fam[#fam + 1] = alts[i] end
+        for i = 1, #fam do fams[fam[i]] = fam end
+    end
+    ns.PAB_SPELL_FAMILY = fams
 end
 ns.PAB_SPELL_CLASS_HINTS = SPELL_CLASS_HINTS
 

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -371,6 +371,22 @@ local function ClassEnabled(class, isBuff, cfg)
     return cfg.classFilters and cfg.classFilters[class.skey] == true
 end
 
+-- Curated FAMILIES (a primary plus its `alts`: rank/talent ids for one buff, and
+-- multi-state buffs like Aspect of Harmony whose aura swaps spell ID as it advances)
+-- expand at RESOLUTION, as the Raid Frames Buff Manager does in BmIncludeMap. Not at
+-- write time: the Filter Editor and both spell dropdowns collapse a family into ONE
+-- same-named row, so only one member is ever reachable to add, and saved filters hold
+-- that member alone. `blocked` is the owning filter's spell map, where an explicit
+-- `false` wins. Show lane and hide lane both expand, or a hide filter carrying one id
+-- of a family would leak the rest.
+local function ExpandFamily(set, id, blocked)
+    local fam = ns.PAB_SPELL_FAMILY and ns.PAB_SPELL_FAMILY[id]
+    if not fam then return end
+    for i = 1, #fam do
+        if not (blocked and blocked[fam[i]] == false) then set[fam[i]] = true end
+    end
+end
+
 -- BuildChain contract: includeCatchAll (default true) appends "every remaining aura
 -- of this polarity" after the per-class groups; callers pass false wherever the UI
 -- promises the Base Filters dropdown restricts what is shown (Custom Debuff Bars with
@@ -404,6 +420,7 @@ local function BuffBarChain(cfg)
                     if on then
                         ex = ex or {}
                         ex[id] = true
+                        ExpandFamily(ex, id, f.spells)
                     end
                 end
             end
@@ -2974,6 +2991,16 @@ function ns.PAB_SetSpellState(filterId, spellID, state)
         end
     end
     Write(spellID)
+    -- Members of a curated family follow the clicked row, deletes included: the editor
+    -- shows one row per NAME, so a member under a different name has a row of its own
+    -- but is still the same buff, and would otherwise linger as a tracked id with no
+    -- row left to clear it from. Only ids the filter already holds are rewritten.
+    local fam = ns.PAB_SPELL_FAMILY and ns.PAB_SPELL_FAMILY[spellID]
+    if fam then
+        for i = 1, #fam do
+            if fam[i] ~= spellID and f.spells[fam[i]] ~= nil then Write(fam[i]) end
+        end
+    end
     local name = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(spellID)
     if name then
         for id in pairs(f.spells) do
@@ -2993,22 +3020,6 @@ end
 -- Union of a buff-side cfg's direct spells (cfg.spells) and the enabled spells of
 -- every filter it references (cfg.filters), minus own-only tracking (see above).
 -- Sorted so the caller's signature diffing stays deterministic.
---
--- Curated FAMILIES (a primary plus its `alts`: rank/talent ids for one buff, and
--- multi-state buffs like Aspect of Harmony whose aura swaps spell ID as it advances)
--- expand here, as the Raid Frames Buff Manager does in BmIncludeMap. Not at write
--- time: the Filter Editor and both spell dropdowns collapse a family into ONE
--- same-named row, so only one member is ever reachable to add or toggle, and saved
--- filters hold that member alone. An explicit `false` still wins, so unchecking a
--- member whose name differs from its primary's (the only kind with its own row) sticks.
-local function ExpandFamily(set, id, blocked)
-    local fam = ns.PAB_SPELL_FAMILY and ns.PAB_SPELL_FAMILY[id]
-    if not fam then return end
-    for i = 1, #fam do
-        if not (blocked and blocked[fam[i]] == false) then set[fam[i]] = true end
-    end
-end
-
 function ns.PAB_ResolveSpells(cfg)
     local set = {}
     local direct
@@ -4637,6 +4648,7 @@ local function BuildMixedRealSpells(cfg)
                         if on then
                             negSet = negSet or {}
                             negSet[id] = true
+                            ExpandFamily(negSet, id, nf.spells)
                         end
                     end
                 end
@@ -4748,6 +4760,7 @@ local function BuildPreviewSlots(isBuff, cfg, list, listLen, count)
                             if on then
                                 subSet = subSet or {}
                                 subSet[id] = true
+                                ExpandFamily(subSet, id, f.spells)
                             end
                         end
                     end


### PR DESCRIPTION
Bug: reported by Telleria in ellesmere-UI-helper Discord (2026-08-28)

Issue: Aspect of Harmony has three states, and a Player Aura Bars filter only tracked the first. The buff showed while Vitality accumulated, then vanished as it advanced. Typing the higher spell IDs in by hand appeared to do nothing.

Root cause: PAB holds a curated family's alternates as separate keys, but the Filter Editor and both spell dropdowns dedupe rows by spell NAME, so only the lowest id is ever offered to add, and PAB_AddSpellToFilter writes that id alone. PAB_SetSpellState's same-name pass cannot rescue a filter the alternates never entered.

Fix: PAB_ResolveSpells now expands a family from whichever member a config holds, as the Raid Frames Buff Manager does in BmIncludeMap; resolving rather than writing needs no migration and repairs saved filters. The catch-all's excludeSpellIDs expands too, and the editor's toggle and delete move a family as a unit. A test build is with the reporter.
