### PR TITLE
Feature/Fix (Player Aura Bars): add Element Options to the unlock mode cog menu

### DIFF
--- a/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_PlayerAuraBars_ManagerPages.lua
@@ -52,9 +52,25 @@ local pabInhSel = nil
 -- session-sticky file local defaulting to the Buffs bar, so a nav targeting a
 -- debuff-side section must pre-select the right pane or the section scan
 -- silently misses.
-EllesmereUI._setPABSelection = function(kind, id)
+--
+-- `bucket` = the bar's owning editing-spec bucket, passed by unlock mode's
+-- "Element Options". The view is session-sticky too and BuildPage validates the
+-- selection against the current view's bucket only, so a bar from another bucket
+-- would be dropped back to the default tile. Same move as the inherited pane's
+-- "Edit in <group>" link.
+EllesmereUI._setPABSelection = function(kind, id, bucket)
     pabSel = { kind = kind, id = id or "default" }
     pabInhSel = nil
+    if bucket then
+        pabSpecSel = bucket
+    elseif pabSel.id == "default" and pabSpecSel ~= "allspecs"
+        and not (type(pabSpecSel) == "string" and pabSpecSel:match("^spec%d")) then
+        -- The two built-in bars are All Specs content: they are listed in the All
+        -- Specs view and in concrete spec views, but never in a group bucket, so a
+        -- stale group view would drop this selection. Concrete spec views list
+        -- them, so those stay untouched.
+        pabSpecSel = "allspecs"
+    end
 end
 
 -- Editing-spec group buckets (labels/icons mirror the RaidFrames roster in

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -2473,6 +2473,37 @@ local function CreateBars()
     SyncCancelCVar()
 end
 
+-- Unlock mode's cog menu only offers "Element Options" for keys in
+-- EllesmereUI._ELEMENT_SETTINGS_MAP; a module adds its own dynamic keys there the
+-- way EllesmereUIDataBars.lua does, so EUI_UnlockMode.lua's static map needs no
+-- PAB branch. barId nil = one of the two built-in bars.
+--
+-- No sectionName/highlightText: NavigateToElementSettings scans the page
+-- wrapper's DIRECT children for section headers, and PABMP_BuildPage builds past
+-- `parent` into its own root on the shared scroll frame, so nothing is scannable.
+local function MapElementSettings(key, kind, barId)
+    if not EllesmereUI then return end
+    EllesmereUI._ELEMENT_SETTINGS_MAP = EllesmereUI._ELEMENT_SETTINGS_MAP or {}
+    EllesmereUI._ELEMENT_SETTINGS_MAP[key] = {
+        module = "EllesmereUIUnitFrames",
+        page = "Player Aura Bars",
+        preSelectFn = function()
+            if not EllesmereUI._setPABSelection then return end
+            if not barId then
+                EllesmereUI._setPABSelection(kind, "default")
+                return
+            end
+            -- Owning bucket resolved at click time, not baked in at registration:
+            -- the tile's "Add To" menu can move a bar to another editing-spec
+            -- bucket long after its key was mapped.
+            local bar, bucket
+            if kind == "buff" then bar, bucket = ns.PAB_GetCustomBuffBar(barId)
+            else bar, bucket = ns.PAB_GetCustomDebuffBar(barId) end
+            if bar then EllesmereUI._setPABSelection(kind, barId, bucket) end
+        end,
+    }
+end
+
 -- Unlock-mode registration, patterned on EllesmereUIDamageMeters.lua's
 -- ns.RegisterDMUnlock/MakeSATimerUnlockElement (observed EUI.MakeUnlockElement field
 -- usage, not a verified schema). Both bars use noResize (AuraKit sizes the container
@@ -2545,6 +2576,8 @@ function RegisterPABUnlock()
         MakeBarElement("PAB_Buffs", buffLabel, 700, true, function() return buffsParent end),
         MakeBarElement("PAB_Debuffs", "Debuffs", 701, false, function() return debuffsParent end),
     }
+    MapElementSettings("PAB_Buffs", "buff")
+    MapElementSettings("PAB_Debuffs", "debuff")
     EllesmereUI:RegisterUnlockElements(elements, "EllesmereUIUnitFrames")
     -- Registration alone only updates the element table; a mover already built
     -- this session keeps the label CreateMover baked into its FontString. No-op
@@ -3775,6 +3808,7 @@ local function RegisterPABCustomUnlock()
 
     local function MakeCustomBarElement(barId, bar, order, isBuff, parents)
         local key = (isBuff and "PAB_CustomBuff_" or "PAB_CustomDebuff_") .. barId
+        MapElementSettings(key, isBuff and "buff" or "debuff", barId)
         return key, MK({
             key = key,
             label = "PAB: " .. (bar.name or (isBuff and "Buff Bar" or "Debuff Bar")),
@@ -3871,15 +3905,24 @@ local function RegisterPABCustomUnlock()
     end
 
     -- Retire keys for bars deleted since the last call -- safe here (unlike TBB)
-    -- because PAB custom-bar ids are permanent, see doc comment above.
+    -- because PAB custom-bar ids are permanent, see doc comment above. The
+    -- element-options map entry is retired with the mover; a leftover entry would
+    -- be harmless (no mover, no cog) but the id is gone for good either way.
+    local elemMap = EllesmereUI._ELEMENT_SETTINGS_MAP
     if prevBuffKeys then
         for key in pairs(prevBuffKeys) do
-            if not pabRegisteredCustomBuffKeys[key] then EllesmereUI:UnregisterUnlockElement(key) end
+            if not pabRegisteredCustomBuffKeys[key] then
+                EllesmereUI:UnregisterUnlockElement(key)
+                if elemMap then elemMap[key] = nil end
+            end
         end
     end
     if prevDebuffKeys then
         for key in pairs(prevDebuffKeys) do
-            if not pabRegisteredCustomDebuffKeys[key] then EllesmereUI:UnregisterUnlockElement(key) end
+            if not pabRegisteredCustomDebuffKeys[key] then
+                EllesmereUI:UnregisterUnlockElement(key)
+                if elemMap then elemMap[key] = nil end
+            end
         end
     end
 end


### PR DESCRIPTION
## What does this PR do?

Player Aura Bars movers now offer **Element Options** in their unlock mode cog menu, the same shortcut other modules already have. It covers the two built-in bars and every custom buff and debuff bar, and it opens the Player Aura Bars page with that exact bar already selected in the sidebar, including switching the Editing Spec view to the bucket the bar actually lives in, so a bar created for a role or a single spec opens on its own settings instead of falling back to the default tile.

Internally the module registers its own `EllesmereUI._ELEMENT_SETTINGS_MAP` entries the way EllesmereUIDataBars does for its per-bar keys, so the static map in `EUI_UnlockMode.lua` needs no PAB branch and a deleted custom bar retires its entry along with its mover. A custom bar's owning bucket is resolved at click time rather than baked in at registration, since the tile's "Add To" menu can move a bar to another bucket after its key was mapped. `EllesmereUI._setPABSelection` gained an optional third argument for that bucket; its existing two-argument caller is unchanged and now also survives a stale group-bucket view.

## How was it tested?

Tested in game on the live client.

## Screenshots

No new chrome: this adds the standard Element Options row to the existing cog menu, identical to the entry other modules already show.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; the menu entry only appears for movers that already exist
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, no Blizzard frames touched
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added