### PR TITLE
Fix Grow Direction not moving action bars

### DIFF
--- a/EUI_UnlockMode.lua
+++ b/EUI_UnlockMode.lua
@@ -7422,30 +7422,37 @@ local function CreateMover(barKey)
                     end
 
                     -- Restore the bar's visual center so it doesn't jump,
-                    -- then re-anchor based on the new growth direction.
-                    if barFrame and preCX and preCY then
-                        local postCX, postCY = barFrame:GetCenter()
-                        if postCX and postCY then
-                            local dx = preCX - postCX
-                            local dy = preCY - postCY
-                            if math.abs(dx) > 0.5 or math.abs(dy) > 0.5 then
-                                local pt, relTo, relPt, offX, offY = barFrame:GetPoint(1)
-                                if pt then
-                                    barFrame:ClearAllPoints()
-                                    barFrame:SetPoint(pt, relTo, relPt, offX + dx, offY + dy)
+                    -- then re-anchor based on the new growth direction. Skipped in
+                    -- combat: a protected bar's SetPoint is blocked there, so the
+                    -- frame never actually moved -- capturing its (unchanged) point
+                    -- into pendingPositions would let Save & Exit commit the stale
+                    -- pre-change position over the already-correct combat-deferred
+                    -- write the bar's own module just made.
+                    if not InCombatLockdown() then
+                        if barFrame and preCX and preCY then
+                            local postCX, postCY = barFrame:GetCenter()
+                            if postCX and postCY then
+                                local dx = preCX - postCX
+                                local dy = preCY - postCY
+                                if math.abs(dx) > 0.5 or math.abs(dy) > 0.5 then
+                                    local pt, relTo, relPt, offX, offY = barFrame:GetPoint(1)
+                                    if pt then
+                                        barFrame:ClearAllPoints()
+                                        barFrame:SetPoint(pt, relTo, relPt, offX + dx, offY + dy)
+                                    end
                                 end
                             end
                         end
-                    end
-                    EllesmereUI.RecenterBarAnchor(barKey)
-                    -- Store in pending (committed on Save & Exit)
-                    if barFrame then
-                        local pt2, relTo2, relPt2, offX2, offY2 = barFrame:GetPoint(1)
-                        if pt2 then
-                            pendingPositions[barKey] = {
-                                point = pt2, relPoint = relPt2, x = offX2, y = offY2,
-                            }
-                            hasChanges = true
+                        EllesmereUI.RecenterBarAnchor(barKey)
+                        -- Store in pending (committed on Save & Exit)
+                        if barFrame then
+                            local pt2, relTo2, relPt2, offX2, offY2 = barFrame:GetPoint(1)
+                            if pt2 then
+                                pendingPositions[barKey] = {
+                                    point = pt2, relPoint = relPt2, x = offX2, y = offY2,
+                                }
+                                hasChanges = true
+                            end
                         end
                     end
 

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7355,7 +7355,32 @@ function EAB:SetGrowDirectionForBar(barKey, dir)
     local s = self.db.profile.bars[barKey]
     if not s then return end
     s.growDirection = dir or "up"
+    -- Growth direction alone never changes frame size, so the OnSizeChanged/
+    -- ApplyAnchorPosition fallback never fires and the bar stays parked at
+    -- whatever edge it was last anchored to. Re-derive the edge for the new
+    -- direction here so picking a direction has a visible effect immediately.
+    if not InCombatLockdown() then
+        if EllesmereUI.IsUnlockAnchored and EllesmereUI.IsUnlockAnchored(barKey) then
+            if EllesmereUI.ReapplyOwnAnchor then
+                EllesmereUI.ReapplyOwnAnchor(barKey)
+            end
+        else
+            local frame = barFrames[barKey]
+            if frame then
+                local point, _, relPoint, x, y = frame:GetPoint(1)
+                if point then
+                    local centerPos = self:ConvertEdgeToCenter(barKey, { point = point, relPoint = relPoint, x = x, y = y })
+                    local sp, sx, sy = self:ConvertCenterToEdge(barKey, centerPos.point, centerPos.x, centerPos.y)
+                    local rpt = centerPos.relPoint or relPoint
+                    self.db.profile.barPositions[barKey] = { point = sp, relPoint = rpt, x = sx, y = sy }
+                    frame:ClearAllPoints()
+                    frame:SetPoint(sp, UIParent, rpt, sx, sy)
+                end
+            end
+        end
+    end
     LayoutBar(barKey)
