### PR TITLE
Fix party and raid aura displays freezing on a stale unit binding

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -2496,6 +2496,7 @@ local function BmAcquireChain(button, d, health, ch, iscale, counters)
 
     local cc = entry.container
     entry.parked = nil
+    cc:SetEnabled(true)
     cc:SetUnit(button:GetAttribute("unit") or NO_UNIT)
     -- anchorMembers is per-GROUP (one entry per segment); memberIndex/segIndex
     -- let the anchor pass tell member boundaries from intra-member segments.
@@ -2540,6 +2541,14 @@ local function BmParkUnbound(d, counters)
                         (j == 1) and "chain" or ("chain" .. j), 0)
                 end
                 entry.container:SetShown(false)
+                -- Visibility is shared with presentation, so a park that rests on
+                -- it alone is undone by any later SetShown. IsEnabled is the other
+                -- half of the engine's registration test and nothing but us drives
+                -- it. Dropping the binding too forces a real reparse on re-acquire:
+                -- parking and re-acquiring on the SAME unit used to leave SetUnit a
+                -- no-op and restore the caps over whatever was parsed before.
+                entry.container:SetEnabled(false)
+                entry.container:SetUnit(NO_UNIT)
             end
         end
     end
@@ -3264,10 +3273,13 @@ local function RepointStale(d, unit)
     RebindContainer(d.rfcDispel, unit)
     RebindContainer(d.rfcBm, unit)
     RebindContainer(d.rfcBmSimple, unit)
-    -- Every chain container comes from the pool, parked ones included.
+    -- Every chain container comes from the pool; a parked one sits on NO_UNIT
+    -- deliberately, so leave it there.
     if d.rfcBmPool then
         for _, entry in pairs(d.rfcBmPool) do
-            if type(entry) == "table" then RebindContainer(entry.container, unit) end
+            if type(entry) == "table" and not entry.parked then
+                RebindContainer(entry.container, unit)
+            end
         end
     end
     -- Debuff Manager tiles keep their own per-container stamp beside the binding;

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -3229,6 +3229,42 @@ local function ApplyAssistGate(button, d, unit)
 end
 ns.RFC_ApplyAssistGate = ApplyAssistGate
 
+-- Per-container binding audit. Every build job reads the button's live unit
+-- attribute at its OWN run time and stamps d.rfcUnit, so a reassignment landing
+-- between two jobs leaves the containers that finished earlier bound to the
+-- previous occupant while d.rfcUnit already reads current -- the d.rfcUnit
+-- comparison every reassignment path uses can never see that. A container left
+-- on a token that no longer fires UNIT_AURA freezes on whatever it last parsed;
+-- SetUnit re-registers and reparses.
+local function RebindContainer(c, unit)
+    if c and c:GetUnit() ~= unit then c:SetUnit(unit) end
+end
+
+local function RepointStale(d, unit)
+    RebindContainer(d.rfcDebuffs, unit)
+    RebindContainer(d.rfcDispLoc, unit)
+    RebindContainer(d.rfcDispel, unit)
+    RebindContainer(d.rfcBm, unit)
+    RebindContainer(d.rfcBmSimple, unit)
+    -- Every chain container comes from the pool, parked ones included.
+    if d.rfcBmPool then
+        for _, entry in pairs(d.rfcBmPool) do
+            if type(entry) == "table" then RebindContainer(entry.container, unit) end
+        end
+    end
+    -- Debuff Manager tiles keep their own per-container stamp beside the binding;
+    -- rebinding them here behind its back would desync the two, so let it re-point.
+    if d.dmTiles and ns.DM_OnUnitAssigned then
+        for _, c in pairs(d.dmTiles) do
+            if c:GetUnit() ~= unit then
+                ns.DM_OnUnitAssigned(d, unit)
+                break
+            end
+        end
+    end
+end
+ns.RFC_RepointStale = RepointStale
+
 -- Called from the OnAttributeChanged("unit") watch when the secure header
 -- (re)assigns a button. SetUnit re-registers events; the explicit refresh
 -- covers assignments where the new unit's auras produce no UNIT_AURA edge.
@@ -3251,6 +3287,10 @@ function ns.RFC_OnUnitAssigned(button, d, unit)
     -- Assist state can still flip without a unit change; its same-state early-out
     -- keeps that call near-free.
     if d.rfcUnit == unit then
