### PR TITLE
Fix(Visibility Options): Mouseover still combining as AND under Match Any

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -8556,6 +8556,27 @@ function EAB_VTABLE.Hover.GetState(barKey, frame)
     return state
 end
 
+-- The alpha a bar RESTS at while the cursor is not on it, plus whether that resting state
+-- is a hover gate. Single source of truth for every alpha writer here, so a fade-out
+-- cannot land on a different verdict than the visibility refresh would. mouseoverEnabled
+-- is STATIC (true whenever mouseover is selected at all, any Match Mode), so it can only
+-- answer "is the hover mechanism wired"; VisWantsMouseover answers "is it gating now".
+-- _savedBarAlpha is load-bearing: ApplyMode parks mouseoverAlpha at 0 and stashes the real
+-- value there while a mouseover selection is stored, so the shown branch would paint 0.
+-- On the vtable, not a chunk local (main chunk is at the 200-local cap).
+function EAB_VTABLE.Hover.RestingAlpha(barKey, s)
+    s = s or EAB_VTABLE.Hover.GetSettings(barKey)
+    if not s then return 1, false end
+    local wantsHover
+    if s.mouseoverEnabled and EllesmereUI.VisWantsMouseover then
+        wantsHover = EllesmereUI.VisWantsMouseover(s, "barVisibility", nil, EllesmereUI.VIS_CAPS_DEFAULT)
+    else
+        wantsHover = s.mouseoverEnabled
+    end
+    if wantsHover then return 0, true end
+    return s._savedBarAlpha or s.mouseoverAlpha or 1, false
+end
+
 -- Fade ONE bar in, no broadcast. The fadeDir memo makes repeat calls while
 -- already fading/faded O(1) table reads, so a sweep across a bar's 12 buttons
 -- costs 12 memo hits and one real fade. On the vtable, not a chunk local
@@ -8599,11 +8620,15 @@ function EAB_VTABLE.Hover.FadeOut(barKey, state)
     if _gridState.shown then return end  -- keep bars visible during spell drag
     local s = EAB_VTABLE.Hover.GetSettings(barKey)
     if s and s.mouseoverEnabled and state and state.fadeDir ~= "out" then
+        -- Fade back to the bar's RESTING alpha, not a hardcoded 0: under Any a passing
+        -- disjunct keeps the bar visible with no hover involved, and fading it away here
+        -- would leave it wrong until the next visibility refresh.
+        local resting = EAB_VTABLE.Hover.RestingAlpha(barKey, s)
         state.fadeDir = "out"
         StopFade(state.frame)
         -- `manual`: same lockstep rationale as FadeInOne.
-        FadeTo(state.frame, 0, s.mouseoverSpeed or 0.15, true)
-        if barKey == "MainBar" then SyncPagingAlpha(0) end
+        FadeTo(state.frame, resting, s.mouseoverSpeed or 0.15, true)
+        if barKey == "MainBar" then SyncPagingAlpha(resting) end
     end
 end
 
@@ -8764,11 +8789,14 @@ local function AttachHoverHooks(barKey)
     end
 end
 
-function EAB:RefreshMouseover()
+-- onlyHoverGated: visit ONLY the bars whose hover gate can move on a state edge (Match
+-- Any plus mouseover). The edge-driven caller passes it so a target change does not drag
+-- every other bar through a StopFade/SetAlpha it cannot need.
+function EAB:RefreshMouseover(onlyHoverGated)
     for _, info in ipairs(ALL_BARS) do
         local key = info.key
         local s = self.db.profile.bars[key]
-        if s then
+        if s and (not onlyHoverGated or (s.mouseoverEnabled and s.visibilityMatch == "any")) then
             local frame = barFrames[key] or (info.isDataBar and dataBarFrames[key]) or (info.isBlizzardMovable and blizzMovableHolders[key]) or (extraBarHolders[key]) or (info.visibilityOnly and _G[info.frameName])
             if frame then
                 -- For extra bars (MicroBar, BagBar), fade the Blizzard frame directly
