### PR TITLE
Fix: Liquid Luster missing as a default potion preset in CDM buff bars

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -412,6 +412,15 @@ local BUFF_BAR_PRESETS = {
         duration = 30,
     },
     {
+        key      = "liquid_luster",
+        name     = "Liquid Luster",
+        -- Picker art runtime-resolved (fileID not known statically at authoring
+        -- time), mirroring CDM_ITEM_PRESETS' liquid_luster entry below.
+        icon     = (C_Item and C_Item.GetItemIconByID and C_Item.GetItemIconByID(271887)) or 134400,
+        spellIDs = { 1295132 },
+        duration = 30,
+    },
+    {
         key      = "invis_potion",
         name     = "Invisibility Potion",
         icon     = 134764,


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1531510764891013260

Issue: Liquid Luster was already in the CD/Utility bar item preset list (CDM_ITEM_PRESETS) but missing from BUFF_BAR_PRESETS, the separate list that feeds the Custom Buff Bar preset picker, so it never showed up as an option there alongside Light's Potential and Potion of Recklessness.
Fix: Added a liquid_luster entry to BUFF_BAR_PRESETS (spell 1295132, 30s duration), matching the shape of the other two combat potion entries.