### PR TITLE
Add Broker/LDB plugin block type to Databars

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -28,6 +28,8 @@ externals:
     tag: 1.0
   Libs/CallbackHandler-1.0:
     url: https://repos.wowace.com/wow/callbackhandler/trunk/CallbackHandler-1.0
+  Libs/LibDataBroker-1.1:
+    url: https://github.com/tekkub/libdatabroker-1-1
   Libs/LibSharedMedia-3.0:
     url: https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0
   Libs/LibDeflate:

--- a/EllesmereUI.toc
+++ b/EllesmereUI.toc
@@ -14,6 +14,7 @@ EllesmereUI_ClientGate.lua
 # Libraries
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua
+Libs\LibDataBroker-1.1\LibDataBroker-1.1.lua
 Libs\LibSharedMedia-3.0\LibSharedMedia-3.0.lua
 Libs\LibDeflate\LibDeflate.lua
 Libs\LibKeystone\LibKeystone.lua

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -37,6 +37,8 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 --   ns.SolveLayout(barCfg, L, measureFn) -> segments (pure)
 --   ns.GetLiveAutoLength(barId, blockId) -> px | nil
 --   ns.BuildCurrencyList() -> values, order
+--   ns.BuildLDBList() -> values, order      LibDataBroker sources, by name
+--   ns.GetLDB() -> LibDataBroker-1.1 | nil
 --   ns.LocationWidthMode(blockSettings) -> "auto" | "manual"
 --   ns.LOC_MAX_WIDTH_DEFAULT               Manual-mode width before one is set
 --   ns.BlockTextDynamic(blockType) -> r, g, b   state-driven Text Color swatch
