### PR TITLE
Fix Sweeping Strikes / Whirlwind threshold config

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -6602,7 +6602,7 @@ initFrame:SetScript("OnEvent", function(self)
 
 					-- Threshold input bounds (Enhance five-bar minimum). Bar-type reads the threshold as % (max 100) or an absolute value (higher cap)
 					local threshIsValue = isBar and not isStagger and ent.thresholdMode == "value"
-					local threshMax = isStagger and 500 or (isBar and (threshIsValue and 1000 or 100) or 10)
+					local threshMax = isStagger and 500 or (isBar and (threshIsValue and 1000 or 100) or 20)
 					local entryIsEnhance = false
 					local pp = DB()
 					if pp and pp.secondary.enhanceFiveBar == true then

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -5651,7 +5651,7 @@ local function UpdateSecondaryResource()
             if ns.WC_Thresholds then
                 ns.WC_Thresholds(powerType,
                     (_tsEntry and _tsEntry.thresholdMode) or sp.thresholdMode,
-                    _tsThreshCount, _tsR, _tsG, _tsB, _tsA,
+                    _tsEntry and _tsThreshCount or nil, _tsR, _tsG, _tsB, _tsA,
                     _tsBandOn, _tsBands, _tsBandReverse, _tsReverse)
             end
         end

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -3796,13 +3796,6 @@ local function BuildBars()
             secondaryFrame._barBg:SetColorTexture(sp.barBgR or 0, sp.barBgG or 0, sp.barBgB or 0, sp.barBgA or 0.5)
         end
 
-        -- Warrior charge buffs: hand the engine-slot module the resolved build
-        -- (it parks itself for every other power type and non-warriors; see
-        -- EUI_ResourceBars_WarriorCharges.lua).
-        if ns.WC_Sync then
-            ns.WC_Sync(secondaryFrame, sp, cachedSecondary and cachedSecondary.power, g)
-        end
-
         if sp.showText then
             if not secondaryFrame._countText then
                 -- Parent to a high-level overlay so text renders above pip fills and borders
@@ -3834,6 +3827,15 @@ local function BuildBars()
             end
         elseif secondaryFrame._countText then
             secondaryFrame._countText:Hide()
+        end
+
+        -- Warrior charge buffs: hand the engine-slot module the resolved build
+        -- (it parks itself for every other power type and non-warriors; see
+        -- EUI_ResourceBars_WarriorCharges.lua). Must run after _countText is
+        -- created and styled above -- the engine bakes its count-text font from
+        -- this fontstring at slot-creation time and never re-reads it.
+        if ns.WC_Sync then
+            ns.WC_Sync(secondaryFrame, sp, cachedSecondary and cachedSecondary.power, g)
         end
 
         secondaryFrame:Show()


### PR DESCRIPTION
Two related fixes for threshold configuration on the Warrior charge bars (Sweeping Strikes / Whirlwind Stacks).

## 1. Charge bar showed a threshold overlay when thresholds were disabled

These two powers have no Lua-comparable count, so their threshold coloring is routed through `ns.WC_Thresholds` and rendered by the engine module as a fill-masked range strip. In `UpdateSecondaryResource()` that call passed `_tsThreshCount` unconditionally:

```lua
ns.WC_Thresholds(powerType,
    (_tsEntry and _tsEntry.thresholdMode) or sp.thresholdMode,
    _tsThreshCount, _tsR, _tsG, _tsB, _tsA,
    ...)
```

When the threshold entry is disabled (or a tracked buff is active) the resolver nils `_tsEntry`, but `_tsThreshCount` still falls back to the legacy global `sp.thresholdCount`. `HostThresholds` then builds a single-band spec from any `count > 0`, so the strip rendered regardless of configuration. Every other threshold renderer in that function already guards on `_tsEntry`; this path did not.

Fix: pass the count only when the entry is enabled — `_tsEntry and _tsThreshCount or nil`. With `count` nil and no bands, `HostThresholds` clears the spec and `StyleThresholds` hides all strips.

## 2. Threshold input clamped to 10

The count-based threshold input for the class/secondary resource bar clamped to 10, but Sweeping Strikes stacks to 18 with Broad Strokes. Raised the pip/count cap to 20; bar-type (percent/value) and stagger caps unchanged.

## Testing

- `/reload` on Arms Warrior with the Sweeping Strikes secondary bar, thresholds disabled: overlay no longer appears; enabling thresholds still renders the strip.
- Threshold input now accepts values up to 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)