### PR TITLE
feat+fix(blizzskin): skin the BNet friend online/offline toast and fix a taint issue

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -41,6 +41,7 @@ local WINDOW_ENABLE_KEYS = {
     itemupgrade     = "reskinItemUpgrade",
     loot            = "reskinLoot",
     loottoast       = "reskinLootToast",
+    bnettoast       = "reskinBNetToast",
     lootroll        = "reskinLootRoll",
     loothistory     = "reskinLootHistory",
     groupinvite     = "reskinGroupInvite",
@@ -98,6 +99,7 @@ do
         { marker = "readyCheckStyleSeeded", keys = { "readycheck" } },
         { marker = "queueChoiceTradeStyleSeeded",
           keys = { "queuestatus", "delvepicker", "playerchoice", "trade" } },
+        { marker = "bnetToastStyleSeeded", keys = { "bnettoast" } },
     }
     local function SeedBatch(marker, newKeys)
         if EllesmereUIDB[marker] then return end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_CharacterSheet.lua
@@ -342,6 +342,9 @@ local function PreSkinCharacterSheet()
     local BASE_V = BASE_B - BASE_T  -- 0.75
     local function UpdateBgTexCoords()
         local fw, fh = frame:GetSize()
+        -- Secrecy test BEFORE the zero check: that check is itself a
+        -- comparison and throws on a secret size. Matches the engine.
+        if issecretvalue and (issecretvalue(fw) or issecretvalue(fh)) then return end
         if fw == 0 or fh == 0 then return end
         local frameAspect = fw / fh
         if frameAspect > BG_ASPECT then
@@ -354,9 +357,10 @@ local function PreSkinCharacterSheet()
             bg:SetTexCoord(BASE_L + trimU, BASE_R - trimU, BASE_T, BASE_B)
         end
     end
-    hooksecurefunc(frame, "SetSize", UpdateBgTexCoords)
-    hooksecurefunc(frame, "SetWidth", UpdateBgTexCoords)
-    hooksecurefunc(frame, "SetHeight", UpdateBgTexCoords)
+    -- Script hook, never hooksecurefunc(frame, "SetSize"/...): that form
+    -- writes a field onto a Blizzard frame that Blizzard reads back. Same
+    -- conversion as WSkin.Shell in the window engine.
+    frame:HookScript("OnSizeChanged", UpdateBgTexCoords)
     UpdateBgTexCoords()
     -- Standard window-reskin border (AdventureMap_TopBorder atlas), as on every skinned window.
     if ns.WSkin and ns.WSkin.AtlasBorder then ns.WSkin.AtlasBorder(frame) end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_GroupFinder.lua
@@ -175,6 +175,9 @@ local function SkinAtlasPanel(frame)
         local BASE_U, BASE_V = BASE_R - BASE_L, BASE_B - BASE_T
         local function UpdateBgTexCoords()
             local fw, fh = frame:GetSize()
+            -- Secrecy test BEFORE the zero check: that check is itself a
+            -- comparison and throws on a secret size. Matches the engine.
+            if issecretvalue and (issecretvalue(fw) or issecretvalue(fh)) then return end
             if fw == 0 or fh == 0 then return end
             local fa = fw / fh
             if fa > BG_ASPECT then
@@ -187,9 +190,10 @@ local function SkinAtlasPanel(frame)
                 bg:SetTexCoord(BASE_L + trimU, BASE_R - trimU, BASE_T, BASE_B)
             end
         end
-        hooksecurefunc(frame, "SetSize", UpdateBgTexCoords)
-        hooksecurefunc(frame, "SetWidth", UpdateBgTexCoords)
-        hooksecurefunc(frame, "SetHeight", UpdateBgTexCoords)
+        -- Script hook, never hooksecurefunc(frame, "SetSize"/...): that form
+        -- writes a field onto a Blizzard frame that Blizzard reads back. Same
+        -- conversion as WSkin.Shell in the window engine.
+        frame:HookScript("OnSizeChanged", UpdateBgTexCoords)
         UpdateBgTexCoords()
     end
     -- Window border: the shared atlas frame border every other reskinned

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_InspectSheet.lua
@@ -361,6 +361,9 @@ local function SkinInspectSheet()
         local BASE_V = BASE_B - BASE_T
         local function UpdateBgTexCoords()
             local fw, fh = frame:GetSize()
