### PR TITLE
Fix Assisted Highlight glow customization

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -492,6 +492,11 @@ local defaults = {
         -- (default, unchanged behavior), 2 = flat tint over the whole button
         -- instead, 3 = both. The overlay leaves the button edge free for the
         -- proc glow, which is the point of offering it.
+        -- Optional custom Assisted Highlight glows are purely additive. A value
+        -- of 0 keeps the existing assistGlowStyle path and its current behavior.
+        assistGlowType = 0,
+        assistGlowColor = { r = 0.15, g = 0.5, b = 1 },
+        assistGlowUseClassColor = false,
         assistGlowStyle = 1,
         assistGlowOverlayColor = { r = 0.15, g = 0.5, b = 1 },
         assistGlowOverlayAlpha = 30,
@@ -10763,6 +10768,98 @@ do
         return hf
     end
 
+    -- Optional custom Assisted Highlight glows reuse the existing glow engines,
+    -- but remain completely separate from Custom Proc Glow profile state. These
+    -- helpers are stored on ns instead of file-scope locals because this chunk
+    -- intentionally stays at Lua's local-variable ceiling.
+    ns._AssistCustomGlowColor = function()
+        local p = EAB.db and EAB.db.profile
+        if p and p.assistGlowUseClassColor then
+            local _, class = UnitClass("player")
+            local cc = RAID_CLASS_COLORS[class]
+            if cc then return cc.r, cc.g, cc.b end
+            return 1, 1, 1
+        end
+        local c = (p and p.assistGlowColor) or { r = 0.15, g = 0.5, b = 1 }
+        return c.r or 0.15, c.g or 0.5, c.b or 1
+    end
+
+    ns._AssistCustomGlowStop = function(btn)
+        local fd = EFD(btn)
+        local wrapper = fd.assistGlowWrapper
+        if wrapper then
+            _G_Glows.StopAllGlows(wrapper)
+            wrapper:Hide()
+        end
+    end
+
+    ns._AssistCustomGlowStart = function(btn, loopIdx, cr, cg, cb, bW, bH)
+        local loopEntry = LOOP_GLOW_TYPES[loopIdx]
+        if not loopEntry then
+            ns._AssistCustomGlowStop(btn)
+            return false
+        end
+
+        local fd = EFD(btn)
+        if not fd.assistGlowWrapper then
+            local wrapper = CreateFrame("Frame", nil, btn)
+            wrapper:SetAllPoints(btn)
+            fd.assistGlowWrapper = wrapper
+        end
+
+        local wrapper = fd.assistGlowWrapper
+        wrapper:SetAllPoints(btn)
+        wrapper:SetFrameLevel(btn:GetFrameLevel() + 15)
+        wrapper:SetAlpha(1)
+
+        local wfd = EFD(wrapper)
+        if fd.shapeMask and fd.shapeApplied and fd.shapeMaskPath then
+            if not wfd.ownMask then
+                wfd.ownMask = wrapper:CreateMaskTexture()
+            end
+            wfd.ownMask:ClearAllPoints()
+            PP.Point(wfd.ownMask, "TOPLEFT", btn, "TOPLEFT", 1, -1)
+            PP.Point(wfd.ownMask, "BOTTOMRIGHT", btn, "BOTTOMRIGHT", -1, 1)
+            wfd.ownMask:SetTexture(fd.shapeMaskPath, "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+            wfd.ownMask:Show()
+        elseif wfd.ownMask then
+            wfd.ownMask:Hide()
+        end
+
+        -- This teardown/start pair is intentionally reached only after the
+        -- change guard in AssistShow detects a real type/size/color change.
+        _G_Glows.StopAllGlows(wrapper)
+        wrapper:Show()
+
+        if loopEntry.procedural then
+            local N, th, period = 8, 2, 4
+            local lineLen = floor((bW + bH) * (2 / N - 0.1))
+            lineLen = min(lineLen, min(bW, bH))
+            if lineLen < 1 then lineLen = 1 end
+            _G_Glows.StartProceduralAnts(wrapper, N, th, period, lineLen, cr, cg, cb, bW, bH)
+        elseif loopEntry.buttonGlow then
+            _G_Glows.StartButtonGlow(wrapper, bW, cr, cg, cb, nil, bH)
+        elseif loopEntry.autocast then
+            _G_Glows.StartAutoCastShine(wrapper, bW, cr, cg, cb, 1.0, bH)
+        elseif loopEntry.shapeGlow then
+            local maskPath = fd.shapeMaskPath or SHAPE_MASKS[fd.shapeName or ""]
+            local borderPath = SHAPE_BORDERS[fd.shapeName or ""]
+            _G_Glows.StartShapeGlow(wrapper, min(bW, bH), cr, cg, cb, 1.20, {
+                maskPath    = maskPath,
+                borderPath  = borderPath,
+                shapeMask   = fd.shapeMask,
+                anchorFrame = btn,
+            })
+        else
+            _G_Glows.StartFlipBookGlow(wrapper, bW, loopEntry, cr, cg, cb, bH)
+        end
+
+        if wfd.ownMask and wfd.ownMask:IsShown() then
+            MaskFrameTextures(wrapper, wfd.ownMask)
+        end
+        return true
+    end
+
     -- Ring teardown alone. Split out of AssistHide because AssistShow also
     -- needs it on its own: with the overlay style picked, or with Blizzard
     -- painting its own ring on a hovered button, our ring must go while the
@@ -10843,6 +10940,14 @@ do
     -- button that stops being the suggestion (or the CVar going off) must not
     -- leave it invisible for whoever shows it next.
     local function AssistHide(btn)
+        local fd = EFD(btn)
+        if fd.assistCustomActive then
+            ns._AssistCustomGlowStop(btn)
+            fd.assistCustomActive = nil
+            fd.assistCustomType = nil
+            fd.assistCustomW, fd.assistCustomH = nil, nil
+            fd.assistCustomR, fd.assistCustomG, fd.assistCustomB = nil, nil, nil
+        end
         ns._AssistRingHide(btn)
         ns._AssistOverlay(btn)
         local bf = btn.AssistedCombatHighlightFrame
@@ -10873,7 +10978,99 @@ do
     local function AssistShow(btn)
         local fd = EFD(btn)
         local p = EAB.db and EAB.db.profile
+        local customType = (p and p.assistGlowType) or 0
+        if customType < 1 or customType > #LOOP_GLOW_TYPES or not LOOP_GLOW_TYPES[customType] then
+            customType = 0
+        end
+
+        if customType > 0 then
+            -- Purely additive opt-in path. Existing users never create this
+            -- wrapper and continue through the original legacy style code below.
+            local ov = fd.assistOverlay
+            if ov and ov:IsShown() then ns._AssistOverlay(btn) end
+            local hf = fd.assistHL
+            if hf and hf:IsShown() then ns._AssistRingHide(btn) end
+
+            local bf = btn.AssistedCombatHighlightFrame
+            if bf and bf:GetAlpha() ~= 0 then bf:SetAlpha(0) end
+
+            local cr, cg, cb = ns._AssistCustomGlowColor()
+            local bW, bH = btn:GetWidth() or 45, btn:GetHeight() or 45
+
+            -- UpdateAssistHighlights may revisit the same suggestion up to about
+            -- seven times per second. Do not Stop/Start the custom engine unless
+            -- something that affects its rendering actually changed.
+            if fd.assistCustomActive
+               and fd.assistCustomType == customType
+               and fd.assistCustomW == bW
+               and fd.assistCustomH == bH
+               and fd.assistCustomR == cr
+               and fd.assistCustomG == cg
+               and fd.assistCustomB == cb
+               and fd.assistGlowWrapper
+               and fd.assistGlowWrapper:IsShown() then
+                return
+            end
+
+            if ns._AssistCustomGlowStart(btn, customType, cr, cg, cb, bW, bH) then
+                fd.assistCustomActive = true
+                fd.assistCustomType = customType
+                fd.assistCustomW, fd.assistCustomH = bW, bH
+                fd.assistCustomR, fd.assistCustomG, fd.assistCustomB = cr, cg, cb
+            end
+            return
+        end
+
+        -- Leaving an opt-in custom glow returns to the exact pre-existing EUI
+        -- Assisted Highlight style path and restores Blizzard's frame alpha.
+        if fd.assistCustomActive then
+            ns._AssistCustomGlowStop(btn)
+            fd.assistCustomActive = nil
+            fd.assistCustomType = nil
+            fd.assistCustomW, fd.assistCustomH = nil, nil
+            fd.assistCustomR, fd.assistCustomG, fd.assistCustomB = nil, nil, nil
+            local bf = btn.AssistedCombatHighlightFrame
+            if bf and bf:GetAlpha() ~= 1 then bf:SetAlpha(1) end
+        end
+
         local style = (p and p.assistGlowStyle) or 1
+
+        -- Explicit "Default (Blizzard)" entry. Keep all EUI-only styling out of
+        -- this path: no overlay, no outset and no procedural glow. Our custom
+        -- EABButton frames are normally absent from Blizzard's candidate list,
+        -- so when Blizzard has not already created/shown its own highlight frame
+        -- we fall back to the same Blizzard assisted-highlight template locally.
+        -- The animation state is change-guarded so the 0.15 s rescan does not
+        -- restart the flipbook. Existing profiles still default to style 1.
+        if style == 0 then
+            ns._AssistOverlay(btn)
+            local bf = btn.AssistedCombatHighlightFrame
+            if bf and bf:GetAlpha() ~= 1 then bf:SetAlpha(1) end
+            if bf and bf:IsShown() then
+                ns._AssistRingHide(btn)
+                return
+            end
+
+            local hf = fd.assistHL
+            if not hf then
+                hf = AssistCreate(btn)
+                if not hf then return end
+                fd.assistHL = hf
+            end
+            local s = (btn:GetWidth() or 45) / 45
+            if s < 0.05 then s = 0.05 end
+            if hf:GetScale() ~= s then hf:SetScale(s) end
+            hf:SetFrameLevel(btn:GetFrameLevel() + 15)
+            hf:Show()
+            if hf.Flipbook and hf.Flipbook.Anim then
+                if _assistInCombat then
+                    if not hf.Flipbook.Anim:IsPlaying() then hf.Flipbook.Anim:Play() end
+                else
+                    if hf.Flipbook.Anim:IsPlaying() then hf.Flipbook.Anim:Stop() end
+                end
+            end
+            return
+        end
 
         -- Tint: always ours, Blizzard never paints one.
         ns._AssistOverlay(btn, style)

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -5432,8 +5432,63 @@ initFrame:SetScript("OnEvent", function(self)
         end
     end
 
+    -- Assisted Highlight preview uses only local textures, so opening the
+    -- options page never starts/stops any live glow engine.
+    local function UpdateAssistGlowPreview(f)
+        if not f then return end
+        local p = EAB.db and EAB.db.profile or {}
+        local customType = p.assistGlowType or 0
+        local style = p.assistGlowStyle or 1
+
+        if not f._assistOverlay then
+            local ov = f:CreateTexture(nil, "OVERLAY", nil, 1)
+            ov:SetAllPoints()
+            f._assistOverlay = ov
+        end
+        if not f._assistRing then
+            local ring = {}
+            for i = 1, 4 do
+                local t = f:CreateTexture(nil, "OVERLAY", nil, 2)
+                t:SetColorTexture(1, 1, 1, 1)
+                ring[i] = t
+            end
+            f._assistRing = ring
+        end
+
+        local ov = f._assistOverlay
+        local ring = f._assistRing
+        ov:Hide()
+        for i = 1, 4 do ring[i]:Hide() end
+
+        if customType > 0 then
+            local cr, cg, cb
+            if p.assistGlowUseClassColor then
+                local _, class = UnitClass("player")
+                local cc = RAID_CLASS_COLORS[class]
+                cr, cg, cb = cc and cc.r or 1, cc and cc.g or 1, cc and cc.b or 1
+            else
+                local c = p.assistGlowColor or { r = 0.15, g = 0.5, b = 1 }
+                cr, cg, cb = c.r or 0.15, c.g or 0.5, c.b or 1
+            end
+            for i = 1, 4 do ring[i]:SetColorTexture(cr, cg, cb, 1) end
+            ring[1]:ClearAllPoints(); ring[1]:SetPoint("TOPLEFT", f); ring[1]:SetPoint("TOPRIGHT", f); ring[1]:SetHeight(2)
+            ring[2]:ClearAllPoints(); ring[2]:SetPoint("BOTTOMLEFT", f); ring[2]:SetPoint("BOTTOMRIGHT", f); ring[2]:SetHeight(2)
+            ring[3]:ClearAllPoints(); ring[3]:SetPoint("TOPLEFT", ring[1], "BOTTOMLEFT"); ring[3]:SetPoint("BOTTOMLEFT", ring[2], "TOPLEFT"); ring[3]:SetWidth(2)
+            ring[4]:ClearAllPoints(); ring[4]:SetPoint("TOPRIGHT", ring[1], "BOTTOMRIGHT"); ring[4]:SetPoint("BOTTOMRIGHT", ring[2], "TOPRIGHT"); ring[4]:SetWidth(2)
+            for i = 1, 4 do ring[i]:Show() end
+            return
+        end
+
+        if style == 2 or style == 3 then
+            local c = p.assistGlowOverlayColor or { r = 0.15, g = 0.5, b = 1 }
+            local a = (p.assistGlowOverlayAlpha or 30) / 100
+            ov:SetColorTexture(c.r or 0.15, c.g or 0.5, c.b or 1, a)
+            ov:Show()
+        end
+    end
+
     -- Persistent preview icon frames (survive page cache restores)
-    local _pushedPreview, _highlightPreview, _procGlowPreview
+    local _pushedPreview, _highlightPreview, _procGlowPreview, _assistGlowPreview
 
     local function BuildAnimationsPage(pageName, parent, yOffset)
         local W = EllesmereUI.Widgets
@@ -5779,65 +5834,169 @@ initFrame:SetScript("OnEvent", function(self)
         end
         y = y - h
 
-        -- Assisted Highlight. Blizzard's ring sits on the same button edge as
-        -- the proc glow and has no size control of its own, so we offer two
-        -- ways to tell them apart: push the ring clear with an outset, or drop
-        -- the ring for a flat tint that leaves the edge to the proc glow.
-        -- Values mirror p.assistGlowStyle: 1 = ring, 2 = overlay, 3 = both.
+        -- Keep the existing EUI styles and append custom glow engines as
+        -- explicit opt-in entries in the same Assisted Highlight dropdown.
         local function AssistOff()
             return not (GetCVarBool and GetCVarBool("assistedCombatHighlight"))
         end
+        local assistValues = {
+            [0] = "Default (Blizzard)",
+            [1] = "Glow Ring",
+            [2] = "Button Overlay",
+            [3] = "Ring + Overlay",
+        }
+        local assistOrder = { 0, 1, 2, 3 }
+        for i, entry in ipairs(ns.LOOP_GLOW_TYPES or {}) do
+            if not entry.shapeGlow then
+                assistValues[100 + i] = entry.name
+                assistOrder[#assistOrder + 1] = 100 + i
+            end
+        end
+        local function assistCustomSelected()
+            return (p.assistGlowType or 0) > 0
+        end
+
         local assistRow
         assistRow, h = W:DualRow(parent, y,
             { type="dropdown", text="Assisted Highlight",
-              values={ [1]="Glow Ring", [2]="Button Overlay", [3]="Ring + Overlay" },
-              order={ 1, 2, 3 },
-              tooltip="How Blizzard's next-spell suggestion is drawn on the button. Button Overlay replaces the blue ring with a flat tint, leaving the button edge free for the proc glow.",
+              values=assistValues, order=assistOrder,
+              tooltip="Use Blizzard-style highlighting, the existing EUI styles, or an optional custom glow. Existing users keep Glow Ring unless they choose another entry.",
               disabled=AssistOff,
               disabledTooltip="This option requires Blizzard's Assisted Highlight to be enabled",
               rawTooltip=true,
-              getValue=function() return p.assistGlowStyle or 1 end,
+              getValue=function()
+                  local custom = p.assistGlowType or 0
+                  if custom > 0 then return 100 + custom end
+                  return p.assistGlowStyle or 1
+              end,
               setValue=function(v)
-                  p.assistGlowStyle = v
+                  if v >= 100 then
+                      -- Custom glows are opt-in and do not overwrite the user's
+                      -- saved legacy style; switching back restores that style.
+                      p.assistGlowType = v - 100
+                  else
+                      p.assistGlowType = 0
+                      p.assistGlowStyle = v
+                  end
                   if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
-                  -- Deferred like the proc-glow dropdown above: a synchronous
-                  -- rebuild tears the dropdown down inside its own click handler.
+                  UpdateAssistGlowPreview(_assistGlowPreview)
                   C_Timer.After(0, function() EllesmereUI:RefreshPage() end)
               end },
+            { type="toggle", text="Use Class Color",
+              disabled=function() return AssistOff() or not assistCustomSelected() end,
+              disabledTooltip="This option requires a custom Assisted Highlight glow to be selected",
+              rawTooltip=true,
+              getValue=function() return p.assistGlowUseClassColor end,
+              setValue=function(v)
+                  p.assistGlowUseClassColor = v
+                  if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
+                  UpdateAssistGlowPreview(_assistGlowPreview)
+                  EllesmereUI:RefreshPage()
+              end })
+
+        if not EllesmereUI._prebuilding then
+            local leftRgn = assistRow._leftRegion
+            _assistGlowPreview = CreatePreviewIcon(leftRgn)
+            if _assistGlowPreview._icon then
+                _assistGlowPreview._icon:SetTexture(GetNthActionButtonIcon(4))
+                _assistGlowPreview._icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+            end
+            UpdateAssistGlowPreview(_assistGlowPreview)
+            EllesmereUI.RegisterWidgetRefresh(function() UpdateAssistGlowPreview(_assistGlowPreview) end)
+
+            local assistSwatchGet = function()
+                local c = p.assistGlowColor or { r = 0.15, g = 0.5, b = 1 }
+                return c.r, c.g, c.b
+            end
+            local assistSwatchSet = function(r, g, b)
+                p.assistGlowColor = { r = r, g = g, b = b }
+                if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
+                UpdateAssistGlowPreview(_assistGlowPreview)
+            end
+            local assistSwatch, assistUpdateSwatch = EllesmereUI.BuildColorSwatch(
+                leftRgn, leftRgn:GetFrameLevel() + 5,
+                assistSwatchGet, assistSwatchSet, nil, 20)
+            PP.Point(assistSwatch, "RIGHT", _assistGlowPreview, "LEFT", -12, 0)
+            assistSwatch:HookScript("OnEnter", function(self)
+                if AssistOff() then
+                    EllesmereUI.ShowWidgetTooltip(self, "This option requires Blizzard's Assisted Highlight to be enabled")
+                elseif not assistCustomSelected() then
+                    EllesmereUI.ShowWidgetTooltip(self, "This option requires a custom Assisted Highlight glow to be selected")
+                elseif p.assistGlowUseClassColor then
+                    EllesmereUI.ShowWidgetTooltip(self, EllesmereUI.DisabledTooltip("Class Colors", "disabled"))
+                end
+            end)
+            assistSwatch:HookScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = AssistOff() or not assistCustomSelected() or p.assistGlowUseClassColor
+                assistSwatch:SetAlpha(off and 0.15 or 1)
+                assistSwatch:SetMouseClickEnabled(not off)
+                assistUpdateSwatch()
+            end)
+            local initAssistOff = AssistOff() or not assistCustomSelected() or p.assistGlowUseClassColor
+            assistSwatch:SetAlpha(initAssistOff and 0.15 or 1)
+            assistSwatch:SetMouseClickEnabled(not initAssistOff)
+        end
+        y = y - h
+
+        local overlayOpacityRow
+        overlayOpacityRow, h = W:DualRow(parent, y,
             { type="slider", text="Overlay Opacity", min=0, max=100, step=1,
               tooltip="Opacity of the Button Overlay tint.",
-              disabled=function() return AssistOff() or (p.assistGlowStyle or 1) == 1 end,
-              disabledTooltip="This option requires the Button Overlay style",
+              disabled=function()
+                  local style = p.assistGlowStyle or 1
+                  return AssistOff() or assistCustomSelected() or (style ~= 2 and style ~= 3)
+              end,
+              disabledTooltip="This option requires the Button Overlay or Ring + Overlay style",
               rawTooltip=true,
               getValue=function() return p.assistGlowOverlayAlpha or 30 end,
               setValue=function(v)
                   p.assistGlowOverlayAlpha = v
                   if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
-              end });  y = y - h
+                  UpdateAssistGlowPreview(_assistGlowPreview)
+              end },
+            { type="spacer" }); y = y - h
 
-        -- Inline swatch: overlay tint color, next to the opacity slider it belongs to.
         if not EllesmereUI._prebuilding then
-            EllesmereUI.BuildInlineSwatches(assistRow._rightRegion, {
-                { tooltip = "Button Overlay Color", hasAlpha = false,
-                  getValue = function()
-                      local c = p.assistGlowOverlayColor or { r = 0.15, g = 0.5, b = 1 }
-                      return c.r, c.g, c.b
-                  end,
-                  setValue = function(r, g, b)
-                      p.assistGlowOverlayColor = { r = r, g = g, b = b }
-                      if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
-                  end },
-            }, {
-                disabled = function() return AssistOff() or (p.assistGlowStyle or 1) == 1 end,
-                disabledTooltip = "This option requires the Button Overlay style",
-            })
+            local leftRgn = overlayOpacityRow._leftRegion
+            local ctrl = leftRgn._control
+            local overlaySwatch, overlayUpdateSwatch = EllesmereUI.BuildColorSwatch(
+                leftRgn, leftRgn:GetFrameLevel() + 5,
+                function()
+                    local c = p.assistGlowOverlayColor or { r = 0.15, g = 0.5, b = 1 }
+                    return c.r, c.g, c.b
+                end,
+                function(r, g, b)
+                    p.assistGlowOverlayColor = { r = r, g = g, b = b }
+                    if ns.UpdateAssistHighlights then ns.UpdateAssistHighlights() end
+                    UpdateAssistGlowPreview(_assistGlowPreview)
+                end, false, 20)
+            if ctrl then
+                PP.Point(overlaySwatch, "RIGHT", ctrl, "LEFT", -10, 0)
+            else
+                PP.Point(overlaySwatch, "RIGHT", leftRgn, "RIGHT", -6, 0)
+            end
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local style = p.assistGlowStyle or 1
+                local disabled = AssistOff() or assistCustomSelected() or (style ~= 2 and style ~= 3)
+                overlaySwatch:SetAlpha(disabled and 0.15 or 1)
+                overlaySwatch:SetMouseClickEnabled(not disabled)
+                overlayUpdateSwatch()
+            end)
+            local initOverlayStyle = p.assistGlowStyle or 1
+            local initOverlayOff = AssistOff() or assistCustomSelected() or (initOverlayStyle ~= 2 and initOverlayStyle ~= 3)
+            overlaySwatch:SetAlpha(initOverlayOff and 0.15 or 1)
+            overlaySwatch:SetMouseClickEnabled(not initOverlayOff)
         end
 
         _, h = W:DualRow(parent, y,
             { type="slider", text="Assisted Highlight Outset", min=-10, max=30, step=1,
               tooltip="Moves the blue Assisted Highlight ring outward (or inward at negative values) so it no longer overlaps the proc glow on the same button. With Ring + Overlay the tint resizes along with it, so the two stay flush.",
-              disabled=function() return AssistOff() or (p.assistGlowStyle or 1) == 2 end,
-              disabledTooltip="This option requires a style that draws the glow ring",
+              disabled=function()
+                  local style = p.assistGlowStyle or 1
+                  return AssistOff() or assistCustomSelected() or (style ~= 1 and style ~= 3)
+              end,
+              disabledTooltip="This option requires Glow Ring or Ring + Overlay",
               rawTooltip=true,
               getValue=function() return p.assistGlowOutset or 0 end,
               setValue=function(v)


### PR DESCRIPTION
## Summary

Add opt-in Assisted Highlight glow customization to Action Bars while preserving the existing EUI Assisted Highlight behavior and settings.

This update is now based on v9.1.5 and addresses the performance/settings concerns raised in review.

## Changes

- Keep the existing Assisted Highlight options:
  - Default (Blizzard)
  - Glow Ring
  - Button Overlay
  - Ring + Overlay
  - Overlay Opacity
  - Assisted Highlight Outset
- Add the Custom Proc Glow styles to the existing Assisted Highlight dropdown as optional choices.
- Add an independent Assisted Highlight color setting.
- Add independent Class Color support for custom Assisted Highlight glows.
- Keep Assisted Highlight settings fully separate from Custom Proc Glow:
  - `assistGlowType`
  - `assistGlowColor`
  - `assistGlowUseClassColor`
- Preserve the existing `assistGlowStyle` setting and its default behavior for existing users.
- Add a dedicated Assisted Highlight preview.

## Performance / compatibility

Custom Assisted Highlight glows are purely opt-in.

Existing users continue to use the previous Assisted Highlight path unless they explicitly select one of the new custom glow types.

The custom glow path is change-guarded before calling `StopAllGlows()` and starting a new procedural glow. The guard checks the active glow type, button size, glow color, and wrapper state.

As a result, the rate-limited Assisted Highlight rescan does not restart the procedural animation when nothing has changed.

The existing Blizzard/EUI highlight path remains separate and does not use the procedural custom-glow engine.

## Behavior

Custom Proc Glow and Assisted Highlight use independent settings.

Changing:

`procGlowType` / `procGlowColor` / `procGlowUseClassColor`

does not change:

`assistGlowType` / `assistGlowColor` / `assistGlowUseClassColor`

and vice versa.

Switching back from a custom Assisted Highlight glow restores the selected legacy/Blizzard Assisted Highlight behavior.

## Testing

The implementation was previously tested in-game on v9.1.3 with:

- Default (Blizzard)
- Glow Ring
- Button Overlay
- Ring + Overlay
- Custom Assisted Highlight glow types
- Custom colors
- Class colors
- Overlay opacity
- Assisted Highlight outset
- Switching between legacy and custom glow modes
- Independence from Custom Proc Glow

The same Assisted Highlight commit has now been cleanly rebased onto v9.1.5 without conflicts or additional unrelated changes.