### PR TITLE
Feature(Damage Meters): Add hotkey keybind to hide every meter window at once

### DIFF
--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -132,6 +132,11 @@ local DM_DEFAULTS = {
             standaloneTimerDesatOOC = false,
             refreshRate = 1,
             hideResetButton = false, -- display the "reset data" button on the damage meter header
+            -- Hotkey that hides/shows every meter window at once. Runtime only:
+            -- the hidden state is never saved, so a reload restores the configured visibility.
+            toggleWindowsKey          = nil,
+            toggleIncludeTimer        = false, -- also toggle the standalone combat timer
+            toggleIncludeSpellHistory = false, -- also toggle the spell history icon strip and bar window
             hdrBgColor      = { r = 0x1B/255, g = 0x1B/255, b = 0x1B/255 },
             hdrBgAlpha      = 1,
             hdrBottomBorderSize = 0,
@@ -440,6 +445,13 @@ local _inEncounter = false       -- true between ENCOUNTER_START and ENCOUNTER_E
 local _playerGUID
 local _windows = {}  -- array of active window tables
 ns._windows = _windows
+
+-- Hotkey toggle state. Deliberately not persisted: a window hidden by accident would
+-- otherwise stay gone after a reload with nothing on screen explaining why. Every place
+-- that can show one of the toggled frames consults this flag, because the shared
+-- visibility dispatcher, the standalone timer ticker and the spell history rebuild all
+-- re-show their frames on their own schedule. Options mode and unlock mode still win.
+ns._toggleHidden = false
 
 -- Bumped whenever a build of the windows starts or _EDM_Apply() supersedes one. The
 -- login build is staggered across frames, so a rebuild arriving while it is still in
@@ -4393,6 +4405,8 @@ local function CreateDMWindow(winIdx)
         if not frame then return end
         local c = DB()
         if EUI._unlockActive or ns._optionsOpen then frame:SetAlpha(1); frame:EnableMouse(true); frame:Show(); return end
+        -- Hotkey toggle outranks every configured rule but yields to the two modes above
+        if ns._toggleHidden then frame:Hide(); return end
         local vis = EUI.EvalVisibility and EUI.EvalVisibility(c)
         if not vis or vis == false then frame:Hide(); return end
         -- Per-window instance visibility
@@ -4410,6 +4424,9 @@ local function CreateDMWindow(winIdx)
     if EUI.RegisterMouseoverTarget then
         -- Hover-gated sets only reveal while their conditions pass; a legacy single "mouseover" behaves exactly as before
         EUI.RegisterMouseoverTarget(frame, function()
+            -- The mouseover scanner shows the frame without going through UpdateVisibility,
+            -- so the toggle has to be refused here as well
+            if ns._toggleHidden then return false end
             local c = DB()
             return c ~= nil and EUI.VisWantsMouseover(c, "visibility")
         end)
@@ -4757,6 +4774,13 @@ UpdateSATimerText = function()
     if not _saTimer or not _saTimerFS then return end
     local cfg = DB()
     if not cfg.standaloneTimer then return end
+    -- The timer runs on its own ticker and re-shows itself every 0.1s, so the hotkey
+    -- toggle has to be checked here rather than hiding the frame from the outside
+    if ns._toggleHidden and cfg.toggleIncludeTimer and not ns._optionsOpen
+       and not EUI._unlockActive and not _saTimerPreview then
+        if _saTimer:IsShown() then _saTimer:Hide() end
+        return
+    end
     -- Same source as the window's Current timer so the two can never disagree. Visible while
     -- combat is live (or polling a group fight we're not in); out of combat it hides unless Show Out of Combat keeps it up (last fight's frozen duration).
     local live = _inCombat or _needsFinalRefresh
@@ -4952,6 +4976,51 @@ ns.HideSATimerPreview = function()
         return
     end
     if not _inCombat then _saTimer:Hide() end
+end
+
+-------------------------------------------------------------------------------
+--  Show/hide all windows hotkey
+-------------------------------------------------------------------------------
+
+-- Re-applies the current toggle state to every frame it covers. Also used by the
+-- options page when the Combat Timer / Spell History checkboxes change while the
+-- toggle is already active, so the newly included element follows immediately.
+ns.ApplyDMToggleState = function()
+    -- The row tooltip is parented to UIParent, not to the window, so it would be
+    -- left floating if the hotkey is pressed while hovering a row
+    if ns._toggleHidden and _ttFrame then _ttFrame:Hide() end
+    for _, w in ipairs(_windows) do w.UpdateVisibility() end
+    if _saTimer then UpdateSATimerText() end
+    if ns.ApplySpellHistory then ns.ApplySpellHistory() end
+end
+
+ns.ToggleDMWindows = function()
+    ns._toggleHidden = not ns._toggleHidden
+    ns.ApplyDMToggleState()
+end
+
+-- Override bindings are protected, so a rebind during combat has to wait for regen;
+-- pressing the key itself is a hardware click and works in combat.
+ns.ApplyDMToggleKeybind = function()
+    local btn = _G.EllesmereUIDMToggleBindBtn
+    if not btn then return end
+    if InCombatLockdown() then
+        if not ns._toggleBindPending then
+            ns._toggleBindPending = CreateFrame("Frame")
+            ns._toggleBindPending:SetScript("OnEvent", function(self)
+                self:UnregisterAllEvents()
+                ns.ApplyDMToggleKeybind()
+            end)
+        end
+        ns._toggleBindPending:RegisterEvent("PLAYER_REGEN_ENABLED")
+        return
+    end
+    if ns._toggleBindPending then ns._toggleBindPending:UnregisterAllEvents() end
+    ClearOverrideBindings(btn)
+    local key = DB().toggleWindowsKey
+    if key and key ~= "" then
+        SetOverrideBindingClick(btn, true, key, "EllesmereUIDMToggleBindBtn")
+    end
 end
 
 -- Accent color callback for standalone timer
@@ -5312,6 +5381,15 @@ if not _G["EllesmereUIDMResetBindBtn"] then
     end)
 end
 
