### PR TITLE
feat(powerbars): add Boss Health Marker spark to UnitFrames and ResourceBars

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -4457,6 +4457,21 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.SpecOverrides_AttachEditLock(powerColorRow._rightRegion,
                 "Thresholds have their own per-spec system and can't be edited while editing a spec group")
         end
+
+        -- Row 6: Boss Health Marker | (empty slot)
+        _, h = W:DualRow(parent, y,
+            { type = "toggle", text = "Boss Health Marker",
+              tooltip = "Shows a vertical marker on your power bar indicating the primary boss's health percentage.",
+              disabled = powerOff,
+              disabledTooltip = powerDisTip,
+              getValue = function() local c = cfg(); return c and c.bossPacingEnabled == true end,
+              setValue = function(v)
+                  local c = cfg(); if not c then return end
+                  c.bossPacingEnabled = v and true or false
+                  RebuildPower()
+              end },
+            { type = "label", text = "" }
+        );  y = y - h
         end   -- close Power Bar hidden-while-disabled gate
 
         -- Synced overlay covers the built content so the height stays constant

--- a/EllesmereUIOptions/EUI_UnitFrames_Options.lua
+++ b/EllesmereUIOptions/EUI_UnitFrames_Options.lua
@@ -1615,6 +1615,13 @@ initFrame:SetScript("OnEvent", function(self)
             ppPreviewFS = ppOvr:CreateFontString(nil, "OVERLAY")
             SetPVFont(ppPreviewFS, PREVIEW_FONT, 9)
             ppPreviewFS:Hide()
+
+            -- Boss Health Marker spark preview
+            local bossSpark = power:CreateTexture(nil, "OVERLAY", nil, 7)
+            bossSpark:SetColorTexture(1, 0.25, 0.25, 0.95)
+            bossSpark:SetSize(2, powerH > 0 and powerH or 6)
+            bossSpark:Hide()
+            pf._bossSpark = bossSpark
         end
 
         -- Bar texture: applied to the fill textures directly (preview uses plain Frames, not StatusBars)
@@ -2730,6 +2737,24 @@ initFrame:SetScript("OnEvent", function(self)
                         pf._powerFill:SetPoint("BOTTOMLEFT", power, "BOTTOMLEFT", 0, 0)
                     end
                     PP.Width(pf._powerFill, math.floor(pvPw * (_previewPowerPct or 0.85) + 0.5))
+                end
+
+                if pf._bossSpark then
+                    local showSpark = (unitKey == "player") and (s.bossPacingEnabled == true) and (pvPpPos ~= "none") and (ph > 0)
+                    if showSpark then
+                        local sparkPct = 0.65
+                        local sparkX = math.floor(pvPw * sparkPct + 0.5)
+                        pf._bossSpark:SetSize(2, ph)
+                        pf._bossSpark:ClearAllPoints()
+                        if s.powerReverseFill then
+                            pf._bossSpark:SetPoint("CENTER", power, "RIGHT", -sparkX, 0)
+                        else
+                            pf._bossSpark:SetPoint("CENTER", power, "LEFT", sparkX, 0)
+                        end
+                        pf._bossSpark:Show()
+                    else
+                        pf._bossSpark:Hide()
+                    end
                 end
 
                 -- Power bar opacity: the fill's region alpha is set AFTER PV_FillColor
@@ -7939,12 +7964,9 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.RegisterWidgetRefresh(function() updatePBSwatch() end)
         end
 
-        -- Row 6: Power Type override (player-only, spec-dependent)
+        -- Row 6: Boss Health Marker (Left) + Power Type override (Right, player-only, spec-dependent)
         do
             local _, playerClass = UnitClass("player")
-            -- Specs that offer an alternative power type on the player power bar.
-            -- { defaultLabel, altLabel, altPowerType (Enum.PowerType value to force) }
-            -- For Shadow Priest the alt is "no override" (nil) so UnitPowerType returns Insanity.
             local SPEC_POWER_ALTS = {
                 DRUID  = {
                     [1] = { "Astral Power", "Mana",     0 },   -- Balance
@@ -7959,62 +7981,84 @@ initFrame:SetScript("OnEvent", function(self)
                 },
             }
             local classAlts = SPEC_POWER_ALTS[playerClass]
-            if classAlts then
-                local spec = GetSpecialization and GetSpecialization()
-                local data = spec and classAlts[spec]
-                local ptValues = {}
-                local ptOrder  = { "default", "alt" }
-                if data then
-                    ptValues["default"] = data[1]
-                    ptValues["alt"]     = data[2]
-                end
-
-                local sharedPowerRow5
-                sharedPowerRow5, h = W:DualRow(parent, y,
-                    { type="dropdown", text="Power Type",
-                      values = ptValues, order = ptOrder,
-                      -- Stored by SPEC ID, not the GetSpecialization() index: one
-                      -- profile holds one set, so an index key collides across
-                      -- classes (slot 3 is Guardian, Shadow AND Augmentation).
-                      -- classAlts stays index-keyed, it is already per class.
-                      getValue = function()
-                          local s = GetSpecialization and GetSpecialization()
-                          if not s or not classAlts[s] then return "default" end
-                          local sid = C_SpecializationInfo
-                              and C_SpecializationInfo.GetSpecializationInfo(s)
-                          if not sid then return "default" end
-                          local ov = UNIT_DB_MAP["player"]().powerTypeOverride
-                          if ov and ov[sid] then return "alt" end
-                          return "default"
-                      end,
-                      setValue = function(v)
-                          local s = GetSpecialization and GetSpecialization()
-                          if not s then return end
-                          local sid = C_SpecializationInfo
-                              and C_SpecializationInfo.GetSpecializationInfo(s)
-                          if not sid then return end
-                          local pdb = UNIT_DB_MAP["player"]()
-                          if v == "alt" then
-                              if not pdb.powerTypeOverride then pdb.powerTypeOverride = {} end
-                              pdb.powerTypeOverride[sid] = true
-                          else
-                              if pdb.powerTypeOverride then pdb.powerTypeOverride[sid] = nil end
-                          end
-                          ReloadAndUpdate()
-                      end },
-                    { type="label", text="" }); y = y - h
-
-                local function UpdatePowerTypeRow()
-                    local s = GetSpecialization and GetSpecialization()
-                    if selectedUnit == "player" and s and classAlts[s] then
-                        sharedPowerRow5:Show()
-                    else
-                        sharedPowerRow5:Hide()
-                    end
-                end
-                RegisterWidgetRefresh(UpdatePowerTypeRow)
-                UpdatePowerTypeRow()
+            local ptValues = {}
+            local ptOrder  = { "default", "alt" }
+            local spec = GetSpecialization and GetSpecialization()
+            local initData = classAlts and spec and classAlts[spec]
+            if initData then
+                ptValues["default"] = initData[1]
+                ptValues["alt"]     = initData[2]
+            else
+                ptValues["default"] = "Default"
+                ptValues["alt"]     = "Alternate"
             end
+
+            local sharedPowerRow5
+            sharedPowerRow5, h = W:DualRow(parent, y,
+                { type = "toggle", text = "Boss Health Marker",
+                  tooltip = "Shows a vertical marker on your power bar indicating the primary boss's health percentage.",
+                  getValue = function() return SVal("bossPacingEnabled", false) end,
+                  setValue = function(v)
+                      SSet("bossPacingEnabled", v)
+                      ReloadAndUpdate()
+                  end },
+                { type = "dropdown", text = "Power Type",
+                  values = ptValues,
+                  order = ptOrder,
+                  disabled = function()
+                      local s = GetSpecialization and GetSpecialization()
+                      return not (classAlts and s and classAlts[s])
+                  end,
+                  disabledTooltip = function()
+                      return "No alternate power type for the current specialization."
+                  end,
+                  getValue = function()
+                      local s = GetSpecialization and GetSpecialization()
+                      if not s or not classAlts or not classAlts[s] then return "default" end
+                      local sid = C_SpecializationInfo and C_SpecializationInfo.GetSpecializationInfo(s)
+                      if not sid then return "default" end
+                      local ov = UNIT_DB_MAP["player"]().powerTypeOverride
+                      if ov and ov[sid] then return "alt" end
+                      return "default"
+                  end,
+                  setValue = function(v)
+                      local s = GetSpecialization and GetSpecialization()
+                      if not s then return end
+                      local sid = C_SpecializationInfo and C_SpecializationInfo.GetSpecializationInfo(s)
+                      if not sid then return end
+                      local pdb = UNIT_DB_MAP["player"]()
+                      if v == "alt" then
+                          if not pdb.powerTypeOverride then pdb.powerTypeOverride = {} end
+                          pdb.powerTypeOverride[sid] = true
+                      else
+                          if pdb.powerTypeOverride then pdb.powerTypeOverride[sid] = nil end
+                      end
+                      ReloadAndUpdate()
+                  end }
+            ); y = y - h
+
+            local function UpdatePowerRow5()
+                if selectedUnit == "player" then
+                    sharedPowerRow5:Show()
+                    local s = GetSpecialization and GetSpecialization()
+                    local d = classAlts and s and classAlts[s]
+                    if d then
+                        ptValues["default"] = d[1]
+                        ptValues["alt"]     = d[2]
+                    end
+                    if sharedPowerRow5._rightRegion then
+                        if d then
+                            sharedPowerRow5._rightRegion:Show()
+                        else
+                            sharedPowerRow5._rightRegion:Hide()
+                        end
+                    end
+                else
+                    sharedPowerRow5:Hide()
+                end
+            end
+            RegisterWidgetRefresh(UpdatePowerRow5)
+            UpdatePowerRow5()
         end
 
         _, h = W:Spacer(parent, y, 20); y = y - h

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -79,15 +79,6 @@ end
 
 local floor, ceil, abs, min, max = math.floor, math.ceil, math.abs, math.min, math.max
 local format = string.format
-local UnitHealth, UnitHealthMax = UnitHealth, UnitHealthMax
-local UnitPower, UnitPowerMax = UnitPower, UnitPowerMax
-local UnitClass = UnitClass
-local GetSpecialization = GetSpecialization
-local InCombatLockdown = InCombatLockdown
-local GetShapeshiftFormID = GetShapeshiftFormID
-local IsPlayerSpell = IsPlayerSpell
-local UnitSpellHaste = UnitSpellHaste
-local GetInventoryItemID = GetInventoryItemID
 
 -------------------------------------------------------------------------------
 --  Constants
@@ -1197,6 +1188,7 @@ local DEFAULTS = {
             hashWidth   = 1,
             hashColorR  = 1, hashColorG = 1, hashColorB = 1, hashColorA = 0.7,
             expandIfNoResource = false,
+            bossPacingEnabled = false,
             -- Shift elements anchored to the power bar when the spec has no primary
             -- power (e.g. BM/MM Hunter, Focus shows as class resource). "None"/"Up"/
             -- "Down", visual-only.
@@ -3879,6 +3871,8 @@ local function BuildBars()
         end
     end
 
+    ns.UpdateBossPacingEventRegistration()
+
     ReapplyInternalBarAnchors()
 
     -- "Shift Elements if No Resource": re-cascade the class resource bar so
@@ -4065,6 +4059,98 @@ local function UpdateHealthBar()
         healthBar._text:Show()
     else
         healthBar._text:Hide()
+    end
+end
+
+-------------------------------------------------------------------------------
+--  Boss Health Pacing Spark (Power / Mana Bar)
+-------------------------------------------------------------------------------
+do
+    local _bossPacingFrame = nil
+
+    function ns.UpdateBossPacing()
+        local pp = _G._ERB_ResolvePowerCfg()
+        if not pp or not pp.bossPacingEnabled or not primaryBar or not primaryBar:IsShown() then
+            if primaryBar and primaryBar._bossPacingBar then
+                primaryBar._bossPacingBar:Hide()
+            end
+            return
+        end
+
+        if not UnitExists("boss1") or UnitIsDead("boss1") then
+            if primaryBar._bossPacingBar then
+                primaryBar._bossPacingBar:Hide()
+            end
+            return
+        end
+
+        local bp = primaryBar._bossPacingBar
+        if not bp then
+            bp = CreateFrame("StatusBar", "ERB_BossPacingBar", primaryBar)
+            bp:SetAllPoints(primaryBar)
+            bp:SetFrameLevel(primaryBar:GetFrameLevel() + 6)
+            bp:SetStatusBarTexture("Interface\\BUTTONS\\WHITE8X8")
+            local tex = bp:GetStatusBarTexture()
+            if tex then
+                tex:SetColorTexture(0, 0, 0, 0)
+            end
+
+            local spark = bp:CreateTexture(nil, "OVERLAY", nil, 7)
+            spark:SetColorTexture(1, 0.25, 0.25, 0.95)
+            spark:SetSize(2, primaryBar:GetHeight() or 14)
+            spark:SetPoint("CENTER", bp:GetStatusBarTexture(), "RIGHT", 0, 0)
+            bp._spark = spark
+
+            primaryBar._bossPacingBar = bp
+        end
+
+        local gOri = ERB.db and ERB.db.profile and ERB.db.profile.general and ERB.db.profile.general.orientation
+        local ppOri = pp.orientation or gOri or "HORIZONTAL"
+        if ppOri == "HORIZONTAL" then
+            bp:SetOrientation("HORIZONTAL")
+            bp._spark:SetSize(2, primaryBar:GetHeight() or 14)
+            bp._spark:ClearAllPoints()
+            bp._spark:SetPoint("CENTER", bp:GetStatusBarTexture(), "RIGHT", 0, 0)
+        else
+            bp:SetOrientation(ppOri == "VERTICAL_DOWN" and "VERTICAL_DOWN" or "VERTICAL")
+            bp._spark:SetSize(primaryBar:GetWidth() or 214, 2)
+            bp._spark:ClearAllPoints()
+            bp._spark:SetPoint("CENTER", bp:GetStatusBarTexture(), ppOri == "VERTICAL_DOWN" and "BOTTOM" or "TOP", 0, 0)
+        end
+
+        bp:SetMinMaxValues(0, UnitHealthMax("boss1"))
+        bp:SetValue(UnitHealth("boss1"))
+        bp:Show()
+    end
+
+    function ns.UpdateBossPacingEventRegistration()
+        local pp = _G._ERB_ResolvePowerCfg()
+        local enabled = pp and (pp.bossPacingEnabled == true)
+        if enabled then
+            if not _bossPacingFrame then
+                _bossPacingFrame = CreateFrame("Frame")
+                _bossPacingFrame:SetScript("OnEvent", function(self, event, unit)
+                    if event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" then
+                        if unit == "boss1" then ns.UpdateBossPacing() end
+                    else
+                        ns.UpdateBossPacing()
+                    end
+                end)
+            end
+            _bossPacingFrame:RegisterUnitEvent("UNIT_HEALTH", "boss1")
+            _bossPacingFrame:RegisterUnitEvent("UNIT_MAXHEALTH", "boss1")
+            _bossPacingFrame:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
+            _bossPacingFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
+            _bossPacingFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+            ns.UpdateBossPacing()
+        else
+            if _bossPacingFrame then
+                _bossPacingFrame:UnregisterAllEvents()
+            end
+            if primaryBar and primaryBar._bossPacingBar then
+                primaryBar._bossPacingBar:Hide()
+            end
+        end
     end
 end
 
@@ -6217,8 +6303,12 @@ local function UpdateVisibility()
             primaryBar:Show()
             EllesmereUI.SetElementVisibility(primaryBar, true)
             primaryBar:SetAlpha(ns.ResolveBarAlpha(pp))
+            ns.UpdateBossPacing()
         else
             EllesmereUI.SetElementVisibility(primaryBar, false)
+            if primaryBar._bossPacingBar then
+                primaryBar._bossPacingBar:Hide()
+            end
         end
     end
 

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -250,6 +250,7 @@ local defaults = {
             powerPercentPowerColor = true,
             powerBgPowerColored = false,
             powerPercentTextPowerColor = false,
+            bossPacingEnabled = false,
             healthClassColored = true,
             customBgColor = { r = 0.067, g = 0.067, b = 0.067 },
             bgClassColored = false,
@@ -5681,6 +5682,95 @@ local function CreatePowerBar(frame, unit, settings)
     return power
 end
 
+-------------------------------------------------------------------------------
+--  Player Power Bar: Boss Health Pacing Marker
+-------------------------------------------------------------------------------
+do
+    local _ufBossPacingFrame = nil
+
+    function ns.UpdatePlayerBossPacing()
+        local pf = frames and frames.player
+        local power = pf and pf.Power
+        local pCfg = db and db.profile and db.profile.player
+        if not pCfg or not pCfg.bossPacingEnabled or not power or not power:IsShown() then
+            if power and power._bossPacingBar then
+                power._bossPacingBar:Hide()
+            end
+            return
+        end
+
+        if not UnitExists("boss1") or UnitIsDead("boss1") then
+            if power._bossPacingBar then
+                power._bossPacingBar:Hide()
+            end
+            return
+        end
+
+        local bp = power._bossPacingBar
+        if not bp then
+            bp = CreateFrame("StatusBar", "EUF_PlayerBossPacingBar", power)
+            bp:SetAllPoints(power)
+            bp:SetFrameLevel(power:GetFrameLevel() + 6)
+            bp:SetStatusBarTexture("Interface\\BUTTONS\\WHITE8X8")
+            local tex = bp:GetStatusBarTexture()
+            if tex then
+                tex:SetColorTexture(0, 0, 0, 0)
+            end
+
+            local spark = bp:CreateTexture(nil, "OVERLAY", nil, 7)
+            spark:SetColorTexture(1, 0.25, 0.25, 0.95)
+            spark:SetSize(2, power:GetHeight() or 6)
+            spark:SetPoint("CENTER", bp:GetStatusBarTexture(), "RIGHT", 0, 0)
+            bp._spark = spark
+
+            power._bossPacingBar = bp
+        end
+
+        bp:SetReverseFill(power:GetReverseFill() and true or false)
+        bp:SetOrientation(power:GetOrientation() or "HORIZONTAL")
+        if bp._spark then
+            bp._spark:SetSize(2, power:GetHeight() or 6)
+            bp._spark:ClearAllPoints()
+            bp._spark:SetPoint("CENTER", bp:GetStatusBarTexture(), "RIGHT", 0, 0)
+        end
+
+        bp:SetMinMaxValues(0, UnitHealthMax("boss1"))
+        bp:SetValue(UnitHealth("boss1"))
+        bp:Show()
+    end
+
+    function ns.UpdatePlayerBossPacingEventRegistration()
+        local pCfg = db and db.profile and db.profile.player
+        local enabled = pCfg and (pCfg.bossPacingEnabled == true)
+        if enabled then
+            if not _ufBossPacingFrame then
+                _ufBossPacingFrame = CreateFrame("Frame")
+                _ufBossPacingFrame:SetScript("OnEvent", function(self, event, unit)
+                    if event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" then
+                        if unit == "boss1" then ns.UpdatePlayerBossPacing() end
+                    else
+                        ns.UpdatePlayerBossPacing()
+                    end
+                end)
+            end
+            _ufBossPacingFrame:RegisterUnitEvent("UNIT_HEALTH", "boss1")
+            _ufBossPacingFrame:RegisterUnitEvent("UNIT_MAXHEALTH", "boss1")
+            _ufBossPacingFrame:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
+            _ufBossPacingFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
+            _ufBossPacingFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+            ns.UpdatePlayerBossPacing()
+        else
+            if _ufBossPacingFrame then
+                _ufBossPacingFrame:UnregisterAllEvents()
+            end
+            local pf = frames and frames.player
+            if pf and pf.Power and pf.Power._bossPacingBar then
+                pf.Power._bossPacingBar:Hide()
+            end
+        end
+    end
+end
+
 local function CreatePortrait(frame, side, frameHeight, unit)
     local portraitHeight = frameHeight or 46
     local uKey = UnitToSettingsKey(unit)
@@ -11105,6 +11195,8 @@ local function UnitFrame_OnEnter(self)
             end)
         end
     end
+
+    ns.UpdatePlayerBossPacingEventRegistration()
 end
 
 local function UnitFrame_OnLeave(self)


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in **Boss Health Marker** toggle (`bossPacingEnabled`) to the Player Power Bar in both **Unit Frames** (`Unit Frames > Main Frames > Power Bar`) and **Resource Bars** (`Resource Bars > Primary Bar`).

During boss encounters, this renders a subtle 2px vertical sparkline on the player's power bar that aligns with `boss1` current health percentage, assisting healers and DPS with resource and mana pacing against boss phases.

Key highlights:
- **Zero Cost / Opt-In**: Setting defaults to `false` across both modules.
- **Strict Lazy Event Handling**: Event frames (`UNIT_HEALTH`, `UNIT_MAXHEALTH` for `boss1`, `INSTANCE_ENCOUNTER_ENGAGE_UNIT`, `PLAYER_REGEN_DISABLED/ENABLED`) are only registered when `bossPacingEnabled == true`.
- **Zero Taint / Secret Value Safe**: The sparkline is parented to a 0-alpha `StatusBar` tracking `UnitHealth("boss1")`, using native UI frame alignment without running Lua math on protected combat values.
- **Live Settings Preview**: In `EUI_UnitFrames_Options.lua`, toggling the checkbox renders a live sparkline preview directly on the unit frame preview bar at the top of the settings page.
- **Clean 2-Slot Layout**: Paired cleanly with the specialization-dependent **Power Type** override in a unified DualRow with zero layout shift or vertical gutters.
- **Local Chunk Compliance**: Wrapped in a scoped `do ... end` block to respect Lua 5.1's 200 local variable limit.

## How was it tested?

- Tested on retail client build 12.1.0.69587.
- Verified toggle defaults to OFF and produces 0 overhead when disabled.
- Tested during boss encounters in raid/dungeon; confirmed spark tracks boss health smoothly and hides outside of boss encounters.
- Tested live settings preview in UnitFrames options pane.

## Screenshots

| Type | Setting | Live |
|---|---|---|
| Unitframe | <img width="1410" height="828" alt="boss_pacing_unit_setting" src="https://github.com/user-attachments/assets/2711338f-1a86-46dc-9389-ae1000bea4e2" /> | <img width="420" height="190" alt="boss_pacing_unit_live" src="https://github.com/user-attachments/assets/c313a740-18d4-4815-bb6a-7ff89f594921" /> |
| Resource Bar | <img width="1212" height="626" alt="boss_pacing_bar_setting" src="https://github.com/user-attachments/assets/e7609f3f-d0a8-4f1d-b97c-d04782422bbf" /> | <img width="424" height="135" alt="boss_pacing_bar_live" src="https://github.com/user-attachments/assets/254e09b4-da42-4a8d-af6e-75515e2a373f" /> |

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added