@@ -8792,11 +8820,18 @@ function EAB:RefreshMouseover()
                     if info.visibilityOnly and not info.isDataBar and not info.isBlizzardMovable then
                         AttachExtraBarHoverHooks(info)
                     end
-                    StopFade(frame)
-                    frame:SetAlpha(0)
                     local state = hoverStates[key]
-                    if state then state.fadeDir = "out" end
-                    if key == "MainBar" then SyncPagingAlpha(0) end
+                    -- A bar the cursor is sitting on keeps what the hover gave it. This
+                    -- used to be safe by accident (the function only ran on settings
+                    -- changes); it now also runs on combat/group/mount edges, where
+                    -- repainting would yank a hovered bar invisible mid-hover.
+                    if not (state and state.isHovered) then
+                        local resting = EAB_VTABLE.Hover.RestingAlpha(key, s)
+                        StopFade(frame)
+                        frame:SetAlpha(resting)
+                        if state then state.fadeDir = (resting == 0) and "out" or nil end
+                        if key == "MainBar" then SyncPagingAlpha(resting) end
+                    end
                 else
                     StopFade(frame)
                     frame:SetAlpha(s.mouseoverAlpha or 1)
@@ -9123,16 +9158,17 @@ function EAB_VTABLE.ExtraBars.ApplyManagedNonSecureAlpha(info, frame, s)
     if not frame or not s or not frame:IsShown() then return end
 
     local hstate = hoverStates[info.key]
-    if s.mouseoverEnabled then
+    local resting, hoverGated = EAB_VTABLE.Hover.RestingAlpha(info.key, s)
+    if hoverGated then
         if hstate and hstate.isHovered then
             frame:SetAlpha(1)
             hstate.fadeDir = "in"
         else
-            frame:SetAlpha(0)
+            frame:SetAlpha(resting)
             if hstate then hstate.fadeDir = "out" end
         end
     else
-        frame:SetAlpha(s.mouseoverAlpha or 1)
+        frame:SetAlpha(resting)
         if hstate then hstate.fadeDir = nil end
     end
 end
@@ -9311,10 +9347,17 @@ function EAB:_RefreshSoftTargetGate()
     --   _anyNonMacroVis  -- any bar using ANY non-macro visibility option, or
     --   a managed non-secure bar; when false, UpdateHousingVisibility has
     --   nothing it could ever change and skips entirely.
-    local anySoft, anyNonMacro = false, false
+    --   _anyHoverGated   -- any bar whose hover gate can OPEN and CLOSE on a state edge
+    --   (Match Any plus mouseover). Only those need the resting alpha re-derived when
+    --   combat/group/mount state moves; under All a mouseover bar is hover-gated for as
+    --   long as the setting stands, so its alpha never changes off an edge.
+    local anySoft, anyNonMacro, anyHoverGated = false, false, false
     for _, info in ipairs(ALL_BARS) do
         local s = self.db.profile.bars[info.key]
         if s then
+            if s.mouseoverEnabled and s.visibilityMatch == "any" then
+                anyHoverGated = true
+            end
             -- Under Any the counter lane carries the soft-target correction too, so it
             -- arms the same machinery; under All it never did and still does not.
             if s.visHideNoTarget or (s.visHideWithTarget and s.visibilityMatch == "any") then
@@ -9336,6 +9379,18 @@ function EAB:_RefreshSoftTargetGate()
     end
     self._anyHideNoTarget = anySoft
     self._anyNonMacroVis = anyNonMacro
+    self._anyHoverGated = anyHoverGated
+end
+
+-- Re-derive the resting alpha of every hover-gated bar. Registered once with the shared
+-- visibility dispatcher (below), which already watches the exact edge set this depends on
+-- (combat, group, target, mount, zone, shapeshift, gliding) and fans out one frame later.
+-- Alpha only: no Show/Hide, no driver registration, so this is safe inside combat lockdown
+-- and carries no taint exposure. Fully gated -- users with no Any-plus-mouseover bar pay
+-- one flag read per dispatcher event.
+function EAB:RefreshHoverGatedAlpha()
+    if not self._anyHoverGated then return end
+    self:RefreshMouseover(true)
 end
 
 function EAB:RefreshRuntimeVisibility()
