### PR TITLE
Unit Frames: option to hide trailing zeros on health percent text

### DIFF
--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -1318,7 +1318,9 @@ initFrame:SetScript("OnEvent", function(self)
                 return cfg and AbbreviateNumbers(v, cfg) or AbbreviateNumbers(v)
             end
             local function _pvPct(p01)
-                return _G._EUI_TextDecimals and string.format("%.1f", p01 * 100) or tostring(math.floor(p01 * 100))
+                if not _G._EUI_TextDecimals then return tostring(math.floor(p01 * 100)) end
+                if _G._EUI_PctTrim then return tostring(math.floor(p01 * 1000 + 0.5) / 10) end
+                return string.format("%.1f", p01 * 100)
             end
             local function _pvName()
                 if unitKey == "player" then return UnitName("player") or "Player" end
@@ -5228,6 +5230,13 @@ initFrame:SetScript("OnEvent", function(self)
                       get=function() return db.profile.showDecimalBoss2 ~= false end,
                       set=function(v)
                           db.profile.showDecimalBoss2 = v
+                          if ns.ApplyTextDecimalGlobals then ns.ApplyTextDecimalGlobals() end
+                          ReloadAndUpdate(); UpdatePreview()
+                      end },
+                    { type="toggle", label="Hide Trailing Zeros",
+                      get=function() return db.profile.showDecimalTrimZeros == true end,
+                      set=function(v)
+                          db.profile.showDecimalTrimZeros = v
                           if ns.ApplyTextDecimalGlobals then ns.ApplyTextDecimalGlobals() end
                           ReloadAndUpdate(); UpdatePreview()
                       end },

--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -1319,7 +1319,8 @@ initFrame:SetScript("OnEvent", function(self)
             end
             local function _pvPct(p01)
                 if not _G._EUI_TextDecimals then return tostring(math.floor(p01 * 100)) end
-                if _G._EUI_PctTrim then return tostring(math.floor(p01 * 1000 + 0.5) / 10) end
+                local trim = _G._EUI_PctTrim
+                if trim then return AbbreviateNumbers(trim.curve:Evaluate(p01), trim.cfg) end
                 return string.format("%.1f", p01 * 100)
             end
             local function _pvName()

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -222,6 +222,8 @@ local defaults = {
         showDecimalBoss2 = true,
         -- With decimals on, "Only Show for % Health" keeps the decimal on PERCENT (77.3%) but leaves VALUES whole (240k); same inline cog.
         showDecimalPercentOnly = false,
+        -- With decimals on, "Hide Trailing Zeros" drops a zero decimal from the PERCENT (100.0% -> 100%, 99.5% unchanged); same inline cog.
+        showDecimalTrimZeros = false,
         -- Player Threat (Non-Tank): additive "Shadow" border on the PLAYER frame while
         -- pulling/holding aggro, instanced content only; global, default off (zero cost
         -- until enabled). Colors mirror the nameplate non-tank threat defaults (has/near aggro).
@@ -2167,9 +2169,10 @@ EllesmereUI.IsSmartPowerPercent = EUI_IsSmartPowerPercent
 -- Show Decimal on Text (global): AbbreviateNumbers config emitting one decimal per
 -- magnitude band (240500 -> "240.5k", 2405000 -> "2.4m"). AbbreviateNumbers runs in
 -- Blizzard's secure context, so a secret value plus this config stays secret-safe
--- (like the no-config call on secret health/power). Tags read two _G flags:
+-- (like the no-config call on secret health/power). Tags read these _G flags:
 --   _G._EUI_AbbrevDecimalCfg = this table when on, nil when off
 --   _G._EUI_TextDecimals     = true/false, selects "%.1f" vs "%d" for percents
+--   _G._EUI_PctTrim          = the trailing-zero percent pair below, nil when off
 ns._decimalAbbrevConfig = { breakpointData = {
     { breakpoint = 1e9, abbreviation = "b", significandDivisor = 1e8, fractionDivisor = 10, abbreviationIsGlobal = false },
     { breakpoint = 1e6, abbreviation = "m", significandDivisor = 1e5, fractionDivisor = 10, abbreviationIsGlobal = false },
@@ -2182,6 +2185,26 @@ ns._decimalAbbrevConfig2 = { breakpointData = {
     { breakpoint = 1e6, abbreviation = "m", significandDivisor = 1e4, fractionDivisor = 100, abbreviationIsGlobal = false },
     { breakpoint = 1e3, abbreviation = "k", significandDivisor = 1e1, fractionDivisor = 100, abbreviationIsGlobal = false },
 } }
+-- "Hide Trailing Zeros": AbbreviateNumbers drops a zero fraction ("100") but keeps a
+-- real one ("99.5"), which "%.1f" cannot do and a SECRET percent forbids doing with
+-- Lua string ops. It TRUNCATES though, so a fractional significandDivisor misreads
+-- (0.1 turns 33.3 into "33.2"); the curve does the scaling instead, handing over whole
+-- tenths/hundredths, +0.5 so truncation lands on the same value "%.1f" would round to.
+local function MakePctTrim(scale, fractionDivisor)
+    if not (C_CurveUtil and C_CurveUtil.CreateCurve and Enum and Enum.LuaCurveType) then return nil end
+    local curve = C_CurveUtil.CreateCurve()
+    curve:SetType(Enum.LuaCurveType.Linear)
+    curve:AddPoint(0.0, 0.5)
+    curve:AddPoint(1.0, scale + 0.5)
+    return {
+        curve = curve,
+        cfg = { breakpointData = {
+            { breakpoint = 0, abbreviation = "", significandDivisor = 1, fractionDivisor = fractionDivisor, abbreviationIsGlobal = false },
+        } },
+    }
+end
+ns._pctTrim  = MakePctTrim(1000, 10)
+ns._pctTrim2 = MakePctTrim(10000, 100)
 function ns.ApplyTextDecimalGlobals()
     if db and db.profile and db.profile.showDecimalOnText then
         _G._EUI_TextDecimals = true
@@ -2191,21 +2214,28 @@ function ns.ApplyTextDecimalGlobals()
         local percentOnly = db.profile.showDecimalPercentOnly
         _G._EUI_AbbrevDecimalCfg = ns._decimalAbbrevConfig
         if percentOnly then _G._EUI_AbbrevDecimalCfg = nil end
+        -- Percent-only, so "Only Show for % Health" never withholds these.
+        local trimZeros = db.profile.showDecimalTrimZeros
+        _G._EUI_PctTrim = trimZeros and ns._pctTrim or nil
         -- Boss frames get a second decimal place. Tags use the 1-decimal path
         -- for non-boss units when the flag is set, and ignore it when nil.
         if db.profile.showDecimalBoss2 ~= false then
             _G._EUI_BossExtraDecimal = true
             _G._EUI_AbbrevDecimalCfg2 = ns._decimalAbbrevConfig2
             if percentOnly then _G._EUI_AbbrevDecimalCfg2 = nil end
+            _G._EUI_PctTrim2 = trimZeros and ns._pctTrim2 or nil
         else
             _G._EUI_BossExtraDecimal = false
             _G._EUI_AbbrevDecimalCfg2 = nil
+            _G._EUI_PctTrim2 = nil
         end
     else
         _G._EUI_TextDecimals = false
         _G._EUI_AbbrevDecimalCfg = nil
         _G._EUI_BossExtraDecimal = false
         _G._EUI_AbbrevDecimalCfg2 = nil
+        _G._EUI_PctTrim = nil
+        _G._EUI_PctTrim2 = nil
     end
 end
 
@@ -2234,9 +2264,17 @@ do
     if not unit or not UnitExists(unit) then return "" end
     if not UnitIsConnected(unit) then return "OFFLINE" end
     if UnitIsDeadOrGhost(unit) then return "DEAD" end
+    local boss = _G._EUI_BossExtraDecimal and string.sub(unit, 1, 4) == "boss"
+    local trim
+    if boss then trim = _G._EUI_PctTrim2 else trim = _G._EUI_PctTrim end
+    if trim then
+      local scaled = UnitHealthPercent(unit, true, trim.curve)
+      if not scaled then return "0" end
+      return AbbreviateNumbers(scaled, trim.cfg)
+    end
     local pct = UnitHealthPercent(unit, true, CurveConstants.ScaleTo100)
     if not pct then return "0" end
-    if _G._EUI_BossExtraDecimal and string.sub(unit, 1, 4) == "boss" then
+    if boss then
       return string_format("%.2f", pct)
     end
     return string_format(_G._EUI_TextDecimals and "%.1f" or "%d", pct)
@@ -2626,8 +2664,14 @@ do
     -- _EUI_ globals; the compiled strings stay registered only while the tag
     -- engine still runs).
     P.perhp = function(u)
+        local boss = _G._EUI_BossExtraDecimal and string.sub(u, 1, 4) == "boss"
+        local trim
+        if boss then trim = _G._EUI_PctTrim2 else trim = _G._EUI_PctTrim end
+        if trim then
+            return AbbreviateNumbers(UnitHealthPercent(u, true, trim.curve), trim.cfg)
+        end
         local fmt = _G._EUI_TextDecimals and "%.1f" or "%d"
-        if _G._EUI_BossExtraDecimal and string.sub(u, 1, 4) == "boss" then fmt = "%.2f" end
+        if boss then fmt = "%.2f" end
         return sf(fmt, UnitHealthPercent(u, true, CurveConstants.ScaleTo100))
     end
     P.perpp = function(u)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2172,7 +2172,7 @@ EllesmereUI.IsSmartPowerPercent = EUI_IsSmartPowerPercent
 -- (like the no-config call on secret health/power). Tags read these _G flags:
 --   _G._EUI_AbbrevDecimalCfg = this table when on, nil when off
 --   _G._EUI_TextDecimals     = true/false, selects "%.1f" vs "%d" for percents
---   _G._EUI_PctTrim          = the trailing-zero percent pair below, nil when off
+--   _G._EUI_PctTrim          = { curve, cfg } trimming the percent, nil when off
 ns._decimalAbbrevConfig = { breakpointData = {
     { breakpoint = 1e9, abbreviation = "b", significandDivisor = 1e8, fractionDivisor = 10, abbreviationIsGlobal = false },
     { breakpoint = 1e6, abbreviation = "m", significandDivisor = 1e5, fractionDivisor = 10, abbreviationIsGlobal = false },
@@ -2187,11 +2187,10 @@ ns._decimalAbbrevConfig2 = { breakpointData = {
 } }
 -- "Hide Trailing Zeros": AbbreviateNumbers drops a zero fraction ("100") but keeps a
 -- real one ("99.5"), which "%.1f" cannot do and a SECRET percent forbids doing with
--- Lua string ops. It TRUNCATES though, so a fractional significandDivisor misreads
--- (0.1 turns 33.3 into "33.2"); the curve does the scaling instead, handing over whole
--- tenths/hundredths, +0.5 so truncation lands on the same value "%.1f" would round to.
+-- Lua string ops. It TRUNCATES though, so a fractional significandDivisor reads a tenth
+-- low (0.1 renders 33.3 as "33.2"); the curve scales instead, handing over whole
+-- tenths/hundredths, +0.5 so truncation lands where "%.1f" would have rounded.
 local function MakePctTrim(scale, fractionDivisor)
-    if not (C_CurveUtil and C_CurveUtil.CreateCurve and Enum and Enum.LuaCurveType) then return nil end
     local curve = C_CurveUtil.CreateCurve()
     curve:SetType(Enum.LuaCurveType.Linear)
     curve:AddPoint(0.0, 0.5)
@@ -2260,13 +2259,12 @@ do
 end
 
 do
-  TagFns.perhpnosign = function(unit)
-    if not unit or not UnitExists(unit) then return "" end
-    if not UnitIsConnected(unit) then return "OFFLINE" end
-    if UnitIsDeadOrGhost(unit) then return "DEAD" end
+  -- Health percent under the decimal options. "Hide Trailing Zeros" reads the percent
+  -- through a scaling curve so AbbreviateNumbers can drop the zero "%.1f" would pad.
+  local function PercentHP(unit)
     local boss = _G._EUI_BossExtraDecimal and string.sub(unit, 1, 4) == "boss"
-    local trim
-    if boss then trim = _G._EUI_PctTrim2 else trim = _G._EUI_PctTrim end
+    local trim = _G._EUI_PctTrim
+    if boss then trim = _G._EUI_PctTrim2 end
     if trim then
       local scaled = UnitHealthPercent(unit, true, trim.curve)
       if not scaled then return "0" end
@@ -2274,10 +2272,16 @@ do
     end
     local pct = UnitHealthPercent(unit, true, CurveConstants.ScaleTo100)
     if not pct then return "0" end
-    if boss then
-      return string_format("%.2f", pct)
-    end
+    if boss then return string_format("%.2f", pct) end
     return string_format(_G._EUI_TextDecimals and "%.1f" or "%d", pct)
+  end
+
+  TagFns.perhp = PercentHP
+  TagFns.perhpnosign = function(unit)
+    if not unit or not UnitExists(unit) then return "" end
+    if not UnitIsConnected(unit) then return "OFFLINE" end
+    if UnitIsDeadOrGhost(unit) then return "DEAD" end
+    return PercentHP(unit)
   end
 end
 
@@ -2654,6 +2658,7 @@ do
 
     -- Function-registered tag methods are shared directly: one body, no drift.
     P.curhpshort  = TagFns.curhpshort
+    P.perhp       = TagFns.perhp
     P.perhpnosign = TagFns.perhpnosign
     P.level       = TagFns.level
     P.name        = TagFns.name
@@ -2663,17 +2668,6 @@ do
     -- String-compiled tag methods get real equivalents (same logic, same
     -- _EUI_ globals; the compiled strings stay registered only while the tag
     -- engine still runs).
-    P.perhp = function(u)
-        local boss = _G._EUI_BossExtraDecimal and string.sub(u, 1, 4) == "boss"
-        local trim
-        if boss then trim = _G._EUI_PctTrim2 else trim = _G._EUI_PctTrim end
-        if trim then
-            return AbbreviateNumbers(UnitHealthPercent(u, true, trim.curve), trim.cfg)
-        end
-        local fmt = _G._EUI_TextDecimals and "%.1f" or "%d"
-        if boss then fmt = "%.2f" end
-        return sf(fmt, UnitHealthPercent(u, true, CurveConstants.ScaleTo100))
-    end
     P.perpp = function(u)
         local pType = _G._EUI_ResolvedPowerType[u] or UnitPowerType(u)
         return sf("%d", UnitPowerPercent(u, pType, true, CurveConstants.ScaleTo100))


### PR DESCRIPTION
## What does this PR do?

With **Show Decimal on Health Text** on, a unit at full health reads `100.0%`. This adds
**Hide Trailing Zeros** to the **Health Text Decimals** cog, which renders that as `100%`
and leaves `99.5%` alone.

Global, health percent only, default off.

| | decimals off | decimals on | + Hide Trailing Zeros |
|---|---|---|---|
| full health | `100%` | `100.0%` | `100%` |
| damaged | `99%` | `99.5%` | `99.5%` |
| boss, Show 2 for Boss | `99%` | `99.55%` | `99.55%` |
| boss at full | `100%` | `100.00%` | `100%` |

`UnitHealthPercent` is `SecretReturns`, so the zero cannot be trimmed with a `gsub`.
`AbbreviateNumbers` drops a zero fraction and keeps a real one, so the percent goes
through it instead of `"%.1f"`.

It truncates, though, so the obvious config (`significandDivisor = 0.1`) reads a tenth
low on about a third of values: `33.3` renders as `33.2`, `7.1` as `7`. The curve does
the scaling instead. A linear `0 -> 0.5`, `1 -> 1000.5` curve hands `UnitHealthPercent`
whole tenths, so the config divides by integers only, and the `+0.5` puts the truncation
where `"%.1f"` would have rounded. Boss frames use `10000` / `100`.

Worth flagging:

- **Nameplates have the same trailing zero and are not covered.** Their decimals are
  per-slot behind their own cog, and trimming there needs a second `UnitHealthPercent`
  call per plate per update. Own change; happy to follow up.
- **`AbbreviateNumbers` is ~4.3x slower than `string.format`**, 0.94us against 0.22us
  measured over 50k calls. That is ~0.7us per repaint, only while the option is on, and
  the call count is unchanged.
- No migration: an absent `showDecimalTrimZeros` reads as `false`.

Second commit shares one body between `perhp` and `perhpnosign`, which were the same
number written twice, and points the options preview at the same curve and config the
frames use.

One new locale key, `Hide Trailing Zeros`.

## How was it tested?

In game on live (12.1). Verified the formatter first: `1000 -> 100`, `995 -> 99.5`,
`333 -> 33.3`, `71 -> 7.1`, `5 -> 0.5`, and the boss config `10000 -> 100`,
`9955 -> 99.55`, `3333 -> 33.33`. Swept it offline against `"%.1f"` and `"%.2f"` across
~16k health/max combinations with zero drift.

Player and target frames in all four toggle combinations, health falling through
fractional values, `Health %` and `Health % (No Sign)`, `Only Show for % Health` both
ways, options preview against the live frame, toggling without `/reload`, and profile
switch. Health percent is secret on an outdoor enemy target, so that is the path being
exercised.

Not tested on a live `boss1` frame; the 2-decimal curve and config were verified through
the shipped globals.

## Screenshots
Before:
<img width="1128" height="260" alt="CleanShot 2026-08-31 at 23 37 58@2x" src="https://github.com/user-attachments/assets/1a667b33-fb0f-495e-bc22-c78c6a69d211" />

After:
<img width="1126" height="280" alt="CleanShot 2026-08-31 at 23 36 20@2x" src="https://github.com/user-attachments/assets/ea2ebd62-3f9f-4d83-918a-e92a031b708d" />

Setting:
<img width="714" height="570" alt="CleanShot 2026-08-31 at 23 38 44@2x" src="https://github.com/user-attachments/assets/647758e8-e172-4552-a880-3c0048da86fe" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events, hooks or frames; one nil global read in the existing percent path
- [x] Cheap while enabled: same call count, the trim curve replaces `ScaleTo100` rather than adding one
- [x] No writes onto Blizzard-owned frames -- N/A, only our own text pieces
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