+-- Show/hide all windows keybind button (hidden, receives override binding click)
+if not _G["EllesmereUIDMToggleBindBtn"] then
+    local btn = CreateFrame("Button", "EllesmereUIDMToggleBindBtn", UIParent)
+    btn:Hide()
+    btn:SetScript("OnClick", function()
+        if ns.ToggleDMWindows then ns.ToggleDMWindows() end
+    end)
+end
+
 -- Init
 local initFrame = CreateFrame("Frame")
 initFrame:RegisterEvent("PLAYER_LOGIN")
@@ -5337,6 +5415,9 @@ initFrame:SetScript("OnEvent", function(self)
     if cfg.resetDataKey and _G.EllesmereUIDMResetBindBtn then
         SetOverrideBindingClick(_G.EllesmereUIDMResetBindBtn, true, cfg.resetDataKey, "EllesmereUIDMResetBindBtn")
     end
+
+    -- Restore show/hide all windows keybind
+    ns.ApplyDMToggleKeybind()
 
     -- Defer window creation off the login frame to avoid blocking
     local cfg = DB()
@@ -5398,6 +5479,10 @@ initFrame:SetScript("OnEvent", function(self)
                 SetOverrideBindingClick(_G.EllesmereUIDMResetBindBtn, true, c.resetDataKey, "EllesmereUIDMResetBindBtn")
             end
         end
+        -- Clear the hotkey toggle so a profile swap never lands in a hidden state whose
+        -- cause is no longer visible, then bind the new profile's key
+        ns._toggleHidden = false
+        ns.ApplyDMToggleKeybind()
         -- Recreate windows from new profile
         if not c.windows then c.windows = {} end
         local wc = math.max(1, c.windowCount or 1)

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -132,9 +132,9 @@ local DM_DEFAULTS = {
             standaloneTimerDesatOOC = false,
             refreshRate = 1,
             hideResetButton = false, -- display the "reset data" button on the damage meter header
-            -- Hotkey that hides/shows every meter window at once. Runtime only:
-            -- the hidden state is never saved, so a reload restores the configured visibility.
-            toggleWindowsKey          = nil,
+            -- toggleWindowsKey (unset by default) is the hotkey that hides/shows every
+            -- meter window at once. Runtime only: the hidden state is never saved, so a
+            -- reload restores the configured visibility.
             toggleIncludeTimer        = false, -- also toggle the standalone combat timer
             toggleIncludeSpellHistory = false, -- also toggle the spell history icon strip and bar window
             hdrBgColor      = { r = 0x1B/255, g = 0x1B/255, b = 0x1B/255 },
@@ -4985,42 +4985,70 @@ end
 -- Re-applies the current toggle state to every frame it covers. Also used by the
 -- options page when the Combat Timer / Spell History checkboxes change while the
 -- toggle is already active, so the newly included element follows immediately.
-ns.ApplyDMToggleState = function()
+-- includeSpellHistory is read here rather than inside ApplySpellHistory because that
+-- entry point rebuilds the icon strip and the bar window unconditionally; with the
+-- default (Spell History not covered) the hotkey would pay both rebuilds per press.
+ns.ApplyDMToggleState = function(includeSpellHistory)
     -- The row tooltip is parented to UIParent, not to the window, so it would be
     -- left floating if the hotkey is pressed while hovering a row
     if ns._toggleHidden and _ttFrame then _ttFrame:Hide() end
     for _, w in ipairs(_windows) do w.UpdateVisibility() end
     if _saTimer then UpdateSATimerText() end
-    if ns.ApplySpellHistory then ns.ApplySpellHistory() end
+    if includeSpellHistory == nil then includeSpellHistory = DB().toggleIncludeSpellHistory end
+    if includeSpellHistory and ns.ApplySpellHistory then ns.ApplySpellHistory() end
 end
 
 ns.ToggleDMWindows = function()
     ns._toggleHidden = not ns._toggleHidden
     ns.ApplyDMToggleState()
+    -- The mouseover scan caches each target's isActive answer per visibility
+    -- generation, so without a bump it keeps the pre-toggle answer and re-shows a
+    -- hover-gated window on the next pass. Deferred by a frame the way the
+    -- dispatcher defers its own events: this runs from a hardware keypress, and
+    -- other modules' updaters have no business running in that context.
+    if EUI.RequestVisibilityUpdate then C_Timer.After(0, EUI.RequestVisibilityUpdate) end
 end
 
--- Override bindings are protected, so a rebind during combat has to wait for regen;
--- pressing the key itself is a hardware click and works in combat.
-ns.ApplyDMToggleKeybind = function()
-    local btn = _G.EllesmereUIDMToggleBindBtn
-    if not btn then return end
-    if InCombatLockdown() then
-        if not ns._toggleBindPending then
-            ns._toggleBindPending = CreateFrame("Frame")
-            ns._toggleBindPending:SetScript("OnEvent", function(self)
-                self:UnregisterAllEvents()
-                ns.ApplyDMToggleKeybind()
-            end)
+-- Both damage meter hotkeys live on override bindings, which are protected: a rebind
+-- during combat has to wait for regen (pressing the key itself is a hardware click and
+-- works in combat). UPDATE_BINDINGS matters too -- LoadBindings, which the settings
+-- panel runs on cancel and on a binding-set switch, drops every override, so a
+-- configured key would otherwise stay dead until the next profile change. Our own
+-- writes raise that event as well, hence the short self-write window.
+do
+    local kbFrame = CreateFrame("Frame")
+    local selfWriteUntil = 0
+
+    ns.ApplyDMKeybinds = function()
+        if InCombatLockdown() then
+            kbFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+            return
         end
-        ns._toggleBindPending:RegisterEvent("PLAYER_REGEN_ENABLED")
-        return
+        kbFrame:UnregisterEvent("PLAYER_REGEN_ENABLED")
+        local c = DB()
+        selfWriteUntil = GetTime() + 0.5
+        local resetBtn = _G.EllesmereUIDMResetBindBtn
+        if resetBtn then
+            ClearOverrideBindings(resetBtn)
+            if c.resetDataKey and c.resetDataKey ~= "" then
+                SetOverrideBindingClick(resetBtn, true, c.resetDataKey, "EllesmereUIDMResetBindBtn")
+            end
+        end
+        local toggleBtn = _G.EllesmereUIDMToggleBindBtn
+        if toggleBtn then
+            ClearOverrideBindings(toggleBtn)
+            if c.toggleWindowsKey and c.toggleWindowsKey ~= "" then
+                SetOverrideBindingClick(toggleBtn, true, c.toggleWindowsKey, "EllesmereUIDMToggleBindBtn")
+            end
+        end
     end
-    if ns._toggleBindPending then ns._toggleBindPending:UnregisterAllEvents() end
-    ClearOverrideBindings(btn)
-    local key = DB().toggleWindowsKey
-    if key and key ~= "" then
-        SetOverrideBindingClick(btn, true, key, "EllesmereUIDMToggleBindBtn")
-    end
+
+    kbFrame:RegisterEvent("UPDATE_BINDINGS")
+    kbFrame:SetScript("OnEvent", function(_, event)
+        -- Ours, echoing back: ignore, or we re-enter forever
+        if event == "UPDATE_BINDINGS" and GetTime() < selfWriteUntil then return end
+        ns.ApplyDMKeybinds()
+    end)
 end
 
 -- Accent color callback for standalone timer
@@ -5407,17 +5435,11 @@ initFrame:SetScript("OnEvent", function(self)
     -- Disable Blizzard's built-in damage meter UI; C_DamageMeter API still works
     SetCVarSafe("damageMeterEnabled", 0)
     AppendDMSharedMedia()
-    local cfg = DB()
 
     _playerGUID = UnitGUID("player")
 
-    -- Restore reset data keybind
-    if cfg.resetDataKey and _G.EllesmereUIDMResetBindBtn then
-        SetOverrideBindingClick(_G.EllesmereUIDMResetBindBtn, true, cfg.resetDataKey, "EllesmereUIDMResetBindBtn")
-    end
-
-    -- Restore show/hide all windows keybind
-    ns.ApplyDMToggleKeybind()
+    -- Restore the reset data and show/hide all windows keybinds
+    ns.ApplyDMKeybinds()
 
     -- Defer window creation off the login frame to avoid blocking
     local cfg = DB()
@@ -5471,18 +5493,11 @@ initFrame:SetScript("OnEvent", function(self)
         -- Hide tooltip
         if _ttFrame then _ttFrame:Hide() end
         _activeRow = nil
-        -- Re-apply keybind from new profile
         local c = DB()
-        if _G.EllesmereUIDMResetBindBtn then
-            ClearOverrideBindings(_G.EllesmereUIDMResetBindBtn)
-            if c.resetDataKey then
-                SetOverrideBindingClick(_G.EllesmereUIDMResetBindBtn, true, c.resetDataKey, "EllesmereUIDMResetBindBtn")
-            end
-        end
         -- Clear the hotkey toggle so a profile swap never lands in a hidden state whose
-        -- cause is no longer visible, then bind the new profile's key
+        -- cause is no longer visible, then re-apply both keybinds from the new profile
         ns._toggleHidden = false
-        ns.ApplyDMToggleKeybind()
+        ns.ApplyDMKeybinds()
         -- Recreate windows from new profile
         if not c.windows then c.windows = {} end
         local wc = math.max(1, c.windowCount or 1)

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters_SpellHistory.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters_SpellHistory.lua
@@ -455,6 +455,9 @@ end
 local function ShouldHide(hideInDungeon, hideInRaid, hideInDelve, hideInPvP, hideOutOfInstance)
     -- Always visible while configuring or positioning the element.
     if ns._optionsOpen or EUI._unlockActive then return false end
+    -- Show/hide all windows hotkey. Both displays rebuild themselves on every cast, so
+    -- the check belongs here rather than in a one-off hide from the main file.
+    if ns._toggleHidden and ns.EDM.DB().toggleIncludeSpellHistory then return true end
     local _, iType = IsInInstance()
     if hideInDungeon and iType == "party" then return true end
     if hideInRaid and iType == "raid" then return true end

--- a/EllesmereUIOptions/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIOptions/EUI_DamageMeters_Options.lua
@@ -28,6 +28,123 @@ initFrame:SetScript("OnEvent", function(self)
     -- All settings are picked up on the next refresh cycle (0.3s combat,
     -- 2s idle). Just Set() and go.
 
+    -- Shared capture button for both damage meter hotkeys (reset data, show/hide
+    -- windows). One copy so the chord capture cannot drift apart between the two
+    -- rows: Blizzard's own key conversion and ignore test, and
+    -- CreateKeyChordStringUsingMetaKeyState for the canonical ALT-CTRL-SHIFT order
+    -- (hand-rolled modifiers in any other order store a string the engine never
+    -- matches). Returns the button so the caller can anchor its cog to it.
+    local function MakeKeybindButton(rgn, dbKey, tooltip)
+        -- Own alias: this helper sits outside the page builders, where PP is a local
+        local PP = EllesmereUI.PP
+        local kbBtn = CreateFrame("Button", nil, rgn)
+        PP.Size(kbBtn, 120, 26)
+        PP.Point(kbBtn, "RIGHT", rgn, "RIGHT", -10, 0)
+        kbBtn:SetFrameLevel(rgn:GetFrameLevel() + 2)
+        kbBtn:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+        local kbBg = EllesmereUI.SolidTex(kbBtn, "BACKGROUND", EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
+        kbBg:SetAllPoints()
+        kbBtn._border = EllesmereUI.MakeBorder(kbBtn, 1, 1, 1, EllesmereUI.DD_BRD_A, EllesmereUI.PanelPP)
+        local kbLbl = EllesmereUI.MakeFont(kbBtn, 12, nil, 1, 1, 1)
+        kbLbl:SetAlpha(EllesmereUI.DD_TXT_A)
+        kbLbl:SetPoint("CENTER")
+
+        local function FormatKey(key)
+            if not key or key == "" then return EllesmereUI.L("Not Bound") end
+            local parts = {}
+            for mod in key:gmatch("(%u+)%-") do
+                parts[#parts + 1] = mod:sub(1, 1) .. mod:sub(2):lower()
+            end
+            local actualKey = key:match("[^%-]+$") or key
+            parts[#parts + 1] = actualKey
+            return table.concat(parts, " + ")
+        end
+        local function RefreshLabel() kbLbl:SetText(FormatKey(Cfg(dbKey))) end
+        RefreshLabel()
+
+        local listening = false
+
+        kbBtn:SetScript("OnClick", function(self, button)
+            if button == "RightButton" then
+                if listening then listening = false; self:EnableKeyboard(false) end
+                Set(dbKey, nil)
+                if ns.ApplyDMKeybinds then ns.ApplyDMKeybinds() end
+                RefreshLabel()
+                return
+            end
+            if listening then return end
+            listening = true
+            kbLbl:SetText(EllesmereUI.L("Press a key..."))
+            self:EnableKeyboard(true)
+        end)
+
+        kbBtn:SetScript("OnKeyDown", function(self, key)
+            if not listening then self:SetPropagateKeyboardInput(true); return end
+            -- Bare modifiers pass through so they can be held for the chord
+            if GetConvertedKeyOrButton then key = GetConvertedKeyOrButton(key) end
+            local ignore
+            if IsKeyPressIgnoredForBinding then
+                ignore = IsKeyPressIgnoredForBinding(key)
+            else
+                ignore = (key == "LSHIFT" or key == "RSHIFT"
+                    or key == "LCTRL" or key == "RCTRL"
+                    or key == "LALT" or key == "RALT"
+                    or key == "LMETA" or key == "RMETA"
+                    or key == "UNKNOWN")
+            end
+            if ignore then self:SetPropagateKeyboardInput(true); return end
+            self:SetPropagateKeyboardInput(false)
+            listening = false
+            self:EnableKeyboard(false)
+            if key ~= "ESCAPE" then
+                local fullKey
+                if CreateKeyChordStringUsingMetaKeyState then
+                    fullKey = CreateKeyChordStringUsingMetaKeyState(key)
+                else
+                    -- Mirror the helper's order exactly, META included: dropping it
+                    -- would store CMD+F as plain "F" and override the bare key
+                    local mods = ""
+                    if IsAltKeyDown() then mods = mods .. "ALT-" end
+                    if IsControlKeyDown() then mods = mods .. "CTRL-" end
+                    if IsShiftKeyDown() then mods = mods .. "SHIFT-" end
+                    if IsMetaKeyDown and IsMetaKeyDown() then mods = mods .. "META-" end
+                    fullKey = mods .. key
+                end
+                Set(dbKey, fullKey)
+                if ns.ApplyDMKeybinds then ns.ApplyDMKeybinds() end
+            end
+            RefreshLabel()
+        end)
+
+        kbBtn:SetScript("OnEnter", function(self)
+            kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_HA)
+            if kbBtn._border and kbBtn._border.SetColor then
+                kbBtn._border:SetColor(1, 1, 1, 0.3)
+            end
+            EllesmereUI.ShowWidgetTooltip(self, tooltip)
+        end)
+        kbBtn:SetScript("OnLeave", function()
+            if listening then return end
+            kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
+            if kbBtn._border and kbBtn._border.SetColor then
+                kbBtn._border:SetColor(1, 1, 1, EllesmereUI.DD_BRD_A)
+            end
+            EllesmereUI.HideWidgetTooltip()
+        end)
+
+        EllesmereUI.RegisterWidgetRefresh(RefreshLabel)
+
+        rgn:HookScript("OnHide", function()
+            if listening then
+                listening = false
+                kbBtn:EnableKeyboard(false)
+                RefreshLabel()
+            end
+        end)
+
+        return kbBtn
+    end
+
     -- Bar texture dropdown values (same pattern as Resource Bars / Nameplates)
     local dmTexValues = {}
     local dmTexOrder = {}
@@ -242,121 +359,8 @@ initFrame:SetScript("OnEvent", function(self)
 
         if not EllesmereUI._prebuilding then
             local rgn = rrRow._leftRegion
-            local KB_W, KB_H = 120, 26
-            local kbBtn = CreateFrame("Button", nil, rgn)
-            PP.Size(kbBtn, KB_W, KB_H)
-            PP.Point(kbBtn, "RIGHT", rgn, "RIGHT", -10, 0)
-            kbBtn:SetFrameLevel(rgn:GetFrameLevel() + 2)
-            kbBtn:RegisterForClicks("LeftButtonUp", "RightButtonUp")
-            local kbBg = EllesmereUI.SolidTex(kbBtn, "BACKGROUND", EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
-            kbBg:SetAllPoints()
-            kbBtn._border = EllesmereUI.MakeBorder(kbBtn, 1, 1, 1, EllesmereUI.DD_BRD_A, EllesmereUI.PanelPP)
-            local kbLbl = EllesmereUI.MakeFont(kbBtn, 12, nil, 1, 1, 1)
-            kbLbl:SetAlpha(EllesmereUI.DD_TXT_A)
-            kbLbl:SetPoint("CENTER")
-
-            local function FormatKey(key)
-                if not key then return EllesmereUI.L("Not Bound") end
-                local parts = {}
-                for mod in key:gmatch("(%u+)%-") do
-                    parts[#parts + 1] = mod:sub(1, 1) .. mod:sub(2):lower()
-                end
-                local actualKey = key:match("[^%-]+$") or key
-                parts[#parts + 1] = actualKey
-                return table.concat(parts, " + ")
-            end
-
-            local function RefreshLabel()
-                kbLbl:SetText(FormatKey(Cfg("resetDataKey")))
-            end
-            RefreshLabel()
-
-            local listening = false
-
-            kbBtn:SetScript("OnClick", function(self, button)
-                if button == "RightButton" then
-                    if listening then
-                        listening = false
-                        self:EnableKeyboard(false)
-                    end
-                    local prev = Cfg("resetDataKey")
-                    if prev and _G.EllesmereUIDMResetBindBtn then
-                        ClearOverrideBindings(_G.EllesmereUIDMResetBindBtn)
-                    end
-                    Set("resetDataKey", nil)
-                    RefreshLabel()
-                    return
-                end
-                if listening then return end
-                listening = true
-                kbLbl:SetText(EllesmereUI.L("Press a key..."))
-                kbBtn:EnableKeyboard(true)
-            end)
-
-            kbBtn:SetScript("OnKeyDown", function(self, key)
-                if not listening then
-                    self:SetPropagateKeyboardInput(true)
-                    return
-                end
-                if key == "LSHIFT" or key == "RSHIFT" or key == "LCTRL" or key == "RCTRL"
-                   or key == "LALT" or key == "RALT" or key == "LMETA" or key == "RMETA" then
-                    self:SetPropagateKeyboardInput(true)
-                    return
-                end
-                self:SetPropagateKeyboardInput(false)
-                if key == "ESCAPE" then
-                    listening = false
-                    self:EnableKeyboard(false)
-                    RefreshLabel()
-                    return
-                end
-                -- Blizzard's canonical chord order is ALT-CTRL-SHIFT-KEY, and
-                -- CreateKeyChordStringUsingMetaKeyState is what produces it.
-                -- Hand-rolling the modifiers built SHIFT-CTRL-ALT-KEY, a chord
-                -- string the engine never generates, so any bind using more
-                -- than one modifier was stored in a form nothing could match.
-                -- Single-modifier binds happen to agree, which is why this
-                -- survived.
-                local fullKey
-                if CreateKeyChordStringUsingMetaKeyState then
-                    fullKey = CreateKeyChordStringUsingMetaKeyState(key)
-                else
-                    local mods = ""
-                    if IsAltKeyDown() then mods = mods .. "ALT-" end
-                    if IsControlKeyDown() then mods = mods .. "CTRL-" end
-                    if IsShiftKeyDown() then mods = mods .. "SHIFT-" end
-                    if IsMetaKeyDown and IsMetaKeyDown() then
-                        mods = mods .. "META-"
-                    end
-                    fullKey = mods .. key
-                end
-
-                if _G.EllesmereUIDMResetBindBtn then
-                    ClearOverrideBindings(_G.EllesmereUIDMResetBindBtn)
-                    SetOverrideBindingClick(_G.EllesmereUIDMResetBindBtn, true, fullKey, "EllesmereUIDMResetBindBtn")
-                end
-                Set("resetDataKey", fullKey)
-
-                listening = false
-                self:EnableKeyboard(false)
-                RefreshLabel()
-            end)
-
-            kbBtn:SetScript("OnEnter", function(self)
-                kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_HA)
-                if kbBtn._border and kbBtn._border.SetColor then
-                    kbBtn._border:SetColor(1, 1, 1, 0.3)
-                end
-                EllesmereUI.ShowWidgetTooltip(self, "Left-click to set a keybind.\nRight-click to unbind.")
-            end)
-            kbBtn:SetScript("OnLeave", function()
-                if listening then return end
-                kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
-                if kbBtn._border and kbBtn._border.SetColor then
-                    kbBtn._border:SetColor(1, 1, 1, EllesmereUI.DD_BRD_A)
-                end
-                EllesmereUI.HideWidgetTooltip()
-            end)
+            local kbBtn = MakeKeybindButton(rgn, "resetDataKey",
+                "Left-click to set a keybind.\nRight-click to unbind.")
 
             -- Inline cog: hide reset button
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -379,16 +383,6 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
             cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
-
-            EllesmereUI.RegisterWidgetRefresh(RefreshLabel)
-
-            rgn:HookScript("OnHide", function()
-                if listening then
-                    listening = false
-                    kbBtn:EnableKeyboard(false)
-                    RefreshLabel()
-                end
-            end)
         end
         y = y - h
 
@@ -1617,101 +1611,8 @@ initFrame:SetScript("OnEvent", function(self)
 
         if not EllesmereUI._prebuilding then
             local rgn = extrasRow._rightRegion
-            local kbBtn = CreateFrame("Button", nil, rgn)
-            PP.Size(kbBtn, 120, 26)
-            PP.Point(kbBtn, "RIGHT", rgn, "RIGHT", -10, 0)
-            kbBtn:SetFrameLevel(rgn:GetFrameLevel() + 2)
-            kbBtn:RegisterForClicks("LeftButtonUp", "RightButtonUp")
-            local kbBg = EllesmereUI.SolidTex(kbBtn, "BACKGROUND", EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
-            kbBg:SetAllPoints()
-            kbBtn._border = EllesmereUI.MakeBorder(kbBtn, 1, 1, 1, EllesmereUI.DD_BRD_A, EllesmereUI.PanelPP)
-            local kbLbl = EllesmereUI.MakeFont(kbBtn, 12, nil, 1, 1, 1)
-            kbLbl:SetAlpha(EllesmereUI.DD_TXT_A)
-            kbLbl:SetPoint("CENTER")
-
-            local function FormatKey(key)
-                if not key or key == "" then return EllesmereUI.L("Not Bound") end
-                local parts = {}
-                for mod in key:gmatch("(%u+)%-") do
-                    parts[#parts + 1] = mod:sub(1, 1) .. mod:sub(2):lower()
-                end
-                local actualKey = key:match("[^%-]+$") or key
-                parts[#parts + 1] = actualKey
-                return table.concat(parts, " + ")
-            end
-            local function RefreshLabel() kbLbl:SetText(FormatKey(Cfg("toggleWindowsKey"))) end
-            RefreshLabel()
-
-            local listening = false
-
-            kbBtn:SetScript("OnClick", function(self, button)
-                if button == "RightButton" then
-                    if listening then listening = false; self:EnableKeyboard(false) end
-                    Set("toggleWindowsKey", nil)
-                    if ns.ApplyDMToggleKeybind then ns.ApplyDMToggleKeybind() end
-                    RefreshLabel()
-                    return
-                end
-                if listening then return end
-                listening = true
-                kbLbl:SetText(EllesmereUI.L("Press a key..."))
-                self:EnableKeyboard(true)
-            end)
-
-            kbBtn:SetScript("OnKeyDown", function(self, key)
-                if not listening then self:SetPropagateKeyboardInput(true); return end
-                -- Blizzard's own conversion and ignore test: bare modifiers pass through
-                -- so they can be held for the chord, and META/UNKNOWN are covered too
-                if GetConvertedKeyOrButton then key = GetConvertedKeyOrButton(key) end
-                local ignore
-                if IsKeyPressIgnoredForBinding then
-                    ignore = IsKeyPressIgnoredForBinding(key)
-                else
-                    ignore = (key == "LSHIFT" or key == "RSHIFT"
-                        or key == "LCTRL" or key == "RCTRL"
-                        or key == "LALT" or key == "RALT"
-                        or key == "LMETA" or key == "RMETA"
-                        or key == "UNKNOWN")
-                end
-                if ignore then self:SetPropagateKeyboardInput(true); return end
-                self:SetPropagateKeyboardInput(false)
-                listening = false
-                self:EnableKeyboard(false)
-                if key ~= "ESCAPE" then
-                    -- Canonical chord order is ALT-CTRL-SHIFT-KEY; hand-rolling it in any
-                    -- other order stores a string the engine never matches
-                    local fullKey
-                    if CreateKeyChordStringUsingMetaKeyState then
-                        fullKey = CreateKeyChordStringUsingMetaKeyState(key)
-                    else
-                        local mods = ""
-                        if IsAltKeyDown() then mods = mods .. "ALT-" end
-                        if IsControlKeyDown() then mods = mods .. "CTRL-" end
-                        if IsShiftKeyDown() then mods = mods .. "SHIFT-" end
-                        if IsMetaKeyDown and IsMetaKeyDown() then mods = mods .. "META-" end
-                        fullKey = mods .. key
-                    end
-                    Set("toggleWindowsKey", fullKey)
-                    if ns.ApplyDMToggleKeybind then ns.ApplyDMToggleKeybind() end
-                end
-                RefreshLabel()
-            end)
-
-            kbBtn:SetScript("OnEnter", function(self)
-                kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_HA)
-                if kbBtn._border and kbBtn._border.SetColor then
-                    kbBtn._border:SetColor(1, 1, 1, 0.3)
-                end
-                EllesmereUI.ShowWidgetTooltip(self, "Hide and show every damage meter window at once. The state is not saved; a reload restores the configured visibility.\n\nThe bound key is taken over while it is set. Use the cog to include the combat timer and Spell History.\n\nLeft-click to set a keybind.\nRight-click to unbind.")
-            end)
-            kbBtn:SetScript("OnLeave", function()
-                if listening then return end
-                kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
-                if kbBtn._border and kbBtn._border.SetColor then
-                    kbBtn._border:SetColor(1, 1, 1, EllesmereUI.DD_BRD_A)
-                end
-                EllesmereUI.HideWidgetTooltip()
-            end)
+            local kbBtn = MakeKeybindButton(rgn, "toggleWindowsKey",
+                "Hide and show every damage meter window at once. The state is not saved; a reload restores the configured visibility.\n\nThe bound key is taken over while it is set. Use the cog to include the combat timer and Spell History.\n\nLeft-click to set a keybind.\nRight-click to unbind.")
 
             -- Inline cog: which extra elements the keybind covers
             local _, cogShow = EllesmereUI.BuildCogPopup({
@@ -1727,7 +1628,9 @@ initFrame:SetScript("OnEvent", function(self)
                       get = function() return Cfg("toggleIncludeSpellHistory") == true end,
                       set = function(v)
                           Set("toggleIncludeSpellHistory", v)
-                          if ns.ApplyDMToggleState then ns.ApplyDMToggleState() end
+                          -- Forced: turning the option off has to reach Spell History
+                          -- too, and by then the flag no longer asks for it
+                          if ns.ApplyDMToggleState then ns.ApplyDMToggleState(true) end
                       end },
                 },
             })
@@ -1743,16 +1646,6 @@ initFrame:SetScript("OnEvent", function(self)
             cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
             cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
             cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
-
-            EllesmereUI.RegisterWidgetRefresh(RefreshLabel)
-
-            rgn:HookScript("OnHide", function()
-                if listening then
-                    listening = false
-                    kbBtn:EnableKeyboard(false)
-                    RefreshLabel()
-                end
-            end)
         end
         y = y - h
 

--- a/EllesmereUIOptions/EUI_DamageMeters_Options.lua
+++ b/EllesmereUIOptions/EUI_DamageMeters_Options.lua
@@ -1606,12 +1606,154 @@ initFrame:SetScript("OnEvent", function(self)
         -- ── EXTRAS ───────────────────────────────────────────────────
         _, h = W:SectionHeader(parent, "EXTRAS", y); y = y - h
 
-        _, h = W:DualRow(parent, y,
+        -- Show Spell Tooltips | Show/Hide Windows Keybind (+ inline cog: what the keybind covers)
+        local extrasRow
+        extrasRow, h = W:DualRow(parent, y,
             { type="toggle", text="Show Spell Tooltips on Hover",
               tooltip="Show the game's spell tooltip when you hover a spell in a breakdown window.",
               getValue = function() return Cfg("showSpellTooltips") ~= false end,
               setValue = function(v) Set("showSpellTooltips", v) end },
-            { type="label", text="" })
+            { type="label", text="Show/Hide Windows Keybind" })
+
+        if not EllesmereUI._prebuilding then
+            local rgn = extrasRow._rightRegion
+            local kbBtn = CreateFrame("Button", nil, rgn)
+            PP.Size(kbBtn, 120, 26)
+            PP.Point(kbBtn, "RIGHT", rgn, "RIGHT", -10, 0)
+            kbBtn:SetFrameLevel(rgn:GetFrameLevel() + 2)
+            kbBtn:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+            local kbBg = EllesmereUI.SolidTex(kbBtn, "BACKGROUND", EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
+            kbBg:SetAllPoints()
+            kbBtn._border = EllesmereUI.MakeBorder(kbBtn, 1, 1, 1, EllesmereUI.DD_BRD_A, EllesmereUI.PanelPP)
+            local kbLbl = EllesmereUI.MakeFont(kbBtn, 12, nil, 1, 1, 1)
+            kbLbl:SetAlpha(EllesmereUI.DD_TXT_A)
+            kbLbl:SetPoint("CENTER")
+
+            local function FormatKey(key)
+                if not key or key == "" then return EllesmereUI.L("Not Bound") end
+                local parts = {}
+                for mod in key:gmatch("(%u+)%-") do
+                    parts[#parts + 1] = mod:sub(1, 1) .. mod:sub(2):lower()
+                end
+                local actualKey = key:match("[^%-]+$") or key
+                parts[#parts + 1] = actualKey
+                return table.concat(parts, " + ")
+            end
+            local function RefreshLabel() kbLbl:SetText(FormatKey(Cfg("toggleWindowsKey"))) end
+            RefreshLabel()
+
+            local listening = false
+
+            kbBtn:SetScript("OnClick", function(self, button)
+                if button == "RightButton" then
+                    if listening then listening = false; self:EnableKeyboard(false) end
+                    Set("toggleWindowsKey", nil)
+                    if ns.ApplyDMToggleKeybind then ns.ApplyDMToggleKeybind() end
+                    RefreshLabel()
+                    return
+                end
+                if listening then return end
+                listening = true
+                kbLbl:SetText(EllesmereUI.L("Press a key..."))
+                self:EnableKeyboard(true)
+            end)
+
+            kbBtn:SetScript("OnKeyDown", function(self, key)
+                if not listening then self:SetPropagateKeyboardInput(true); return end
+                -- Blizzard's own conversion and ignore test: bare modifiers pass through
+                -- so they can be held for the chord, and META/UNKNOWN are covered too
+                if GetConvertedKeyOrButton then key = GetConvertedKeyOrButton(key) end
+                local ignore
+                if IsKeyPressIgnoredForBinding then
+                    ignore = IsKeyPressIgnoredForBinding(key)
+                else
+                    ignore = (key == "LSHIFT" or key == "RSHIFT"
+                        or key == "LCTRL" or key == "RCTRL"
+                        or key == "LALT" or key == "RALT"
+                        or key == "LMETA" or key == "RMETA"
+                        or key == "UNKNOWN")
+                end
+                if ignore then self:SetPropagateKeyboardInput(true); return end
+                self:SetPropagateKeyboardInput(false)
+                listening = false
+                self:EnableKeyboard(false)
+                if key ~= "ESCAPE" then
+                    -- Canonical chord order is ALT-CTRL-SHIFT-KEY; hand-rolling it in any
+                    -- other order stores a string the engine never matches
+                    local fullKey
+                    if CreateKeyChordStringUsingMetaKeyState then
+                        fullKey = CreateKeyChordStringUsingMetaKeyState(key)
+                    else
+                        local mods = ""
+                        if IsAltKeyDown() then mods = mods .. "ALT-" end
+                        if IsControlKeyDown() then mods = mods .. "CTRL-" end
+                        if IsShiftKeyDown() then mods = mods .. "SHIFT-" end
+                        if IsMetaKeyDown and IsMetaKeyDown() then mods = mods .. "META-" end
+                        fullKey = mods .. key
+                    end
+                    Set("toggleWindowsKey", fullKey)
+                    if ns.ApplyDMToggleKeybind then ns.ApplyDMToggleKeybind() end
+                end
+                RefreshLabel()
+            end)
+
+            kbBtn:SetScript("OnEnter", function(self)
+                kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_HA)
+                if kbBtn._border and kbBtn._border.SetColor then
+                    kbBtn._border:SetColor(1, 1, 1, 0.3)
+                end
+                EllesmereUI.ShowWidgetTooltip(self, "Hide and show every damage meter window at once. The state is not saved; a reload restores the configured visibility.\n\nThe bound key is taken over while it is set. Use the cog to include the combat timer and Spell History.\n\nLeft-click to set a keybind.\nRight-click to unbind.")
+            end)
+            kbBtn:SetScript("OnLeave", function()
+                if listening then return end
+                kbBg:SetColorTexture(EllesmereUI.DD_BG_R, EllesmereUI.DD_BG_G, EllesmereUI.DD_BG_B, EllesmereUI.DD_BG_A)
+                if kbBtn._border and kbBtn._border.SetColor then
+                    kbBtn._border:SetColor(1, 1, 1, EllesmereUI.DD_BRD_A)
+                end
+                EllesmereUI.HideWidgetTooltip()
+            end)
+
+            -- Inline cog: which extra elements the keybind covers
+            local _, cogShow = EllesmereUI.BuildCogPopup({
+                title = "Keybind Scope",
+                rows = {
+                    { type = "toggle", label = "Include Combat Timer",
+                      get = function() return Cfg("toggleIncludeTimer") == true end,
+                      set = function(v)
+                          Set("toggleIncludeTimer", v)
+                          if ns.ApplyDMToggleState then ns.ApplyDMToggleState() end
+                      end },
+                    { type = "toggle", label = "Include Spell History",
+                      get = function() return Cfg("toggleIncludeSpellHistory") == true end,
+                      set = function(v)
+                          Set("toggleIncludeSpellHistory", v)
+                          if ns.ApplyDMToggleState then ns.ApplyDMToggleState() end
+                      end },
+                },
+            })
+            local cogBtn = CreateFrame("Button", nil, rgn)
+            cogBtn:SetSize(26, 26)
+            cogBtn:SetPoint("RIGHT", kbBtn, "LEFT", -8, 0)
+            rgn._lastInline = cogBtn
+            cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
+            cogBtn:SetAlpha(0.4)
+            local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
+            cogTex:SetAllPoints()
+            cogTex:SetTexture(EllesmereUI.COGS_ICON)
+            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.7) end)
+            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
+
+            EllesmereUI.RegisterWidgetRefresh(RefreshLabel)
+
+            rgn:HookScript("OnHide", function()
+                if listening then
+                    listening = false
+                    kbBtn:EnableKeyboard(false)
+                    RefreshLabel()
+                end
+            end)
+        end
         y = y - h
 
         return math.abs(y)


### PR DESCRIPTION
## What does this PR do?

Adds a keybind to Damage Meters that hides or shows every meter window at once, without touching the configured visibility rules underneath - a reload always restores the normal state. The keybind is set from a new row in Options > Damage Meters > Extras, with an inline cog to also include the standalone combat timer and the Spell History icon strip / bar window in the toggle. T

The hidden/shown state itself is never saved - it's a runtime-only flag, so a /reload or relogin always brings every window back to whatever its normal visibility rules say, as if the toggle had never been pressed. The keybind itself, of course, stays configured.

## How was it tested?

Tested in-game on live.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - no key bound by default, both "include" toggles default off
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - the override binding is only laid down once a key is set; no polling involved
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - the toggle is a single override-binding click, and its own visibility pass reuses each window's existing UpdateVisibility
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - the binding target is an addon-owned button, not a Blizzard frame
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
