### PR TITLE
feat(player-aura-bars): Add Border Style settings to Player Aura Bars in the Unit Frames module

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -3330,7 +3330,9 @@ do
 
     -- BackdropTemplate does arithmetic on its owner's width/height, so it is unusable for
     -- frames anchored to secret aura geometry. This variant draws the same eight edge-file
-    -- slices manually, keeping the PP path for Solid; `state` is any caller-owned table caching the eight textures (FFD, AuraKit button data).
+    -- slices manually, keeping the PP path for Solid; `state` is any caller-owned table
+    -- caching the eight textures (FFD, AuraKit button data). edgeScale is preview-only
+    -- geometry compensation; live callers leave it nil.
     local SECRET_BORDER_UV = {
         topLeft     = { 0.5078125, 0.0625, 0.5078125, 0.9375, 0.6171875, 0.0625, 0.6171875, 0.9375 },
         topRight    = { 0.6328125, 0.0625, 0.6328125, 0.9375, 0.7421875, 0.0625, 0.7421875, 0.9375 },
@@ -3343,7 +3345,7 @@ do
     }
 
     function EllesmereUI.ApplySecretSafeBorderStyle(borderFrame, state, size, r, g, b, a,
-        textureKey, offsetX, offsetY, shiftX, shiftY, addonKey, sizeKey)
+        textureKey, offsetX, offsetY, shiftX, shiftY, addonKey, sizeKey, edgeScale)
         if not borderFrame or not state then return end
         size, textureKey = size or 0, textureKey or "solid"
         local edges = state._secretBorderEdges
@@ -3370,10 +3372,15 @@ do
             end
             state._secretBorderEdges = edges
         end
-        local edgeSize = EDGE_MAP[size] or EDGE_MAP[1]
+        -- Preview surfaces can cancel their own panel scale without scaling the
+        -- saved 0-4 texture-size key (a fractional key would fall through EDGE_MAP).
+        -- Live aura buttons omit edgeScale and stay byte-for-byte equivalent.
+        edgeScale = edgeScale or 1
+        local edgeSize = (EDGE_MAP[size] or EDGE_MAP[1]) * edgeScale
         local ox, oy, sx, sy = EllesmereUI.GetBorderDefaults(addonKey, textureKey, sizeKey)
         ox = offsetX ~= nil and offsetX or ox; oy = offsetY ~= nil and offsetY or oy
         sx = shiftX ~= nil and shiftX or sx; sy = shiftY ~= nil and shiftY or sy
+        ox, oy, sx, sy = ox * edgeScale, oy * edgeScale, sx * edgeScale, sy * edgeScale
         if EllesmereUI.BorderTextureUsesScaleOffset(textureKey) then
             ox, oy = edgeSize / 2 + ox, edgeSize / 2 + oy
         end

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -1093,14 +1093,152 @@ local function BuildCoreFields(frame, fontPath, sy, cfg, apply, isBuff)
     return sy
 end
 
--- "Display": Border Size [swatch] | Spacing; Icons per Row (+Max Rows/Max
--- Total/Row Spacing cog) | spacer.
+-- "Display": Border Style (+offset cog) | spacer; Border Size [swatch] |
+-- Spacing; Icons per Row (+Max Rows/Max Total/Row Spacing cog) | spacer.
 local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
     local W = EllesmereUI.Widgets
     local PP = EllesmereUI.PanelPP
     local _, hh = 0, 0
 
     _, hh = W:SectionHeader(frame, "DISPLAY", sy); sy = sy - hh
