### PR TITLE
Fix: LFG Reminder never firing on non-English/Russian clients

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL_Keys.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Keys.lua
@@ -22,6 +22,18 @@ do
         for _, n in ipairs(e.names) do
             TELEPORT_BY_NAME[n] = e.spellID
         end
+        -- Locale-agnostic: GetLFGDungeonInfo returns the dungeon's name in
+        -- whatever locale THIS client is running -- the same source the LFG
+        -- teleport prompt's activity fullName comes from -- so this covers
+        -- every client locale automatically instead of only the languages
+        -- hardcoded in `names` above (English/Russian only, so e.g. a German
+        -- client never got a match and the LFG Reminder popup silently never fired).
+        if e.dungeonID and GetLFGDungeonInfo then
+            local ok, localName = pcall(GetLFGDungeonInfo, e.dungeonID)
+            if ok and type(localName) == "string" and localName ~= "" then
+                TELEPORT_BY_NAME[localName:lower()] = e.spellID
+            end
+        end
     end
     if C_ChallengeMode and C_ChallengeMode.GetMapTable then
         local maps = C_ChallengeMode.GetMapTable()


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1544272017027633213

Issue: QoL's LFG Reminder popup silently never fired on a German client (and every other locale besides English/Russian) because TELEPORT_BY_NAME was seeded only from a hardcoded English/Russian alias list, while the joined LFGList activity's fullName comes back in the client's own locale and never matched.
Fix: For each SEASON_PORTALS entry, also seed TELEPORT_BY_NAME with GetLFGDungeonInfo(dungeonID)'s live, client-locale dungeon name (pcall-wrapped), so the lookup self-corrects for every client locale automatically instead of relying on hardcoded translations.