### PR TITLE
Fix(Unit Frames): apply a SharedMedia font that registers after the login build

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -14007,6 +14007,29 @@ function EllesmereUF:OnInitialize()
 
     ResolveFontPath()
 
+    -- Unit frame text is fonted only while frames are built, from a path this
+    -- module snapshots; every other module resolves per repaint and heals off
+    -- the shared cache, so a SharedMedia pack registering after the login build
+    -- leaves ONLY the unit frames on the fallback face for the session.
+    -- Deferred a tick so a registration inside the login dispatch lands after
+    -- this module's own setup, and coalesced because a pack registers its faces
+    -- one at a time. The cache drop is ours: the core listens for this event too
+    -- and CallbackHandler does not order its receivers.
+    local LSM = LibStub and LibStub("LibSharedMedia-3.0", true)
+    if LSM then
+        local fontCheckPending
+        LSM.RegisterCallback(EllesmereUF, "LibSharedMedia_Registered", function(_, mediatype)
+            if mediatype ~= "font" or fontCheckPending then return end
+            fontCheckPending = true
+            C_Timer.After(0, function()
+                fontCheckPending = false
+                EllesmereUI.InvalidateFontCache()
+                if EllesmereUI.GetFontPath("unitFrames") == GetSelectedFont() then return end
+                if ns.ReloadFrames then ns.ReloadFrames() end
+            end)
+        end)
+    end
+
     -- Append SharedMedia textures to runtime tables so SM texture keys resolve
     if EllesmereUI.AppendSharedMediaTextures then
         EllesmereUI.AppendSharedMediaTextures(

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -14010,23 +14010,35 @@ function EllesmereUF:OnInitialize()
     -- Unit frame text is fonted only while frames are built, from a path this
     -- module snapshots; every other module resolves per repaint and heals off
     -- the shared cache, so a SharedMedia pack registering after the login build
-    -- leaves ONLY the unit frames on the fallback face for the session.
-    -- Deferred a tick so a registration inside the login dispatch lands after
-    -- this module's own setup, and coalesced because a pack registers its faces
-    -- one at a time. The cache drop is ours: the core listens for this event too
-    -- and CallbackHandler does not order its receivers.
+    -- leaves ONLY the unit frames on the fallback face for the session. What is
+    -- tracked here is the last path actually REPAINTED, never the snapshot:
+    -- ReloadFrames refreshes that before its own lockdown return, so a combat
+    -- reload would otherwise look settled and never retry. Deferred a tick to
+    -- land after the core's own receiver and this module's login setup.
     local LSM = LibStub and LibStub("LibSharedMedia-3.0", true)
     if LSM then
-        local fontCheckPending
+        local paintedFont = EllesmereUI.GetFontPath("unitFrames")
+        local checkPending
+        local fontRegen = CreateFrame("Frame")
+        local function RepaintForFont()
+            checkPending = false
+            local want = EllesmereUI.GetFontPath("unitFrames")
+            if want == paintedFont or not ns.ReloadFrames then return end
+            if InCombatLockdown() then
+                fontRegen:RegisterEvent("PLAYER_REGEN_ENABLED")
+                return
+            end
+            paintedFont = want
+            ns.ReloadFrames()
+        end
+        fontRegen:SetScript("OnEvent", function(self)
+            self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+            RepaintForFont()
+        end)
         LSM.RegisterCallback(EllesmereUF, "LibSharedMedia_Registered", function(_, mediatype)
-            if mediatype ~= "font" or fontCheckPending then return end
-            fontCheckPending = true
-            C_Timer.After(0, function()
-                fontCheckPending = false
-                EllesmereUI.InvalidateFontCache()
-                if EllesmereUI.GetFontPath("unitFrames") == GetSelectedFont() then return end
-                if ns.ReloadFrames then ns.ReloadFrames() end
-            end)
+            if mediatype ~= "font" or checkPending then return end
+            checkPending = true
+            C_Timer.After(0, RepaintForFont)
         end)
     end
 


### PR DESCRIPTION
Bug: reported by Discord user @boeckske_agentzero23 in the EllesmereUI bug channel (2026-08-28, on the current release).

Issue: a font loaded through a custom font loader and picked as the general font applies everywhere in the UI except the unit frames, which stay on the fallback face. A bundled EUI font applies normally, and setting the font override on the Unit Frames card instead of the global font makes no difference. Toggling Dark Mode off and on fixes the unit frames for the session, which is the tell: the font resolves correctly by then, so this is timing rather than resolution.

Root cause: the unit frames module keeps the resolved path in a local, cachedFontPath, refreshed only by ResolveFontPath from OnInitialize, ReloadFrames and the options page, and SetFSFont reads it through GetSelectedFont. Every sibling module calls EllesmereUI.GetFontPath at paint time instead, so when a late LibSharedMedia_Registered drops the shared font cache they pick the new face up on their next repaint. Unit frames never re-read, so a SharedMedia pack that registers after the login build, either from a PLAYER_LOGIN handler dispatching later than ours or on demand, leaves only the unit frames on the fallback face until something calls ReloadFrames, which is what the Dark Mode toggle does. Bundled fonts resolve out of FONT_FILES with no SharedMedia involvement, which is why they always worked, and a per-module override fails identically because it walks the same GetFontPath("unitFrames").

Fix: the module registers its own LibSharedMedia_Registered receiver. On a font registration it re-resolves and calls ns.ReloadFrames only when the path changed, so a login with no SharedMedia font in play does no work at all. Two details matter. The check is deferred a tick, because ns.ReloadFrames is assigned from a C_Timer.After(0) inside EnableBody and a registration arriving during the login dispatch would otherwise find it missing; the same tick also puts the check after the core's own receiver, which is what repopulates _smFontPaths. And what it tracks as done is the path last actually repainted, never the module snapshot: ReloadFrames refreshes that snapshot before its own InCombatLockdown return, so after a reload in combat the snapshot would match while nothing had been painted and no retry would ever fire. A rebuild blocked by lockdown re-arms on PLAYER_REGEN_ENABLED through its own frame, the same shape RealiseClassPowerStyle uses a few lines above for the same reason.

Not yet verified in game.