+
+    local textureValues, textureOrder = EllesmereUI.GetBorderTextureDropdown()
+    local styleRow
+    styleRow, hh = W:DualRow(frame, sy,
+        {
+            type = "dropdown", text = "Border Style",
+            disabled = function()
+                return cfg.iconShape and cfg.iconShape ~= "none"
+            end,
+            disabledTooltip = "This option requires a non-custom shape to be selected",
+            rawTooltip = true,
+            values = textureValues, order = textureOrder,
+            getValue = function() return cfg.borderTexture or "solid" end,
+            setValue = function(v)
+                cfg.borderTexture = v
+                cfg.borderTextureOffset = nil
+                cfg.borderTextureOffsetY = nil
+                cfg.borderTextureShiftX = nil
+                cfg.borderTextureShiftY = nil
+                local color, behind = EllesmereUI.GetBorderStyleSelectDefaults(v)
+                cfg.borderR, cfg.borderG, cfg.borderB, cfg.borderA = color.r, color.g, color.b, 1
+                cfg.borderBehind = behind
+                local defaultSize = EllesmereUI.GetBorderDefaultSize("unitframes", v)
+                if defaultSize then cfg.borderSize = defaultSize end
+                apply()
+            end,
+        },
+        { type = "label", text = "" }
+    ); sy = sy - hh
+    do
+        local rgn = styleRow._leftRegion
+        local _, cogShow = EllesmereUI.BuildCogPopup({
+            title = "Border Offset",
+            rows = {
+                { type = "slider", label = "Offset X", min = -10, max = 10, step = 1,
+                  get = function()
+                      if cfg.borderTextureOffset ~= nil then return cfg.borderTextureOffset end
+                      return EllesmereUI.GetBorderDefaults("unitframes", cfg.borderTexture or "solid", cfg.borderSize or 1)
+                  end,
+                  set = function(v) cfg.borderTextureOffset = v; apply() end },
+                { type = "slider", label = "Offset Y", min = -10, max = 10, step = 1,
+                  get = function()
+                      if cfg.borderTextureOffsetY ~= nil then return cfg.borderTextureOffsetY end
+                      local _, y = EllesmereUI.GetBorderDefaults("unitframes", cfg.borderTexture or "solid", cfg.borderSize or 1)
+                      return y
+                  end,
+                  set = function(v) cfg.borderTextureOffsetY = v; apply() end },
+                { type = "slider", label = "Shift X", min = -10, max = 10, step = 1,
+                  get = function()
+                      if cfg.borderTextureShiftX ~= nil then return cfg.borderTextureShiftX end
+                      local _, _, x = EllesmereUI.GetBorderDefaults("unitframes", cfg.borderTexture or "solid", cfg.borderSize or 1)
+                      return x
+                  end,
+                  set = function(v) cfg.borderTextureShiftX = v == 0 and nil or v; apply() end },
+                { type = "slider", label = "Shift Y", min = -10, max = 10, step = 1,
+                  get = function()
+                      if cfg.borderTextureShiftY ~= nil then return cfg.borderTextureShiftY end
+                      local _, _, _, y = EllesmereUI.GetBorderDefaults("unitframes", cfg.borderTexture or "solid", cfg.borderSize or 1)
+                      return y
+                  end,
+                  set = function(v) cfg.borderTextureShiftY = v == 0 and nil or v; apply() end },
+                { type = "toggle", label = "Show Behind",
+                  get = function() return cfg.borderBehind == true end,
+                  set = function(v) cfg.borderBehind = v; apply() end },
+            },
+        })
+        local cogBtn = ns._PAMakeCogBtn(rgn, cogShow)
+        local function UpdateBorderCogVisibility()
+            cogBtn:SetShown((cfg.borderTexture or "solid") ~= "solid"
+                and not (cfg.iconShape and cfg.iconShape ~= "none"))
+        end
+        EllesmereUI.RegisterWidgetRefresh(UpdateBorderCogVisibility)
+        UpdateBorderCogVisibility()
+
+        local keys, labels = {}, {}
+        for _, entry in ipairs(PabAllBarEntries()) do
+            keys[#keys + 1] = entry.key
+            labels[entry.key] = entry.label
+        end
+        local function CopyBorderStyleTo(entry)
+            local target = entry.cfg
+            target.borderTexture = cfg.borderTexture
+            target.borderTextureOffset = cfg.borderTextureOffset
+            target.borderTextureOffsetY = cfg.borderTextureOffsetY
+            target.borderTextureShiftX = cfg.borderTextureShiftX
+            target.borderTextureShiftY = cfg.borderTextureShiftY
+            target.borderBehind = cfg.borderBehind
+            target.borderR, target.borderG, target.borderB, target.borderA =
+                cfg.borderR, cfg.borderG, cfg.borderB, cfg.borderA
+            -- Border textures and custom shape masks are mutually exclusive in
+            -- the editor. A bulk style sync follows the same "last choice wins"
+            -- rule as a direct selection so it cannot create a locked combination.
+            if (cfg.borderTexture or "solid") ~= "solid" then
+                target.iconShape = "none"
+            end
+            PabApplyBarEntry(entry)
+        end
+        EllesmereUI.BuildSyncIcon({
+            region = rgn,
+            tooltip = "Apply Border Style to all Bars",
+            onClick = function()
+                for _, entry in ipairs(PabAllBarEntries()) do
+                    if entry.cfg ~= cfg then CopyBorderStyleTo(entry) end
+                end
+                EllesmereUI:RefreshPage()
+            end,
+            isSynced = function()
+                local texture = cfg.borderTexture or "solid"
+                for _, entry in ipairs(PabAllBarEntries()) do
+                    local c = entry.cfg
+                    if (c.borderTexture or "solid") ~= texture
+                        or c.borderTextureOffset ~= cfg.borderTextureOffset
+                        or c.borderTextureOffsetY ~= cfg.borderTextureOffsetY
+                        or c.borderTextureShiftX ~= cfg.borderTextureShiftX
+                        or c.borderTextureShiftY ~= cfg.borderTextureShiftY
+                        or (c.borderBehind == true) ~= (cfg.borderBehind == true) then
+                        return false
+                    end
+                end
+                return true
+            end,
+            flashTargets = function() return { rgn } end,
+            multiApply = {
+                elementKeys = keys,
+                elementLabels = labels,
+                getCurrentKey = function() return PabBarKeyOf(cfg, isBuff) end,
+                onApply = function(checkedKeys)
+                    local byKey = {}
+                    for _, entry in ipairs(PabAllBarEntries()) do byKey[entry.key] = entry end
+                    for _, key in ipairs(checkedKeys) do
+                        local entry = byKey[key]
+                        if entry then CopyBorderStyleTo(entry) end
+                    end
+                    EllesmereUI:RefreshPage()
+                end,
+            },
+        })
+    end
 
     local borderRow
     borderRow, hh = W:DualRow(frame, sy,
@@ -1257,6 +1395,14 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
         {
             type = "dropdown", text = "Icon Shape",
             values = SHAPE_VALUES, order = SHAPE_ORDER,
+            itemDisabled = function(v)
+                return v ~= "none" and (cfg.borderTexture or "solid") ~= "solid"
+            end,
+            itemDisabledTooltip = function(v)
+                if v ~= "none" and (cfg.borderTexture or "solid") ~= "solid" then
+                    return "This option requires the Border Style to be set to Solid"
+                end
+            end,
             getValue = function() return cfg.iconShape or "none" end,
             setValue = function(v)
                 cfg.iconShape = v
@@ -1292,6 +1438,14 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
         local function CopyShapeTo(entry)
             local shape = cfg.iconShape
             entry.cfg.iconShape = shape
+            if shape and shape ~= "none" then
+                entry.cfg.borderTexture = "solid"
+                entry.cfg.borderTextureOffset = nil
+                entry.cfg.borderTextureOffsetY = nil
+                entry.cfg.borderTextureShiftX = nil
+                entry.cfg.borderTextureShiftY = nil
+                entry.cfg.borderBehind = false
+            end
             local sz = entry.cfg.borderSize or 1
             if shape and shape ~= "none" and sz >= 1 and sz <= 3 then
                 entry.cfg.borderSize = BORDER_SIZE_NUM[BORDER_SIZE_DEFAULT_SHAPE]

--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -1093,8 +1093,18 @@ local function BuildCoreFields(frame, fontPath, sy, cfg, apply, isBuff)
     return sy
 end
 
--- "Display": Border Style (+offset cog) | spacer; Border Size [swatch] |
--- Spacing; Icons per Row (+Max Rows/Max Total/Row Spacing cog) | spacer.
+local function FontOutlineField(cfg, apply)
+    return {
+        type = "dropdown", text = "Font Outline",
+        values = FONT_OUTLINE_VALUES, order = FONT_OUTLINE_ORDER,
+        getValue = function() return cfg.fontOutline or "default" end,
+        setValue = function(v) cfg.fontOutline = v; apply() end,
+    }
+end
+
+-- "Display": Border Style (+offset cog) | Border Size [swatch]; Icons Per Row
+-- (+grid cog) | Spacing (+row-spacing cog); Icon Shape | Icon Zoom; remaining
+-- toggles are packed by polarity without placeholder slots.
 local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
     local W = EllesmereUI.Widgets
     local PP = EllesmereUI.PanelPP
@@ -1128,7 +1138,19 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
                 apply()
             end,
         },
-        { type = "label", text = "" }
+        {
+            type = "dropdown", text = "Border Size",
+            values = BORDER_SIZE_VALUES, order = BORDER_SIZE_LEVELS,
+            itemDisabled = function(v)
+                local shape = cfg.iconShape
+                return shape and shape ~= "none" and BORDER_SIZE_SHAPE_DISABLED[v] or false
+            end,
+            itemDisabledTooltip = function()
+                return "This option requires a non-custom shape to be selected"
+            end,
+            getValue = function() return BORDER_SIZE_KEY[cfg.borderSize or 1] or "thin" end,
+            setValue = function(v) cfg.borderSize = BORDER_SIZE_NUM[v] or 1; apply() end,
+        }
     ); sy = sy - hh
     do
         local rgn = styleRow._leftRegion
@@ -1240,20 +1262,12 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
         })
     end
 
