### PR TITLE
Feat(QoL): Bloodlust Ready display, live icon previews and pixel-perfect offsets

### DIFF
--- a/EllesmereUIOptions/EUI_QoL_BattleRes_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_BattleRes_Options.lua
@@ -683,15 +683,22 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
         -- Show Sated / Show Ready: independent toggles. Sated gates the real lockout
         -- countdown, Ready gates the label shown once that lockout is gone -- either,
         -- both or neither can be on.
+        -- Toggle controls don't self-trigger a refresh pass (unlike sliders/
+        -- dropdowns), so without the explicit RefreshPage() the Ready row below
+        -- stays stale (not greyed/ungreyed) until something else repaints the page.
         row, h = W:DualRow(parent, y,
-            { type="toggle", text="Show Sated",
+            { type="toggle", text="Show Icon when Sated",
               tooltip="Show the Sated/Exhaustion lockout countdown on the icon.",
               getValue=function() return BL_Cfg("showSated") ~= false end,
-              setValue=function(v) BL_Set("showSated", v); BL_Refresh() end },
-            { type="toggle", text="Show Ready",
+              setValue=function(v)
+                  BL_Set("showSated", v); BL_Refresh(); EllesmereUI:RefreshPage()
+              end },
+            { type="toggle", text="Show Icon with Ready Text",
               tooltip="Once the lockout expires, show a Ready label on the icon in place of the countdown. The visibility rule above still applies.",
               getValue=function() return BL_Cfg("showReady") == true end,
-              setValue=function(v) BL_Set("showReady", v); BL_Refresh() end })
+              setValue=function(v)
+                  BL_Set("showReady", v); BL_Refresh(); EllesmereUI:RefreshPage()
+              end })
         y = y - h
 
         -- Ready appearance: offset cog, colour swatch and size slider on one row,