@@ -13949,6 +14004,16 @@ function EAB:FinishSetup()
     -- machinery costs nothing. The state token is four cached booleans (no per-tick
     -- allocation); refresh only runs when a token actually flips.
     self:_RefreshSoftTargetGate()
+    -- Hover-gated bars (Match Any plus mouseover) need their resting alpha re-derived
+    -- whenever the state their other disjuncts read moves. Rather than hand-wiring the
+    -- five relevant events here, ride the shared visibility dispatcher: it already watches
+    -- exactly that set, pcall-wraps each updater and defers one frame (imperceptible for
+    -- alpha). Same registration Friends, Quest Tracker and Damage Meters use.
+    if EllesmereUI.RegisterVisibilityUpdater then
+        EllesmereUI.RegisterVisibilityUpdater(function()
+            EAB:RefreshHoverGatedAlpha()
+        end)
+    end
     local lastI, lastE, lastF, lastT
     local function PollSoftTargetState()
         if InCombatLockdown() then return end

--- a/EllesmereUIOptions/EllesmereUI_Widgets.lua
+++ b/EllesmereUIOptions/EllesmereUI_Widgets.lua
@@ -8466,7 +8466,7 @@ EllesmereUI.VIS_ROW_ITEMS = {
     { key = "always",    label = "Always" },
     { key = "mouseover", label = "Mouseover",
       tooltip = "Reveal on hover only. Combines with the conditions below: hover-reveals while they all pass, stays hidden while any fails.",
-      tooltipAny = "Reveal on hover only. Combines with the conditions below: hover-reveals while at least ONE passes, stays hidden while none does." },
+      tooltipAny = "Combines with the conditions below: shows outright once at least one passes, otherwise still reveals on hover." },
     -- Modifiers, not conditions: they decide how the rows below combine, so they stay
     -- out of the summary and the Show/Hide lane pairs. Radio pair (matchValue) over one
     -- scalar: picking one unpicks the other, there is no "neither" state.

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -10884,19 +10884,59 @@ function ns.ResolveFrameAlpha(s, inCombat)
     return 1
 end
 
+-- The alpha a unit frame RESTS at while the cursor is not on it, plus whether that resting
+-- state is a hover gate (an alpha 0 a hover may legitimately lift). Single source of truth:
+-- the visibility pass and both hover handlers derive from it, so a mouse leave cannot land
+-- on a different verdict than the pass would. On ns for the 200-locals cap. hiddenByOpts
+-- leads because it did in the pass too (it re-forced 0 at the end of the chain); returning
+-- hoverGated false with it stops a hover from revealing what an option lane has hidden.
+function ns.ResolveVisResting(s, frame, ext, hiddenByOpts, inCombat)
+    if hiddenByOpts then return 0, false end
+    local shownAlpha = ns.ResolveFrameAlpha(s, inCombat)
+    if ext == "mouseover" then return 0, true end
+    if ext ~= nil then
+        -- Driver registered: it owns hiding, so alpha only carries the ooc fade.
+        if frame and frame._euiVisDriver then return shownAlpha, false end
+        return ext and shownAlpha or 0, false
+    end
+    local vis = s.barVisibility or "always"
+    if vis == "in_combat" then return inCombat and shownAlpha or 0, false end
+    if vis == "out_of_combat" then return (not inCombat) and shownAlpha or 0, false end
+    if vis == "mouseover" then
+        -- Legacy single mouseover: a configured "Hide if" override that is NOT currently
+        -- triggering counts as a positive show, so the frame does not require hover
+        -- (fixes "dismount in combat keeps frame hidden" / "hide if no target inverted").
+        local hasAnyHideOpt = EllesmereUI and EllesmereUI.VisHasAnyOption
+                           and EllesmereUI.VisHasAnyOption(s)
+        if hasAnyHideOpt then return shownAlpha, false end
+        return 0, true
+    end
+    return shownAlpha, false
+end
+
+-- Same verdict for callers outside the visibility pass (the hover handlers): derives the
+-- two inputs the pass would have handed over. State is left nil so the shared engine fills
+-- it from its own combat/group tracking.
+function ns.ResolveVisRestingLive(s, frame)
+    local hiddenByOpts = EllesmereUI and EllesmereUI.CheckVisibilityOptions
+                      and EllesmereUI.CheckVisibilityOptions(s)
+    local ext = EllesmereUI.EvalVisibilityExtended
+        and EllesmereUI.EvalVisibilityExtended(s, "barVisibility", nil, EllesmereUI.VIS_CAPS_DEFAULT)
+    return ns.ResolveVisResting(s, frame, ext, hiddenByOpts, InCombatLockdown())
+end
+
 local function UnitFrame_OnEnter(self)
     local unit = self._euiUnit
     if not unit then return end
     local unitKey = unit:match("^boss%d$") and "boss" or unit
     local s = db and db.profile and db.profile[unitKey]
     if s and (s.barVisibility or "always") == "mouseover" then
