### PR TITLE
Feature(CDM): Show glows only in combat

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -131,13 +131,22 @@ do
     end
 
     local function StartStackGlow(st, width, height)
+        -- Handed to StartNativeGlow instead of called after it: the combat
+        -- replay of Show Glows Only in Combat restarts from the recorded opts,
+        -- so a mask applied out here would be missing on every texture that
+        -- replay creates fresh. One closure per state, not per start.
+        local post = st._applyMask2
+        if not post then
+            post = function() ApplySecondStackGlowMask(st) end
+            st._applyMask2 = post
+        end
         ns.StartNativeGlow(st.glow, st.style, st.r, st.g, st.b, {
             owner = st.icon, width = width, height = height,
             N = st.lines, th = st.thickness, period = st.speed,
             bg = st.background and { r = st.bgR, g = st.bgG, b = st.bgB } or nil,
             maskWith = st.mask,
+            postStart = post,
         })
-        ApplySecondStackGlowMask(st)
         st.width, st.height = width, height
         st.started = true
     end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -88,16 +88,6 @@ do
         return value >= threshold
     end
 
-    local function ApplySecondStackGlowMask(st)
-        if not st.mask2 then return end
-        for _, region in ipairs({ st.glow:GetRegions() }) do
-            if region.AddMaskTexture and region._euiTGMask2 ~= st.mask2 then
-                region._euiTGMask2 = st.mask2
-                region:AddMaskTexture(st.mask2)
-            end
-        end
-    end
-
     -- LIVE-FIRST: the item's auraDataCached is (re)written on aura
     -- ASSIGNMENT, so an update-only stack change can leave it holding the
     -- gain-time count -- a threshold crossing would then wait for the next
@@ -131,21 +121,15 @@ do
     end
 
     local function StartStackGlow(st, width, height)
-        -- Handed to StartNativeGlow instead of called after it: the combat
-        -- replay of Show Glows Only in Combat restarts from the recorded opts,
-        -- so a mask applied out here would be missing on every texture that
-        -- replay creates fresh. One closure per state, not per start.
-        local post = st._applyMask2
-        if not post then
-            post = function() ApplySecondStackGlowMask(st) end
-            st._applyMask2 = post
-        end
+        -- Both gate masks go over as data: the combat replay of Show Glows Only
+        -- in Combat restarts from the recorded opts, so a mask bound out here
+        -- would be missing on every texture that replay creates fresh.
         ns.StartNativeGlow(st.glow, st.style, st.r, st.g, st.b, {
             owner = st.icon, width = width, height = height,
             N = st.lines, th = st.thickness, period = st.speed,
             bg = st.background and { r = st.bgR, g = st.bgG, b = st.bgB } or nil,
             maskWith = st.mask,
-            postStart = post,
+            maskWith2 = st.mask2,
         })
         st.width, st.height = width, height
         st.started = true

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -2388,15 +2388,15 @@ function EllesmereUI.IsPandemicGlowSyncedToAll(payload, opts)
     return true
 end
 
--- Show Glows Only in Combat (global). Every CDM glow -- proc, active state, max
--- stacks, buff, pandemic, CD ready, custom active states, bar glows, tracking
--- bars -- starts here, so the whole feature is one gate on this function
--- instead of a condition bolted onto thirteen decision sites.
--- overlay -> its last StartNativeGlow request. Weak keys are form only: the
--- values reach the key frames back through opts.owner and Lua 5.1 has no
--- ephemerons, so nothing drops out (WoW frames are permanent anyway). The
--- rec.active filter is what keeps the combat sweep below short.
-ns._cdmGlowRec = setmetatable({}, { __mode = "k" })
+-- Show Glows Only in Combat (global). Bar Glows and the Tracking Bars gate
+-- their own "Only In Combat" toggles at the decision site, which works because
+-- a ticker re-evaluates them. This one gates the renderer: the proc glow and
+-- the CD ready flush are pure edges with no re-assert, so a suppressed request
+-- can only come back by being replayed from here.
+-- overlay -> its last StartNativeGlow request. Plain table: the record holds
+-- the owning frame anyway and WoW frames are permanent, so weak keys would
+-- collect nothing. The rec.active filter keeps the sweep below short.
+ns._cdmGlowRec = {}
 
 -- Cached toggle: StartNativeGlow tests it on every glow start, so it must not
 -- walk the DB there. Re-read on apply/profile change, at world entry, and from
@@ -2414,33 +2414,39 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
 
     _G_Glows.StopAllGlows(overlay)
 
+    -- Threshold glows pass the owning icon and its size explicitly so every
+    -- style sizes exactly like the normal buff-glow path.
+    local parent = (opts and opts.owner) or overlay:GetParent()
+
     -- Record the request verbatim, pre-defaulting, so a nil colour stays nil.
     -- Recorded even with the gate off: the option has to be flippable
     -- mid-session, and the proc glow and CD ready glow are edge-driven, so a
     -- suppressed request can only ever come back by being replayed from here.
+    -- The owner and its resolved spellID ride along so the replay can tell a
+    -- record that is still current from one whose pooled icon has since been
+    -- handed a different spell. fc.spellID is the identity the rest of this
+    -- file already branches on, so it is a plain value, never secret.
     local rec = ns._cdmGlowRec[overlay]
     if not rec then rec = {}; ns._cdmGlowRec[overlay] = rec end
+    local ownerFC = parent and _ecmeFC[parent]
     rec.style, rec.r, rec.g, rec.b, rec.opts = styleIdx, cr, cg, cb, opts