+        -- No binding audit here: this branch is the roster-reprocess storm path
+        -- (every button, every roster/name event, several times at pull start)
+        -- and the audit is a per-container read. The 1s sweep owns it instead,
+        -- which bounds a stale binding to one second either way.
         ApplyAssistGate(button, d, unit)
         return
     end

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -3150,13 +3150,25 @@ local function AssistProbe(unit)
         end
         return true
     end
+    -- LIVENESS, not identity: UNIT_AURA stops for a unit that disconnects, dies,
+    -- leaves render range or phases, and nothing clears the containers for the
+    -- duration, so they hide rather than sit frozen on what they last parsed.
     if not (UnitIsConnected(unit)
         and not UnitIsDeadOrGhost(unit)
-        and UnitCanAssist("player", unit)
         and UnitIsVisible(unit)
         and not UnitPhaseReason(unit)) then
         return false
     end
+    -- Assist is the only IDENTITY term left, and it is dead for group tokens
+    -- since 12.1.0 build 69497: CanApplyIdentityCandidateFilters short-circuits
+    -- on `isHelpful and UnitIsPlayerControlledOrGroupMember`, a token-SHAPE test,
+    -- and every container gated here is helpful spell-ID filtered. Friendly Boss
+    -- slots host bossN, outside the exemption, and keep the test.
+    if UnitIsPlayerControlledOrGroupMember and UnitIsPlayerControlledOrGroupMember(unit) then
+        return true
+    end
+    -- Evaluated in here so a secret answer errors inside the caller's pcall.
+    if not UnitCanAssist("player", unit) then return false end
     return true
 end
 

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -10,6 +10,12 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local _, ns = ...
 
 local AK -- EllesmereUI.AuraKit, resolved at first use
+-- The engine's own null binding: the AuraContainer intrinsic is born on unitToken
+-- "none" (Blizzard_AuraContainer.xml KeyValues). A button with no unit attribute
+-- yet has to land back on that, never on "player" -- that is a unit whose auras
+-- really do stream, so an unbound container renders the local player's buffs onto
+-- whoever the button later shows.
+local NO_UNIT = "none"
 local FALLBACK_FONT = "Interface\\AddOns\\EllesmereUI\\media\\fonts\\Expressway.TTF"
 
 -- Marks debuff rendering as container-owned; the legacy UpdateDebuffs body
@@ -2470,7 +2476,7 @@ local function BmAcquireChain(button, d, health, ch, iscale, counters)
         local shell = d.rfcBmShellPool and table.remove(d.rfcBmShellPool)
         if shell then
             DeclareGroups(shell)
-            AK.FinishContainer(shell, button:GetAttribute("unit") or "player")
+            AK.FinishContainer(shell, button:GetAttribute("unit") or NO_UNIT)
             entry = { container = shell, groups = totalGroups }
             pool[poolKey] = entry
         else
@@ -2478,7 +2484,7 @@ local function BmAcquireChain(button, d, health, ch, iscale, counters)
             AK.QueueBuildJob(function()
                 local cc = AK.CreateContainerShell(button, { point = { "CENTER", health, "CENTER" } })
                 DeclareGroups(cc)
-                AK.FinishContainer(cc, button:GetAttribute("unit") or "player")
+                AK.FinishContainer(cc, button:GetAttribute("unit") or NO_UNIT)
                 pool[poolKey] = { container = cc, groups = totalGroups }
                 BmPoolReloadSoon() -- rebind the buttons waiting on this shell
             end, "rf:bmpool-shell")
@@ -2490,7 +2496,7 @@ local function BmAcquireChain(button, d, health, ch, iscale, counters)
 
     local cc = entry.container
     entry.parked = nil
-    cc:SetUnit(button:GetAttribute("unit") or "player")
+    cc:SetUnit(button:GetAttribute("unit") or NO_UNIT)
     -- anchorMembers is per-GROUP (one entry per segment); memberIndex/segIndex
     -- let the anchor pass tell member boundaries from intra-member segments.
     local anchorMembers = {}
@@ -2780,7 +2786,7 @@ local function ReloadBm(button, d, s, cls)
             -- pool shells are pending -- rebuilding again would orphan it).
             if d.rfcBm or d.rfcBmSig ~= nil then return end
             if InCombatLockdown() then d.rfcBmPending = true; return end
-            local unit = button:GetAttribute("unit") or "player"
+            local unit = button:GetAttribute("unit") or NO_UNIT
             CreateBmContainer(button, d.rfcHealth, d, unit)
             -- Fresh/retargeted containers may default shown at alpha 1;
             -- clear the readable state cache and re-drive the trust gate so
