### PR TITLE
Feat: add an optional center reticle to the cursor circle

### DIFF
--- a/EllesmereUIOptions/EUI_QoL_Cursor_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_Cursor_Options.lua
@@ -298,7 +298,7 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        -- Combat Only
+        -- Combat Only ---- Center Reticle
         _, h = W:DualRow(parent, y,
             { type="toggle", text="Combat Only",
               tooltip="Only shows the cursor circle while you are in combat.",
@@ -309,7 +309,14 @@ initFrame:SetScript("OnEvent", function(self)
                 if _G._ECL_ApplyCombatOnlyEvents then _G._ECL_ApplyCombatOnlyEvents() end
                 if _G._ECL_UpdateVisibility then _G._ECL_UpdateVisibility() end
               end },
-            { type="label", text="" }
+            { type="toggle", text="Center Reticle",
+              tooltip="Adds a small filled dot at the center of the cursor circle. Uses the same color and opacity as the circle.",
+              getValue=function() local p = DB(); return p and p.reticle or false end,
+              setValue=function(v)
+                local p = DB(); if not p then return end
+                p.reticle = v
+                RefreshAddon()
+              end }
         );  y = y - h
         end   -- close Cursor Circle hidden-while-disabled gate
 

--- a/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL_Cursor.lua
@@ -31,7 +31,7 @@ local GetSpellCooldown = C_Spell and C_Spell.GetSpellCooldown or GetSpellCooldow
 local UnitCastingInfo = UnitCastingInfo or CastingInfo
 local UnitChannelInfo = UnitChannelInfo or ChannelInfo
 
-local f, t
+local f, t, reticle
 local lastX, lastY
 
 local lastScale, lastHex, lastTex, lastAlpha
@@ -91,15 +91,34 @@ local UpdateVisibility
 
 local lastUseClassColor
 
+local function CursorSize(p)
+    local size = floor((p.baseSize or DEF_BASESIZE) * (p.scale or DEF_SCALE) + 0.5)
+    if size < 8 then return 8 end
+    if size > 512 then return 512 end
+    return size
+end
+
+local function ApplyReticle(p, size, r, g, b, a)
+    if not reticle then return end
+    if not p.reticle then
+        reticle:Hide()
+        return
+    end
+    -- ~20% of the ring so the mask has enough pixels to stay circular.
+    local dot = max(4, floor(size * 0.2 + 0.5))
+    reticle:SetSize(dot, dot)
+    reticle:SetColorTexture(r, g, b, a)
+    reticle:Show()
+end
+
 local function Apply()
     if not f or not t then return end
     local p = ECL.db.profile
 
     local scale = p.scale or DEF_SCALE
+    local size = CursorSize(p)
     if scale ~= lastScale then
         lastScale = scale
-        local size = floor((p.baseSize or DEF_BASESIZE) * scale + 0.5)
-        if size < 8 then size = 8 elseif size > 512 then size = 512 end
         f:SetSize(size, size)
     end
 
@@ -110,10 +129,11 @@ local function Apply()
     -- changed. Accent mode also needs per-frame re-read since ELLESMERE_GREEN
     -- mutates in place when the user changes their accent color mid-session.
     local a = (p.alpha or 100) / 100
+    local r, g, b
     if hex ~= lastHex or p.useClassColor or p.useAccentColor or colorModeChanged or a ~= lastAlpha then
         lastHex = hex
         lastAlpha = a
-        local r, g, b = ResolveColor(p)
+        r, g, b = ResolveColor(p)
         t:SetVertexColor(r, g, b, a)
     end
 
@@ -125,6 +145,11 @@ local function Apply()
         local path = (ringKey and RING_TEXTURES[ringKey]) or RING_TEXTURES[tex] or TEX_CUSTOM
         t:SetTexture(path)
     end
+
+    -- Reticle is cheap and Apply() only runs on setting changes, so always
+    -- refresh it (toggle, scale, and color all land here).
+    if not r then r, g, b = ResolveColor(p) end
+    ApplyReticle(p, size, r, g, b, a)
 
     UpdateVisibility()
 end
@@ -1275,6 +1300,7 @@ function ECL:OnInitialize()
                     combatOnly = false,
                 },
                 trail = false,
+                reticle = false,
                 visibility       = "always",
                 visOnlyInstances = false,
                 visHideHousing   = false,
@@ -1341,6 +1367,22 @@ function ECL:OnEnable()
     t = f:CreateTexture(nil, "OVERLAY")
     t:SetAllPoints(f)
     t:SetTexture(TEX_CUSTOM)
+
+    -- Center reticle: solid fill through the shared portrait circle mask,
+    -- same construction as the patch-notes sidebar dot.
+    reticle = f:CreateTexture(nil, "OVERLAY", nil, 1)
+    reticle:SetPoint("CENTER")
+    reticle:SetColorTexture(1, 1, 1, 1)
+    if reticle.SetSnapToPixelGrid then
+        reticle:SetSnapToPixelGrid(false)
+        reticle:SetTexelSnappingBias(0)
+    end
+    local reticleMask = f:CreateMaskTexture()
+    reticleMask:SetTexture("Interface\\AddOns\\EllesmereUI\\media\\portraits\\circle_mask.tga",
+        "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
+    reticleMask:SetAllPoints(reticle)
+    reticle:AddMaskTexture(reticleMask)
+    reticle:Hide()
 
     -- No OnUpdate: the shared cursor service drives positioning. The frame
     -- is SHOWN by default and isVisible initializes TRUE, so the first


### PR DESCRIPTION
## What does this PR do?

Adds a Center Reticle toggle under Quality of Life -> Cursor. When enabled, a small filled dot sits in the middle of the cursor circle and uses the same color and opacity as the ring (custom, class, or accent). Off by default.

## How was it tested?

Code review against `.github/CONTRIBUTING.md`. Please enable the cursor circle, turn on Center Reticle, and confirm the dot follows color, opacity, and scale changes.

## Screenshots

**Before**
<img width="542" height="313" alt="image" src="https://github.com/user-attachments/assets/5786726f-ba00-4dfd-9c03-572159f87413" />

**After**
<img width="505" height="275" alt="image" src="https://github.com/user-attachments/assets/6b7eaed6-898e-4e0f-99b4-a23fe5777cae" />


## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work; the dot texture is created with the cursor circle and stays hidden while the toggle is off
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added

## Contact Info
- Discord: espyr