### PR TITLE
Add vehicle (and possess) visibility condition to action bars

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12673,6 +12673,7 @@ EllesmereUI.VIS_OPT_KEYS = {
     "visHideDragonriding", "visOnlySkyriding",
     "visHideNoTarget", "visHideWithTarget",
     "visHideNoEnemy", "visHideWithEnemy",
+    "visOnlyVehicle", "visHideVehicle",
 }
 
 -- Cache player class once at load time (never changes).
@@ -12701,6 +12702,22 @@ function EllesmereUI.IsInInstancedContent()
     end
     return iType == "party" or iType == "raid" or iType == "scenario"
         or iType == "arena" or iType == "pvp"
+end
+
+-- Vehicle-family probe for the Vehicle axis. Three states, not one: Blizzard treats
+-- vehicle UI, override bars and possess bars as one situation everywhere (the pet bar's
+-- own wrapper tests all three), and each has its own macro token for the secure driver.
+--
+-- UnitHasVehicleUI rather than UnitInVehicle: the latter is true for vehicles that leave
+-- your own bars alone (some flight paths, escort quests), where hiding a bar would take
+-- away the actions you are still meant to be using.
+function EllesmereUI.IsInVehicleLike()
+    if UnitHasVehicleUI and UnitHasVehicleUI("player") then return true end
+    local hasOverride = HasOverrideActionBar
+        or (C_ActionBar and C_ActionBar.HasOverrideActionBar)
+    if hasOverride and hasOverride() then return true end
+    if IsPossessBarVisible and IsPossessBarVisible() then return true end
+    return false
 end
 
 -- Runtime check: returns true if the element should be HIDDEN by visibility options.
@@ -12841,6 +12858,15 @@ function EllesmereUI.CheckVisibilityOptions(opts)
         if UnitExists("target") and UnitCanAttack("player", "target") then return true end
     end
 
+    -- Vehicle axis. Here rather than in the non-macro subset because it IS
+    -- macro-expressible, like the target axes above: secure callers compile it into
+    -- their own driver, and only the insecure ones resolve it here.
+    if opts.visHideVehicle or opts.visOnlyVehicle then
+        local inVehicle = EllesmereUI.IsInVehicleLike()
+        if opts.visHideVehicle and inVehicle then return true end
+        if opts.visOnlyVehicle and not inVehicle then return true end
+    end
+
     return false
 end
 
@@ -12867,6 +12893,10 @@ EllesmereUI.VIS_OPT_AXES = {
       probe = function()
           return (UnitExists("target") and UnitCanAttack("player", "target")) and true or false
       end },
+    -- Neither luaOnly nor needsEdge: all three states have macro tokens, and the secure
+    -- driver re-evaluates them in combat, which is when they mostly happen.
+    { show = "visOnlyVehicle", hide = "visHideVehicle",
+      probe = function() return EllesmereUI.IsInVehicleLike() end },
 }
 
 -- Whether this axis has to be resolved in Lua for a consumer with these edges.

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -534,6 +534,8 @@ for _, info in ipairs(BAR_CONFIG) do
         visHideMounted = false,
         visHideNoTarget = false,
         visHideNoEnemy = false,
+        visHideVehicle = false,
+        visOnlyVehicle = false,
         hideKeybind = false,
         keybindFontSize = 12,
         keybindFontColor = { r = 1, g = 1, b = 1 },
@@ -8894,6 +8896,17 @@ local function BuildVisibilityString(info, s, visOverride)
         if s.visHideWithTarget then visOptHide = visOptHide .. "[exists] hide; " end
         if s.visHideNoEnemy then visOptHide = visOptHide .. "[noharm] hide; " end
         if s.visHideWithEnemy then visOptHide = visOptHide .. "[harm] hide; " end
