### PR TITLE
Fix: CDM buff bar duration text going blank after 9.1.1

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -5265,8 +5265,13 @@ function ns.CdmEnsureCooldownTextClone(icon, cd, fd)
     -- Our own preset/custom frames run their own Cooldown AND their own Threshold
     -- Text apply, which attaches the formatter straight to f._cooldown at injection
     -- time (EllesmereUICdmHooks). A clone would orphan that, so they keep the
-    -- single-widget layout and today's behaviour.
-    if icon._isCustomBuffFrame or icon._isCustomSpellFrame then return nil end
+    -- single-widget layout and today's behaviour. Same for a real Blizzard
+    -- buff-viewer frame (fd._isBuffViewerFrame): a clone would hide the real
+    -- widget's numbers with nothing driving the clone's, blanking the aura's
+    -- duration text.
+    if icon._isCustomBuffFrame or icon._isCustomSpellFrame or (fd and fd._isBuffViewerFrame) then
+        return nil
+    end
     local ok, tc = pcall(CreateFrame, "Cooldown", nil, icon, "CooldownFrameTemplate")
     if not ok or not tc then return nil end
     fd.cdTextClone = tc


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1543932556146114611

Issue: The 9.1.1 stack-glow/duration-text commit (276e8df6) added a swipe-less countdown-number clone widget for cooldown icons, but its exclusion check missed real Blizzard buff-viewer frames (fd._isBuffViewerFrame), unlike every sibling hook in the file. The real widget's numbers were hidden and nothing reliably drove the clone's, so tracked buff bar icons lost their duration text and read as a bare cooldown swipe after a buff expired out of combat and the icon was reused in combat.
Fix: Excluded fd._isBuffViewerFrame from ns.CdmEnsureCooldownTextClone, matching the existing exclusion pattern for EUI's own custom buff/spell frames, so buff-viewer icons keep the pre-9.1.1 single-widget layout.