### PR TITLE
Fix: UntrustedLayoutScriptExecution taint anchoring weapon enchant host

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
@@ -415,16 +415,34 @@ local function LayoutHost(key, rec)
         hosts[key] = host
     end
     host.rec = rec
-    if not (host.secure and InCombatLockdown()) then
-        -- Parent from rec.parent ONLY -- rec.anchorTo can be an engine aura
-        -- container, which carries forbidden aspects
-        -- (UntrustedLayoutScriptExecution): SetParent into it hard-errors for
-        -- the secure host ("child object would inherit forbidden aspects").
-        -- Anchoring is legal, so the host RIDES the container's rect while
-        -- living in the plain bar frame's tree.
-        host.frame:SetParent(rec.parent or rec.frame)
+    if host.secure and InCombatLockdown() then return end
+    -- Parent from rec.parent ONLY -- rec.anchorTo can be an engine aura
+    -- container, which carries forbidden aspects
+    -- (UntrustedLayoutScriptExecution): SetParent into it hard-errors for
+    -- the secure host ("child object would inherit forbidden aspects").
+    -- Anchoring is legal, so the host RIDES the container's rect while
+    -- living in the plain bar frame's tree.
+    local function DoAnchor()
+        local r = host.rec
+        if not r then return end -- cleared before this ran
+        host.frame:SetParent(r.parent or r.frame)
         host.frame:ClearAllPoints()
-        host.frame:SetAllPoints(rec.anchorTo or rec.parent or rec.frame)
+        host.frame:SetAllPoints(r.anchorTo or r.parent or r.frame)
+    end
+    if host.secure then
+        -- Some callers (e.g. Unlock Mode's grow-direction dropdown) reach
+        -- here from a live, insecure OnClick handler; anchoring the secure
+        -- host straight onto an engine aura container from that stack throws
+        -- UntrustedLayoutScriptExecution. AuraKit's own job queue gives the
+        -- anchor write a fresh, untainted execution context instead.
+        local AK = EllesmereUI.AuraKit
+        if AK and AK.QueueLiveBuildJob then
+            AK.QueueLiveBuildJob(DoAnchor, "uf:weaponench-anchor")
+        else
+            DoAnchor()
+        end
+    else
+        DoAnchor()
     end
 end
 


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1543199099195752600

Issue: Anchoring the secure weapon-enchant host directly onto an engine aura container from an insecure OnClick stack (e.g. Unlock Mode's grow-direction dropdown) threw UntrustedLayoutScriptExecution.
Fix: Route the secure host's anchor write through AuraKit's job queue (QueueLiveBuildJob) to give it a fresh, untainted execution context instead of anchoring inline from the tainted caller.