### PR TITLE
Fix: Mistweaver Monk shows wrong power bar color after zoning

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2310,6 +2310,7 @@ _G._EUI_ResolvedPowerType = _G._EUI_ResolvedPowerType or {}
 
 local PLAYER_POWER_DEFAULT = {
     PRIEST = { [3] = 0 },   -- Shadow: default to Mana
+    MONK   = { [2] = 0 },   -- Mistweaver: default to Mana
 }
 local PLAYER_POWER_ALT = {
     DRUID  = { [1] = 0, [2] = 0, [3] = 0 },  -- Balance/Feral/Guardian -> Mana


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1544377339981594805

Issue: PLAYER_POWER_DEFAULT in EllesmereUIUnitFrames.lua overrides which power type a player-frame power bar defaults to for specs whose class has multiple power types, so it doesn't rely on a raw UnitPowerType() read that can transiently report the wrong type right after a zone transition, before spec-power resync settles. Priest (Shadow), Druid, and Shaman already had this override; Monk was missing it, so Mistweaver could briefly show the wrong power bar color (e.g. Energy) after zoning through an instance, delve, or portal.
Fix: added MONK = { [2] = 0 } (Mistweaver -> Mana) to PLAYER_POWER_DEFAULT, matching the existing entries for the other affected classes.