-        -- Hover-gated sets only reveal while their conditions pass; a
-        -- legacy single "mouseover" reveals unconditionally as before.
-        local eligible = true
-        if EllesmereUI.VisWantsMouseover then
-            eligible = EllesmereUI.VisWantsMouseover(s, "barVisibility", nil, EllesmereUI.VIS_CAPS_DEFAULT)
-        end
-        if eligible then
+        -- Reveal only what is actually hover-gated right now. Under Any the frame may
+        -- already be shown on another passing disjunct, in which case there is nothing to
+        -- reveal and OnLeave must not undo anything either -- both handlers read the same
+        -- resting verdict so they cannot disagree.
+        local _, hoverGated = ns.ResolveVisRestingLive(s, self)
+        if hoverGated then
             local a = ns.ResolveFrameAlpha(s, InCombatLockdown())
             ;(self._visWrap or self):SetAlpha(a)
             -- 3D models don't inherit parent alpha: reveal the portrait too
@@ -10939,26 +10979,10 @@ local function UnitFrame_OnLeave(self)
     local unitKey = unit:match("^boss%d$") and "boss" or unit
     local s = db and db.profile and db.profile[unitKey]
     if s and (s.barVisibility or "always") == "mouseover" then
-        local vmActive = EllesmereUI.GetActiveVisibilityModes
-            and EllesmereUI.GetActiveVisibilityModes(s, "barVisibility")
-        local leaveAlpha
-        if vmActive then
-            -- Hover-gated set: hidden again on leave; the visibility pass
-            -- re-evaluates the conditions on the next event.
-            leaveAlpha = 0
-        else
-            -- Mirror UpdateFrameVisibility's mouseover logic: when a positive
-            -- "Hide if" override is configured and currently not triggering,
-            -- keep the frame shown on mouse leave instead of re-hiding it.
-            local hiddenByOpts = EllesmereUI and EllesmereUI.CheckVisibilityOptions
-                                 and EllesmereUI.CheckVisibilityOptions(s)
-            -- Shared walk over every option lane: a hand-written subset here left a frame
-            -- fading out on mouse leave whenever it used a lane the list had not caught up to.
-            local hasAnyHideOpt = EllesmereUI and EllesmereUI.VisHasAnyOption
-                               and EllesmereUI.VisHasAnyOption(s)
-            local keepShown = (not hiddenByOpts) and hasAnyHideOpt
-            leaveAlpha = keepShown and ns.ResolveFrameAlpha(s, InCombatLockdown()) or 0
-        end
+        -- Return to the resting alpha the visibility pass would paint, never a hardcoded
+        -- 0: under Any a passing disjunct keeps the frame visible with no hover involved,
+        -- and hiding it here would leave it wrong until the next visibility event fires.
+        local leaveAlpha = ns.ResolveVisRestingLive(s, self)
         ;(self._visWrap or self):SetAlpha(leaveAlpha)
         -- 3D models don't inherit parent alpha: hide/dim the portrait too
         local bd3d = self.Portrait and self.Portrait.backdrop and self.Portrait.backdrop._3d
