### PR TITLE
fix(abr): middle-click dismiss also casts the buff

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -2246,6 +2246,9 @@ function EABR.EnsureProviderCastButton()
     btn:SetSize(ICON_SIZE, ICON_SIZE)
     btn:RegisterForClicks("LeftButtonDown", "LeftButtonUp", "MiddleButtonUp")
     securecallfunction(btn.SetPassThroughButtons, btn, "RightButton")
+    -- MiddleButton is the dismiss click: NOOP its action type so it cannot fall
+    -- back to the plain "type" attribute and cast the reminder.
+    btn:SetAttribute("*type3", ATTRIBUTE_NOOP)
     btn:SetAttribute("useOnKeyDown", false)
     btn:SetFrameStrata(GetStrata())
     btn:SetFrameLevel(120)
@@ -2723,6 +2726,9 @@ local function GetOrCreateIcon(index)
     btn:SetSize(ICON_SIZE, ICON_SIZE)
     btn:RegisterForClicks("LeftButtonDown", "LeftButtonUp", "MiddleButtonUp")
     securecallfunction(btn.SetPassThroughButtons, btn, "RightButton")
+    -- MiddleButton is the dismiss click: NOOP its action type so it cannot fall
+    -- back to the plain "type" attribute and cast the reminder.
+    btn:SetAttribute("*type3", ATTRIBUTE_NOOP)
     btn:SetFrameStrata(GetStrata())
     btn:Hide()
 


### PR DESCRIPTION
Bug: Discord report from @SpraxX (v9.0.8, AuraBuff Reminders)

Issue: Middle-clicking an AuraBuff Reminder casts the buff as well as dismissing the icon. The options tooltip advertises the two clicks as separate actions ("Left Click to apply buffs (out of combat), Middle Click to hide until next load screen"), so the middle click should only hide the reminder.

Root cause: The reminder icons are SecureActionButtons registered for MiddleButtonUp purely so the PostClick hook can record the dismiss, but SetIconSpell/SetIconItem/SetIconMacro write the cast attributes unsuffixed. SecureButton_GetModifiedAttribute resolves a click through prefix/name/suffix and ends at the bare name, so a middle click finds no type3 and falls back to plain "type", handing PerformAction a real action to run. The dismiss then hides the icon, which is why it reads as "activates, then hides".

Fix: Set "*type3" to ATTRIBUTE_NOOP at creation on both the pooled icons and the provider cast button, so the middle button's action type resolves to nil while left-click casting is untouched (suffix 1 never consults type3). The "*" prefix form is needed because SecureButton_GetModifierPrefix swaps the prefix when shift/ctrl/alt is held, and a bare type3 would still fall through on a modified middle click. Both call sites only run out of combat, so no attribute write lands under lockdown. Verified in game.
