### PR TITLE
Refactor(questtracker): background anchor

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
@@ -321,14 +321,14 @@ local function ApplyTopDivider()
     tex:Show()
 end
 
--- Find the frame that sits at the absolute bottom of all visible content
--- across every tracker module. Used to anchor the BG's bottom edge.
+-- Find the module that sits at the bottom of the tracker. Used to anchor the
+-- BG's bottom edge.
 --
 -- Reference-only: no coordinate is read here, because Blizzard's block geometry
 -- turns into a secret value once our execution is tainted and comparing one
--- throws. Blizzard's container anchors each displayed module below the previous
--- one in ipairs(modules) order, so the last displayed module owns the bottom
--- edge, and its GetLastBlock returns that module's lowest block.
+-- throws. The container anchors each displayed module below the previous one in
+-- ipairs(modules) order, so the last displayed one owns the bottom edge -- the
+-- same frame Blizzard anchors its own NineSlice background to.
 local function IsUsableAnchor(frame)
     if not frame or type(frame) ~= "table" then return false end
     if not frame.IsShown or not frame.GetObjectType then return false end
@@ -340,7 +340,7 @@ local function GetLowestContentFrame()
     if not otf then return nil end
     local modules = otf.modules or otf.MODULES
     if not modules then return nil end
-    local lowestFrame
+    local lowestModule
     local _scenarioTracker = _G.ScenarioObjectiveTracker
     local _widgetTracker = _G.UIWidgetObjectiveTracker
     for _, tracker in ipairs(modules) do
@@ -356,22 +356,16 @@ local function GetLowestContentFrame()
         -- refuses to touch these frames for the same reason.
         if tracker == _scenarioTracker or tracker == _widgetTracker then
             -- skip
-        -- hasContents is the same gate the old block scan effectively used:
-        -- Blizzard sets it when a module adds a block, clears it on relayout.
-        elseif tracker.hasContents and IsUsableAnchor(tracker) then
-            local candidate = tracker.GetLastBlock and tracker:GetLastBlock()
-            if not IsUsableAnchor(candidate) then
-                -- Collapsed section: its blocks are freed and hidden while the
-                -- Header stays visible as the section's bottom edge.
-                candidate = tracker.Header
-            end
-            if IsUsableAnchor(candidate) then
-                -- Later module == further down, so the last one wins.
-                lowestFrame = candidate
-            end
+        -- EndLayout hides a module that has nothing to display, so IsShown is
+        -- the content gate, and a later module sits further down. Anchoring to
+        -- the module rather than to its lowest block matters: blocks go back
+        -- into Blizzard's pool on collapse, which clears their points and drags
+        -- an anchored BG along; module frames are permanent.
+        elseif IsUsableAnchor(tracker) then
+            lowestModule = tracker
         end
     end
-    return lowestFrame
+    return lowestModule
 end
 
 -- Event-driven resize with a debounce. Every QueueResize call coalesces into a single
@@ -440,13 +434,16 @@ local function ResizeBGToContent()
         bg._divider:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
         bg._divider:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
     end
-    -- Third anchor instead of SetHeight: the bottom edge was "anchor top +
-    -- topOfs - lowest bottom + 15" fed into SetHeight, so pointing BOTTOM at the
-    -- same frame with the same gap lands it in the same place, coordinate-free.
+    -- UpdateHeight sizes a module to contentsHeight + bottomSpacing, so its
+    -- bottom sits bottomSpacing below its last block. Adding that back keeps the
+    -- 15px gap the old SetHeight calculation produced, still coordinate-free.
+    local bottomSpacing = lowest.bottomSpacing
+    if issecretvalue and issecretvalue(bottomSpacing) then bottomSpacing = nil end
+    if type(bottomSpacing) ~= "number" then bottomSpacing = 0 end
     bg:ClearAllPoints()
     bg:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
     bg:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
-    bg:SetPoint("BOTTOM",   lowest,      "BOTTOM",               0,       -15)
+    bg:SetPoint("BOTTOM",   lowest,      "BOTTOM",               0, bottomSpacing - 15)
     bg._lastLowest = lowest
 end
 EQT.ResizeBGToContent = ResizeBGToContent

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
@@ -14,13 +14,6 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local _, ns = ...
 local EQT = ns.EQT
 