@@ -12348,13 +12372,6 @@ function InitializeFrames()
                     frame._euiVisDriver = wantDriver
                 end
 
-                -- Whole-frame out-of-combat fade: the alpha to use whenever the frame is
-                -- "shown" below. 1 unless "Fade Out of Combat" is on and we're out of
-                -- combat, in which case the chosen oocAlpha. Uses the event-tracked
-                -- _ufInCombat (authoritative on regen transitions, which lead
-                -- InCombatLockdown()) so the fade flips instantly.
-                local shownAlpha = ns.ResolveFrameAlpha(s, _ufInCombat)
-
                 -- Combat-sensitive and mouseover modes use SetAlpha to show/hide
                 -- (not a restricted API); the frame stays technically shown so it can
                 -- transition instantly, alpha controls visibility. For the player frame
@@ -12362,54 +12379,11 @@ function InitializeFrames()
                 -- the inner frame's alpha (oUF updates, secure templates) can fight us --
                 -- alpha inherits down the parent chain so wrapper alpha 0 always wins.
                 local alphaTarget = frame._visWrap or frame
-                local bodyAlpha
-                if ext == "mouseover" then
-                    -- Hover-gated set with passing conditions: hidden until
-                    -- hovered (the hover handlers reveal it).
-                    bodyAlpha = 0
-                elseif ext ~= nil then
-                    if frame._euiVisDriver then
-                        -- The driver owns hiding; alpha only carries the
-                        -- ooc fade (hide-options still force 0 below).
-                        bodyAlpha = shownAlpha
-                    else
-                        -- Driver not registered yet (selection changed in
-                        -- combat): alpha covers until the regen pass.
-                        bodyAlpha = (not hiddenByOpts and ext) and shownAlpha or 0
-                    end
-                elseif vis == "in_combat" then
-                    bodyAlpha = (not hiddenByOpts and _ufInCombat) and shownAlpha or 0
-                elseif vis == "out_of_combat" then
-                    bodyAlpha = (not hiddenByOpts and not _ufInCombat) and shownAlpha or 0
-                elseif vis == "mouseover" then
-                    -- Mouseover: hidden by default; hover toggles alpha. But when the user
-                    -- has configured any positive "Hide if" override (no target, no enemy,
-                    -- mounted, etc.) and it's NOT currently triggering, treat the frame as
-                    -- a positive-show so it doesn't require hover to see (fixes "dismount
-                    -- in combat keeps frame hidden" / "hide if no target inverted").
-                    local hasAnyHideOpt = EllesmereUI and EllesmereUI.VisHasAnyOption
-                                       and EllesmereUI.VisHasAnyOption(s)
-                    if hiddenByOpts then
-                        bodyAlpha = 0
-                    elseif hasAnyHideOpt then
-                        bodyAlpha = shownAlpha
-                    else
-                        bodyAlpha = 0
-                    end
-                else
-                    -- Non-combat modes: restore the resting alpha (full, or the
-                    -- out-of-combat fade); Show/Hide controls visibility below.
-                    bodyAlpha = shownAlpha
-                end
-
-                -- Alpha-only hide for the "visHide*" overrides (mounted, no target,
-                -- housing, etc). Force alpha 0 now so the frame still looks hidden, but
-                -- leave the secure Show/Hide state alone below -- otherwise a dismount
-                -- landing inside a combat lockdown would leave the frame permanently
-                -- hidden (Show/SetAttribute are restricted in combat).
-                if hiddenByOpts then
-                    bodyAlpha = 0
-                end
+                -- Shared with both hover handlers. Forces 0 for the visHide* overrides too,
+                -- so the frame looks hidden while the secure bucket below stays untouched:
+                -- a dismount inside a lockdown would otherwise hide it permanently.
+                -- _ufInCombat leads InCombatLockdown() on regen, so the ooc fade is instant.
+                local bodyAlpha = ns.ResolveVisResting(s, frame, ext, hiddenByOpts, _ufInCombat)
                 alphaTarget:SetAlpha(bodyAlpha)
 
                 -- 3D PlayerModel frames don't inherit parent alpha, so the model must

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -256,12 +256,13 @@ _G._EBS_UpdateVisEventRegistration = function() end
 --    dragon axis:  show_dragonriding / show_not_dragonriding
 --  An axis with none (or all) of its items checked imposes no constraint.
 --  Never / Always are exclusive single selections and never appear in a set.
