### PR TITLE
Fix(Damage Meters): sizes ignore UI Scale, rendering inconsistent with the rest of the UI

### DIFF
--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -973,14 +973,15 @@ local function ApplyBarTexture(fill, texPath, texKey)
     end
 end
 
--- Physical pixel spacing: convert user values to physical pixels (user setting = physical pixel count).
--- Snapped through PP.Scale so accumulated row offsets (stride * index) don't drift off the pixel
--- grid from float dust -- without this, a spacing of 1 can round to 0px on some rows and 2px on others.
+-- The meter windows are plain UIParent children with no SetScale of their own, so
+-- snapping against UIParent's effective scale keeps sizes consistent with the rest of the UI.
 local function PhysicalPixels(userValue)
     local PP = EUI and EUI.PP
-    local mult = (PP and PP.mult) or 1
-    local value = (userValue or 0) * mult
-    if PP and PP.Scale then return PP.Scale(value) end
+    local value = userValue or 0
+    if PP and PP.SnapForES then
+        local es = (UIParent and UIParent:GetEffectiveScale()) or 1
+        return PP.SnapForES(value, es)
+    end
     return value
 end
 


### PR DESCRIPTION
## What does this PR do?
`PhysicalPixels()` converts every configured size (bar height, spacing, icon size, header height) by multiplying by `EllesmereUI.PP.mult` (`= PP.perfect / ppUIScale`, where `PP.perfect = 768 / physicalScreenHeight`). Once rendered through the meter window's own effective scale, the `ppUIScale` term cancels: the actual on-screen result is `userValue * (768 / physicalScreenHeight)`, independent of UI Scale entirely. `EllesmereUIResourceBars` does this correctly already, via `PP.SnapForES(value, frame:GetEffectiveScale())` -- no separate resolution multiplier. This fixes `EllesmereUIDamageMeters` to match that pattern.

Invisible at default UI Scale (Blizzard's auto "pixel perfect" value for a resolution *is* `768/physicalHeight`, so the bug is a no-op there) -- only shows once UI Scale is manually raised above that default.

## How was it tested?
Same account, `ppUIScale = 0.80`, Damage Meters `Bar Height` set to `16` (matching Resource Bars' own Power Bar `Height` of `16` for a direct same-value comparison), at two resolutions (1440p and 2880p). Before the fix, the meter rows render visibly thinner than the Power Bar despite the identical configured value, worse at 2880p than 1440p exactly as the `768/physicalHeight` formula predicts. After the fix, meter rows match the Power Bar's height at both resolutions.

## Screenshots

Before, 1440p
<img width="547" height="249" alt="31" src="https://github.com/user-attachments/assets/583a98db-8a8d-4b1d-a9cb-463b9b020a4e" />

After, 1440p
<img width="547" height="249" alt="32" src="https://github.com/user-attachments/assets/520b53fd-ad6c-4d3c-9c35-21db9286ab87" />

Before, 2880p
<img width="1110" height="437" alt="33" src="https://github.com/user-attachments/assets/04f66a4c-38e4-4d41-bada-df526068be6e" />

After, 2880p
<img width="1110" height="437" alt="34" src="https://github.com/user-attachments/assets/c8d73c77-fe48-46f1-b2fe-4b9ada4169b6" />

## Checklist
- [x] N/A: no new setting is introduced.
- [x] N/A: this is a correction to existing enabled behavior.
- [x] Cheap while enabled: same call as before, `PP.SnapForES` is the same helper Resource Bars already calls.
- [x] N/A: no writes onto Blizzard-owned frames.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added.