+    rec.owner, rec.sid = parent, ownerFC and ownerFC.spellID or nil
     rec.active = true
     -- Suppressed overlays keep _glowActive = true: the buff ticker's active-glow
     -- integrity pass and the preset cd-state re-assert restart any glow whose
     -- overlay reads dark, so the truth would churn every tick for exactly the
     -- users who asked for less work out of combat.
     -- Options previews opt out on their own overlay rather than through opts:
-    -- three of the four preview call sites pass no opts, and a non-nil opts
+    -- three overlays serve the four preview call sites, and a non-nil opts
     -- flips the pixel-glow branch off the bar's Lines/Thickness/Speed.
     if ns._cdmGlowOOCGate and not _inCombat and not overlay._euiGlowPreview then
         rec.suppressed = true
-        ns._cdmGlowAnySuppressed = true  -- lets the sweep run once after the option goes off
         overlay._glowActive = true
         overlay:SetAlpha(0)
         return
     end
     rec.suppressed = false
 
-    -- Threshold glows pass the owning icon and its size explicitly so every
-    -- style sizes exactly like the normal buff-glow path.
-    local parent = (opts and opts.owner) or overlay:GetParent()
     if not parent then return end
     local pW = (opts and opts.width) or parent:GetWidth()
     local pH = (opts and opts.height) or parent:GetHeight()
@@ -2512,14 +2518,24 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
     if opts and opts.maskWith and _G_Glows.ApplyMaskWith then
         _G_Glows.ApplyMaskWith(overlay, opts.maskWith)
     end
+    -- Second gate mask (two-gate threshold glows). ApplyMaskWith dedupes on one
+    -- key per region, so a second mask needs a key of its own and cannot go
+    -- through the core helper. Data rather than a callback, so the combat replay
+    -- below re-binds it on the textures that replay creates fresh.
+    local mask2 = opts and opts.maskWith2
+    if mask2 then
+        for _, r in ipairs({ overlay:GetRegions() }) do
+            if r.AddMaskTexture and r._euiTGMask2 ~= mask2 then
+                r._euiTGMask2 = mask2
+                r:AddMaskTexture(mask2)
+            end
+        end
+    end
 
     overlay._glowActive = true
     overlay:SetAlpha(1)
     -- NEVER Show()/Hide() -- the overlay is always shown (created in DecorateFrame).
     -- Toggling visibility on a child of a Blizzard viewer frame triggers Layout hooks and causes position cascades.
-    -- Caller-side work that must follow every real start (the threshold glow's
-    -- second mask). Riding on opts means the combat replay below runs it too.
-    if opts and opts.postStart then opts.postStart(overlay) end
 end
 
 StopNativeGlow = function(overlay)
@@ -2537,14 +2553,12 @@ ns.StopNativeGlow = StopNativeGlow
 -- Combat edges for Show Glows Only in Combat. Entering combat replays what was
 -- suppressed; leaving combat takes the running glows down but keeps their
 -- records, so the next pull lights them again without waiting for their owners
--- to re-fire. Also the transition when the option itself is switched: with the
--- gate off everything is due to be shown, which is what un-suppresses glows the
--- moment the user turns the option back off while standing around.
--- Both flags false (the default) makes this two boolean tests per combat edge.
-function ns.CDMGlowCombatSync()
-    if not ns._cdmGlowOOCGate and not ns._cdmGlowAnySuppressed then return end
+-- to re-fire. force is for the three callers that may just have changed the
+-- gate itself (the option, a profile apply, world entry): with the gate off
+-- there is nothing to do unless glows are still suppressed under the old value.
+function ns.CDMGlowCombatSync(force)
+    if not force and not ns._cdmGlowOOCGate then return end
     local show = _inCombat or not ns._cdmGlowOOCGate
-    local anySuppressed = false
     -- Replays are collected here and run after the traversal: StartNativeGlow
     -- writes into _cdmGlowRec, and inserting a key during pairs() is undefined
     -- in Lua 5.1. It only ever rewrites an existing key today, but that is not
@@ -2554,30 +2568,16 @@ function ns.CDMGlowCombatSync()
     local n = 0
     for overlay, rec in pairs(ns._cdmGlowRec) do
         if rec.active and not overlay._euiGlowPreview then
-            if show then
-                if rec.suppressed then
-                    if overlay:IsVisible() then
-                        n = n + 1
-                        queue[n] = overlay
-                    else
-                        -- Hidden or recycled while suppressed: drop the request
-                        -- rather than replay it onto whatever spell sits on that
-                        -- icon now. Clearing _glowActive hands the decision back
-                        -- to the owning driver, whose integrity pass restarts the
-                        -- glow on the next tick if it is still wanted.
-                        rec.active = false
-                        rec.suppressed = false
-                        overlay._glowActive = false
-                    end
+            if not show then
+                if not rec.suppressed then
+                    _G_Glows.StopAllGlows(overlay)
+                    overlay:SetAlpha(0)
+                    rec.suppressed = true
+                    -- _glowActive deliberately stays true (see StartNativeGlow).
                 end
             elseif rec.suppressed then
-                anySuppressed = true
-            else
-                _G_Glows.StopAllGlows(overlay)
-                overlay:SetAlpha(0)
-                rec.suppressed = true
-                anySuppressed = true
-                -- _glowActive deliberately stays true (see StartNativeGlow).
+                n = n + 1
+                queue[n] = overlay
             end
         end
     end
@@ -2585,11 +2585,23 @@ function ns.CDMGlowCombatSync()
         local overlay = queue[i]
         queue[i] = nil
         local rec = ns._cdmGlowRec[overlay]
