### PR TITLE
Fix(Unit Frames): keep the frame built when Visibility is set to Never

### DIFF
--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -2393,10 +2393,7 @@ initFrame:SetScript("OnEvent", function(self)
             local isMini = (unitKey == "pet" or unitKey == "boss" or unitKey == "targettarget" or unitKey == "focustarget")
             local ds = s
             if isMini then
-                local ef = db.profile.enabledFrames
-                if ef.focus ~= false and db.profile.focus then ds = db.profile.focus
-                elseif ef.target ~= false and db.profile.target then ds = db.profile.target
-                else ds = db.profile.player end
+                ds = ns.GetMiniDonorSettings and ns.GetMiniDonorSettings() or db.profile.player
             end
 
             -- The preview mocks the EUI frame, so it counts as "enabled" only when the
@@ -12613,13 +12610,12 @@ initFrame:SetScript("OnEvent", function(self)
 
     ---------------------------------------------------------------------------
     --  Mini frame donor settings helper
-    --  Returns the settings table from focus (if enabled) target player
+    --  Returns the settings table from focus (if usable) target player. Routed
+    --  through the runtime resolver so the options preview and the live frames
+    --  can never disagree about which frame is on screen to inherit from.
     ---------------------------------------------------------------------------
     local function GetMiniDonorSettings()
-        local ef = db.profile.enabledFrames
-        if ef.focus ~= false and db.profile.focus then return db.profile.focus end
-        if ef.target ~= false and db.profile.target then return db.profile.target end
-        return db.profile.player
+        return ns.GetMiniDonorSettings and ns.GetMiniDonorSettings() or db.profile.player
     end
 
     ---------------------------------------------------------------------------

--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -4581,12 +4581,13 @@ initFrame:SetScript("OnEvent", function(self)
               legacyKey = "barVisibility",
               caps = { partyIncludesRaid = false, luaDragonriding = true },
               refreshPageArg = true,
-              -- Visibility owns only the hidden/not-hidden axis: "never" disables
-              -- the frame, any visible mode re-enables it. frameSource (the inline
-              -- cog's EUI/Blizzard choice) is left intact so it resumes on re-enable.
+              -- Visibility is a RUNTIME axis and never touches enabledFrames: that
+              -- key decides whether the frame is built at all, once, at login, so a
+              -- Spec Override carrying "never" used to leave the frame uncreated for
+              -- the session with no way back but a /reload. "never" is hidden by the
+              -- visibility pass instead (ns.UpdateFrameVisibility), which reverses.
               applyScalarFn = function(s, mode)
                   s.barVisibility = mode
-                  db.profile.enabledFrames[selectedUnit] = (mode ~= "never")
               end,
               onChanged = function()
                   local s = UNIT_DB_MAP[selectedUnit]()
@@ -4678,8 +4679,8 @@ initFrame:SetScript("OnEvent", function(self)
         end
 
         -- ONE sync icon now that both halves share a control: set-aware for correct
-        -- multi-selection compare/copy, and VisFullCopy carries the option booleans too;
-        -- runs each target's scalar side effects (enabledFrames) + boolean-trio derivation.
+        -- multi-selection compare/copy, and VisFullCopy carries the option booleans too,
+        -- plus each target's boolean-trio derivation.
         if not EllesmereUI._prebuilding then
             local rgn = visRow._leftRegion
             local function CopyVisToUnit(key)
@@ -4688,7 +4689,6 @@ initFrame:SetScript("OnEvent", function(self)
                 if dst == src then return end
                 EllesmereUI.VisFullCopy(dst, src, "barVisibility", nil, function(t, mode)
                     t.barVisibility = mode
-                    db.profile.enabledFrames[key] = (mode ~= "never")
                 end)
                 SyncUnitVisBooleans(dst)
             end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2880,6 +2880,15 @@ end
 -- frame at runtime and the frame stays built, so a Spec Override can lift it again
 -- without a /reload.
 
+--- The Visibility mode actually in force for a settings table. An applied override
+--- REPLACES the whole shared setting, "never" included, so every reader that acts on
+--- "never" alone resolves it here instead of off the stored scalar. On ns for the
+--- 200-locals cap.
+function ns.VisEffective(s)
+    if not s then return nil end
+    return (EllesmereUI.VisOverrideValue and EllesmereUI.VisOverrideValue(s)) or s.barVisibility
+end
+
 --- True when the unit has no EllesmereUI frame at all -- the enabledFrames flag, which
 --- only the "Enable X Frame" toggles write now that Visibility no longer touches it.
 --- On ns for the 200-locals cap.
@@ -2895,8 +2904,7 @@ function ns.GetUnitFrameSource(unit)
     if fs == "blizzard" then
         -- Visibility "never" over Blizzard's frame: we spawn nothing of our own to
         -- hide, so suppressing Blizzard's is the only way to honor it.
-        local s = db.profile[unit]
-        if s and s.barVisibility == "never" then return "hidden" end
+        if ns.VisEffective(db.profile[unit]) == "never" then return "hidden" end
         -- ToT/focus-target have no standalone Blizzard frame (native one is a child
         -- of TargetFrame/FocusFrame, lives only while that parent does), so
         -- "blizzard" is honored for them ONLY when the parent is itself on
@@ -3057,9 +3065,9 @@ end
 function ns.GetMiniDonorSettings()
     local ef = db.profile.enabledFrames
     local focus = db.profile.focus
-    if ef.focus ~= false and focus and focus.barVisibility ~= "never" then return focus end
+    if ef.focus ~= false and focus and ns.VisEffective(focus) ~= "never" then return focus end
     local target = db.profile.target
-    if ef.target ~= false and target and target.barVisibility ~= "never" then return target end
+    if ef.target ~= false and target and ns.VisEffective(target) ~= "never" then return target end
     return db.profile.player
 end
 local GetMiniDonorSettings = ns.GetMiniDonorSettings
@@ -10935,7 +10943,7 @@ local function ApplyBlizzCastbarState()
         -- counts as no replacement too: our cast bar is built now but hides with the
         -- frame, and taking Blizzard's away would leave no player cast bar at all.
         local suppress = (db.profile.player.showPlayerCastbar
-            and db.profile.player.barVisibility ~= "never"
+            and ns.VisEffective(db.profile.player) ~= "never"
             and ns.GetUnitFrameSource("player") == "eui") or false
         EllesmereUI.SetPlayerCastBarSuppressed("UnitFrames", suppress)
     end
@@ -10971,8 +10979,8 @@ function ns.ResolveVisResting(s, frame, ext, hiddenByOpts, inCombat)
     end
     local vis = s.barVisibility or "always"
     -- Never rides the alpha too, not just the Show/Hide bucket: that bucket is
-    -- lockdown-gated, so a Never picked (or applied by an override) in combat would
-    -- otherwise leave the frame at full alpha until PLAYER_REGEN_ENABLED.
+    -- lockdown-gated, so a Never picked in combat would otherwise leave the frame at
+    -- full alpha until PLAYER_REGEN_ENABLED. An override reaches the ext block above.
     if vis == "never" then return 0, false end
     if vis == "in_combat" then return inCombat and shownAlpha or 0, false end
     if vis == "out_of_combat" then return (not inCombat) and shownAlpha or 0, false end
@@ -12404,8 +12412,8 @@ function InitializeFrames()
         for _, unitKey in ipairs({"player", "target", "focus"}) do
             local s = db.profile[unitKey]
             local frame = frames[unitKey]
-            -- The enabledFrames gate through VisUnitDisabled: a unit disabled purely by a
-            -- shared Visibility of "never" comes back while an override replaces it.
+            -- Visibility "never" no longer clears enabledFrames, so a frame hidden that
+            -- way stays on this path and is hidden below, reversibly.
             if frame and not ns.VisUnitDisabled(db.profile, unitKey) and s then
                 local hiddenByOpts = EllesmereUI and EllesmereUI.CheckVisibilityOptions and EllesmereUI.CheckVisibilityOptions(s)
                 local vis = s.barVisibility or "always"
@@ -12450,8 +12458,13 @@ function InitializeFrames()
                 elseif drvSet and EllesmereUI.BuildVisibilityDriverString then
                     visTail = EllesmereUI.BuildVisibilityDriverString("", drvSet)
                 end
+                -- Off the override, never the stored scalar: an override REPLACES the
+                -- shared setting, so a profile-level "never" under an override of Always
+                -- must not pin anything, and an override of "never" must pin even though
+                -- the stored scalar says otherwise.
+                local visNever = (visOv or vis) == "never"
                 local wantDriver
-                if vis == "never" then
+                if visNever then
                     -- Never is terminal, so it pins the secure driver instead of
                     -- riding the Show/Hide bucket below: that bucket is lockdown-
                     -- gated, and acquiring a target in combat would otherwise let
@@ -12502,7 +12515,7 @@ function InitializeFrames()
                 -- Written only when it moves: this pass runs on every target change,
                 -- and for the "blizzard" style the bar is Blizzard's own frame.
                 if unitKey == "player" and frames._classPowerBar then
-                    local cpWant = (vis == "never") and 0 or 1
+                    local cpWant = visNever and 0 or 1
                     if frames._classPowerBar:GetAlpha() ~= cpWant then
                         frames._classPowerBar:SetAlpha(cpWant)
                     end
@@ -12514,7 +12527,7 @@ function InitializeFrames()
                 -- next re-evaluation -- so this whole bucket steps aside.
                 if not isLocked and not frame._euiVisDriver then
                     local shouldShow
-                    if vis == "never" then
+                    if visNever then
                         -- Ahead of the engine verdict: Never is exclusive, but under
                         -- a leftover Any match the engine evaluates the scalar and
                         -- answers false rather than nil, which would keep the frame
@@ -12601,7 +12614,7 @@ function InitializeFrames()
                 -- condition-hidden mini absorbs no clicks either.
                 if mini then
                     local miniWant
-                    if (not miniAlways) and vis == "never" then
+                    if (not miniAlways) and visNever then
                         -- The parent is hidden outright, so alpha 0 alone would leave
                         -- the mini an invisible click blocker; pin it like the
                         -- disabled-parent branch below does.
@@ -13625,8 +13638,7 @@ local function RegisterUFUnlockElements()
                     if key == "pet" and db.profile.pet and db.profile.pet.alwaysShow then
                         return false
                     end
-                    local s = db.profile[MOVER_VIS_OF[key] or key]
-                    return s ~= nil and s.barVisibility == "never"
+                    return ns.VisEffective(db.profile[MOVER_VIS_OF[key] or key]) == "never"
                 end,
                 getFrame = function(k)
                     if k == "boss" then return frames["boss1"] end
@@ -13868,7 +13880,7 @@ local function RegisterUFUnlockElements()
                     -- effect without a /reload.
                     local s = GetCBSettings()
                     if not s then return true end
-                    if s.barVisibility == "never" then return true end
+                    if ns.VisEffective(s) == "never" then return true end
                     if unitKey == "player" then return not s.showPlayerCastbar end
                     return s.showCastbar == false
                 end,

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -3051,12 +3051,16 @@ local function LayoutCastbarIcon(castbar, inWidth, iconH, onRight, offX, offY, i
 end
 
 -- Donor settings table for mini frames (focus > target > player); source of
--- inherited border, texture and font settings.
+-- inherited border, texture and font settings. A frame that is disabled, or that
+-- Visibility keeps off screen entirely, is not a donor -- before Visibility and
+-- enabledFrames were split, "never" cleared that flag and fell out here for free.
 local function GetMiniDonorSettings()
     local ef = db.profile.enabledFrames
-    if ef.focus ~= false and db.profile.focus then return db.profile.focus end
-    if ef.target ~= false and db.profile.target then return db.profile.target end
-    return db.profile.player
+    local function usable(unitKey)
+        local s = db.profile[unitKey]
+        return ef[unitKey] ~= false and s ~= nil and s.barVisibility ~= "never" and s
+    end
+    return usable("focus") or usable("target") or db.profile.player
 end
 
 -- Boss "Simple Debuff Display" mode: "none"|"left"|"right". Tolerates legacy booleans
@@ -10965,6 +10969,10 @@ function ns.ResolveVisResting(s, frame, ext, hiddenByOpts, inCombat)
         return ext and shownAlpha or 0, false
     end
     local vis = s.barVisibility or "always"
+    -- Never rides the alpha too, not just the Show/Hide bucket: that bucket is
+    -- lockdown-gated, so a Never picked (or applied by an override) in combat would
+    -- otherwise leave the frame at full alpha until PLAYER_REGEN_ENABLED.
+    if vis == "never" then return 0, false end
     if vis == "in_combat" then return inCombat and shownAlpha or 0, false end
     if vis == "out_of_combat" then return (not inCombat) and shownAlpha or 0, false end
     if vis == "mouseover" then
@@ -12480,6 +12488,14 @@ function InitializeFrames()
                     bd3d:SetAlpha(bodyAlpha)
                 end
 
+                -- A class resource bar unlocked from the frame is parented to UIParent
+                -- and so survives its owner being hidden. Only Never takes it along:
+                -- that used to leave the player frame unspawned and the bar with it,
+                -- and the other hiding modes have always kept their own bar visible.
+                if unitKey == "player" and frames._classPowerBar then
+                    frames._classPowerBar:SetAlpha(vis == "never" and 0 or 1)
+                end
+
                 -- Show/Hide and SetAttribute are restricted during lockdown.
                 -- When a condition driver is registered it owns Show/Hide
                 -- entirely -- a manual toggle would de-sync it until its
@@ -12573,7 +12589,12 @@ function InitializeFrames()
                 -- condition-hidden mini absorbs no clicks either.
                 if mini then
                     local miniWant
-                    if (not miniAlways) and visTail then
+                    if (not miniAlways) and vis == "never" then
+                        -- The parent is hidden outright, so alpha 0 alone would leave
+                        -- the mini an invisible click blocker; pin it like the
+                        -- disabled-parent branch below does.
+                        miniWant = "hide"
+                    elseif (not miniAlways) and visTail then
                         miniWant = "[@" .. ns.UF_MINI_OF[unitKey] .. ",noexists] hide; " .. visTail
                     end
                     if mini._euiVisDriver ~= miniWant and not isLocked then

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -3054,7 +3054,7 @@ end
 -- inherited border, texture and font settings. A frame that is disabled, or that
 -- Visibility keeps off screen entirely, is not a donor -- before Visibility and
 -- enabledFrames were split, "never" cleared that flag and fell out here for free.
-local function GetMiniDonorSettings()
+function ns.GetMiniDonorSettings()
     local ef = db.profile.enabledFrames
     local function usable(unitKey)
         local s = db.profile[unitKey]
@@ -3062,6 +3062,7 @@ local function GetMiniDonorSettings()
     end
     return usable("focus") or usable("target") or db.profile.player
 end
+local GetMiniDonorSettings = ns.GetMiniDonorSettings
 
 -- Boss "Simple Debuff Display" mode: "none"|"left"|"right". Tolerates legacy booleans
 -- (true/nil="left", false="none") so existing/imported profiles read correctly with no
@@ -12450,7 +12451,13 @@ function InitializeFrames()
                     visTail = EllesmereUI.BuildVisibilityDriverString("", drvSet)
                 end
                 local wantDriver
-                if visTail then
+                if vis == "never" then
+                    -- Never is terminal, so it pins the secure driver instead of
+                    -- riding the Show/Hide bucket below: that bucket is lockdown-
+                    -- gated, and acquiring a target in combat would otherwise let
+                    -- the unit watch show an alpha-0 click blocker until regen.
+                    wantDriver = "hide"
+                elseif visTail then
                     wantDriver = "[@" .. unitKey .. ",noexists] hide; " .. visTail
                 end
                 if frame._euiVisDriver ~= wantDriver and not isLocked then
@@ -12621,7 +12628,7 @@ function InitializeFrames()
                     mini:SetAlpha(miniAlways and 1 or (frame:IsShown() and bodyAlpha or 0))
                 end
             elseif frame then
-                -- Parent disabled ("Never" clears enabledFrames): a leftover condition
+                -- Parent disabled (the "Enable X Frame" toggles): a leftover condition
                 -- driver must not keep re-showing the frame, so pin it to a constant
                 -- hide. Frames that never had a driver keep the legacy disabled path
                 -- untouched. The mini inherits both.
@@ -13594,6 +13601,10 @@ local function RegisterUFUnlockElements()
 
         local function Rebuild() ns.ReloadFrames() end
 
+        -- Which frame's Visibility governs each mover (the minis follow their
+        -- parent, and so does a class resource bar unlocked from the player frame).
+        local MOVER_VIS_OF = { pet = "player", targettarget = "target",
+                               focustarget = "focus", classPower = "player" }
         local function MakeUFElement(key, order)
             return MK({
                 key = key,
@@ -13602,10 +13613,14 @@ local function RegisterUFUnlockElements()
                 order = orderBase + order,
                 -- Visibility "never" keeps the frame built but never on screen, so
                 -- there is nothing to drag. Re-read on each unlock-mode open, so
-                -- lifting it (a spec override, the dropdown) needs no /reload. Units
-                -- without a Visibility dropdown have no barVisibility and never gate.
+                -- lifting it (a spec override, the dropdown) needs no /reload. The
+                -- minis and an unlocked class resource bar have no Visibility of
+                -- their own and ride the frame they follow; Always Show Pet opts out.
                 isHidden = function()
-                    local s = db.profile[key]
+                    if key == "pet" and db.profile.pet and db.profile.pet.alwaysShow then
+                        return false
+                    end
+                    local s = db.profile[MOVER_VIS_OF[key] or key]
                     return s ~= nil and s.barVisibility == "never"
                 end,
                 getFrame = function(k)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -12486,12 +12486,16 @@ function InitializeFrames()
                 -- next re-evaluation -- so this whole bucket steps aside.
                 if not isLocked and not frame._euiVisDriver then
                     local shouldShow
-                    if ext ~= nil then
+                    if vis == "never" then
+                        -- Ahead of the engine verdict: Never is exclusive, but under
+                        -- a leftover Any match the engine evaluates the scalar and
+                        -- answers false rather than nil, which would keep the frame
+                        -- secure-Shown at alpha 0 and still eating clicks.
+                        shouldShow = false
+                    elseif ext ~= nil then
                         -- Engine-owned: frame stays secure-Shown; the alpha
                         -- bucket above drives visibility.
                         shouldShow = true
-                    elseif vis == "never" then
-                        shouldShow = false
                     elseif vis == "in_combat" or vis == "out_of_combat" or vis == "mouseover" then
                         -- Frame is kept shown; alpha (above) drives visibility.
                         shouldShow = true
@@ -13575,6 +13579,14 @@ local function RegisterUFUnlockElements()
                 label = UNIT_LABELS[key] or key,
                 group = "Unit Frames",
                 order = orderBase + order,
+                -- Visibility "never" keeps the frame built but never on screen, so
+                -- there is nothing to drag. Re-read on each unlock-mode open, so
+                -- lifting it (a spec override, the dropdown) needs no /reload. Units
+                -- without a Visibility dropdown have no barVisibility and never gate.
+                isHidden = function()
+                    local s = db.profile[key]
+                    return s ~= nil and s.barVisibility == "never"
+                end,
                 getFrame = function(k)
                     if k == "boss" then return frames["boss1"] end
                     if k == "classPower" then return frames._classPowerBar end
@@ -13815,6 +13827,7 @@ local function RegisterUFUnlockElements()
                     -- effect without a /reload.
                     local s = GetCBSettings()
                     if not s then return true end
+                    if s.barVisibility == "never" then return true end
                     if unitKey == "player" then return not s.showPlayerCastbar end
                     return s.showCastbar == false
                 end,

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -3056,11 +3056,11 @@ end
 -- enabledFrames were split, "never" cleared that flag and fell out here for free.
 function ns.GetMiniDonorSettings()
     local ef = db.profile.enabledFrames
-    local function usable(unitKey)
-        local s = db.profile[unitKey]
-        return ef[unitKey] ~= false and s ~= nil and s.barVisibility ~= "never" and s
-    end
-    return usable("focus") or usable("target") or db.profile.player
+    local focus = db.profile.focus
+    if ef.focus ~= false and focus and focus.barVisibility ~= "never" then return focus end
+    local target = db.profile.target
+    if ef.target ~= false and target and target.barVisibility ~= "never" then return target end
+    return db.profile.player
 end
 local GetMiniDonorSettings = ns.GetMiniDonorSettings
 
@@ -12499,8 +12499,13 @@ function InitializeFrames()
                 -- and so survives its owner being hidden. Only Never takes it along:
                 -- that used to leave the player frame unspawned and the bar with it,
                 -- and the other hiding modes have always kept their own bar visible.
+                -- Written only when it moves: this pass runs on every target change,
+                -- and for the "blizzard" style the bar is Blizzard's own frame.
                 if unitKey == "player" and frames._classPowerBar then
-                    frames._classPowerBar:SetAlpha(vis == "never" and 0 or 1)
+                    local cpWant = (vis == "never") and 0 or 1
+                    if frames._classPowerBar:GetAlpha() ~= cpWant then
+                        frames._classPowerBar:SetAlpha(cpWant)
+                    end
                 end
 
                 -- Show/Hide and SetAttribute are restricted during lockdown.

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2875,21 +2875,17 @@ end
 -- Per-unit frame source resolver. Returns "eui" (spawn skinned frame, default),
 -- "blizzard" (don't spawn, leave Blizzard's default in place), or "hidden" (don't
 -- spawn, actively disable Blizzard's too). "hidden" has highest precedence so a
--- legacy disabled frame (enabledFrames[unit]==false: Visibility "never" or an
--- "Enable X Frame" toggle off) keeps meaning "no frame at all".
---- True when the unit has no EllesmereUI frame at all. That is the enabledFrames flag,
---- with the one exception an applied Visibility override carves out: the same flag is how
---- a shared Visibility of "never" is stored (applyScalarFn writes it), and an override
---- REPLACES the whole Visibility setting, "never" included. A frame source of "hidden" is
---- the cog's own choice rather than a Visibility setting, so it still wins. On ns for the
---- 200-locals cap.
+-- disabled frame (enabledFrames[unit]==false, the "Enable X Frame" toggles) keeps
+-- meaning "no frame at all". Visibility "never" is NOT one of these: it hides our
+-- frame at runtime and the frame stays built, so a Spec Override can lift it again
+-- without a /reload.
+
+--- True when the unit has no EllesmereUI frame at all -- the enabledFrames flag, which
+--- only the "Enable X Frame" toggles write now that Visibility no longer touches it.
+--- On ns for the 200-locals cap.
 function ns.VisUnitDisabled(profile, unitKey)
     local ef = profile and profile.enabledFrames
-    if not ef or ef[unitKey] ~= false then return false end
-    if (profile.frameSource and profile.frameSource[unitKey]) == "hidden" then return true end
-    local s = profile[unitKey]
-    local ov = s and EllesmereUI.VisOverrideValue and EllesmereUI.VisOverrideValue(s)
-    return not (ov and ov ~= "never")
+    return (ef and ef[unitKey] == false) or false
 end
 
 function ns.GetUnitFrameSource(unit)
@@ -2897,6 +2893,10 @@ function ns.GetUnitFrameSource(unit)
     if ns.VisUnitDisabled(db.profile, unit) then return "hidden" end
     local fs = db.profile.frameSource and db.profile.frameSource[unit]
     if fs == "blizzard" then
+        -- Visibility "never" over Blizzard's frame: we spawn nothing of our own to
+        -- hide, so suppressing Blizzard's is the only way to honor it.
+        local s = db.profile[unit]
+        if s and s.barVisibility == "never" then return "hidden" end
         -- ToT/focus-target have no standalone Blizzard frame (native one is a child
         -- of TargetFrame/FocusFrame, lives only while that parent does), so
         -- "blizzard" is honored for them ONLY when the parent is itself on
@@ -2911,38 +2911,16 @@ function ns.GetUnitFrameSource(unit)
     return "eui"
 end
 
--- Write a unit's frame source, keeping the legacy enabledFrames flag and per-unit
--- "never" visibility in sync so existing readers stay correct. Only takes full effect
--- after a UI reload (oUF permanently disables the Blizzard frame at spawn, and secure
--- frames can't be created/torn down in combat) -- callers should also prompt a reload.
+-- Write a unit's frame source, keeping the legacy enabledFrames flag in sync so
+-- existing readers stay correct (and so the cog is the way back for a frame an old
+-- profile left disabled). Only takes full effect after a UI reload -- the spawn
+-- permanently disables the Blizzard frame, and secure frames can't be created or
+-- torn down in combat -- so callers should also prompt a reload.
 function ns.SetUnitFrameSource(unit, source)
     if not db or not db.profile then return end
     db.profile.frameSource = db.profile.frameSource or {}
     db.profile.frameSource[unit] = source
     db.profile.enabledFrames[unit] = (source ~= "hidden")
-    -- Keep the player/target/focus "Visibility" dropdown ("never") consistent
-    -- with the hidden state; other units have no barVisibility key.
-    local s = db.profile[unit]
-    if s and s.barVisibility ~= nil then
-        if source == "hidden" then
-            -- Stash the visible mode so hidden->visible keeps an "in_combat"/"mouseover"
-            -- preference. Multi-selection sets stash the same way and MUST also clear,
-            -- or they stay authoritative over the forced "never" and the frame keeps showing.
-            if type(s.visibilityModes) == "table" and next(s.visibilityModes) then
-                s._preHiddenVisibilityModes = s.visibilityModes
-            end
-            s.visibilityModes = nil
-            if s.barVisibility ~= "never" then
-                s._preHiddenBarVisibility = s.barVisibility
-            end
-            s.barVisibility = "never"
-        elseif s.barVisibility == "never" then
-            s.barVisibility = s._preHiddenBarVisibility or "always"
-            s._preHiddenBarVisibility = nil
-            s.visibilityModes = s._preHiddenVisibilityModes
-            s._preHiddenVisibilityModes = nil
-        end
-    end
 end
 
 -- Cast-bar icon "part of the bar" resolver. True = icon counts inside the cast bar's
@@ -10948,8 +10926,11 @@ local function ApplyBlizzCastbarState()
     if EllesmereUI and EllesmereUI.SetPlayerCastBarSuppressed and db and db.profile and db.profile.player then
         -- Only suppress Blizzard's player cast bar when EUI actually provides a
         -- replacement. If the player is on the Blizzard (or hidden) frame source,
-        -- there is no EUI cast bar, so leave Blizzard's alone.
+        -- there is no EUI cast bar, so leave Blizzard's alone. Visibility "never"
+        -- counts as no replacement too: our cast bar is built now but hides with the
+        -- frame, and taking Blizzard's away would leave no player cast bar at all.
         local suppress = (db.profile.player.showPlayerCastbar
+            and db.profile.player.barVisibility ~= "never"
             and ns.GetUnitFrameSource("player") == "eui") or false
         EllesmereUI.SetPlayerCastBarSuppressed("UnitFrames", suppress)
     end

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -4187,11 +4187,42 @@ EllesmereUI.RegisterMigration({
     scope       = "profile",
     description = "Clear the enabledFrames flag Visibility \"Never\" used to write for player/target/focus, so the frame is built and a Spec Override can lift the hide without a reload.",
     body = function(ctx)
+        local UNITS = { "player", "target", "focus" }
         local uf = ctx.profile.addons and ctx.profile.addons.EllesmereUIUnitFrames
         local ef = uf and uf.enabledFrames
-        if type(ef) ~= "table" then return end
-        for _, unitKey in ipairs({ "player", "target", "focus" }) do
-            if ef[unitKey] == false then ef[unitKey] = nil end
+        if type(ef) == "table" then
+            for _, unitKey in ipairs(UNITS) do
+                if ef[unitKey] == false then ef[unitKey] = nil end
+            end
         end
+        -- Auto-capture banked the key alongside barVisibility while the two were
+        -- written together, and nothing blacklists it -- left in place, the next
+        -- spec apply writes false back and the frame goes missing again at the
+        -- following login. Other units keep theirs: their Enable toggles own it.
+        local stale = {}
+        for _, unitKey in ipairs(UNITS) do
+            stale["EllesmereUIUnitFrames\31enabledFrames\30" .. unitKey] = true
+        end
+        local function strip(store)
+            if type(store) ~= "table" then return end
+            for i = #store, 1, -1 do
+                local e = store[i]
+                local vals = type(e) == "table" and e.values
+                if type(vals) == "table" then
+                    for _, m in pairs(vals) do
+                        if type(m) == "table" then
+                            for fkey in pairs(m) do
+                                if stale[fkey] then m[fkey] = nil end
+                            end
+                        end
+                    end
+                    if type(vals.default) ~= "table" or next(vals.default) == nil then
+                        table.remove(store, i)
+                    end
+                end
+            end
+        end
+        strip(ctx.profile.specOverrides)
+        strip(ctx.profile.condOverrides)
     end,
 })

--- a/EllesmereUI_Migration.lua
+++ b/EllesmereUI_Migration.lua
@@ -4175,3 +4175,23 @@ EllesmereUI.RegisterMigration({
         end
     end,
 })
+
+-- Visibility "Never" used to write enabledFrames[unit] = false, and that key decides
+-- whether the frame is BUILT, once, at login -- so a Spec Override carrying it left
+-- the frame uncreated for the whole session with no way back but a /reload.
+-- Visibility no longer touches it and the visibility pass hides the frame at runtime
+-- instead, so clear the flag the old pairing left behind. player/target/focus have no
+-- Enable toggle of their own, so a stored false there can only have come from it.
+EllesmereUI.RegisterMigration({
+    id          = "uf_visibility_never_keeps_frame_v1",
+    scope       = "profile",
+    description = "Clear the enabledFrames flag Visibility \"Never\" used to write for player/target/focus, so the frame is built and a Spec Override can lift the hide without a reload.",
+    body = function(ctx)
+        local uf = ctx.profile.addons and ctx.profile.addons.EllesmereUIUnitFrames
+        local ef = uf and uf.enabledFrames
+        if type(ef) ~= "table" then return end
+        for _, unitKey in ipairs({ "player", "target", "focus" }) do
+            if ef[unitKey] == false then ef[unitKey] = nil end
+        end
+    end,
+})


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1484909708392530121

Issue: with a spec override setting the player frame's Visibility to Never for healer or tank, switching back to a spec without the override left the frame hidden until /reload. It looks intermittent because it depends on which spec the session started on.

Root cause: the Visibility dropdown wrote enabledFrames[unit] alongside barVisibility, and that key is build-time. ns.GetUnitFrameSource reports the unit hidden and InitializeFrames skips the spawn, once, at login. A spec override applies a couple of frames later, so a spec carrying Never left the frame uncreated, and switching back wrote the key true again with no frame to show.

Fix: Visibility no longer touches enabledFrames, so the frame is always built and Never hides it the way in_combat and mouseover do, pinned on a state-visibility driver so it holds in combat too. A migration clears the flag the old pairing wrote and strips it from existing override stores. Verified in game by the reporter.
