### PR TITLE
feat(databars): add Lockout Details toggle with live instance sync

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars.lua
@@ -218,7 +218,7 @@ ns.BLOCK_TYPES = {
 }
 
 ns.BLOCK_DEFAULTS = {
-    clock      = { localTime = true, twentyFour = true, showMail = true, showResting = true, fontSizeClock = nil, fontSizeInfo = nil },
+    clock      = { localTime = true, twentyFour = true, showMail = true, showResting = true, lockoutDetails = false, fontSizeClock = nil, fontSizeInfo = nil },
     fps        = {},
     ms         = { showIcon = false },
     -- widthMode/maxWidth deliberately unset: "auto" is the resolved default

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -340,7 +340,8 @@ ns.BlockFactories.clock = function(blockCfg, slot, content, barCtx)
     local inst = { cfg = blockCfg, slot = slot, content = content, ctx = barCtx }
     inst.key = InstKey(barCtx, blockCfg)
     inst.events = { "PLAYER_UPDATE_RESTING", "PLAYER_REGEN_ENABLED",
-                    "MAIL_INBOX_UPDATE", "UPDATE_PENDING_MAIL" }
+                    "MAIL_INBOX_UPDATE", "UPDATE_PENDING_MAIL",
+                    "UPDATE_INSTANCE_INFO", "ENCOUNTER_END", "BOSS_KILL" }
 
     local infoTimer, infoIndex = 0, 1
     local lastTimeStr
@@ -637,17 +638,24 @@ ns.BlockFactories.clock = function(blockCfg, slot, content, barCtx)
         end
     end
 
-    inst.eventFrame = MakeEventFrame(inst, function(self, event)
-        if event == "PLAYER_REGEN_ENABLED" then
-            if needsResize then needsResize = false; self:Refresh() end
-        else
-            self:Refresh()
+    local function ShortenDifficulty(diffName)
+        if not diffName or diffName == "" then return "" end
+        local lower = diffName:lower()
+        if lower:find("mythic") then return "M"
+        elseif lower:find("heroic") then return "H"
+        elseif lower:find("looking for raid") or lower:find("raid finder") or lower:find("lfr") then return "LFR"
+        elseif lower:find("normal") then return "N"
+        elseif lower:find("timewalking") then return "TW"
+        elseif lower:find("story") then return "Story"
+        elseif lower:find("world") then return "W"
+        elseif lower:find("delve") then return "DLV"
         end
-    end)
+        return diffName
+    end
 