-        if rec then
-            StartNativeGlow(overlay, rec.style, rec.r, rec.g, rec.b, rec.opts)
+        if rec and rec.suppressed then
+            local fc = rec.owner and _ecmeFC[rec.owner]
+            if rec.sid and fc and fc.spellID ~= rec.sid then
+                -- Pooled onto a different spell while suppressed: drop the
+                -- request instead of lighting the new spell in the old style.
+                -- Only the active-state integrity pass and the preset cd-state
+                -- re-assert read _glowActive, so clearing it wakes those two;
+                -- every other owner keeps its own memo and re-decides on its
+                -- own next edge.
+                rec.active = false
+                rec.suppressed = false
+                overlay._glowActive = false
+            else
+                StartNativeGlow(overlay, rec.style, rec.r, rec.g, rec.b, rec.opts)
+            end
         end
     end
-    ns._cdmGlowAnySuppressed = anySuppressed or nil
 end
 
 -- Our bar frames (keyed by bar key)
@@ -9526,6 +9538,9 @@ function ECME:OnInitialize()
 
     -- Expose for options
     _G._ECME_AceDB = self.db
+    -- First read of the glow gate: without it the cached value stays nil until
+    -- the first PLAYER_ENTERING_WORLD and only works because nil is falsy.
+    ns.RefreshGlowCombatGate()
     _G._ECME_Apply = function()
         -- Profile switches land here, so the cached glow gate is re-read before
         -- the rebuild restarts any glow under the new profile's setting.
@@ -9551,8 +9566,9 @@ function ECME:OnInitialize()
         if ns.UpdateCustomBuffBars then ns.UpdateCustomBuffBars() end
         -- A profile that switches the gate off has to release the glows the old
         -- profile suppressed: the edge-driven ones (proc, cd ready) have no
-        -- ticker to bring them back on their own.
-        ns.CDMGlowCombatSync()
+        -- ticker to bring them back on their own. Forced, because the gate the
+        -- sweep tests against is already the new profile's.
+        ns.CDMGlowCombatSync(true)
     end
 
     -- Append SharedMedia textures to TBB runtime tables
@@ -10537,11 +10553,10 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
             _inCombat = true
             _CDMApplyVisibility()
             ns.RefreshItemCountOOCBars()
