### PR TITLE
Fix(CDM): Glow at Stacks showed a faint glow before the minimum stack count was reached

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -59,6 +59,14 @@ do
         return width, height
     end
 
+    -- The gate oversizes the icon by pad on every side and the mask matches the
+    -- gate exactly, so a FULL fill puts the open mask over the whole glow --
+    -- flipbook/pixel textures overhang the icon edges.
+    local function SizeStackGlowMask(st, width, height)
+        if not (st.mask and st.pad) then return end
+        st.mask:SetSize(width + st.pad * 2, height + st.pad * 2)
+    end
+
     -- LIVE-FIRST: the item's auraDataCached is (re)written on aura
     -- ASSIGNMENT, so an update-only stack change can leave it holding the
     -- gain-time count -- a threshold crossing would then wait for the next
@@ -107,6 +115,9 @@ do
             ns.StopNativeGlow(st.glow)
             st.started = nil
         end
+        -- Unconditional: the wrapper is created at alpha 1, so anything an
+        -- engine left on it would show through a gate that never opened.
+        if st.glow then st.glow:SetAlpha(0) end
         if st.gate then st.gate:SetValue(0) end
     end
 
@@ -160,12 +171,19 @@ do
             if gft then gft:SetAlpha(0) end
             st.gate:EnableMouse(false)
 
-            -- The mask shadows the (alpha-0) fill rect: value below the
-            -- window = zero-width rect = everything masked away.
+            -- The mask rides the (alpha-0) fill's RIGHT edge at a FIXED
+            -- gate-sized rect instead of shadowing the fill rect: at value =
+            -- min the fill is zero-wide, and a zero-area mask samples
+            -- undefined -- a partly passing mask reads as a faint glow below
+            -- the threshold. Parked a gate-width left it covers nothing; at
+            -- value = max it lands on the gate. NEAREST for the Raid Frames
+            -- absorb bound's reason: bilinear ramps WHITE8X8's edge texel into
+            -- the black border, and that leak shows along every edge.
             st.mask = st.gate:CreateMaskTexture()
             st.mask:SetTexture("Interface\\Buttons\\WHITE8x8",
-                "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
-            st.mask:SetAllPoints(gft or st.gate)
+                "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE", "NEAREST")
+            st.mask:SetPoint("RIGHT", gft or st.gate, "RIGHT", 0, 0)
+            SizeStackGlowMask(st, StackGlowSize(icon))
 
             st.glow = CreateFrame("Frame", nil, icon)
             st.glow:SetAllPoints(icon)
@@ -229,6 +247,7 @@ do
                 st.gate:SetPoint("TOPLEFT", icon, "TOPLEFT", -pad, pad)
                 st.gate:SetPoint("BOTTOMRIGHT", icon, "BOTTOMRIGHT", pad, -pad)
             end
+            SizeStackGlowMask(st, width, height)
             StartStackGlow(st, width, height)
         end
         st.gate:SetValue(applications)

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -2412,6 +2412,13 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
             maskPath   = maskPath,
             borderPath = borderPath,
             shapeMask  = shapeMask,
