### PR TITLE
Fix(Chat): keep the display bridge off windows Blizzard has not opened yet

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat_Engine.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Engine.lua
@@ -901,9 +901,24 @@ local function ChatFrameWheel(cf, delta)
     end
 end
 
+-- Blizzard opens a new permanent window (ChatFrameUtil.PopOutChat) or a
+-- temporary whisper window by taking one it considers unopened and seeding it
+-- from the source frame inside its own copy loop: GetMessageInfo, compare the
+-- line's accessID, AddMessage, next line. An AddMessage hook taints the rest of
+-- that loop, so the NEXT GetMessageInfo answers with a secret accessID and the
+-- compare throws (ChatFrameUtil.lua:711) with the pop-out half done. Unopened
+-- frames therefore stay unbridged; the first integrate pass after Blizzard
+-- opens one installs the bridge and backfills our window from its buffer.
+local function IsChatFrameOpen(cf)
+    if cf.isTemporary then return cf.inUse == true end
+    local id = cf:GetID()
+    return id > 0 and FCF_IsChatWindowIndexActive(id)
+end
+
 local function InstallBridge(cf)
     local d = CFD(cf)
-    if d.bridged then return end
+    if d.bridged then return false end
+    if not IsChatFrameOpen(cf) then return false end
     d.bridged = true
     -- EngineTail's signature matches the hook's (self arrives as its cf);
     -- the trailing MessageFormatter argument is dropped by arity.
@@ -918,6 +933,7 @@ local function InstallBridge(cf)
     end
     cf:SetScript("OnMouseWheel", ChatFrameWheel)
     cf:EnableMouseWheel(true)
+    return true
 end
 
 -------------------------------------------------------------------------------
@@ -996,7 +1012,14 @@ local function IntegrateChatFrame(cf)
         RebuildWindowFromBuffer(cf)
         return
     end
-    InstallBridge(cf)
+    -- A frame bridged only now was opened since the last pass (a pop-out, a
+    -- reused temporary window): its lines were copied in behind our back. The
+    -- empty check keeps a late bridge on a window we already render from
+    -- rebuilding it out from under the lines it is already showing.
+    if InstallBridge(cf) and win.smf:GetNumMessages() == 0 then
+        RebuildWindowFromBuffer(cf)
+        return
+    end
     local theirs = cf:GetNumMessages()
     if theirs < win.smf:GetNumMessages() then
         RebuildWindowFromBuffer(cf)


### PR DESCRIPTION
Bug: reported by Discord user 265682780711550976 in the EllesmereUI bug channel (2026-09-01, on 9.0.7). LUA error, "secrets".

Issue: right-clicking the [Guild] channel link in chat and picking Move to New Window throws "ChatFrameUtil.lua:711: attempt to compare local 'messageAccessID' (a secret number value, while execution tainted by 'EllesmereUIChat')". The new window opens and docks but stays empty, and the guild lines are still in the old tab, because the error aborts the pop-out before it copies or removes anything.

Root cause: ChatFrameUtil.PopOutChat seeds the new window from the source frame inside one loop: GetMessageInfo(i), compare that line's accessID, AddMessage, next i. The display engine bridges every chat frame with hooksecurefunc(cf, "AddMessage", EngineTail), so the first copied line enters our hook and taints the rest of Blizzard's loop. Iteration two's GetMessageInfo then answers with a secret accessID and the compare throws. The bridge's own note calls AddMessage "the LAST step of Blizzard's message pipeline", which holds for the CHAT_MSG handler it was written against but not for this copy loop.

Fix: InstallBridge now skips frames Blizzard has not opened, so the frame it hands to FCF_OpenNewWindow carries no hook while it copies. The predicate is Blizzard's own FCF_IsChatWindowIndexActive, the one FCF_GetNextOpenChatWindowIndex draws the pop-out target from, with cf.inUse for temporaries. InstallBridge reports whether it installed, and IntegrateChatFrame backfills our window from Blizzard's buffer when a frame is bridged late and our side is still empty, so the copied lines appear a tick after the pop-out. The empty check keeps a late bridge from wiping session history replayed into a window we already render. SetChatWindowShown fires UPDATE_CHAT_WINDOWS, which drives that deferred pass. Side effect: unused chat frames no longer get a bridge, a wheel handler or scroll hooks until they are opened.

Known limitation: the gate only protects a frame's first opening. hooksecurefunc cannot be undone, and restoring cf.AddMessage by hand is worse than the bug, since chat frames get their methods by Mixin copy, so the field has no metatable to fall back to and a hand-written value is read by the secure MessageEventHandler on every line. Once a frame is bridged it therefore taints any later re-seed: closing a popped-out window frees its index while the hook is still attached, and FCF_OpenTemporaryWindow sets inUse before its own identical copy loop, so a pooled whisper window reused for a second conversation is exposed the same way. Blizzard's clearable addMessageObserver slot has the same every-line read problem and is not a way out. Closing those cases means taking the tail off hooksecurefunc(cf, "AddMessage") altogether and driving the engine from chat events plus an incremental sync off cf.historyBuffer, which is what the module's own rule already points at: no EUI code may execute inside a Blizzard chat-state execution. That is an engine rewrite touching every line of live chat rendering, so it is deliberately not in this PR. This change is the containment, and it fixes the reported case.

Not yet verified in game.
