### PR TITLE
Fix(minimap): staying visible after switching to Mouseover visibility

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -4095,8 +4095,9 @@ local function ApplyMinimap()
             minimap:SetAlpha(1)
             minimap:Show()
         elseif vis == "mouseover" then
-            minimap:SetAlpha(0)
-            minimap:Show()
+            -- Idle state is a real Hide(), not alpha 0 -- see UpdateMinimapVisibility.
+            minimap:SetAlpha(1)
+            if minimap:IsMouseOver() then minimap:Show() else minimap:Hide() end
         elseif vis then
             minimap:SetAlpha(1)
             minimap:Show()
@@ -5153,8 +5154,13 @@ local function UpdateMinimapVisibility()
     if InCombatLockdown() then return end
     local vis = EllesmereUI.EvalVisibility(p)
     if vis == "mouseover" then
-        minimap:SetAlpha(0)
-        minimap:Show()
+        -- Mouseover idle is a real Hide(), not alpha 0: frame alpha does not cover
+        -- everything drawn on this frame, so an alpha-0 map still left its icons on
+        -- screen until the first hover. Hide() is also exactly what the shared
+        -- mouseover poll applies, so both ends of the mode agree. Shown (not hidden)
+        -- while the cursor already sits on the map, so a re-apply mid-hover cannot blink.
+        minimap:SetAlpha(1)
+        if minimap:IsMouseOver() then minimap:Show() else minimap:Hide() end
     elseif vis then
         minimap:SetAlpha(1)
         minimap:Show()

--- a/EllesmereUI_Visibility.lua
+++ b/EllesmereUI_Visibility.lua
@@ -105,7 +105,11 @@ local MouseoverScan  -- defined with the scan below; bound here for the subscrib
 
 function EUI.RegisterMouseoverTarget(frame, isActive)
     if not frame or type(isActive) ~= "function" then return end
-    mouseoverTargets[#mouseoverTargets + 1] = { frame = frame, visible = false, isActive = isActive }
+    -- visible starts nil = "state not applied yet", not false: the scan below treats nil
+    -- as unknown and applies the hidden state on its first active tick. Seeding false
+    -- would make that first tick a no-op (already-false edge), so a target that becomes
+    -- active with the cursor away never received its Hide() until the first real hover.
+    mouseoverTargets[#mouseoverTargets + 1] = { frame = frame, visible = nil, isActive = isActive }
     -- First target arms the shared 0.15s scan on the Mouse service (same-key
     -- subscribe is idempotent). No targets registered = the scan never runs.
     EllesmereUI.Mouse.SubscribeTick("visMouseover", 0.15, MouseoverScan)
@@ -238,10 +242,15 @@ MouseoverScan = function(rawX, rawY)
             if active then
                 t._wasActive = true
                 local over = IsCursorOver(frame, rawX, rawY)
-                if over and not t.visible then
-                    t.visible = true
-                    frame:SetAlpha(1); frame:EnableMouse(true); frame:Show()
-                elseif not over and t.visible then
+                -- Compared against true/false rather than truthiness, so the unknown
+                -- state (nil, at registration and after a deactivation) applies once
+                -- instead of being read as "already hidden".
+                if over then
+                    if t.visible ~= true then
+                        t.visible = true
+                        frame:SetAlpha(1); frame:EnableMouse(true); frame:Show()
+                    end
+                elseif t.visible ~= false then
                     t.visible = false
                     frame:Hide()
                 end


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1545069536875778068

## What does this PR do?

Fixes the minimap staying partially visible after switching its Visibility option from Always to Mouseover: parts of it (the icons on the map) kept showing until the first time you hovered the minimap and moved away again, which is when they finally disappeared.

There were two causes. The shared mouseover poll in `EllesmereUI_Visibility.lua` is edge-triggered and seeded each target's `visible` flag with `false`, while deactivating a target resets it to `nil`. Both are falsy, so a target that became active while the cursor was away matched neither the show nor the hide branch and never received its `Hide()` -- not just the first time, but on every switch back into Mouseover. The flag is now tracked as `nil` = state not applied yet and compared against `true`/`false` instead of truthiness, so the first active tick always applies the correct state. On top of that, the minimap rendered its mouseover idle state as `SetAlpha(0)` plus `Show()` in both `ApplyMinimap` and `UpdateMinimapVisibility`, and frame alpha does not cover everything drawn on that frame. It now hides for real at full alpha, which is exactly what the poll itself applies, and stays shown when the cursor is already over the map so that a re-apply mid-hover cannot blink.

No settings were added or changed; every other module using the shared poll already applied its hidden state through its own visibility updater, so the poll change only removes the missing initial apply.

## How was it tested?

Tested in game on the live client.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, bugfix, no new settings
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- the existing 0.15s mouseover scan is unchanged in cadence and cost; only its state comparison changed
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added