---  Mouseover combines as one more AND gate (hover-gated conditions): the
+--  Mouseover under All is one more AND gate (hover-gated conditions): the
 --  element is hover-revealed while every condition axis passes and hidden
---  outright while any fails. A set containing mouseover stores the scalar
---  "mouseover" as its representative, so every legacy mouseover mechanism
---  (Action Bars' mouseoverEnabled fade, UF hover handlers, the dispatcher
---  poll) engages without per-module rewiring.
+--  outright while any fails. Under Any it is a disjunct of its own instead: a
+--  passing condition shows the element outright, and hover stays available when
+--  none passes. A set containing mouseover stores the scalar "mouseover" as its
+--  representative, so every legacy mouseover mechanism (Action Bars' fade, UF
+--  hover handlers, the dispatcher poll) engages without per-module rewiring.
 -------------------------------------------------------------------------------
 
 EUI.VIS_AXES = {

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -526,8 +526,12 @@ local function EvalAnyMatch(store, legacyKey, vm, state, caps)
     end
     -- Nothing constrained at all reads as Always, exactly as it does under All.
     local pass = (constrained == 0) or (passed > 0)
+    -- Mouseover is a disjunct in its own right under Any, not a gate on top of the
+    -- others: a passing condition shows outright (no hover needed), and a set that
+    -- constrains nothing but mouseover -- or whose other conditions all fail -- stays
+    -- hover-revealable instead of hiding outright.
     if sel.mouseover then
-        return pass and "mouseover" or false
+        return (passed > 0) and true or "mouseover"
     end
     return pass
 end
@@ -671,7 +675,12 @@ end
 -- grammar). `opts` = the option lanes the driver can express (Lua-only ones are the
 -- caller's); `wrap` = tokens every bracket must carry (Pet Bar); `extraConstrained` =
 -- axes decided outside this string, so a Lua-only-constrained selection compiles to hide.
-function EUI.BuildVisibilityDriverStringAny(prefix, vm, opts, extraConstrained, wrap)
+-- `hasMouseover` = the selection also carries the hover-gate: this compiler cannot
+-- express mouseover as a macro token, so every branch that would otherwise HIDE the
+-- frame outright falls back to showing it instead -- a hard-hidden secure frame can
+-- never be revealed again by the unprotected Lua hover poll. The alpha layer (outside
+-- this compiler) is what actually decides full opacity vs. hover-gated 0 from there.
+function EUI.BuildVisibilityDriverStringAny(prefix, vm, opts, extraConstrained, wrap, hasMouseover)
     vm, opts, wrap = vm or {}, opts or {}, wrap or ""
     local lead = (wrap ~= "") and (wrap .. ",") or ""
     local out, axes = "", 0
@@ -730,16 +739,24 @@ function EUI.BuildVisibilityDriverStringAny(prefix, vm, opts, extraConstrained, 
     end
 
     local wrappedShow = (wrap ~= "") and ("[" .. wrap .. "] show; hide") or "show"
+    local noMatch = hasMouseover and wrappedShow or "hide"
     if axes == 0 then
         -- Nothing this string can decide: either nothing is constrained anywhere
         -- (Always), or the only constrained axes are Lua-only ones that all failed.
-        if (extraConstrained or 0) > 0 then return prefix .. "hide", 0 end
+        if (extraConstrained or 0) > 0 then return prefix .. noMatch, 0 end
         return prefix .. wrappedShow, 0
     end
     if dragonTail then
+        -- Under mouseover the negative-dragon veto would just be dead weight: dropping
+        -- it lets the trailing wrappedShow (itself the hover-gated fallback) cover the
+        -- airborne case too, instead of nesting wrappedShow's own bracket/semicolons
+        -- inside this clause's action slot.
+        if hasMouseover then
+            return prefix .. out .. wrappedShow, axes
+        end
         return prefix .. out .. "[" .. lead .. "advflyable,flying] hide; " .. wrappedShow, axes
     end
-    return prefix .. out .. "hide", axes
+    return prefix .. out .. noMatch, axes
 end
 
 -- Two macro tokens disagree with their Lua probe: [exists] counts a soft target and
@@ -837,7 +854,8 @@ function EUI.BuildAnyMatchTail(store, legacyKey, vm, wrap, edges)
             end
         end
     end
-    local tail, axes = EUI.BuildVisibilityDriverStringAny("", modes, opts, luaC + dropped, wrap)
+    local hasMouseover = (vm and vm.mouseover) or (store[legacyKey] == "mouseover") or false
+    local tail, axes = EUI.BuildVisibilityDriverStringAny("", modes, opts, luaC + dropped, wrap, hasMouseover)
     return tail, axes + luaC + dropped, axes
 end
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1781, which added the Match Mode row (Match All / Match Any) to the unified Visibility checklist. Mouseover did not take part in the "Any" logic: it stayed an AND gate layered on top of the other conditions, so a selection like "Any: Mouseover or In Combat" was hidden outright out of combat and hovering could not reveal it. That is exactly the behaviour Match Any exists to replace.

Mouseover is now a disjunct in its own right. A passing condition shows the element outright with no hover needed, and when none of the conditions pass the element stays hover-revealable instead of hiding. Match All is untouched, and so is every selection that does not use Mouseover.

Three layers had to follow for that to actually reach the screen. The secure driver compiler used to compile a hover-gated selection's no-match case to a hard `hide`, and a hard-hidden secure frame can never be revealed again by the unprotected Lua hover poll, so it now falls back to `show` and leaves the decision to the alpha layer. Unit Frames hand-rolled its hover handlers on static stored settings and disagreed with itself, with `OnEnter` reading the live state while `OnLeave` hardcoded alpha 0, which made a mouse-leave hide a frame that had just been legitimately shown and left it wrong until the next visibility event fired; both handlers and the visibility pass now derive from one shared resolver. Action Bars decided every alpha write from the persisted `mouseoverEnabled` flag, which is true whenever Mouseover appears anywhere in a selection and therefore cannot tell an already-shown bar from a hover-gated one; its alpha writers now share one resting-alpha helper, and that alpha is re-derived on the state edges through the shared visibility dispatcher rather than only when settings change.

Two smaller fixes ride along. A hover could previously reveal a Unit Frame that a "Hide if" option lane had hidden, because the hover eligibility check never looked at those lanes. And the Mouseover row's tooltip under Match Any described the old behaviour, so it has been rewritten.

Users on Match All see no change at all. Users who combined Mouseover with a condition under Match Any get the behaviour the mode advertises.

## How was it tested?

Tested in-game on live.

## Screenshots

Not a visual change beyond the corrected tooltip text; the affected behaviour is show/hide timing rather than appearance.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new settings; this corrects the behaviour of the existing Match Mode row, and only for selections that combine Mouseover with a condition under Match Any
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added

The Action Bars edge refresh rides the existing shared visibility dispatcher rather than adding its own events, and is gated behind a flag computed in a bar walk that already runs, so users without a Match Any plus Mouseover bar pay one flag read per dispatcher event. The refresh visits only the bars whose hover gate can actually move. Everything added there writes alpha only, with no `Show`/`Hide` and no driver registration, so it stays clear of combat lockdown and carries no taint exposure.
