### PR TITLE
feat(cdm): add per-buff stack glow thresholds

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -38,6 +38,132 @@ ns._spellOrderDirty = true  -- start dirty so first reanchor builds caches
 local hookFrameData = setmetatable({}, { __mode = "k" })
 ns._hookFrameData = hookFrameData
 
+-- Stack counts may be secret in restricted combat. A one-unit StatusBar range
+-- performs the threshold comparison in C; its fill clips the glow at the edge.
+-- Frames are created only for icons with an enabled per-spell threshold.
+local function StackGlowSize(icon)
+    local width, height = icon:GetWidth(), icon:GetHeight()
+    if not width or width < 5 then width = 36 end
+    if not height or height < 5 then height = width end
+    return width, height
+end
+
+local function StartStackGlow(st, width, height)
+    local opts = {
+        owner = st.icon, width = width, height = height,
+        N = st.lines, th = st.thickness, period = st.speed,
+    }
+    if st.background then
+        opts.bg = { r = st.bgR, g = st.bgG, b = st.bgB }
+    end
+    ns.StartNativeGlow(st.glow, st.style, st.r, st.g, st.b, opts)
+    st.width, st.height = width, height
+    st.started = true
+end
+
+local function StopStackGlow(st)
+    if st.started then
+        ns.StopNativeGlow(st.glow)
+        st.started = nil
+    end
+    if st.gate then st.gate:SetValue(0) end
+end
+
+local function StackGlowOnHide(icon)
+    local fd = hookFrameData[icon]
+    local st = fd and fd.stackGlow
+    if st then StopStackGlow(st) end
+end
+
+function ns.StackGlow_Configure(icon, threshold, style, r, g, b, settings)
+    local fd = icon and hookFrameData[icon]
+    if not fd then return end
+    local st = fd.stackGlow
+    threshold, style = tonumber(threshold), tonumber(style)
+    if not (threshold and threshold >= 2 and style and ns.GLOW_STYLES[style]) then
+        if st and st.threshold then
+            st.threshold = nil
+            StopStackGlow(st)
+            ns._btDirty = true
+            if ns.ArmBuffTicker then ns.ArmBuffTicker() end
+        end
+        return
+    end
+    threshold = floor(threshold)
+    local lines = (settings and settings.buffGlowLines) or 8
+    local thickness = (settings and settings.buffGlowThickness) or 2
+    local speed = (settings and settings.buffGlowSpeed) or 4
+    local background = settings and settings.buffGlowBackground or false
+    local bgR = background and (settings.buffGlowBackgroundR or 0) or nil
+    local bgG = background and (settings.buffGlowBackgroundG or 0) or nil
+    local bgB = background and (settings.buffGlowBackgroundB or 0) or nil
+
+    if not st then
+        st = {}
+        fd.stackGlow = st
+        st.icon = icon
+        st.gate = CreateFrame("StatusBar", nil, icon)
+        st.gate:SetPoint("TOPLEFT", icon, "TOPLEFT", -12, 12)
+        st.gate:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT", 12, -12)
+        st.gate:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
+        st.gate:GetStatusBarTexture():SetAlpha(0)
+
+        st.clip = CreateFrame("Frame", nil, st.gate)
+        st.clip:SetAllPoints(st.gate:GetStatusBarTexture())
+        st.clip:SetClipsChildren(true)
+        st.clip:EnableMouse(false)
+
+        st.glow = CreateFrame("Frame", nil, st.clip)
+        st.glow:SetAllPoints(icon)
+        st.glow:EnableMouse(false)
+        icon:HookScript("OnHide", StackGlowOnHide)
+    end
+
+    st.gate:SetFrameLevel(icon:GetFrameLevel() + 16)
+    st.clip:SetFrameLevel(st.gate:GetFrameLevel() + 1)
+    st.glow:SetFrameLevel(st.clip:GetFrameLevel() + 1)
+    local changed = st.threshold ~= threshold or st.style ~= style
+        or st.r ~= r or st.g ~= g or st.b ~= b or st.lines ~= lines
+        or st.thickness ~= thickness or st.speed ~= speed
+        or st.background ~= background or st.bgR ~= bgR or st.bgG ~= bgG or st.bgB ~= bgB
+    st.threshold, st.style = threshold, style
+    st.r, st.g, st.b = r, g, b
+    st.lines, st.thickness, st.speed = lines, thickness, speed
+    st.background, st.bgR, st.bgG, st.bgB = background, bgR, bgG, bgB
+    if changed then
+        StopStackGlow(st)
+        st.gate:SetMinMaxValues(threshold - 1, threshold)
+    end
+    ns._btDirty = true
+    if ns.ArmBuffTicker then ns.ArmBuffTicker() end
+end
+
+function ns.StackGlow_Feed(icon, applications, active)
+    local fd = icon and hookFrameData[icon]
+    local st = fd and fd.stackGlow
+    if not (st and st.threshold) then return end
+    if not active then
+        StopStackGlow(st)
+        return
+    end
+    local secret = issecretvalue and issecretvalue(applications)
+    if not secret then
+        if applications == nil then
+            applications = st.threshold
+        elseif applications < st.threshold then
+            StopStackGlow(st)
+            st.gate:SetValue(applications)
+            return
+        end
+    end
+    local width, height = StackGlowSize(icon)
+    if not st.started or math.abs(width - st.width) > 0.01
+       or math.abs(height - st.height) > 0.01 then
+        StartStackGlow(st, width, height)
+    end
+    st.gate:SetValue(applications)
+end
+
 -- Force active buff glows to re-apply on the next buff tick (<=0.1s): the tick
 -- only (re)starts a glow when fd.buffGlowActive is false, so live option edits
 -- (color, pixel Lines/Thickness/Speed) never reach an already-glowing icon.
