### PR TITLE
Fix: quest objectives stop updating until /reload

### DIFF
--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker.lua
@@ -158,6 +158,9 @@ _G._EQT_RefreshAll = function()
     if EQT.RefreshFonts then EQT.RefreshFonts() end
     if EQT.UpdateVisibility then EQT.UpdateVisibility() end
     if EQT.RestyleAll then EQT.RestyleAll() end
+    -- Before ApplyBackground: the BG's top anchor depends on whether the
+    -- master header is suppressed.
+    if EQT.ApplyMasterHeaderVisibility then EQT.ApplyMasterHeaderVisibility() end
     if EQT.ApplyBackground then EQT.ApplyBackground() end
     if EQT.ApplyForceOnScreen then EQT.ApplyForceOnScreen() end
     -- The hotkey is a per-profile setting backed by an override binding, so a

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Skin.lua
@@ -239,8 +239,11 @@ local function EnsureAccentDivider(header)
     local isMasterHeader = (header == otf.HeaderMenu or header == otf.Header)
 
     -- Divider is visible only when the tracker itself is currently being
-    -- rendered (Blizzard hides the tracker frame when it has no content).
+    -- rendered (Blizzard hides the tracker frame when it has no content). The
+    -- master header is suppressed with alpha rather than Hide(), so an alpha-0
+    -- header counts as not rendered too -- see ApplyMasterHeaderVisibility.
     local headerShown = header.IsShown and header:IsShown()
+        and (not header.GetAlpha or header:GetAlpha() > 0)
     local active
 
     if isMasterHeader then
@@ -1083,14 +1086,17 @@ end
 
 -------------------------------------------------------------------------------
 -- Master "All Objectives" header visibility. SkinHeader() above is always
--- applied to it in InitSkin(); this only controls Show/Hide, driven by the
+-- applied to it in InitSkin(); this only controls visibility, driven by the
 -- "hideAllObjectivesHeader" option so the user can opt into showing it.
 -- Defaults to hidden (nil in DB reads as hidden) -- see ShouldHideMasterHeader.
 --
--- ObjectiveTrackerFrameMixin:Update() unconditionally calls self.Header:Show() on every
--- layout pass whenever the tracker has any module to display (verified against
--- Gethe/wow-ui-source, Blizzard_ObjectiveTracker.lua), so hiding it requires a
--- persistent HookScript("OnShow", ...) fight rather than a one-time Hide().
+-- Suppressed with alpha, never Hide() -- same pattern as ApplyPOISuppression above, and
+-- layout-equivalent (the container spaces the first module by topModulePadding alone).
+-- ObjectiveTrackerFrameMixin:Update() calls self.Header:Show() before the container layout,
+-- so a Hide() must be fought from an OnShow script that taints the whole pass.
+-- ScenarioObjectiveTracker lays out first, and its LayoutContents call to ShouldShowMawBuffs
+-- -> C_UnitAuras.GetAuraDataByIndex hard-errors while tainted: the pass unwinds before
+-- DirtiableMixin clears self.dirty, nothing schedules another, and it freezes until /reload.
 -------------------------------------------------------------------------------
 -- Default is "hidden" (true) when the DB key is unset. `~= false` treats
 -- nil the same as true, while still honoring an explicit user choice of
@@ -1100,27 +1106,19 @@ local function ShouldHideMasterHeader()
 end
 EQT.ShouldHideMasterHeader = ShouldHideMasterHeader
 
-local _masterHeaderShowHooked = false
 local function ApplyMasterHeaderVisibility()
     local otf = _G.ObjectiveTrackerFrame
     if not otf then return end
     local header = otf.HeaderMenu or otf.Header
     if not header then return end
 
-    if not _masterHeaderShowHooked then
-        _masterHeaderShowHooked = true
-        header:HookScript("OnShow", function(self)
-            if ShouldHideMasterHeader() then self:Hide() end
-        end)
-    end
+    local hide = ShouldHideMasterHeader()
+    header:SetAlpha(hide and 0 or 1)
+    -- The header frame takes no mouse input of its own, but the collapse-all
+    -- button would still be clickable while invisible.
+    local minBtn = header.MinimizeButton
+    if minBtn and minBtn.EnableMouse then minBtn:EnableMouse(not hide) end
 
