### PR TITLE
Fix: Demonic Gateway unusable in combat with Disable Right Click Targeting on

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -2942,7 +2942,14 @@ do
                 macro = macro .. (inInstance and "[@mouseover,harm,nodead]1;"
                     or "[@mouseover,harm,nodead,combat]1;")
             end
-            if allyCombat then macro = macro .. "[@mouseover,help,nodead,combat]1;" end
+            -- "group" restricts the match to actual party/raid members -- this
+            -- feature exists to stop a stray right-click from targeting/
+            -- interacting with an ally UNIT FRAME during combat, but plain
+            -- [help] also matches any friendly-classified summoned object
+            -- (e.g. a Warlock's Demonic Gateway), which blocked right-clicking
+            -- the gateway itself to use it. A gateway is never a group member,
+            -- so this excludes it while leaving the party/raid protection intact.
+            if allyCombat then macro = macro .. "[@mouseover,help,group,nodead,combat]1;" end
             macro = macro .. "0"
             SecureStateDriverManager:RegisterEvent("UPDATE_MOUSEOVER_UNIT")
             -- [combat] arms re-evaluate on combat edges even when the mouseover


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1543319249131536635

Issue: QoL's "Disable Right Click Targeting" (Ally in Combat) option builds a secure macro conditional, [@mouseover,help,nodead,combat], fed to a SecureHandlerStateTemplate's RegisterStateDriver to rebind right-click to mouselook while hovering any friendly-classified unit in combat. A Warlock's Demonic Gateway also satisfies plain [help] (it's a friendly-classified summoned object), so right-clicking it to use it -- or using it via the Gateway Control Shard, which resolves through the same click -- got swallowed by the same block meant for party/raid frames. The bound Interact keybind bypassed it entirely (a different code path), which is why that always worked.
Fix: added the group qualifier -- [@mouseover,help,group,nodead,combat] -- restricting the match to actual party/raid members. A summoned Gateway is never a group member, so this excludes it while leaving the feature's real intent (stop a stray right-click from targeting/interacting with an ally unit frame mid-fight) fully intact.