### PR TITLE
feat(mythic-timer): add Always Show Split Times option

### DIFF
--- a/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
+++ b/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
@@ -562,7 +562,13 @@ local function UpdateObjectiveCompletion(obj, objectiveIndex)
 end
 
 local function BuildSplitCompareText(referenceTime, currentTime, deltaOnly, fasterColor, slowerColor)
-    if not referenceTime or not currentTime then return "" end
+    if not referenceTime then return "" end
+
+    -- No time to compare yet (boss still alive): the reference on its own, in the
+    -- same gray parentheses a completed objective uses, just without the +/-.
+    if not currentTime then
+        return format("  |cff888888(%s)|r", FormatTime(referenceTime))
+    end
 
     local diff = currentTime - referenceTime
     local color = diff <= 0 and fasterColor or slowerColor
@@ -989,10 +995,10 @@ local PREVIEW_RUN = {
     _previewAffixNames = { "Tyrannical", "Xal'atath's Bargain: Ascendant" },
     _previewAffixIDs = { 9, 152 },
     objectives    = {
-        { name = "Kyrioss",                 completed = true,  elapsed = 510,  quantity = 1,     totalQuantity = 1,   rawQuantity = 1, rawTotalQuantity = 1, percent = 0, isWeighted = false },
-        { name = "Stormguard Gorren",       completed = true,  elapsed = 1005, quantity = 1,     totalQuantity = 1,   rawQuantity = 1, rawTotalQuantity = 1, percent = 0, isWeighted = false },
-        { name = "Lua Error Monstrosity",   completed = false, elapsed = 0,    quantity = 0,     totalQuantity = 1,   rawQuantity = 0, rawTotalQuantity = 1, percent = 0, isWeighted = false },
-        { name = "|cffff3333Ellesmere|r",    completed = false, elapsed = 0,    quantity = 0,     totalQuantity = 1,   rawQuantity = 0, rawTotalQuantity = 1, percent = 0, isWeighted = false },
+        { name = "Kyrioss",                 completed = true,  elapsed = 510,  quantity = 1,     totalQuantity = 1,   rawQuantity = 1, rawTotalQuantity = 1, percent = 0, isWeighted = false, previewSplit = 528 },
+        { name = "Stormguard Gorren",       completed = true,  elapsed = 1005, quantity = 1,     totalQuantity = 1,   rawQuantity = 1, rawTotalQuantity = 1, percent = 0, isWeighted = false, previewSplit = 972 },
+        { name = "Lua Error Monstrosity",   completed = false, elapsed = 0,    quantity = 0,     totalQuantity = 1,   rawQuantity = 0, rawTotalQuantity = 1, percent = 0, isWeighted = false, previewSplit = 1500 },
+        { name = "|cffff3333Ellesmere|r",    completed = false, elapsed = 0,    quantity = 0,     totalQuantity = 1,   rawQuantity = 0, rawTotalQuantity = 1, percent = 0, isWeighted = false, previewSplit = 1770 },
         { name = "Enemy Forces",            completed = false, elapsed = 0,    quantity = 78.42, totalQuantity = 100, rawQuantity = 188, rawTotalQuantity = 240, percent = 78.42, isWeighted = true },
     },
 }
@@ -2553,14 +2559,24 @@ local function RenderStandalone()
                     timeStr = format("|cff%02x%02x%02x%s|r",
                         floor(cR * 255), floor(cG * 255), floor(cB * 255), FormatTime(obj.elapsed))
                 end
+                local compareMode = p.objectiveCompareMode or COMPARE_NONE
                 local compareSuffix = ""
-                if obj.completed and obj.referenceElapsed then
-                    compareSuffix = BuildSplitCompareText(obj.referenceElapsed, obj.elapsed, p.objectiveCompareDeltaOnly, p.splitFasterColor, p.splitSlowerColor)
-                elseif (not obj.completed) and p.showUpcomingSplitTargets and (p.objectiveCompareMode or COMPARE_NONE) ~= COMPARE_NONE then
-                    local target = GetReferenceObjectiveTime(run, i, p.objectiveCompareMode or COMPARE_NONE)
-                    if target then
-                        compareSuffix = "  |cff888888PB " .. FormatTime(target) .. "|r"
+                if obj.completed then
+                    local reference = obj.referenceElapsed
+                    if isPreview then
+                        reference = (compareMode ~= COMPARE_NONE) and obj.previewSplit or nil
                     end
+                    if reference then
+                        compareSuffix = BuildSplitCompareText(reference, obj.elapsed, p.objectiveCompareDeltaOnly, p.splitFasterColor, p.splitSlowerColor)
+                    end
+                elseif p.showUpcomingSplitTargets and compareMode ~= COMPARE_NONE then
+                    local target
+                    if isPreview then
+                        target = obj.previewSplit
+                    else
+                        target = GetReferenceObjectiveTime(run, i, compareMode)
+                    end
+                    compareSuffix = BuildSplitCompareText(target)
                 end
                 -- Timer/split text uses its own FontString (never truncated).
                 -- Boss name uses the remaining width (truncated with "..." by

--- a/EllesmereUIOptions/EUI_MythicTimer_Options.lua
+++ b/EllesmereUIOptions/EUI_MythicTimer_Options.lua
@@ -947,9 +947,16 @@ initFrame:SetScript("OnEvent", function(self)
               order=compareModeOrder,
               getValue=function() return Cfg("objectiveCompareMode") or "NONE" end,
               setValue=function(v) Set("objectiveCompareMode", v); Refresh() end })
-        -- Strict scoping cog: only meaningful for the level scopes (Per Dungeon is the fallback it removes).
+        -- Split Compare cog: strict scoping (only meaningful for the level scopes,
+        -- since Per Dungeon is the fallback it removes) and the upcoming-split target.
         if not EllesmereUI._prebuilding then
         _AttachPopupButton(row._rightRegion, EllesmereUI.COGS_ICON, "Split Compare", {
+            { type="toggle", label="Always Show Split Times",
+              tooltip="Shows your best split on upcoming bosses instead of only killed ones.",
+              disabled=function() return (Cfg("objectiveCompareMode") or "NONE") == "NONE" end,
+              disabledTooltip="This option requires a Split Compare mode",
+              get=function() return Cfg("showUpcomingSplitTargets") == true end,
+              set=function(v) Set("showUpcomingSplitTargets", v); Refresh() end },
             { type="toggle", label="Strict Comparison Mode",
               tooltip="Compare only against splits from the same key level (off: new key levels compare against your dungeon best).",
               disabled=function()


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

<!-- User-facing description: what changes for the player? -->
Allows the user to select whether or not to always show mythic+ splits for the dungeon.

## How was it tested?

<!-- Client build, what you tested in game, etc. -->
Latest retail

## Screenshots

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
