### PR TITLE
Add a per-bar option to draw the cooldown countdown above the keybind

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7557,12 +7557,59 @@ function EAB_VTABLE.CooldownFonts.ApplyToButton(btn, fontPath, cdSize, cdOX, cdO
     end)
 end
 
+-- Blizzard parks HotKey and Count in TextOverlayContainer (frameLevel 500) while the
+-- cooldown frames declare useParentLevel, so the countdown always draws BENEATH the
+-- keybind. OPT-IN per bar: drop that container to just above the button and put the
+-- cooldown frames one step above it. Lowering the text rather than raising the
+-- cooldown keeps the swipe below the assist ring (+15), tint (+14) and proc alerts,
+-- which are deliberately stacked above it. A bar the option was never on for is
+-- skipped entirely. SetFrameLevel and SetUsingParentLevel are both protected and
+-- these frames inherit the button's protection, so combat defers to the regen pass.
+ns._eabCdLayerRaised = {}
+function EAB:ApplyCooldownTextLayerForBar(barKey)
+    local s = self.db.profile.bars[barKey]
+    if not s then return end
+    local buttons = barButtons[barKey]
+    if not buttons then return end
+    local onTop = s.cooldownTextOnTop or false
+    if not onTop and not ns._eabCdLayerRaised[barKey] then return end
+    if InCombatLockdown() then ns._eabApplyDeferred = true return end
+
+    for i = 1, #buttons do
+        local btn = buttons[i]
+        if not btn then break end
+        local host = btn.TextOverlayContainer
+        local bfd = host and EFD(btn)
+        local base = host and btn:GetFrameLevel()
+        if host and onTop then
+            -- Stored as an OFFSET, not the raw level: a bar relayout shifts every
+            -- child with the button, so a captured absolute would restore stale.
+            bfd.textLvlOffset = bfd.textLvlOffset or (host:GetFrameLevel() - base)
+            host:SetFrameLevel(base + 1)
+            if btn.cooldown then
+                btn.cooldown:SetUsingParentLevel(false)
+                btn.cooldown:SetFrameLevel(base + 2)
+            end
+            if btn.chargeCooldown then btn.chargeCooldown:SetFrameLevel(base + 2) end
+        elseif host and bfd.textLvlOffset then
+            host:SetFrameLevel(base + bfd.textLvlOffset)
+            -- Re-slaving the cooldown restores its level too, so no write here.
+            if btn.cooldown then btn.cooldown:SetUsingParentLevel(true) end
+            if btn.chargeCooldown then btn.chargeCooldown:SetFrameLevel(base) end
+            bfd.textLvlOffset = nil
+        end
+    end
+    ns._eabCdLayerRaised[barKey] = onTop or nil
+end
+
 function EAB:ApplyCooldownFontsForBar(barKey)
     local s = self.db.profile.bars[barKey]
     if not s then return end
     local buttons = barButtons[barKey]
     if not buttons then return end
     local fontPath, cdSize, cdOX, cdOY, cdColor, cdFit = EAB_VTABLE.CooldownFonts.GetSettings(s)