@@ -701,7 +708,7 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
         row, h = W:DualRow(parent, y,
             { type="slider", text="Ready",
               disabled=readyOff,
-              disabledTooltip="Show Ready",
+              disabledTooltip="Show Icon with Ready Text",
               min=8, max=30, step=1, isPercent=false,
               getValue=function() return BL_Cfg("readySize") or 12 end,
               setValue=function(v) BL_Set("readySize", v); BL_Refresh() end },
@@ -733,7 +740,7 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
             readyColorBlock:SetFrameLevel(swatch:GetFrameLevel() + 10)
             readyColorBlock:EnableMouse(true)
             readyColorBlock:SetScript("OnEnter", function()
-                EllesmereUI.ShowWidgetTooltip(swatch, EllesmereUI.DisabledTooltip("Show Ready"))
+                EllesmereUI.ShowWidgetTooltip(swatch, EllesmereUI.DisabledTooltip("Show Icon with Ready Text"))
             end)
             readyColorBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
             EllesmereUI.RegisterWidgetRefresh(function()
@@ -744,7 +751,7 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
             -- itself as the "control region" lands it in the empty gap instead of
             -- stacking both on the slider's left edge.
             _attachOffsetCog(swatch, "Ready Position", "readyOffsetX", "readyOffsetY",
-                readyOff, "Show Ready")
+                readyOff, "Show Icon with Ready Text")
         end
     end
     end   -- close Bloodlust hidden-while-Never gate

--- a/EllesmereUIOptions/EUI_QoL_BattleRes_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_BattleRes_Options.lua
@@ -244,6 +244,21 @@ _G._EUI_BuildBattleResSection = function(parent, yOffset, W, PP)
 
     _, h = W:SectionHeader(parent, "BATTLE RES", y); y = y - h
 
+    -- Live preview: forces the icon on screen for as long as this page is (mirrors
+    -- the Bloodlust Tracker section below). PollCharges reads real charge data
+    -- regardless, so this alone is enough to preview it from anywhere.
+    if not EllesmereUI._prebuilding and _G._EUI_BattleRes_SetPreviewOwner then
+        _G._EUI_BattleRes_SetPreviewOwner(parent)
+        if not parent._brPreviewHooked then
+            parent._brPreviewHooked = true
+            parent:HookScript("OnHide", function()
+                if _G._EUI_BattleRes_UpdateVisibility then
+                    _G._EUI_BattleRes_UpdateVisibility()
+                end
+            end)
+        end
+    end
+
     row, h = W:DualRow(parent, y,
         { type="dropdown", text="Enable BattleRes Icon",
           values=VIS_VALUES, order=VIS_ORDER,

--- a/EllesmereUIOptions/EUI_QoL_BattleRes_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_BattleRes_Options.lua
@@ -471,7 +471,11 @@ local function BL_BR()
 end
 
 -- Keys stored independently on the bloodlust profile (everything else proxies).
-local BL_OWN_KEYS = { visibility = true, enabled = true, pos = true }
+local BL_OWN_KEYS = {
+    visibility = true, enabled = true, pos = true,
+    showSated = true, showReady = true, readySize = true, readyColor = true,
+    readyOffsetX = true, readyOffsetY = true,
+}
 
 local function BL_Cfg(key, fallback)
     local bl = BL_P()
@@ -549,6 +553,22 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
 
     _, h = W:SectionHeader(parent, "BLOODLUST TRACKER", y); y = y - h
 
+    -- Live preview: the icon is forced on screen for as long as this page is, so the
+    -- ready label, sizes and offsets can be judged without waiting for a real lust.
+    -- The runtime keys off the page's own visibility, so the OnHide hook only has to
+    -- poke it; a hidden search pre-build never owns the preview.
+    if not EllesmereUI._prebuilding and _G._EUI_Bloodlust_SetPreviewOwner then
+        _G._EUI_Bloodlust_SetPreviewOwner(parent)
+        if not parent._blPreviewHooked then
+            parent._blPreviewHooked = true
+            parent:HookScript("OnHide", function()
+                if _G._EUI_Bloodlust_UpdateVisibility then
+                    _G._EUI_Bloodlust_UpdateVisibility()
+                end
+            end)
+        end
+    end
+
     row, h = W:DualRow(parent, y,
         { type="dropdown", text="Enable Bloodlust Icon",
           values=VIS_VALUES, order=VIS_ORDER,
@@ -613,7 +633,10 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
     y = y - h
 
     do
-        local function _attachOffsetCog(rgn, popupTitle, xKey, yKey)
+        -- disabledFn/disabledText: optional, block the popup + grey the cog while
+        -- the row it belongs to is disabled (Duration/Count Position pass neither
+        -- and stay always-on, unchanged).
+        local function _attachOffsetCog(rgn, popupTitle, xKey, yKey, disabledFn, disabledText)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = popupTitle,
                 rows = {
@@ -633,12 +656,96 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
             cogTex:SetAllPoints()
             cogTex:SetTexture(EllesmereUI.RESIZE_ICON)
             cogBtn:SetAlpha(0.4)
-            cogBtn:SetScript("OnClick", function(self) cogShow(self) end)
-            cogBtn:SetScript("OnEnter", function(self) self:SetAlpha(0.75) end)
-            cogBtn:SetScript("OnLeave", function(self) self:SetAlpha(0.4) end)
+            cogBtn:SetScript("OnClick", function(self)
+                if disabledFn and disabledFn() then return end
+                cogShow(self)
+            end)
+            cogBtn:SetScript("OnEnter", function(self)
+                if disabledFn and disabledFn() then
+                    EllesmereUI.ShowWidgetTooltip(self, EllesmereUI.DisabledTooltip(disabledText))
+                    return
+                end
+                self:SetAlpha(0.75)
+            end)
+            cogBtn:SetScript("OnLeave", function(self)
+                if disabledFn and disabledFn() then EllesmereUI.HideWidgetTooltip(); return end
+                self:SetAlpha(0.4)
+            end)
+            if disabledFn then
+                EllesmereUI.RegisterWidgetRefresh(function()
+                    cogBtn:SetAlpha(disabledFn() and 0.15 or 0.4)
+                end)
+            end
         end
         _attachOffsetCog(row._leftRegion,  "Duration Position", "durationOffsetX", "durationOffsetY")
         _attachOffsetCog(row._rightRegion, "Count Position",    "countOffsetX",    "countOffsetY")
+
+        -- Show Sated / Show Ready: independent toggles. Sated gates the real lockout
+        -- countdown, Ready gates the label shown once that lockout is gone -- either,
+        -- both or neither can be on.
+        row, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Sated",
+              tooltip="Show the Sated/Exhaustion lockout countdown on the icon.",
+              getValue=function() return BL_Cfg("showSated") ~= false end,
+              setValue=function(v) BL_Set("showSated", v); BL_Refresh() end },
+            { type="toggle", text="Show Ready",
+              tooltip="Once the lockout expires, show a Ready label on the icon in place of the countdown. The visibility rule above still applies.",
+              getValue=function() return BL_Cfg("showReady") == true end,
+              setValue=function(v) BL_Set("showReady", v); BL_Refresh() end })
+        y = y - h
+
+        -- Ready appearance: offset cog, colour swatch and size slider on one row,
+        -- disabled (not hidden) while Show Ready is off so the layout never
+        -- reshuffles on the toggle.
+        local function readyOff() return BL_Cfg("showReady") ~= true end
+        row, h = W:DualRow(parent, y,
+            { type="slider", text="Ready",
+              disabled=readyOff,
+              disabledTooltip="Show Ready",
+              min=8, max=30, step=1, isPercent=false,
+              getValue=function() return BL_Cfg("readySize") or 12 end,
+              setValue=function(v) BL_Set("readySize", v); BL_Refresh() end },
+            { type="label", text="" })
+        y = y - h
+        do
+            local leftRgn = row._leftRegion
+            local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(leftRgn, leftRgn:GetFrameLevel() + 5,
+                function()
+                    local c = BL_Cfg("readyColor")
+                    if c then return c.r or 1, c.g or 1, c.b or 1 end
+                    return 1, 1, 1
+                end,
+                function(r, g, b)
+                    BL_Set("readyColor", { r = r, g = g, b = b })
+                    BL_Refresh()
+                end, false, 20)
+            PP.Point(swatch, "RIGHT", leftRgn._control, "LEFT", -12, 0)
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = readyOff()
+                swatch:SetAlpha(off and 0.3 or 1)
+                updateSwatch()
+            end)
+            -- The slider's own "disabled" already blocks clicks on itself; the
+            -- swatch is a manual inline extra, so it needs the same click-block
+            -- overlay the ActionBars range-colour swatch uses.
+            local readyColorBlock = CreateFrame("Frame", nil, swatch)
+            readyColorBlock:SetAllPoints()
+            readyColorBlock:SetFrameLevel(swatch:GetFrameLevel() + 10)
+            readyColorBlock:EnableMouse(true)
+            readyColorBlock:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(swatch, EllesmereUI.DisabledTooltip("Show Ready"))
+            end)
+            readyColorBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+            EllesmereUI.RegisterWidgetRefresh(function()
+                readyColorBlock:SetShown(readyOff())
+            end)
+            readyColorBlock:SetShown(readyOff())
+            -- Cog anchors LEFT of the swatch (not the slider): passing the swatch
+            -- itself as the "control region" lands it in the empty gap instead of
+            -- stacking both on the slider's left edge.
+            _attachOffsetCog(swatch, "Ready Position", "readyOffsetX", "readyOffsetY",
+                readyOff, "Show Ready")
+        end
     end
     end   -- close Bloodlust hidden-while-Never gate
 

--- a/EllesmereUIOptions/EUI_QoL_BattleRes_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_BattleRes_Options.lua
@@ -245,12 +245,20 @@ _G._EUI_BuildBattleResSection = function(parent, yOffset, W, PP)
     _, h = W:SectionHeader(parent, "BATTLE RES", y); y = y - h
 
     -- Live preview: forces the icon on screen for as long as this page is (mirrors
-    -- the Bloodlust Tracker section below). PollCharges reads real charge data
-    -- regardless, so this alone is enough to preview it from anywhere.
+    -- the Bloodlust Tracker section below). PollCharges falls back to stand-in
+    -- charge data wherever the brez pool reports none, so it previews from anywhere.
+    -- The OnSHOW hook is what makes revisits work: the options panel caches built
+    -- pages and re-shows the wrapper without re-running this builder, so without it
+    -- the preview would arm on the first visit only.
     if not EllesmereUI._prebuilding and _G._EUI_BattleRes_SetPreviewOwner then
         _G._EUI_BattleRes_SetPreviewOwner(parent)
         if not parent._brPreviewHooked then
             parent._brPreviewHooked = true
+            parent:HookScript("OnShow", function()
+                if _G._EUI_BattleRes_SetPreviewOwner then
+                    _G._EUI_BattleRes_SetPreviewOwner(parent)
+                end
+            end)
             parent:HookScript("OnHide", function()
                 if _G._EUI_BattleRes_UpdateVisibility then
                     _G._EUI_BattleRes_UpdateVisibility()
@@ -572,10 +580,18 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
     -- ready label, sizes and offsets can be judged without waiting for a real lust.
     -- The runtime keys off the page's own visibility, so the OnHide hook only has to
     -- poke it; a hidden search pre-build never owns the preview.
+    -- The OnSHOW hook is what makes revisits work: the options panel caches built
+    -- pages and re-shows the wrapper without re-running this builder, so without it
+    -- the preview would arm on the first visit only.
     if not EllesmereUI._prebuilding and _G._EUI_Bloodlust_SetPreviewOwner then
         _G._EUI_Bloodlust_SetPreviewOwner(parent)
         if not parent._blPreviewHooked then
             parent._blPreviewHooked = true
+            parent:HookScript("OnShow", function()
+                if _G._EUI_Bloodlust_SetPreviewOwner then
+                    _G._EUI_Bloodlust_SetPreviewOwner(parent)
+                end
+            end)
             parent:HookScript("OnHide", function()
                 if _G._EUI_Bloodlust_UpdateVisibility then
                     _G._EUI_Bloodlust_UpdateVisibility()
@@ -650,8 +666,11 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
     do
         -- disabledFn/disabledText: optional, block the popup + grey the cog while
         -- the row it belongs to is disabled (Duration/Count Position pass neither
-        -- and stay always-on, unchanged).
-        local function _attachOffsetCog(rgn, popupTitle, xKey, yKey, disabledFn, disabledText)
+        -- and stay always-on, unchanged). anchorTo: optional, anchor the cog to
+        -- something other than the row's own control while keeping rgn as parent
+        -- (parenting it to the anchor instead would multiply the cog's disabled
+        -- alpha by that anchor's, greying it into invisibility).
+        local function _attachOffsetCog(rgn, popupTitle, xKey, yKey, disabledFn, disabledText, anchorTo)
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = popupTitle,
                 rows = {
@@ -665,7 +684,7 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
             })
             local cogBtn = CreateFrame("Button", nil, rgn)
             cogBtn:SetSize(26, 26)
-            PP.Point(cogBtn, "RIGHT", rgn._control or rgn, "LEFT", -6, 0)
+            PP.Point(cogBtn, "RIGHT", anchorTo or rgn._control or rgn, "LEFT", -6, 0)
             cogBtn:SetFrameLevel(rgn:GetFrameLevel() + 5)
             local cogTex = cogBtn:CreateTexture(nil, "OVERLAY")
             cogTex:SetAllPoints()
@@ -721,7 +740,7 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
         -- reshuffles on the toggle.
         local function readyOff() return BL_Cfg("showReady") ~= true end
         row, h = W:DualRow(parent, y,
-            { type="slider", text="Ready",
+            { type="slider", text="Ready Size",
               disabled=readyOff,
               disabledTooltip="Show Icon with Ready Text",
               min=8, max=30, step=1, isPercent=false,
@@ -762,11 +781,11 @@ _G._EUI_BuildBloodlustSection = function(parent, yOffset, W, PP)
                 readyColorBlock:SetShown(readyOff())
             end)
             readyColorBlock:SetShown(readyOff())
-            -- Cog anchors LEFT of the swatch (not the slider): passing the swatch
-            -- itself as the "control region" lands it in the empty gap instead of
-            -- stacking both on the slider's left edge.
-            _attachOffsetCog(swatch, "Ready Position", "readyOffsetX", "readyOffsetY",
-                readyOff, "Show Icon with Ready Text")
+            -- Cog anchors LEFT of the swatch (not the slider) so it lands in the
+            -- empty gap instead of stacking both on the slider's left edge, while
+            -- staying parented to the row region like the other two.
+            _attachOffsetCog(leftRgn, "Ready Position", "readyOffsetX", "readyOffsetY",
+                readyOff, "Show Icon with Ready Text", swatch)
         end
     end
     end   -- close Bloodlust hidden-while-Never gate

--- a/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
@@ -85,6 +85,15 @@ end
 
 local frame, iconTex, borderTex, durationFS, countFS, cooldownFrame, textFS
 
+-- Options-page live preview: forces the icon on screen for as long as the
+-- owning page is. No stand-in data needed here (unlike the Bloodlust
+-- tracker) -- PollCharges already reads the player's real Battle Rez charges
+-- everywhere, so forcing visibility alone is enough to preview the real state.
+local _previewOwner
+local function _previewActive()
+    return _previewOwner ~= nil and _previewOwner:IsVisible() and true or false
+end
+
 local function IsTextMode()
     local p = P()
     return (p and p.displayMode) == "text"
@@ -403,6 +412,9 @@ local function ShouldShow()
     if not p or not p.enabled then return false end
     local v = p.visibility or "MPLUS_AND_RAID"
     if v == "NEVER" then return false end
+    -- Options preview: forced on screen while the page is up, skipping the instance
+    -- and M+/raid gates below -- the point is to configure it from anywhere.
+    if _previewActive() then return true end
 
     -- Hard gate: must be in a party or raid instance. Prevents any stuck state from
     -- showing the icon in town/open world. Unlock mode relies on the overlay mover for
@@ -504,6 +516,12 @@ local function UpdateVisibility()
     end
 end
 _G._EUI_BattleRes_UpdateVisibility = UpdateVisibility
+
+-- The options page hands us its frame on build; _previewActive() takes it from there.
+function _G._EUI_BattleRes_SetPreviewOwner(f)
+    _previewOwner = f
+    UpdateVisibility()
+end
 
 -------------------------------------------------------------------------------
 --  Frame creation

--- a/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
@@ -64,6 +64,15 @@ local defaults = {
             enabled    = true,
             visibility = "NEVER",  -- MPLUS_AND_RAID | MPLUS | RAID | NEVER
             pos        = nil,      -- { centerX, centerY } stored after first move
+            -- Show Sated / Show Ready: independent toggles. Own keys, never proxied to
+            -- battleRes (which has no ready state). Sated on / Ready off = the
+            -- pre-existing behaviour (countdown only, hidden once it expires).
+            showSated    = true,
+            showReady    = false,
+            readySize    = 12,
+            readyColor   = { r = 1, g = 1, b = 1 },
+            readyOffsetX = 0,
+            readyOffsetY = 0,
         },
     },
 }

--- a/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
@@ -85,10 +85,10 @@ end
 
 local frame, iconTex, borderTex, durationFS, countFS, cooldownFrame, textFS
 
--- Options-page live preview: forces the icon on screen for as long as the
--- owning page is. No stand-in data needed here (unlike the Bloodlust
--- tracker) -- PollCharges already reads the player's real Battle Rez charges
--- everywhere, so forcing visibility alone is enough to preview the real state.
+-- Options-page live preview: forces the icon on screen for as long as the owning
+-- page is. Real charge data is used whenever the brez pool reports any; outside
+-- a raid or key it reports none, so PollCharges falls back to the stand-in below
+-- rather than previewing an icon with no count and no timer.
 local _previewOwner
 local function _previewActive()
     return _previewOwner ~= nil and _previewOwner:IsVisible() and true or false
@@ -161,6 +161,15 @@ local function _resolveBorderColor(p)
     return 0, 0, 0, 1
 end
 
+-- Snap a config-driven layout offset onto the pixel grid. The frame's own edges
+-- and center are snapped already (ApplyShape / ApplyPosition), so snapping the
+-- offset is what keeps the child anchored to it on the grid too.
+local function _snapOff(v)
+    local PP = EllesmereUI and EllesmereUI.PP
+    if PP and PP.Snap then return PP.Snap(v) end
+    return v
+end
+
 local function ApplyShape()
     if not frame then return end
     local p = P()
@@ -191,12 +200,12 @@ local function ApplyShape()
     SetBrezIconFont(durationFS, p.durationSize or 12)
     durationFS:ClearAllPoints()
     durationFS:SetPoint("CENTER", frame, "CENTER",
-        p.durationOffsetX or 0, p.durationOffsetY or 0)
+        _snapOff(p.durationOffsetX or 0), _snapOff(p.durationOffsetY or 0))
 
     SetBrezIconFont(countFS, p.countSize or 11)
     countFS:ClearAllPoints()
     countFS:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
-        -2 + (p.countOffsetX or 0), 2 + (p.countOffsetY or 0))
+        _snapOff(-2 + (p.countOffsetX or 0)), _snapOff(2 + (p.countOffsetY or 0)))
 
     -----------------------------------------------------------------------
     --  BASE CASE: "none" or "cropped" -- plain texture, no mask
