### PR TITLE
Fix(QoL): ally right-click guard blocks Demonic Gateway

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -2942,7 +2942,14 @@ do
                 macro = macro .. (inInstance and "[@mouseover,harm,nodead]1;"
                     or "[@mouseover,harm,nodead,combat]1;")
             end
-            if allyCombat then macro = macro .. "[@mouseover,help,nodead,combat]1;" end
+            -- "group" restricts the match to actual party/raid members -- this
+            -- feature exists to stop a stray right-click from targeting/
+            -- interacting with an ally UNIT FRAME during combat, but plain
+            -- [help] also matches any friendly-classified summoned object
+            -- (e.g. a Warlock's Demonic Gateway), which blocked right-clicking
+            -- the gateway itself to use it. A gateway is never a group member,
+            -- so this excludes it while leaving the party/raid protection intact.
+            if allyCombat then macro = macro .. "[@mouseover,help,group,nodead,combat]1;" end
             macro = macro .. "0"
             SecureStateDriverManager:RegisterEvent("UPDATE_MOUSEOVER_UNIT")
             -- [combat] arms re-evaluate on combat edges even when the mouseover


### PR DESCRIPTION
Bug: reported via Svart; the original report thread went with his PR when his GitHub account was suspended. Fix authored by Svart (svart2521) and re-submitted here on his behalf.

Issue: with the combat ally right-click protection enabled, a Warlock could not right-click their own Demonic Gateway to use it while in combat. Out of combat the gateway worked normally, which made it look like an intermittent gateway bug rather than a UI setting.

Root cause: the protection installs a macro conditional built in EllesmereUIQoL.lua using [@mouseover,help,nodead,combat]. The [help] conditional matches anything the client classifies as friendly, not just players, and a Demonic Gateway is friendly-classified. The guard therefore claimed the click that would have used the gateway.

Fix: add the "group" conditional so the clause only matches actual party or raid members. A gateway is never a group member, so the click falls through to normal interaction, while protection for real ally unit frames is unchanged. Verified in game by right-clicking a gateway in combat with the option on.