### PR TITLE
Fix on-use trinkets with a separate equip proc missing from the Cooldown Manager

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -4179,7 +4179,23 @@ local function UpdateTrinketFrame(slotID)
             scanConclusive = true
         end
     else
-        scanConclusive = (spellID == nil or spellID == 0)
+        -- GetItemSpell reports nothing for an item that carries a passive
+        -- Equip proc alongside a separate on-use ability (Hex Lord's Dooming
+        -- Idol), so the slot read as passive and the icon was dropped. Fall
+        -- back to the localized "Use:" tooltip line the user-added equipment
+        -- slot path above already relies on.
+        local prefix = ITEM_SPELL_TRIGGER_ONUSE
+        local tipData = C_TooltipInfo and C_TooltipInfo.GetItemByID(itemID)
+        if tipData and tipData.lines and prefix then
+            scanConclusive = true
+            for _, tipLine in ipairs(tipData.lines) do
+                local lt = tipLine.leftText
+                if lt and lt:sub(1, #prefix) == prefix then
+                    isRealOnUse = true
+                    break
+                end
+            end
+        end
     end
     if scanConclusive then
         f._trinketIsOnUse = isRealOnUse


### PR DESCRIPTION
Bug: reported directly by a world first raider, no Discord thread.

Issue: Hex Lord's Dooming Idol never appeared in the Cooldown Manager's trinket slot on 9.0.8. Other on-use trinkets in the same slot worked, so it looked item-specific rather than like a broken code path.

Root cause: UpdateTrinketFrame in EllesmereUICdmHooks.lua classifies a trinket by asking C_Item.GetItemSpell for its use spell. That returns nothing for an item carrying both an Equip-triggered proc and a separate on-use ability, and the empty answer was taken as conclusive proof the trinket was passive, so the frame was hidden.

Fix: when GetItemSpell comes back empty, fall back to scanning the item tooltip for the localized ITEM_SPELL_TRIGGER_ONUSE line, the same check the user-added equipment slot path in the same function already relies on. Verified in game: the idol now shows and tracks its cooldown.