### PR TITLE
Fix boss frames showing no name

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2525,7 +2525,10 @@ _G._EUF_RefreshUnitNames = ns.RefreshAllUnitNames
 do
     local function ForceTextRepaint()
         for _, f in pairs(frames) do
-            if type(f) == "table" and f._euiTextZones then
+            -- The painter refuses an empty token, so a frame between units must
+            -- not be blanked here either -- it would never get the value back.
+            if type(f) == "table" and f._euiTextZones
+               and f._euiUnit and UnitExists(f._euiUnit) then
                 local zones = f._euiTextZones
                 for i = 1, #zones do
                     local fs = zones[i].fs
@@ -2806,6 +2809,10 @@ do
     local function PaintText(frame, unit, event)
         local zones = frame._euiTextZones
         if not zones then return end
+        -- An empty token renders every zone blank, and a boss frame outlives the
+        -- gap: the unit watch is a 0.2s poll, so the frame is still shown while
+        -- its slot sits between units. Same probe the health painter pays.
+        if not (unit and UnitExists(unit)) then return end
         local valueOnly = event ~= nil and VALUE_EVENTS[event]
         for i = 1, #zones do
             local z = zones[i]


### PR DESCRIPTION
Bug: reported by @Jλrppi1893 in EllesmereUI-helper Discord (2026-08-27), 9.0.7

Issue: Boss frames sometimes come up with no name and stay that way for the rest of the pull, with no obvious trigger; toggling Boss Frames off and back on restores it. The screenshot shows the tell -- the health bar holds a fill while the name and the percent are both gone.

Root cause: the health painter refuses a unit token that does not exist, so the bar keeps its last fill; PaintText had no such guard and rendered every zone from the empty token -- ResolveUnitNickname returns "" for a nil UnitName, PercentHP returns "0". The frame is on screen without a unit because RegisterUnitWatch is a 0.2s throttled poll rather than an event, so it outlives its slot across a gap.

Fix: PaintText now pays the same UnitExists probe the health painter does, leaving the last good text standing. The cold-login ForceTextRepaint, which blanks every zone before repainting, gets the same condition so it cannot blank a frame the painter would then skip.