--- Frame geometry getters (GetBottom/GetTop) can return secret numbers once our
--- execution is tainted -- seen on Blizzard quest blocks after leaving an arena,
--- where every layout pass then threw "attempt to compare a secret number value".
--- Reading a secret is safe; comparing or doing arithmetic with one is not, so
--- every measured coordinate is filtered through this before it is used.
-local isSecret = issecretvalue or function() return false end
-
 -- Hidden reparent target -- NEVER recursed into.
 local hiddenFrame = CreateFrame("Frame", "EllesmereUIQTHiddenParent", UIParent)
 hiddenFrame:Hide()
@@ -330,13 +323,24 @@ end
 
 -- Find the frame that sits at the absolute bottom of all visible content
 -- across every tracker module. Used to anchor the BG's bottom edge.
+--
+-- Reference-only: no coordinate is read here, because Blizzard's block geometry
+-- turns into a secret value once our execution is tainted and comparing one
+-- throws. Blizzard's container anchors each displayed module below the previous
+-- one in ipairs(modules) order, so the last displayed module owns the bottom
+-- edge, and its GetLastBlock returns that module's lowest block.
+local function IsUsableAnchor(frame)
+    if not frame or type(frame) ~= "table" then return false end
+    if not frame.IsShown or not frame.GetObjectType then return false end
+    return frame:IsShown()
+end
+
 local function GetLowestContentFrame()
     local otf = GetTracker()
     if not otf then return nil end
     local modules = otf.modules or otf.MODULES
     if not modules then return nil end
-    local lowestFrame, lowestY
-    local sawSecret = false
+    local lowestFrame
     local _scenarioTracker = _G.ScenarioObjectiveTracker
     local _widgetTracker = _G.UIWidgetObjectiveTracker
     for _, tracker in ipairs(modules) do
@@ -352,43 +356,22 @@ local function GetLowestContentFrame()
         -- refuses to touch these frames for the same reason.
         if tracker == _scenarioTracker or tracker == _widgetTracker then
             -- skip
-        else
-        local function consider(frame)
-            if not frame or type(frame) ~= "table" then return end
-            if not frame.GetBottom or not frame.GetObjectType then return end
-            if not (frame.IsShown and frame:IsShown()) then return end
-            local ok, otype = pcall(frame.GetObjectType, frame)
-            if not ok then return end
-            if otype ~= "Frame" and otype ~= "Button" then return end
-            local y = frame:GetBottom()
-            if isSecret(y) then
-                sawSecret = true
-                return
+        -- hasContents is the same gate the old block scan effectively used:
+        -- Blizzard sets it when a module adds a block, clears it on relayout.
+        elseif tracker.hasContents and IsUsableAnchor(tracker) then
+            local candidate = tracker.GetLastBlock and tracker:GetLastBlock()
+            if not IsUsableAnchor(candidate) then
+                -- Collapsed section: its blocks are freed and hidden while the
+                -- Header stays visible as the section's bottom edge.
+                candidate = tracker.Header
             end
-            if y and (not lowestY or y < lowestY) then
-                lowestY, lowestFrame = y, frame
+            if IsUsableAnchor(candidate) then
+                -- Later module == further down, so the last one wins.
+                lowestFrame = candidate
             end
         end
-        if tracker.usedBlocks then
-            for _, v in pairs(tracker.usedBlocks) do
-                if type(v) == "table" then
-                    if v.GetBottom then
-                        consider(v)
-                    else
-                        for _, block in pairs(v) do consider(block) end
-                    end
-                end
-            end
-        end
-        -- Only consider the Header as content if the tracker actually has something to
-        -- display. Empty trackers leave their Header shown at stale positions and would
-        -- otherwise stretch the BG past real content when a section clears.
-        if tracker.hasContents then
-            consider(tracker.Header)
-        end
-        end -- else (skip scenario / widget-pool trackers)
     end
-    return lowestFrame, sawSecret
+    return lowestFrame
 end
 
 -- Event-driven resize with a debounce. Every QueueResize call coalesces into a single
@@ -425,12 +408,7 @@ local function ResizeBGToContent()
         if bg:IsShown() then bg:Hide() end
         return
     end
