### PR TITLE
Fix(Unit Frames): wrong power colour on Mistweaver

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2296,6 +2296,7 @@ _G._EUI_ResolvedPowerType = _G._EUI_ResolvedPowerType or {}
 
 local PLAYER_POWER_DEFAULT = {
     PRIEST = { [3] = 0 },   -- Shadow: default to Mana
+    MONK   = { [2] = 0 },   -- Mistweaver: default to Mana
 }
 local PLAYER_POWER_ALT = {
     DRUID  = { [1] = 0, [2] = 0, [3] = 0 },  -- Balance/Feral/Guardian -> Mana


### PR DESCRIPTION
Bug: reported via Svart; the original report thread went with his PR when his GitHub account was suspended. Fix authored by Svart (svart2521) and re-submitted here on his behalf.

Issue: a Mistweaver Monk's power bar drew in the wrong colour, and the power text did not match the resource the spec plays on. Other Monk specs looked correct, so it presented as a Mistweaver-only display bug.

Root cause: PLAYER_POWER_DEFAULT in EllesmereUIUnitFrames.lua lists the specs whose displayed power should be forced rather than taken from UnitPowerType. Shadow Priest was there; Mistweaver was not, so the bar, its text and the colour resolver all fell through to whatever UnitPowerType reported.

Fix: add MONK spec index 2 to that table with Mana, alongside the existing Shadow entry. The table is nested per class so the index cannot collide with another class's slot 2, all three consumers read from the same resolver so they stay in agreement, and anyone who prefers the previous display can still set powerTypeOverride.