@@ -9434,6 +9560,25 @@ function ns.SetupViewerHooks()
     do
         local cdmBuffTickFrame = ns.TakeShell()
         local _, _cachedClassToken = UnitClass("player")
+        local function ReadBuffApplications(frame)
+            local ad = frame and frame.auraDataCached
+            local applications = ad and ad.applications
+            if (issecretvalue and issecretvalue(applications)) or applications ~= nil then
+                return applications
+            end
+            local auraInstID = frame and frame.auraInstanceID
+            local auraUnit = frame and frame.auraDataUnit
+            if auraInstID and auraUnit
+               and not (issecretvalue and issecretvalue(auraInstID)) then
+                local ok, data = pcall(C_UnitAuras.GetAuraDataByAuraInstanceID,
+                    auraUnit, auraInstID)
+                applications = ok and data and data.applications
+                if (issecretvalue and issecretvalue(applications)) or applications ~= nil then
+                    return applications
+                end
+            end
+            return nil
+        end
         -- 10 Hz anim ticker: the C engine fires the body at cadence and
         -- sleeps between fires, replacing a per-frame OnUpdate whose
         -- accumulator check ran at frame rate (~200x/sec) just to gate this
@@ -9545,8 +9690,15 @@ function ns.SetupViewerHooks()
                                 -- Buff glow shows on active buffs. isActiveBuff above
                                 -- already counts shown totems and our preset/custom
                                 -- own-frames as active, so this just reads it.
-                                local glowActive = isActiveBuff
+                                local buffPresent = isActiveBuff
                                     or (bd.barType == "custom_buff" and frame:IsShown())
+                                local glowActive = buffPresent
+                                if fd and fd._bgThreshold then
+                                    glowActive = false
+                                    local applications = 0
+                                    if buffPresent then applications = ReadBuffApplications(frame) end
+                                    ns.StackGlow_Feed(frame, applications, buffPresent)
+                                end
                                 -- Effective Buff Glow = per-icon override (fd._bgT,
                                 -- stashed by RefreshCDMIconAppearance) falling back to
                                 -- the bar's Buff Glow. nil override => inherit; 0 => None.

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -2346,9 +2346,12 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
 
     _G_Glows.StopAllGlows(overlay)
 
