### PR TITLE
feat(cdm): add min-stack threshold gate to bar glows

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
@@ -175,6 +175,55 @@ local overlayFrames = {}  -- [key] = overlay frame
 local lastStates = {}     -- [key] = bool (last glow state for change detection)
 local _cachedBG = nil     -- cached barGlows reference (refreshed on SetupOverlays)
 
+-------------------------------------------------------------------------------
+--  Stack-threshold gate (secret-safe)
+--  Applications counts read SECRET even in open-world content, so the
+--  threshold compare can never happen in Lua (a hard error on a secret).
+--  Same trick as the per-icon Glow at Stacks feature
+--  (EllesmereUICdmHooks.lua's StackGlow_Configure/Feed): a one-unit
+--  StatusBar window [threshold-1, threshold] performs the compare C-side
+--  via SetValue, and a CLAMPTOBLACKADDITIVE mask riding that fill's edge
+--  is handed to StartNativeGlow so the glow texture itself is cropped by
+--  the fill -- Lua never reads the count, just forwards it.
+-------------------------------------------------------------------------------
+local stackGates = {}  -- [key] = { gate=StatusBar, mask=MaskTexture, pad=n, threshold=n }
+
+local function StackGateSize(overlay)
+    local w, h = overlay:GetWidth(), overlay:GetHeight()
+    if not w or w < 5 then w = 36 end
+    if not h or h < 5 then h = w end
+    return w, h
+end
+
+local function EnsureStackGate(overlay, key, threshold)
+    local st = stackGates[key]
+    if not st then
+        st = {}
+        stackGates[key] = st
+        local w, h = StackGateSize(overlay)
+        local pad = math.ceil(math.max(w, h) * 0.4)
+        if pad < 12 then pad = 12 end
+        st.pad = pad
+        st.gate = CreateFrame("StatusBar", nil, overlay)
+        st.gate:SetPoint("TOPLEFT", overlay, "TOPLEFT", -pad, pad)
+        st.gate:SetPoint("BOTTOMRIGHT", overlay, "BOTTOMRIGHT", pad, -pad)
+        st.gate:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
+        local gft = st.gate:GetStatusBarTexture()
+        if gft then gft:SetAlpha(0) end
+        st.gate:EnableMouse(false)
+        st.mask = st.gate:CreateMaskTexture()
+        st.mask:SetTexture("Interface\\Buttons\\WHITE8x8",
+            "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE", "NEAREST")
+        st.mask:SetPoint("RIGHT", gft or st.gate, "RIGHT", 0, 0)
+        st.mask:SetSize(w + pad * 2, h + pad * 2)
+    end
+    if st.threshold ~= threshold then
+        st.threshold = threshold
+        st.gate:SetMinMaxValues(threshold - 1, threshold)
+    end
+    return st
+end
+
 --- Rebuild overlay frames from assignments
 local function SetupOverlays()
     local bg = ns.GetBarGlows()
@@ -275,7 +324,29 @@ local function UpdateOverlayVisuals()
                 shouldGlow = (InCombatLockdown and InCombatLockdown()) or UnitAffectingCombat("player") or false
             end
 
-            -- Only update on state change (avoids restarting animations)
+            -- Stack threshold (ACTIVE mode only): fed to the gate every tick
+            -- regardless of state-change dedupe below, so the mask tracks a
+            -- live stack count while the glow keeps running.
+            local threshold = (mode ~= "MISSING") and entry.stackThreshold or nil
+            local gateSt
+            if shouldGlow and threshold and threshold > 1 and spellID and spellID > 0 then
+                gateSt = EnsureStackGate(overlay, key, threshold)
+                -- Same sid/baseSID/linked resolution as auraActive above, so
+                -- this matches whatever spellID the entry was saved against
+                -- (a raw GetPlayerAuraBySpellID(spellID) query missed on the
+                -- override/linked-id drift these tracked buffs can have).
+                local stacks = ns._tickBlizzAuraStacks and ns._tickBlizzAuraStacks[spellID]
+                -- Secret probe FIRST: `stacks or 0` / `stacks == nil` would
+                -- themselves hard-error if stacks is secret (any truthy/nil
+                -- test on a secret value errors, not just `<`/`>=`).
+                if issecretvalue and issecretvalue(stacks) then
+                    gateSt.gate:SetValue(stacks)
+                else
+                    gateSt.gate:SetValue(stacks or 0)
+                end
+            end
+
+            -- Only update start/stop on state change (avoids restarting animations)
             if shouldGlow ~= lastStates[key] then
                 lastStates[key] = shouldGlow
                 if shouldGlow then
@@ -297,7 +368,12 @@ local function UpdateOverlayVisuals()
                         cg = entry.glowColor.g or 0.788
                         cb = entry.glowColor.b or 0.137
                     end
-                    StartNativeGlow(overlay, style, cr, cg, cb)
+                    if threshold and threshold > 1 then
+                        gateSt = gateSt or EnsureStackGate(overlay, key, threshold)
+                        StartNativeGlow(overlay, style, cr, cg, cb, { maskWith = gateSt.mask })
+                    else
+                        StartNativeGlow(overlay, style, cr, cg, cb)
+                    end
                 else
                     StopNativeGlow(overlay)
                 end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -98,6 +98,9 @@ do
         end
         return nil
     end
+    -- Exported for the aura active-cache below (Bar Glows stack threshold):
+    -- same secret-safe applications read, off whatever pool frame is active.
+    ns._ReadBuffApplications = ReadBuffApplications
 
     local function StartStackGlow(st, width, height)
         ns.StartNativeGlow(st.glow, st.style, st.r, st.g, st.b, {
@@ -1443,6 +1446,14 @@ ns._cdidRouteMap = _cdidRouteMap
 -------------------------------------------------------------------------------
 local _activeCache = {}
 ns._tickBlizzActiveCache = _activeCache
+
+-- Per-spellID application count, same population pass as _activeCache above,
+-- same sid/baseSID/linked resolution (so it matches whatever spellID a Bar
+-- Glow entry was saved against). Value is a plain number, a SECRET number,
+-- or nil (no stack data). Consumed by Bar Glows' stack-threshold gate --
+-- forwarded straight into a StatusBar:SetValue, never compared in Lua.
+local _activeStacksCache = {}
+ns._tickBlizzAuraStacks = _activeStacksCache
 
 -------------------------------------------------------------------------------
 --  IsFrameIncluded
@@ -10080,7 +10091,9 @@ function ns.SetupViewerHooks()
                 ns._acLastFull = _btNow
             do
                 local ac = _activeCache
+                local asc = _activeStacksCache
                 wipe(ac)
+                wipe(asc)
                 for vi = 1, 4 do
                     local vf = GetViewerFrame(vi)
                     -- BuffIcon (3) / BuffBar (4) viewers SHOW a frame only while its
@@ -10102,13 +10115,21 @@ function ns.SetupViewerHooks()
                                 local sid, baseSID = ResolveFrameSpellID(frame)
                                 if sid and sid > 0 then
                                     ac[sid] = true
-                                    if baseSID and baseSID > 0 then ac[baseSID] = true end
+                                    local apps = ns._ReadBuffApplications and ns._ReadBuffApplications(frame)
+                                    if apps ~= nil then asc[sid] = apps end
+                                    if baseSID and baseSID > 0 then
+                                        ac[baseSID] = true
+                                        if apps ~= nil then asc[baseSID] = apps end
+                                    end
                                     local fc = _ecmeFC[frame]
                                     local linked = fc and fc.linkedSpellIDs
                                     if linked then
                                         for li = 1, #linked do
                                             local lsid = linked[li]
-                                            if lsid and lsid > 0 then ac[lsid] = true end
+                                            if lsid and lsid > 0 then
+                                                ac[lsid] = true
+                                                if apps ~= nil then asc[lsid] = apps end
+                                            end
                                         end
                                     end
                                 end

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -1544,6 +1544,34 @@ initFrame:SetScript("OnEvent", function(self)
                         }
                     );  y = y - h
 
+                    -- Row: Require Min Stacks | Min Stack Count
+                    -- Same fail-open bias as the per-icon Glow at Stacks feature:
+                    -- an unknown/secret application count never blocks the glow.
+                    local stackRow
+                    stackRow, h = W:DualRow(parent, y,
+                        { type = "toggle", text = "Require Min Stacks",
+                          tooltip = "Only glow once the buff has reached this many stacks/applications.",
+                          disabled = function() return entry.mode == "MISSING" end,
+                          disabledTooltip = "Not available in Buff Missing mode",
+                          getValue = function() return (entry.stackThreshold or 0) > 1 end,
+                          setValue = function(v)
+                              entry.stackThreshold = v and math.max(2, tonumber(entry.stackThreshold) or 2) or nil
+                              Refresh()
+                          end,
+                        },
+                        { type = "input", text = "Min Stack Count", inputWidth = 42, commitOnBlur = true,
+                          disabled = function() return entry.mode == "MISSING" or not ((entry.stackThreshold or 0) > 1) end,
+                          disabledTooltip = "Enable Require Min Stacks",
+                          getValue = function() return tostring(tonumber(entry.stackThreshold) or 2) end,
+                          setValue = function(v)
+                              local t = math.floor(tonumber(v) or 2)
+                              if t < 2 then t = 2 end
+                              if t > 99 then t = 99 end
+                              entry.stackThreshold = t
+                          end,
+                        }
+                    );  y = y - h
+
                     -- Helper: resolve current glow color and restart preview if active
                     local pvKey = assignKey .. "_" .. aIdx
                     local function RefreshPreviewGlow()


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds an opt-in "Require Min Stacks" setting to Cooldown Manager Bar Glows. The glow only starts once the tracked buff/debuff reaches a configured stack/application count (2-99), instead of glowing on presence alone.

Applications counts can be a SECRET value even in open-world content, so the threshold compare never happens in Lua (any compare on a secret value hard-errors). Instead a one-unit StatusBar window `[threshold-1, threshold]` performs the compare C-side via `SetValue`, and a mask riding that fill's edge crops the native glow texture -- same technique already used by the per-icon "Glow at Stacks" feature.

<!-- User-facing description: what changes for the player? -->

## How was it tested?

- Verified the new stack cache (`ns._tickBlizzAuraStacks`) is populated from the same sid/baseSID/linked resolution pass as the existing active cache, so it matches whatever spellID a Bar Glow entry is saved against.
- Verified the option row follows the existing `DualRow` pattern and is disabled in Buff Missing mode (stacks don't apply there).
- Verified the gate/mask frames are only created lazily on first use (threshold > 1 and glow active), so unopted-in users pay nothing.

<!-- Client build, what you tested in game, etc. -->

## Screenshots

N/A -- adds one settings row using the existing DualRow widget shape; no new visual style.

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
