### PR TITLE
Revert(CDM): drop the countdown-number clone widget

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -5219,197 +5219,6 @@ function ns.StyleOverlayCooldownText(oCd, barData, ssb, iconScale)
     end
 end
 
--- Font/colour/anchor for one Cooldown widget's countdown FontString. Split out
--- of RefreshCDMIconAppearance so the text clone below can also be styled from
--- its arming hook. Returns true once a FontString actually existed: the engine
--- creates it lazily on the first armed countdown, so an unarmed widget has
--- nothing to style yet.
-function ns.CdmStyleCooldownNumber(target, barData, ssb, fontScale)
-    if not target then return false end
-    fontScale = fontScale or 1
-    local cdFont = GetCDMFont()
-    local cdSize = ((ssb and ssb.cooldownFontSize) or (barData and barData.cooldownFontSize) or 12) * fontScale
-    local cdR = (ssb and ssb.cooldownTextR) or (barData and barData.cooldownTextR) or 1
-    local cdG = (ssb and ssb.cooldownTextG) or (barData and barData.cooldownTextG) or 1
-    local cdB = (ssb and ssb.cooldownTextB) or (barData and barData.cooldownTextB) or 1
-    local cdPosition = (ssb and ssb.cooldownTextPosition)
-        or (barData and barData.cooldownTextPosition) or "center"
-    local cdX = (ssb and ssb.cooldownTextX) or (barData and barData.cooldownTextX) or 0
-    local cdY = (ssb and ssb.cooldownTextY) or (barData and barData.cooldownTextY) or 0
-    local found = false
-    -- Keep the FontString ON its widget: REPARENTING it makes Blizzard's engine
-    -- re-center it and ignore the user's position and X/Y offset. Our own anchor
-    -- also overrides the engine's stale baseline (raw SetFont vs SetCountdownFont).
-    for _, rgn in pairs({ target:GetRegions() }) do
-        if rgn and rgn.GetObjectType and rgn:GetObjectType() == "FontString" then
-            EllesmereUI.ApplyIconTextFont(rgn, cdFont, cdSize, "cdm")
-            rgn:SetTextColor(cdR, cdG, cdB)
-            ns.AnchorCooldownText(rgn, target, cdPosition, cdX, cdY)
-            found = true
-        end
-    end
-    return found
-end
-
--- Countdown carrier: a swipe-less Cooldown that renders ONLY the number, at
--- icon+19. Swipe and number are drawn C-side by ONE widget and cannot be layered
--- apart, but the icon needs them apart: a glow overlay has to sit ABOVE the swipe
--- (below it, the swipe clips a Pixel Glow ring's inner edge and the ring reads
--- thinner) and BELOW the number (above it, the interior-painting styles --
--- Modern/Classic WoW Glow, GCD, Shape Glow -- wash the digits out). So the real
--- widget keeps the swipe at icon+14 with its own numbers off and this clone
--- carries the number. Built only for icons that show Duration Text.
-function ns.CdmEnsureCooldownTextClone(icon, cd, fd)
-    if not (icon and cd and fd) then return nil end
-    if fd.cdTextClone then return fd.cdTextClone end
-    -- Our own preset/custom frames run their own Cooldown AND their own Threshold
-    -- Text apply, which attaches the formatter straight to f._cooldown at injection
-    -- time (EllesmereUICdmHooks). A clone would orphan that, so they keep the
-    -- single-widget layout and today's behaviour.
-    if icon._isCustomBuffFrame or icon._isCustomSpellFrame then return nil end
-    local ok, tc = pcall(CreateFrame, "Cooldown", nil, icon, "CooldownFrameTemplate")
-    if not ok or not tc then return nil end
-    fd.cdTextClone = tc
-    tc:SetAllPoints(icon)
-    tc:SetFrameLevel(icon:GetFrameLevel() + 19)
-    tc:EnableMouse(false)
-    if tc.SetDrawSwipe then tc:SetDrawSwipe(false) end
-    if tc.SetDrawEdge then tc:SetDrawEdge(false) end
-    if tc.SetDrawBling then tc:SetDrawBling(false) end
-    tc:SetHideCountdownNumbers(false)
-
-    -- Seed: the clone is built lazily, so the widget can already be armed and the
-    -- forwarding hooks below only see future calls. GetCooldownTimes returns
-    -- MILLISECONDS, and that division is why the secret probe comes first --
-    -- arithmetic on a secret value is a hard error, as is testing one for nil.
-    -- Under restriction the next arm seeds it instead.
-    if cd.GetCooldownTimes then
-        local okT, cdStart, cdDur = pcall(cd.GetCooldownTimes, cd)
-        if okT and not (issecretvalue and (issecretvalue(cdStart) or issecretvalue(cdDur)))
-           and cdStart and cdDur and cdDur > 0 then
-            tc:SetCooldown(cdStart / 1000, cdDur / 1000)
-        end
-    end
-
-    if fd._cdTextCloneHooked then return tc end
-    fd._cdTextCloneHooked = true
-    -- One-time bootstrap styling. The engine creates the countdown FontString on
-    -- the first armed countdown, so a refresh that ran before the widget was ever
-    -- armed found nothing to style and the first number would render in
-    -- Blizzard's default font. Self-retiring: it stops the moment it lands.
-    local function BootstrapStyle()
-        if fd._cdTextStyled then return end
-        local st = fd._cdTextStyle
-        if not st then return end
-        if ns.CdmStyleCooldownNumber(fd.cdTextClone, st.barData, st.ssb, st.fontScale) then
-            fd._cdTextStyled = true
-        end
-    end
-    -- Forward every setter that arms the widget, matching the per-frame hook
-    -- pattern the charge/recharge repairs already use. The closures read fd,
-    -- which is keyed on the icon and so survives Blizzard's frame pooling.
-    hooksecurefunc(cd, "SetCooldown", function(_, start, duration, modRate)
-        local t = fd.cdTextClone
-        if not t then return end
-        -- Raw cooldown numbers are AllowedWhenUntainted ONLY: in restricted
-        -- content Blizzard arms the real widget with SECRET start/duration,
-        -- and forwarding them from this tainted hook is a hard error (live
-        -- 9.1.1 storm). Duration objects are the secret-safe carrier and
-        -- keep riding the SetCooldownFromDurationObject forward; for a
-        -- secret RAW arm, fall back to the real widget's own number for
-        -- this arm (the old under-the-glow layering) instead of showing
-        -- none. Flip edges only; the routing guard keeps the choke hook
-        -- from undoing our writes.
-        if issecretvalue and (issecretvalue(start) or issecretvalue(duration)
-            or issecretvalue(modRate)) then
-            -- Secret raw arm: raw numbers cannot cross tainted execution, but
-            -- a DURATION OBJECT can -- the AB swipe channel's carrier
-            -- (C_Spell.GetSpellCooldownDuration -> SetCooldownFromDuration
-            -- Object, engine fills the secret timing C-side). ONE fetch per
-            -- icon per frame: a same-frame duplicate arm keeps the first
-            -- outcome (plain GetTime compare; never memo across frames --
-            -- every arm edge re-decides).
-            local now = GetTime()
-            if fd._cdDurFetchAt == now then return end
-            fd._cdDurFetchAt = now
-            local sid = icon.GetSpellID and icon:GetSpellID()
-            if sid and not (issecretvalue(sid))
-               and C_Spell and C_Spell.GetSpellCooldownDuration
-               and t.SetCooldownFromDurationObject then
-                local okD, durObj = pcall(C_Spell.GetSpellCooldownDuration, sid)
-                if okD and durObj then
-                    t:SetCooldownFromDurationObject(durObj)
-                    BootstrapStyle()
-                    if fd._cdRealNumShown then
-                        -- Object lane carried it: number back on the clone.
-                        fd._cdRealNumShown = nil
-                        fd._cdTextRouting = true
-                        cd:SetHideCountdownNumbers(true)
-                        fd._cdTextRouting = false
-                        t:SetHideCountdownNumbers(false)
-                    end
-                    return
-                end
-            end
-            -- No object (item-sourced icons, odd arms): the real widget's own
-            -- number for this arm -- present under the glow beats absent.
-            if not fd._cdRealNumShown then
-                fd._cdRealNumShown = true
-                fd._cdTextRouting = true
-                cd:SetHideCountdownNumbers(false)
-                fd._cdTextRouting = false
-                t:SetHideCountdownNumbers(true)
-                local st = fd._cdTextStyle
-                if st and ns.CdmStyleCooldownNumber then
-                    ns.CdmStyleCooldownNumber(cd, st.barData, st.ssb, st.fontScale)
-                end
-            end
-            return
-        end
-        if fd._cdRealNumShown then
-            -- Plain again (restriction lifted): numbers back on the clone.
-            fd._cdRealNumShown = nil
-            fd._cdTextRouting = true
-            cd:SetHideCountdownNumbers(true)
-            fd._cdTextRouting = false
-            t:SetHideCountdownNumbers(false)
-        end
-        t:SetCooldown(start, duration, modRate)
-        BootstrapStyle()
-    end)
-    hooksecurefunc(cd, "Clear", function()
-        local t = fd.cdTextClone
-        if t then t:Clear() end
-    end)
-    if cd.SetCooldownFromDurationObject then
-        hooksecurefunc(cd, "SetCooldownFromDurationObject", function(_, durObj)
-            local t = fd.cdTextClone
-            if not (t and t.SetCooldownFromDurationObject) then return end
-            t:SetCooldownFromDurationObject(durObj)
-            BootstrapStyle()
-        end)
-    end
-    if cd.SetUseAuraDisplayTime then
-        hooksecurefunc(cd, "SetUseAuraDisplayTime", function(_, use)
-            local t = fd.cdTextClone
-            if t and t.SetUseAuraDisplayTime then t:SetUseAuraDisplayTime(use) end
-        end)
-    end
-    -- Choke point. Eight sites across this module set the real widget's number
-    -- visibility; rather than teach each one about the clone, force the real
-    -- widget's numbers off here and pass the caller's intent through. The guard
-    -- blocks the recursion our own re-write would otherwise cause.
-    hooksecurefunc(cd, "SetHideCountdownNumbers", function(_, hide)
-        local t = fd.cdTextClone
-        if not t or fd._cdTextRouting then return end
-        fd._cdTextRouting = true
-        cd:SetHideCountdownNumbers(true)
-        t:SetHideCountdownNumbers(hide)
-        fd._cdTextRouting = false
-    end)
-    return tc
-end
-
 -------------------------------------------------------------------------------
 --  Per-spell Threshold Text (engine countdown formatters)
 --
