### PR TITLE
Fix hover and target borders on borderless raid and party frames

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_Options.lua
@@ -4896,6 +4896,36 @@ initFrame:SetScript("OnEvent", function(self)
             targetSwatch:SetScript("OnEnter", function() EllesmereUI.ShowWidgetTooltip(targetSwatch, "Target") end)
             targetSwatch:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
 
+            -- Highlight thickness. Shown only while the frame is borderless (Border Size 0):
+            -- with a border drawn the highlight recolors THAT and these sizes do nothing.
+            local _, hlCogShow = EllesmereUI.BuildCogPopup({
+                title = "Highlight Border",
+                rows = {
+                    { type="slider", label="Hover Border Size", min=1, max=4, step=1,
+                      get=function() return SVal("hoverBorderSize", 1) end,
+                      set=function(v) SSet("hoverBorderSize", v) end },
+                    { type="slider", label="Target Border Size", min=1, max=4, step=1,
+                      get=function() return SVal("targetBorderSize", 1) end,
+                      set=function(v) SSet("targetBorderSize", v) end },
+                },
+            })
+            local hlCog = CreateFrame("Button", nil, rightRgn)
+            hlCog:SetSize(26, 26)
+            hlCog:SetPoint("RIGHT", rightRgn._lastInline, "LEFT", -8, 0)
+            rightRgn._lastInline = hlCog
+            hlCog:SetFrameLevel(rightRgn:GetFrameLevel() + 5)
+            hlCog:SetAlpha(0.4)
+            local hlCogTex = hlCog:CreateTexture(nil, "OVERLAY")
+            hlCogTex:SetAllPoints(); hlCogTex:SetTexture(EllesmereUI.DIRECTIONS_ICON)
+            hlCog:SetScript("OnEnter", function(s) s:SetAlpha(0.7) end)
+            hlCog:SetScript("OnLeave", function(s) s:SetAlpha(0.4) end)
+            hlCog:SetScript("OnClick", function(s) hlCogShow(s) end)
+            local function UpdateHLCogVis()
+                if SVal("borderSize", 1) > 0 then hlCog:Hide() else hlCog:Show() end
+            end
+            EllesmereUI.RegisterWidgetRefresh(UpdateHLCogVis)
+            UpdateHLCogVis()
+
             -- Gray a swatch when its border state is off but keep it clickable so the color can be pre-set (matches the Heal Prediction swatch).
             UpdateHBSwatchVis = function()
                 hoverSwatch:SetAlpha(SVal("hoverBorderEnabled", true) and 1 or 0.3)

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -3223,6 +3223,33 @@ do
     end
 end
 
+-- Hover/target highlight on a BORDERLESS frame (Border Size 0): the highlight recolors the
+-- frame's own border, and with none drawn there is nothing to recolor, so it draws its own at
+-- hoverBorderSize/targetBorderSize in the configured border style. `size` nil/0 = not
+-- highlighted. The drawn size is cached on the border frame so a group-wide target swap is a
+-- color write per button rather than a restyle; callers clear it when the base border returns.
+function ns.ApplyHighlightBorder(bf, s, size, r, g, b, a)
+    if not (PP and bf) then return end
+    local texKey = s.borderTexture or "solid"
+    if not size or size <= 0 then
+        if bf._hlBorderSize then
+            bf._hlBorderSize = nil
+            EllesmereUI.ApplyBorderStyle(bf, 0, r, g, b, a, texKey)
+        end
+        return
+    end
+    -- IsShown: a base restyle to Border Size 0 hides the frame without clearing the cache,
+    -- so the size alone would let a hover/target repaint after one land on a hidden border.
+    if bf._hlBorderSize == size and bf:IsShown() then
+        EllesmereUI.SetBorderStyleColor(bf, r, g, b, a)
+        return
+    end
+    EllesmereUI.ApplyBorderStyle(bf, size, r, g, b, a, texKey,
+        s.borderTextureOffset, s.borderTextureOffsetY,
+        s.borderTextureShiftX, s.borderTextureShiftY, "unitframes", size)
+    bf._hlBorderSize = size
+end
+
 -------------------------------------------------------------------------------
 --  Style a single button (called once per button at creation time)
 -------------------------------------------------------------------------------
@@ -3703,27 +3730,32 @@ local function StyleButton(button)
         if container then container:SetFrameLevel(lvl + 1) end
     end
 
-    -- Recolor the single border for the current state: hover > target > normal.
+    -- Recolor the single border for the current state: hover > target > normal. A borderless
+    -- frame has nothing to recolor, so the highlight draws its own (ns.ApplyHighlightBorder).
     local function ApplyBorderColor()
         if not (PP and d.borderFrame) then return end
         -- Re-called long after StyleButton: resolve LIVE (see LiveS note) so party overrides and profile swaps are honored.
         local s = LiveS()
-        if (s.borderSize or 1) <= 0 then return end
         local r, g, b, a
-        local raised = false
+        local raised, hlSize = false, nil
         if d._hovered and s.hoverBorderEnabled ~= false then
             local c = s.hoverBorderColor or { r = 1, g = 1, b = 1 }
             r, g, b, a = c.r, c.g, c.b, s.hoverBorderAlpha or 1
-            raised = true
+            raised, hlSize = true, s.hoverBorderSize or 1
         elseif d._isTarget and s.targetBorderEnabled ~= false then
             local c = s.targetBorderColor or { r = 1, g = 1, b = 1 }
             r, g, b, a = c.r, c.g, c.b, s.targetBorderAlpha or 1
-            raised = true
+            raised, hlSize = true, s.targetBorderSize or 1
         else
             local c = s.borderColor or { r = 0, g = 0, b = 0 }
             r, g, b, a = c.r, c.g, c.b, s.borderAlpha or 1
         end
         ApplyBorderLevel(raised)
+        if (s.borderSize or 1) <= 0 then
+            ns.ApplyHighlightBorder(d.borderFrame, s, hlSize, r, g, b, a)
+            return
+        end
+        d.borderFrame._hlBorderSize = nil
         EllesmereUI.SetBorderStyleColor(d.borderFrame, r, g, b, a)
     end
     d.ApplyBorderColor = ApplyBorderColor
@@ -5342,17 +5374,16 @@ end
 FB.ApplyBorderColor = function(b)
     if not PP or not b._borderFrame or not db then return end
     local s = ns._scaledProfile or db.profile
-    if (s.borderSize or 1) <= 0 then return end
     local r, g, bcol, a
-    local raised = false
+    local raised, hlSize = false, nil
     if b._fbHovered and s.hoverBorderEnabled ~= false then
         local c = s.hoverBorderColor or { r = 1, g = 1, b = 1 }
         r, g, bcol, a = c.r, c.g, c.b, s.hoverBorderAlpha or 1
-        raised = true
+        raised, hlSize = true, s.hoverBorderSize or 1
     elseif UnitIsUnit(FB.UnitOf(b), "target") and s.targetBorderEnabled ~= false then
         local c = s.targetBorderColor or { r = 1, g = 1, b = 1 }
         r, g, bcol, a = c.r, c.g, c.b, s.targetBorderAlpha or 1
-        raised = true
+        raised, hlSize = true, s.targetBorderSize or 1
     else
         local c = s.borderColor or { r = 0, g = 0, b = 0 }
         r, g, bcol, a = c.r, c.g, c.b, s.borderAlpha or 1
@@ -5365,6 +5396,11 @@ FB.ApplyBorderColor = function(b)
         local container = PP.GetBorders(b._borderFrame)
         if container then container:SetFrameLevel(lvl + 1) end
     end
+    if (s.borderSize or 1) <= 0 then
+        ns.ApplyHighlightBorder(b._borderFrame, s, hlSize, r, g, bcol, a)
+        return
+    end
+    b._borderFrame._hlBorderSize = nil
     EllesmereUI.SetBorderStyleColor(b._borderFrame, r, g, bcol, a)
 end
 
@@ -11897,17 +11933,16 @@ local function CreatePreviewFrame(index)
         -- tier-scaled, so the effective overlay may shadow them safely.
         local s = ns._previewSettingsOverride or (ns._partyPvActive and ns._scaledPartyProxy)
             or ns._pvOverlayProxy or ns._scaledProfile
-        if (s.borderSize or 1) <= 0 then return end
         local r, g, b, a
-        local raised = false
+        local raised, hlSize = false, nil
         if f._hovered and s.hoverBorderEnabled ~= false then
             local c = s.hoverBorderColor or { r = 1, g = 1, b = 1 }
             r, g, b, a = c.r, c.g, c.b, s.hoverBorderAlpha or 1
-            raised = true
+            raised, hlSize = true, s.hoverBorderSize or 1
         elseif f._isTarget and s.targetBorderEnabled ~= false then
             local c = s.targetBorderColor or { r = 1, g = 1, b = 1 }
             r, g, b, a = c.r, c.g, c.b, s.targetBorderAlpha or 1
-            raised = true
+            raised, hlSize = true, s.targetBorderSize or 1
         else
             local c = s.borderColor or { r = 0, g = 0, b = 0 }
             r, g, b, a = c.r, c.g, c.b, s.borderAlpha or 1
@@ -11923,6 +11958,11 @@ local function CreatePreviewFrame(index)
             bdrFrame:SetFrameLevel(lvl)
             if container then container:SetFrameLevel(lvl + 1) end
         end
+        if (s.borderSize or 1) <= 0 then
+            ns.ApplyHighlightBorder(bdrFrame, s, hlSize, r, g, b, a)
+            return
+        end
+        bdrFrame._hlBorderSize = nil
         EllesmereUI.SetBorderStyleColor(bdrFrame, r, g, b, a)
     end
     f._ApplyBorderColor = PvApplyBorderColor

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -3233,8 +3233,9 @@ function ns.ApplyHighlightBorder(bf, s, size, r, g, b, a)
     local texKey = s.borderTexture or "solid"
     if not size or size <= 0 then
         if bf._hlBorderSize then
-            bf._hlBorderSize = nil
             EllesmereUI.ApplyBorderStyle(bf, 0, r, g, b, a, texKey)
+            -- Keep the cache when the style call bailed (still shown) so the next one retries the hide.
+            if not bf:IsShown() then bf._hlBorderSize = nil end
         end
         return
     end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1543222579144302755 (reported by Snackbarxx)

Issue: on 9.0.8 the Hover Border and Target Border ticks do nothing for anyone running Border Size 0. Both stay ticked, the colours keep their values, and no outline appears on hover or on target, in party or in raid.

Root cause: the highlights have no border of their own. ApplyBorderColor in EllesmereUIRaidFrames.lua recolours the frame's existing border, so it returns on (s.borderSize or 1) <= 0 before it reads either setting, and a borderless frame has nothing to recolour. That is why the toggles look live and are inert.

Fix: with the base border off, the highlight now draws its own through ns.ApplyHighlightBorder at hoverBorderSize/targetBorderSize (dead keys until now) in the configured border style, and hides it again on leave. Raid, party, Extra Frames, friendly boss frames and the options preview all route through it, and a cog on the Hover Borders row sets the two sizes, shown only while Border Size is 0. Borderless profiles gain the highlight on upgrade, with the existing ticks as the off switch. Verified in party and raid.
