### PR TITLE
Feat(Visibility Options): add Resting and InVehicle conditions

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -12656,7 +12656,7 @@ EllesmereUI.VIS_OPT_ITEMS = {
       tooltip = "This bar will only show if you have an enemy targeted" },
 }
 
--- Every visibility-option DB field, including the four counter-lane keys that have
+-- Every visibility-option DB field, including the counter-lane keys that have
 -- no row in the legacy VIS_OPT_ITEMS list above (they exist only as Hide/Show lanes
 -- in the unified Visibility row, EllesmereUI.VIS_ROW_ITEMS). Sync copies and equality
 -- checks iterate THIS list so a lane set through the unified row is never dropped by
@@ -12668,6 +12668,8 @@ EllesmereUI.VIS_OPT_KEYS = {
     "visHideDragonriding", "visOnlySkyriding",
     "visHideNoTarget", "visHideWithTarget",
     "visHideNoEnemy", "visHideWithEnemy",
+    "visOnlyResting", "visHideResting",
+    "visOnlyVehicle", "visHideVehicle",
 }
 
 -- Cache player class once at load time (never changes).
@@ -12807,6 +12809,20 @@ function EllesmereUI.CheckVisibilityOptionsNonMacro(opts, skipMountAxis)
         if not (EllesmereUI.IsPlayerSkyriding and EllesmereUI.IsPlayerSkyriding()) then return "mountaxis" end
     end
 
+    -- Resting axis: Only Show while Resting / Hide while Resting share one probe.
+    if opts.visOnlyResting or opts.visHideResting then
+        local resting = IsResting() and true or false
+        if opts.visOnlyResting and not resting then return true end
+        if opts.visHideResting and resting then return true end
+    end
+
+    -- Vehicle axis: Only Show in Vehicle / Hide in Vehicle share one probe.
+    if opts.visOnlyVehicle or opts.visHideVehicle then
+        local inVehicle = UnitInVehicle("player") and true or false
+        if opts.visOnlyVehicle and not inVehicle then return true end
+        if opts.visHideVehicle and inVehicle then return true end
+    end
+
     return false
 end
 
@@ -12854,6 +12870,10 @@ EllesmereUI.VIS_OPT_AXES = {
       probe = function() return EllesmereUI.IsPlayerMountedLike() end },
     { show = "visOnlySkyriding", hide = "visHideDragonriding", luaOnly = true,
       probe = function() return EllesmereUI.IsPlayerSkyriding() end },
+    { show = "visOnlyResting", hide = "visHideResting", luaOnly = true,
+      probe = function() return IsResting() and true or false end },
+    { show = "visOnlyVehicle", hide = "visHideVehicle", luaOnly = true,
+      probe = function() return UnitInVehicle("player") and true or false end },
     -- needsEdge: [exists]/[harm] re-evaluate on soft-target changes that
     -- UnitExists("target") ignores; a consumer without those edges resolves the axis in Lua.
     { show = "visHideNoTarget", hide = "visHideWithTarget", needsEdge = "softTarget",

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -13853,6 +13853,11 @@ function EAB:FinishSetup()
     self:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED", function()
         self:UpdateHousingVisibility()
     end)
+    -- Resting: IsResting() has no dedicated poll, so without this the Resting axis only
+    -- re-evaluated when some unrelated event above happened to fire afterward.
+    self:RegisterEvent("PLAYER_UPDATE_RESTING", function()
+        self:UpdateHousingVisibility()
+    end)
     self:RegisterEvent("UPDATE_SHAPESHIFT_FORM", function()
         self:UpdateHousingVisibility()
     end)

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -9926,6 +9926,9 @@ eventFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 -- Visibility option events: mounted, target, instance zone changes
 eventFrame:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED")
 eventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
+-- Resting: IsResting() has no dedicated poll, so without this the Resting
+-- axis only re-evaluated when some unrelated event above happened to fire.
+eventFrame:RegisterEvent("PLAYER_UPDATE_RESTING")
 -- Dragonriding visibility modes: capability edge (mount/dismount/zone) plus
 -- the airborne edge (takeoff/landing while staying mounted; probed at load
 -- in EllesmereUI_Visibility.lua -- absent = the checklist items lock).
@@ -10129,7 +10132,7 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
         if ns.QueueReanchor then ns.QueueReanchor() end
         return
     end
-    if event == "PLAYER_TARGET_CHANGED" then
+    if event == "PLAYER_TARGET_CHANGED" or event == "PLAYER_UPDATE_RESTING" then
         _CDMApplyVisibility()
         return
     end

--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -2433,7 +2433,7 @@ do
         "PLAYER_TARGET_CHANGED", "GROUP_ROSTER_UPDATE",
         "PLAYER_MOUNT_DISPLAY_CHANGED", "PLAYER_CAN_GLIDE_CHANGED",
         "ZONE_CHANGED_NEW_AREA", "UPDATE_SHAPESHIFT_FORM",
-        "PLAYER_ENTERING_WORLD",
+        "PLAYER_ENTERING_WORLD", "PLAYER_UPDATE_RESTING",
     }
 
     -- Legacy scalar evaluation for the modes the multi engine declines.