@@ -283,8 +292,9 @@ local function ApplyShape()
     if borderPath and bs > 0 then
         borderTex:SetTexture(borderPath)
         borderTex:ClearAllPoints()
-        borderTex:SetPoint("TOPLEFT", frame, "TOPLEFT", -bs, bs)
-        borderTex:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", bs, -bs)
+        local bsp = _snapOff(bs)
+        borderTex:SetPoint("TOPLEFT", frame, "TOPLEFT", -bsp, bsp)
+        borderTex:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", bsp, -bsp)
         local r, g, b, a = _resolveBorderColor(p)
         borderTex:SetVertexColor(r, g, b, a)
         borderTex:Show()
@@ -463,11 +473,34 @@ local function _setDur(s)
     end
 end
 
+-- Options preview stand-in. The shared brez pool only reports charges inside a
+-- raid or key, and BREZ_SPELL_ID is Rebirth, so for most characters in most
+-- places GetSpellCharges returns nothing and the preview would be a bare icon --
+-- exactly the two texts the Count and Duration options tune. Same placeholder
+-- count ApplyText measures with, plus a looping countdown.
+local _previewExpiry = 0
+local function _showPreviewCharges()
+    if _previewExpiry <= GetTime() then
+        -- Once per cycle: re-setting the SAME values each poll is idempotent, but
+        -- re-setting new ones would restart the swipe animation twice a second.
+        _previewExpiry = GetTime() + 90
+        if cooldownFrame then cooldownFrame:SetCooldown(GetTime(), 90) end
+    end
+    local timeText = FormatTime(_previewExpiry - GetTime())
+    if IsTextMode() then
+        _setTextDisplay("2", timeText, false)
+        return
+    end
+    _setCount("2", false)
+    _setDur(timeText)
+end
+
 local function PollCharges()
     if not frame then return end
     local textMode = IsTextMode()
     local info = C_Spell and C_Spell.GetSpellCharges and C_Spell.GetSpellCharges(BREZ_SPELL_ID)
     if not info or not info.maxCharges then
+        if _previewActive() then return _showPreviewCharges() end
         if textMode then
             _setTextDisplay("", "", false)
         else
@@ -513,6 +546,17 @@ local function UpdateVisibility()
     else
         if frame:IsShown() then frame:Hide() end
         if _ticker then _ticker:Cancel(); _ticker = nil end
+        -- Preview just ended: drop the stand-in swipe and texts so no later path
+        -- can surface them as if they were real charge data.
+        if _previewExpiry ~= 0 and not _previewActive() then
+            _previewExpiry = 0
+            if cooldownFrame then cooldownFrame:Clear() end
+            if IsTextMode() then
+                _setTextDisplay("", "", false)
+            else
+                _setCount("", false); _setDur("")
+            end
+        end
     end
 end
 _G._EUI_BattleRes_UpdateVisibility = UpdateVisibility
@@ -520,6 +564,7 @@ _G._EUI_BattleRes_UpdateVisibility = UpdateVisibility
 -- The options page hands us its frame on build; _previewActive() takes it from there.
 function _G._EUI_BattleRes_SetPreviewOwner(f)
     _previewOwner = f
+    _previewExpiry = 0  -- every visit starts a fresh stand-in countdown
     UpdateVisibility()
 end
 

--- a/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_BattleRes.lua
@@ -166,6 +166,7 @@ local function ApplyShape()
     local size = p.iconSize or 40
     local fw, fh = size, size
     if shape == "cropped" then fh = math.floor(size * 0.80 + 0.5) end
+    if PP and PP.Snap then fw, fh = PP.Snap(fw), PP.Snap(fh) end
     frame:SetSize(fw, fh)
     iconTex:ClearAllPoints()
     iconTex:SetAllPoints(frame)
@@ -334,7 +335,10 @@ local function ApplyText()
     local h = textFS:GetStringHeight() or 0
     if w < 1 then w = (p.textSize or 14) * 4 end
     if h < 1 then h = p.textSize or 14 end
-    frame:SetSize(math.ceil(w) + 4, math.ceil(h) + 2)
+    local tw, th = math.ceil(w) + 4, math.ceil(h) + 2
+    local PPt = EllesmereUI and EllesmereUI.PP
+    if PPt and PPt.Snap then tw, th = PPt.Snap(tw), PPt.Snap(th) end
+    frame:SetSize(tw, th)
 end
 
 -------------------------------------------------------------------------------
@@ -344,13 +348,16 @@ local function ApplyPosition()
     if not frame then return end
     local p = P()
     if not p then return end
-    local pos = p.pos
     frame:ClearAllPoints()
-    if pos and pos.centerX and pos.centerY then
-        frame:SetPoint("CENTER", UIParent, "CENTER", pos.centerX, pos.centerY)
-    else
-        frame:SetPoint("CENTER", UIParent, "CENTER", 0, 200)
+    local pos = p.pos
+    local cx = (pos and pos.centerX) or 0
+    local cy = (pos and pos.centerY) or 200
+    local PPp = EllesmereUI and EllesmereUI.PP
+    if PPp and PPp.SnapCenterForDim then
+        cx = PPp.SnapCenterForDim(cx, frame:GetWidth())
+        cy = PPp.SnapCenterForDim(cy, frame:GetHeight())
     end
+    frame:SetPoint("CENTER", UIParent, "CENTER", cx, cy)
 end
 
 local function SavePosition()
@@ -360,6 +367,11 @@ local function SavePosition()
     local fw, fh = frame:GetSize()
     local cx = left + fw / 2 - UIParent:GetWidth() / 2
     local cy = bottom + fh / 2 - UIParent:GetHeight() / 2
+    local PPp = EllesmereUI and EllesmereUI.PP
+    if PPp and PPp.SnapCenterForDim then
+        cx = PPp.SnapCenterForDim(cx, fw)
+        cy = PPp.SnapCenterForDim(cy, fh)
+    end
     local p = P(); if p then p.pos = { centerX = cx, centerY = cy } end
 end
 

