### PR TITLE
fix(raidframes): use rez range for dead units when available

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -8245,11 +8245,22 @@ local function UpdateButtonRange(unit, btn)
     elseif UnitPhaseReason and UnitPhaseReason(unit) then
         ApplyRangeAlpha(btn, oorAlpha)
     elseif UnitIsDeadOrGhost(unit) then
-        -- Dead units use the standard ~40yd interact range (UnitInRange), the same
-        -- secret-safe path living non-spell-range units take, so corpses fade with
-        -- distance. (A rez-spell-only check would force full alpha for players with
-        -- no rez or an indeterminate rez range.)
-        ApplyRangeAlphaSecret(btn, UnitInRange(unit), 1, oorAlpha)
+        -- Ghost units need to be checked using a rez-spell because UnitInRange checks the ghost's range, not the corpse's.
+        -- We want to provide rez-range feedback based on the corpse's position.
+        if playerHasRez then
+            local r = C_Spell_IsSpellInRange(playerRezSpell, unit)
+            if r == true then
+                ApplyRangeAlpha(btn, 1)
+            elseif r == false then
+                ApplyRangeAlpha(btn, oorAlpha)
+            else
+                -- Use the standard ~40yd interact range (UnitInRange) as fallback
+                ApplyRangeAlphaSecret(btn, UnitInRange(unit), 1, oorAlpha)
+            end
+        else
+            -- Use the standard ~40yd interact range (UnitInRange) when player has no rez spell
+            ApplyRangeAlphaSecret(btn, UnitInRange(unit), 1, oorAlpha)
+        end
     elseif usesSpellRange then
         local r = C_Spell_IsSpellInRange(playerFriendlySpell, unit)
         if r == true then


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where dead units could have incorrect range-based alpha. The existing `UnitInRange` check was intended to determine whether the corpse was in range, but apparently for ghosts it checks the ghost's position instead of the corpse's position.

For players with a resurrection spell, the rez spell's range is now used to correctly determine the corpse's range. `UnitInRange` remains the fallback when no rez spell is available or its range cannot be determined.

## How was it tested?

Tested on the live 12.1 client, build 9.0.7.

* Checked range alpha is based on the corpse's position with a resurrection spell available.
* Checked `UnitInRange` fallback without a resurrection spell.


## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [n/a] New settings default **OFF** (no behavior change without opt-in)
- [n/a] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [n/a] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [n/a] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
