### PR TITLE
fix(cursor): trail ignores Combat Only

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
@@ -237,13 +237,11 @@ local function ApplyTrail()
         trailContainer:SetScript("OnUpdate", function(_, elapsed)
             if not trailEnabled then return end
 
-            local p = ECL.db and ECL.db.profile
-            local circleEnabled = p and p.enabled ~= false
-            local inInstance = not (p and p.instanceOnly) or InRealInstancedContent()
-
-            -- Only spawn new dots when the cursor circle would be visible
-            local hiddenGate = not (p and p.onlyWhenHidden) or mouselookActive
-            if circleEnabled and inInstance and hiddenGate then
+            -- Only spawn dots while the cursor circle itself is visible, so the
+            -- trail follows every gate on the circle (Combat Only, Only Show in
+            -- Instances, Only Show When Hidden, the Visibility block) rather
+            -- than re-deriving a subset of them.
+            if isVisible then
                 local cx, cy = GetCursorPosition()
                 trailTimer = trailTimer + elapsed
                 local dx = cx - trailLastCX


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1543614443018129449 (reported by @Fatisko, v9.0.8)

Issue: With QoL > Cursor > Combat Only enabled, the cursor circle correctly hides out of combat but the Cursor Trail keeps drawing. The shared Visibility block (Only in Raid, Hide While Mounted, and the rest) never reached the trail either.

Root cause: ApplyTrail's trailContainer OnUpdate in EllesmereUIQoL_Cursor.lua re-derived its own spawn gate from three of the circle's rules (enabled, Only Show in Instances, Only Show When Hidden) instead of reading the circle's resolved visibility, so combatOnly was never mirrored into it. UpdateVisibility does call HideTrailDots on the hide edge, which is why the dots blink out for one frame and come straight back: the spawner itself never stopped.

Fix: Gate spawning on isVisible, the flag UpdateVisibility already owns, so the trail follows every gate on the circle instead of a hand-copied subset. Every edge that changes circle visibility already routes through UpdateVisibility. Verified in game.