--- a/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
@@ -244,6 +244,7 @@ local function ApplyShape()
     local size = EP("iconSize") or 40
     local fw, fh = size, size
     if shape == "cropped" then fh = math.floor(size * 0.80 + 0.5) end
+    if PP and PP.Snap then fw, fh = PP.Snap(fw), PP.Snap(fh) end
     frame:SetSize(fw, fh)
     iconTex:ClearAllPoints()
     iconTex:SetAllPoints(frame)
@@ -393,12 +394,18 @@ local function ApplyPosition()
     local p = P()
     if not p then return end
     frame:ClearAllPoints()
+    local cx, cy
     if p.pos and p.pos.centerX and p.pos.centerY then
-        frame:SetPoint("CENTER", UIParent, "CENTER", p.pos.centerX, p.pos.centerY)
+        cx, cy = p.pos.centerX, p.pos.centerY
     else
-        local cx, cy = _defaultLeftOfBrezCenter()
-        frame:SetPoint("CENTER", UIParent, "CENTER", cx, cy)
+        cx, cy = _defaultLeftOfBrezCenter()
     end
+    local PPp = EllesmereUI and EllesmereUI.PP
+    if PPp and PPp.SnapCenterForDim then
+        cx = PPp.SnapCenterForDim(cx, frame:GetWidth())
+        cy = PPp.SnapCenterForDim(cy, frame:GetHeight())
+    end
+    frame:SetPoint("CENTER", UIParent, "CENTER", cx, cy)
 end
 
 local function SavePosition()
@@ -408,6 +415,11 @@ local function SavePosition()
     local fw, fh = frame:GetSize()
     local cx = left + fw / 2 - UIParent:GetWidth() / 2
     local cy = bottom + fh / 2 - UIParent:GetHeight() / 2
+    local PPp = EllesmereUI and EllesmereUI.PP
+    if PPp and PPp.SnapCenterForDim then
+        cx = PPp.SnapCenterForDim(cx, fw)
+        cy = PPp.SnapCenterForDim(cy, fh)
+    end
     local p = P(); if p then p.pos = { centerX = cx, centerY = cy } end
 end
 

--- a/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
@@ -20,8 +20,22 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 --  existing BattleRes data is never touched.
 -------------------------------------------------------------------------------
 
--- The active lust BUFF id, used purely as the default/preview icon texture.
+-- Last-resort texture source for the active-aura path, used only if a lockout
+-- debuff ever reports no icon of its own. The resting, ready and preview icon
+-- resolve per character through _lustBuffIcon below.
 local PREVIEW_SPELL_ID = 2825  -- Bloodlust
+
+-- Player-castable lust spells, checked in this order: the first one the character
+-- actually knows supplies the icon, so a Mage sees Time Warp and an Evoker sees
+-- Fury of the Aspects rather than the faction default. Spec- and talent-gated
+-- spells leave the spellbook on their own, so no class/spec table is needed.
+local LUST_SPELLS = {
+    2825,    -- Bloodlust (Shaman, Horde)
+    32182,   -- Heroism (Shaman, Alliance)
+    80353,   -- Time Warp (Mage)
+    390386,  -- Fury of the Aspects (Evoker)
+    272678,  -- Primal Rage (Hunter)
+}
 
 -- Sated / Exhaustion debuff ids (every lust variant's lockout debuff). These
 -- mirror the SATED_DEBUFFS list used by the Raid Frames lust filter.
@@ -101,9 +115,42 @@ local function EP_borderColor()
     return { r = 0, g = 0, b = 0, a = 1 }
 end
 
+-- Ready-display keys are OWN keys: BattleRes has no ready state, so they read
+-- straight from the bloodlust slice instead of EP()'s proxy chain.
+local READY_DEFAULTS = {
+    showSated    = true,
+    showReady    = false,
+    readySize    = 12,
+    readyOffsetX = 0,
+    readyOffsetY = 0,
+}
+
+local function RP(key)
+    local bl = P()
+    if bl and bl[key] ~= nil then return bl[key] end
+    return READY_DEFAULTS[key]
+end
+
+local function RP_color()
+    local c = P() and P().readyColor
+    if c then return c.r or 1, c.g or 1, c.b or 1 end
+    return 1, 1, 1
+end
+
 local frame, iconTex, borderTex, durationFS, countFS, cooldownFrame
+local readyOverlay, readyFS  -- ready label on its own frame, above the cooldown widget
 local buffOverlay, buffTex, buffCooldown, buffDurationFS  -- the 40s active-lust overlay (sits on top of the debuff icon)
 local _satedActive = false
+local _readyShown = false       -- ready label currently rendered (idempotence for the 0.5s poll)
+local _previewOwner             -- options page frame driving the live preview (nil = none)
+local _previewExpiry = 0        -- stand-in lockout expiry for the preview countdown
+
+-- Preview runs exactly as long as the owning options page is on screen. Reading
+-- IsVisible() beats latching a boolean: a page that was hidden, destroyed or
+-- replaced by a rebuild ends the preview on its own, in any order.
+local function _previewActive()
+    return _previewOwner ~= nil and _previewOwner:IsVisible() and true or false
+end
 local _satedWasPresent = false  -- rising-edge baseline so only a FRESH debuff arms the buff window
 local _buffExpiry = 0           -- GetTime() when the 40s active-buff window ends
 local _buffZoneGuard = 0        -- suppress rising edges until this time (set on zone-in)
@@ -219,6 +266,20 @@ local function ApplyShape()
     countFS:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
         -2 + (EP("countOffsetX") or 0), 2 + (EP("countOffsetY") or 0))
 
+    -- Ready label: same font family as the countdown it replaces, but its own
+    -- size, colour and offset. Dropped back to hidden so the next poll re-renders
+    -- it with the new style instead of leaving a stale string on screen.
+    if readyOverlay and readyFS then
+        readyOverlay:SetAllPoints(frame)
+        readyFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, RP("readySize") or 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
+        readyFS:ClearAllPoints()
+        readyFS:SetPoint("CENTER", readyOverlay, "CENTER",
+            RP("readyOffsetX") or 0, RP("readyOffsetY") or 0)
+        readyFS:SetTextColor(RP_color())
+        readyOverlay:Hide()
+        _readyShown = false
+    end
+
     -----------------------------------------------------------------------
     --  BASE CASE: "none" or "cropped" -- plain texture, no mask
     -----------------------------------------------------------------------
@@ -250,6 +311,13 @@ local function ApplyShape()
 
         if PP then
             if not PP.GetBorders(frame) then PP.CreateBorder(frame, 0, 0, 0, 1, 1, "OVERLAY", 2) end
+            -- PP.CreateBorder parents its container to frame+1, the SAME level
+            -- cooldownFrame sits at -- a level TIE that the border only wins by
+            -- creation order. readyOverlay/buffOverlay sit explicitly higher still
+            -- (frame+3/+5), so raise the border above all three every pass instead
+            -- of relying on an implicit tie-break that a future overlay could flip.
+            local brd = PP.GetBorders(frame)
+            if brd and buffOverlay then brd:SetFrameLevel(buffOverlay:GetFrameLevel() + 1) end
             if bs > 0 then
                 local r, g, b, a = _resolveBorderColor()
                 PP.UpdateBorder(frame, bs, r, g, b, a)
@@ -433,8 +501,25 @@ end
 --  icon. We cannot read the actual buff, so the 40s window is self-timed. After
 --  40s (or on death) the overlay hides, revealing the untouched debuff icon.
 -------------------------------------------------------------------------------
--- Horde casts Bloodlust, Alliance casts Heroism; both active buffs last 40s.
+-- Icon for "this character's lust". Falls back to the faction buff (Horde
+-- Bloodlust / Alliance Heroism) for everyone who cannot cast one themselves.
+-- Cached, but only once a real spell was found: at login the spellbook can still
+-- be empty, and caching the fallback then would stick for the session.
+local _lustIconCache
 local function _lustBuffIcon()
+    if _lustIconCache then return _lustIconCache end
+    for i = 1, #LUST_SPELLS do
+        local sid = LUST_SPELLS[i]
+        local known = (IsPlayerSpell and IsPlayerSpell(sid))
+            or (IsSpellKnown and IsSpellKnown(sid))
+        if known then
+            local tex = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(sid)
+            if tex then
+                _lustIconCache = tex
+                return tex
+            end
+        end
+    end
     return (UnitFactionGroup("player") == "Alliance") and 132313 or 136012
 end
 
@@ -477,6 +562,27 @@ local function _showBuffOverlay()
     _setBuffDur("40")
     buffOverlay:Show()
     buffOverlay:SetScript("OnUpdate", _buffOnUpdate)
+end
+
+-- Lockout gone: swap to the lust icon, clear the swipe and show the label in
+-- place of the countdown. Guarded so the 0.5s poll re-applies nothing.
+local function _showReadyState()
+    if _readyShown or not frame then return end
+    iconTex:SetTexture(_lustBuffIcon())
+    -- Clear(), never SetCooldown(0, 0): a zero-duration cooldown makes the widget
+    -- hide itself, and the leftover swipe has to go either way.
+    if cooldownFrame then cooldownFrame:Clear() end
+    if readyOverlay then
+        if readyFS then readyFS:SetText(EllesmereUI.L("Ready")) end
+        readyOverlay:Show()
+    end
+    _readyShown = true
+end
+
+local function _hideReadyState()
+    if not _readyShown then return end
+    if readyOverlay then readyOverlay:Hide() end
+    _readyShown = false
 end
 
 local function _hideBuffOverlay()
