### PR TITLE
Fix GCD bar filling for a hard cast after an instant under Only Instant Casts

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -8078,13 +8078,13 @@ BuildGCDBar = function()
             end
         end
 
-        -- How each spell last behaved, keyed by spellID: "hard" once it has
-        -- ever opened a cast, channel or empower bar, "instant" once it has
-        -- finished with no cast bar at all. "hard" is sticky -- a proc (e.g.
-        -- Infusion of Light) makes one CAST instant, not the spell -- so a
-        -- procced cast simply falls back to the slower, always-correct
-        -- SUCCEEDED edge. Instant-only reads this to decide whether a press
-        -- may arm the bar; see the SPELL_UPDATE_COOLDOWN edge below.
+        -- Whether a spell channels, keyed by spellID: "channel" once it has
+        -- opened a channel or empower bar (sticky), "plain" once it has
+        -- finished with neither. castTime answers the cast-time question on
+        -- the press edge below, but it reports 0 for a channel and so cannot
+        -- tell one from an instant -- hence the wait for a first classified
+        -- SUCCEEDED. Unknown means wait, so the first cast of a spell is late
+        -- rather than wrong.
         local castKind = {}
 
         gcdBarFrame:SetScript("OnEvent", function(self, event, unit, arg2, arg3, arg4)
@@ -8102,22 +8102,26 @@ BuildGCDBar = function()
             -- tenth of the way in. Same-frame collapse absorbs the storm.
             if event == "SPELL_UPDATE_COOLDOWN" then
                 local now = GetTime()
-                if self._gcdCapStamp == now then return end
+                local sent = self._sentSpellID
+                self._sentSpellID = nil   -- one press edge per send
+                -- A cooldown edge that beat UNIT_SPELLCAST_SENT to the frame
+                -- must not collapse the one behind it, or the press would stay
+                -- unconsumed and the NEXT GCD's edge would read it.
+                if self._gcdCapStamp == now and not sent then return end
                 self._gcdCapStamp = now
                 if gc.instantOnly then
                     -- Hard casts and channels predict a GCD at the press too,
                     -- and this edge IS the press: UNIT_SPELLCAST_START only
                     -- lands a round trip later, so a one-frame-later cast read
                     -- found nothing on any real latency and the bar filled for
-                    -- every hard cast. Arm only when the spell just
-                    -- sent has already been seen finishing instantly; every
-                    -- other press waits for its own SUCCEEDED, which arrives
-                    -- classified. Unknown always means "wait", so the first
-                    -- cast of a spell is late rather than wrong.
-                    local sent = self._sentSpellID
-                    self._sentSpellID = nil   -- one press edge per send
-                    if not (sent and castKind[sent] == "instant"
+                    -- every hard cast. Ask the spell behind the press instead:
+                    -- castTime carries the current haste and proc state, so a
+                    -- Flash of Light under Infusion of Light reads 0 while the
+                    -- same spell unprocced reads its full cast.
+                    if not (sent and castKind[sent] == "plain"
                         and (now - (self._sentAt or 0)) < 1) then return end
+                    local info = C_Spell.GetSpellInfo(sent)
+                    if not info or info.castTime ~= 0 then return end
                     -- An off-GCD press landing mid-cast must not open the bar
                     -- on the hard cast's own GCD.
                     if UnitCastingInfo("player") or UnitChannelInfo("player") then return end
@@ -8174,13 +8178,10 @@ BuildGCDBar = function()
                 -- (e.g. Swiftness Regrowth) will count as instant cast
                 if event ~= "UNIT_SPELLCAST_START" then
                     self._realCastSpellID = spellID
-                    if spellID then castKind[spellID] = "hard" end
+                    if spellID then castKind[spellID] = "channel" end
                 else
                     local _, _, _, st, et = UnitCastingInfo("player")
-                    if st and et and et > st then
-                        self._realCastSpellID = spellID
-                        if spellID then castKind[spellID] = "hard" end
-                    end
+                    if st and et and et > st then self._realCastSpellID = spellID end
                 end
                 if gc.instantOnly then return end  -- instant-only: don't fill for hard casts
             elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
@@ -8204,9 +8205,9 @@ BuildGCDBar = function()
                     -- a hard cast, so an off-GCD instant fired mid-cast must
                     -- not open it on the cast's own GCD either.
                     if UnitCastingInfo("player") then return end
-                    -- Got here with no cast bar of its own: this spell is an
-                    -- instant, so its next press may arm the bar directly.
-                    if succeededID and not castKind[succeededID] then castKind[succeededID] = "instant" end
+                    -- Finished with no channel of its own, so the press edge
+                    -- may judge its next press on cast time alone.
+                    if succeededID and not castKind[succeededID] then castKind[succeededID] = "plain" end
                     local gc2 = ERB.db.profile.gcdBar
                     if gc2 and gc2.enabled then captureGCD(self, gc2) end
                 end)


### PR DESCRIPTION
**Bug:** Reported by Whittlez (9.0.7): with Resource Bars > GCD Bar > Only Instant Casts ticked, casting an instant and then a hard cast Flash of Light fills the GCD bar for the whole Flash of Light cast. Pressing Flash of Light repeatedly does not reproduce it. It only happens to a Flash of Light that follows an instant.

**Issue:** The GCD bar arms from SPELL_UPDATE_COOLDOWN, which is the client's own GCD prediction and so fires at the press, a full round trip before UNIT_SPELLCAST_START can say whether that press opened a cast bar. Under Only Instant Casts that edge has to decide at the press whether the spell behind it is instant, and it was deciding from history.

**Root cause:** A session table recorded how each spell last behaved, "instant" for anything that finished with no cast bar at all, and the press edge armed for any spell already marked instant. A proc makes one cast instant rather than the spell: Infusion of Light makes Flash of Light instant, so for a Holy paladin the first Flash of Light of a session is the procced one, and that is the cast the table learns from. Every later unprocced Flash of Light then armed the bar at the press. The intended guard was that "hard" is sticky, but "hard" was only written at UNIT_SPELLCAST_START, which lands after the press edge has already put the fill on screen. Pressing Flash of Light repeatedly does not reproduce it because by then the record has flipped to "hard", which is exactly the asymmetry in the report.

A second defect sits in the same handler. SPELL_UPDATE_COOLDOWN fires several times per frame and a same frame collapse absorbs the storm, but the collapse returned before consuming the pending UNIT_SPELLCAST_SENT. A cooldown edge that beat SENT to the frame therefore left the press unconsumed, and the next GCD's edge read it, arming the bar for the following spell on the strength of the previous press.

**Fix:** Read the cast time instead of remembering one. SpellInfo.castTime carries the current haste and proc state, so a procced Flash of Light reads 0 and an unprocced one reads its full cast, with nothing to go stale in between. The session table survives only for the question castTime cannot answer, since a channel also reports 0: it now records whether a spell channels rather than how long it took, "channel" once it has opened a channel or empower bar and "plain" once it has finished with neither, and a spell it has not classified yet still waits for its own UNIT_SPELLCAST_SUCCEEDED. Hard casts need no record at all any more, because castTime rejects them on the first press. The send is consumed before the collapse gate, and the gate no longer collapses an edge that has one pending.

C_Spell.GetSpellInfo carries no secret return annotation in SpellDocumentation.lua, unlike C_Spell.GetSpellCooldown, and the UNIT_SPELLCAST_SENT restriction predicate applies only to units other than the player and pet, so the castTime comparison cannot raise on a player cast and needs no pcall. Cost is one GetSpellInfo call per press while Only Instant Casts is on, plus one table write per cast. With the option off, none of the instant path runs and behaviour is unchanged.

**Testing:** not yet confirmed in game. A test build is with Whittlez and this should not be merged before it comes back confirmed.
