### PR TITLE
Fix: AH Current Expansion Only filter not applying

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -797,10 +797,18 @@ qolFrame:SetScript("OnEvent", function(self)
             if not AuctionHouseFrame or not AuctionHouseFrame.SearchBar then return end
             C_Timer.After(0, function()
                 local fb = AuctionHouseFrame.SearchBar.FilterButton
-                if not fb or not fb.filters then return end
+                if not fb or not fb.GetFilters or not fb.ToggleFilter then return end
                 if not (Enum and Enum.AuctionHouseFilter and Enum.AuctionHouseFilter.CurrentExpansionOnly) then return end
-                fb.filters[Enum.AuctionHouseFilter.CurrentExpansionOnly] = true
-                AuctionHouseFrame.SearchBar:UpdateClearFiltersButton()
+                local filterEnum = Enum.AuctionHouseFilter.CurrentExpansionOnly
+                local filters = fb:GetFilters()
+                -- Direct fb.filters[...] mutation never reaches the search query;
+                -- ToggleFilter is the only path that actually re-runs the AH search.
+                if not (filters and filters[filterEnum]) then
+                    fb:ToggleFilter(filterEnum)
+                end
+                if AuctionHouseFrame.SearchBar.UpdateClearFiltersButton then
+                    AuctionHouseFrame.SearchBar:UpdateClearFiltersButton()
+                end
             end)
         end)
     end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1543090757924028537

Issue: The Current Expansion Only option mutated AuctionHouseFrame.SearchBar.FilterButton.filters directly, which changes internal state but never triggers the Auction House's search re-query, so the filter never actually applied to results.
Fix: Apply the filter through the FilterButton's own GetFilters()/ToggleFilter() API instead, checking current state first so it only toggles on when not already set.