### PR TITLE
Fix(CDM): Apply to Bar leaves preset icons on the default value

### DIFF
--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -8933,6 +8933,15 @@ initFrame:SetScript("OnEvent", function(self)
                     AB.RunBarApply = function(applyKeys, applyWrite, val, allSpecs)
                         if not applyWrite then return end
                         local keys = applyKeys or {}
+                        -- Resolve the value ONCE, before anything below clears a thing. A payload
+                        -- writer (custom colour, Threshold Seconds) reads the source spell's own keys
+                        -- back out of its entry, and the sweeps clear exactly those keys -- re-running
+                        -- it per tier and per stamp would make the result depend on sweep order.
+                        local temp = {}
+                        applyWrite(temp, val)
+                        local function stamp(t)
+                            for _, k in ipairs(keys) do t[k] = temp[k] end
+                        end
                         local touchesCas = false
                         for _, k in ipairs(keys) do
                             if AB.CAS_KEYS[k] then touchesCas = true; break end
@@ -8955,10 +8964,10 @@ initFrame:SetScript("OnEvent", function(self)
                                 end
                             end)
                             if touchesCas then
-                                AB.StampMemberCas(bsX, applyWrite, val, keys)
+                                AB.StampMemberCas(bsX, stamp, val, keys)
                             end
                             if touchesHosted then
-                                AB.StampHostedBuffs(prof, bsX, applyWrite, val, keys)
+                                AB.StampHostedBuffs(prof, bsX, stamp, val, keys)
                             end
                         end
                         if allSpecs then
@@ -8969,7 +8978,7 @@ initFrame:SetScript("OnEvent", function(self)
                                 -- New tier table: chained results are stale.
                                 ns._cdmResGen = (ns._cdmResGen or 0) + 1
                             end
-                            applyWrite(abs, val)
+                            stamp(abs)
                             AB.FlipSessionGates(abs)
                             local spAll = ns.GetActiveSpecProfiles and ns.GetActiveSpecProfiles()
                             if spAll then
@@ -8989,7 +8998,7 @@ initFrame:SetScript("OnEvent", function(self)
                                 ns._cdmResGen = (ns._cdmResGen or 0) + 1
                             end
                             ns.ChainSettings(bs, bdSel and bdSel.barSpellSettings)
-                            applyWrite(bs, val)
+                            stamp(bs)
                             AB.FlipSessionGates(bs)
                             local spAll = ns.GetActiveSpecProfiles and ns.GetActiveSpecProfiles()
                             local specKeyA = ns.GetActiveSpecKey and ns.GetActiveSpecKey()


### PR DESCRIPTION
Bug: found while working on #1881, not reported separately

Issue: applying a setting that carries a value to a whole bar leaves the bar's trinkets, racials and custom icons on the setting's default instead of the value that was applied, while the ordinary spells on the same bar take it correctly. Applying a second time appears to fix it. It only shows on a bar that has no Apply to Bar for that setting yet, which is why it has gone unnoticed: once the bar has one, the wrong read falls through to the right value by accident.

Root cause: the writers behind Active State's custom colour, Threshold Seconds and Threshold Color push the value the source spell currently holds, so they read it back out of that spell's own settings entry. RunBarApply ran each writer once for the bar tier and then again for every preset and hosted buff stamp, and the sweeps that run in between clear exactly the keys those writers read. The member sweep clears the source entry before the stamps run, which is normally hidden because the cleared read falls through the settings chain to the tier the apply just wrote, except that the entry is only re-linked to that tier at the end of RunBarApply, so an apply creating the tier leaves the read pointing at the old link and it finds nothing. Apply to Bar (All Specs) sweeps each spec profile in undefined order, so whether the stamps still see a live source depends on where the active spec falls in it. In the single spec branch the All Specs unapply runs first and can clear the source preset's own entry before the tier write reads it.

Fix: resolve the value once at the top of RunBarApply into a scratch table, and have the tier write and both stamps copy from that. This is the same simulate once shape CountApplyOverwrites already uses, so the apply now agrees with the count that drives its own overwrite prompt, and none of the three orderings can affect the result any more. Confirmed in game on both Apply to Bar and Apply to Bar (All Specs).