+    self:ApplyAlwaysShowButtons(barKey)
     self:LayoutAnchoredBarsFrom(barKey, 0)
 end
 

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7371,7 +7371,18 @@ function EAB:SetGrowDirectionForBar(barKey, dir)
         if frame then
             local point, _, relPoint, x, y = frame:GetPoint(1)
             if point then
-                local centerPos = self:ConvertEdgeToCenter(barKey, { point = point, relPoint = relPoint, x = x, y = y })
+                local centerPos
+                if point == "CENTER" or point == "LEFT" or point == "RIGHT" or point == "TOP" or point == "BOTTOM" then
+                    centerPos = self:ConvertEdgeToCenter(barKey, { point = point, relPoint = relPoint, x = x, y = y })
+                elseif EllesmereUI.ConvertToCenterPos then
+                    -- Legacy corner-anchored bar (pre-dates the CENTER/CENTER position
+                    -- system): normalize via the general converter, which reads live
+                    -- frame bounds, before pinning the new grow-direction edge.
+                    local cp, crp, cx, cy = EllesmereUI.ConvertToCenterPos(barKey, point, relPoint, x, y)
+                    centerPos = { point = cp, relPoint = crp, x = cx, y = cy }
+                else
+                    centerPos = { point = point, relPoint = relPoint, x = x, y = y }
+                end
                 local sp, sx, sy = self:ConvertCenterToEdge(barKey, centerPos.point, centerPos.x, centerPos.y)
                 local rpt = centerPos.relPoint or relPoint
                 local PPa = EllesmereUI and EllesmereUI.PP

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7397,17 +7397,14 @@ function EAB:SetGrowDirectionForBar(barKey, dir)
                     end
                 end
                 self.db.profile.barPositions[barKey] = { point = sp, relPoint = rpt, x = sx, y = sy }
-                if InCombatLockdown() then
-                    -- Store the write, defer the SetPoint: reapplied from
-                    -- barPositions on PLAYER_REGEN_ENABLED by the same mechanism
-                    -- a blocked anchor apply uses.
-                    if EllesmereUI._AnchorPark then
-                        EllesmereUI._AnchorPark.ParkBarPos(barKey)
-                    end
-                else
+                if not InCombatLockdown() then
                     frame:ClearAllPoints()
                     frame:SetPoint(sp, UIParent, rpt, sx, sy)
                 end
+                -- If in combat, the barPositions write above already stands; the
+                -- unconditional LayoutBar call below sets ns._eabApplyDeferred and
+                -- the existing PLAYER_REGEN_ENABLED -> ApplyAll -> LayoutBar pass
+                -- re-syncs this frame's SetPoint from that entry once combat drops.
             end
         end
     end

--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -7359,20 +7359,41 @@ function EAB:SetGrowDirectionForBar(barKey, dir)
     -- ApplyAnchorPosition fallback never fires and the bar stays parked at
     -- whatever edge it was last anchored to. Re-derive the edge for the new
     -- direction here so picking a direction has a visible effect immediately.