+
+    self:ApplyCooldownTextLayerForBar(barKey)
 
     C_Timer.After(0, function()
         for i = 1, #buttons do

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -4753,12 +4753,14 @@ initFrame:SetScript("OnEvent", function(self)
                         local ox = s.cooldownTextXOffset or 0
                         local oy = s.cooldownTextYOffset or 0
                         local ft = s.cooldownFontFit or false
+                        local top = s.cooldownTextOnTop or false
                         for _, key in ipairs(GROUP_BAR_ORDER) do
                             if c then EAB.db.profile.bars[key].cooldownTextColor = { r=c.r, g=c.g, b=c.b } end
                             EAB.db.profile.bars[key].cooldownFontSize = sz
                             EAB.db.profile.bars[key].cooldownTextXOffset = ox
                             EAB.db.profile.bars[key].cooldownTextYOffset = oy
                             EAB.db.profile.bars[key].cooldownFontFit = ft
+                            EAB.db.profile.bars[key].cooldownTextOnTop = top
                             EAB:ApplyCooldownFontsForBar(key)
                         end
                         EllesmereUI:RefreshPage()
@@ -4770,12 +4772,14 @@ initFrame:SetScript("OnEvent", function(self)
                         local ox = s.cooldownTextXOffset or 0
                         local oy = s.cooldownTextYOffset or 0
                         local ft = s.cooldownFontFit or false
+                        local top = s.cooldownTextOnTop or false
                         for _, key in ipairs(GROUP_BAR_ORDER) do
                             local b = EAB.db.profile.bars[key]
                             if (b.cooldownFontSize or 12) ~= sz then return false end
                             if (b.cooldownTextXOffset or 0) ~= ox then return false end
                             if (b.cooldownTextYOffset or 0) ~= oy then return false end
                             if (b.cooldownFontFit or false) ~= ft then return false end
+                            if (b.cooldownTextOnTop or false) ~= top then return false end
                             if c then
                                 local bc = b.cooldownTextColor
                                 if not bc or bc.r ~= c.r or bc.g ~= c.g or bc.b ~= c.b then return false end
@@ -4795,12 +4799,14 @@ initFrame:SetScript("OnEvent", function(self)
                             local ox = s.cooldownTextXOffset or 0
                             local oy = s.cooldownTextYOffset or 0
                             local ft = s.cooldownFontFit or false
+                            local top = s.cooldownTextOnTop or false
                             for _, key in ipairs(checkedKeys) do
                                 if c then EAB.db.profile.bars[key].cooldownTextColor = { r=c.r, g=c.g, b=c.b } end
                                 EAB.db.profile.bars[key].cooldownFontSize = sz
                                 EAB.db.profile.bars[key].cooldownTextXOffset = ox
                                 EAB.db.profile.bars[key].cooldownTextYOffset = oy
                                 EAB.db.profile.bars[key].cooldownFontFit = ft
+                                EAB.db.profile.bars[key].cooldownTextOnTop = top
                                 EAB:ApplyCooldownFontsForBar(key)
                             end
                             EllesmereUI:RefreshPage()
@@ -4848,6 +4854,12 @@ initFrame:SetScript("OnEvent", function(self)
                           get=function() return SVal("cooldownFontFit", false) end,
                           set=function(v)
                               SSet("cooldownFontFit", v and true or false, function(k) EAB:ApplyCooldownFontsForBar(k) end)
+                          end },
+                        { type="toggle", label="Draw Above Keybind",
+                          tooltip="Draws the countdown in front of the keybind and charges text instead of behind them. Those texts then sit under the cooldown swipe, so they dim while the cooldown runs.",
+                          get=function() return SVal("cooldownTextOnTop", false) end,
+                          set=function(v)
+                              SSet("cooldownTextOnTop", v and true or false, function(k) EAB:ApplyCooldownTextLayerForBar(k) end)
                           end },
                     },
                 })


### PR DESCRIPTION
Request: Discord report from @Qpa (v9.0.8, Action Bars). On small action bars the text elements overlap and the keybind always wins, with no way to reverse it. Qpa noted this is current behavior rather than a bug, and asked for a layering option so the cooldown timer can be brought in front of the hotkey.

Issue: With only Keybind and Cooldown text enabled on a small bar, the two land in the same few pixels and the countdown is the one that gets hidden, which is usually the more useful of the pair.

Root cause: Blizzard's ActionButtonTemplate puts HotKey and Count inside a TextOverlayContainer declared at frameLevel 500, while $parentCooldown and chargeCooldown are declared useParentLevel="true" and so render at the button's own level. The countdown therefore can never draw above the keybind. The macro Name fontstring sits on the button's own layers, which is why it was already below the countdown.

Fix: Adds "Draw Above Keybind" to the per-bar Cooldown Text cog, off by default. When enabled, the bar's TextOverlayContainer drops to the button's frame level + 1 and the cooldown frames go to + 2.

Lowering the text rather than raising the cooldown is deliberate. The cooldown swipe is a region of the same frame as the countdown, so raising that frame would carry the swipe above the assisted combat highlight ring (+15), the assist tint (+14) and proc alerts, all of which are stacked above the swipe on purpose. Holding the cooldown at +2 leaves every one of those untouched. The keybind and charges text do end up under the swipe and dim while a cooldown runs, which is the tradeoff the option exists to make and is stated in its tooltip.

Turning the option back off re-slaves the cooldown with SetUsingParentLevel(true) and restores the container from a stored offset rather than an absolute level, since a bar relayout shifts every child's level along with the button. Bars that never enable the option return before touching any frame, so they keep useParentLevel intact and cost nothing. SetFrameLevel and SetUsingParentLevel are both protected and these frames inherit the action button's protection, so the pass is gated on InCombatLockdown and healed by the existing PLAYER_REGEN_ENABLED re-apply. The new key is carried by the Cooldown Text sync icon and its multi-apply.

Tested in game on live: the countdown draws in front of the keybind on a small bar, proc glow and assist highlight render unchanged on a button mid-cooldown, toggling the option back off restores the default order, a relayout after reverting still renders correctly, and flipping the option in combat applies cleanly on the combat drop. Pet and stance bars inherit SmallActionButtonTemplate, so they carry the same container and behave identically.