+            -- Secrecy test BEFORE the zero check: that check is itself a
+            -- comparison and throws on a secret size. Matches the engine.
+            if issecretvalue and (issecretvalue(fw) or issecretvalue(fh)) then return end
             if fw == 0 or fh == 0 then return end
             local frameAspect = fw / fh
             if frameAspect > BG_ASPECT then
@@ -373,9 +376,10 @@ local function SkinInspectSheet()
                 bg:SetTexCoord(BASE_L + trimU, BASE_R - trimU, BASE_T, BASE_B)
             end
         end
-        hooksecurefunc(frame, "SetSize", UpdateBgTexCoords)
-        hooksecurefunc(frame, "SetWidth", UpdateBgTexCoords)
-        hooksecurefunc(frame, "SetHeight", UpdateBgTexCoords)
+        -- Script hook, never hooksecurefunc(frame, "SetSize"/...): that form
+        -- writes a field onto a Blizzard frame that Blizzard reads back. Same
+        -- conversion as WSkin.Shell in the window engine.
+        frame:HookScript("OnSizeChanged", UpdateBgTexCoords)
         UpdateBgTexCoords()
         -- Follows the Character Sheet window's style pick (the two share one
         -- enable + style setting).

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowEngine.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowEngine.lua
@@ -281,9 +281,13 @@ function WSkin.Shell(winKey, frame, opts)
                 bg:SetTexCoord(BASE_L + trimU, BASE_R - trimU, BASE_T, BASE_B)
             end
         end