-    clockTextFrame:SetScript("OnEnter", function()
-        isMouseOver = true
-        ApplyClockColor()
+    local function ShowClockTooltip()
+        if not isMouseOver then return end
+        if RequestRaidInfo then RequestRaidInfo() end
         -- Tooltips are all-white by design (no accent tinting).
         local ar, ag, ab = 1, 1, 1
         ns.Tip_Begin(clockTextFrame)
@@ -664,10 +672,25 @@ ns.BlockFactories.clock = function(blockCfg, slot, content, barCtx)
         if numInstances > 0 then
             ns.Tip_AddLine(" ")
             ns.Tip_AddLine(L["SAVED_INSTANCES"], 1, 0.82, 0)
+            local d = D()
+            local showDetails = (d.lockoutDetails == true)
             for i = 1, numInstances do
-                local name, _, reset, _, locked, extended = GetSavedInstanceInfo(i)
+                local name, _, reset, _, locked, extended, _, _, _, difficultyName, numEncounters, encounterProgress = GetSavedInstanceInfo(i)
                 if locked or extended then
-                    ns.Tip_AddDouble(name, ns.FormatTimeLeft(reset), 1, 1, 1, 0.6, 0.6, 0.6)
+                    local displayName = name
+                    if showDetails then
+                        local total = tonumber(numEncounters) or 0
+                        local progress = tonumber(encounterProgress) or 0
+                        local diffShort = ShortenDifficulty(difficultyName)
+                        if total > 0 and diffShort ~= "" then
+                            displayName = format("%s (%s %d/%d)", name, diffShort, progress, total)
+                        elseif total > 0 then
+                            displayName = format("%s (%d/%d)", name, progress, total)
+                        elseif diffShort ~= "" then
+                            displayName = format("%s (%s)", name, diffShort)
+                        end
+                    end
+                    ns.Tip_AddDouble(displayName, ns.FormatTimeLeft(reset), 1, 1, 1, 0.6, 0.6, 0.6)
                 end
             end
         end
@@ -694,6 +717,26 @@ ns.BlockFactories.clock = function(blockCfg, slot, content, barCtx)
         ns.Tip_AddDouble(L["RIGHT_CLICK"], L["TOGGLE_CLOCK"], 1, 1, 1, r, g, b)
         ns.Tip_AddDouble(L["SHIFT_MIDDLE_CLICK"], L["RELOAD_UI"], 1, 1, 1, r, g, b)
         ns.Tip_Show()
+    end
+
+    inst.eventFrame = MakeEventFrame(inst, function(self, event)
+        if event == "PLAYER_REGEN_ENABLED" then
+            if needsResize then needsResize = false; self:Refresh() end
+        elseif event == "ENCOUNTER_END" or event == "BOSS_KILL" then
+            if RequestRaidInfo then RequestRaidInfo() end
+        elseif event == "UPDATE_INSTANCE_INFO" then
+            if isMouseOver then
+                ShowClockTooltip()
+            end
+        else
+            self:Refresh()
+        end
+    end)
+
+    clockTextFrame:SetScript("OnEnter", function()
+        isMouseOver = true
+        ApplyClockColor()
+        ShowClockTooltip()
     end)
     clockTextFrame:SetScript("OnLeave", function()
         isMouseOver = false

--- a/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
+++ b/EllesmereUIOptions/EllesmereUIDataBars_Options.lua
@@ -2781,6 +2781,7 @@ initFrame:SetScript("OnEvent", function(self)
                       end },
                     MkToggle("Mail Alert", "showMail", "Shows an envelope icon when you have unread mail."),
                     MkToggle("Resting Icon", "showResting", "Shows a rest icon while your character is resting."),
+                    MkToggle("Lockout Details", "lockoutDetails", "Shows difficulty and boss progress for saved raid lockouts in the tooltip."),
                 }
             elseif b.type == "combat" then
                 typeRows = {


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in **Lockout Details** toggle (`lockoutDetails`) to the Clock databar block settings (`Data Bars > Bar > Blocks > Clock`).

When enabled, the clock tooltip displays difficulty abbreviations and boss kill progress for saved raid/instance lockouts (e.g. `Liberation of Undermine (H 4/8)`, `Tidebound Grotto (W 1/1)`, `Nerub-ar Palace (M 8/8)`).

Key highlights:
- **Zero Cost / Opt-In**: Setting defaults to `false`. When disabled, the clock tooltip retains its standard name-only layout and registers no additional instance events.
- **Live Sync**: Automatically queries `RequestRaidInfo()` on tooltip hover and upon encounter completions (`BOSS_KILL` / `ENCOUNTER_END`).
- **Live Tooltip Update**: Listens to `UPDATE_INSTANCE_INFO` while hovering so the tooltip updates dynamically without requiring the user to re-hover.
- **Compact Difficulty Alignment**: Shortens difficulty names to standard abbreviations (`M`, `H`, `N`, `LFR`, `TW`, `W`, `DLV`, `Story`) for clean vertical alignment.

## How was it tested?

- Tested on retail client build 12.1.0.69587.
- Verified toggle appears in Clock block settings and toggles dynamically.
- Tested killing raid bosses mid-session; confirmed instance progress updates immediately upon kill and hover.
- Tested `World` (Tidebound Grotto) and `Delve` instances.
- Verified `.tools/extract-locale-keys.sh` passes with 0 diff.

## Screenshots

| Settings | Live |
|---|---|
| <img width="1246" height="277" alt="clock_raid_progress_setting" src="https://github.com/user-attachments/assets/7ba453f9-7286-43ab-aeee-c5c3ff631143" /> | <img width="652" height="509" alt="clock_raid_progress_live" src="https://github.com/user-attachments/assets/751ba8b5-14fc-40f7-9157-7c2965ac48fc" /> |

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added