### PR TITLE
Fix(ActionBars): out of range tint lost when a spell override swaps a button

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -3477,7 +3477,18 @@ function EAB_VTABLE.ForceButtonRefresh(btn, action)
         -- on CHANGES, so nothing repaints until hover. Mirrors Blizzard's
         -- UpdateUsable; pcall-guarded in case the usability booleans are
         -- restricted (tint then left for the usable-event path).
-        pcall(ns._TintUsableIcon, icon, action)
+        -- Skipped while the range system owns the color, same rule as
+        -- DispWalkUsable: a spell override changes the texture and lands here,
+        -- and painting the usable tint over a live range tint strands a white
+        -- icon that only a hover undoes -- this path bypasses UpdateUsable, so
+        -- the re-apply hook never sees it, and the range cache still reads
+        -- out-of-range so no later event repaints either.
+        local rfd = EFD(btn)
+        if rfd.rangeTinted then
+            rfd.usableState = nil
+        else
+            pcall(ns._TintUsableIcon, icon, action)
+        end
     end
     if btn.Count and C_ActionBar and C_ActionBar.GetActionDisplayCount then
         -- No `or ""` on the raw return: it is secret while cooldowns are


### PR DESCRIPTION
Bug: reported by Thyminde in the EllesmereUI Discord

Issue: with Out of Range Coloring enabled, a button whose spell is replaced by another - Survival's Raptor Swipe replacing Raptor Strike every other cast - stops going red when the swap leaves the player out of range, while other melee abilities on the same bar tint correctly. Hovering the stuck button brings the red back.

Root cause: an override changes the button texture, so ns._cdIconHeal calls ForceButtonRefresh, whose usable-tint mirror repaints over a live range tint. DispWalkUsable already skips buttons the range system owns; this path did not. It also bypasses UpdateUsable, so the re-apply hook never fires, and since the range cache still reads out of range, the next report hits the no-change gate and returns.

Fix: skip the usable mirror while the button is range tinted, and clear the usable memo so it repaints once the range system releases the colour. Confirmed in game by the reporter.