@@ -532,7 +638,16 @@ local function ShouldShow()
     if not p or not p.enabled then return false end
     local v = p.visibility or "NEVER"
     if v == "NEVER" then return false end
-    if not _satedActive then return false end
+    -- Options preview: forced on screen while the page is up, skipping the instance
+    -- and M+/raid gates below -- the point is to configure it from anywhere.
+    if _previewActive() then return true end
+    -- Show Sated / Show Ready are independent: which one gates visibility depends
+    -- on which state the icon is currently in.
+    if _satedActive then
+        if RP("showSated") == false then return false end
+    elseif not RP("showReady") then
+        return false
+    end
 
     -- Hard gate: must be in a party or raid instance. Prevents any stuck state
     -- from showing the icon in town / open world.
@@ -556,17 +671,53 @@ local function _setDur(s)
     end
 end
 
+-- Options preview with no real lockout and no ready label: a stand-in 10 minute
+-- countdown so icon size, shape and the duration offsets can be judged. It loops
+-- on expiry, so a long options session keeps showing something.
+local function _showPreviewLockout()
+    if not frame then return end
+    _hideReadyState()
+    iconTex:SetTexture(_lustBuffIcon())
+    if _previewExpiry <= GetTime() then
+        _previewExpiry = GetTime() + 600
+        -- Once per cycle: re-setting the SAME values each poll is idempotent, but
+        -- re-setting new ones would restart the swipe animation twice a second.
+        if cooldownFrame then cooldownFrame:SetCooldown(GetTime(), 600) end
+    end
+    _setDur(FormatTime(_previewExpiry - GetTime()))
+end
+
 -- Text ticker: updates the countdown number and re-confirms the debuff is still present
 -- (a safety net in case a UNIT_AURA removal event is ever missed). When the remaining
 -- time is secret (in combat) the swipe still animates but the number is left blank.
 local function PollSated()
     if not frame then return end
-    local aura = _findSated()
+    local aura, auraSid = _findSated()
     if not aura then
         _satedActive = false
         _satedExpiryGuess = 0
+        if RP("showReady") then
+            -- Render in place and RETURN: UpdateVisibility calls back into this
+            -- function whenever the icon is shown, so re-entering it here would
+            -- recurse forever now that "not sated" can still mean "shown".
+            _setDur("")
+            _showReadyState()
+            return
+        end
+        if _previewActive() then
+            -- Same reasoning; the stand-in sets its own countdown text.
+            _showPreviewLockout()
+            return
+        end
         _setDur("")
         return UpdateVisibility()
+    end
+    if _readyShown then
+        -- Coming back from the ready state (normally the UNIT_AURA edge, but this
+        -- poll is also the safety net for a missed one): restore the debuff icon
+        -- and its swipe, not just the text.
+        _hideReadyState()
+        _applyActiveAura(aura, auraSid)
     end
     local exp = aura.expirationTime
     if exp and not issecretvalue(exp) then
@@ -586,7 +737,15 @@ function UpdateVisibility()
     if not frame then return end
     if ShouldShow() then
         if not frame:IsShown() then frame:Show() end
-        if not _ticker then _ticker = C_Timer.NewTicker(0.5, PollSated) end
+        -- The ticker exists to animate the countdown, so it runs only while the
+        -- lockout does. In the ready state there is nothing to count down and a
+        -- fresh debuff arrives on UNIT_AURA, so polling there would just burn
+        -- aura lookups for the whole encounter.
+        if _satedActive or (_previewActive() and not RP("showReady")) then
+            if not _ticker then _ticker = C_Timer.NewTicker(0.5, PollSated) end
+        elseif _ticker then
+            _ticker:Cancel(); _ticker = nil
+        end
         PollSated()
     else
         if frame:IsShown() then frame:Hide() end
@@ -594,6 +753,13 @@ function UpdateVisibility()
     end
 end
 _G._EUI_Bloodlust_UpdateVisibility = UpdateVisibility
+
+-- The options page hands us its frame on build; _previewActive() takes it from there.
+function _G._EUI_Bloodlust_SetPreviewOwner(f)
+    _previewOwner = f
+    _previewExpiry = 0  -- every visit starts a fresh stand-in countdown
+    UpdateVisibility()
+end
 
 local function _refreshSated()
     local aura, sid = _findSated()
@@ -643,6 +809,11 @@ local function _onEvent(_, event, _, updateInfo)
             if aura then _applyActiveAura(aura, sid) end
             _showBuffOverlay()
         end
+    elseif event == "PLAYER_SPECIALIZATION_CHANGED" then
+        -- A spec swap can add or remove this character's lust spell. Drop the cached
+        -- icon and the ready-render latch so the next pass re-renders with the new one.
+        _lustIconCache = nil
+        _readyShown = false
     elseif event == "PLAYER_DEAD" then
         -- Buffs drop on death; hide the active-lust overlay even if 40s remain.
         _hideBuffOverlay()
@@ -660,6 +831,7 @@ local function _onEvent(_, event, _, updateInfo)
         or event == "WORLD_STATE_TIMER_STOP" then
         _state.inChallenge = false
     elseif event == "PLAYER_ENTERING_WORLD" then
+        _lustIconCache = nil
         _refreshSated()
         -- Baseline the edge tracker so a debuff already present on login/zone-in
         -- is NOT mistaken for a fresh cast (no buff overlay reconstruction), and
@@ -688,6 +860,7 @@ local function _ensureEvents(enabled)
         _eventFrame:RegisterEvent("WORLD_STATE_TIMER_STOP")
         _eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
         _eventFrame:RegisterEvent("PLAYER_DEAD")
+        _eventFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
     else
         _eventFrame:UnregisterAllEvents()
     end
@@ -705,11 +878,7 @@ local function CreateBloodlustFrame()
 
     iconTex = frame:CreateTexture(nil, "ARTWORK")
     iconTex:SetAllPoints(frame)
-    local previewIcon
-    if C_Spell and C_Spell.GetSpellTexture then
-        previewIcon = C_Spell.GetSpellTexture(PREVIEW_SPELL_ID)
-    end
-    iconTex:SetTexture(previewIcon or 136080)
+    iconTex:SetTexture(_lustBuffIcon() or 136080)
     iconTex:SetTexCoord(0.08, 0.92, 0.08, 0.92)
 
     borderTex = frame:CreateTexture(nil, "OVERLAY")
@@ -724,6 +893,20 @@ local function CreateBloodlustFrame()
     durationFS = cooldownFrame:CreateFontString(nil, "OVERLAY")
     durationFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 14, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     durationFS:SetText("")
+
+    -- Ready label on its OWN overlay, mirroring the buff overlay below: it is
+    -- shown precisely when no cooldown runs, so its lifetime must not hang off the
+    -- cooldown widget, and sitting above that widget keeps a swipe off the text.
+    readyOverlay = CreateFrame("Frame", nil, frame)
+    readyOverlay:SetAllPoints(frame)
+    readyOverlay:SetFrameLevel(cooldownFrame:GetFrameLevel() + 2)
+    readyOverlay:Hide()
+
+    readyFS = readyOverlay:CreateFontString(nil, "OVERLAY")
+    -- SetFont FIRST: SetText on a fontstring that has no font yet errors out, and
+    -- this runs before ApplyShape ever styles it.
+    readyFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
+    readyFS:SetText("")
 
     countFS = cooldownFrame:CreateFontString(nil, "OVERLAY")
     countFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")

--- a/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
@@ -138,7 +138,7 @@ local function RP_color()
 end
 
 local frame, iconTex, borderTex, durationFS, countFS, cooldownFrame
-local textOverlay, readyFS  -- shared text layer: every fontstring lives above the border/swipes
+local textOverlay, buffTextOverlay, readyFS  -- text layers (see CreateBloodlustFrame for the level stack)
 local buffOverlay, buffTex, buffCooldown, buffDurationFS  -- the 40s active-lust overlay (sits on top of the debuff icon)
 local _satedActive = false
 local _readyShown = false       -- ready label currently rendered (idempotence for the 0.5s poll)