+        -- Only Bar 1 can act on either lane here: bars 2-10 and the Stance Bar carry
+        -- [vehicleui]/[overridebar] in their hide-prefix below, and the Pet Bar's wrapper
+        -- demands novehicleui,nooverridebar,nopossessbar -- so there the Hide lane is
+        -- already satisfied and the Show lane would leave the bar permanently hidden.
+        -- The options page locks the row on those (caps.lockedFns in the options file).
+        if s.visHideVehicle then
+            visOptHide = visOptHide .. "[vehicleui][overridebar][possessbar] hide; "
+        end
+        if s.visOnlyVehicle then
+            visOptHide = visOptHide .. "[novehicleui,nooverridebar,nopossessbar] hide; "
+        end
     end
 
     -- Authoritative multi-select set. Explicit overrides (toggle keybind,
@@ -9380,6 +9393,7 @@ function EAB:_RefreshSoftTargetGate()
     self._anyHideNoTarget = anySoft
     self._anyNonMacroVis = anyNonMacro
     self._anyHoverGated = anyHoverGated
+    self:_RefreshVehicleVisibilityGate()
 end
 
 -- Re-derive the resting alpha of every hover-gated bar. Registered once with the shared
@@ -9391,6 +9405,44 @@ end
 function EAB:RefreshHoverGatedAlpha()
     if not self._anyHoverGated then return end
     self:RefreshMouseover(true)
+end
+
+EAB._vehicleVisibilityEvents = {
+    "UNIT_ENTERED_VEHICLE", "UNIT_EXITED_VEHICLE",
+    "UPDATE_OVERRIDE_ACTIONBAR", "UPDATE_POSSESS_BAR",
+}
+
+function EAB:_OnVehicleVisibilityEvent(_, event, unit)
+    if (event == "UNIT_ENTERED_VEHICLE" or event == "UNIT_EXITED_VEHICLE")
+       and unit ~= "player" then
+        return
+    end
+    self:UpdateHousingVisibility()
+end
+
+function EAB:_RefreshVehicleVisibilityGate()
+    local wanted = false
+    for _, info in ipairs(EXTRA_BARS) do
+        if EAB_VTABLE.ExtraBars.IsManagedNonSecureBar(info) then
+            local s = self.db.profile.bars[info.key]
+            if s and (s.visHideVehicle or s.visOnlyVehicle) then
+                wanted = true
+                break
+            end
+        end
+    end
+    if wanted == self._vehicleVisibilityEventsOn then return end
+    self._vehicleVisibilityEventsOn = wanted
+    for _, event in ipairs(self._vehicleVisibilityEvents) do
+        if wanted then
+            if not (C_EventUtils and C_EventUtils.IsEventValid)
+               or C_EventUtils.IsEventValid(event) then
+                self:RegisterEvent(event, "_OnVehicleVisibilityEvent")
+            end
+        else
+            self:UnregisterEvent(event)
+        end
+    end
 end
 
 function EAB:RefreshRuntimeVisibility()

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -1177,12 +1177,24 @@ initFrame:SetScript("OnEvent", function(self)
         s.combatShowEnabled = (v == "in_combat")
     end
 
+    -- Which bars the Vehicle axis means anything on: Bar 1, plus the insecure bars that
+    -- resolve it in Lua. Everywhere else the driver already hides in a vehicle, so the
+    -- Show lane would leave the bar permanently hidden (see BuildVisibilityString). The
+    -- row is locked on those bars, leaving a sync copy as the only route a lane has to
+    -- reach one -- which the strip below closes, as noGroupModes does for group items.
+    local function AllowsVehicleLanes(barKey)
+        return barKey == "MainBar" or VISIBILITY_ONLY[barKey] or false
+    end
+
     local function CopyVisibilitySettings(dst, src, dstKey)
         -- The merged Visibility control owns the option booleans too, so every copy
         -- carries them alongside the mode selection.
         local optKeys = EllesmereUI.VIS_OPT_KEYS
         if optKeys then
             for i = 1, #optKeys do dst[optKeys[i]] = src[optKeys[i]] or nil end
+        end
+        if not AllowsVehicleLanes(dstKey) then
+            dst.visOnlyVehicle, dst.visHideVehicle = nil, nil
         end
         if VisibilityCompat then
             -- Pet Bar ignores group modes: strip them from a copied multi-selection.
@@ -1200,6 +1212,20 @@ initFrame:SetScript("OnEvent", function(self)
         dst.combatHideEnabled = src.combatHideEnabled
         dst.combatShowEnabled = src.combatShowEnabled
         dst.dragShow = src.dragShow
+    end
+
+    -- Sync-icon equality that matches what CopyVisibilitySettings actually does:
+    -- VisFullEquals walks every option key, so comparing the vehicle lanes raw against a
+    -- bar that has them stripped would report "not synced" forever after a correct copy.
+    local _visSyncScratch = {}
+    local function VisEqualsForTarget(src, dst, dstKey)
+        if AllowsVehicleLanes(dstKey) then
+            return EllesmereUI.VisFullEquals(src, "barVisibility", dst, "barVisibility")
+        end
+        wipe(_visSyncScratch)
+        for k, v in pairs(src) do _visSyncScratch[k] = v end
+        _visSyncScratch.visOnlyVehicle, _visSyncScratch.visHideVehicle = nil, nil
+        return EllesmereUI.VisFullEquals(_visSyncScratch, "barVisibility", dst, "barVisibility")
     end
 
 
@@ -1260,7 +1286,11 @@ initFrame:SetScript("OnEvent", function(self)
                   end,
                   legacyKey = "barVisibility",
                   label = leftLabel,
-                  caps = { partyIncludesRaid = false, luaDragonriding = true },
+                  -- vehicleAxis with no lockedFns: every bar this page reaches (Micro
+                  -- Menu, Bag Bar, XP, Rep, House Favor) is insecure and resolves the
+                  -- axis through EllesmereUI.CheckVisibilityOptions, so both lanes work.
+                  caps = { partyIncludesRaid = false, luaDragonriding = true,
+                           vehicleAxis = true },
                   applyScalarFn = function(s, mode) ApplyVisibilityKey(s, mode) end,
                   disabledFn = disabledFn, disabledTooltip = disTip, rawTooltip = disTip and true or nil,
                   onChanged = function()
@@ -1701,6 +1731,17 @@ initFrame:SetScript("OnEvent", function(self)
             -- edge event; secure bars' drivers re-evaluate natively and never lock.
             if IsDataBar() then visCaps.luaDragonriding = true end
 
+            -- Vehicle axis: opt-in, and locked on the bars that cannot act on it (see
+            -- AllowsVehicleLanes). lockedFn rather than a build-time flag so it follows
+            -- the bar selector without a page rebuild.
+            visCaps.vehicleAxis = true
+            visCaps.lockedFns = {
+                vehicle = function() return not AllowsVehicleLanes(SelectedKey()) end,
+            }
+            visCaps.lockedTooltips = visCaps.lockedTooltips or {}
+            visCaps.lockedTooltips.vehicle =
+                "Only Action Bar 1 can change this. Every other action bar is always hidden in vehicles, on override bars and on possess bars."
+
             visRow1, h = EllesmereUI.BuildVisibilityRow(W, parent, y,
                 { getStore = function()
                       local s = SB()
@@ -1755,7 +1796,7 @@ initFrame:SetScript("OnEvent", function(self)
                         local src = SB()
                         for _, key in ipairs(GROUP_BAR_ORDER) do
                             local dst = EAB.db.profile.bars[key]
-                            if not EllesmereUI.VisFullEquals(src, "barVisibility", dst, "barVisibility") then return false end
+                            if not VisEqualsForTarget(src, dst, key) then return false end
                             if (src.dragShow or false) ~= (dst.dragShow or false) then return false end
                         end
                         return true

--- a/EllesmereUIOptions/EllesmereUI_Widgets.lua
+++ b/EllesmereUIOptions/EllesmereUI_Widgets.lua
@@ -8444,7 +8444,9 @@ end
 --  prior counterpart use a new key (EllesmereUI.VIS_OPT_KEYS).
 --  opts = {
 --      getStore/legacyKey  = store accessor + scalar key (required)
---      caps                = { noMouseover, noGroupModes, luaDragonriding, lockedTooltips }
+--      caps                = { noMouseover, noGroupModes, luaDragonriding, lockedTooltips,
+--                              vehicleAxis (opts in to any requiresCap row),
+--                              lockedFns = { [rowKey] = fn -> bool } live per-row lock }
 --      applyScalarFn       = optional fn(store, mode) for scalar side effects
 --      getOption/setOption = optional fn(key)/fn(key, value) when option booleans live
 --                            outside getStore() (Resource Bars writes three stores)
@@ -8496,6 +8498,10 @@ EllesmereUI.VIS_ROW_ITEMS = {
     { key = "mounted", label = "Mounted", axis = "opt",
       show = "visOnlyMounted", hide = "visHideMounted",
       tooltip = "Druid travel, aquatic and flight forms count as mounted." },
+    -- requiresCap: only a module that declares it draws the row.
+    { key = "vehicle", label = "Vehicle", axis = "opt", requiresCap = "vehicleAxis",
+      show = "visOnlyVehicle", hide = "visHideVehicle",
+      tooltip = "Vehicles that replace your action bar, override bars (some quest and boss mechanics) and possess bars (mind control)." },
     { key = "target", label = "Target", axis = "opt",
       show = "visHideNoTarget", hide = "visHideWithTarget",
       tooltip = "*Blizzard's auto targeting (soft target) setting can cause brief flickering when your actual target dies but a soft-target is still active." },
@@ -8541,6 +8547,11 @@ function EllesmereUI.AttachVisibilityChecklist(region, opts)
     for _, def in ipairs(EllesmereUI.VIS_ROW_ITEMS) do
         if def.isHeader then
             items[#items + 1] = def
+        elseif def.requiresCap and not caps[def.requiresCap] then
+            -- Opt-in row, absent unless the module declares the capability: the list is
+            -- shared by eleven modules, and a condition only one of them can act on must
+            -- not render elsewhere as a checkbox that does nothing. Not `listed` either,
+            -- so the row cannot claim a scalar it does not draw.
         elseif not (def.key == "mouseover" and caps.noMouseover) then
             local item = { key = def.key, label = def.label, tooltip = def.tooltip,
                            dual = def.axis and true or nil,
@@ -8549,6 +8560,15 @@ function EllesmereUI.AttachVisibilityChecklist(region, opts)
                 item.locked = true
                 item.lockedTooltip = (caps.lockedTooltips and caps.lockedTooltips[def.key])
                     or "This element cannot use group-based visibility."
+            end
+            -- Live lock for a row inert on some of the module's targets. Evaluated on
+            -- hover/click, so it follows the page's own selector without a rebuild. Set
+            -- before the two assignments below, which own their keys outright.
+            local capLock = caps.lockedFns and caps.lockedFns[def.key]
+            if capLock then
+                item.lockedFn = capLock
+                item.lockedTooltip = (caps.lockedTooltips and caps.lockedTooltips[def.key])
+                    or item.lockedTooltip
             end
             -- Only the airborne row needs the takeoff/landing edge; the mount row
             -- rides PLAYER_CAN_GLIDE_CHANGED, which is always registered.

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -727,6 +727,15 @@ function EUI.BuildVisibilityDriverStringAny(prefix, vm, opts, extraConstrained, 
     elseif opts.visHideWithEnemy and not opts.visHideNoEnemy then
         axes = axes + 1; emit("noharm")
     end
+    -- Vehicle axis: one axis, three disjuncts, the shape the group axis above has.
+    -- Show is three bracket groups (adjacent groups OR); Hide is one, because its
+    -- three negations have to AND.
+    if opts.visOnlyVehicle and not opts.visHideVehicle then
+        axes = axes + 1
+        emit("vehicleui"); emit("overridebar"); emit("possessbar")
+    elseif opts.visHideVehicle and not opts.visOnlyVehicle then
+        axes = axes + 1; emit("novehicleui,nooverridebar,nopossessbar")
+    end
 
     -- Dragonriding axis. NOT(advflyable AND flying) has no single bracket form, so the
     -- negative lane becomes the TAIL: once no other disjunct matched, hide while


### PR DESCRIPTION
## What does this PR do?

Adds a Vehicle visibility condition to Action Bars.

The condition covers vehicle UI, override bars, and possess bars. It provides Show and Hide lanes and supports both Match All Conditions and Match Any Conditions.

The condition is available on Action Bar 1 and on Lua-managed action-bar chrome such as the Micro Menu, Bag Bar, and data bars. It is locked on bars whose existing vehicle rules already force the same behavior.

## How was it tested?

- LuaJIT syntax check passed for all changed files.
- Verified Match All and Match Any secure driver output with a standalone harness.
- Tested configuration in-game on live.
- Tested normal dungeon gameplay

 with no reported errors.
- Vehicle, override-bar, and possess-bar runtime testing is still pending.

## Screenshots

<img width="2560" height="1440" alt="Wow_tUCQxK76Mv" src="https://github.com/user-attachments/assets/30a1e13c-7e95-4ce8-8260-9a3d063466d6" />

<img width="2560" height="1440" alt="CDVuRKncDm" src="https://github.com/user-attachments/assets/73e6c692-4d3f-441c-96ee-c5eb93a32795" />

## Checklist


- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added