-        hooksecurefunc(frame, "SetSize", UpdateBgTexCoords)
-        hooksecurefunc(frame, "SetWidth", UpdateBgTexCoords)
-        hooksecurefunc(frame, "SetHeight", UpdateBgTexCoords)
+        -- OnSizeChanged, NOT hooksecurefunc(frame, "SetSize"/"SetWidth"/"SetHeight"):
+        -- that form is a FIELD WRITE onto a Blizzard frame, and the field is read
+        -- back from Blizzard's own code. BNToastMixin:ShowToast calls SetHeight in
+        -- the chain that opens a Battle.net whisper (same reasoning as the SetPoint
+        -- note in EllesmereUIChat). A script hook writes nothing, and it also fires
+        -- for anchor-driven resizes the setter hooks never saw.
+        frame:HookScript("OnSizeChanged", UpdateBgTexCoords)
         UpdateBgTexCoords()
 
         -- Black top bar behind the window title. Sits above both style backdrops

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -12380,11 +12380,11 @@ WSkin.RegisterWindow({
 
 -------------------------------------------------------------------------------
 --  BNet toast (BNToastFrame): a friend coming online or going offline, plus
---  broadcasts and club invites. A permanent named frame, not a pooled alert, so
---  it takes a plain window registration rather than the loot-toast sweep.
---  TAINT: clicking it opens a Battle.net whisper, whose target is a SECRET
---  string, so nothing here may write a field onto the frame -- script hooks and
---  the external FFD table only (WSkin.Shell was converted for the same reason).
+--  broadcasts and club invites. Alert-system driven like the loot toasts, but a
+--  SINGLETON rather than a pool instance, so it takes a plain window
+--  registration instead of their pool sweep. TAINT: clicking it opens a
+--  Battle.net whisper, whose target is a SECRET string, so nothing here writes a
+--  field onto the frame (WSkin.Shell was converted for the same reason).
 -------------------------------------------------------------------------------
 function LP.SkinBNetToast(f)
     if not f or f:IsForbidden() then return end

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -12377,6 +12377,77 @@ WSkin.RegisterWindow({
         Wire("ReadyCheckListenerFrame", LP.SkinReadyCheckList)
     end,
 })
+
+-------------------------------------------------------------------------------
+--  BNet toast (BNToastFrame): a friend coming online or going offline, plus
+--  broadcasts and club invites. A permanent named frame, not a pooled alert, so
+--  it takes a plain window registration rather than the loot-toast sweep.
+--  TAINT: clicking it opens a Battle.net whisper, whose target is a SECRET
+--  string, so nothing here may write a field onto the frame -- script hooks and
+--  the external FFD table only (WSkin.Shell was converted for the same reason).
+-------------------------------------------------------------------------------
+function LP.SkinBNetToast(f)
+    if not f or f:IsForbidden() then return end
+    local icon = f.IconTexture
+
+    -- The Blizzard art is a BACKDROP (BACKDROP_TOAST_12_12), and
+    -- BackdropTemplateMixin lays its pieces out as ordinary regions ON THE
+    -- FRAME via NineSliceUtil, so the shell fade reaches them. No SetBackdrop
+    -- call is needed, and none is made: that would re-enter Blizzard code.
+    -- No top bar, same as the loot toast -- there is no title row to sit on.
+    WSkin.Shell("bnettoast", f, { noTopBar = true })
+
+    -- The shell faded every region including the toast-type icon. Bring it
+    -- back and keep it out of later restrip passes. It is NOT squared:
+    -- IconTexture is a SetTexCoord crop out of one sheet, re-picked per toast
+    -- type, and WSkin.SquareIcon would overwrite those coordinates.
+    if icon then
+        icon:SetAlpha(1)
+        WSkin.Register(f, { [icon] = true })
+    end
+
+    -- Blizzard flair burst. SetAlpha(0) is not enough: the texture carries its
+    -- OWN alpha animation, which drives alpha every frame and wins over our
+    -- write (same shape as the loot toast art). Clear the texture instead.
+    local glow = f.glow
+    if glow then
+        if glow.SetAtlas then glow:SetAtlas("") end
+        if glow.SetTexture then glow:SetTexture("") end
+        glow:SetAlpha(0)
+    end
+
+    -- Font only, never color: ShowToast recolors these per toast type (account
+    -- name blue, status grey, some of it as an inline color code), and the
+    -- stock colors read correctly on the dark shell.
+    for _, k in ipairs({ "TopLine", "MiddleLine", "BottomLine", "DoubleLine" }) do
+        WSkin.Font(f[k])
+    end
+
+    if f.CloseButton then WSkin.CloseButton(f.CloseButton) end
+
+    -- Hover panel for a truncated broadcast. Inherits TooltipBackdropTemplate,
+    -- so the house panel replaces a real tooltip backdrop.
+    local tip = f.TooltipFrame
+    if tip then
+        WSkin.Panel(tip)
+        if tip.NineSlice then WSkin.FadeNineSlice(tip.NineSlice) end
+        if tip.Text then WSkin.Font(tip.Text) end
+    end
+end
+
+WSkin.RegisterWindow({
+    key = "bnettoast",
+    apply = function()
+        LP.WhenFrameExists("BNToastFrame", function(f)
+            local pass = WSkin.Debounce(function() LP.SkinBNetToast(f) end)
+            -- Blizzard repaints nothing on the frame between toasts, but the
+            -- pass is idempotent and one debounced call per toast is cheap
+            -- insurance against a future template change.
+            WSkin.HookShow(f, pass)
+            LP.SkinBNetToast(f)
+        end)
+    end,
+})
 end
 
 -------------------------------------------------------------------------------

--- a/EllesmereUIOptions/EUI_BlizzardSkin_Options.lua
+++ b/EllesmereUIOptions/EUI_BlizzardSkin_Options.lua
@@ -2015,6 +2015,16 @@ initFrame:SetScript("OnEvent", function(self)
             buildContent = BuildLootToastContent,
         },
         {
+            key   = "bnettoast",
+            title = "Friend Notifications",
+            desc  = "The Battle.net popup when a friend comes online or goes offline, plus broadcasts and invites.",
+            reloadMsg = "Changing the Friend Notifications reskin requires a UI reload to fully swap between Blizzard and Ellesmere styles.",
+            setEnabled = function(v)
+                if not EllesmereUIDB then EllesmereUIDB = {} end
+                EllesmereUIDB.reskinBNetToast = v
+            end,
+        },
+        {
             key   = "lootroll",
             title = "Loot Roll Popups",
             desc  = "The need / greed / pass roll popups, with a squared icon and a flat roll timer.",
@@ -3218,6 +3228,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.reskinItemUpgrade = nil
                 EllesmereUIDB.reskinLoot = nil
                 EllesmereUIDB.reskinLootToast = nil
+                EllesmereUIDB.reskinBNetToast = nil
                 EllesmereUIDB.lootToastQualityStrip = nil
                 EllesmereUIDB.lootToastQualityStripMoney = nil
                 EllesmereUIDB.lootToastScale = nil

--- a/EllesmereUI_Profiles.lua
+++ b/EllesmereUI_Profiles.lua
@@ -1855,6 +1855,7 @@ do
         "reskinAchievements", "reskinMail", "reskinCatalyst", "reskinSocket",
         "reskinItemUpgrade", "reskinLoot", "reskinLootToast", "lootToastQualityStrip",
         "lootToastQualityStripMoney", "lootToastScale",
+        "reskinBNetToast",
         "reskinLootRoll", "reskinLootHistory", "reskinGroupInvite",
         "reskinReadyCheck",
         "reskinMicroMenu", "reskinHousing", "reskinDressUp", "reskinTransmog",


### PR DESCRIPTION
## What does this PR do?

Adds a Blizzard window skin for the Battle.net toast -- the popup that appears when a friend comes online or goes offline, and for broadcasts and club invites. It was the last visible popup with no EllesmereUI skin, still carrying its gold `BACKDROP_TOAST_12_12` frame and Blizzard's default font while every comparable element (loot toasts, loot rolls, group invites, ready check) already runs through the window skin engine.

It appears as a new "Friend Notifications" card under Blizz UI Enhanced > Blizzard Window Skins with the usual EllesmereUI / Modern / Blizz Default choice. Existing accounts do not simply get it switched on: a new style-seed batch gives the toast whichever style the user already runs most of their windows with, "off" included.

The skin is chrome only -- house shell and border in place of the backdrop, house close button, the UI font on the four text lines, and a house panel on the hover tooltip that a truncated broadcast shows. Text colors stay Blizzard's, since `ShowToast` sets them per toast type. The toast-type icon is left native: it is a `SetTexCoord` crop out of one sheet, re-picked per type, so squaring it would overwrite those coordinates. The flair glow is cleared rather than alpha'd out, because it carries its own alpha animation that would otherwise animate straight over the write. Position is untouched and stays with the existing Unlock Mode element in the chat module.

### Also in this PR: a taint fix that reaches every skinned window

`WSkin.Shell` kept its backdrop crop current with `hooksecurefunc(frame, "SetSize"/"SetWidth"/"SetHeight", ...)`, which assigns a wrapper onto the Blizzard frame's own table -- a field write that Blizzard then reads back from its own code, against the rule the window engine's own header states. That is not academic for this window: `BNToastMixin:ShowToast` calls `SetHeight` immediately before showing the alert, and `BNToastMixin:OnClick` runs `ChatFrameUtil.SendBNetTell(accountInfo.accountName)` -- the same chain, with a secret string in it. It is the hazard the chat module already documents for `SetPoint` on this very frame.

All three hooks are replaced by one `HookScript("OnSizeChanged")`, which is C-side and writes nothing, and which additionally fires for anchor-driven resizes the setter hooks never saw. The Character Sheet, Inspect Sheet and Group Finder carry their own copy of that shell code and adopt it via `WSkin.AdoptShell`, so they are converted in the same way -- PVEFrame being the most taint-sensitive of the three. Those three copies were also missing the engine's `issecretvalue` test, and the zero check they run instead is itself a comparison that throws on a secret size; since the switch widens when that function runs, the guard is added there too. After this, no shell code hooks a Blizzard frame's size setters.

## How was it tested?

Tested in game on live.

## Screenshots
<img width="939" height="83" alt="grafik" src="https://github.com/user-attachments/assets/300ffc44-ef69-4162-b1f1-2337140e968e" />
<img width="266" height="59" alt="friend request" src="https://github.com/user-attachments/assets/dfd856d9-f30d-4a75-8845-4f6a21565cc1" />
<img width="246" height="59" alt="offline" src="https://github.com/user-attachments/assets/9a5a30c0-74d2-4e5d-a995-50f63bbf5fbe" />
<img width="262" height="69" alt="online" src="https://github.com/user-attachments/assets/4480d539-29da-4665-8388-f9acac50dddd" />

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A: the new key follows the existing window-skin convention, where an absent value means enabled. Accounts that already have window skins do not get an unasked-for change, because the style-seed batch gives the new key whatever style the majority of their windows already use, including Blizz Default.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