--- a/EllesmereUIOptions/EllesmereUI_Widgets.lua
+++ b/EllesmereUIOptions/EllesmereUI_Widgets.lua
@@ -8502,6 +8502,12 @@ EllesmereUI.VIS_ROW_ITEMS = {
     { key = "enemyTarget", label = "Enemy Target", axis = "opt",
       show = "visHideNoEnemy", hide = "visHideWithEnemy",
       tooltip = "A target you can attack." },
+    { key = "resting", label = "Resting", axis = "opt",
+      show = "visOnlyResting", hide = "visHideResting",
+      tooltip = "While resting, in a city or at an inn." },
+    { key = "vehicle", label = "In Vehicle", axis = "opt",
+      show = "visOnlyVehicle", hide = "visHideVehicle",
+      tooltip = "While seated in a vehicle." },
 }
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -9121,7 +9121,7 @@ local function OnEvent(self, event, ...)
     elseif event == "PLAYER_TARGET_CHANGED" then
         UpdateVisibility()
     elseif event == "PLAYER_MOUNT_DISPLAY_CHANGED" or event == "PLAYER_CAN_GLIDE_CHANGED"
-        or event == "PLAYER_IS_GLIDING_CHANGED" then
+        or event == "PLAYER_IS_GLIDING_CHANGED" or event == "PLAYER_UPDATE_RESTING" then
         UpdateVisibility()
     elseif event == "ZONE_CHANGED_NEW_AREA" then
         -- Re-check secondary max power: UnitPowerMax can change across zone
@@ -9447,6 +9447,9 @@ function ERB:OnEnable()
     -- Visibility option events
     eventFrame:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED")
     eventFrame:RegisterEvent("PLAYER_CAN_GLIDE_CHANGED")
+    -- Resting: IsResting() has no dedicated poll, so without this the Resting
+    -- axis only re-evaluated when some unrelated event above happened to fire.
+    eventFrame:RegisterEvent("PLAYER_UPDATE_RESTING")
     -- Airborne edge for the dragonriding visibility modes (probed at load
     -- in EllesmereUI_Visibility.lua; absent = the checklist items lock)
     if EllesmereUI._hasGlidingEvent then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -12581,6 +12581,9 @@ function InitializeFrames()
         frames._visFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
         frames._visFrame:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED")
         frames._visFrame:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
+        -- Resting: IsResting() has no dedicated poll, so without this the Resting
+        -- axis only re-evaluated when some unrelated event above happened to fire.
+        frames._visFrame:RegisterEvent("PLAYER_UPDATE_RESTING")
         frames._visFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
         frames._visFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
         -- Dragonriding visibility modes: capability edge plus the airborne

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -143,6 +143,11 @@ visFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 visFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 visFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
 visFrame:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
+-- Resting edge: IsResting() itself has no dedicated poll, so without this the Resting
+-- checklist row only re-evaluates when some unrelated event (mount/zone/combat) happens
+-- to fire the dispatcher afterward -- e.g. it looked "bound to landing" because dismounting
+-- fires PLAYER_MOUNT_DISPLAY_CHANGED, not because resting is actually tied to mounting.
+visFrame:RegisterEvent("PLAYER_UPDATE_RESTING")
 -- Dragonriding edges: mount-capability changes fire PLAYER_CAN_GLIDE_CHANGED
 -- (repo-proven event); takeoff/landing while staying mounted fires
 -- PLAYER_IS_GLIDING_CHANGED, which is probed because nothing registered it before this


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds two new conditions to the shared visibility checklist used across most EllesmereUI modules: Resting and In Vehicle. They follow the same independent Show/Hide option-axis pattern already used by Instances, Housing, and Mounted, so any module that already exposes the unified visibility row (Action Bars, Unit Frames, aura displays, Quest Tracker, and others) picks up the two new rows automatically with no per-module changes. Resting resolves via `IsResting()` and In Vehicle via `UnitInVehicle("player")`. Also registers `PLAYER_UPDATE_RESTING` as a re-evaluation trigger everywhere a visibility re-check can be triggered: the shared visibility dispatcher and, since several modules build their own separate hand-rolled visibility event frame instead of consuming the shared one, Action Bars, Unit Frames, Cooldown Manager, Resource Bars, and Data Bars. `IsResting()` had no dedicated event driving a refresh anywhere, so the Resting row previously only updated incidentally when an unrelated event (mount, zone, combat) happened to fire afterward.

### Why there is no "Full Health" condition

A Full Health condition was prototyped alongside these and dropped: a tainted addon cannot read current health as a value it may branch on, so no show/hide decision can be derived from it. Measured in game standing in the open world (not in an instance), `C_Secrets.HasSecretRestrictions()` already reports `true`, and `UnitHealth`, `UnitHealthMissing` (predicted and unpredicted) and `UnitHealthPercent` all return secret values. Only `UnitHealthMax` comes back clean, which is the same split `ns.ApplyHashLines` in the Resource Bars already assumes when it caches a last known good maximum.

There is no documented clean boolean for "is at full health", and no Blizzard cached frame field holds that conclusion the way `wasSetFromCharges` does for spell charges. The one secret safe threshold pattern this addon uses, a `C_CurveUtil` curve evaluated engine side by `UnitHealthPercent`, yields a color for a setter rather than a value Lua can test, so it can tint a texture but cannot decide whether a frame is shown. Worth noting that the health percent shown on Raid Frames and Unit Frames is not evidence to the contrary: `string.format` and `SetValue` accept secret values, displaying one never requires reading it.

## How was it tested?

Tested in-game on live.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, this change only adds Lua-side visibility probes, no Blizzard frame is touched
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
