### PR TITLE
Fix: Minimap tracking button (and other hidden buttons) still clickable after being disabled

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -276,6 +276,13 @@ local function HideMinimapButton(name)
             for _, entry in ipairs(minimapButtonMap) do
                 for _, btnName in ipairs(entry.names) do
                     if btnName == name and mp[entry.key] then
+                        -- Alpha alone leaves the button SHOWN (a WoW frame at
+                        -- alpha 0 still receives mouse/tooltip events) -- Hide()
+                        -- it too, matching the initial suppression below, or a
+                        -- later Blizzard-driven Show() (tracking-spell change,
+                        -- login re-eval, etc.) leaves an invisible but fully
+                        -- clickable hotspot at the button's old position.
+                        self:Hide()
                         self:SetAlpha(0)
                         return
                     end


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1544552188691353701

Issue: HideMinimapButton's reactive Show hook only reset the button's alpha to 0 when Blizzard's own code re-showed it later, never re-hiding it -- a WoW frame at alpha 0 that is still Shown keeps receiving mouse/tooltip/click events, leaving an invisible but fully functional hotspot at the button's old position. All five hide options routed through this shared function (tracking, game time/calendar, mail, raid difficulty, crafting order) were equally affected.
Fix: The reactive hook now calls Hide() again alongside SetAlpha(0), matching the function's own initial-hide behavior, so a later Blizzard-driven Show() stays fully suppressed instead of just invisible.