### PR TITLE
Fix: Chat throwing LUA error in raid

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat_Tabs.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Tabs.lua
@@ -712,7 +712,16 @@ function ECHAT.TabsSweepBlizzard()
             -- in lockdown; a refused heal retries on the next sweep.
             if InCombatLockdown() then pcall(gdm.Show, gdm) else gdm:Show() end
         end
-        if gdm:GetAlpha() ~= 0 then gdm:SetAlpha(0) end
+        -- GetAlpha can return a secret number mid-combat in a raid (same
+        -- class as the cursor-position guards elsewhere in this file); a
+        -- secret result can't be safely compared for the ~= 0 skip-optimization,
+        -- so just re-assert 0 unconditionally in that case.
+        local gdmAlpha = gdm:GetAlpha()
+        if issecretvalue and issecretvalue(gdmAlpha) then
+            gdm:SetAlpha(0)
+        elseif gdmAlpha ~= 0 then
+            gdm:SetAlpha(0)
+        end
         local ob = gdm.overflowButton
         if ob then
             if ob.SetIgnoreParentAlpha and not ob:IsIgnoringParentAlpha() then


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1543701559849001161

Issue: TabsSweepBlizzard read GeneralDockManager's alpha via GetAlpha() and compared it to 0 to decide whether to re-assert 0; under WoW's secret-value system this read can return a secret number mid-combat in a raid, and comparing a secret value throws a taint error.
Fix: Guard the alpha read with issecretvalue() -- when the value is secret, unconditionally re-assert SetAlpha(0) instead of comparing it, matching the same pattern already used for the cursor-position guards elsewhere in this file.