-    if not InCombatLockdown() then
-        if EllesmereUI.IsUnlockAnchored and EllesmereUI.IsUnlockAnchored(barKey) then
-            if EllesmereUI.ReapplyOwnAnchor then
-                EllesmereUI.ReapplyOwnAnchor(barKey)
-            end
-        else
-            local frame = barFrames[barKey]
-            if frame then
-                local point, _, relPoint, x, y = frame:GetPoint(1)
-                if point then
-                    local centerPos = self:ConvertEdgeToCenter(barKey, { point = point, relPoint = relPoint, x = x, y = y })
-                    local sp, sx, sy = self:ConvertCenterToEdge(barKey, centerPos.point, centerPos.x, centerPos.y)
-                    local rpt = centerPos.relPoint or relPoint
-                    self.db.profile.barPositions[barKey] = { point = sp, relPoint = rpt, x = sx, y = sy }
+    if EllesmereUI.IsUnlockAnchored and EllesmereUI.IsUnlockAnchored(barKey) then
+        -- ReapplyOwnAnchor -> ApplyAnchorPosition already parks itself via
+        -- EllesmereUI._AnchorPark when combat blocks a protected frame's SetPoint,
+        -- so it's safe to call unconditionally here.
+        if EllesmereUI.ReapplyOwnAnchor then
+            EllesmereUI.ReapplyOwnAnchor(barKey)
+        end
+    else
+        local frame = barFrames[barKey]
+        if frame then
+            local point, _, relPoint, x, y = frame:GetPoint(1)
+            if point then
+                local centerPos = self:ConvertEdgeToCenter(barKey, { point = point, relPoint = relPoint, x = x, y = y })
+                local sp, sx, sy = self:ConvertCenterToEdge(barKey, centerPos.point, centerPos.x, centerPos.y)
+                local rpt = centerPos.relPoint or relPoint
+                local PPa = EllesmereUI and EllesmereUI.PP
+                if PPa then
+                    local es = frame:GetEffectiveScale()
+                    if sp == "CENTER" and rpt == "CENTER" and PPa.SnapCenterForDim then
+                        sx = PPa.SnapCenterForDim(sx, frame:GetWidth() or 0, es)
+                        sy = PPa.SnapCenterForDim(sy, frame:GetHeight() or 0, es)
+                    elseif PPa.SnapForES then
+                        sx = PPa.SnapForES(sx, es)
+                        sy = PPa.SnapForES(sy, es)
+                    end
+                end
+                self.db.profile.barPositions[barKey] = { point = sp, relPoint = rpt, x = sx, y = sy }
+                if InCombatLockdown() then
+                    -- Store the write, defer the SetPoint: reapplied from
+                    -- barPositions on PLAYER_REGEN_ENABLED by the same mechanism
+                    -- a blocked anchor apply uses.
+                    if EllesmereUI._AnchorPark then
+                        EllesmereUI._AnchorPark.ParkBarPos(barKey)
+                    end
+                else
                     frame:ClearAllPoints()
                     frame:SetPoint(sp, UIParent, rpt, sx, sy)
                 end

--- a/EllesmereUIOptions/EUI_ActionBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ActionBars_Options.lua
@@ -2368,7 +2368,7 @@ initFrame:SetScript("OnEvent", function(self)
                               return val
                           end,
                           set=function(v)
-                              SSet("growDirection", v, function(k) EAB:ApplyIconRowOverrides(k) end)
+                              SSet("growDirection", v, function(k) EAB:SetGrowDirectionForBar(k, v) end)
                               SUpdatePreviewAndResize()
                           end },
                     },


### PR DESCRIPTION
```
Bug: The "Grow Right" setting doesn't move the Stance Bar (reported by @Flocki).

Issue: Picking a Grow Direction other than Centered writes the setting but the
bar never visibly reacts, on any horizontal or vertical bar that hasn't been
manually dragged -- not specific to the Stance Bar.

Root cause: Grow Direction only ever fed a multi-row stacking flag that a
single-row bar never exercises. The actual "grow toward an edge" mechanism in
this codebase is which frame edge stays pinned when the bar resizes, but
nothing ever re-derived that edge when Grow Direction changed outside of a
manual drag -- only the drag-save path used it.

Fix: Grow Direction changes now re-anchor the bar to the new edge immediately,
reusing the frame's current on-screen center so there's no jump; only future
resizes grow from the newly pinned edge. Also handles anchor-chained bars,
legacy corner-anchored positions, combat lockdown (deferred instead of
dropped), and a race where Unlock Mode's Save & Exit could commit a stale
position over the correct one if triggered mid-combat.
```