### PR TITLE
Fix Class Resource pips widening after a zone change

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -8901,10 +8901,12 @@ local function CreateCustomClassPower(playerFrame, style)
                 pips[i]:Show()
             end
             shownPipCount = max
-            -- Re-stretch pips if in "above" position
-            if container._repositionForWidth then
-                local fw = db and db.profile and db.profile.player and db.profile.player.frameWidth or 181
-                container._repositionForWidth(fw)
+            -- Only "above" stretches the row across the health bar (see
+            -- PositionClassPowerBar); every other position keeps the natural pip
+            -- width laid out just above.
+            if isModern and (db.profile.player.classPowerPosition or "top") == "above"
+               and container._repositionForWidth then
+                container._repositionForWidth(db.profile.player.frameWidth or 181)
             end
         end
 

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -9070,7 +9070,9 @@ local function CreateCustomClassPower(playerFrame, style)
     -- Uses Snap() to round all positions to physical pixel boundaries
     -- so gaps between pips are guaranteed identical.
     container._repositionForWidth = function(targetW)
-        local n = #pips
+        -- shownPipCount, not #pips: the table is a high-water mark, so a shrunk
+        -- max would divide the width by the old pip count and leave a gap.
+        local n = shownPipCount
         if n <= 0 then return end
         local efs = container:GetEffectiveScale()
         if efs <= 0 then efs = 1 end


### PR DESCRIPTION
Bug: reported by Bjønn in the EllesmereUI-helper Discord (2026-08-28, v9.0.7).

Issue: with Class Resource set to Modern and the pip Size adjusted, the player frame's row came back much wider after any zone change and stayed wide until a reload. The options preview kept showing the correct size, so the profile itself looked fine.

Root cause: UpdatePips rebuilds the pip row whenever the resource max changes, then re-stretched it across the frame width unconditionally. That stretch belongs only to the Above Health Bar position, where PositionClassPowerBar anchors the row to the health bar's edges. A loading screen re-reads the max because talent data reloads with the zone, so every other position lost its pip width.

Fix: gate the re-stretch on Modern plus Above Health Bar, the pair PositionClassPowerBar tests. _repositionForWidth also now divides by the shown pip count instead of #pips, a high-water mark that left a gap at the right edge once a max shrank. Verified in game.
