### PR TITLE
Fix live previews staying visible after switching options modules

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -10813,6 +10813,11 @@ function EllesmereUI:SelectModule(folderName)
         EllesmereUI:SaveContentHeaderToCache(oldKey)
     end
 
+    -- Notify the module being left (mirrors onReset). No-op if unset.
+    if activeModule and modules[activeModule] and modules[activeModule].onModuleLeave then
+        modules[activeModule].onModuleLeave()
+    end
+
     -- Restore the old module page's inline-search filter and clear the search box BEFORE
     -- switching modules, while activeModule/activePage still point to the filtered page.
     -- SetText("") fires ApplyInlineSearch("") via OnTextChanged; doing this after the switch would target the new module and leave the old page stuck in its filtered layout.

--- a/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
@@ -3070,6 +3070,10 @@ initFrame:SetScript("OnEvent", function(self)
             end
             if _G._EABR_RequestRefresh then _G._EABR_RequestRefresh() end
         end,
+        -- Tears down the Ready Check Mana Warning preview on module switch.
+        onModuleLeave = function()
+            if _G._EABR_RCWarnHidePreview then _G._EABR_RCWarnHidePreview() end
+        end,
     })
 
     -- Register unlock elements after a short delay

--- a/EllesmereUIOptions/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIOptions/EUI_DamageMeters_Options.lua
@@ -2068,6 +2068,16 @@ initFrame:SetScript("OnEvent", function(self)
             local d = _G._EDM_DB
             if d and d.ResetProfile then d:ResetProfile() end
         end,
+        -- Mirrors RegisterOnHide below: SA Timer Preview + forced-visible
+        -- meter windows, on module switch instead of just window close.
+        onModuleLeave = function()
+            if ns.HideSATimerPreview then ns.HideSATimerPreview() end
+            ns._optionsOpen = false
+            for _, w in ipairs(ns._windows or {}) do
+                if w.UpdateVisibility then w.UpdateVisibility() end
+            end
+            if ns.ApplySpellHistory then ns.ApplySpellHistory() end
+        end,
     })
 
     -- Show preview when panel opens on DM page, hide when panel closes

--- a/EllesmereUIOptions/EUI_QoL_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_Options.lua
@@ -2854,6 +2854,13 @@ initFrame:SetScript("OnEvent", function(self)
             if _G._EUI_AutoLogging_Check then _G._EUI_AutoLogging_Check() end
             EllesmereUI:InvalidatePageCache()
         end,
+        -- Tears down Duration Warning, Raid Tools, and Movement Alert
+        -- previews on module switch (Movement Alert also stops its ticker).
+        onModuleLeave = function()
+            if EllesmereUI._durWarnHidePreview then EllesmereUI._durWarnHidePreview() end
+            if _G._EUI_RaidTools_Preview then _G._EUI_RaidTools_Preview(false) end
+            if EllesmereUI._MovementAlertPreview then EllesmereUI._MovementAlertPreview(false) end
+        end,
     })
 
     SLASH_EQOL1 = "/qol"

--- a/EllesmereUIOptions/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_Options.lua
@@ -715,6 +715,8 @@ initFrame:SetScript("OnEvent", function(self)
                     end
                 end
             end
+            -- Exposed for onModuleLeave below.
+            ns.StopHealthAnim = StopHealthAnim
 
             local function StartHealthAnim()
                 if ns._healthAnimTicker then return end
@@ -1784,6 +1786,8 @@ initFrame:SetScript("OnEvent", function(self)
                     end
                 end
             end
+            -- Exposed for onModuleLeave below.
+            ns.StopPowerAnim = StopPowerAnim
 
             local function StartPowerAnim()
                 if ns._powerAnimTicker then return end
@@ -6151,6 +6155,17 @@ initFrame:SetScript("OnEvent", function(self)
             if db.sv then db.sv._capturedOnce_RF = nil end
             db:ResetProfile()
             ReloadUI()
+        end,
+        -- Tears down all 6 Raid Frames preview mechanisms on cross-module
+        -- switch (Real/Party/Size/HealthAnim/PowerAnim/HM previews).
+        onModuleLeave = function()
+            if ns.HidePreview then ns.HidePreview() end
+            if ns.HidePartyPreview then ns.HidePartyPreview() end
+            ns._sizePreviewTier = nil
+            if ns._HideSizePreview then ns._HideSizePreview() end
+            if ns._healthAnimActive and ns.StopHealthAnim then ns.StopHealthAnim() end
+            if ns._powerAnimActive and ns.StopPowerAnim then ns.StopPowerAnim() end
+            if ns._hmPreview and ns.HM_SetPreview then ns.HM_SetPreview(false) end
         end,
     })
 

--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -16157,6 +16157,13 @@ initFrame:SetScript("OnEvent", function(self)
             db:ResetProfile()
             ReloadUI()
         end,
+        -- Tears down Boss Preview on module switch (RegisterOnHide above
+        -- only covers closing the whole options window).
+        onModuleLeave = function()
+            if ns._bossPreviewActive and ns.SetBossPreview then
+                ns.SetBossPreview(false)
+            end
+        end,
     })
 
     ---------------------------------------------------------------------------


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1514207652908109996

Issue: Nine separate preview/forced-visibility mechanisms across six modules (Raid Frames' Real, Party, Size, Health Bar Animation, Power Bar Animation, and HealerMana position previews; AuraBuffReminders' Ready Check Mana Warning preview; QoL's Duration Warning, Raid Tools, and Movement Alert previews; UnitFrames' Boss Preview; DamageMeters' SA Timer preview and forced-visible meter windows) were only ever torn down via RegisterOnHide (the whole options window closing) or an in-page interaction, with no equivalent hook for switching to a different module while the window stayed open, so each one just kept running or stayed visible behind whatever module the user navigated to next.
Fix: Added an onModuleLeave hook to EllesmereUI:SelectModule, mirroring the existing onReset config-field pattern and firing right before the old module gets overwritten, then wired all nine mechanisms to tear down through it.