### PR TITLE
Fix(Blizzskin): Accept label wrapping mid-word on the group invite popups

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -12018,6 +12018,27 @@ WSkin.RegisterWindow({
     end,
 })
 
+-- Blizzard's button label is auto-sized: the box is exactly the string width,
+-- so it carries no slack. At a fractional effective scale the stored width can
+-- land a float hair UNDER the string it holds (Accept 46.499996 for a 46.5px
+-- string, Decline a clean 48.0) and WoW breaks the last glyph onto a second
+-- line. Which strings land on an unlucky value follows the typeface, not the
+-- word length, so the global font swap decides who is hit. Pinning the label to
+-- the button gives it 118px instead of 47: centered text looks identical and
+-- can no longer wrap. One-shot per label.
+function LP.PinButtonLabel(b)
+    if not b or (b.IsForbidden and b:IsForbidden()) then return end
+    local fs = b.Text or (b.GetFontString and b:GetFontString())
+    if not fs then return end
+    local d = GetFFD(fs)
+    if d.labelPinned then return end
+    d.labelPinned = true
+    fs:ClearAllPoints()
+    fs:SetPoint("LEFT", b, "LEFT", 2, 0)
+    fs:SetPoint("RIGHT", b, "RIGHT", -2, 0)
+    if fs.SetWordWrap then fs:SetWordWrap(false) end
+end
+
 -------------------------------------------------------------------------------
 --  Group invite popups. Two frames, one setting, because they are one thing to
 --  the player: LFGListInviteDialog (premade-group leader accepted your
@@ -12070,6 +12091,7 @@ function LP.SkinInvite(fr, roleChecks)
         if b then
             WSkin.Button(b)
             WSkin.StateButtonLabel(b)
+            LP.PinButtonLabel(b)
         end
     end
     -- Templates naming their buttons globally rather than off the frame (LFGInvitePopupAcceptButton / ...DeclineButton).
@@ -12080,6 +12102,7 @@ function LP.SkinInvite(fr, roleChecks)
             if b then
                 WSkin.Button(b)
                 WSkin.StateButtonLabel(b)
+                LP.PinButtonLabel(b)
             end
         end
     end


### PR DESCRIPTION
## What does this PR do?

Fixes the Accept button on the group invite popups rendering its label broken across two lines ("Accep" / "t") instead of on one.

Blizzard's button label is auto-sized: the text box ends up exactly as wide as the string it holds, leaving it no slack at all. At a fractional effective UI scale the stored width can land a float hair under what the string actually needs - measured on the invite dialog, Accept came out at 46.499996 for a 46.5px string while Decline sat on a clean 48.0 - and the last glyph is pushed onto a second line. Which strings land on an unlucky value depends on the typeface in use, so it is the font that decides who is affected, not the length of the word, which is why the shorter label broke while the longer one next to it did not.

The label is now pinned to the button's own width, so it gets the button's full 118px instead of its own 47. The text stays centered and looks identical to before, but no rounding can make a string that narrow fail to fit. It is applied once per label in both button loops of the invite skin, so it covers both LFGListInviteDialog (premade group leader accepted your application) and LFGInvitePopup (group finder party invite with role checks).

## How was it tested?

Tested in game on the live retail client: the Accept label renders on a single line on the group invite popup, and the label's measured width is the button width rather than the string width.

## Screenshots

Before: 
<img width="406" height="276" alt="grafik" src="https://github.com/user-attachments/assets/f5135d85-98f5-4f41-895c-362d207abc31" />

After:
<img width="416" height="277" alt="grafik" src="https://github.com/user-attachments/assets/449d9f87-2d10-4d7a-ab4c-3af6e6d531e2" />

After: Accept rendering on a single centered line, unchanged otherwise.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; this is a rendering fix inside the existing invite window skin
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - runs once per label, guarded by a flag, on a skin pass that already existed
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - the one-shot flag lives in the skin's existing weak-keyed external table
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added