@@ -134,6 +136,7 @@ local L = {
     DELVE_JOURNEY        = "Delver's Journey",
     COMPANION_LEVEL      = "Companion Level",
     SELECT_CURRENCY      = "Select a currency",
+    SELECT_PLUGIN        = "Select a plugin",
     OPEN_SETTINGS        = "Open Settings",
     CRESTS               = "Crests",
     SEASON_MAXIMUM       = "Current Season Maximum",
@@ -168,6 +171,7 @@ local wipe              = wipe
 local format            = string.format
 local tinsert, tremove  = table.insert, table.remove
 local tconcat           = table.concat
+local tsort             = table.sort
 local floor             = math.floor
 local max, min, abs     = math.max, math.min, math.abs
 
@@ -209,6 +213,7 @@ ns.BLOCK_TYPES = {
     { key = "ilvl",       label = "Item Level" },
     { key = "greatvault", label = "Great Vault" },
     { key = "audio",      label = "Audio" },
+    { key = "ldb",        label = "Broker Plugin" },
     { key = "spacer",     label = "Spacer" },
 }
 
@@ -241,6 +246,12 @@ ns.BLOCK_DEFAULTS = {
     ilvl       = { prefix = "short", value = "equipped", precision = 0 },
     greatvault = {},
     audio      = { channel = "master" },
+    -- Broker plugin: one block type for every LibDataBroker data source, picked
+    -- by name (source). stripColors defaults ON -- broker text arrives full of
+    -- the plugin's own |cff.. codes, which would silently beat this block's Text
+    -- Color and its accent hover. maxWidth nil = size from the live string.
+    ldb        = { source = nil, showIcon = true, showLabel = false, showText = true,
+                   stripColors = true, maxWidth = nil },
     spacer     = {},
 }
 
@@ -3127,6 +3138,50 @@ function ns.BuildCurrencyList()
     for i = #collapsed, 1, -1 do
         C_CurrencyInfo.ExpandCurrencyList(collapsed[i], false)
     end
+    return values, order
+end
+
+-------------------------------------------------------------------------------
+--  LibDataBroker access (the "ldb" block type)
+-------------------------------------------------------------------------------
+-- The suite ships the library itself (EllesmereUI parent, beside the
+-- CallbackHandler it needs) rather than borrowing it from whichever broker addon
+-- happens to load: every broker we read sorts after EllesmereUIDataBars, so
+-- borrowing would hand back nil at our load time. Resolved lazily all the same --
+-- a half-updated install must go quiet here, not error.
+local _ldb
+function ns.GetLDB()
+    if _ldb then return _ldb end
+    if not LibStub then return nil end
+    _ldb = LibStub:GetLibrary("LibDataBroker-1.1", true)
+    return _ldb
+end
+
+-- Display label for one data object. The registered NAME is what the block
+-- stores, so it always leads; a self-declared label that differs rides along in
+-- grey, so a plugin that calls itself something other than its name is still
+-- findable in the picker.
+function ns.LDBLabel(name, obj)
+    if not obj then return name end
+    local lbl = obj.label
+    if type(lbl) == "string" and lbl ~= "" and lbl ~= name then
+        return name .. " |cff808080(" .. lbl .. ")|r"
+    end
+    return name
+end
+
+-- Every data source registered right now, sorted case-insensitively. Rebuilt at
+-- each dropdown open (never cached): plugins register on their own schedule, and
+-- some appear only after their addon finishes loading.
+function ns.BuildLDBList()
+    local values, order = {}, {}
+    local LDB = ns.GetLDB()
+    if not LDB then return values, order end
+    for name, obj in LDB:DataObjectIterator() do
+        values[name] = ns.LDBLabel(name, obj)
+        order[#order + 1] = name
+    end
+    tsort(order, function(a, b) return a:lower() < b:lower() end)
     return values, order
 end
 

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -6645,6 +6645,421 @@ ns.BlockFactories.audio = function(blockCfg, slot, content, barCtx)
     return inst
 end
 
+-------------------------------------------------------------------------------
+--  BROKER PLUGIN (LibDataBroker) -- one block type for every data source
+-------------------------------------------------------------------------------
+-- The only block whose content is written by code we do not own, and three
+-- rules follow from that:
+--   1. Never write to the data object. A display READS; the plugin owns its own
+--      text, and a stray write would fight whoever set it.
+--   2. Every call into the plugin (OnEnter/OnLeave/OnClick/OnTooltipShow/
+--      OnMouseWheel) goes through pcall. A plugin that errors inside our hover
+--      or refresh path would otherwise take the bar's layout down with it.
+--   3. Width is never assumed stable. The other text blocks reserve width from
+--      a stable template so neighbours never shift; broker text has no shape we
+--      can predict, so this one measures live and offers a Max Width clamp.
+--
+-- Tooltips route three ways, in the plugin's own order of preference:
+--   OnEnter        the plugin draws its own tooltip (LibQTip, usually) into the
+--                  frame we hand it, and OnLeave takes it away. The owned
+--                  tooltip stays out of it -- two tooltips for one block, and
+--                  the plugin's is the one carrying the data.
+--   OnTooltipShow  the broker contract's GameTooltip path, and the one place in
+--                  this addon that still uses GameTooltip: the plugin writes
+--                  into it directly, which we cannot re-render.
+--   neither        name + text in the owned tooltip, so hover is never dead.
+
+-- Attributes worth a repaint. The library fires a per-NAME event carrying the
+-- changed key, so one registration covers the whole plugin and this set decides
+-- what is worth redrawing: a bar full of broker blocks never wakes for each
+-- other's updates, and a plugin parking its own state on the data object does
+-- not drag us through a re-measure for a key we never render.
+local LDB_WATCH = {
+    text = true, value = true, suffix = true, label = true,
+    icon = true, iconR = true, iconG = true, iconB = true, iconCoords = true,
+}
+
+-- Broker text arrives full of the plugin's own color codes, which silently beat
+-- this block's Text Color and its accent hover. Stripping them (default on)
+-- hands the color back to the block; leaving them keeps the plugin's palette.
+local function LDBStripColors(str)
+    if not str then return str end
+    str = str:gsub("|c%x%x%x%x%x%x%x%x", "")
+    str = str:gsub("|cn[%a%d_]+:", "")   -- named-color form (|cnGREEN_FONT_COLOR:)
+    str = str:gsub("|r", "")
+    return str
+end
+
+-- text is the display string; value+suffix is the fallback pair for plugins
+-- that publish the number and its unit separately.
+local function LDBDisplayText(obj)
+    if not obj then return nil end
+    local t = obj.text
+    if type(t) == "string" and t ~= "" then return t end
+    local v = obj.value
+    if v ~= nil then
+        local str = tostring(v)
+        local suf = obj.suffix
+        if type(suf) == "string" and suf ~= "" then str = str .. " " .. suf end
+        return str
+    end
+    return nil
+end
+
+ns.BlockFactories.ldb = function(blockCfg, slot, content, barCtx)
+    local inst = { cfg = blockCfg, slot = slot, content = content, ctx = barCtx }
+    inst.key = InstKey(barCtx, blockCfg)
+
+    local mouseOver = false
+    local bound        -- source name we currently hold attribute callbacks for
+    local tipMode      -- "own" | "gametip" | nil; picked at hover, read at leave
+
+    -- The collapse flip below is a Show/Hide, which lockdown can refuse. A block
+    -- built or re-sourced mid-combat therefore settles here rather than waiting
+    -- for a plugin update that may never come.
+    inst.events = { "PLAYER_REGEN_ENABLED" }
+
+    local function D() return blockCfg.settings or {} end
+    local function BC() return barCtx.cfg end
+
+    local button = CreateFrame("Button", nil, content)
+    button:EnableMouse(true)
+    button:RegisterForClicks("AnyUp")
+
+    local icon = button:CreateTexture(nil, "OVERLAY")
+    local text = button:CreateFontString(nil, "OVERLAY")
+    AttachTextOffset(inst, text)
+
+    -- The chosen source, or nil while its addon has not registered it yet.
+    local function Obj()
+        local name = D().source
+        if not name then return nil end
+        local LDB = ns.GetLDB()
+        if not LDB then return nil end
+        return LDB:GetDataObjectByName(name)
+    end
+
+    local function Unbind()
+        local LDB = ns.GetLDB()
+        if LDB and bound then
+            pcall(LDB.UnregisterCallback, inst, "LibDataBroker_AttributeChanged_" .. bound)
+        end
+        bound = nil
+    end
+
+    -- Idempotent: re-binds only when the chosen source actually changed.
+    local function Bind()
+        local name = D().source
+        if bound == name then return end
+        Unbind()
+        if not name then return end
+        local LDB = ns.GetLDB()
+        if not LDB then return end
+        -- Args are (event, sourceName, key, value, obj); only the key matters.
+        local function OnAttr(_, _, key)
+            if LDB_WATCH[key] and not inst._dead then inst:Refresh() end
+        end
+        pcall(LDB.RegisterCallback, inst, "LibDataBroker_AttributeChanged_" .. name, OnAttr)
+        bound = name
+    end
+
+    -- Untouched Icon Color leaves the plugin's artwork alone, honouring the
+    -- iconR/G/B tint if it declares one; any explicit choice in the options wins,
+    -- exactly as on every other icon-bearing block.
+    local function IconTint(obj)
+        local b = blockCfg
+        if b.iconColor or b.useIconClassColor or b.useIconAccentColor or b.useIconDefaultColor then
+            return IconColorOf(b)
+        end
+        if obj and type(obj.iconR) == "number" then
+            return obj.iconR, obj.iconG or 1, obj.iconB or 1
+        end
+        return 1, 1, 1
+    end
+
+    function inst:Refresh()
+        local s = D()
+        local barCfg = BC()
+        local barH = barCtx.GetThickness()
+        local fontSize = max(9, floor(CONTENT_BASE * 0.4333 + 0.5))
+        local isSide = barCtx.IsVertical()
+        local gap = ICON_GAP
+        Bind()
+
+        local obj = Obj()
+
+        -- A source picked on a session where its addon WAS loaded, opened on one
+        -- where it is not: collapse rather than show a dead slot. GetAutoLength
+        -- reports 0 and the solver drops the block and its gaps entirely.
+        local collapsed = (s.source ~= nil) and (obj == nil)
+        -- Show/Hide can be protected (another block on this bar may hold a
+        -- secure child): flip only on a real state change, never in lockdown.
+        if content:IsShown() == collapsed and not InCombatLockdown() then
+            if collapsed then content:Hide() else content:Show() end
+        end
+        if collapsed then
+            MaybeRelayout(inst)
+            return
+        end
+
+        local str
+        local placeholder = false
+        if not s.source then
+            -- Bar text goes straight through SetText, which does not route
+            -- through the locale like the Tip_* helpers do, so translate by hand.
+            str = EllesmereUI.L(L["SELECT_PLUGIN"])
+            placeholder = true
+        else
+            local body = LDBDisplayText(obj)
+            if s.showText == false then body = nil end
+            local lbl = obj.label
+            if s.showLabel and type(lbl) == "string" and lbl ~= "" then
+                if body then str = lbl .. ": " .. body else str = lbl end
+            else
+                str = body
+            end
+            if s.stripColors ~= false then str = LDBStripColors(str) end
+            if not str then str = "" end
+        end
+
+        local iconSz = 0
+        local tex = obj and obj.icon
+        if s.showIcon ~= false and tex then
+            iconSz = fontSize + 2
+            icon:SetTexture(tex)
+            local c = obj.iconCoords
+            if type(c) == "table" and #c == 4 then
+                icon:SetTexCoord(c[1], c[2], c[3], c[4])
+            else
+                icon:SetTexCoord(0, 1, 0, 1)
+            end
+            icon:SetSize(iconSz, iconSz)
+            local ir, ig, ib = IconTint(obj)
+            icon:SetVertexColor(ir, ig, ib, 1)
+            icon:Show()
+        else
+            icon:Hide()
+        end
+
+        -- Only steal the wheel for a plugin that asked for it.
+        button:EnableMouseWheel((obj and obj.OnMouseWheel) ~= nil)
+
+        if placeholder then
+            text:SetTextColor(0.55, 0.55, 0.55, 1)
+        elseif mouseOver then
+            local ar, ag, ab = ns.GetAccent()
+            text:SetTextColor(ar, ag, ab, 1)
+        else
+            local tr, tg, tb = BlockColorOf(blockCfg)
+            text:SetTextColor(tr, tg, tb, 1)
+        end
+
+        ns.SetFont(text, fontSize, barCfg)
+
+        if isSide then
+            local slotW = VSlotW(inst)
+            local innerW = max(24, slotW - 8)
+            local totalH = 8
+            if iconSz > 0 then
+                icon:ClearAllPoints()
+                icon:SetPoint("TOP", button, "TOP", 0, -4)
+                totalH = totalH + iconSz + 2
+            end
+            ns.SetWrappedText(text, innerW, "CENTER")
+            text:SetText(str)
+            text:ClearAllPoints()
+            if iconSz > 0 then
+                text:SetPoint("TOP", icon, "BOTTOM", 0, -2)
+            else
+                text:SetPoint("TOP", button, "TOP", 0, -4)
+            end
+            totalH = totalH + ns.SnapToPixelGrid(text:GetStringHeight() or fontSize) + 4
+            totalH = max(totalH, barH)
+            content:SetSize(slotW, totalH)
+            button:SetSize(slotW, totalH)
+        else
+            ns.ResetInlineText(text, "LEFT")
+            text:SetText(str)
+            local iconPad = 0
+            if iconSz > 0 then
+                iconPad = iconSz + gap
+                icon:ClearAllPoints()
+                icon:SetPoint("LEFT", button, "LEFT", 0, 0)
+            end
+            text:ClearAllPoints()
+            text:SetPoint("LEFT", button, "LEFT", iconPad, 0)
+            local w = s.maxWidth
+            if w then
+                -- Max Width: the block holds this width whatever the plugin
+                -- publishes, and longer strings clip. The setting that stops a
+                -- chatty broker from shoving its neighbours on every update.
+                text:SetWidth(max(20, w - iconPad - 2))
+                text:SetWordWrap(false)
+            else
+                w = iconPad + ns.SnapToPixelGrid(text:GetStringWidth() or 40) + 2
+            end
+            if w < 24 then w = 24 end
+            content:SetSize(w, barH)
+            button:SetSize(w, barH)
+        end
+
+        button:ClearAllPoints()
+        button:SetPoint("CENTER", content, "CENTER", 0, 0)
+        MaybeRelayout(inst)
+    end
+
+    local function HideTip()
+        if tipMode == "own" then
+            local obj = Obj()
+            if obj and obj.OnLeave then pcall(obj.OnLeave, button) end
+        elseif tipMode == "gametip" then
+            if GameTooltip:IsOwned(button) then GameTooltip:Hide() end
+        else
+            ns.Tip_Hide(button)
+        end
+        tipMode = nil
+    end
+
+    local function ShowTip()
+        local s = D()
+        local ar, ag, ab = ns.GetAccent()
+        -- Cleared up front so every early return below leaves the LAST hover's
+        -- route behind: HideTip reads this to decide whose tooltip to take away.
+        tipMode = nil
+        -- Unconfigured: the placeholder is the whole block, so the tooltip has
+        -- to say where a plugin is actually picked.
+        if not s.source then
+            ns.Tip_Begin(button)
+            ns.Tip_AddLine(L["SELECT_PLUGIN"], 1, 1, 1)
+            ns.Tip_AddLine(" ")
+            ns.Tip_AddDouble(L["LEFT_CLICK"], L["OPEN_SETTINGS"], 1, 1, 1, ar, ag, ab)
+            ns.Tip_Show()
+            return
+        end
+        local obj = Obj()
+        if not obj then return end
+        if obj.OnEnter then
+            tipMode = "own"
+            pcall(obj.OnEnter, button)
+            return
+        end
+        if obj.OnTooltipShow then
+            tipMode = "gametip"
+            GameTooltip:SetOwner(button, "ANCHOR_NONE")
+            GameTooltip:ClearAllPoints()
+            -- Same flip the owned tooltip does: a top bar drops its tooltip
+            -- below itself, a bottom bar lifts it above.
+            if barCtx.IsBarAtTop() then
+                GameTooltip:SetPoint("TOPLEFT", button, "BOTTOMLEFT", 0, -6)
+            else
+                GameTooltip:SetPoint("BOTTOMLEFT", button, "TOPLEFT", 0, 6)
+            end
+            GameTooltip:ClearLines()
+            if pcall(obj.OnTooltipShow, GameTooltip) then
+                GameTooltip:Show()
+            else
+                GameTooltip:Hide()
+                tipMode = nil
+            end
+            return
+        end
+        ns.Tip_Begin(button)
+        ns.Tip_AddLine(ns.LDBLabel(s.source, obj), 1, 1, 1)
+        local body = LDBDisplayText(obj)
+        if body then
+            ns.Tip_AddLine(" ")
+            ns.Tip_AddLine(LDBStripColors(body), 0.8, 0.8, 0.8)
+        end
+        ns.Tip_Show()
+    end
+
+    button:SetScript("OnEnter", function()
+        mouseOver = true
+        inst:Refresh()
+        ShowTip()
+    end)
+    button:SetScript("OnLeave", function()
+        mouseOver = false
+        HideTip()
+        inst:Refresh()
+    end)
+    button:SetScript("OnClick", function(_, mb)
+        -- No plugin picked yet: nothing to forward the click to, so send the
+        -- player to the picker instead of dead-ending there.
+        if not D().source then
+            -- Options surface is LoadOnDemand; load it so OpenBlockSettings exists.
+            if not ns.OpenBlockSettings then EllesmereUI:EnsureLoaded() end
+            if ns.OpenBlockSettings then
+                ns.OpenBlockSettings(barCtx.id, blockCfg.id, "ldb")
+            end
+            return
+        end
+        local obj = Obj()
+        if obj and obj.OnClick then pcall(obj.OnClick, button, mb) end
+    end)
+    button:SetScript("OnMouseWheel", function(_, delta)
+        local obj = Obj()
+        if obj and obj.OnMouseWheel then pcall(obj.OnMouseWheel, button, delta) end
+    end)
+
+    -- A source whose plugin registers later -- its addon loads after us, or on
+    -- demand -- binds the moment it appears; without this the block would sit
+    -- collapsed until something else happened to force a Refresh.
+    local function OnCreated(_, name)
+        if name == D().source and not inst._dead then
+            Bind()
+            inst:Refresh()
+        end
+    end
+
+    function inst:Enable()
+        content:Show()
+        if not self.eventFrame then
+            self.eventFrame = MakeEventFrame(self, function(me)
+                if not me._dead then me:Refresh() end
+            end)
+        end
+        RegisterInstEvents(self)
+        local LDB = ns.GetLDB()
+        if LDB then
+            pcall(LDB.RegisterCallback, inst, "LibDataBroker_DataObjectCreated", OnCreated)
+        end
+        Bind()
+    end
+
+    function inst:Disable()
+        UnregisterInstEvents(self)
+        local LDB = ns.GetLDB()
+        if LDB then
+            pcall(LDB.UnregisterCallback, inst, "LibDataBroker_DataObjectCreated")
+        end
+        Unbind()
+        content:Hide()
+    end
+
+    function inst:GetAutoLength()
+        if not content:IsShown() then return 0 end
+        if barCtx.IsVertical() then
+            return max(content:GetHeight() or 40, 30)
+        end
+        return max(content:GetWidth() or 60, 24)
+    end
+
+    function inst:Destroy()
+        self._dead = true
+        UnregisterInstEvents(self)
+        local LDB = ns.GetLDB()
+        if LDB then
+            pcall(LDB.UnregisterCallback, inst, "LibDataBroker_DataObjectCreated")
+        end
+        Unbind()
+        HideTip()
+        content:Hide()
+    end
+
+    return inst
+end
+
 ns.BlockFactories.spacer = function(blockCfg, slot, content, barCtx)
     local inst = { cfg = blockCfg, slot = slot, content = content, ctx = barCtx }
     inst.key = InstKey(barCtx, blockCfg)

--- a/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
@@ -1352,8 +1352,10 @@ initFrame:SetScript("OnEvent", function(self)
                     if cfg.blocks[bi].type == t.key then onBar = true break end
                 end
                 -- Spacers are the one type meant to repeat on a bar, so the
-                -- already-on-bar dim cue never applies to them.
-                if t.key == "spacer" then onBar = false end
+                -- already-on-bar dim cue never applies to them. Broker blocks
+                -- repeat for the same reason: one per plugin is the normal setup,
+                -- so a second one is not the accident the dim cue warns about.
+                if t.key == "spacer" or t.key == "ldb" then onBar = false end
                 local baseA = tDimA
                 local hoverA = 1
                 if onBar then baseA = 0.28; hoverA = 0.55 end
@@ -1384,6 +1386,8 @@ initFrame:SetScript("OnEvent", function(self)
                         -- so aim at the picker itself: that target pulses until
                         -- it is filled in, instead of the one-shot section glow.
                         if typeKey == "currency" then navKey = navKey .. ":currency" end
+                        -- Same for a broker block: unusable until a plugin is picked.
+                        if typeKey == "ldb" then navKey = navKey .. ":ldb" end
                         C_Timer.After(0.05, function()
                             if _edbNavigateFn then _edbNavigateFn(navKey) end
                         end)
@@ -2519,6 +2523,7 @@ initFrame:SetScript("OnEvent", function(self)
                 profession = true, profession2 = true, currency = true,
                 greatvault = true, audio = true, location = true, coords = true,
                 ilvl = true,
+                ldb = true,
             }
             if ICON_COLOR_BLOCKS[b.type] then
                 local function IconFlagsOff()
@@ -3119,6 +3124,49 @@ initFrame:SetScript("OnEvent", function(self)
                       end,
                       setValue = function(v) s.precision = v; Apply() end },
                 }
+            elseif b.type == "ldb" then
+                -- Rebuilt on every page draw, never cached: plugins register on
+                -- their own schedule and some only appear once their addon has
+                -- finished loading.
+                local lValues, lOrder = ns.BuildLDBList()
+                lValues._noLoc = true
+                lValues._menuOpts = { searchable = true, itemHeight = 26 }
+                lValues[""] = L("Select a plugin")
+                table.insert(lOrder, 1, "")
+                -- A source whose addon is not loaded this session still has to
+                -- read as the current pick: an empty-looking dropdown invites a
+                -- change the player never meant to make, and the block itself is
+                -- only collapsed, not unconfigured.
+                if s.source and not lValues[s.source] then
+                    lValues[s.source] = s.source .. " |cff808080(" .. L("not loaded") .. ")|r"
+                    lOrder[#lOrder + 1] = s.source
+                end
+                typeRows = {
+                    { type = "dropdown", text = "Plugin",
+                      tooltip = "Any LibDataBroker plugin registered right now. One block per plugin -- add the block again for a second one.",
+                      values = lValues, order = lOrder,
+                      getValue = function() return s.source or "" end,
+                      setValue = function(v)
+                          if v == "" then s.source = nil else s.source = v end
+                          Apply()
+                      end },
+                    MkToggleOn("Show Icon", "showIcon", "Shows the plugin's own icon next to its text."),
+                    MkToggleOn("Show Text", "showText",
+                        "Shows the plugin's text. Off leaves an icon-only block that still carries the plugin's tooltip and clicks."),
+                    MkToggle("Show Label", "showLabel", "Prefixes the plugin's own name to its text."),
+                    -- Default ON: broker text arrives carrying the plugin's color
+                    -- codes, which would otherwise silently beat the Text Color
+                    -- row above and the accent hover.
+                    MkToggleOn("Strip Colors", "stripColors",
+                        "Removes the color codes the plugin writes into its own text, so this block's Text Color applies. Off keeps the plugin's colors."),
+                    { type = "slider", pixel = true, text = "Max Width", min = 0, max = 400, step = 5,
+                      tooltip = "Holds the block at this width and clips longer text, so a plugin whose text keeps changing length never shifts the blocks beside it. Zero sizes the block to whatever the plugin currently says.",
+                      getValue = function() return s.maxWidth or 0 end,
+                      setValue = function(v)
+                          if v == 0 then s.maxWidth = nil else s.maxWidth = v end
+                          Apply()
+                      end },
+                }
             end
 
             local msIconRow
@@ -3152,6 +3200,14 @@ initFrame:SetScript("OnEvent", function(self)
                 -- never touched, so point at it and hold the pulse until they
                 -- do. k == 1 is the Width dropdown; the slider rides its right
                 -- slot. Released by the first drag (maxWidth stops being nil).
+                -- Same contract for a broker block with no plugin picked:
+                -- clicking its placeholder on the live bar lands on the picker,
+                -- which pulses until it is filled in.
+                if b.type == "ldb" and k == 1 then
+                    parent._edbClickTargets["block:" .. blockId .. ":ldb"] =
+                        { section = secHdr, target = row, slotSide = "left",
+                          holdWhile = function() return s.source == nil end }
+                end
                 if b.type == "location" and k == 1 then
                     parent._edbClickTargets["block:" .. blockId .. ":maxwidth"] =
                         { section = secHdr, target = row, slotSide = "right",


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds a **Broker Plugin** block type to Databars, letting any LibDataBroker (LDB) plugin (SavedInstances, Socialite, BrokerAnything, Titan plugins, etc.) display as a native block. Bounced off @ellesmere on Discord; submitting as-is per that conversation, with the three points below flagged for discussion.

For the player: **Add Block > Broker Plugin** adds a block that can display any currently registered LDB plugin. The block renders the selected plugin's icon and text, and forwards clicks / hover / mouse-wheel events. The block config offers Show Icon / Show Text / Show Label toggles, a Max Width clamp (so plugins whose text changes length can't shift neighboring blocks), and Strip Colors (default on, so the block's Text Color row applies over plugin-embedded color codes).

Implementation is intentionally generic, modeled on the Currency block. It adds LDB-specific options, and exempts itself from the "already on this bar" dimming (like spacers) since multiple plugin blocks can be added.

### Flagged for review

1. **New external library**<br>Adds LibDataBroker (~90 LOC) as a `.pkgmeta` external loaded from the parent TOC, following the existing libs pattern. It provides the plugin registry and the per-source attribute-changed callbacks that keep the block event-driven with no polling.<br>In principle, it could expect a plugin's embedded copy to be available, but nolib-stripped builds don't ship one, which is why other LDB displays (Titan / Bazooka / ElvUI) all include it. I know external libs are generally avoided here -- happy to discuss alternatives.

2. **Tooltips**<br>Plugins choose their own tooltip path: `OnTooltipShow` goes through GameTooltip (which BlizzardSkin styles); plugins drawing their own via `OnEnter` (LibQTip etc.) won't match the built-in style, but nothing any LDB display can change there. Databars' GameTooltip sites were deliberately replaced by the EUI tooltip, and this reintroduces one for the `OnTooltipShow` call.

3. **Third-party code exposure**<br>Mouse interactions execute plugin code by design. Lua errors are trapped by `pcall`, but a plugin attempting a protected action in combat shows the standard blocked-action message attributed to EUI. This is inherent to any LDB display; others carry the same exposure.

## How was it tested?

Running on live (Midnight 12.1) since mid August, rebased through v9.0.8. Used daily with several LDB plugins:
- SavedInstances (launcher type, late registration, text arriving after login, LibQTip tooltip)
- Socialite (data source, color-coded text, self-drawn tooltip with clickable rows)
- Scoreboard (GameTooltip driven from `OnEnter`)
- TSM (Icon launcher)

## Screenshots
| Image | Description |
|-|-|
| <img width="1119" height="464" alt="image" src="https://github.com/user-attachments/assets/a8de8956-4373-445f-b53f-357a19e617b4" /> | Broker block with an `OnTooltipShow` plugin (GameTooltip, BlizzardSkin-styled) |
| <img width="973" height="421" alt="image" src="https://github.com/user-attachments/assets/6aebc5c0-3015-4df0-9ad2-b9eb957c3b16" /> | Socialite with its `OnEnter` self-drawn tooltip |
| <img width="1163" height="652" alt="image" src="https://github.com/user-attachments/assets/e0579993-3020-453a-9bba-fc75cb5b6f65" /> | SavedInstances with its `OnEnter` self-drawn tooltip, BugSack/TSM launchers |
| <img width="1316" height="971" alt="image" src="https://github.com/user-attachments/assets/12793e42-daae-4c67-ad0a-b146d2ef230a" /> | Block options with the Broker Plugin picker open |

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)<br>*Fully opt-in: nothing exists until a Broker Plugin block is added to a bar. Per-block sub-settings (Show Icon / Show Text / Strip Colors) default on, matching the existing block convention for currency and clock.*
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built<br>*The LDB library itself loads for everyone, but no events are subscribed, no frames built. One LibStub registration only **(review point 1 above)***
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)<br>*Event-driven via LDB per-source attribute callbacks (no heartbeat, no OnUpdate, no timers). Repaints are filtered to rendered attributes only.*
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames<br>*All frames are created by this addon and no hooks are used. GameTooltip is used via its public API only, for the `OnTooltipShow` contract **(review point 2 above).***
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added