### PR TITLE
Add Guardian of Ancient Kings (Glyph of the Queen) to the Defensives filter

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
@@ -4294,7 +4294,9 @@ function ns.BMP_BuildAssignedFilters(parent, sy, ind, fontPath)
         local function SpellEntry(id)
             local name = (ns.SPELL_NAME_BY_ID and ns.SPELL_NAME_BY_ID[id])
                 or (C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(id))
-            return { key = id, label = (name or ("Spell " .. tostring(id))),
+            local label = name or ("Spell " .. tostring(id))
+            -- Truncated rows (long/duplicate names) still need to be told apart on hover.
+            return { key = id, label = label, tooltip = label,
                 icon = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(id) }
         end
         local function ByLabel(a, b) return a.label < b.label end

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -352,6 +352,9 @@ for _, spec in ipairs(HEALER_SPECS) do
         end
     end
 end
+-- 212641 is Guardian of Ancient Kings with Glyph of the Queen applied; Blizzard's
+-- client reports it under the same name as the base buff (86659).
+STORED_NAME_BY_ID[212641] = "Guardian of Ancient Kings (Glyph of the Queen)"
 -- Display-name lookup. Curated names win: they distinguish variants the client
 -- API cannot ("Echo Reversion" vs "Reversion") and localize via L(); the client
 -- name is the uncurated fallback. No cache -- L() must stay live for locale swaps.
@@ -3165,7 +3168,9 @@ function ns.BM_BuildPage(pageName, parent, yOffset)
                             -- by Blizzard); SPELL_NAME_BY_ID already falls back to
                             -- the live API internally when no curated name exists.
                             local name = SPELL_NAME_BY_ID[id]
-                            return { key = id, label = (name or ("Spell " .. tostring(id))),
+                            local label = name or ("Spell " .. tostring(id))
+                            -- Truncated rows still need to be told apart on hover.
+                            return { key = id, label = label, tooltip = label,
                                 icon = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(id) }
                         end
                         -- Dynamic items: fresh per menu open. Spells already supplied by

--- a/EllesmereUI_BuffPresets.lua
+++ b/EllesmereUI_BuffPresets.lua
@@ -80,6 +80,7 @@ spells = {
         [184662] = { class = "PALADIN", disabled = true },
         [31850] = { class = "PALADIN" },
         [86659] = { class = "PALADIN" },
+        [212641] = { class = "PALADIN" },
         [114216] = { class = "PRIEST", alts = { 114214 }, disabled = true },
         [19236] = { class = "PRIEST" },
         [47585] = { class = "PRIEST" },


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1537858711916126318

Issue: 212641, the buff that replaces Guardian of Ancient Kings (86659) when Glyph of the Queen is applied, was missing from the Defensives filter, and Blizzard reports the same spell name for both IDs so any dropdown showing it couldn't be told apart from the base buff.
Fix: Added 212641 alongside 86659 in the curated Defensives spell list, curated its display name as "Guardian of Ancient Kings (Glyph of the Queen)" via SPELL_NAME_BY_ID, and added a hover tooltip to the Extra Spells spell pickers (both the assigned-indicator editor and the Add New indicator popup) so truncated/duplicate-looking names are readable on hover.