@@ -160,6 +160,7 @@ local _buffZoneGuard = 0        -- suppress rising edges until this time (set on
 -- restrictions hide the real value in combat, this carries the countdown.
 local _satedExpiryGuess = 0
 local UpdateVisibility  -- forward declaration (referenced by PollSated below)
+local _ticker           -- 0.5s countdown ticker (PollSated cancels it directly, see there)
 local FormatTime        -- forward declaration (shared by the debuff text and the buff overlay)
 
 -------------------------------------------------------------------------------
@@ -175,6 +176,15 @@ local function _resolveBorderColor()
     local c = EP_borderColor()
     if c then return c.r or 0, c.g or 0, c.b or 0, c.a or 1 end
     return 0, 0, 0, 1
+end
+
+-- Snap a config-driven layout offset onto the pixel grid. The frame's own edges
+-- and center are snapped already (ApplyShape / ApplyPosition), so snapping the
+-- offset is what keeps the child anchored to it on the grid too.
+local function _snapOff(v)
+    local PP = EllesmereUI and EllesmereUI.PP
+    if PP and PP.Snap then return PP.Snap(v) end
+    return v
 end
 
 -- Configure the buff overlay (texture coords + optional shape mask) so it
@@ -193,7 +203,8 @@ local function _applyBuffShape()
     -- Match the debuff icon's duration text exactly (font, size, position).
     buffDurationFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, EP("durationSize") or 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     buffDurationFS:ClearAllPoints()
-    buffDurationFS:SetPoint("CENTER", frame, "CENTER", EP("durationOffsetX") or 0, EP("durationOffsetY") or 0)
+    buffDurationFS:SetPoint("CENTER", frame, "CENTER",
+        _snapOff(EP("durationOffsetX") or 0), _snapOff(EP("durationOffsetY") or 0))
 
     if shape == "none" or shape == "cropped" then
         if buffTex._mask then
@@ -260,12 +271,12 @@ local function ApplyShape()
     durationFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, EP("durationSize") or 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     durationFS:ClearAllPoints()
     durationFS:SetPoint("CENTER", frame, "CENTER",
-        EP("durationOffsetX") or 0, EP("durationOffsetY") or 0)
+        _snapOff(EP("durationOffsetX") or 0), _snapOff(EP("durationOffsetY") or 0))
 
     countFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, EP("countSize") or 11, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     countFS:ClearAllPoints()
     countFS:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT",
-        -2 + (EP("countOffsetX") or 0), 2 + (EP("countOffsetY") or 0))
+        _snapOff(-2 + (EP("countOffsetX") or 0)), _snapOff(2 + (EP("countOffsetY") or 0)))
 
     -- Ready label: same font family as the countdown it replaces, but its own
     -- size, colour and offset. Dropped back to hidden so the next poll re-renders
@@ -274,7 +285,7 @@ local function ApplyShape()
         readyFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, RP("readySize") or 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
         readyFS:ClearAllPoints()
         readyFS:SetPoint("CENTER", frame, "CENTER",
-            RP("readyOffsetX") or 0, RP("readyOffsetY") or 0)
+            _snapOff(RP("readyOffsetX") or 0), _snapOff(RP("readyOffsetY") or 0))
         readyFS:SetTextColor(RP_color())
         readyFS:Hide()
         _readyShown = false
@@ -313,11 +324,10 @@ local function ApplyShape()
             if not PP.GetBorders(frame) then PP.CreateBorder(frame, 0, 0, 0, 1, 1, "OVERLAY", 2) end
             -- PP.CreateBorder parents its container to frame+1, the SAME level
             -- cooldownFrame sits at -- a level TIE the border only won by creation
-            -- order. Pin it to the stack position documented at textOverlay's
-            -- creation (frame+7, one below the text layer) instead of an implicit
-            -- tie-break that a future overlay could flip.
+            -- order. Pin it to its slot in the stack documented at CreateBloodlustFrame
+            -- instead of an implicit tie-break a future overlay could flip.
             local brd = PP.GetBorders(frame)
-            if brd then brd:SetFrameLevel(frame:GetFrameLevel() + 7) end
+            if brd then brd:SetFrameLevel(frame:GetFrameLevel() + 2) end
             if bs > 0 then
                 local r, g, b, a = _resolveBorderColor()
                 PP.UpdateBorder(frame, bs, r, g, b, a)
@@ -361,10 +371,11 @@ local function ApplyShape()
 
     local borderPath = SHAPE_BORDERS[shape]
     if borderPath and bs > 0 then
+        local bsp = _snapOff(bs)
         borderTex:SetTexture(borderPath)
         borderTex:ClearAllPoints()
-        borderTex:SetPoint("TOPLEFT", frame, "TOPLEFT", -bs, bs)
-        borderTex:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", bs, -bs)
+        borderTex:SetPoint("TOPLEFT", frame, "TOPLEFT", -bsp, bsp)
+        borderTex:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", bsp, -bsp)
         local r, g, b, a = _resolveBorderColor()
         borderTex:SetVertexColor(r, g, b, a)
         borderTex:Show()
@@ -514,11 +525,16 @@ end
 -------------------------------------------------------------------------------
 -- Icon for "this character's lust". Falls back to the faction buff (Horde
 -- Bloodlust / Alliance Heroism) for everyone who cannot cast one themselves.
--- Cached, but only once a real spell was found: at login the spellbook can still
--- be empty, and caching the fallback then would stick for the session.
+-- The fallback is cached too: without that, every character who cannot cast a
+-- lust re-runs the whole probe on every call, including twice a second from the
+-- options preview. A cache taken before the spellbook is populated is corrected
+-- by the PLAYER_ENTERING_WORLD reset below (registered on PLAYER_LOGIN, so it
+-- catches the login zone-in), and a spec swap drops it as well -- those are the
+-- only points at which one of these spells can appear or disappear.
 local _lustIconCache
+local _lustIconResolved = false
 local function _lustBuffIcon()
-    if _lustIconCache then return _lustIconCache end
+    if _lustIconResolved then return _lustIconCache end
     for i = 1, #LUST_SPELLS do
         local sid = LUST_SPELLS[i]
         local known = (IsPlayerSpell and IsPlayerSpell(sid))
@@ -527,11 +543,14 @@ local function _lustBuffIcon()
             local tex = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(sid)
             if tex then
                 _lustIconCache = tex
+                _lustIconResolved = true
                 return tex
             end
         end
     end
-    return (UnitFactionGroup("player") == "Alliance") and 132313 or 136012
+    _lustIconCache = (UnitFactionGroup("player") == "Alliance") and 132313 or 136012
+    _lustIconResolved = true
+    return _lustIconCache
 end
 
 -- Countdown text for the overlay, deduped so we only SetText on a real change.
@@ -550,9 +569,14 @@ local _buffAccum = 0
 local function _buffOnUpdate(_, elapsed)
     local rem = _buffExpiry - GetTime()
     if rem <= 0 then
+        _buffExpiry = 0
         buffOverlay:SetScript("OnUpdate", nil)
         buffOverlay:Hide()
         _setBuffDur("")
+        -- The window is part of the visibility rule (ShouldShow keeps the icon up
+        -- for it even with "Show when Sated" off), so its end has to re-evaluate
+        -- rather than wait for the next unrelated event.
+        UpdateVisibility()
         return
     end
     _buffAccum = _buffAccum + (elapsed or 0)
@@ -649,16 +673,25 @@ local function ShouldShow()
     if not p or not p.enabled then return false end
     local v = p.visibility or "NEVER"
     if v == "NEVER" then return false end
-    -- Options preview: forced on screen while the page is up, skipping the instance
-    -- and M+/raid gates below -- the point is to configure it from anywhere.
-    if _previewActive() then return true end
     -- Show Sated / Show Ready are independent: which one gates visibility depends
-    -- on which state the icon is currently in.
+    -- on which state the icon is currently in. This gate sits ABOVE the preview
+    -- short-circuit on purpose, so both toggles show what they do while the
+    -- options page is open; the preview only replaces the content gates below it.
     if _satedActive then
-        if RP("showSated") == false then return false end
+        -- The 40s active-lust overlay is worth seeing even when the lockout
+        -- countdown itself is switched off, so only the remainder of the lockout
+        -- after that window is suppressed.
+        if RP("showSated") == false and _buffExpiry <= GetTime() then return false end
+    elseif _previewActive() then
+        -- No real lockout to key off, so either state is previewable: show as long
+        -- as the user has asked for one of them.
+        if not RP("showReady") and RP("showSated") == false then return false end
     elseif not RP("showReady") then
         return false
     end
+    -- Options preview: forced on screen while the page is up, skipping the instance
+    -- and M+/raid gates below -- the point is to configure it from anywhere.
+    if _previewActive() then return true end
 
     -- Hard gate: must be in a party or raid instance. Prevents any stuck state
     -- from showing the icon in town / open world.
@@ -688,11 +721,13 @@ end
 local function _showPreviewLockout()
     if not frame then return end
     _hideReadyState()
-    iconTex:SetTexture(_lustBuffIcon())
     if _previewExpiry <= GetTime() then
-        _previewExpiry = GetTime() + 600
         -- Once per cycle: re-setting the SAME values each poll is idempotent, but
         -- re-setting new ones would restart the swipe animation twice a second.
+        -- The texture goes here for the same reason -- nothing about it changes
+        -- between ticks.
+        _previewExpiry = GetTime() + 600
+        iconTex:SetTexture(_lustBuffIcon())
         if cooldownFrame then cooldownFrame:SetCooldown(GetTime(), 600) end
     end
     _setDur(FormatTime(_previewExpiry - GetTime()))
@@ -710,13 +745,19 @@ local function PollSated()
         if RP("showReady") then
             -- Render in place and RETURN: UpdateVisibility calls back into this
             -- function whenever the icon is shown, so re-entering it here would