@@ -2970,7 +2976,7 @@ local function QueueDebuffPhase(button, health, d)
         local c = d.rfcDebuffShell
         if not c then return end
         d.rfcDebuffShell = nil
-        local unit = button:GetAttribute("unit") or "player"
+        local unit = button:GetAttribute("unit") or NO_UNIT
         AK.FinishContainer(c, unit)
         d.rfcHealth = health
         d.rfcDebuffs = c
@@ -3010,7 +3016,7 @@ local function QueueDispLocPhase(button, health, d)
         local c = d.rfcDispLocShell
         if not c then return end
         d.rfcDispLocShell = nil
-        local unit = button:GetAttribute("unit") or "player"
+        local unit = button:GetAttribute("unit") or NO_UNIT
         AK.FinishContainer(c, unit)
         d.rfcDispLoc = c
         local sNow = ProxyFor(d)
@@ -3038,7 +3044,7 @@ local function QueueButtonGroups(button, health, d)
         local c = d.rfcDispelShell
         if not c then return end
         d.rfcDispelShell = nil
-        local unit = button:GetAttribute("unit") or "player"
+        local unit = button:GetAttribute("unit") or NO_UNIT
         AK.FinishContainer(c, unit)
         d.rfcDispel = c
         local sNow = ProxyFor(d)
@@ -3052,7 +3058,7 @@ local function QueueButtonGroups(button, health, d)
     AK.QueueBuildJob(function()
         d.rfcPending = nil
         d.rfcGroupsPending = nil
-        local unit = button:GetAttribute("unit") or "player"
+        local unit = button:GetAttribute("unit") or NO_UNIT
         CreateBmContainer(button, health, d, unit)
         d.rfcUnit = unit
         -- Shells baked the dispel filters from rfcTotemKnown at build time; if a

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_DebuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_DebuffManager.lua
@@ -2269,7 +2269,10 @@ function ns.DM_OnUnitAssigned(d, unit)
     local tiles = d.dmTiles
     if not tiles then return end
     for _, c in pairs(tiles) do
-        if c._dmUnit ~= unit then
+        -- The container's own binding, not the stamp beside it: the stamp is a
+        -- shadow, and a re-point that reaches the container by any other route
+        -- would leave it lying about what the tile is actually parsing.
+        if c:GetUnit() ~= unit then
             c:SetUnit(unit)
             c:UpdateAllAuras()
             c._dmUnit = unit

--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -8382,13 +8382,21 @@ end  -- range fading section (do-block keeps its locals out of the 200-cap)
 --  render-visibility edge has no event, so a unit that ghosts (loadscreen, out
 --  of render range, disconnect) keeps whatever its containers last parsed. On
 --  regain the containers are re-parsed in place (the same UpdateAllAuras lever
---  the assist gate uses on its own false->true edge).
+--  the assist gate uses on its own false->true edge). The same pass audits each
+--  container's own unit binding, which nothing else re-drives once the header
+--  stops re-asserting the token.
 -------------------------------------------------------------------------------
 local ghostTicker = nil
 
 local function GhostAuraCheck()
     local function checkUnit(unit, btn)
         local d = GetFFD(btn)
+        -- unitToButton et al. only ever gain entries on reassignment, never drop
+        -- the old one, so unit/btn here can be a stale pairing; re-confirm against
+        -- the button's own live attribute before writing to it.
+        if btn:GetAttribute("unit") == unit and ns.RFC_RepointStale then
+            ns.RFC_RepointStale(d, unit)
+        end
         if not UnitIsVisible(unit) or not UnitIsConnected(unit) then
             if not d.ghostCleared then
                 d.ghostCleared = true


### PR DESCRIPTION
Bug: reported by Sliskeh in EllesmereUI-helper Discord (2026-08-27 and 2026-08-30)

Issue: A buff monitor or debuff icon sits frozen on one party or raid member until a fresh cast resets it, while every other display on that frame keeps updating. Seen in raid and keys with the member in view.

Root cause: A button's aura containers are finished by separate build jobs, each stamping d.rfcUnit as it runs. A reassignment between two of them leaves the earlier containers on the previous occupant while d.rfcUnit already reads current, so the check RFC_OnUnitAssigned and RebuildUnitMap both use cannot see it. A container on a token that no longer fires UNIT_AURA never updates again.

Fix: The 1s sweep now compares each container's own GetUnit against the button's live unit and re-points mismatches. Unassigned containers take the engine's null token rather than "player", parked pool entries are unbound so a re-acquire reparses, and the trust gate drops its assist test for group tokens, exempted by build 69497. Verified in game.