-    local lowest, sawSecret = GetLowestContentFrame()
-    -- Every candidate's position came back secret (tainted execution): there is
-    -- nothing measurable this pass and no later pass will fix it before a
-    -- reload, so leave the BG exactly as it is instead of entering the
-    -- transient-content retry below, which would re-queue itself forever.
-    if not lowest and sawSecret then return end
+    local lowest = GetLowestContentFrame()
     -- Transient "no visible content" states happen for a frame during
     -- track/untrack/collapse/expand while blocks are recycled. Keep the
     -- BG at its last position to avoid a hide/show blink.
@@ -457,32 +435,18 @@ local function ResizeBGToContent()
     local leftOfs = GetBGLeftOffset()
     local anchorFrame, anchorPoint = GetBGTopAnchor()
     anchorFrame = anchorFrame or otf
-    local topY = (anchorPoint == "BOTTOM") and anchorFrame:GetBottom() or anchorFrame:GetTop()
-    local lowestBottom = lowest:GetBottom()
-    if isSecret(topY) or isSecret(lowestBottom) then
-        -- Cannot measure this pass. Keep the last known geometry rather than
-        -- risking arithmetic on a secret value.
-        topY, lowestBottom = nil, nil
-    end
     if bg._divider then
         bg._divider:ClearAllPoints()
         bg._divider:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
         bg._divider:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
     end
-    if topY and lowestBottom then
-        local h = topY + topOfs - lowestBottom + 15
-        if h < 1 then h = 1 end
-        bg:ClearAllPoints()
-        bg:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
-        bg:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
-        bg:SetHeight(h)
-        bg._lastHeight = h
-    elseif bg._lastHeight then
-        bg:ClearAllPoints()
-        bg:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
-        bg:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
-        bg:SetHeight(bg._lastHeight)
-    end
+    -- Third anchor instead of SetHeight: the bottom edge was "anchor top +
+    -- topOfs - lowest bottom + 15" fed into SetHeight, so pointing BOTTOM at the
+    -- same frame with the same gap lands it in the same place, coordinate-free.
+    bg:ClearAllPoints()
+    bg:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)
+    bg:SetPoint("TOPRIGHT", anchorFrame, anchorPoint .. "RIGHT", 11, topOfs)
+    bg:SetPoint("BOTTOM",   lowest,      "BOTTOM",               0,       -15)
     bg._lastLowest = lowest
 end
 EQT.ResizeBGToContent = ResizeBGToContent

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
@@ -14,6 +14,13 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local _, ns = ...
 local EQT = ns.EQT
 
+-- Frame geometry getters (GetBottom/GetTop) can return secret numbers once our
+-- execution is tainted -- seen on Blizzard quest blocks after leaving an arena,
+-- where every layout pass then threw "attempt to compare a secret number value".
+-- Reading a secret is safe; comparing or doing arithmetic with one is not, so
+-- every measured coordinate is filtered through this before it is used.
+local isSecret = issecretvalue or function() return false end
+
 -- Hidden reparent target -- NEVER recursed into.
 local hiddenFrame = CreateFrame("Frame", "EllesmereUIQTHiddenParent", UIParent)
 hiddenFrame:Hide()
@@ -329,6 +336,7 @@ local function GetLowestContentFrame()
     local modules = otf.modules or otf.MODULES
     if not modules then return nil end
     local lowestFrame, lowestY
+    local sawSecret = false
     local _scenarioTracker = _G.ScenarioObjectiveTracker
     local _widgetTracker = _G.UIWidgetObjectiveTracker
     for _, tracker in ipairs(modules) do
@@ -353,6 +361,10 @@ local function GetLowestContentFrame()
             if not ok then return end
             if otype ~= "Frame" and otype ~= "Button" then return end
             local y = frame:GetBottom()
+            if isSecret(y) then
+                sawSecret = true
+                return
+            end
             if y and (not lowestY or y < lowestY) then
                 lowestY, lowestFrame = y, frame
             end
@@ -376,7 +388,7 @@ local function GetLowestContentFrame()
         end
         end -- else (skip scenario / widget-pool trackers)
     end
-    return lowestFrame
+    return lowestFrame, sawSecret
 end
 
 -- Event-driven resize with a debounce. Every QueueResize call coalesces into a single