-    if ShouldHideMasterHeader() then
-        header:Hide()
-    else
-        header:Show()
-    end
-    -- Header:Hide()/Show() above don't retrigger our own hooks, so refresh
-    -- the divider's active-state directly (it reads header:IsShown() live).
     EnsureAccentDivider(header)
 end
 EQT.ApplyMasterHeaderVisibility = ApplyMasterHeaderVisibility

--- a/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
+++ b/EllesmereUIQuestTracker/EllesmereUIQuestTracker_Visibility.lua
@@ -41,15 +41,13 @@ local function GetBGLeftOffset()
     return EQT.Cfg("showQuestIcons") and -19 or -6
 end
 
--- When "Hide All Objectives" is on, otf.Header/HeaderMenu is Hidden but Blizzard's
--- topModulePadding still reserves its layout slot above the first module (the same
--- "dead gap" this suite has run into before) -- otf:GetTop() doesn't move to reclaim
--- it. Anchor the BG's top edge to the header's own bottom edge in that case instead,
--- so the BG shrinks to skip the empty gap. A Hidden frame's rect (GetBottom/GetTop)
--- still reflects its anchored layout position, since Blizzard doesn't reflow on
--- Hide(). When the header is shown, keep anchoring to the tracker's own top edge so
--- the BG covers the header as before. Returns: anchorFrame, relPoint ("TOP" or
--- "BOTTOM" -- caller appends LEFT/RIGHT).
+-- When "Hide All Objectives" is on, otf.Header/HeaderMenu is faded to alpha 0 but
+-- Blizzard's topModulePadding still reserves its layout slot above the first module
+-- (the same "dead gap" this suite has run into before) -- otf:GetTop() doesn't move to
+-- reclaim it. Anchor the BG's top edge to the header's own bottom edge in that case
+-- instead, so the BG shrinks to skip the empty gap. When the header is shown, keep
+-- anchoring to the tracker's own top edge so the BG covers the header as before.
+-- Returns: anchorFrame, relPoint ("TOP" or "BOTTOM" -- caller appends LEFT/RIGHT).
 local function GetBGTopAnchor()
     local otf = GetTracker()
     if not otf then return nil, "TOP" end


### PR DESCRIPTION
Bug: reported by @Shinny on 9.0.7 - quest objective progress randomly stops updating and stays stuck until /reload (a fishing count frozen at 7/13, a summon bar frozen at 7%). The accompanying error is Blizzard_ScenarioObjectiveTracker.lua:187 in LayoutContents, reached from ObjectiveTrackerContainer:Update via DirtiableMixin.

Issue: the "All Objectives" master header is hidden by default, and it was held down by a HookScript("OnShow", ...) that re-hid it whenever Blizzard showed it. ObjectiveTrackerFrameMixin:Update calls self.Header:Show() immediately before it runs the container layout, and because our hook had just hidden the header that Show() fired OnShow on every single pass. Our script therefore executed inside Blizzard's update chain and tainted the rest of it.

Root cause: ScenarioObjectiveTracker is uiOrder 1, so its LayoutContents was the very next thing to run. Line 187 is ShouldShowMawBuffs(), which reads C_UnitAuras.GetAuraDataByIndex("player", 1, "MAW") - flagged RequiresUnitAuraAccess, so it hard-errors under taint. The freeze is permanent because DirtiableMixin's callback is `method(self); self.dirty = nil`: the throw skips the clear, self.dirty stays true, and MarkDirty only schedules a pass `if not self.dirty`. Nothing ever queues another one. Taint injected in the tail of a pass cannot do this, since every MarkDirty during a pass is swallowed by that same flag - only code running before the first module lays out matters, and this hook was the only such site.

Fix: suppress the header with alpha instead of fighting Show(), matching ApplyPOISuppression already in the file - SetAlpha(0) plus EnableMouse(false) on the MinimizeButton so an invisible collapse-all is not clickable. The header's shown state has no effect on layout (the container spaces the first module by topModulePadding alone and never reads the header's rect), so this is visually identical with no addon code left in Blizzard's update chain. EnsureAccentDivider now treats an alpha-0 header as not rendered, and _EQT_RefreshAll re-applies the suppression on a profile swap, which the old always-live hook had been covering for free. As a side effect this also removes a latent combat block: Hide() on the tracker's header routed through EditMode's protected path, while SetAlpha is the same combat-safe route HardHide already uses.