-            -- Deferred one frame so _CDMApplyVisibility above lands first: the
-            -- sweep's IsVisible() test has to see the bars this pull actually
-            -- shows. CDMGlowCombatSync re-reads _inCombat, so a pull that ended
-            -- inside that frame takes the suppress branch instead.
-            C_Timer.After(0, ns.CDMGlowCombatSync)
+            -- Straight through, same as the exit edge below: the sweep only
+            -- touches our own overlays, so it needs nothing from the visibility
+            -- pass above, and a deferral would leave the pull one frame dark.
+            ns.CDMGlowCombatSync()
         elseif event == "PLAYER_REGEN_ENABLED" then
             -- Buffer combat exit: brief out-of-combat blips (mob dies, re-aggro) shouldn't flash visibility changes.
             C_Timer.After(0.1, function()
@@ -10576,10 +10591,12 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
     end
     if event == "PLAYER_ENTERING_WORLD" then
         _inCombat = InCombatLockdown and InCombatLockdown() or false
-        -- Covers a login or zone-in that lands mid-combat: the regen events
-        -- above never fire for that transition.
+        -- Re-read the gate (a profile may have loaded), then reconcile against
+        -- the combat state sampled just above: the regen events never fire for
+        -- a zone-in that lands mid-combat. At the very first world entry nothing
+        -- is recorded yet, so only the gate read matters there.
         ns.RefreshGlowCombatGate()
-        ns.CDMGlowCombatSync()
+        ns.CDMGlowCombatSync(true)
         -- PvP instance transition backstop: entering or leaving a PvP instance rebuilds viewer pools (PvP talents activate/deactivate). Rebuild + reanchor so the new pool frames are claimed.
         local _, instType = IsInInstance()
         local wasPvP = ns._cdmWasInPvP

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -597,6 +597,10 @@ local DEFAULTS = {
             -- seeds it into existing profiles at login, and an explicit
             -- false (user turned it off) survives the logout default-strip.
             stableKeybinds = true,
+            -- Suppress every CDM glow while out of combat (global, all bars).
+            -- Off by default: opt-in, and off means the gate in StartNativeGlow
+            -- is a single boolean test that never fires.
+            glowsOnlyInCombat = false,
             -- The 3 default bars (match Blizzard CDM)
             bars = {
                 {
@@ -2384,6 +2388,23 @@ function EllesmereUI.IsPandemicGlowSyncedToAll(payload, opts)
     return true
 end
 
+-- Show Glows Only in Combat (global). Every CDM glow -- proc, active state, max
+-- stacks, buff, pandemic, CD ready, custom active states, bar glows, tracking
+-- bars -- starts here, so the whole feature is one gate on this function
+-- instead of a condition bolted onto thirteen decision sites.
+-- overlay -> its last StartNativeGlow request. Weak-keyed: a recycled icon's
+-- record drops out with the frame. Only currently lit (or suppressed) overlays
+-- carry rec.active, so the combat sweep below stays a handful of entries.
+ns._cdmGlowRec = setmetatable({}, { __mode = "k" })
+
+-- Cached toggle: StartNativeGlow tests it on every glow start, so it must not
+-- walk the DB there. Re-read on apply/profile change, at world entry, and from
+-- the option itself.
+function ns.RefreshGlowCombatGate()
+    local p = ECME and ECME.db and ECME.db.profile
+    ns._cdmGlowOOCGate = (p and p.cdmBars and p.cdmBars.glowsOnlyInCombat) and true or false
+end
+
 StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
     if not overlay then return end
     local styleIdx = tonumber(style) or 1
@@ -2391,6 +2412,30 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
     local entry = GLOW_STYLES[styleIdx]
 
     _G_Glows.StopAllGlows(overlay)
+
+    -- Record the request verbatim, pre-defaulting, so a nil colour stays nil.
+    -- Recorded even with the gate off: the option has to be flippable
+    -- mid-session, and the proc glow and CD ready glow are edge-driven, so a
+    -- suppressed request can only ever come back by being replayed from here.
+    local rec = ns._cdmGlowRec[overlay]
+    if not rec then rec = {}; ns._cdmGlowRec[overlay] = rec end
+    rec.style, rec.r, rec.g, rec.b, rec.opts = styleIdx, cr, cg, cb, opts
+    rec.active = true
+    -- Suppressed overlays keep _glowActive = true: the buff ticker's active-glow
+    -- integrity pass and the preset cd-state re-assert restart any glow whose
+    -- overlay reads dark, so the truth would churn every tick for exactly the
+    -- users who asked for less work out of combat.
+    -- Options previews opt out on their own overlay rather than through opts:
+    -- three of the four preview call sites pass no opts, and a non-nil opts
+    -- flips the pixel-glow branch off the bar's Lines/Thickness/Speed.
+    if ns._cdmGlowOOCGate and not _inCombat and not overlay._euiGlowPreview then
+        rec.suppressed = true
+        ns._cdmGlowAnySuppressed = true  -- lets the sweep run once after the option goes off
+        overlay._glowActive = true
+        overlay:SetAlpha(0)
+        return
+    end
+    rec.suppressed = false
 
     -- Threshold glows pass the owning icon and its size explicitly so every
     -- style sizes exactly like the normal buff-glow path.
@@ -2478,10 +2523,54 @@ StopNativeGlow = function(overlay)
     _G_Glows.StopAllGlows(overlay)
     overlay._glowActive = false
     overlay:SetAlpha(0)
+    local rec = ns._cdmGlowRec[overlay]
+    if rec then rec.active = false; rec.suppressed = false end
     -- No Hide() -- just alpha 0. Same reason as above.
 end
 ns.StartNativeGlow = StartNativeGlow
 ns.StopNativeGlow = StopNativeGlow
+
+-- Combat edges for Show Glows Only in Combat. Entering combat replays what was
+-- suppressed; leaving combat takes the running glows down but keeps their
+-- records, so the next pull lights them again without waiting for their owners
+-- to re-fire. Also the transition when the option itself is switched: with the
+-- gate off everything is due to be shown, which is what un-suppresses glows the
+-- moment the user turns the option back off while standing around.
+-- Both flags false (the default) makes this two boolean tests per combat edge.
+function ns.CDMGlowCombatSync()
+    if not ns._cdmGlowOOCGate and not ns._cdmGlowAnySuppressed then return end
+    local show = _inCombat or not ns._cdmGlowOOCGate
+    local anySuppressed = false
+    for overlay, rec in pairs(ns._cdmGlowRec) do
+        if rec.active and not overlay._euiGlowPreview then
+            if show then
+                if rec.suppressed then
+                    if overlay:IsVisible() then
+                        StartNativeGlow(overlay, rec.style, rec.r, rec.g, rec.b, rec.opts)
+                    else
+                        -- Hidden or recycled while suppressed: drop the request
+                        -- rather than replay it onto whatever spell sits on that
+                        -- icon now. Clearing _glowActive hands the decision back
+                        -- to the owning driver, whose integrity pass restarts the
+                        -- glow on the next tick if it is still wanted.
+                        rec.active = false
+                        rec.suppressed = false
+                        overlay._glowActive = false
+                    end
+                end
+            elseif rec.suppressed then
+                anySuppressed = true
+            else
+                _G_Glows.StopAllGlows(overlay)
+                overlay:SetAlpha(0)
+                rec.suppressed = true
+                anySuppressed = true
+                -- _glowActive deliberately stays true (see StartNativeGlow).
+            end
+        end
+    end
+    ns._cdmGlowAnySuppressed = anySuppressed or nil
+end
 
 -- Our bar frames (keyed by bar key)
 local cdmBarFrames = {}
@@ -9418,6 +9507,9 @@ function ECME:OnInitialize()
     -- Expose for options
     _G._ECME_AceDB = self.db
     _G._ECME_Apply = function()
+        -- Profile switches land here, so the cached glow gate is re-read before
+        -- the rebuild restarts any glow under the new profile's setting.
+        ns.RefreshGlowCombatGate()
         if ns._skipNextApplyRebuild then
             ns._skipNextApplyRebuild = false
         elseif ns._specChangeJustRan then
@@ -9437,6 +9529,10 @@ function ECME:OnInitialize()
         end
         if ns.UpdateCustomBuffAuraTracking then ns.UpdateCustomBuffAuraTracking() end
         if ns.UpdateCustomBuffBars then ns.UpdateCustomBuffBars() end
+        -- A profile that switches the gate off has to release the glows the old
+        -- profile suppressed: the edge-driven ones (proc, cd ready) have no
+        -- ticker to bring them back on their own.
+        ns.CDMGlowCombatSync()
     end
 
     -- Append SharedMedia textures to TBB runtime tables
@@ -10421,6 +10517,11 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
             _inCombat = true
             _CDMApplyVisibility()
             ns.RefreshItemCountOOCBars()
+            -- Deferred one frame: replaying suppressed glows builds textures, and
+            -- the pull frame is already paying for the visibility pass above.
+            -- CDMGlowCombatSync re-reads _inCombat, so a pull that ended inside
+            -- that frame takes the suppress branch instead.
+            C_Timer.After(0, ns.CDMGlowCombatSync)
         elseif event == "PLAYER_REGEN_ENABLED" then
             -- Buffer combat exit: brief out-of-combat blips (mob dies, re-aggro) shouldn't flash visibility changes.
             C_Timer.After(0.1, function()
@@ -10428,6 +10529,7 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
                     _inCombat = false
                     _CDMApplyVisibility()
                     ns.RefreshItemCountOOCBars()
+                    ns.CDMGlowCombatSync()
                 end
             end)
         else
@@ -10454,6 +10556,10 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
     end
     if event == "PLAYER_ENTERING_WORLD" then
         _inCombat = InCombatLockdown and InCombatLockdown() or false
+        -- Covers a login or zone-in that lands mid-combat: the regen events
+        -- above never fire for that transition.
+        ns.RefreshGlowCombatGate()
+        ns.CDMGlowCombatSync()
         -- PvP instance transition backstop: entering or leaving a PvP instance rebuilds viewer pools (PvP talents activate/deactivate). Rebuild + reanchor so the new pool frames are claimed.
         local _, instType = IsInInstance()
         local wasPvP = ns._cdmWasInPvP

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -2403,7 +2403,11 @@ ns._cdmGlowRec = {}
 -- the option itself.
 function ns.RefreshGlowCombatGate()
     local p = ECME and ECME.db and ECME.db.profile
-    ns._cdmGlowOOCGate = (p and p.cdmBars and p.cdmBars.glowsOnlyInCombat) and true or false
+    local on = (p and p.cdmBars and p.cdmBars.glowsOnlyInCombat) and true or false
+    ns._cdmGlowOOCGate = on
+    -- Sticky: once the gate has been on there may be suppressed glows left to
+    -- release, so the sweep has to stay reachable after it goes off again.
+    if on then ns._cdmGlowGateEverOn = true end
 end
 
 StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
@@ -2553,11 +2557,11 @@ ns.StopNativeGlow = StopNativeGlow
 -- Combat edges for Show Glows Only in Combat. Entering combat replays what was
 -- suppressed; leaving combat takes the running glows down but keeps their
 -- records, so the next pull lights them again without waiting for their owners
--- to re-fire. force is for the three callers that may just have changed the
--- gate itself (the option, a profile apply, world entry): with the gate off
--- there is nothing to do unless glows are still suppressed under the old value.
-function ns.CDMGlowCombatSync(force)
-    if not force and not ns._cdmGlowOOCGate then return end
+-- to re-fire. The option, a profile apply and world entry call it after
+-- re-reading the gate, so a change takes effect at once. Never having had the
+-- gate on makes this two reads and a return for the whole session.
+function ns.CDMGlowCombatSync()
+    if not ns._cdmGlowOOCGate and not ns._cdmGlowGateEverOn then return end
     local show = _inCombat or not ns._cdmGlowOOCGate
     -- Replays are collected here and run after the traversal: StartNativeGlow
     -- writes into _cdmGlowRec, and inserting a key during pairs() is undefined
@@ -9566,9 +9570,8 @@ function ECME:OnInitialize()
         if ns.UpdateCustomBuffBars then ns.UpdateCustomBuffBars() end
         -- A profile that switches the gate off has to release the glows the old
         -- profile suppressed: the edge-driven ones (proc, cd ready) have no
-        -- ticker to bring them back on their own. Forced, because the gate the
-        -- sweep tests against is already the new profile's.
-        ns.CDMGlowCombatSync(true)
+        -- ticker to bring them back on their own.
+        ns.CDMGlowCombatSync()
     end
 
     -- Append SharedMedia textures to TBB runtime tables
@@ -10596,7 +10599,7 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
         -- a zone-in that lands mid-combat. At the very first world entry nothing
         -- is recorded yet, so only the gate read matters there.
         ns.RefreshGlowCombatGate()
-        ns.CDMGlowCombatSync(true)
+        ns.CDMGlowCombatSync()
         -- PvP instance transition backstop: entering or leaving a PvP instance rebuilds viewer pools (PvP talents activate/deactivate). Rebuild + reanchor so the new pool frames are claimed.
         local _, instType = IsInInstance()
         local wasPvP = ns._cdmWasInPvP

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -2392,9 +2392,10 @@ end
 -- stacks, buff, pandemic, CD ready, custom active states, bar glows, tracking
 -- bars -- starts here, so the whole feature is one gate on this function
 -- instead of a condition bolted onto thirteen decision sites.
--- overlay -> its last StartNativeGlow request. Weak-keyed: a recycled icon's
--- record drops out with the frame. Only currently lit (or suppressed) overlays
--- carry rec.active, so the combat sweep below stays a handful of entries.
+-- overlay -> its last StartNativeGlow request. Weak keys are form only: the
+-- values reach the key frames back through opts.owner and Lua 5.1 has no
+-- ephemerons, so nothing drops out (WoW frames are permanent anyway). The
+-- rec.active filter is what keeps the combat sweep below short.
 ns._cdmGlowRec = setmetatable({}, { __mode = "k" })
 
 -- Cached toggle: StartNativeGlow tests it on every glow start, so it must not
@@ -2516,6 +2517,9 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
     overlay:SetAlpha(1)
     -- NEVER Show()/Hide() -- the overlay is always shown (created in DecorateFrame).
     -- Toggling visibility on a child of a Blizzard viewer frame triggers Layout hooks and causes position cascades.
+    -- Caller-side work that must follow every real start (the threshold glow's
+    -- second mask). Riding on opts means the combat replay below runs it too.
+    if opts and opts.postStart then opts.postStart(overlay) end
 end
 
 StopNativeGlow = function(overlay)
@@ -2541,12 +2545,20 @@ function ns.CDMGlowCombatSync()
     if not ns._cdmGlowOOCGate and not ns._cdmGlowAnySuppressed then return end
     local show = _inCombat or not ns._cdmGlowOOCGate
     local anySuppressed = false
+    -- Replays are collected here and run after the traversal: StartNativeGlow
+    -- writes into _cdmGlowRec, and inserting a key during pairs() is undefined
+    -- in Lua 5.1. It only ever rewrites an existing key today, but that is not
+    -- a property this loop should rest on.
+    local queue = ns._cdmGlowSyncScratch
+    if not queue then queue = {}; ns._cdmGlowSyncScratch = queue end
+    local n = 0
     for overlay, rec in pairs(ns._cdmGlowRec) do
         if rec.active and not overlay._euiGlowPreview then
             if show then
                 if rec.suppressed then
                     if overlay:IsVisible() then
-                        StartNativeGlow(overlay, rec.style, rec.r, rec.g, rec.b, rec.opts)
+                        n = n + 1
+                        queue[n] = overlay
                     else
                         -- Hidden or recycled while suppressed: drop the request
                         -- rather than replay it onto whatever spell sits on that
@@ -2567,6 +2579,14 @@ function ns.CDMGlowCombatSync()
                 anySuppressed = true
                 -- _glowActive deliberately stays true (see StartNativeGlow).
             end
+        end
+    end
+    for i = 1, n do
+        local overlay = queue[i]
+        queue[i] = nil
+        local rec = ns._cdmGlowRec[overlay]
+        if rec then
+            StartNativeGlow(overlay, rec.style, rec.r, rec.g, rec.b, rec.opts)
         end
     end
     ns._cdmGlowAnySuppressed = anySuppressed or nil
@@ -10517,10 +10537,10 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, updateInfo, arg3)
             _inCombat = true
             _CDMApplyVisibility()
             ns.RefreshItemCountOOCBars()
-            -- Deferred one frame: replaying suppressed glows builds textures, and
-            -- the pull frame is already paying for the visibility pass above.
-            -- CDMGlowCombatSync re-reads _inCombat, so a pull that ended inside
-            -- that frame takes the suppress branch instead.
+            -- Deferred one frame so _CDMApplyVisibility above lands first: the
+            -- sweep's IsVisible() test has to see the bars this pull actually
+            -- shows. CDMGlowCombatSync re-reads _inCombat, so a pull that ended
+            -- inside that frame takes the suppress branch instead.
             C_Timer.After(0, ns.CDMGlowCombatSync)
         elseif event == "PLAYER_REGEN_ENABLED" then
             -- Buffer combat exit: brief out-of-combat blips (mob dies, re-aggro) shouldn't flash visibility changes.

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -18984,7 +18984,7 @@ initFrame:SetScript("OnEvent", function(self)
         -- above -- it takes the cooldown edge row's free slot where that row
         -- exists, and closes the section on its own for buff-family bars.
         local glowCombatCfg = { type="toggle", text="Show Glows Only in Combat (global)",
-              tooltip = "Hide every Cooldown Manager glow while you are out of combat: proc glows, active state, max stacks, buff and pandemic glows, cooldown ready glows and bar glows.\n\nThey come back the moment you enter combat, including a glow that started before the pull.\n\nApplies to every CDM bar and to the Tracking Bars at once. Glows from other EllesmereUI modules are not affected.",
+              tooltip = "Hide every Cooldown Manager glow while you are out of combat: proc glows, active state, max stacks, buff and pandemic glows, cooldown ready glows and bar glows.\n\nThey come back the moment you enter combat, including a glow that started before the pull.\n\nApplies to every CDM bar and to the Tracking Bars at once. Glows from other EllesmereUI modules are not affected.\n\nThe Bar Glows page keeps its own per-mapping Only In Combat toggle; this one applies on top of it.",
               getValue=function()
                   local p = DB()
                   return (p and p.cdmBars and p.cdmBars.glowsOnlyInCombat) == true

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -326,6 +326,7 @@ initFrame:SetScript("OnEvent", function(self)
         glowOvr:SetAllPoints(iconFrame)
         glowOvr:SetFrameLevel(iconFrame:GetFrameLevel() + 2)
         glowOvr:EnableMouse(false)
+        glowOvr._euiGlowPreview = true  -- exempt from Show Glows Only in Combat
 
         local function RefreshPreview()
             EllesmereUI.Glows.StopAllGlows(glowOvr)
@@ -1606,6 +1607,7 @@ initFrame:SetScript("OnEvent", function(self)
                                     local ov = CreateFrame("Frame", nil, previewBtn)
                                     ov:SetAllPoints(previewBtn)
                                     ov:SetFrameLevel(previewBtn:GetFrameLevel() + 10)
+                                    ov._euiGlowPreview = true  -- exempt from Show Glows Only in Combat
                                     _bgPreviewGlowOverlays[pvKey] = ov
                                 end
                                 local ov = _bgPreviewGlowOverlays[pvKey]
@@ -6320,6 +6322,7 @@ initFrame:SetScript("OnEvent", function(self)
             ov:SetAllPoints(slot)
             ov:SetFrameLevel(slot:GetFrameLevel() + 3)
             ov:SetAlpha(0)
+            ov._euiGlowPreview = true  -- exempt from Show Glows Only in Combat
             slot._glowOverlay = ov
         end
         _cdmActivePreviewOverlay = slot._glowOverlay
@@ -18673,6 +18676,29 @@ initFrame:SetScript("OnEvent", function(self)
         local isAnyBuffBar = isBuffGlowBar  -- buffs or custom_buff
         if not isCustomBuffBar and not isFocusKick then
         _, h = W:SectionHeader(parent, "EXTRAS", y);  y = y - h
+
+        -- Global, not per-bar: one gate for every glow the Cooldown Manager
+        -- draws, so it is labelled as such and sits in a full-width row.
+        _, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Glows Only in Combat (global)",
+              tooltip = "Hide every Cooldown Manager glow while you are out of combat: proc glows, active state, max stacks, buff and pandemic glows, cooldown ready glows and bar glows.\n\nThey come back the moment you enter combat, including a glow that started before the pull.\n\nApplies to every CDM bar and to the Tracking Bars at once. Glows from other EllesmereUI modules are not affected.",
+              getValue=function()
+                  local p = DB()
+                  return (p and p.cdmBars and p.cdmBars.glowsOnlyInCombat) == true
+              end,
+              setValue=function(v)
+                  local p = DB()
+                  if not p or not p.cdmBars then return end
+                  p.cdmBars.glowsOnlyInCombat = v and true or false
+                  -- Re-read the cached gate, then let the sweep take the running
+                  -- glows down (or bring the suppressed ones back) immediately
+                  -- instead of waiting for the next combat edge.
+                  if ns.RefreshGlowCombatGate then ns.RefreshGlowCombatGate() end
+                  if ns.CDMGlowCombatSync then ns.CDMGlowCombatSync() end
+                  EllesmereUI:RefreshPage()
+              end },
+            { type = "label", text = "" }
+        );  y = y - h
 
         -- Hide Items if Missing: one config, hosted in a different row per bar
         -- family. Buff bars carry it in the tooltip row's right slot; CD and

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -18677,29 +18677,6 @@ initFrame:SetScript("OnEvent", function(self)
         if not isCustomBuffBar and not isFocusKick then
         _, h = W:SectionHeader(parent, "EXTRAS", y);  y = y - h
 
-        -- Global, not per-bar: one gate for every glow the Cooldown Manager
-        -- draws, so it is labelled as such and sits in a full-width row.
-        _, h = W:DualRow(parent, y,
-            { type="toggle", text="Show Glows Only in Combat (global)",
-              tooltip = "Hide every Cooldown Manager glow while you are out of combat: proc glows, active state, max stacks, buff and pandemic glows, cooldown ready glows and bar glows.\n\nThey come back the moment you enter combat, including a glow that started before the pull.\n\nApplies to every CDM bar and to the Tracking Bars at once. Glows from other EllesmereUI modules are not affected.",
-              getValue=function()
-                  local p = DB()
-                  return (p and p.cdmBars and p.cdmBars.glowsOnlyInCombat) == true
-              end,
-              setValue=function(v)
-                  local p = DB()
-                  if not p or not p.cdmBars then return end
-                  p.cdmBars.glowsOnlyInCombat = v and true or false
-                  -- Re-read the cached gate, then let the sweep take the running
-                  -- glows down (or bring the suppressed ones back) immediately
-                  -- instead of waiting for the next combat edge.
-                  if ns.RefreshGlowCombatGate then ns.RefreshGlowCombatGate() end
-                  if ns.CDMGlowCombatSync then ns.CDMGlowCombatSync() end
-                  EllesmereUI:RefreshPage()
-              end },
-            { type = "label", text = "" }
-        );  y = y - h
-
         -- Hide Items if Missing: one config, hosted in a different row per bar
         -- family. Buff bars carry it in the tooltip row's right slot; CD and
         -- utility bars keep it beside Mirror Key Presses further down.
@@ -19002,6 +18979,28 @@ initFrame:SetScript("OnEvent", function(self)
                   end
               end });  y = y - h
 
+        -- Global, not per-bar: one gate for every glow the Cooldown Manager
+        -- draws, hence the label. Same hosting trick as Hide Items if Missing
+        -- above -- it takes the cooldown edge row's free slot where that row
+        -- exists, and closes the section on its own for buff-family bars.
+        local glowCombatCfg = { type="toggle", text="Show Glows Only in Combat (global)",
+              tooltip = "Hide every Cooldown Manager glow while you are out of combat: proc glows, active state, max stacks, buff and pandemic glows, cooldown ready glows and bar glows.\n\nThey come back the moment you enter combat, including a glow that started before the pull.\n\nApplies to every CDM bar and to the Tracking Bars at once. Glows from other EllesmereUI modules are not affected.",
+              getValue=function()
+                  local p = DB()
+                  return (p and p.cdmBars and p.cdmBars.glowsOnlyInCombat) == true
+              end,
+              setValue=function(v)
+                  local p = DB()
+                  if not p or not p.cdmBars then return end
+                  p.cdmBars.glowsOnlyInCombat = v and true or false
+                  -- Re-read the cached gate, then let the sweep take the running
+                  -- glows down (or bring the suppressed ones back) right away
+                  -- instead of waiting for the next combat edge.
+                  if ns.RefreshGlowCombatGate then ns.RefreshGlowCombatGate() end
+                  if ns.CDMGlowCombatSync then ns.CDMGlowCombatSync() end
+                  EllesmereUI:RefreshPage()
+              end }
+
         -- Cooldown/utility bars only: buff bars have no cooldown edge.
         if barData.barType == "cooldowns" or barData.barType == "utility" then
         _, h = W:DualRow(parent, y,
@@ -19012,7 +19011,9 @@ initFrame:SetScript("OnEvent", function(self)
                   BD().showCooldownEdge = v and true or nil
                   ns.BuildAllCDMBars(); Refresh()
               end },
-            { type="label", text="" });  y = y - h
+            glowCombatCfg);  y = y - h
+        else
+        _, h = W:DualRow(parent, y, glowCombatCfg, { type="label", text="" });  y = y - h
         end
 
         end -- custom_buff extras guard

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -18999,7 +18999,7 @@ initFrame:SetScript("OnEvent", function(self)
                   -- glows down (or bring the suppressed ones back) right away
                   -- instead of waiting for the next combat edge.
                   if ns.RefreshGlowCombatGate then ns.RefreshGlowCombatGate() end
-                  if ns.CDMGlowCombatSync then ns.CDMGlowCombatSync(true) end
+                  if ns.CDMGlowCombatSync then ns.CDMGlowCombatSync() end
                   EllesmereUI:RefreshPage()
               end }
 

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -329,7 +329,9 @@ initFrame:SetScript("OnEvent", function(self)
         glowOvr._euiGlowPreview = true  -- exempt from Show Glows Only in Combat
 
         local function RefreshPreview()
-            EllesmereUI.Glows.StopAllGlows(glowOvr)
+            -- Through the CDM wrapper, not Glows directly: it also clears this
+            -- overlay's glow record, so a preview left off keeps no stale one.
+            ns.StopNativeGlow(glowOvr)
             if isOffFn() then
                 iconFrame:SetAlpha(0.3)
                 return
@@ -18997,7 +18999,7 @@ initFrame:SetScript("OnEvent", function(self)
                   -- glows down (or bring the suppressed ones back) right away
                   -- instead of waiting for the next combat edge.
                   if ns.RefreshGlowCombatGate then ns.RefreshGlowCombatGate() end
-                  if ns.CDMGlowCombatSync then ns.CDMGlowCombatSync() end
+                  if ns.CDMGlowCombatSync then ns.CDMGlowCombatSync(true) end
                   EllesmereUI:RefreshPage()
               end }
 


### PR DESCRIPTION
## What does this PR do?

Adds a global Cooldown Manager option, "Show Glows Only in Combat", that hides every CDM glow while you are out of combat and brings them back the moment you enter combat, including a glow that had already started before the pull. It covers proc glows, active state glows, max stacks and glow at stacks, buff and pandemic glows, cooldown ready glows, the custom active state presets, bar glows and the Tracking Bars. Off by default. It applies to every CDM bar at once rather than per bar, which is why the label carries "(global)". The Bar Glows page keeps its existing per-mapping "Only In Combat" toggle; this one applies on top of it. Glows drawn by other EllesmereUI modules are not affected.

Every CDM glow starts in one function, StartNativeGlow, so the gate lives there instead of being bolted onto the individual decision sites. Each request is recorded on its overlay and replayed on the way into combat, because the proc glow and the cooldown ready glow are purely edge driven and have no periodic re-assert to bring them back on their own. A suppressed overlay deliberately keeps _glowActive true: the buff ticker's active-glow integrity pass and the preset cooldown-state re-assert both restart any glow whose overlay reads dark, so reporting the real state there would churn every tick for exactly the users who asked for less work out of combat. Options previews opt out through a flag on their own overlay, so the preview icons keep glowing while the panel is open.

The replay is guarded against a pooled icon that was handed a different spell while its glow sat suppressed: each record is stamped with the owning frame and its resolved spellID, and a record whose icon has since moved on is dropped instead of replayed. Blizzard's viewer frames are never hidden by this addon (visibility is alpha driven, and even unclaimed pool frames stay visible), so a visibility test would not have caught that case. The option's own toggle, a profile switch and world entry force the reconciliation pass to run, so the setting takes effect immediately rather than waiting for the next combat edge.

The threshold glow's second gate mask travels with the recorded request as a maskWith2 option alongside the existing maskWith, so a replayed glow binds both masks on the textures it creates fresh and cannot pulse below the stack threshold.

In the options UI the toggle sits in the EXTRAS section, taking the free slot on the "Always Show Cooldown Edge" row for cooldown and utility bars and closing the section on its own row for buff-family bars, which have no cooldown edge. That is the same hosting trick "Hide Items if Missing" already uses in that section.

One residual cost worth naming honestly: with the option off, StartNativeGlow still writes its small per-overlay record on every glow start, so the setting can be flipped mid-session without a reload and a glow that is already running can be released again. That is fourteen table operations and no allocation, riding on a call that already tears down and rebuilds a glow engine's textures. Nothing else runs: no events, hooks, frames, timers or polling are added, and the combat reconciliation pass returns after two reads for any session that never switches the option on.

## How was it tested?

Tested in game on the live retail client. Worth noting: Extra tests would be required to confirm its working in different scenarios.

## Screenshot
<img width="930" height="347" alt="grafik" src="https://github.com/user-attachments/assets/cbf8cfc1-f17a-4c1a-9c37-5166e9a6f96d" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built. The one thing that still runs with the option off is the per-overlay record write in StartNativeGlow described above, which exists so the option can be turned on and off mid-session; the combat reconciliation pass itself returns immediately unless the option has been on at some point in the session.
- [x] Cheap while enabled: event-driven, no polling, no timer-based logic, no per-frame allocations
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames. The glow state lives on the addon's own overlay frames; Blizzard icon frames are only read, through the existing weak-keyed frame cache.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
