### PR TITLE
Add per-bar action bar fade conditions

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -524,6 +524,12 @@ for _, info in ipairs(BAR_CONFIG) do
         buttonHeight = 0,
         mouseoverEnabled = false,
         mouseoverAlpha = 1,
+        -- Optional Advanced Fade layer. OFF preserves native 9.1.5 alpha behavior.
+        advancedFadeEnabled = false,
+        fadeMaxAlpha = 1,
+        fadeInSpeed = 0.15,
+        fadeOutSpeed = 0.15,
+        fadeConditions = {},
         combatShowEnabled = false,
         combatHideEnabled = false,
         housingHideEnabled = false,
@@ -611,6 +617,12 @@ for _, info in ipairs(EXTRA_BARS) do
     defaults.profile.bars[info.key] = {
         mouseoverEnabled = false,
         mouseoverAlpha = 1,
+        -- Optional Advanced Fade layer. OFF preserves native 9.1.5 alpha behavior.
+        advancedFadeEnabled = false,
+        fadeMaxAlpha = 1,
+        fadeInSpeed = 0.15,
+        fadeOutSpeed = 0.15,
+        fadeConditions = {},
         combatShowEnabled = false,
         combatHideEnabled = false,
         housingHideEnabled = false,
@@ -8589,6 +8601,267 @@ function EAB_VTABLE.Hover.GetState(barKey, frame)
     return state
 end
 
+-------------------------------------------------------------------------------
+--  Advanced Fade (optional per-bar alpha layer)
+--
+--  IMPORTANT CONTRACT:
+--    advancedFadeEnabled ~= true  -> this layer is inert for that bar.
+--  Native Visibility / Bar Opacity / mouseover remain authoritative and untouched.
+--  The layer is applied only after stock alpha writers have completed.
+-------------------------------------------------------------------------------
+function EAB_VTABLE.Hover.AdvancedFadeEnabled(s)
+    return s and s.advancedFadeEnabled == true
+end
+
+function EAB_VTABLE.Hover.HasCustomFade(s)
+    if not EAB_VTABLE.Hover.AdvancedFadeEnabled(s) then return false end
+    local c = s.fadeConditions
+    return type(c) == "table" and (c.combat or c.party or c.raid or c.instance
+        or c.mounted or c.flying or c.target or c.enemy_target or c.mouseover) and true or false
+end
+
+function EAB_VTABLE.Hover.CustomFadeConditionMet(barKey, s)
+    if not EAB_VTABLE.Hover.AdvancedFadeEnabled(s) then return false end
+    local c = s.fadeConditions
+    if type(c) ~= "table" then return false end
+    local state = hoverStates[barKey]
+
+    -- OR semantics: any selected condition raises the visible bar to Maximum Opacity.
+    if c.mouseover and state then
+        local hoverFrame = state.frame
+        if (hoverFrame and hoverFrame.IsMouseOver and hoverFrame:IsMouseOver()) or state.isHovered then
+            return true
+        end
+    end
+    if c.combat then
+        local combat = (EllesmereUI.IsInCombat and EllesmereUI.IsInCombat())
+            or InCombatLockdown()
+            or (UnitAffectingCombat and UnitAffectingCombat("player"))
+        if combat then return true end
+    end
+    local inRaid = IsInRaid and IsInRaid()
+    if c.raid and inRaid then return true end
+    if c.party and IsInGroup and IsInGroup() and not inRaid then return true end
+    if c.instance and IsInInstance then
+        local inside = IsInInstance()
+        if inside then return true end
+    end
+    if c.mounted and IsMounted and IsMounted() then return true end
+    if c.flying then
+        local airborne = EllesmereUI.IsAirborneSkyriding and EllesmereUI.IsAirborneSkyriding()
+        if airborne then return true end
+    end
+    if c.target and UnitExists and UnitExists("target") then return true end
+    if c.enemy_target and UnitExists and UnitExists("target")
+        and UnitCanAttack and UnitCanAttack("player", "target") then return true end
+    return false
+end
+
+function EAB_VTABLE.Hover.CustomFadeFrame(barKey)
+    local info = BAR_LOOKUP[barKey]
+    if not info or info.noManagedVisibility then return nil, info end
+    local frame = barFrames[barKey]
+        or (info.isDataBar and dataBarFrames[barKey])
+        or (info.isBlizzardMovable and blizzMovableHolders[barKey])
+        or extraBarHolders[barKey]
+        or (info.visibilityOnly and info.frameName and _G[info.frameName])
+    if info.visibilityOnly and not info.isDataBar and not info.isBlizzardMovable
+        and info.frameName and _G[info.frameName] then
+        frame = _G[info.frameName]
+    end
+    return frame, info
+end
+
+function EAB_VTABLE.Hover.RefreshCustomFadeBar(barKey, animate, force)
+    local s = EAB_VTABLE.Hover.GetSettings(barKey)
+    if not EAB_VTABLE.Hover.AdvancedFadeEnabled(s) then return false end
+
+    local enabled = EAB_VTABLE.Hover.HasCustomFade(s)
+    if not enabled and not force then return false end
+
+    -- Temporary surfacing modes remain authoritative over alpha rules.
+    if _gridState.shown or _dragState.visible or _quickKeybindState.open then
+        local st = hoverStates[barKey]
+        if st then st.customFadeTarget = nil end
+        return false
+    end
+
+    local frame = EAB_VTABLE.Hover.CustomFadeFrame(barKey)
+    if not frame then return false end
+    local state = hoverStates[barKey]
+
+    -- Visibility has absolute priority. When it currently uses Mouseover as the live
+    -- gate, stock EUI owns the hidden/off-hover side entirely. We only adjust alpha
+    -- while the bar is already legitimately revealed by hover.
+    local visibilityWantsHover
+    if EllesmereUI.VisWantsMouseover then
+        visibilityWantsHover = EllesmereUI.VisWantsMouseover(
+            s, "barVisibility", nil, EllesmereUI.VIS_CAPS_DEFAULT)
+    else
+        visibilityWantsHover = s.mouseoverEnabled
+    end
+    if visibilityWantsHover then
+        -- Use the frame's real cursor state instead of the hover memo here.  The memo is
+        -- intentionally lazy in stock EUI and can be stale across reload/profile edges;
+        -- Advanced Fade must never use that staleness to defeat Visibility.
+        local over = frame.IsMouseOver and frame:IsMouseOver() or false
+        if not over then
+            if state then state.customFadeTarget = nil end
+            local current = frame:GetAlpha()
+            StopFade(frame)
+            if animate and abs(current) >= 0.01 then
+                FadeTo(frame, 0, s.mouseoverSpeed or 0.15, true)
+            else
+                frame:SetAlpha(0)
+            end
+            if barKey == "MainBar" then SyncPagingAlpha(0) end
+            return true
+        end
+    end
+
+    -- Visibility's Mouseover mode parks the user's real Bar Opacity in
+    -- _savedBarAlpha. Use that as the native/base visible alpha; otherwise use the
+    -- normal opacity value. This reads native state rather than replacing its storage.
+    local base
+    if s.mouseoverEnabled and s._savedBarAlpha ~= nil then
+        base = s._savedBarAlpha
+    else
+        base = s.mouseoverAlpha or 1
+    end
+
+    local target = base
+    if enabled and EAB_VTABLE.Hover.CustomFadeConditionMet(barKey, s) then
+        target = s.fadeMaxAlpha
+        if target == nil then target = 1 end
+    end
+    if target < 0 then target = 0 elseif target > 1 then target = 1 end
+
+    if state and not force and state.customFadeTarget == target then return true end
+    if state then state.customFadeTarget = target end
+
+    local current = frame:GetAlpha()
+    StopFade(frame)
+    if animate and enabled and abs(current - target) >= 0.01 then
+        local duration = (target > current) and (s.fadeInSpeed or 0.15) or (s.fadeOutSpeed or 0.15)
+        if duration < 0.01 then duration = 0.01 end
+        FadeTo(frame, target, duration, true)
+    else
+        frame:SetAlpha(target)
+    end
+    if barKey == "MainBar" then SyncPagingAlpha(target) end
+    return true
+end
+
+function EAB:RefreshCustomFadeGate()
+    local any = false
+    if self.db and self.db.profile and self.db.profile.bars then
+        for _, info in ipairs(ALL_BARS) do
+            if EAB_VTABLE.Hover.HasCustomFade(self.db.profile.bars[info.key]) then
+                any = true
+                break
+            end
+        end
+    end
+    self._anyCustomFade = any
+    -- Hook the native alpha edges lazily.  A fresh login/reload with every
+    -- Advanced Fade toggle OFF registers none of these hooks at all.
+    if any and self.EnsureAdvancedFadeHooks then self:EnsureAdvancedFadeHooks() end
+    return any
+end
+
+function EAB:RefreshCustomFadeForBar(barKey, animate)
+    self:RefreshCustomFadeGate()
+    return EAB_VTABLE.Hover.RefreshCustomFadeBar(barKey, animate, true)
+end
+
+function EAB:RefreshAllCustomFade(animate, force)
+    local any = self:RefreshCustomFadeGate()
+    if not any and not force then return end
+    for _, info in ipairs(ALL_BARS) do
+        local s = self.db.profile.bars[info.key]
+        -- force means restore/re-evaluate every ENABLED Advanced Fade bar (including
+        -- one with an empty condition set), never a disabled/native bar.
+        if s and s.advancedFadeEnabled == true and (force or EAB_VTABLE.Hover.HasCustomFade(s)) then
+            EAB_VTABLE.Hover.RefreshCustomFadeBar(info.key, animate, force and true or false)
+        end
+    end
+end
+
+-- One-time handoff when the master toggle is switched OFF.  This does not touch
+-- any persisted Visibility/Opacity setting.  It only stops an Advanced Fade that may
+-- already be in flight and paints the exact native hover presentation for this instant.
+function EAB_VTABLE.Hover.ReleaseAdvancedFadeBar(barKey)
+    local s = EAB_VTABLE.Hover.GetSettings(barKey)
+    if not s then return end
+    local frame, info = EAB_VTABLE.Hover.CustomFadeFrame(barKey)
+    if not frame then return end
+
+    StopFade(frame)
+    local state = hoverStates[barKey]
+    local over = frame.IsMouseOver and frame:IsMouseOver() or false
+    local target
+
+    if info and info.noManagedVisibility then
+        target = 1
+    elseif s.mouseoverEnabled then
+        local wantsHover
+        if EllesmereUI.VisWantsMouseover then
+            wantsHover = EllesmereUI.VisWantsMouseover(
+                s, "barVisibility", nil, EllesmereUI.VIS_CAPS_DEFAULT)
+        else
+            wantsHover = true
+        end
+        if wantsHover then
+            target = over and (s._savedBarAlpha or 1) or 0
+        else
+            target = s._savedBarAlpha or s.mouseoverAlpha or 1
+        end
+    else
+        target = s.mouseoverAlpha or 1
+    end
+
+    frame:SetAlpha(target)
+    if state then
+        state.customFadeTarget = nil
+        state.isHovered = over
+        if s.mouseoverEnabled and over then
+            state.fadeDir = "in"
+        elseif s.mouseoverEnabled and target == 0 then
+            state.fadeDir = "out"
+        else
+            state.fadeDir = nil
+        end
+    end
+    if barKey == "MainBar" then SyncPagingAlpha(target) end
+end
+
+-- Enable/disable changes do not rebuild Visibility, drivers, or native settings.
+-- ON merely arms our optional hooks; OFF performs the one-time alpha handoff above.
+function EAB:RefreshAdvancedFadeEnabled(changed)
+    if type(changed) == "string" then
+        local s = self.db.profile.bars[changed]
+        if s and s.advancedFadeEnabled ~= true then
+            EAB_VTABLE.Hover.ReleaseAdvancedFadeBar(changed)
+        end
+    elseif type(changed) == "table" then
+        for _, barKey in ipairs(changed) do
+            local s = self.db.profile.bars[barKey]
+            if s and s.advancedFadeEnabled ~= true then
+                EAB_VTABLE.Hover.ReleaseAdvancedFadeBar(barKey)
+            end
+        end
+    end
+
+    self:RefreshCustomFadeGate()
+
+    -- If anything remains enabled, run the stock mouseover refresh first.  Our lazy
+    -- post-hook then layers Advanced Fade only onto enabled bars.  When all toggles are
+    -- OFF, no custom refresh is needed after the one-time handoff.
+    if self._anyCustomFade then
+        self:RefreshMouseover()
+    end
+end
+
 -- The alpha a bar RESTS at while the cursor is not on it, plus whether that resting state
 -- is a hover gate. Single source of truth for every alpha writer here, so a fade-out
 -- cannot land on a different verdict than the visibility refresh would. mouseoverEnabled
@@ -8874,6 +9147,41 @@ function EAB:RefreshMouseover(onlyHoverGated)
                 end
             end
         end
+    end
+end
+
+-- Advanced Fade hooks are installed lazily, only after at least one enabled bar
+-- actually has a Fade Condition.  Therefore a fresh login/reload with all master
+-- toggles OFF runs the stock 9.1.5 alpha functions with no Advanced Fade hooks at all.
+function EAB:EnsureAdvancedFadeHooks()
+    if self._advancedFadeHooksInstalled then return end
+    self._advancedFadeHooksInstalled = true
+
+    hooksecurefunc(EAB, "ApplyBarOpacity", function(_, barKey)
+        EAB_VTABLE.Hover.RefreshCustomFadeBar(barKey, false, true)
+    end)
+
+    hooksecurefunc(EAB_VTABLE.Hover, "FadeIn", function(barKey)
+        EAB_VTABLE.Hover.RefreshCustomFadeBar(barKey, true, false)
+    end)
+
+    hooksecurefunc(EAB_VTABLE.Hover, "FadeOut", function(barKey)
+        EAB_VTABLE.Hover.RefreshCustomFadeBar(barKey, true, false)
+    end)
+
+    hooksecurefunc(EAB, "RefreshMouseover", function(self, onlyHoverGated)
+        if not onlyHoverGated and self._anyCustomFade then
+            self:RefreshAllCustomFade(false, true)
+        end
+    end)
+
+    -- Reuse EUI's existing visibility-edge dispatcher; no new polling or OnUpdate.
+    if EllesmereUI.RegisterVisibilityUpdater then
+        EllesmereUI.RegisterVisibilityUpdater(function()
+            if EAB._anyCustomFade then
+                EAB:RefreshAllCustomFade(true, false)
+            end
+        end)
     end
 end
 
@@ -12824,6 +13132,11 @@ function EAB:OnInitialize()
         or (rawDB.profiles and not next(rawDB.profiles))
 
     self.db = EllesmereUI.Lite.NewDB("EllesmereUIActionBarsDB", defaults, true)
+
+    -- Read only our own settings.  If every Advanced Fade toggle/condition is OFF,
+    -- this leaves the entire native alpha/Visibility runtime completely untouched.
+    self:RefreshCustomFadeGate()
+
     -- Expose for ApplyAnchorPosition's growth-direction edge read.
     EllesmereUI._abBarPositions = self.db.profile.barPositions
 

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -1839,7 +1839,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- Bar Opacity keeps this row (and its sync icon, now on the left region) with
         -- Always Show Buttons as its partner; Toggle Action Bar sits in the Visibility row.
         row, h = W:DualRow(parent, y,
-            { type="slider", text="Bar Opacity", min=0, max=100, step=5,
+            { type="slider", text="Bar Opacity", min=0, max=100, step=(SB().advancedFadeEnabled == true) and 1 or 5,
               getValue=function()
                   local bs = SB()
                   if bs.mouseoverEnabled then
@@ -1850,7 +1850,13 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v)
                   local bs = SB()
                   if bs.mouseoverEnabled then
+                      -- Native 9.1.5 only stores the shown alpha here; with Advanced
+                      -- Fade OFF we intentionally keep that exact behavior.  When our
+                      -- optional layer is ON, repaint its current visible target live.
                       bs._savedBarAlpha = v / 100
+                      if bs.advancedFadeEnabled == true and EAB.RefreshCustomFadeForBar then
+                          EAB:RefreshCustomFadeForBar(SelectedKey(), false)
+                      end
                   else
                       SSet("mouseoverAlpha", v / 100, function(k) EAB:ApplyBarOpacity(k) end)
                   end
@@ -1909,6 +1915,285 @@ initFrame:SetScript("OnEvent", function(self)
                     end,
                 },
             })
+        end
+
+        -----------------------------------------------------------------------
+        --  ADVANCED FADE (optional; OFF = native EUI 9.1.5 behavior)
+        -----------------------------------------------------------------------
+        do
+            local FADE_ORDER = { "combat", "party", "raid", "instance", "mounted", "flying", "target", "enemy_target", "mouseover" }
+            local FADE_LABELS = {
+                combat = "In Combat",
+                party = "In Party",
+                raid = "In Raid",
+                instance = "In Instance",
+                mounted = "Mounted",
+                flying = "Skyriding (Airborne)",
+                target = "Target",
+                enemy_target = "Enemy Target",
+                mouseover = "Mouseover",
+            }
+
+            local function AdvancedFadeOn()
+                return SB().advancedFadeEnabled == true
+            end
+
+            local function EnsureFadeConditions(bs)
+                if type(bs.fadeConditions) ~= "table" then bs.fadeConditions = {} end
+                return bs.fadeConditions
+            end
+
+            local function RefreshFade(barKey, animate)
+                if EAB.RefreshCustomFadeForBar then
+                    EAB:RefreshCustomFadeForBar(barKey, animate)
+                end
+            end
+
+            -- Each Advanced Fade setting owns its own Apply-to state. Do not
+            -- group these together: changing Maximum Opacity must not make the
+            -- Fade Conditions (or speed) sync affordance appear, and vice versa.
+            local function CopyFadeSetting(dst, src, setting)
+                if setting == "fadeConditions" then
+                    local out = {}
+                    local sc = src.fadeConditions
+                    if type(sc) == "table" then
+                        for i = 1, #FADE_ORDER do
+                            local k = FADE_ORDER[i]
+                            if sc[k] then out[k] = true end
+                        end
+                    end
+                    dst.fadeConditions = out
+                elseif setting == "fadeMaxAlpha" then
+                    dst.fadeMaxAlpha = src.fadeMaxAlpha ~= nil and src.fadeMaxAlpha or 1
+                elseif setting == "fadeInSpeed" then
+                    dst.fadeInSpeed = src.fadeInSpeed or 0.15
+                elseif setting == "fadeOutSpeed" then
+                    dst.fadeOutSpeed = src.fadeOutSpeed or 0.15
+                end
+            end
+
+            local function FadeSettingEqual(a, b, setting)
+                if setting == "fadeConditions" then
+                    local ac, bc = a.fadeConditions, b.fadeConditions
+                    for i = 1, #FADE_ORDER do
+                        local k = FADE_ORDER[i]
+                        if (type(ac) == "table" and ac[k] and true or false) ~= (type(bc) == "table" and bc[k] and true or false) then
+                            return false
+                        end
+                    end
+                    return true
+                elseif setting == "fadeMaxAlpha" then
+                    return (a.fadeMaxAlpha ~= nil and a.fadeMaxAlpha or 1) == (b.fadeMaxAlpha ~= nil and b.fadeMaxAlpha or 1)
+                elseif setting == "fadeInSpeed" then
+                    return (a.fadeInSpeed or 0.15) == (b.fadeInSpeed or 0.15)
+                elseif setting == "fadeOutSpeed" then
+                    return (a.fadeOutSpeed or 0.15) == (b.fadeOutSpeed or 0.15)
+                end
+                return true
+            end
+
+            local function BuildFadeSettingSync(rgn, setting, label)
+                EllesmereUI.BuildSyncIcon({
+                    region  = rgn,
+                    tooltip = "Apply " .. label .. " to all Bars",
+                    onClick = function()
+                        local src = SB()
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            local dst = EAB.db.profile.bars[key]
+                            if dst then CopyFadeSetting(dst, src, setting) end
+                        end
+                        if setting == "fadeConditions" and EAB.RefreshCustomFadeGate then
+                            EAB:RefreshCustomFadeGate()
+                        end
+                        if (setting == "fadeConditions" or setting == "fadeMaxAlpha") and EAB.RefreshAllCustomFade then
+                            EAB:RefreshAllCustomFade(true, true)
+                        end
+                        EllesmereUI:RefreshPage()
+                    end,
+                    isSynced = function()
+                        local src = SB()
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            local dst = EAB.db.profile.bars[key]
+                            if dst and not FadeSettingEqual(src, dst, setting) then return false end
+                        end
+                        return true
+                    end,
+                    flashTargets = function() return { rgn } end,
+                    multiApply = {
+                        elementKeys   = GROUP_BAR_ORDER,
+                        elementLabels = SHORT_LABELS,
+                        getCurrentKey = function() return SelectedKey() end,
+                        onApply       = function(checkedKeys)
+                            local src = SB()
+                            for _, key in ipairs(checkedKeys) do
+                                local dst = EAB.db.profile.bars[key]
+                                if dst then CopyFadeSetting(dst, src, setting) end
+                            end
+                            if setting == "fadeConditions" and EAB.RefreshCustomFadeGate then
+                                EAB:RefreshCustomFadeGate()
+                            end
+                            if (setting == "fadeConditions" or setting == "fadeMaxAlpha") and EAB.RefreshAllCustomFade then
+                                EAB:RefreshAllCustomFade(true, true)
+                            end
+                            EllesmereUI:RefreshPage()
+                        end,
+                    },
+                })
+            end
+
+            -- Per-bar master switch. Its Apply-to control copies ONLY the enable state;
+            -- each bar keeps its own saved Advanced Fade settings.
+            local enableRow
+            enableRow, h = W:DualRow(parent, y,
+                { type="toggle", text="Enable Advanced Fade",
+                  tooltip="Enable the optional Advanced Fade layer for this bar. When disabled, Bar Opacity and Visibility behave exactly as in native EUI 9.1.5.",
+                  getValue=function() return AdvancedFadeOn() end,
+                  setValue=function(v)
+                      SB().advancedFadeEnabled = v and true or false
+                      if EAB.RefreshAdvancedFadeEnabled then EAB:RefreshAdvancedFadeEnabled(SelectedKey()) end
+                      -- Rebuild is intentional: native Bar Opacity uses step 5 while OFF
+                      -- and step 1 only while this optional layer is enabled.
+                      EllesmereUI:RefreshPage(true)
+                  end },
+                { type="label", text="" });  y = y - h
+
+            do
+                local rgn = enableRow._leftRegion
+                EllesmereUI.BuildSyncIcon({
+                    region  = rgn,
+                    tooltip = "Apply Enable Advanced Fade to all Bars",
+                    onClick = function()
+                        local v = AdvancedFadeOn()
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            local dst = EAB.db.profile.bars[key]
+                            if dst then dst.advancedFadeEnabled = v end
+                        end
+                        if EAB.RefreshAdvancedFadeEnabled then EAB:RefreshAdvancedFadeEnabled(GROUP_BAR_ORDER) end
+                        EllesmereUI:RefreshPage(true)
+                    end,
+                    isSynced = function()
+                        local v = AdvancedFadeOn()
+                        for _, key in ipairs(GROUP_BAR_ORDER) do
+                            local dst = EAB.db.profile.bars[key]
+                            if dst and (dst.advancedFadeEnabled == true) ~= v then return false end
+                        end
+                        return true
+                    end,
+                    flashTargets = function() return { rgn } end,
+                    multiApply = {
+                        elementKeys   = GROUP_BAR_ORDER,
+                        elementLabels = SHORT_LABELS,
+                        getCurrentKey = function() return SelectedKey() end,
+                        onApply       = function(checkedKeys)
+                            local v = AdvancedFadeOn()
+                            for _, key in ipairs(checkedKeys) do
+                                local dst = EAB.db.profile.bars[key]
+                                if dst then dst.advancedFadeEnabled = v end
+                            end
+                            if EAB.RefreshAdvancedFadeEnabled then EAB:RefreshAdvancedFadeEnabled(checkedKeys) end
+                            EllesmereUI:RefreshPage(true)
+                        end,
+                    },
+                })
+            end
+
+            local fadeItems = {}
+            for i = 1, #FADE_ORDER do
+                local k = FADE_ORDER[i]
+                fadeItems[#fadeItems + 1] = { key = k, label = FADE_LABELS[k] }
+            end
+
+            local fadeRow
+            fadeRow, h = W:DualRow(parent, y,
+                { type="slider", text="Maximum Opacity", min=0, max=100, step=1,
+                  disabled=function() return not AdvancedFadeOn() end,
+                  disabledTooltip="Enable Advanced Fade",
+                  tooltip="Opacity used while any selected Fade Condition is true. Visibility still decides whether the bar is shown.",
+                  getValue=function() return floor(((SB().fadeMaxAlpha ~= nil and SB().fadeMaxAlpha or 1) * 100) + 0.5) end,
+                  setValue=function(v)
+                      if not AdvancedFadeOn() then return end
+                      SB().fadeMaxAlpha = v / 100
+                      RefreshFade(SelectedKey(), true)
+                      EllesmereUI:RefreshPage()
+                  end },
+                { type="dropdown", text="Fade Conditions",
+                  values={ __placeholder = "..." }, order={ "__placeholder" },
+                  tooltip="Select one or more conditions. They use OR logic: if any selected condition is true, the bar fades to Maximum Opacity.",
+                  getValue=function() return "__placeholder" end,
+                  setValue=function() end });  y = y - h
+
+            if not EllesmereUI._prebuilding then
+                local rgn = fadeRow._rightRegion
+                if rgn._control then rgn._control:Hide() end
+
+                local fadeDD, fadeDDRefresh = EllesmereUI.BuildVisOptsCBDropdown(
+                    rgn, 170, rgn:GetFrameLevel() + 2,
+                    fadeItems,
+                    function(k)
+                        local c = EnsureFadeConditions(SB())
+                        return c[k] and true or false
+                    end,
+                    function(k, v)
+                        if not AdvancedFadeOn() then return end
+                        local c = EnsureFadeConditions(SB())
+                        c[k] = v and true or nil
+                        if EAB.RefreshCustomFadeGate then EAB:RefreshCustomFadeGate() end
+                        RefreshFade(SelectedKey(), true)
+                        -- In-place refresh makes Apply-to reappear immediately when the
+                        -- current bar diverges after a previous Apply All/Multiple.
+                        EllesmereUI:RefreshPage()
+                    end)
+
+                PP.Point(fadeDD, "RIGHT", rgn, "RIGHT", -20, 0)
+                rgn._control = fadeDD
+                rgn._lastInline = nil
+                EllesmereUI.RegisterWidgetRefresh(fadeDDRefresh)
+
+                -- BuildVisOptsCBDropdown has no config-level disabled callback, so use
+                -- the exact EUI pattern used by other native dependent checkbox menus.
+                local function UpdateFadeConditionsDisabled()
+                    local off = not AdvancedFadeOn()
+                    fadeDD:SetAlpha(off and 0.3 or 1)
+                    fadeDD:EnableMouse(not off)
+                    if rgn._label then rgn._label:SetAlpha(off and 0.3 or 1) end
+                end
+                UpdateFadeConditionsDisabled()
+                EllesmereUI.RegisterWidgetRefresh(UpdateFadeConditionsDisabled)
+            end
+
+            -- Independent Apply-to controls: each one compares/copies ONLY the
+            -- setting beside it, matching the native EUI sync affordance semantics.
+            if AdvancedFadeOn() then
+                BuildFadeSettingSync(fadeRow._leftRegion,  "fadeMaxAlpha",    "Maximum Opacity")
+                BuildFadeSettingSync(fadeRow._rightRegion, "fadeConditions", "Fade Conditions")
+            end
+
+            row, h = W:DualRow(parent, y,
+                { type="slider", text="Fade In Speed", min=0.01, max=2.00, step=0.01,
+                  disabled=function() return not AdvancedFadeOn() end,
+                  disabledTooltip="Enable Advanced Fade",
+                  tooltip="Fade-in duration in seconds. Lower values are faster.",
+                  getValue=function() return SB().fadeInSpeed or 0.15 end,
+                  setValue=function(v)
+                      if not AdvancedFadeOn() then return end
+                      SB().fadeInSpeed = v
+                      EllesmereUI:RefreshPage()
+                  end },
+                { type="slider", text="Fade Out Speed", min=0.01, max=2.00, step=0.01,
+                  disabled=function() return not AdvancedFadeOn() end,
+                  disabledTooltip="Enable Advanced Fade",
+                  tooltip="Fade-out duration in seconds. Lower values are faster.",
+                  getValue=function() return SB().fadeOutSpeed or 0.15 end,
+                  setValue=function(v)
+                      if not AdvancedFadeOn() then return end
+                      SB().fadeOutSpeed = v
+                      EllesmereUI:RefreshPage()
+                  end });  y = y - h
+
+            if AdvancedFadeOn() then
+                BuildFadeSettingSync(row._leftRegion,  "fadeInSpeed",  "Fade In Speed")
+                BuildFadeSettingSync(row._rightRegion, "fadeOutSpeed", "Fade Out Speed")
+            end
         end
 
         if not visOnly then


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds an opt-in **Advanced Fade** system for individual action bars, built on top of the existing Action Bars fade/visibility behavior.

When **Advanced Fade is disabled**, the bar keeps the stock EllesmereUI 9.1.5 behavior. Enabling it adds per-bar controls for:

- **Maximum Opacity**
- **Fade Conditions**: In Combat, In Party, In Raid, In Instance, Mounted, Skyriding (Airborne), Target, Enemy Target, and Mouseover
- **Fade In Speed** and **Fade Out Speed**
- 1% `Bar Opacity` slider steps while Advanced Fade is enabled (stock 5% steps are preserved while disabled)
- Independent **Apply to All / Multiple** sync controls for Enable Advanced Fade, Maximum Opacity, Fade Conditions, Fade In Speed, and Fade Out Speed

Fade conditions use OR semantics. Existing Visibility rules retain priority over Advanced Fade, including Mouseover visibility behavior.

The PR is based on the current **EllesmereUI 9.1.5** Action Bars implementation, so the 9.1.5 Visibility behavior/fixes remain upstream and are not replaced by custom compatibility logic.

## How was it tested?

Tested in-game on live with EllesmereUI 9.1.5. Regression coverage included:

- Advanced Fade OFF matching stock 9.1.5 behavior
- Live ON/OFF switching with settings preserved
- Visibility `Mouseover` and `Match Any Condition` with Skyriding hide rules
- Visibility precedence while Advanced Fade is enabled
- Per-bar isolation between enabled and disabled bars
- Independent Apply to All / Multiple behavior for each Advanced Fade setting
- Persistence of enable state, opacity, conditions, and fade speeds after `/reload`

All of the above passed in-game testing.

## Screenshots / Demo

In-game walkthrough of the current Advanced Fade options and behavior:

https://youtu.be/fJSAN2ECOhA

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [ ] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [ ] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [ ] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live 9.1.5; no additional client version gates introduced by this feature