@@ -5733,18 +5542,12 @@ local function RefreshCDMIconAppearance(barKey)
         if cd then
             cd:ClearAllPoints()
             cd:SetAllPoints(icon)
-            -- Above the border (icon+13) and BELOW the glow overlays (icon+16/+17):
-            -- a swipe drawn over a glow clips the ring's inner edge and it reads
-            -- thinner. The countdown number rides fd.cdTextClone instead, the only
-            -- way to get it above the glow -- see ns.CdmEnsureCooldownTextClone.
+            -- Above the border (icon+13); still below glow (icon+16) / text (icon+23).
             pcall(cd.SetFrameLevel, cd, icon:GetFrameLevel() + 14)
             -- Per-icon Duration Text override (ssb) falls back to the bar's values. Only Show
             -- Numbers no longer forces this on: hiding the duration (bar toggle or per-icon) under it leaves just the stack count.
             local showCD = ns.CdmDurationTextOn(barData)
             if ssb and ssb.showCooldownText ~= nil then showCD = ssb.showCooldownText end
-            local cdNum = (showCD and ns.CdmEnsureCooldownTextClone(icon, cd, fd))
-                or (fd and fd.cdTextClone) or cd
-            if cdNum ~= cd then cdNum:SetFrameLevel(icon:GetFrameLevel() + 19) end
             cd:SetSwipeColor(0, 0, 0, barData.swipeAlpha or 0.7)
             -- Per-spell Reverse Swipe: flips this icon's swipe direction away from the bar default
             -- (buffs fill up, cooldowns deplete). Entire block is gated by the session flag, so it
