### PR TITLE
fix(resourcebars): arcane soul helper showing in spellslinger

### DIFF
--- a/EllesmereUIResourceBars/EUI_ResourceBars_ArcaneSoul.lua
+++ b/EllesmereUIResourceBars/EUI_ResourceBars_ArcaneSoul.lua
@@ -691,6 +691,19 @@ local function Park()
     if S.proxy then S.proxy:Hide() end
 end
 
+-- Mover callbacks are NOT unlock-mode-only: the spec-override layer flush
+-- re-applies stored positions on every spec/talent change, and GetBarFrame
+-- resolves anchors at any time. Both used to call Activate() behind nothing but
+-- EnabledForClass(), and Activate() ends in proxy:Show() -- so a swap away from
+-- Sunfury parked the display and the very same flush turned it straight back
+-- on. Spellslinger casts Arcane Surge too, so the Surge slot kept matching and
+-- the countdown rendered for real. Placement is always safe; SHOWING is the
+-- gate's to decide, and unlock mode is the one caller that overrides it (the
+-- mover has to be grabbable for any Mage).
+local function MoverShowOK()
+    return (EllesmereUI and EllesmereUI._unlockActive) or GateOK()
+end
+
 local function Activate()
     EnsureProxy()
     ApplyLook()
@@ -821,8 +834,16 @@ function ns.AS_MakeUnlockElement(MK)
         isHidden = function() return not EnabledForClass() end,
         getFrame = function()
             if not EnabledForClass() then return nil end
-            Activate()
-            if EllesmereUI._unlockActive then ShowSample() end
+            if EllesmereUI._unlockActive then
+                Activate()
+                ShowSample()
+            else
+                -- Outside unlock mode this is a pure geometry request (anchor
+                -- resolution), so it hands back the proxy WITHOUT showing it.
+                -- See MoverShowOK: Activate() ends in proxy:Show().
+                EnsureProxy()
+                if MoverShowOK() then Activate() end
+            end
             return S.proxy
         end,
         getSize = function() return ProxySize() end,
@@ -847,9 +868,10 @@ function ns.AS_MakeUnlockElement(MK)
         end,
         applyPos = function()
             if not EnabledForClass() then return end
-            Activate()
-            -- applyPos IS the "put it where it is stored" request, so it places
-            -- unconditionally -- unlike getFrame/Activate above.
+            EnsureProxy()
+            -- applyPos IS the "put it where it is stored" request, so it PLACES
+            -- unconditionally -- but placing is not showing (see MoverShowOK).
+            if MoverShowOK() then Activate() end
             ApplyPosition()
             if EllesmereUI._unlockActive then ShowSample() end
         end,


### PR DESCRIPTION
## What does this PR do?

Fixes the Arcane Soul helper appearing for Arcane Mages on the Spellslinger
hero tree. It is meant for Sunfury only.

The spec gate itself was correct: on a hero tree swap `TRAIT_CONFIG_UPDATED`
fires, `GateOK()` reads tree 40 and returns false, and `Park()` hides the
display. The problem was that the unlock mover's `getFrame` and `applyPos`
callbacks both called `Activate()` (which ends in `proxy:Show()`) behind only
`EnabledForClass()`, with no hero-tree check. Those callbacks are not
unlock-mode-only: the spec-override layer flush calls `applyPos` on every
spec/talent change, so it re-showed the display the gate had just parked.
It then rendered for real because Spellslinger casts Arcane Surge too, so the
Surge slot kept matching.

Both callbacks now show through a `MoverShowOK()` helper (`_unlockActive or
GateOK()`). Placement is unchanged and still unconditional; only showing is
gated. Unlock mode still overrides so the mover stays grabbable for any Mage,
matching the existing `isHidden`.

## How was it tested?

Live, 12.1. Instrumented the module with a temporary event probe (removed
before commit) and confirmed on an Arcane Mage that `TRAIT_CONFIG_UPDATED`
is caught on a hero tree swap and that `GateOK()` returns false on tree 40
while the display stayed on screen, which isolated the mover path as the
cause. Sunfury (39) unaffected.

## Screenshots

N/A

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new settings; bug fix only
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A, touches only this module's own frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added