@@ -413,7 +425,12 @@ local function ResizeBGToContent()
         if bg:IsShown() then bg:Hide() end
         return
     end
-    local lowest = GetLowestContentFrame()
+    local lowest, sawSecret = GetLowestContentFrame()
+    -- Every candidate's position came back secret (tainted execution): there is
+    -- nothing measurable this pass and no later pass will fix it before a
+    -- reload, so leave the BG exactly as it is instead of entering the
+    -- transient-content retry below, which would re-queue itself forever.
+    if not lowest and sawSecret then return end
     -- Transient "no visible content" states happen for a frame during
     -- track/untrack/collapse/expand while blocks are recycled. Keep the
     -- BG at its last position to avoid a hide/show blink.
@@ -442,6 +459,11 @@ local function ResizeBGToContent()
     anchorFrame = anchorFrame or otf
     local topY = (anchorPoint == "BOTTOM") and anchorFrame:GetBottom() or anchorFrame:GetTop()
     local lowestBottom = lowest:GetBottom()
+    if isSecret(topY) or isSecret(lowestBottom) then
+        -- Cannot measure this pass. Keep the last known geometry rather than
+        -- risking arithmetic on a secret value.
+        topY, lowestBottom = nil, nil
+    end
     if bg._divider then
         bg._divider:ClearAllPoints()
         bg._divider:SetPoint("TOPLEFT",  anchorFrame, anchorPoint .. "LEFT",  leftOfs, topOfs)


### PR DESCRIPTION
Bug report: https://discord.com/channels/585577383847788554/1543493338785652827

## What does this PR do?

Fixes a Lua error storm in the Quest Tracker background, and the background blanking out when a section is minimized.

Zoning out of an arena leaves our execution tainted. From that point on Blizzard's objective tracker block geometry is a secret value, and `GetLowestContentFrame` was comparing `frame:GetBottom()` results directly to find the lowest visible block. Every layout event then threw `attempt to compare local 'y' (a secret number value, while execution tainted by 'EllesmereUIQuestTracker')`, repeating until reload (nearly 4000 errors in the report this came from). The height calculation that followed had the same problem, since it did arithmetic on those coordinates.

The measurement is now gone entirely rather than guarded. Blizzard's own layout makes it unnecessary: `ObjectiveTrackerContainerMixin:Update` walks `ipairs(self.modules)` and anchors each displayed module's `TOP` to the previous module's `BOTTOM`, so array order is top-to-bottom screen order and the last displayed module owns the bottom edge -- which is exactly the frame Blizzard anchors its own NineSlice background to. `EndLayout` hides a module that has nothing to display, so `IsShown` is the content gate, and it covers a collapsed section correctly because that module stays visible at header height. The background's bottom edge is now a third anchor point on that module instead of a computed `SetHeight`, so the resize pass never reads, compares or calculates a coordinate and cannot trip over a secret value at all.

`UpdateHeight` sizes a module to `contentsHeight + bottomSpacing`, so its bottom sits `bottomSpacing` below its last block; that value is added back into the anchor offset to keep the same 15px gap the old calculation produced. It is plain module settings data rather than geometry, but it is guarded anyway.

The second commit is a follow-up to a bug found while testing the first: anchoring to the module's lowest *block* made the background disappear for about a second when a section was minimized, because collapse runs `EndLayout` -> `FreeUnusedBlocks` -> `FreeBlock` -> `ObjectiveTrackerManager:ReleaseFrame(block)`, which returns the block to Blizzard's pool and clears its anchors while our background was still pointing at it. Module frames are permanent and never pooled, which is why the anchor sits on the module.

For the player: no visual change at rest. The background stops throwing errors after an arena and keeps tracking content correctly instead of freezing at its last size, it no longer blanks out when minimizing a section, and it now follows Blizzard's collapse and add/remove animations smoothly instead of settling a tick later. As a side effect the per-block scan (a nested `pairs` walk over `usedBlocks` with a `pcall(GetObjectType)` per block) disappears from every resize pass.

## How was it tested?

Tested in-game on live.

## Screenshots

No visual difference at rest -- the background covers the same rectangle as before, so a before/after pair would be identical. The observable changes are the absence of the error spam and the background no longer blanking out on minimize.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new setting; this is a fix to existing behavior
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added