### PR TITLE
Fix the health bar and percent text outliving a dead unit

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2266,6 +2266,9 @@ do
   -- Health percent under the decimal options. "Hide Trailing Zeros" reads the percent
   -- through a scaling curve so AbbreviateNumbers can drop the zero "%.1f" would pad.
   local function PercentHP(unit)
+    -- Predicted percent (incoming heals) can outlive the unit: a corpse fires no
+    -- further UNIT_HEALTH and the text channel never hears UNIT_HEAL_PREDICTION.
+    if UnitIsDeadOrGhost(unit) then return "0" end
     local boss = _G._EUI_BossExtraDecimal and string.sub(unit, 1, 4) == "boss"
     local trim = _G._EUI_PctTrim
     if boss then trim = _G._EUI_PctTrim2 end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2050,9 +2050,11 @@ do
         -- restricted content, where the value is secret) instead of the value,
         -- and without the interpolation, which otherwise eases toward zero and
         -- leaves a sliver standing on a bar that gets no further ticks.
+        -- UnitIsDead, not UnitIsDeadOrGhost: a ghost is at full health, and
+        -- Blizzard's own bar reads it the same way (CompactUnitFrame_UpdateHealthColor).
         if not UnitIsConnected(unit) then
             element:SetValue(UnitHealthMax(unit), element.smoothing)
-        elseif UnitIsDeadOrGhost(unit) then
+        elseif UnitIsDead(unit) then
             element:SetValue(0)
         else
             element:SetValue(UnitHealth(unit), element.smoothing)
@@ -2275,7 +2277,9 @@ do
   local function PercentHP(unit)
     -- Predicted percent (incoming heals) can outlive the unit: a corpse fires no
     -- further UNIT_HEALTH and the text channel never hears UNIT_HEAL_PREDICTION.
-    if UnitIsDeadOrGhost(unit) then return "0" end
+    -- Corpses only, like Blizzard's health paths: a ghost is at full health, and
+    -- the neighbouring DEAD zone is the piece that speaks for dead-or-ghost.
+    if UnitIsDead(unit) then return "0" end
     local boss = _G._EUI_BossExtraDecimal and string.sub(unit, 1, 4) == "boss"
     local trim = _G._EUI_PctTrim
     if boss then trim = _G._EUI_PctTrim2 end

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2045,10 +2045,17 @@ do
             element._maxSet = true
             element:SetMinMaxValues(0, UnitHealthMax(unit))
         end
-        if UnitIsConnected(unit) then
-            element:SetValue(UnitHealth(unit), element.smoothing)
-        else
+        -- A corpse fires no further UNIT_HEALTH, so the death tick's paint is the
+        -- last one the bar gets: zero it from the dead flag (a plain boolean in
+        -- restricted content, where the value is secret) instead of the value,
+        -- and without the interpolation, which otherwise eases toward zero and
+        -- leaves a sliver standing on a bar that gets no further ticks.
+        if not UnitIsConnected(unit) then
             element:SetValue(UnitHealthMax(unit), element.smoothing)
+        elseif UnitIsDeadOrGhost(unit) then
+            element:SetValue(0)
+        else
+            element:SetValue(UnitHealth(unit), element.smoothing)
         end
         -- Color inputs (class/reaction/dark/disconnect/tap) change via their
         -- own events or identity repaints -- a pure health tick re-runs the


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1538927547067277355

Issue: A dead unit keeps showing live health. The percent zone sits beside DEAD at whatever it last read, so the frame reads "7% - DEAD", and the health bar keeps a matching fill. It only strands when the unit dies with a heal in flight, which is why it looked intermittent.

Root cause: PercentHP reads UnitHealthPercent with usePredicted, so incoming heals fold into the number, and PaintHealth takes UnitHealth straight from the death tick. That tick is the last paint either one gets: a corpse fires no further UNIT_HEALTH, and the text channel never hears UNIT_HEAL_PREDICTION. The value is also secret in restricted content, so nothing in Lua could notice.

Fix: Both now gate on UnitIsDead, a plain boolean where the value is secret, and the bar is set without interpolation so easing cannot strand a sliver. The DEAD label keeps dead-or-ghost, matching Blizzard's own split, so a full-health ghost is untouched. Confirmed in game by the reporter.