-            -- recurse forever now that "not sated" can still mean "shown".
+            -- recurse forever now that "not sated" can still mean "shown". That is
+            -- also why the ticker is cancelled directly rather than by letting
+            -- UpdateVisibility do it: this branch is exactly the path taken when
+            -- the ticker (not a UNIT_AURA edge) is what spots the lockout ending,
+            -- and the ready state has nothing left to count down.
+            if _ticker then _ticker:Cancel(); _ticker = nil end
             _setDur("")
             _showReadyState()
             return
         end
-        if _previewActive() then
-            -- Same reasoning; the stand-in sets its own countdown text.
+        if _previewActive() and RP("showSated") ~= false then
+            -- Same reasoning; the stand-in sets its own countdown text. Gated on
+            -- showSated so switching it off in the options is visible right away.
             _showPreviewLockout()
             return
         end
@@ -743,7 +784,6 @@ local function PollSated()
     end
 end
 
-local _ticker
 function UpdateVisibility()
     if not frame then return end
     if ShouldShow() then
@@ -761,6 +801,13 @@ function UpdateVisibility()
     else
         if frame:IsShown() then frame:Hide() end
         if _ticker then _ticker:Cancel(); _ticker = nil end
+        -- Preview just ended: drop the stand-in swipe and countdown text so no
+        -- later path can surface them as if they were real lockout data.
+        if _previewExpiry ~= 0 and not _previewActive() then
+            _previewExpiry = 0
+            if cooldownFrame then cooldownFrame:Clear() end
+            _setDur("")
+        end
     end
 end
 _G._EUI_Bloodlust_UpdateVisibility = UpdateVisibility
@@ -822,9 +869,11 @@ local function _onEvent(_, event, _, updateInfo)
         end
     elseif event == "PLAYER_SPECIALIZATION_CHANGED" then
         -- A spec swap can add or remove this character's lust spell. Drop the cached
-        -- icon and the ready-render latch so the next pass re-renders with the new one.
+        -- icon and tear the ready label down properly -- clearing only the latch
+        -- would leave the fontstring on screen with the old icon behind it.
+        _lustIconResolved = false
         _lustIconCache = nil
-        _readyShown = false
+        _hideReadyState()
     elseif event == "PLAYER_DEAD" then
         -- Buffs drop on death; hide the active-lust overlay even if 40s remain.
         _hideBuffOverlay()
@@ -842,6 +891,7 @@ local function _onEvent(_, event, _, updateInfo)
         or event == "WORLD_STATE_TIMER_STOP" then
         _state.inChallenge = false
     elseif event == "PLAYER_ENTERING_WORLD" then
+        _lustIconResolved = false
         _lustIconCache = nil
         _refreshSated()
         -- Baseline the edge tracker so a debuff already present on login/zone-in
@@ -901,13 +951,16 @@ local function CreateBloodlustFrame()
     cooldownFrame:SetHideCountdownNumbers(true)  -- we render our own duration text
     cooldownFrame:SetFrameLevel(frame:GetFrameLevel() + 1)
 
-    -- Shared text layer: EVERY fontstring below (duration/count/ready/buff-timer)
-    -- lives here, above the icon border ApplyShape pins to frame+7, so text reads
-    -- over the border and every cooldown swipe in every state -- not just
-    -- whichever one happened to be on screen when a given text was last tuned.
+    -- TWO text layers, one per state, so each state's text reads over its own
+    -- border and swipe while the opaque 40s buff icon still covers the debuff
+    -- text underneath it (a single shared layer puts the lockout countdown on
+    -- top of the buff icon and its 40s number). Level stack inside the frame:
+    --   +0 iconTex   +1 cooldownFrame   +2 PP border (pinned in ApplyShape)
+    --   +3 debuff text: duration / count / ready
+    --   +5 buffOverlay   +6 buffCooldown   +7 buff text
     textOverlay = CreateFrame("Frame", nil, frame)
     textOverlay:SetAllPoints(frame)
-    textOverlay:SetFrameLevel(frame:GetFrameLevel() + 8)
+    textOverlay:SetFrameLevel(frame:GetFrameLevel() + 3)
 
     durationFS = textOverlay:CreateFontString(nil, "OVERLAY")
     durationFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 14, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
@@ -941,7 +994,13 @@ local function CreateBloodlustFrame()
     buffCooldown:SetHideCountdownNumbers(true)
     buffCooldown:SetFrameLevel(buffOverlay:GetFrameLevel() + 1)
 
-    buffDurationFS = textOverlay:CreateFontString(nil, "OVERLAY")
+    -- Parented to the overlay, not to frame: the 40s text hides with the window
+    -- it belongs to instead of relying on every hide path to blank the string.
+    buffTextOverlay = CreateFrame("Frame", nil, buffOverlay)
+    buffTextOverlay:SetAllPoints(buffOverlay)
+    buffTextOverlay:SetFrameLevel(buffCooldown:GetFrameLevel() + 1)
+
+    buffDurationFS = buffTextOverlay:CreateFontString(nil, "OVERLAY")
     buffDurationFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     buffDurationFS:SetText("")
 

--- a/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
@@ -138,7 +138,7 @@ local function RP_color()
 end
 
 local frame, iconTex, borderTex, durationFS, countFS, cooldownFrame
-local readyOverlay, readyFS  -- ready label on its own frame, above the cooldown widget
+local textOverlay, readyFS  -- shared text layer: every fontstring lives above the border/swipes
 local buffOverlay, buffTex, buffCooldown, buffDurationFS  -- the 40s active-lust overlay (sits on top of the debuff icon)
 local _satedActive = false
 local _readyShown = false       -- ready label currently rendered (idempotence for the 0.5s poll)
@@ -269,14 +269,13 @@ local function ApplyShape()
     -- Ready label: same font family as the countdown it replaces, but its own
     -- size, colour and offset. Dropped back to hidden so the next poll re-renders
     -- it with the new style instead of leaving a stale string on screen.
-    if readyOverlay and readyFS then
-        readyOverlay:SetAllPoints(frame)
+    if readyFS then
         readyFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, RP("readySize") or 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
         readyFS:ClearAllPoints()
