### PR TITLE
Fix(Minimap): disabled tracking button still clickable

### DIFF
--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -276,6 +276,13 @@ local function HideMinimapButton(name)
             for _, entry in ipairs(minimapButtonMap) do
                 for _, btnName in ipairs(entry.names) do
                     if btnName == name and mp[entry.key] then
+                        -- Alpha alone leaves the button SHOWN (a WoW frame at
+                        -- alpha 0 still receives mouse/tooltip events) -- Hide()
+                        -- it too, matching the initial suppression below, or a
+                        -- later Blizzard-driven Show() (tracking-spell change,
+                        -- login re-eval, etc.) leaves an invisible but fully
+                        -- clickable hotspot at the button's old position.
+                        self:Hide()
                         self:SetAlpha(0)
                         return
                     end


### PR DESCRIPTION
Bug: reported via Svart; the original report thread went with his PR when his GitHub account was suspended. Fix authored by Svart (svart2521) and re-submitted here on his behalf.

Issue: turning the tracking button off in the minimap button options made it vanish, but the spot it used to occupy still swallowed clicks and showed its tooltip. Because nothing was visible there, it read as the minimap eating clicks at random rather than as a button that was still present.

Root cause: the per-button suppression path in EllesmereUIMinimap.lua only called SetAlpha(0). A frame at alpha 0 is still shown as far as the client is concerned, so it keeps receiving mouse and tooltip events. The initial suppression already hid the frame; only this later re-suppression branch did not, so any Blizzard-driven Show() from a tracking-spell change or a login re-evaluation brought the invisible hotspot back.

Fix: call Hide() alongside the alpha in that branch so both paths agree and a later Show() cannot resurrect the hotspot.