-    local parent = overlay:GetParent()
+    -- A clipped wrapper's parent is only the visible fill. Threshold glows pass
+    -- the owning icon and its full size so every style matches the normal path.
+    local parent = (opts and opts.owner) or overlay:GetParent()
     if not parent then return end
-    local pW, pH = parent:GetWidth(), parent:GetHeight()
+    local pW = (opts and opts.width) or parent:GetWidth()
+    local pH = (opts and opts.height) or parent:GetHeight()
     if pW < 5 then pW = 36 end
     if pH < 5 then pH = 36 end
     local noColor = (cr == nil)
@@ -5415,14 +5418,22 @@ local function RefreshCDMIconAppearance(barKey)
             -- render-equivalent to nil: treat it as inherit, never as a value. Without this fd._bgT would be `false` and the BuffTicker's `effGlowType > 0` compares a boolean with a number and errors.
             if nT == false then nT = nil end
             local nColor = ssb and ssb.buffGlowColor  -- nil / "class" / "custom"
+            local nThreshold = tonumber(ssb and ssb.buffGlowStackThreshold)
+            if not nThreshold or nThreshold < 2 then nThreshold = nil end
+            -- Own custom frames do not expose a native applications count.
+            if icon._isCustomBuffFrame or not ns.StackGlow_Configure then
+                nThreshold = nil
+            end
             local nR, nG, nB
             if nColor == "custom" and ssb then
                 nR, nG, nB = ssb.buffGlowColorR, ssb.buffGlowColorG, ssb.buffGlowColorB
             end
             if fd then
                 if fd._bgT ~= nT or fd._bgColor ~= nColor
-                   or fd._bgR ~= nR or fd._bgG ~= nG or fd._bgB ~= nB then
+                   or fd._bgR ~= nR or fd._bgG ~= nG or fd._bgB ~= nB
+                   or fd._bgThreshold ~= nThreshold then
                     fd._bgT = nT; fd._bgColor = nColor; fd._bgR = nR; fd._bgG = nG; fd._bgB = nB
+                    fd._bgThreshold = nThreshold
                     if fd.buffGlowActive and fd.buffGlowOverlay then
                         StopNativeGlow(fd.buffGlowOverlay)
                         fd.buffGlowActive = false
@@ -5430,7 +5441,32 @@ local function RefreshCDMIconAppearance(barKey)
                 end
                 -- Per-icon Desaturate Inactive override, read by the BuffTicker.
                 fd._desatOverride = (ssb and ssb.desatInactive) or nil
+
+                if nThreshold then
+                    local sgStyle = nT
+                    if sgStyle == nil and (barData.barType == "buffs"
+                       or barData.barType == "custom_buff" or barData.key == "buffs") then
+                        sgStyle = barData.buffGlowType or 0
+                    end
+                    local sgMode = nColor or barData.buffGlowMode
+                    local sgR, sgG, sgB
+                    if sgMode == "class" then
+                        local cc = EllesmereUI.GetClassColor(EllesmereUI._playerClass)
+                        sgR, sgG, sgB = cc.r, cc.g, cc.b
+                    elseif nColor == "custom" then
+                        sgR, sgG, sgB = nR, nG, nB
+                    elseif sgMode == "custom" then
+                        sgR, sgG, sgB = barData.buffGlowR, barData.buffGlowG, barData.buffGlowB
+                    end
+                    ns.StackGlow_Configure(icon, nThreshold, sgStyle, sgR, sgG, sgB, barData)
+                elseif fd.stackGlow then
+                    ns.StackGlow_Configure(icon)
+                end
             end