-    local borderRow
-    borderRow, hh = W:DualRow(frame, sy,
+    local rowRow
+    rowRow, hh = W:DualRow(frame, sy,
         {
-            type = "dropdown", text = "Border Size",
-            values = BORDER_SIZE_VALUES, order = BORDER_SIZE_LEVELS,
-            itemDisabled = function(v)
-                local shape = cfg.iconShape
-                return shape and shape ~= "none" and BORDER_SIZE_SHAPE_DISABLED[v] or false
-            end,
-            itemDisabledTooltip = function()
-                return "This option requires a non-custom shape to be selected"
-            end,
-            getValue = function() return BORDER_SIZE_KEY[cfg.borderSize or 1] or "thin" end,
-            setValue = function(v) cfg.borderSize = BORDER_SIZE_NUM[v] or 1; apply() end
+            type = "slider", text = "Icons Per Row", min = 1, max = 20, step = 1, trackWidth = 120,
+            getValue = function() return cfg.iconsPerRow or (isBuff and 11 or 8) end,
+            setValue = function(v) cfg.iconsPerRow = v; apply() end
         },
         {
             type = "slider", text = "Spacing", min = -5, max = 20, step = 1, trackWidth = 120,
@@ -1262,9 +1276,9 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
         }
     ); sy = sy - hh
     do
-        local rgn = borderRow._leftRegion
+        local rgn = styleRow._rightRegion
         local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(
-            rgn, borderRow:GetFrameLevel() + 3,
+            rgn, styleRow:GetFrameLevel() + 3,
             function()
                 return (cfg.borderR or 0), (cfg.borderG or 0), (cfg.borderB or 0), (cfg.borderA or 1)
             end,
@@ -1278,7 +1292,7 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
         EllesmereUI.RegisterWidgetRefresh(updateSwatch)
     end
     do
-        local rgn = borderRow._leftRegion
+        local rgn = styleRow._rightRegion
         local keys, labels = {}, {}
         for _, entry in ipairs(PabAllBarEntries()) do
             keys[#keys + 1] = entry.key
@@ -1341,7 +1355,7 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
         -- Row Spacing lives here, not in Icons Per Row's cog -- it's spacing between
         -- rows, same family as Spacing (icon-to-icon gap), not a grid-size concern like
         -- Icons Per Row/ Max Rows/Max Total.
-        local rgn = borderRow._rightRegion
+        local rgn = rowRow._rightRegion
         local _, cogShow = EllesmereUI.BuildCogPopup({
             title = "Spacing",
             rows = {
@@ -1355,20 +1369,6 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
         ns._PAMakeCogBtn(rgn, cogShow)
     end
 
-    local rowRow
-    rowRow, hh = W:DualRow(frame, sy,
-        {
-            type = "slider", text = "Icons Per Row", min = 1, max = 20, step = 1, trackWidth = 120,
-            getValue = function() return cfg.iconsPerRow or (isBuff and 11 or 8) end,
-            setValue = function(v) cfg.iconsPerRow = v; apply() end
-        },
-        {
-            type = "dropdown", text = "Font Outline",
-            values = FONT_OUTLINE_VALUES, order = FONT_OUTLINE_ORDER,
-            getValue = function() return cfg.fontOutline or "default" end,
-            setValue = function(v) cfg.fontOutline = v; apply() end
-        }
-    ); sy = sy - hh
     do
         -- Verified against EUI_RaidFrames_BuffManager.lua's "legacy layout"
         -- branch: perRowCfg paired with a blank spacer, cog on
@@ -1523,13 +1523,13 @@ local function BuildDisplayFields(frame, fontPath, sy, cfg, apply, isBuff)
     -- dropdown -- see BuildAssignedBuffsFields.)
     if isBuff then
         _, hh = W:DualRow(frame, sy,
+            FontOutlineField(cfg, apply),
             {
                 type = "toggle", text = "Right-Click to Cancel",
                 tooltip = "Right-clicking a buff icon cancels the buff. Turning this off makes the bar's icons click-through; tooltips still follow the Show Tooltips setting.",
                 getValue = function() return cfg.rightClickCancel ~= false end,
                 setValue = function(v) cfg.rightClickCancel = v; apply() end
-            },
-            { type = "label", text = "" }
+            }
         ); sy = sy - hh
     end
 
@@ -1558,7 +1558,7 @@ local function BuildDispelColorFields(frame, fontPath, sy, cfg, apply)
 
     -- Dispel-type indicator icon on each debuff bar (engine-driven, mirrors
     -- Raid Frames' "Type Icon Position"). "none" (default) = feature off.
-    _, hh = W:SectionHeader(frame, "DEBUFF TYPE ICON", sy); sy = sy - hh
+    _, hh = W:SectionHeader(frame, "DEBUFF DISPLAY", sy); sy = sy - hh
     do
         local function IconOn() return (cfg.dispelIconPosition or "none") ~= "none" end
         local row
@@ -1572,7 +1572,7 @@ local function BuildDispelColorFields(frame, fontPath, sy, cfg, apply)
                   apply()
                   EllesmereUI:RefreshPage()
               end },
-            { type = "label", text = "" }
+            FontOutlineField(cfg, apply)
         ); sy = sy - hh
         local rgn = row._leftRegion
         local _, cogShow = EllesmereUI.BuildCogPopup({

--- a/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
@@ -141,11 +141,17 @@ local function ApplyStyle(b, style)
         if not b._bdr then
             b._bdr = CreateFrame("Frame", nil, b)
             b._bdr:SetAllPoints()
-            PP.CreateBorder(b._bdr, bd[1] or 0, bd[2] or 0, bd[3] or 0, bd[4] or 1, bd.size or 1)
+            b._bdr:EnableMouse(false)
         end
-        PP.UpdateBorder(b._bdr, bd.size or 1, bd[1] or 0, bd[2] or 0, bd[3] or 0, bd[4] or 1)
-        b._bdr:Show()
+        b._bdr:SetFrameLevel(bd.behind
+            and math.max(0, b:GetFrameLevel() - 1)
+            or (b.cd:GetFrameLevel() + 1))
+        EllesmereUI.ApplyBorderStyle(b._bdr, bd.textureSize or bd.size or 1,
+            bd[1] or 0, bd[2] or 0, bd[3] or 0, bd[4] or 1,
+            bd.texture or "solid", bd.offsetX, bd.offsetY, bd.shiftX, bd.shiftY,
+            bd.addonKey or "unitframes", bd.sizeKey or bd.size or 1)
     elseif b._bdr then
+        if EllesmereUI.HideBorderStyle then EllesmereUI.HideBorderStyle(b._bdr) end
         b._bdr:Hide()
     end
     b.cd:SetReverse(style.cooldownReverse ~= false)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -635,6 +635,8 @@ local STYLE_DEBUFFS = "playerAuraBars_debuffs"
 -- stackTextSize/stackPosition/stackOffsetX/Y; stackColorR/G/B (same nil=white rule).
 -- Buff/debuff bars additionally: iconZoom (default 0.07, AK's fallback);
 -- borderSize/borderR/G/B/A (base border color, per-dispel-type override is separate);
+-- borderTexture ("solid" or a built-in/LibSharedMedia key), optional
+-- borderTextureOffset/OffsetY/ShiftX/ShiftY, and borderBehind;
 -- padding (single scalar -> all 4 sides); rowSpacing (optional row gap: feeds
 -- lineSpacing/groupLineSpacing only, nil falls back to `padding`; elementSpacing/
 -- groupSpacing, icon-to-icon within a row, always stay tied to `padding`); maxTotal
@@ -849,6 +851,13 @@ local function PAB_ApplyExtraText(button, d, style)
         SetTexturePixelSnap(border._left, d.pabCenteredSnap)
         SetTexturePixelSnap(border._right, d.pabCenteredSnap)
     end
+    -- Textured borders use the secret-safe eight-slice renderer rather than PP.
+    -- Keep its edge art on the same centered-growth snapping policy.
+    if d._secretBorderEdges then
+        for _, tex in pairs(d._secretBorderEdges) do
+            SetTexturePixelSnap(tex, d.pabCenteredSnap)
+        end
+    end
 end
 
 -- Icon-text outline flag for duration/stack text. Default follows the house icon-text
@@ -877,7 +886,21 @@ local function BuildStyle(isBuff, cfg)
     -- size 0 = no border; no separate "Hide Border" toggle.
     local border
     if borderSize > 0 then
-        border = { borderR, borderG, borderB, borderA, size = borderSize }
+        local textureSize = cfg.borderTextureSizeOverride or borderSize
+        border = {
+            borderR, borderG, borderB, borderA,
+            size = borderSize,
+            texture = cfg.borderTexture or "solid",
+            textureSize = textureSize,
+            offsetX = cfg.borderTextureOffset,
+            offsetY = cfg.borderTextureOffsetY,
+            shiftX = cfg.borderTextureShiftX,
+            shiftY = cfg.borderTextureShiftY,
+            behind = cfg.borderBehind == true,
+            addonKey = "unitframes",
+            sizeKey = textureSize,
+            edgeScale = cfg.borderTextureScaleOverride,
+        }
     end
 
     -- Positions may arrive mixed-case ("Bottom") rather than the uppercase anchor
@@ -1529,10 +1552,9 @@ end
 -- SkinAuraButton sized duration AND stack-count font strings from cfg.textSize, NOT
 -- the duration-only/stack-only split the old External Defensives module uses.
 -- noBorderDebuffs -> debuffCfg.borderSize = 0 (debuffs-only override, applied after
--- the shared borderSize above). NOT migrated, no PAB cfg field exists (known gap):
--- borderTexture/borderTextureOffset(Y)/borderTextureShiftX/Y/borderBehind,
--- durationFormat. Old buffIconZoom/debuffIconZoom are also skipped -- PAB has its own
--- per-bar iconZoom.
+-- the shared borderSize above). Border texture/offset/layer fields now map directly;
+-- durationFormat remains unsupported. Old buffIconZoom/debuffIconZoom are skipped --
+-- PAB has its own per-bar iconZoom.
 local function MigratePlayerAuraStyle(buffCfg, debuffCfg)
     local old = ns.db and ns.db.profile and ns.db.profile.playerAuras
     if not (old and old.enabled) then return end
@@ -1543,6 +1565,12 @@ local function MigratePlayerAuraStyle(buffCfg, debuffCfg)
         if old.borderG then cfg.borderG = old.borderG end
         if old.borderB then cfg.borderB = old.borderB end
         if old.borderA then cfg.borderA = old.borderA end
+        if old.borderTexture then cfg.borderTexture = old.borderTexture end
+        if old.borderTextureOffset ~= nil then cfg.borderTextureOffset = old.borderTextureOffset end
+        if old.borderTextureOffsetY ~= nil then cfg.borderTextureOffsetY = old.borderTextureOffsetY end
+        if old.borderTextureShiftX ~= nil then cfg.borderTextureShiftX = old.borderTextureShiftX end
+        if old.borderTextureShiftY ~= nil then cfg.borderTextureShiftY = old.borderTextureShiftY end
+        if old.borderBehind ~= nil then cfg.borderBehind = old.borderBehind end
         if old.showText ~= nil then cfg.durationShow = old.showText end
         if old.textSize then
             cfg.durationTextSize = old.textSize
@@ -1786,6 +1814,12 @@ local function EnsureExtDefCustomBar(s)
         if from.sortDirection then bar.sortDirection = from.sortDirection end
         if from.borderSize then bar.borderSize = from.borderSize end
         if from.borderR then bar.borderR, bar.borderG, bar.borderB, bar.borderA = from.borderR, from.borderG, from.borderB, from.borderA end
+        if from.borderTexture then bar.borderTexture = from.borderTexture end
+        if from.borderTextureOffset ~= nil then bar.borderTextureOffset = from.borderTextureOffset end
+        if from.borderTextureOffsetY ~= nil then bar.borderTextureOffsetY = from.borderTextureOffsetY end
+        if from.borderTextureShiftX ~= nil then bar.borderTextureShiftX = from.borderTextureShiftX end
+        if from.borderTextureShiftY ~= nil then bar.borderTextureShiftY = from.borderTextureShiftY end
+        if from.borderBehind ~= nil then bar.borderBehind = from.borderBehind end
     end
     local pos = s.extDefPos or (legacy and legacy.unlockPos)
     if pos and pos.point then
@@ -3406,7 +3440,8 @@ end
 -- Bar objects (both kinds) also carry the same shared+category cfg fields as
 -- DefaultBuffsCfg/DefaultDebuffsCfg (iconSize, durationShow/stackShow,
 -- durationPosition/TextSize/OffsetX/Y/ColorR/G/B, stackPosition/TextSize/OffsetX/
--- Y/ColorR/G/B; buff/debuff bars additionally borderSize/R/G/B/A, iconZoom, padding,
+-- Y/ColorR/G/B; buff/debuff bars additionally borderSize/R/G/B/A, borderTexture and
+-- optional texture offset/shift/layer fields, iconZoom, padding,
 -- iconsPerRow, maxRows, maxTotal; debuff bars additionally dispelColorMagic/Curse/
 -- Disease/Poison/Bleed). NOT pre-populated, same as those two starting as {}:
 -- BuildStyle/ComputeGrid apply the same `or <default>` fallbacks either way, so a
@@ -4472,6 +4507,7 @@ local function CreatePreviewIcon(box)
     btn.cooldown:SetHideCountdownNumbers(true)
     btn.cooldown:Hide()
     btn.border = CreateFrame("Frame", nil, btn)
+    btn.borderState = {}
     -- Plain preview region, not a real AuraKit button -- masking is unguarded here.
     btn.shapeMask = btn:CreateMaskTexture()
     btn.shapeMask:Hide()
@@ -4525,6 +4561,11 @@ local function ApplyPreviewScale(cfg, comp)
     out.padding = (cfg.padding or 5) * comp
     out.rowSpacing = cfg.rowSpacing and (cfg.rowSpacing * comp) or nil
     out.borderSize = (cfg.borderSize or 1) * comp
+    -- Textured borders use a discrete 0-4 lookup for edge art. Preserve that raw
+    -- key and scale the resolved edge/offset geometry separately; Solid continues
+    -- to use the compensated borderSize above.
+    out.borderTextureSizeOverride = cfg.borderSize or 1
+    out.borderTextureScaleOverride = comp
     -- PabShapeBorderSize is keyed by the raw 0-4 level, so it must run BEFORE scaling
     -- (unlike out.borderSize above) -- resolve the level, then scale the result,
     -- mirroring iconSize's own scale-after-resolve treatment. BuildStyle prefers this
@@ -5112,7 +5153,9 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
             end
 
             btn.border:SetAllPoints(shapeActive and btn or btn.icon)
-            btn.border:SetFrameLevel(btn:GetFrameLevel() + 1)
+            btn.border:SetFrameLevel(style.border and style.border.behind
+                and math.max(0, btn:GetFrameLevel() - 1)
+                or (btn:GetFrameLevel() + 1))
             local PP = EllesmereUI and EllesmereUI.PanelPP
             if PP and style.border then
                 local br, bg, bb, ba = style.border[1], style.border[2], style.border[3], style.border[4]
@@ -5122,24 +5165,29 @@ local function RenderPreviewIcons(box, icons, isBuff, cfg, fontPath, pool)
                 end
                 local size = style.border.size or 1
                 if shapeActive and style.shapeBorderPath and PP.ApplyMaskedShapeBorder then
+                    if EllesmereUI.HideBorderStyle then EllesmereUI.HideBorderStyle(btn.border) end
+                    if btn.borderState and btn.borderState._secretBorderEdges then
+                        for _, tex in pairs(btn.borderState._secretBorderEdges) do tex:Hide() end
+                    end
                     PP:ApplyMaskedShapeBorder(btn.border, btn.shapeMask, style.shapeBorderPath, style.shapeBorderSize or size, br, bg, bb, ba)
-                    if PP.ShowBorder then PP.ShowBorder(btn.border) end
                     btn.border:Show()
                 else
                     if PP.HideMaskedShapeBorder then PP:HideMaskedShapeBorder(btn.border)
                     elseif btn.border._shapeBorderTex then btn.border._shapeBorderTex:Hide() end
-                    -- PP.CreateBorder is create-once-only; live size/color changes on an
-                    -- already-created host go through PP.UpdateBorder instead.
-                    if btn.borderMade then
-                        PP.UpdateBorder(btn.border, size, br, bg, bb, ba)
-                    elseif PP.CreateBorder then
-                        PP.CreateBorder(btn.border, br, bg, bb, ba, size, "OVERLAY", 7)
-                        btn.borderMade = true
-                    end
-                    if PP.ShowBorder then PP.ShowBorder(btn.border) else btn.border:Show() end
+                    local b = style.border
+                    local appliedSize = (b.texture and b.texture ~= "" and b.texture ~= "solid")
+                        and (b.textureSize or size) or size
+                    EllesmereUI.ApplySecretSafeBorderStyle(btn.border, btn.borderState,
+                        appliedSize, br, bg, bb, ba, b.texture or "solid",
+                        b.offsetX, b.offsetY, b.shiftX, b.shiftY,
+                        b.addonKey or "unitframes", b.sizeKey or size, b.edgeScale)
+                    btn.borderMade = true
                 end
             else
-                if PP and PP.HideBorder then PP.HideBorder(btn.border) else btn.border:Hide() end
+                if EllesmereUI.ApplySecretSafeBorderStyle then
+                    EllesmereUI.ApplySecretSafeBorderStyle(btn.border, btn.borderState,
+                        0, 0, 0, 0, 0, "solid")
+                elseif PP and PP.HideBorder then PP.HideBorder(btn.border) else btn.border:Hide() end
                 if PP and PP.HideMaskedShapeBorder then PP:HideMaskedShapeBorder(btn.border)
                 elseif btn.border._shapeBorderTex then btn.border._shapeBorderTex:Hide() end
             end

--- a/EllesmereUI_AuraKit.lua
+++ b/EllesmereUI_AuraKit.lua
@@ -407,7 +407,17 @@ local function ApplyStyleToRegions(button, style)
         local b = style.border
         if PP and b then
             if shapeActive and style.shapeBorderPath then
-                if d.borderMade then PP.HideBorder(d.borderHost) end
+                -- A previous non-shaped style may have left either PP strips or
+                -- the secret-safe eight-slice texture set on this owned host.
+                -- Clear both before the shape ring takes over.
+                if d.borderMade then
+                    if EllesmereUI.ApplySecretSafeBorderStyle then
+                        EllesmereUI.ApplySecretSafeBorderStyle(d.borderHost, d, 0,
+                            0, 0, 0, 0, "solid")
+                    else
+                        PP.HideBorder(d.borderHost)
+                    end
+                end
                 PP:ApplyMaskedShapeBorder(d.borderHost, d.shapeMask, style.shapeBorderPath,
                     style.shapeBorderSize or b.size or 1, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1)
             else
@@ -427,16 +437,18 @@ local function ApplyStyleToRegions(button, style)
                         d.borderHost:SetFrameLevel(math.max(0, (b.unitFrameLevel or 1) - 1))
                     else
                         d.borderHost:SetFrameLevel(b.behind
-                            and math.max(0, button:GetFrameLevel() - 1)
+                            and math.max(0, (d.buttonFrameLevel or 1) - 1)
                             or (d.cooldown:GetFrameLevel() + 1))
                     end
                     -- addonKey/sizeKey pick the per-module texture offset defaults a
                     -- style leaves nil; CDM passes its own so a textured border sits
                     -- where the module's other icons put theirs.
-                    EllesmereUI.ApplySecretSafeBorderStyle(d.borderHost, d, b.size or 1,
+                    local appliedSize = (b.texture and b.texture ~= "" and b.texture ~= "solid")
+                        and (b.textureSize or b.size or 1) or (b.size or 1)
+                    EllesmereUI.ApplySecretSafeBorderStyle(d.borderHost, d, appliedSize,
                         b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1,
                         b.texture or "solid", b.offsetX, b.offsetY, b.shiftX, b.shiftY,
-                        b.addonKey or "unitframes", b.sizeKey or b.size or 1)
+                        b.addonKey or "unitframes", b.sizeKey or b.size or 1, b.edgeScale)
                     d.borderMade = true
                 elseif d.borderMade then
                     PP.UpdateBorder(d.borderHost, b.size or 1, b[1] or 0, b[2] or 0, b[3] or 0, b[4] or 1)
@@ -1003,6 +1015,10 @@ function AK.MakeInitializer(styleKey, extra)
         d.borderHost:SetAllPoints(button)
         d.borderHost:SetFrameLevel(d.cooldown:GetFrameLevel() + 1)
         d.borderHost:EnableMouse(false)
+        -- Cache while initializeFrame still has legal button access. A textured
+        -- Shadow selected later must never call button:GetFrameLevel() after the
+        -- engine has applied DenyTaintedAccessWhenAurasAreSecret.
+        d.buttonFrameLevel = button:GetFrameLevel()
 
         -- Dispel-ring holder: its own frame between the border host and the text
         -- carrier so the engine-tinted ring ALWAYS WINS over every border AND the DM


### PR DESCRIPTION
## Summary

Adds a **Border Style** setting to Player Aura Bars in the Unit Frames module. Border textures can now be configured independently for the default and custom Buff/Debuff bars.

### Changes

- Added built-in and LibSharedMedia border texture selection
- Added border offset, shift, and layer controls
- Added support to the live bars, preview, sync actions, and weapon enchant icons
- Prevented incompatible combinations of textured borders and custom icon shapes
- Preserved the existing Solid border as the default appearance

### Taint / Secret-Value Safety

Textured borders use addon-owned texture regions attached to the existing addon-owned border host. No aura data is read, no protected attributes are modified, and no custom state is written onto Blizzard-owned aura buttons. The implementation avoids `BackdropTemplate` calculations on restricted aura geometry.

## Checklist

- [x] New settings default **OFF** — N/A: Border Style defaults to **Solid**, preserving the existing appearance
- [x] Zero cost while disabled — no new events, hooks, or update loops
- [x] Cheap while enabled — textured border regions are created lazily and require no per-frame updates
- [x] No writes onto Blizzard-owned frames — state remains in external tables and addon-owned child regions
- [x] Tested in-game on live