### PR TITLE
Fix: Target border size resetting to default when casting with Border Wraps Around Cast Bar

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -2752,6 +2752,14 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
             local hb = PP.GetBorders(plate.health)
             if hb then
                 local sz = (p and p.borderSize) or defaults.borderSize
+                -- The target border-size effect (ApplyTarget) already resized the health
+                -- border before the cast bar showed; carry that size into the wrap instead
+                -- of falling back to the base size, or starting a cast on your target visibly
+                -- shrinks the border back to normal until the next target change.
+                if plate._targetBorderSized then
+                    local tbsz = ns.GetTargetBorderSizeValue()
+                    if tbsz then sz = tbsz end
+                end
                 local col = hb._bdColor
                 local r, g, b, a = 0, 0, 0, 1
                 if col then r, g, b, a = col[1], col[2], col[3], col[4] or 1 end
@@ -2816,7 +2824,12 @@ local frameCache = CreateFramePool("Frame", UIParent, nil, nil, false, function(
             local hb = PP.GetBorders(plate.health)
             if hb then
                 hb._hideBottom = nil
-                PP.SetBorderSize(plate.health, (p and p.borderSize) or defaults.borderSize)
+                local sz = (p and p.borderSize) or defaults.borderSize
+                if plate._targetBorderSized then
+                    local tbsz = ns.GetTargetBorderSizeValue()
+                    if tbsz then sz = tbsz end
+                end
+                PP.SetBorderSize(plate.health, sz)
             end
             if plate.castWrapRegion then
                 local crb = PP.GetBorders(plate.castWrapRegion)


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1534879782989332491

Issue: With Border Wraps Around Cast Bar enabled alongside the target border-size effect, UpdateBorderWrap rebuilt the wrapped border using the plain default border size instead of the target-effect size, so casting on your current target visibly shrank the border back to normal for the cast (and again when the cast ended).
Fix: UpdateBorderWrap now checks whether the plate's border was resized for being targeted and uses the target border-size value on both the wrap-on and wrap-off paths, so the target border stays correctly sized through casting.