+        elseif fd and fd.stackGlow and ns.StackGlow_Configure then
+            -- Blizzard viewer frames are pooled across cooldown and buff
+            -- families. Retire a controller when its frame becomes non-buff.
+            ns.StackGlow_Configure(icon)
         end
         -- Update texture -- fill the entire frame. The border renders on top via PP.CreateBorder so no inset is needed.
         if tex then

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -10713,6 +10713,7 @@ initFrame:SetScript("OnEvent", function(self)
                             local b = cdmBd
                             return valChanged(ss.showItemCount, (b and b.showItemCount) ~= false)
                                 or valChanged(ss.showChargeStackText, (b and b.showChargeStackText) ~= false)
+                                or ss.buffGlowStackThreshold ~= nil
                                 or valChanged(ss.stackCountSize, (b and b.stackCountSize) or 11)
                                 or colChanged(ss.stackCountR, ss.stackCountG, ss.stackCountB,
                                     (b and b.stackCountR) or 1, (b and b.stackCountG) or 1, (b and b.stackCountB) or 1)
@@ -10730,6 +10731,15 @@ initFrame:SetScript("OnEvent", function(self)
                                     { type="toggle", label="Show Charge/Stack Text",
                                       get=function() if ss.showChargeStackText ~= nil then return ss.showChargeStackText end return (cdmBd and cdmBd.showChargeStackText) ~= false end,
                                       set=function(v) EnsureSS(); ss.showChargeStackText = v; if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end if row._updateLabel then row._updateLabel() end end },
+                                    { type="input", label="Glow at Stacks", inputWidth=42, commitOnBlur=true,
+                                      get=function() return tostring(tonumber(ss.buffGlowStackThreshold) or 0) end,
+                                      set=function(v)
+                                          local threshold = math.floor(tonumber(v) or 0)
+                                          if threshold < 2 then threshold = nil end
+                                          EnsureSS(); SetOwn("buffGlowStackThreshold", threshold)
+                                          if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end
+                                          if row._updateLabel then row._updateLabel() end
+                                      end },
                                     { type="slider", label="Size", min=6, max=30, step=1,
                                       get=function() return ss.stackCountSize or (cdmBd and cdmBd.stackCountSize) or 11 end,
                                       set=function(v) EnsureSS(); ss.stackCountSize = v; if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end if row._updateLabel then row._updateLabel() end end },


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in per-buff `Glow at Stacks` threshold under the existing Charge/Stack Text settings. When a threshold of 2 or higher is configured, the selected Buff Glow starts at that stack count; `0`, `1`, or an unset value keeps the existing behavior.

The threshold path is safe for Midnight secret stack values: a one-unit `StatusBar` range performs the comparison in the UI engine and clips an addon-owned glow wrapper. It reuses the existing native glow implementation so Auto-Cast Shine, Pixel Glow, Shape Glow, and the other styles retain their normal size and settings.

No frame, event, timer, or hook is added while the option is disabled. Enabled icons reuse the existing dirty-gated buff update path.

## How was it tested?

- Live Retail / Midnight 12.1 with Soul Fragments (spell 1245577), Auto-Cast Shine, and a 4-stack threshold.
- Verified the opt-in setting, below/above-threshold behavior, glow-style changes, and reload persistence in game.
- Parsed all three changed files as Lua 5.1 with `luaparse`.
- Ran `git diff --check`, an ASCII-only scan, and `.tools/extract-locale-keys.sh` (765 keys, no generated diff).

## Screenshots

Before (ordinary buff tracking, no threshold glow):

![Before: Soul Fragments without a threshold glow](https://raw.githubusercontent.com/0x963D/EllesmereUI/4bfc9e5cac398f7816b66c5fc0582445867812cd/stack-threshold-before.png)

Opt-in setting:

![Glow at Stacks input under Charge/Stack Text](https://raw.githubusercontent.com/0x963D/EllesmereUI/4bfc9e5cac398f7816b66c5fc0582445867812cd/stack-threshold-settings.png)

After (Auto-Cast Shine active above the configured threshold):

![Soul Fragments with Auto-Cast Shine at seven stacks](https://raw.githubusercontent.com/0x963D/EllesmereUI/4bfc9e5cac398f7816b66c5fc0582445867812cd/stack-threshold-glow-7.png)

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: reuses the existing dirty-gated buff update path; no new polling, timer, or per-frame allocation path
- [x] No writes onto Blizzard-owned frames (external weak-table state; `HookScript` only)
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added