-        readyFS:SetPoint("CENTER", readyOverlay, "CENTER",
+        readyFS:SetPoint("CENTER", frame, "CENTER",
             RP("readyOffsetX") or 0, RP("readyOffsetY") or 0)
         readyFS:SetTextColor(RP_color())
-        readyOverlay:Hide()
+        readyFS:Hide()
         _readyShown = false
     end
 
@@ -312,12 +311,12 @@ local function ApplyShape()
         if PP then
             if not PP.GetBorders(frame) then PP.CreateBorder(frame, 0, 0, 0, 1, 1, "OVERLAY", 2) end
             -- PP.CreateBorder parents its container to frame+1, the SAME level
-            -- cooldownFrame sits at -- a level TIE that the border only wins by
-            -- creation order. readyOverlay/buffOverlay sit explicitly higher still
-            -- (frame+3/+5), so raise the border above all three every pass instead
-            -- of relying on an implicit tie-break that a future overlay could flip.
+            -- cooldownFrame sits at -- a level TIE the border only won by creation
+            -- order. Pin it to the stack position documented at textOverlay's
+            -- creation (frame+7, one below the text layer) instead of an implicit
+            -- tie-break that a future overlay could flip.
             local brd = PP.GetBorders(frame)
-            if brd and buffOverlay then brd:SetFrameLevel(buffOverlay:GetFrameLevel() + 1) end
+            if brd then brd:SetFrameLevel(frame:GetFrameLevel() + 7) end
             if bs > 0 then
                 local r, g, b, a = _resolveBorderColor()
                 PP.UpdateBorder(frame, bs, r, g, b, a)
@@ -572,16 +571,16 @@ local function _showReadyState()
     -- Clear(), never SetCooldown(0, 0): a zero-duration cooldown makes the widget
     -- hide itself, and the leftover swipe has to go either way.
     if cooldownFrame then cooldownFrame:Clear() end
-    if readyOverlay then
-        if readyFS then readyFS:SetText(EllesmereUI.L("Ready")) end
-        readyOverlay:Show()
+    if readyFS then
+        readyFS:SetText(EllesmereUI.L("Ready"))
+        readyFS:Show()
     end
     _readyShown = true
 end
 
 local function _hideReadyState()
     if not _readyShown then return end
-    if readyOverlay then readyOverlay:Hide() end
+    if readyFS then readyFS:Hide() end
     _readyShown = false
 end
 
@@ -890,25 +889,26 @@ local function CreateBloodlustFrame()
     cooldownFrame:SetHideCountdownNumbers(true)  -- we render our own duration text
     cooldownFrame:SetFrameLevel(frame:GetFrameLevel() + 1)
 
-    durationFS = cooldownFrame:CreateFontString(nil, "OVERLAY")
+    -- Shared text layer: EVERY fontstring below (duration/count/ready/buff-timer)
+    -- lives here, above the icon border ApplyShape pins to frame+7, so text reads
+    -- over the border and every cooldown swipe in every state -- not just
+    -- whichever one happened to be on screen when a given text was last tuned.
+    textOverlay = CreateFrame("Frame", nil, frame)
+    textOverlay:SetAllPoints(frame)
+    textOverlay:SetFrameLevel(frame:GetFrameLevel() + 8)
+
+    durationFS = textOverlay:CreateFontString(nil, "OVERLAY")
     durationFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 14, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     durationFS:SetText("")
 
-    -- Ready label on its OWN overlay, mirroring the buff overlay below: it is
-    -- shown precisely when no cooldown runs, so its lifetime must not hang off the
-    -- cooldown widget, and sitting above that widget keeps a swipe off the text.
-    readyOverlay = CreateFrame("Frame", nil, frame)
-    readyOverlay:SetAllPoints(frame)
-    readyOverlay:SetFrameLevel(cooldownFrame:GetFrameLevel() + 2)
-    readyOverlay:Hide()
-
-    readyFS = readyOverlay:CreateFontString(nil, "OVERLAY")
     -- SetFont FIRST: SetText on a fontstring that has no font yet errors out, and
     -- this runs before ApplyShape ever styles it.
+    readyFS = textOverlay:CreateFontString(nil, "OVERLAY")
     readyFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     readyFS:SetText("")
+    readyFS:Hide()
 
-    countFS = cooldownFrame:CreateFontString(nil, "OVERLAY")
+    countFS = textOverlay:CreateFontString(nil, "OVERLAY")
     countFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     countFS:SetText("")
 
@@ -929,7 +929,7 @@ local function CreateBloodlustFrame()
     buffCooldown:SetHideCountdownNumbers(true)
     buffCooldown:SetFrameLevel(buffOverlay:GetFrameLevel() + 1)
 
-    buffDurationFS = buffCooldown:CreateFontString(nil, "OVERLAY")
+    buffDurationFS = textOverlay:CreateFontString(nil, "OVERLAY")
     buffDurationFS:SetFont((EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("extras")) or STANDARD_TEXT_FONT, 12, (EllesmereUI and EllesmereUI.SlugFlag and EllesmereUI.SlugFlag("OUTLINE, SLUG")) or "OUTLINE, SLUG")
     buffDurationFS:SetText("")
 

--- a/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Bloodlust.lua
@@ -673,25 +673,23 @@ local function ShouldShow()
     if not p or not p.enabled then return false end
     local v = p.visibility or "NEVER"
     if v == "NEVER" then return false end
+    -- Options preview: forced on screen while the page is up, skipping the state
+    -- gate below along with the instance and M+/raid gates -- the point is to
+    -- configure it from anywhere. It deliberately ignores the two toggles for
+    -- VISIBILITY: everything above them (size, shape, border, zoom, position)
+    -- stays configurable with both switched off, so a blank page would just read
+    -- as broken. Which state gets previewed still follows Show Ready, in PollSated.
+    if _previewActive() then return true end
     -- Show Sated / Show Ready are independent: which one gates visibility depends
-    -- on which state the icon is currently in. This gate sits ABOVE the preview
-    -- short-circuit on purpose, so both toggles show what they do while the
-    -- options page is open; the preview only replaces the content gates below it.
+    -- on which state the icon is currently in.
     if _satedActive then
         -- The 40s active-lust overlay is worth seeing even when the lockout
         -- countdown itself is switched off, so only the remainder of the lockout
         -- after that window is suppressed.
         if RP("showSated") == false and _buffExpiry <= GetTime() then return false end
-    elseif _previewActive() then
-        -- No real lockout to key off, so either state is previewable: show as long
-        -- as the user has asked for one of them.
-        if not RP("showReady") and RP("showSated") == false then return false end
     elseif not RP("showReady") then
         return false
     end
-    -- Options preview: forced on screen while the page is up, skipping the instance
-    -- and M+/raid gates below -- the point is to configure it from anywhere.
-    if _previewActive() then return true end
 
     -- Hard gate: must be in a party or raid instance. Prevents any stuck state
     -- from showing the icon in town / open world.
@@ -755,9 +753,11 @@ local function PollSated()
             _showReadyState()
             return
         end
-        if _previewActive() and RP("showSated") ~= false then
-            -- Same reasoning; the stand-in sets its own countdown text. Gated on
-            -- showSated so switching it off in the options is visible right away.
+        if _previewActive() then
+            -- Same reasoning; the stand-in sets its own countdown text. This is
+            -- the fallback state for the preview: Show Ready above picks the ready
+            -- label when it is on, everything else previews the lockout, including
+            -- the both-off case where the icon has no live state of its own.
             _showPreviewLockout()
             return
         end


### PR DESCRIPTION
## What does this PR do?

Gives the Bloodlust Tracker a Ready display. Until now the icon existed only while the Sated/Exhaustion lockout was running and disappeared at the exact moment the interesting information arrives, so "can we lust again" had to be read as the absence of an icon. Two independent toggles now control it: **Show Icon when Sated** (the existing lockout countdown, on by default, so nothing changes for anyone who does not touch it) and **Show Icon with Ready Text** (off by default), which keeps the icon on screen once the lockout expires, swapped to the lust icon with a "Ready" label in place of the countdown. Either, both or neither can be on, and the existing visibility rule (Never / M+ / Raid / both) still applies on top of whichever is picked. The Ready label carries its own size, color and position, on a row that greys out rather than vanishing while the toggle is off, so the section never reflows on a click.

The icon now resolves to the character's own lust rather than always showing the faction one: Bloodlust or Heroism for a Shaman, Time Warp for a Mage, Fury of the Aspects for an Evoker, Primal Rage for a Hunter, and the faction icon for everyone who cannot cast one. Spec- and talent-gated spells leave the spellbook by themselves, so this is a plain spellbook probe re-run on zone-in and on a spec change instead of a class/spec table that would need maintaining every patch.

Both the Bloodlust Tracker and the Battle Res section now drive a live preview: the icon is forced on screen for as long as its options page is, with stand-in countdown and charge data wherever the real values are not readable, so size, shape, border, colors and every text offset can be judged from anywhere instead of waiting for a real lust or a raid. Show Icon with Ready Text switches the preview between the countdown and the Ready label so that label can be styled; the preview otherwise ignores both toggles for visibility, since size, shape, border, zoom and position stay configurable with both of them off and a blank page would only read as broken. In game the toggles apply in full, and with Show Icon when Sated off the icon still appears for the 40 second active-lust window and hides afterwards, since that window is the most informative part of the display and losing it was not the point of that toggle.

Reworks the icon's internal layering. The text used to be created on the cooldown frames, which put each string above only whichever swipe it happened to share a parent with, and the pixel border won its frame level against the cooldown frame by creation order alone. The Bloodlust icon now has one text layer per state, the lockout countdown, count and Ready label below the 40 second active-lust overlay and that overlay's own timer above it, with the border pinned to its own documented slot in the stack. The active-lust number is therefore the only thing on screen during that window, and the whole stack is written down at frame creation rather than being an implicit tie-break a future overlay could flip.

Finishes the pixel-perfect pass for both icons. Icon size, the stored center position, every text offset (duration, count, Ready and the active-lust timer) and the shape border inset now go through `PP.Snap` / `PP.SnapCenterForDim`, so nothing lands on a half pixel at a non-native UI scale and a saved position no longer drifts a pixel across reloads. Font sizes are deliberately left alone: the codebase has no convention or helper for snapping those, and inventing one belongs in its own change.

## How was it tested?

Tested in game on live.

## Screenshots

Settingsmenu:
<img width="939" height="340" alt="grafik" src="https://github.com/user-attachments/assets/a1f2ce25-5427-48f5-8e23-ed9ddd74953a" />

Live-Preview with Ready enabled (non bloodlust class):
<img width="112" height="87" alt="grafik" src="https://github.com/user-attachments/assets/d86ad4d2-b692-4d19-9b2d-95d638cf1506" />
Live-Preview with Ready enabled (bloodlust class):
<img width="85" height="76" alt="grafik" src="https://github.com/user-attachments/assets/67d918c2-0620-4d21-bfe7-698a25ddf7be" />

Live-Preview without Ready text (non bloodlust class):
<img width="87" height="69" alt="grafik" src="https://github.com/user-attachments/assets/c7eceb99-911b-4da0-acae-110f8fa0538c" />
Live-Preview without Ready text (bloodlust class):
<img width="72" height="72" alt="grafik" src="https://github.com/user-attachments/assets/b76037cb-ec50-443d-81d0-eefd627d2f07" />


Live-Preview Battle Res:
<img width="77" height="73" alt="grafik" src="https://github.com/user-attachments/assets/24abaf08-057f-434f-b9c5-874bd3da1dec" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- Show Icon with Ready Text defaults off. Show Icon when Sated defaults on, because it is the tracker's pre-existing behavior and defaulting it off would itself be a behavior change; an untouched profile renders exactly as before.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- the 0.5s countdown ticker is pre-existing and drives the lockout number; this PR makes it run strictly less by cancelling it in the Ready state, where there is nothing to count down and a fresh debuff arrives on UNIT_AURA anyway. The lust icon lookup is cached and invalidated only on zone-in and spec change.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- every frame here is addon-owned, and the only `HookScript` is on the addon's own options page wrapper.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
