### PR TITLE
refactor(core): centralize number abbreviation into EllesmereUI_NumberFormat

### DIFF
--- a/EllesmereUI.toc
+++ b/EllesmereUI.toc
@@ -27,6 +27,10 @@ EllesmereUI_Lite.lua
 # loaded by the engine at ADDON_LOADED for non-English locales only.
 EllesmereUI_Locale.lua
 
+# Central number-abbreviation engine (K/M/B, or a locale's own algorithm --
+# e.g. CJK 万/亿 grouping -- registered from EllesmereUILocales/<code>.lua).
+EllesmereUI_NumberFormat.lua
+
 # One-time data migration (runs before child addons init)
 EllesmereUI_Migration.lua
 

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -955,44 +955,19 @@ local function PhysicalPixels(userValue)
     return value
 end
 
--- Number formatting
-local _abbreviateCfg
--- East Asian clients group large numbers by ten-thousands (wan) and hundred-millions (yi) rather than K/M/B; Simplified/Traditional Chinese share the math, only the wan/yi glyphs differ
-local CJK = ({
-    zhCN = { thousand = "千", wan = "万", yi = "亿" },
-    zhTW = { thousand = "千", wan = "萬", yi = "億" },
-    koKR = { thousand = "천", wan = "만", yi = "억" },
-})[GetLocale()]
--- Choose the abbreviation breakpoint table: CJK clients normally group by 萬/억, but fall
--- through to K/M/B if forceEnglish is on. Non-CJK clients always get K/M/B (forceEnglish is a no-op).
-local function BuildAbbrevOpts(forceEnglish)
-    if CJK and not forceEnglish then
-        return {
-            { breakpoint = 100000000, abbreviation = CJK.yi,       significandDivisor = 1000000, fractionDivisor = 100, abbreviationIsGlobal = false },
-            { breakpoint = 10000,     abbreviation = CJK.wan,      significandDivisor = 100,      fractionDivisor = 100, abbreviationIsGlobal = false },
-            { breakpoint = 1000,      abbreviation = CJK.thousand, significandDivisor = 100,      fractionDivisor = 10,  abbreviationIsGlobal = false },
-            { breakpoint = 1,         abbreviation = "",           significandDivisor = 1,        fractionDivisor = 1,   abbreviationIsGlobal = false },
-        }
-    else
-        return {
-            { breakpoint = 1000000000, abbreviation = "B", significandDivisor = 10000000, fractionDivisor = 100, abbreviationIsGlobal = false },
-            { breakpoint = 1000000,    abbreviation = "M", significandDivisor = 10000,    fractionDivisor = 100, abbreviationIsGlobal = false },
-            { breakpoint = 1000,       abbreviation = "K", significandDivisor = 100,      fractionDivisor = 10,  abbreviationIsGlobal = false },
-            { breakpoint = 1,          abbreviation = "",  significandDivisor = 1,         fractionDivisor = 1,   abbreviationIsGlobal = false },
-        }
-    end
-end
+-- Number formatting: delegates to the shared EllesmereUI_NumberFormat.lua engine
+-- (breakpoint tables, locale-specific algorithms -- e.g. CJK 萬/억 grouping --
+-- and the AbbreviateNumbers/CreateAbbreviateConfig plumbing all live there now,
+-- shared with EllesmereUIDataBars' gold abbreviation).
+local _forceEnglishUnits = false
 
--- Rebuild _abbreviateCfg from the saved setting: once at load (DB not ready yet -> reads
--- false), once after DB creation, and on every options toggle flip. Cheap: one config object, never touches per-bar/per-refresh work.
+-- Re-read the saved setting: once at load (DB not ready yet -> reads false),
+-- once after DB creation, and on every options toggle flip.
 local function RebuildAbbrevCfg()
-    local forceEnglish = false
+    _forceEnglishUnits = false
     if ns.EDM and ns.EDM.DB then
         local db = ns.EDM.DB()
-        if db and db.forceEnglishUnits then forceEnglish = true end
-    end
-    if CreateAbbreviateConfig then
-        _abbreviateCfg = { config = CreateAbbreviateConfig(BuildAbbrevOpts(forceEnglish)) }
+        if db and db.forceEnglishUnits then _forceEnglishUnits = true end
     end
 end
 RebuildAbbrevCfg()
@@ -1000,21 +975,7 @@ ns.RebuildNumberFormat = RebuildAbbrevCfg
 
 local function AbbrevNumber(n)
     if n == nil then return "0" end
-    if AbbreviateNumbers then
-        return AbbreviateNumbers(n, _abbreviateCfg) or "0"
-    end
-    local num = tonumber(n)
-    if not num then return "?" end
-    if CJK then
-        if num >= 1e8 then return format("%.2f%s", num / 1e8, CJK.yi)
-        elseif num >= 1e4 then return format("%.2f%s", num / 1e4, CJK.wan)
-        elseif num >= 1e3 then return format("%.1f%s", num / 1e3, CJK.thousand)
-        else return format("%.0f", num) end
-    end
-    if num >= 1e9 then return format("%.1fB", num / 1e9)
-    elseif num >= 1e6 then return format("%.1fM", num / 1e6)
-    elseif num >= 1e3 then return format("%.1fK", num / 1e3)
-    else return format("%.0f", num) end
+    return EllesmereUI.AbbreviateNumber(n, _forceEnglishUnits)
 end
 
 local function FormatBarValue(amt, perSec, numFmt)

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -357,62 +357,11 @@ local function CoinMarker(i, coinIcons, coloured)
     return d.symbol
 end
 
--- Gold abbreviation (SI units): 284208 -> "284.2K". CJK clients group by the
--- ten-thousand unit (wan) instead of K/M, matching the Damage Meters number
--- formatting. The gold cap is 99,999,999, under the hundred-million (yi)
--- rollover, so there is no "B"/yi breakpoint to carry.
-local CJK_GOLD = ({
-    zhCN = { wan = "万" },
-    zhTW = { wan = "萬" },
-    koKR = { wan = "만" },
-})[GetLocale()]
-
-local function BuildGoldAbbrevOpts(forceEnglish)
-    if CJK_GOLD and not forceEnglish then
-        return {
-            { breakpoint = 10000, abbreviation = CJK_GOLD.wan, significandDivisor = 100, fractionDivisor = 100, abbreviationIsGlobal = false },
-            { breakpoint = 1,     abbreviation = "",           significandDivisor = 1,   fractionDivisor = 1,   abbreviationIsGlobal = false },
-        }
-    end
-    return {
-        { breakpoint = 1000000, abbreviation = "M", significandDivisor = 10000, fractionDivisor = 100, abbreviationIsGlobal = false },
-        { breakpoint = 1000,    abbreviation = "K", significandDivisor = 100,   fractionDivisor = 10,  abbreviationIsGlobal = false },
-        { breakpoint = 1,       abbreviation = "",  significandDivisor = 1,     fractionDivisor = 1,   abbreviationIsGlobal = false },
-    }
-end
-
--- Two cached configs: the locale's own (CJK wan, or K/M if not CJK) and the
--- English-forced one (Force English Units option). Non-CJK clients never
--- differ between the two, so the second build is skipped for them.
-local _goldAbbrevCfgLocal, _goldAbbrevCfgEnglish
-if CreateAbbreviateConfig then
-    _goldAbbrevCfgLocal = { config = CreateAbbreviateConfig(BuildGoldAbbrevOpts(false)) }
-    _goldAbbrevCfgEnglish = CJK_GOLD
-        and { config = CreateAbbreviateConfig(BuildGoldAbbrevOpts(true)) }
-        or _goldAbbrevCfgLocal
-end
-
--- Fallback for clients missing AbbreviateNumbers/CreateAbbreviateConfig.
-local function AbbrevGoldFallback(gold, forceEnglish)
-    if CJK_GOLD and not forceEnglish then
-        if gold >= 1e4 then return format("%.2f%s", gold / 1e4, CJK_GOLD.wan)
-        else return tostring(gold) end
-    end
-    if gold >= 1e6 then return format("%.2fM", gold / 1e6)
-    elseif gold >= 1e3 then return format("%.1fK", gold / 1e3)
-    else return tostring(gold) end
-end
-
-local function AbbrevGold(gold, forceEnglish)
-    if AbbreviateNumbers then
-        local cfg = forceEnglish and _goldAbbrevCfgEnglish or _goldAbbrevCfgLocal
-        return AbbreviateNumbers(gold, cfg) or tostring(gold)
-    end
-    return AbbrevGoldFallback(gold, forceEnglish)
-end
-
+-- Gold abbreviation (SI units): 284208 -> "284.2K". The breakpoint table and
+-- any locale-specific algorithm (e.g. CJK 万/萬/만 grouping) live in the
+-- shared EllesmereUI_NumberFormat.lua, so every module abbreviates the same way.
 local function GoldDisplay(val, abbreviate, forceEnglish)
-    if abbreviate then return AbbrevGold(val, forceEnglish) end
+    if abbreviate then return EllesmereUI.AbbreviateNumber(val, forceEnglish) end
     return BreakUpLargeNumbers and BreakUpLargeNumbers(val) or tostring(val)
 end
 

--- a/EllesmereUILocales/koKR.lua
+++ b/EllesmereUILocales/koKR.lua
@@ -8,6 +8,18 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("koKR")
 if not L then return end
 
+-- Number abbreviation: 만/억 grouping instead of K/M/B, shared by every module
+-- through EllesmereUI.AbbreviateNumber() (EllesmereUI_NumberFormat.lua). Lives
+-- here, not in the number-format engine, so the algorithm and its glyphs travel
+-- together with this file -- which never loads at all for an English client.
+EllesmereUI.RegisterNumberAbbreviation("koKR", function()
+    return {
+        { breakpoint = 100000000, abbreviation = "억", significandDivisor = 1000000, fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 10000,     abbreviation = "만", significandDivisor = 100,      fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 1,         abbreviation = "",   significandDivisor = 1,        fractionDivisor = 1,   abbreviationIsGlobal = false },
+    }
+end)
+
 L["BLIZZARD POPUPS & GAME MENU"] = "블리자드 팝업 및 게임 메뉴"
 
 -- == Common labels (공용 라벨) =============================================

--- a/EllesmereUILocales/zhCN.lua
+++ b/EllesmereUILocales/zhCN.lua
@@ -7,6 +7,18 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("zhCN")
 if not L then return end
 
+-- Number abbreviation: 万/亿 grouping instead of K/M/B, shared by every module
+-- through EllesmereUI.AbbreviateNumber() (EllesmereUI_NumberFormat.lua). Lives
+-- here, not in the number-format engine, so the algorithm and its glyphs travel
+-- together with this file -- which never loads at all for an English client.
+EllesmereUI.RegisterNumberAbbreviation("zhCN", function()
+    return {
+        { breakpoint = 100000000, abbreviation = "亿", significandDivisor = 1000000, fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 10000,     abbreviation = "万", significandDivisor = 100,      fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 1,         abbreviation = "",   significandDivisor = 1,        fractionDivisor = 1,   abbreviationIsGlobal = false },
+    }
+end)
+
 -- == 常用标签 (Common labels) ===============================================
 L["Anchor"] = "锚点"
 L["Anchor Point"] = "锚点位置"

--- a/EllesmereUILocales/zhTW.lua
+++ b/EllesmereUILocales/zhTW.lua
@@ -5,6 +5,19 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 -- to generate the full remaining key list. Untranslated keys fall back to English.
 local L = EllesmereUI.RegisterLocale("zhTW")
 if not L then return end
+
+-- Number abbreviation: 萬/億 grouping instead of K/M/B, shared by every module
+-- through EllesmereUI.AbbreviateNumber() (EllesmereUI_NumberFormat.lua). Lives
+-- here, not in the number-format engine, so the algorithm and its glyphs travel
+-- together with this file -- which never loads at all for an English client.
+EllesmereUI.RegisterNumberAbbreviation("zhTW", function()
+    return {
+        { breakpoint = 100000000, abbreviation = "億", significandDivisor = 1000000, fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 10000,     abbreviation = "萬", significandDivisor = 100,      fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 1,         abbreviation = "",   significandDivisor = 1,        fractionDivisor = 1,   abbreviationIsGlobal = false },
+    }
+end)
+
 L["Behind Unit Frame"] = "顯示於單位框架後方"
 
 -- == Common labels =========================================================

--- a/EllesmereUIOptions/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIOptions/EUI_DamageMeters_Options.lua
@@ -1368,11 +1368,11 @@ initFrame:SetScript("OnEvent", function(self)
         y = y - h
 
         -- Force English Number Units (K/M/B) | (spacer)
-        -- CJK clients only: zhCN/zhTW/koKR group numbers by wan/eok, so this
-        -- offers K/M/B instead. Every other locale already gets K/M/B and the
-        -- toggle would be a no-op, so the row is skipped for them.
-        local clientLocale = GetLocale()
-        if clientLocale == "zhCN" or clientLocale == "zhTW" or clientLocale == "koKR" then
+        -- Only where the effective locale actually has its own abbreviation
+        -- algorithm (currently CJK's wan/eok grouping, registered from
+        -- EllesmereUILocales/<code>.lua): every other locale already gets
+        -- K/M/B and the toggle would be a no-op, so the row is skipped for them.
+        if EllesmereUI.LocaleHasNumberAbbreviation and EllesmereUI.LocaleHasNumberAbbreviation() then
             _, h = W:DualRow(parent, y,
                 { type="toggle", text="Force English Units (K/M/B)",
                   tooltip = "Always use K/M/B instead of localized units.",

--- a/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
@@ -2902,16 +2902,14 @@ initFrame:SetScript("OnEvent", function(self)
                     MkToggle("Abbreviate Amount", "abbreviate",
                         "Shows large amounts using K/M suffixes (284,208g becomes 284.2Kg) instead of the full grouped number. The tooltip always shows the exact amount."),
                 }
-                -- Force English Units: CJK clients only (zhCN/zhTW/koKR group
-                -- numbers by 万/亿 instead of K/M); every other locale already
-                -- gets K/M, so the toggle would be a no-op there. Mirrors the
-                -- Damage Meters options row (EUI_DamageMeters_Options.lua).
-                do
-                    local clientLocale = GetLocale()
-                    if clientLocale == "zhCN" or clientLocale == "zhTW" or clientLocale == "koKR" then
-                        typeRows[#typeRows + 1] = MkToggle("Force English Units (K/M/B)", "forceEnglishUnits",
-                            "Always use K/M/B instead of localized units.")
-                    end
+                -- Force English Units: only where the effective locale actually
+                -- has its own abbreviation algorithm (currently CJK's 万/亿
+                -- grouping, registered from EllesmereUILocales/<code>.lua); every
+                -- other locale already gets K/M/B, so the toggle would be a no-op.
+                -- Mirrors the Damage Meters options row (EUI_DamageMeters_Options.lua).
+                if EllesmereUI.LocaleHasNumberAbbreviation and EllesmereUI.LocaleHasNumberAbbreviation() then
+                    typeRows[#typeRows + 1] = MkToggle("Force English Units (K/M/B)", "forceEnglishUnits",
+                        "Always use K/M/B instead of localized units.")
                 end
             elseif b.type == "xprep" then
                 typeRows = {

--- a/EllesmereUI_NumberFormat.lua
+++ b/EllesmereUI_NumberFormat.lua
@@ -1,0 +1,88 @@
+if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_ClientGate.lua)
+--------------------------------------------------------------------------------
+--  EllesmereUI_NumberFormat.lua
+--  Central "abbreviate a big number to K/M/B/etc." engine, shared by every module
+--  that squeezes a large number into a small space (Gold in EllesmereUIDataBars,
+--  damage/healing in EllesmereUIDamageMeters, ...). Delegates to the client's own
+--  AbbreviateNumbers/CreateAbbreviateConfig -- guaranteed present on every client
+--  build this addon supports (EUI_CLIENT_BLOCKED gates out anything older, and
+--  both APIs predate that floor by years); this file only supplies the
+--  breakpoint table.
+--
+--  Locale-specific algorithms (CJK 万/亿-style grouping) do NOT live here -- they
+--  are registered from inside the matching EllesmereUILocales/<code>.lua file via
+--  RegisterNumberAbbreviation below, so the algorithm and its glyphs travel
+--  together with the LoadOnDemand child that already never loads at all for an
+--  English client (see EllesmereUI_Locale.lua's "Zero cost on English" note).
+--
+--  AbbreviateNumber() runs on every combat-meter and gold-bar refresh, often many
+--  times a second across a raid frame's worth of bars, so it's written as a hot
+--  path: client API localized to upvalues, and the resolved AbbreviateConfig built
+--  at most once per session (EllesmereUI.LOCALE cannot change without a UI reload,
+--  per EUI__General_Options.lua's language picker, so there is nothing to
+--  invalidate).
+--------------------------------------------------------------------------------
+EllesmereUI = EllesmereUI or {}
+local EllesmereUI = EllesmereUI
+
+local tonumber = tonumber
+local AbbreviateNumbers = AbbreviateNumbers
+local CreateAbbreviateConfig = CreateAbbreviateConfig
+
+-- English/default breakpoint table -- there's no locale-agnostic "generic"
+-- abbreviation, K/M/B is just what English (and every locale without its own
+-- registration below) uses. One table fits every caller: an unreached
+-- breakpoint (e.g. the B tier on gold, capped at 99,999,999) simply never
+-- matches, so there's no need for a caller-specific variant.
+local function EnglishBreakpoints()
+    return {
+        { breakpoint = 1000000000, abbreviation = "B", significandDivisor = 10000000, fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 1000000,    abbreviation = "M", significandDivisor = 10000,    fractionDivisor = 100, abbreviationIsGlobal = false },
+        { breakpoint = 1000,       abbreviation = "K", significandDivisor = 100,      fractionDivisor = 10,  abbreviationIsGlobal = false },
+        { breakpoint = 1,          abbreviation = "",  significandDivisor = 1,        fractionDivisor = 1,   abbreviationIsGlobal = false },
+    }
+end
+
+-- Locale-specific overrides: [localeCode] -> breakpoint-table builder.
+-- Populated by EllesmereUILocales/<code>.lua files at their own load (only the
+-- active locale's file actually runs on a given client).
+local localeBuilders = {}
+
+function EllesmereUI.RegisterNumberAbbreviation(localeCode, builderFn)
+    localeBuilders[localeCode] = builderFn
+end
+
+-- EllesmereUI.LocaleHasNumberAbbreviation(localeCode) -> boolean
+--   True when localeCode (default: the current effective locale) has its own
+--   registered algorithm -- i.e. a "Force English Units" toggle would actually
+--   change something for it. Lets callers (options pages) gate that toggle
+--   without hardcoding which locales happen to have one.
+function EllesmereUI.LocaleHasNumberAbbreviation(localeCode)
+    localeCode = localeCode or EllesmereUI.LOCALE
+    return localeBuilders[localeCode] ~= nil
+end
+
+-- Resolved AbbreviateConfig objects, built at most once and reused for the rest
+-- of the session -- plain upvalues rather than a table keyed by locale, so a
+-- warm call is a truthiness check away from returning instead of a hash lookup.
+local cfgLocalized, cfgEnglish
+
+local function BuildConfig(forceEnglish)
+    if forceEnglish then
+        cfgEnglish = cfgEnglish or { config = CreateAbbreviateConfig(EnglishBreakpoints()) }
+        return cfgEnglish
+    end
+    if not cfgLocalized then
+        local builder = localeBuilders[EllesmereUI.LOCALE]
+        local opts = builder and builder() or EnglishBreakpoints()
+        cfgLocalized = { config = CreateAbbreviateConfig(opts) }
+    end
+    return cfgLocalized
+end
+
+-- EllesmereUI.AbbreviateNumber(n, forceEnglish) -> string
+--   forceEnglish: true skips any locale-specific override and always uses
+--   K/M/B (e.g. DamageMeters' "force English units" setting).
+function EllesmereUI.AbbreviateNumber(n, forceEnglish)
+    return AbbreviateNumbers(tonumber(n) or 0, BuildConfig(forceEnglish))
+end


### PR DESCRIPTION
## Summary
- Moves the duplicated CJK/K-M-B breakpoint tables and AbbreviateNumbers plumbing out of DamageMeters and DataBars into a single shared EllesmereUI_NumberFormat.lua
- Each CJK locale file (zhCN, zhTW, koKR) registers its own abbreviation algorithm, so it ships inside that locale's load-on-demand file and never loads for English clients
- Options pages now query whether the current locale has its own abbreviation algorithm instead of hardcoding the zhCN/zhTW/koKR list
- The hot AbbreviateNumber() call path caches its resolved config instead of rebuilding it on every call

## Test plan
- Rebased onto latest main and resolved the resulting conflicts: DataBars' gold abbreviation now delegates fully to the shared engine, and its Force English Units option keeps the already-translated "(K/M/B)" wording while switching to the new generic locale-capability check
- This is a straight code-movement refactor with no intended behavior change
- Tested in-game: I've been using this branch for a while even before v9.0.8 released

## Caveat about API

`CreateAbbreviateConfig` and `AbbreviateNumbers` are supported on all modern clients by default, so I opted to drop the usual "does this api exist"(eg. `AbbreviateNumbers and AbbreviateNumbers()`) because having a fallback for "this api does not exist" ended up being just a bunch of dead code. I don't believe these functions will be removed anytime soon, so checking for their existence and having a fallback *just in case* made the code more complex than it needed to be.