+            -- Gated (threshold) glows only: ApplyMaskWith below can bind only the
+            -- textures ON the wrapper, and this is the one engine that creates
+            -- them on the anchor frame instead -- unmasked, its pulse showed
+            -- below the stack threshold. The overlay is SetAllPoints on the icon,
+            -- so anchoring there is identical geometry; ungated callers keep the
+            -- icon parenting they have always had.
+            anchorFrame = (opts and opts.maskWith) and overlay or nil,
         })
     elseif entry.procedural then
         -- Pixel Glow params. Pandemic glow passes explicit opts; per-button glows (active-state,
@@ -5212,6 +5219,134 @@ function ns.StyleOverlayCooldownText(oCd, barData, ssb, iconScale)
     end
 end
 
+-- Font/colour/anchor for one Cooldown widget's countdown FontString. Split out
+-- of RefreshCDMIconAppearance so the text clone below can also be styled from
+-- its arming hook. Returns true once a FontString actually existed: the engine
+-- creates it lazily on the first armed countdown, so an unarmed widget has
+-- nothing to style yet.
+function ns.CdmStyleCooldownNumber(target, barData, ssb, fontScale)
+    if not target then return false end
+    fontScale = fontScale or 1
+    local cdFont = GetCDMFont()
+    local cdSize = ((ssb and ssb.cooldownFontSize) or (barData and barData.cooldownFontSize) or 12) * fontScale
+    local cdR = (ssb and ssb.cooldownTextR) or (barData and barData.cooldownTextR) or 1
+    local cdG = (ssb and ssb.cooldownTextG) or (barData and barData.cooldownTextG) or 1
+    local cdB = (ssb and ssb.cooldownTextB) or (barData and barData.cooldownTextB) or 1
+    local cdPosition = (ssb and ssb.cooldownTextPosition)
+        or (barData and barData.cooldownTextPosition) or "center"
+    local cdX = (ssb and ssb.cooldownTextX) or (barData and barData.cooldownTextX) or 0
+    local cdY = (ssb and ssb.cooldownTextY) or (barData and barData.cooldownTextY) or 0
+    local found = false
+    -- Keep the FontString ON its widget: REPARENTING it makes Blizzard's engine
+    -- re-center it and ignore the user's position and X/Y offset. Our own anchor
+    -- also overrides the engine's stale baseline (raw SetFont vs SetCountdownFont).
+    for _, rgn in pairs({ target:GetRegions() }) do
+        if rgn and rgn.GetObjectType and rgn:GetObjectType() == "FontString" then
+            EllesmereUI.ApplyIconTextFont(rgn, cdFont, cdSize, "cdm")
+            rgn:SetTextColor(cdR, cdG, cdB)
+            ns.AnchorCooldownText(rgn, target, cdPosition, cdX, cdY)
+            found = true
+        end
+    end
+    return found
+end
+
+-- Countdown carrier: a swipe-less Cooldown that renders ONLY the number, at
+-- icon+19. Swipe and number are drawn C-side by ONE widget and cannot be layered
+-- apart, but the icon needs them apart: a glow overlay has to sit ABOVE the swipe
+-- (below it, the swipe clips a Pixel Glow ring's inner edge and the ring reads
+-- thinner) and BELOW the number (above it, the interior-painting styles --
+-- Modern/Classic WoW Glow, GCD, Shape Glow -- wash the digits out). So the real
+-- widget keeps the swipe at icon+14 with its own numbers off and this clone
+-- carries the number. Built only for icons that show Duration Text.
+function ns.CdmEnsureCooldownTextClone(icon, cd, fd)
+    if not (icon and cd and fd) then return nil end
+    if fd.cdTextClone then return fd.cdTextClone end
+    -- Our own preset/custom frames run their own Cooldown AND their own Threshold
+    -- Text apply, which attaches the formatter straight to f._cooldown at injection
+    -- time (EllesmereUICdmHooks). A clone would orphan that, so they keep the
+    -- single-widget layout and today's behaviour.
+    if icon._isCustomBuffFrame or icon._isCustomSpellFrame then return nil end
+    local ok, tc = pcall(CreateFrame, "Cooldown", nil, icon, "CooldownFrameTemplate")
+    if not ok or not tc then return nil end
+    fd.cdTextClone = tc
+    tc:SetAllPoints(icon)
+    tc:SetFrameLevel(icon:GetFrameLevel() + 19)
+    tc:EnableMouse(false)
+    if tc.SetDrawSwipe then tc:SetDrawSwipe(false) end
+    if tc.SetDrawEdge then tc:SetDrawEdge(false) end
+    if tc.SetDrawBling then tc:SetDrawBling(false) end
+    tc:SetHideCountdownNumbers(false)
+
+    -- Seed: the clone is built lazily, so the widget can already be armed and the
+    -- forwarding hooks below only see future calls. GetCooldownTimes returns
+    -- MILLISECONDS, and that division is why the secret probe comes first --
+    -- arithmetic on a secret value is a hard error, as is testing one for nil.
+    -- Under restriction the next arm seeds it instead.
+    if cd.GetCooldownTimes then
+        local okT, cdStart, cdDur = pcall(cd.GetCooldownTimes, cd)
+        if okT and not (issecretvalue and (issecretvalue(cdStart) or issecretvalue(cdDur)))
+           and cdStart and cdDur and cdDur > 0 then
+            tc:SetCooldown(cdStart / 1000, cdDur / 1000)
+        end
+    end
+
+    if fd._cdTextCloneHooked then return tc end
+    fd._cdTextCloneHooked = true
+    -- One-time bootstrap styling. The engine creates the countdown FontString on
+    -- the first armed countdown, so a refresh that ran before the widget was ever
+    -- armed found nothing to style and the first number would render in
+    -- Blizzard's default font. Self-retiring: it stops the moment it lands.
+    local function BootstrapStyle()
+        if fd._cdTextStyled then return end
+        local st = fd._cdTextStyle
+        if not st then return end
+        if ns.CdmStyleCooldownNumber(fd.cdTextClone, st.barData, st.ssb, st.fontScale) then
+            fd._cdTextStyled = true
+        end
+    end
+    -- Forward every setter that arms the widget, matching the per-frame hook
+    -- pattern the charge/recharge repairs already use. The closures read fd,
+    -- which is keyed on the icon and so survives Blizzard's frame pooling.
+    hooksecurefunc(cd, "SetCooldown", function(_, start, duration, modRate)
+        local t = fd.cdTextClone
+        if not t then return end
+        t:SetCooldown(start, duration, modRate)
+        BootstrapStyle()
+    end)
+    hooksecurefunc(cd, "Clear", function()
+        local t = fd.cdTextClone
+        if t then t:Clear() end
+    end)
+    if cd.SetCooldownFromDurationObject then
+        hooksecurefunc(cd, "SetCooldownFromDurationObject", function(_, durObj)
+            local t = fd.cdTextClone
+            if not (t and t.SetCooldownFromDurationObject) then return end
+            t:SetCooldownFromDurationObject(durObj)
+            BootstrapStyle()
+        end)
+    end
+    if cd.SetUseAuraDisplayTime then
+        hooksecurefunc(cd, "SetUseAuraDisplayTime", function(_, use)
+            local t = fd.cdTextClone
+            if t and t.SetUseAuraDisplayTime then t:SetUseAuraDisplayTime(use) end
+        end)
+    end
+    -- Choke point. Eight sites across this module set the real widget's number
+    -- visibility; rather than teach each one about the clone, force the real
+    -- widget's numbers off here and pass the caller's intent through. The guard
+    -- blocks the recursion our own re-write would otherwise cause.
+    hooksecurefunc(cd, "SetHideCountdownNumbers", function(_, hide)
+        local t = fd.cdTextClone
+        if not t or fd._cdTextRouting then return end
+        fd._cdTextRouting = true
+        cd:SetHideCountdownNumbers(true)
+        t:SetHideCountdownNumbers(hide)
+        fd._cdTextRouting = false
+    end)
+    return tc
+end
+
 -------------------------------------------------------------------------------
 --  Per-spell Threshold Text (engine countdown formatters)
 --
@@ -5535,12 +5670,18 @@ local function RefreshCDMIconAppearance(barKey)
         if cd then
             cd:ClearAllPoints()
             cd:SetAllPoints(icon)
-            -- Above the border (icon+13); still below glow (icon+16) / text (icon+23).
+            -- Above the border (icon+13) and BELOW the glow overlays (icon+16/+17):
+            -- a swipe drawn over a glow clips the ring's inner edge and it reads
+            -- thinner. The countdown number rides fd.cdTextClone instead, the only
+            -- way to get it above the glow -- see ns.CdmEnsureCooldownTextClone.
             pcall(cd.SetFrameLevel, cd, icon:GetFrameLevel() + 14)
             -- Per-icon Duration Text override (ssb) falls back to the bar's values. Only Show
             -- Numbers no longer forces this on: hiding the duration (bar toggle or per-icon) under it leaves just the stack count.
             local showCD = ns.CdmDurationTextOn(barData)
             if ssb and ssb.showCooldownText ~= nil then showCD = ssb.showCooldownText end
+            local cdNum = (showCD and ns.CdmEnsureCooldownTextClone(icon, cd, fd))
+                or (fd and fd.cdTextClone) or cd
+            if cdNum ~= cd then cdNum:SetFrameLevel(icon:GetFrameLevel() + 19) end
             cd:SetSwipeColor(0, 0, 0, barData.swipeAlpha or 0.7)
             -- Per-spell Reverse Swipe: flips this icon's swipe direction away from the bar default
             -- (buffs fill up, cooldowns deplete). Entire block is gated by the session flag, so it
@@ -5616,34 +5757,28 @@ local function RefreshCDMIconAppearance(barKey)
                 if ttSid and ns.ResolveThresholdTextSettings then
                     tt = ns.ResolveThresholdTextSettings(icon, ttSid, ns.GetBarSpellData(barKey), barKey)
                 end
-                ns.ApplyThresholdFormatter(cd, tt)
+                -- The clone renders the number, so the formatter belongs there too.
+                ns.ApplyThresholdFormatter(cdNum, tt)
             end
             -- Per-spell "Hide CD Text (Charges)" can additionally hide the recharge numbers while
             -- a charge is in hand; the font block below still styles the text (using the bar's showCD) so it is ready when numbers return.
             local hideCD = not showCD
             if ns.CdmShouldHideCountdown then hideCD = ns.CdmShouldHideCountdown(icon, hideCD) end
+            -- With a clone present its SetHideCountdownNumbers hook takes this over:
+            -- the real widget's own numbers go off and hideCD lands on the clone.
             cd:SetHideCountdownNumbers(hideCD)
             -- Apply cooldown text font directly.
             if showCD then
-                local cdFont = GetCDMFont()
-                local cdSize = ((ssb and ssb.cooldownFontSize) or barData.cooldownFontSize or 12) * fontScale
-                local cdR = (ssb and ssb.cooldownTextR) or barData.cooldownTextR or 1
-                local cdG = (ssb and ssb.cooldownTextG) or barData.cooldownTextG or 1
-                local cdB = (ssb and ssb.cooldownTextB) or barData.cooldownTextB or 1
-                local cdPosition = (ssb and ssb.cooldownTextPosition)
-                    or barData.cooldownTextPosition or "center"
-                local cdX = (ssb and ssb.cooldownTextX) or barData.cooldownTextX or 0
-                local cdY = (ssb and ssb.cooldownTextY) or barData.cooldownTextY or 0
-                -- Find Blizzard's countdown FontString on the Cooldown widget. Keep it ON the
-                -- widget (anchored to cd) so the user's position and X/Y offset work -- REPARENTING
-                -- it makes Blizzard's engine re-center and ignore both. Setting our own anchor also
-                -- overrides the engine's stale baseline (raw SetFont vs SetCountdownFont); off-center anchors are where a missed or stomped anchor first becomes visible.
-                for _, rgn in pairs({ cd:GetRegions() }) do
-                    if rgn and rgn.GetObjectType and rgn:GetObjectType() == "FontString" then
-                        EllesmereUI.ApplyIconTextFont(rgn, cdFont, cdSize, "cdm")
-                        rgn:SetTextColor(cdR, cdG, cdB)
-                        ns.AnchorCooldownText(rgn, cd, cdPosition, cdX, cdY)
-                    end
+                if fd then
+                    -- Stashed for the clone's bootstrap restyle, which runs before
+                    -- the next refresh whenever the widget was armed for the first time.
+                    fd._cdTextStyle = fd._cdTextStyle or {}
+                    fd._cdTextStyle.barData = barData
+                    fd._cdTextStyle.ssb = ssb
+                    fd._cdTextStyle.fontScale = fontScale
+                end
+                if ns.CdmStyleCooldownNumber(cdNum, barData, ssb, fontScale) and fd then
+                    fd._cdTextStyled = true
                 end
             end
         end


### PR DESCRIPTION
## What does this PR do?

Fixes two reported bugs on Cooldown Manager buff icons.

**Glow at Stacks showed a faint glow before the minimum stack count was reached.** The threshold's render gate deliberately never compares a stack count in Lua, because counts read secret in restricted content: a one-unit StatusBar window performs the comparison C-side and a mask bound to its fill decides what renders. Two holes let a glow through anyway. Shape Glow creates its textures on the anchor frame rather than on the glow wrapper, so the helper that binds the mask, which walks the wrapper's own regions, never reached them and that style was ungated entirely. For every other style the mask was bound, but its closed state was the status bar fill collapsed to zero width, and a zero-area mask rect has no defined sampling result; the mask texture was also stretched without NEAREST filtering, which the Raid Frames absorb bound already documents as leaking an alpha ramp along every edge. The mask now rides the fill's right edge as a fixed, gate-sized rect that is parked a full gate-width clear of the icon while the gate is closed and lands exactly on the gate when it opens, so no degenerate rect is ever sampled, and the glow wrapper's alpha now drops unconditionally when the gate stops.

**The buff glow drew on top of the duration text.** The countdown number sits on the Cooldown widget at icon+14 while every glow overlay sits at icon+16 or +17, so the styles that paint across the icon interior (Modern WoW Glow, Classic WoW Glow, GCD and Shape Glow) washed the digits out. The edge-drawing styles, Pixel Glow in particular, were never affected, which is why this only showed up for some users. Raising the widget is not a fix on its own: the swipe is drawn by that same widget, and a swipe over a glow clips the ring's inner edge and makes it read visibly thinner, which would have traded a bug that hits a few styles for a regression that hits the most common one. Lifting Blizzard's countdown FontString out of the widget is not an option either, since the engine then re-centers it and drops the user's Duration Text position and X/Y offset. The real widget therefore keeps the swipe at icon+14, below the glows exactly as before, and a swipe-less Cooldown clone carries the number at icon+19, above them. The clone is built only for icons that actually show Duration Text and is fed by forwarding hooks on the setters that arm the widget; a single hook on SetHideCountdownNumbers keeps the real widget's own number off and routes the caller's intent to the clone, so none of the existing call sites had to change. Preset and custom buff frames keep the single-widget layout on purpose: they attach their own Threshold Text formatter directly to their cooldown, which a clone would orphan, so on those the number can still be overdrawn by an interior-painting glow.

## How was it tested?

Tested in game on the live client.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; both changes are fixes to existing behaviour
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- the gate changes only run for spells that armed a stack threshold, and the countdown clone and its hooks are only built for icons that show Duration Text
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- the clone's forwarding hooks fire only when Blizzard arms the widget, and the one-time bootstrap restyle retires itself as soon as it lands
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- all new state lives in the existing per-icon weak table, and every hook is `hooksecurefunc`
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added