@@ -5820,28 +5623,34 @@ local function RefreshCDMIconAppearance(barKey)
                 if ttSid and ns.ResolveThresholdTextSettings then
                     tt = ns.ResolveThresholdTextSettings(icon, ttSid, ns.GetBarSpellData(barKey), barKey)
                 end
-                -- The clone renders the number, so the formatter belongs there too.
-                ns.ApplyThresholdFormatter(cdNum, tt)
+                ns.ApplyThresholdFormatter(cd, tt)
             end
             -- Per-spell "Hide CD Text (Charges)" can additionally hide the recharge numbers while
             -- a charge is in hand; the font block below still styles the text (using the bar's showCD) so it is ready when numbers return.
             local hideCD = not showCD
             if ns.CdmShouldHideCountdown then hideCD = ns.CdmShouldHideCountdown(icon, hideCD) end
-            -- With a clone present its SetHideCountdownNumbers hook takes this over:
-            -- the real widget's own numbers go off and hideCD lands on the clone.
             cd:SetHideCountdownNumbers(hideCD)
             -- Apply cooldown text font directly.
             if showCD then
-                if fd then
-                    -- Stashed for the clone's bootstrap restyle, which runs before
-                    -- the next refresh whenever the widget was armed for the first time.
-                    fd._cdTextStyle = fd._cdTextStyle or {}
-                    fd._cdTextStyle.barData = barData
-                    fd._cdTextStyle.ssb = ssb
-                    fd._cdTextStyle.fontScale = fontScale
-                end
-                if ns.CdmStyleCooldownNumber(cdNum, barData, ssb, fontScale) and fd then
-                    fd._cdTextStyled = true
+                local cdFont = GetCDMFont()
+                local cdSize = ((ssb and ssb.cooldownFontSize) or barData.cooldownFontSize or 12) * fontScale
+                local cdR = (ssb and ssb.cooldownTextR) or barData.cooldownTextR or 1
+                local cdG = (ssb and ssb.cooldownTextG) or barData.cooldownTextG or 1
+                local cdB = (ssb and ssb.cooldownTextB) or barData.cooldownTextB or 1
+                local cdPosition = (ssb and ssb.cooldownTextPosition)
+                    or barData.cooldownTextPosition or "center"
+                local cdX = (ssb and ssb.cooldownTextX) or barData.cooldownTextX or 0
+                local cdY = (ssb and ssb.cooldownTextY) or barData.cooldownTextY or 0
+                -- Find Blizzard's countdown FontString on the Cooldown widget. Keep it ON the
+                -- widget (anchored to cd) so the user's position and X/Y offset work -- REPARENTING
+                -- it makes Blizzard's engine re-center and ignore both. Setting our own anchor also
+                -- overrides the engine's stale baseline (raw SetFont vs SetCountdownFont); off-center anchors are where a missed or stomped anchor first becomes visible.
+                for _, rgn in pairs({ cd:GetRegions() }) do
+                    if rgn and rgn.GetObjectType and rgn:GetObjectType() == "FontString" then
+                        EllesmereUI.ApplyIconTextFont(rgn, cdFont, cdSize, "cdm")
+                        rgn:SetTextColor(cdR, cdG, cdB)
+                        ns.AnchorCooldownText(rgn, cd, cdPosition, cdX, cdY)
+                    end
                 end
             end
         end


### PR DESCRIPTION
## What does this PR do?

Reverts the countdown-number clone widget introduced in 9.1.1, putting the duration text back on the single Cooldown widget it was always on. The stack-glow half of that change is untouched and stays.

Background: 9.1.1 fixed the buff glow drawing over the duration number by giving each cooldown icon a second, swipe-less Cooldown widget to carry the number above the glow overlays, with forwarding hooks mirroring the real widget's state onto it. That approach does not hold up. In restricted content Blizzard arms the widget with secret start/duration values, and forwarding those out of a tainted hook is a hard error, which produced a live error storm; 9.1.2 patched it by falling back to the real widget's own number for such arms. That fallback is the tell: the clone cannot be driven where the values are secret, so in dungeons and raids the number renders under the glow anyway, which is precisely the layering the clone existed to fix. Separately it blanked duration text on buff bar icons once a frame was reused, which #1871 addresses by excluding buff-viewer frames, the very family the bug was reported on.

Reading the shipped code turns up more of the same kind. The existing-clone early return and the caller's fallback both bypass every exclusion, so a frame that ever obtained a clone keeps using it whatever the exclusion later says. Nothing ever retires a clone or unhooks it, so turning Duration Text off leaves the clone in place and the real widget's numbers forced off. The Threshold Text formatter stays attached to the clone while the 9.1.2 fallback renders on the real widget, so per-spell decimals and colour silently stop in restricted content. `SetCooldownFromDurationObject` is forwarded without its second argument, which the module itself passes elsewhere. The fallback sources a spell cooldown duration for what may be an aura. And it adds a `GetTime` plus a `pcall(C_Spell.GetSpellCooldownDuration)` per icon per arm edge, on a path every GCD walks.

The common cause is structural rather than a series of separate slips: mirroring a widget that is driven by C code and roughly ten call sites, whose inputs are secret half the time, leaks at every new setter and every new call site. Hardening it would not change the fact that the fallback lane still hands restricted content the old layering. So the clone comes out. After this revert `EllesmereUICooldownManager.lua` is identical to v9.1.0 apart from the stack-glow fixes, and the duration-text path is byte-identical to code that ran in production for a long time.

What comes back with it: with Duration Text on, the glow styles that paint across the icon interior (Modern WoW Glow, Classic WoW Glow, GCD, Shape Glow) draw over the digits again. The edge-drawing styles (Pixel Glow, Auto-Cast Shine, Action Button Glow) are unaffected, which is why this only ever hit some setups. That is cosmetic and style-dependent, and the right shape for it is an opt-in setting that raises the Cooldown widget above the glow overlays, defaulting off, so the user chooses the tradeoff that comes with it: the swipe rides the same widget and above the glow it clips the inner edge of a Pixel Glow ring, making the ring read thinner. That is not in this PR.

#1871 becomes unnecessary with this and should be closed rather than merged.

## How was it tested?

Tested in game on the live client.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no settings added; this removes a widget and its hooks
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- strictly less than before: one Cooldown frame and five `hooksecurefunc` hooks per icon are no longer created
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- removes the per-arm forwarding work, including the `GetTime` and `C_Spell.GetSpellCooldownDuration` call the 9.1.2 fallback ran on every arm edge in restricted content
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- removes hooks from Blizzard cooldown widgets; no new ones added
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added