### PR TITLE
feat(cdm): add min-stack threshold gate to bar glows

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmBarGlows.lua
@@ -175,6 +175,110 @@ local overlayFrames = {}  -- [key] = overlay frame
 local lastStates = {}     -- [key] = bool (last glow state for change detection)
 local _cachedBG = nil     -- cached barGlows reference (refreshed on SetupOverlays)
 
+-------------------------------------------------------------------------------
+--  Stack-threshold gate (secret-safe)
+--  Applications counts read SECRET even in open-world content, so the
+--  threshold compare can never happen in Lua (a hard error on a secret).
+--  Same trick -- and same 5-operator support -- as the per-icon Glow at
+--  Stacks feature (EllesmereUICdmHooks.lua's StackGlow_Configure/Feed):
+--  one-unit StatusBar windows perform lower/upper bounds C-side via
+--  SetValue; equality intersects one of each (two gates). A fixed-size
+--  CLAMPTOBLACKADDITIVE mask rides each gate's fill edge and is handed to
+--  StartNativeGlow so the glow texture itself is cropped by the fill(s) --
+--  Lua never reads the count, just forwards it.
+-------------------------------------------------------------------------------
+local stackGates = {}  -- [key] = { gate,mask,fill, gate2,mask2,fill2, pad, threshold, operator, closeValue, openValue, closeValue2 }
+
+local function StackGateSize(overlay)
+    local w, h = overlay:GetWidth(), overlay:GetHeight()
+    if not w or w < 5 then w = 36 end
+    if not h or h < 5 then h = w end
+    return w, h
+end
+
+local function NewStackGate(overlay, pad)
+    local gate = CreateFrame("StatusBar", nil, overlay)
+    gate:SetPoint("TOPLEFT", overlay, "TOPLEFT", -pad, pad)
+    gate:SetPoint("BOTTOMRIGHT", overlay, "BOTTOMRIGHT", pad, -pad)
+    gate:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
+    local fill = gate:GetStatusBarTexture()
+    if fill then fill:SetAlpha(0) end
+    gate:EnableMouse(false)
+    local mask = gate:CreateMaskTexture()
+    mask:SetTexture("Interface\\Buttons\\WHITE8x8",
+        "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE", "NEAREST")
+    return gate, mask, fill
+end
+
+local function SizeStackGateMasks(st, width, height)
+    local w, h = width + st.pad * 2, height + st.pad * 2
+    st.mask:SetSize(w, h)
+    if st.mask2 then st.mask2:SetSize(w, h) end
+end
+
+local function StackGlowMatches(value, operator, threshold)
+    if operator == "lt" then return value < threshold end
+    if operator == "lte" then return value <= threshold end
+    if operator == "eq" then return value == threshold end
+    if operator == "gt" then return value > threshold end
+    return value >= threshold
+end
+
+local function EnsureStackGate(overlay, key)
+    local st = stackGates[key]
+    if not st then
+        st = {}
+        stackGates[key] = st
+        local w, h = StackGateSize(overlay)
+        local pad = math.ceil(math.max(w, h) * 0.4)
+        if pad < 12 then pad = 12 end
+        st.pad = pad
+        st.gate, st.mask, st.fill = NewStackGate(overlay, pad)
+        SizeStackGateMasks(st, w, h)
+    end
+    return st
+end
+
+-- (Re)configure the gate(s) for the current threshold/operator. Mirrors
+-- StackGlow_Configure's edge math exactly: lower bounds park the mask left
+-- and open at max; upper bounds open at min and park right; equality
+-- intersects one lower + one upper gate (both masks applied to the glow).
+local function ConfigureStackGate(overlay, key, threshold, operator)
+    local st = EnsureStackGate(overlay, key)
+    if st.threshold == threshold and st.operator == operator then return st end
+    st.threshold, st.operator = threshold, operator
+
+    local upper = operator == "lt" or operator == "lte"
+    local edge = (operator == "gt" or operator == "lte") and threshold + 1 or threshold
+    st.gate:SetMinMaxValues(edge - 1, edge)
+    st.mask:ClearAllPoints()
+    st.mask:SetPoint(upper and "LEFT" or "RIGHT", st.fill or st.gate, "RIGHT", 0, 0)
+    st.closeValue = upper and edge or edge - 1
+    st.openValue = upper and edge - 1 or edge
+
+    if operator == "eq" and not st.gate2 then
+        local w, h = StackGateSize(overlay)
+        st.gate2, st.mask2, st.fill2 = NewStackGate(overlay, st.pad)
+        SizeStackGateMasks(st, w, h)
+    end
+    if st.gate2 then
+        local equality = operator == "eq"
+        st.gate2:SetMinMaxValues(equality and threshold or 0, equality and threshold + 1 or 1)
+        st.mask2:ClearAllPoints()
+        st.mask2:SetPoint(equality and "LEFT" or "RIGHT", st.fill2 or st.gate2, "RIGHT", 0, 0)
+        st.closeValue2 = equality and threshold + 1 or 0
+    end
+    return st
+end
+
+-- Equality needs a SECOND mask (lower + upper gate intersect). StartNativeGlow's
+-- opts.maskWith already applies gateSt.mask; this adds gateSt.mask2 on top of
+-- the same fresh textures (must run right after the Start call).
+local function ApplySecondStackGateMask(overlay, gateSt)
+    if not (gateSt and gateSt.mask2 and EllesmereUI.Glows and EllesmereUI.Glows.ApplyMaskWith) then return end
+    EllesmereUI.Glows.ApplyMaskWith(overlay, gateSt.mask2)
+end
+
 --- Rebuild overlay frames from assignments
 local function SetupOverlays()
     local bg = ns.GetBarGlows()
@@ -184,8 +288,14 @@ local function SetupOverlays()
             StopNativeGlow(overlay)
             overlay:Hide()
         end
+        ns._anyBarGlowStackGate = false
         return
     end
+
+    -- Whether the buff-tick's aura pool-walk should bother reading applications
+    -- at all (EllesmereUICdmHooks.lua). Zero At Stacks assignments means zero
+    -- extra work there -- no ReadBuffApplications call, no stack cache writes.
+    local anyStack = false
 
     local activeKeys = {}
     for assignKey, buffList in pairs(bg.assignments) do
@@ -225,10 +335,12 @@ local function SetupOverlays()
                     overlay._assignEntry = entry
                     overlay:Show()
                     activeKeys[key] = true
+                    if entry.stackEnabled then anyStack = true end
                 end
             end
         end
     end
+    ns._anyBarGlowStackGate = anyStack
 
     -- Hide overlays that are no longer assigned
     for key, overlay in pairs(overlayFrames) do
@@ -275,7 +387,46 @@ local function UpdateOverlayVisuals()
                 shouldGlow = (InCombatLockdown and InCombatLockdown()) or UnitAffectingCombat("player") or false
             end
 
-            -- Only update on state change (avoids restarting animations)
+            -- At Stacks (ACTIVE mode only): fed to the gate(s) every tick
+            -- regardless of state-change dedupe below, so the mask tracks a
+            -- live stack count while the glow keeps running. A KNOWN count
+            -- that fails the comparison stops the glow outright (Lua-side,
+            -- cheap); an UNKNOWN/SECRET count never blocks it -- the gate's
+            -- open value / the engine-side clamp decide instead.
+            local gateSt
+            local applyMask2 = false
+            if shouldGlow and mode ~= "MISSING" and entry.stackEnabled and spellID and spellID > 0 then
+                local threshold = tonumber(entry.stackThreshold) or 2
+                local operator = entry.stackOperator or "gte"
+                gateSt = ConfigureStackGate(overlay, key, threshold, operator)
+                -- Same sid/baseSID/linked resolution as auraActive above, so
+                -- this matches whatever spellID the entry was saved against
+                -- (a raw GetPlayerAuraBySpellID(spellID) query missed on the
+                -- override/linked-id drift these tracked buffs can have).
+                local stacks = ns._tickBlizzAuraStacks and ns._tickBlizzAuraStacks[spellID]
+                -- Secret probe FIRST: any truthy/nil/relational test on a
+                -- secret value hard-errors, not just `<`/`>=`.
+                local secret = issecretvalue and issecretvalue(stacks)
+                local feedValue
+                if secret then
+                    feedValue = stacks
+                elseif stacks == nil then
+                    feedValue = gateSt.openValue
+                elseif not StackGlowMatches(stacks, operator, threshold) then
+                    shouldGlow = false
+                else
+                    feedValue = stacks
+                end
+                if shouldGlow then
+                    gateSt.gate:SetValue(feedValue)
+                    if gateSt.gate2 then
+                        gateSt.gate2:SetValue(operator == "eq" and feedValue or 1)
+                    end
+                    applyMask2 = gateSt.mask2 ~= nil
+                end
+            end
+
+            -- Only update start/stop on state change (avoids restarting animations)
             if shouldGlow ~= lastStates[key] then
                 lastStates[key] = shouldGlow
                 if shouldGlow then
@@ -297,7 +448,12 @@ local function UpdateOverlayVisuals()
                         cg = entry.glowColor.g or 0.788
                         cb = entry.glowColor.b or 0.137
                     end
-                    StartNativeGlow(overlay, style, cr, cg, cb)
+                    if gateSt then
+                        StartNativeGlow(overlay, style, cr, cg, cb, { maskWith = gateSt.mask })
+                        if applyMask2 then ApplySecondStackGateMask(overlay, gateSt) end
+                    else
+                        StartNativeGlow(overlay, style, cr, cg, cb)
+                    end
                 else
                     StopNativeGlow(overlay)
                 end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -129,6 +129,9 @@ do
         end
         return nil
     end
+    -- Exported for the aura active-cache below (Bar Glows stack threshold):
+    -- same secret-safe applications read, off whatever pool frame is active.
+    ns._ReadBuffApplications = ReadBuffApplications
 
     local function StartStackGlow(st, width, height)
         ns.StartNativeGlow(st.glow, st.style, st.r, st.g, st.b, {
@@ -1500,6 +1503,14 @@ ns._cdidRouteMap = _cdidRouteMap
 -------------------------------------------------------------------------------
 local _activeCache = {}
 ns._tickBlizzActiveCache = _activeCache
+
+-- Per-spellID application count, same population pass as _activeCache above,
+-- same sid/baseSID/linked resolution (so it matches whatever spellID a Bar
+-- Glow entry was saved against). Value is a plain number, a SECRET number,
+-- or nil (no stack data). Consumed by Bar Glows' stack-threshold gate --
+-- forwarded straight into a StatusBar:SetValue, never compared in Lua.
+local _activeStacksCache = {}
+ns._tickBlizzAuraStacks = _activeStacksCache
 
 -------------------------------------------------------------------------------
 --  IsFrameIncluded
@@ -10137,7 +10148,9 @@ function ns.SetupViewerHooks()
                 ns._acLastFull = _btNow
             do
                 local ac = _activeCache
+                local asc = _activeStacksCache
                 wipe(ac)
+                wipe(asc)
                 for vi = 1, 4 do
                     local vf = GetViewerFrame(vi)
                     -- BuffIcon (3) / BuffBar (4) viewers SHOW a frame only while its
@@ -10159,13 +10172,25 @@ function ns.SetupViewerHooks()
                                 local sid, baseSID = ResolveFrameSpellID(frame)
                                 if sid and sid > 0 then
                                     ac[sid] = true
-                                    if baseSID and baseSID > 0 then ac[baseSID] = true end
+                                    -- Zero At Stacks assignments = zero extra reads here
+                                    -- (ns._anyBarGlowStackGate, maintained by
+                                    -- CdmBarGlows.lua's SetupOverlays).
+                                    local apps = ns._anyBarGlowStackGate and ns._ReadBuffApplications
+                                        and ns._ReadBuffApplications(frame)
+                                    if apps ~= nil then asc[sid] = apps end
+                                    if baseSID and baseSID > 0 then
+                                        ac[baseSID] = true
+                                        if apps ~= nil then asc[baseSID] = apps end
+                                    end
                                     local fc = _ecmeFC[frame]
                                     local linked = fc and fc.linkedSpellIDs
                                     if linked then
                                         for li = 1, #linked do
                                             local lsid = linked[li]
-                                            if lsid and lsid > 0 then ac[lsid] = true end
+                                            if lsid and lsid > 0 then
+                                                ac[lsid] = true
+                                                if apps ~= nil then asc[lsid] = apps end
+                                            end
                                         end
                                     end
                                 end

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -892,6 +892,26 @@ initFrame:SetScript("OnEvent", function(self)
 
         local ACCENT = EllesmereUI.ELLESMERE_GREEN or { r = 0.05, g = 0.82, b = 0.62 }
 
+        -- Small inline gear button anchored to the left of a DualRow half's
+        -- control (mirrors the cog pattern used throughout the options UI,
+        -- e.g. the Name Text cog on BuildCDMBarsPage).
+        local function MakeCogBtn(rgn, showFn, anchorTo, iconPath)
+            local anchor = anchorTo or (rgn and (rgn._lastInline or rgn._control)) or rgn
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", anchor, "LEFT", -8, 0)
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints()
+            cogTex:SetTexture(iconPath or EllesmereUI.RESIZE_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) showFn(self) end)
+            if rgn then rgn._lastInline = cogBtn end
+            return cogBtn
+        end
+
         -------------------------------------------------------------------
         --  Content Header: Live Action Bar Preview (replica of BuildLivePreview)
         -------------------------------------------------------------------
@@ -1533,6 +1553,7 @@ initFrame:SetScript("OnEvent", function(self)
                           setValue = function(v)
                               entry.mode = v
                               Refresh()
+                              EllesmereUI:RefreshPage()
                           end,
                         },
                         { type = "toggle", text = "Only In Combat",
@@ -1562,9 +1583,24 @@ initFrame:SetScript("OnEvent", function(self)
                         ns.StartNativeGlow(ov, style, cr, cg, cb)
                     end
 
-                    -- Row 2: Glow Type (with eyeball) | Glow Color Swatch Selectors
-                    local glowRow
-                    glowRow, h = W:DualRow(parent, y,
+                    -- At Stacks (toggle) + gear (Comparison / Stack Count), paired with
+                    -- Glow Type so every row stays filled. Same operator set and same
+                    -- fail-open bias as the per-icon Glow at Stacks feature (Stack Text
+                    -- and Glows cog): an unknown/secret application count never blocks
+                    -- the glow.
+                    local stackRow
+                    stackRow, h = W:DualRow(parent, y,
+                        { type = "toggle", text = "At Stacks",
+                          tooltip = "Only glow once the buff's stack count matches the comparison set via the gear.",
+                          disabled = function() return entry.mode == "MISSING" end,
+                          disabledTooltip = "Not available in Buff Missing mode",
+                          getValue = function() return entry.stackEnabled == true end,
+                          setValue = function(v)
+                              entry.stackEnabled = v or nil
+                              Refresh()
+                              EllesmereUI:RefreshPage()
+                          end,
+                        },
                         { type = "dropdown", text = "Glow Type",
                           values = glowLabels, order = glowOrder,
                           disabled = function() return BarHasCustomShape(curBar) end,
@@ -1578,15 +1614,60 @@ initFrame:SetScript("OnEvent", function(self)
                               Refresh()
                               RefreshPreviewGlow()
                           end,
-                        },
-                        { type = "label", text = "Glow Color" }
+                        }
                     );  y = y - h
+                    do
+                        local rgn = stackRow._leftRegion
+                        local _, cogShow = EllesmereUI.BuildCogPopup({
+                            title = "At Stacks", noOwnerDim = true,
+                            frameStrata = "FULLSCREEN_DIALOG", frameLevel = 350,
+                            rows = {
+                                { type = "dropdown", label = "Comparison",
+                                  values = { lt = "Below (<)", lte = "At Most (<=)", eq = "Exactly (=)", gte = "At Least (>=)", gt = "Above (>)" },
+                                  order = { "lt", "lte", "eq", "gte", "gt" },
+                                  get = function() return entry.stackOperator or "gte" end,
+                                  set = function(v)
+                                      entry.stackOperator = v ~= "gte" and v or nil
+                                      Refresh()
+                                  end },
+                                { type = "input", label = "Stack Count", inputWidth = 42, commitOnBlur = true,
+                                  get = function() return tostring(tonumber(entry.stackThreshold) or 2) end,
+                                  set = function(v)
+                                      local t = math.floor(tonumber(v) or 2)
+                                      if t < 1 then t = 1 end
+                                      if t > 99 then t = 99 end
+                                      entry.stackThreshold = t
+                                      Refresh()
+                                  end },
+                            },
+                        })
+                        local cogBtn = MakeCogBtn(rgn, cogShow, nil, EllesmereUI.COGS_ICON)
+                        local cogDis = CreateFrame("Frame", nil, rgn)
+                        cogDis:SetAllPoints(cogBtn); cogDis:SetFrameLevel(cogBtn:GetFrameLevel() + 5)
+                        cogDis:EnableMouse(true)
+                        cogDis:SetScript("OnEnter", function()
+                            local tip = entry.mode == "MISSING" and "Not available in Buff Missing mode" or "Enable At Stacks"
+                            EllesmereUI.ShowWidgetTooltip(cogBtn, EllesmereUI.DisabledTooltip(tip))
+                        end)
+                        cogDis:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+                        local function UpdateCogDisStack()
+                            if entry.mode == "MISSING" or not entry.stackEnabled then
+                                cogBtn:SetAlpha(0.4)
+                                cogDis:Show()
+                            else
+                                cogDis:Hide()
+                            end
+                        end
+                        cogBtn:HookScript("OnShow", UpdateCogDisStack)
+                        EllesmereUI.RegisterWidgetRefresh(UpdateCogDisStack)
+                        UpdateCogDisStack()
+                    end
 
-                    -- Eyeball preview toggle (on left region of glow type row)
+                    -- Eyeball preview toggle (on right region of the At Stacks / Glow Type row)
                     if not EllesmereUI._prebuilding then
                         local EYE_VIS   = EllesmereUI.EYE_VISIBLE_ICON
                         local EYE_INVIS = EllesmereUI.EYE_INVISIBLE_ICON
-                        local leftRgn = glowRow._leftRegion
+                        local leftRgn = stackRow._rightRegion
                         if leftRgn and leftRgn._control then
                             local eyeBtn = CreateFrame("Button", nil, leftRgn)
                             eyeBtn:SetSize(26, 26)
@@ -1635,12 +1716,28 @@ initFrame:SetScript("OnEvent", function(self)
                         end
                     end
 
-                    -- Inline color swatch for glow color (on right region of row 2)
+                    -- Row: Glow Color (swatches) | Remove Glow
+                    local colorRow
+                    colorRow, h = W:DualRow(parent, y,
+                        { type = "label", text = "Glow Color" },
+                        { type = "labeledButton", text = "Remove Glow", buttonText = "Remove", width = 150,
+                          onClick = function()
+                              table.remove(buffList, removeAIdx)
+                              if #buffList == 0 then
+                                  bg.assignments[assignKey] = nil
+                              end
+                              Refresh()
+                              EllesmereUI:RefreshPage(true)
+                          end,
+                        }
+                    );  y = y - h
+
+                    -- Inline color swatch for glow color (on left region)
                     if not EllesmereUI._prebuilding then
-                        local rightRgn = glowRow._rightRegion
-                        if rightRgn and EllesmereUI.BuildTrioColorSwatch then
+                        local leftRgn = colorRow._leftRegion
+                        if leftRgn and EllesmereUI.BuildTrioColorSwatch then
                             local glowSwatch, defaultSwatch, classSwatch = EllesmereUI.BuildTrioColorSwatch(
-                                rightRgn, glowRow:GetFrameLevel() + 3,
+                                leftRgn, colorRow:GetFrameLevel() + 3,
                                 {
                                     getMode = function() return entry.colorMode or "default" end,
                                     setMode = function(m) entry.colorMode = m end,
@@ -1655,35 +1752,19 @@ initFrame:SetScript("OnEvent", function(self)
                                     onChange = function() Refresh(); RefreshPreviewGlow(); EllesmereUI:RefreshPage() end,
                                     overrideSize = 20,
                                 })
-                            PP.Point(classSwatch, "RIGHT", rightRgn, "RIGHT", -20, 0)
+                            PP.Point(classSwatch, "RIGHT", leftRgn, "RIGHT", -20, 0)
                             PP.Point(glowSwatch, "RIGHT", classSwatch, "LEFT", -8, 0)
                             PP.Point(defaultSwatch, "RIGHT", glowSwatch, "LEFT", -8, 0)
                         end
                     end
 
-                    -- Row 3: Remove Glow on its own row (left slot), after the glow config.
-                    local removeRow
-                    removeRow, h = W:DualRow(parent, y,
-                        { type = "labeledButton", text = "Remove Glow", buttonText = "Remove", width = 150,
-                          onClick = function()
-                              table.remove(buffList, removeAIdx)
-                              if #buffList == 0 then
-                                  bg.assignments[assignKey] = nil
-                              end
-                              Refresh()
-                              EllesmereUI:RefreshPage(true)
-                          end,
-                        },
-                        { type = "spacer" }
-                    );  y = y - h
-
                     -- Buff icon to the LEFT of the Remove button
                     do
-                        local leftRgn = removeRow._leftRegion
-                        if leftRgn and leftRgn._control then
-                            local btn = leftRgn._control
+                        local rightRgn = colorRow._rightRegion
+                        if rightRgn and rightRgn._control then
+                            local btn = rightRgn._control
                             local btnH = btn:GetHeight()
-                            local ico = leftRgn:CreateTexture(nil, "ARTWORK")
+                            local ico = rightRgn:CreateTexture(nil, "ARTWORK")
                             ico:SetSize(btnH, btnH)
                             PP.Point(ico, "RIGHT", btn, "LEFT", -8, 0)
                             ico:SetTexCoord(0.08, 0.92, 0.08, 0.92)


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds an opt-in "At Stacks" setting to Cooldown Manager Bar Glows. The glow only activates once the tracked buff/debuff's stack/application count matches a configured comparison, instead of glowing on presence alone.

- Toggle "At Stacks" sits next to "Glow When" in the entry's option row (rows reordered to Glow When, Only In Combat, At Stacks, Glow Type, Glow Color, Remove Glow so every row pairs into a filled two-column layout, no empty half-rows). A gear icon opens a popup with **Comparison** (`<`, `<=`, `=`, `>=`, `>`) and **Stack Count** (1-99) -- the same operator set as the existing per-icon "Glow at Stacks" feature (Stack Text and Glows cog).
- Applications counts can be a SECRET value even in open-world content, so the threshold compare never happens in Lua (any compare on a secret value hard-errors). One-unit StatusBar windows perform the compare(s) C-side via `SetValue`; equality intersects a lower + an upper gate. A CLAMPTOBLACKADDITIVE mask riding each gate's fill edge crops the native glow texture -- ported directly from the per-icon feature's `StackGlow_Configure`/`StackGlow_Feed` gate/mask logic.
- A known (non-secret) count that fails the comparison stops the glow outright; an unknown/secret count never blocks it -- same fail-open bias as the existing feature.
- The buff-tick's aura pool-walk only reads applications (`ns._ReadBuffApplications`) when at least one Bar Glow assignment actually has At Stacks enabled (`ns._anyBarGlowStackGate`, maintained by `SetupOverlays`). Zero At Stacks assignments = zero extra reads on that tick, same as before this PR.

<!-- User-facing description: what changes for the player? -->

## How was it tested?

- Verified the stack cache (`ns._tickBlizzAuraStacks`) is populated from the same sid/baseSID/linked spellID resolution pass as the existing active-aura cache, so it matches whatever spellID a Bar Glow entry is saved against.
- Verified in-game: toggling At Stacks and changing Comparison/Stack Count via the gear correctly gates the glow (`<`, `<=`, `=`, `>=`, `>`), including with secret stack counts in open-world content.
- Verified the gear's disabled state (Buff Missing mode, At Stacks off) updates immediately on toggle, and the option rows render with no empty half-rows.
- Verified the gate/mask frames are only created lazily on first use, and confirmed via code review that the applications read in the shared aura pool-walk is skipped entirely when no assignment has At Stacks enabled.


https://github.com/user-attachments/assets/ec80b31d-f407-469e-a460-405ac20bcfcb


<!-- Client build, what you tested in game, etc. -->

## Screenshots

<img width="1984" height="1463" alt="image" src="https://github.com/user-attachments/assets/4a8e01b0-937b-4e6c-ad2f-edb7456f8a2b" />

<!-- Required for any visual change: before + after. Delete if not visual. -->

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built; the shared aura-tick pool-walk skips its applications read entirely when no assignment has At Stacks enabled
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
