### PR TITLE
Fix(Minimap): Clip rectangular mode's blips to the visible rectangle

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -4002,6 +4002,19 @@ function EBS._ApplyAddonCompartment()
     end
 end
 
+-- The mask that crops rectangular mode's square canvas covers the terrain only -- the
+-- engine keeps drawing unit blips across the whole canvas, and the one thing that
+-- confines the native render is the minimap's PARENT rect (ordinary child frames and
+-- textures are not clipped by it, so our border and buttons still draw outside).
+-- Parenting the canvas to the 4:3 layout frame is what crops the blips.
+local function DesiredMapParent(minimap)
+    local p = EBS.db and EBS.db.profile.minimap
+    if p and (p.shape or "square") == "rectangular" then
+        return GetFFD(minimap).layoutFrame or UIParent
+    end
+    return UIParent
+end
+
 local function ApplyMinimap()
     if TEMP_DISABLED.minimap then return end
     if InCombatLockdown() then QueueApplyAll(); return end
@@ -4030,17 +4043,22 @@ local function ApplyMinimap()
     -- Snapshot Blizzard's native size/position before we modify anything
     CaptureBlizzardMinimap()
 
-    -- Reparent to UIParent so MinimapCluster layout cannot override our size. Deferred
-    -- via C_Timer.After(0) to avoid tainting the secure frame environment when
+    -- Reparent out of MinimapCluster so its layout cannot override our size, and so the
+    -- native render is clipped by the frame we own rather than by Blizzard's cluster.
+    -- Deferred via C_Timer.After(0) to avoid tainting the secure frame environment when
     -- ApplyMinimap fires during a ShowUIPanel/World Map open -- that taint causes
     -- ADDON_ACTION_BLOCKED when the dungeon pin data provider later calls the protected SetPropagateMouseClicks() on map pins.
-    local needsReparent = minimap:GetParent() ~= UIParent
     local needsClusterHide = MinimapCluster and MinimapCluster:IsShown()
+    -- The rectangular canvas's parent is built later in this pass, so the first switch
+    -- to that shape has to schedule the reparent on the layout frame's absence.
+    local needsReparent = minimap:GetParent() ~= DesiredMapParent(minimap)
+        or ((p.shape or "square") == "rectangular" and not GetFFD(minimap).layoutFrame)
     if needsReparent or needsClusterHide then
         C_Timer.After(0, function()
-            if InCombatLockdown() then return end
-            if needsReparent and minimap:GetParent() ~= UIParent then
-                minimap:SetParent(UIParent)
+            if InCombatLockdown() then QueueApplyAll(); return end
+            local want = DesiredMapParent(minimap)
+            if minimap:GetParent() ~= want then
+                minimap:SetParent(want)
             end
             if needsClusterHide and MinimapCluster then
                 MinimapCluster:SetAlpha(0)
@@ -4048,13 +4066,19 @@ local function ApplyMinimap()
             end
         end)
     end
-    -- Blizzard reparents the minimap during housing transitions and other events; hook SetParent to force it back to UIParent.
+    -- Blizzard reparents the minimap during housing transitions and other events; hook SetParent to force it back.
     if not GetFFD(minimap).parentGuard then
         GetFFD(minimap).parentGuard = true
         hooksecurefunc(minimap, "SetParent", function()
-            if minimap:GetParent() ~= UIParent then
-                if not InCombatLockdown() then
-                    minimap:SetParent(UIParent)
+            local want = DesiredMapParent(minimap)
+            if minimap:GetParent() ~= want then
+                if InCombatLockdown() then
+                    -- Dropping it would leave the map parented to -- and clipped by --
+                    -- whatever reparented it (the cluster, on a battleground or housing
+                    -- transition) for the rest of the session.
+                    QueueApplyAll()
+                else
+                    minimap:SetParent(want)
                 end
             end
         end)
@@ -4163,14 +4187,17 @@ local function ApplyMinimap()
         minimap:SetHitRectInsets(0, 0, 0, 0)
     end
     if isRectangular and not GetFFD(minimap).layoutFrame then
-        local layout = CreateFrame("Frame", nil, minimap)
-        layout:SetPoint("CENTER", minimap, "CENTER")
+        local layout = CreateFrame("Frame", nil, UIParent)
         layout:EnableMouse(false)
         GetFFD(minimap).layoutFrame = layout
     end
     do
         local layout = GetFFD(minimap).layoutFrame
         if layout then
+            -- Re-anchored every pass for the reason the border host below is: this
+            -- anchor spans the deferred SetParent that hangs the canvas off it.
+            layout:ClearAllPoints()
+            layout:SetPoint("CENTER", minimap, "CENTER")
             layout:SetSize(mapSize, isRectangular and (mapSize * 192 / 256) or mapSize)
             layout:SetFrameLevel(minimap:GetFrameLevel())
         end


### PR DESCRIPTION
Bug: reported by Discord user 1306712773564170431 in the EllesmereUI bug channel (2026-08-29, on 9.0.8, still present on 9.1.3).

Issue: With Minimap shape set to Rectangular, player and party arrows draw above and below the map, outside the border, in a band an eighth of the map size deep. It shows up most in a battleground.

Root cause: Rectangular mode keeps the native canvas square and hides those strips with a crop mask, since a non-square canvas misplaces the player arrow and pings (#1656). The mask covers terrain only, so the engine still draws blips across the whole canvas; what confines the native render is the minimap's parent rect, which ApplyMinimap sets to UIParent.

Fix: The canvas now sits inside the 4:3 layout frame every other rectangular-mode element already anchors to, so terrain and blips crop together, while the border and buttons are ordinary children and still draw outside it. The reparent path's combat bailouts also queue the module's existing post-combat apply, so a reparent Blizzard makes in combat no longer leaves the map clipped to MinimapCluster. Tested in game.
