### PR TITLE
Fix(Chat): Lua error from a secret alpha read in raid

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat_Tabs.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Tabs.lua
@@ -712,7 +712,16 @@ function ECHAT.TabsSweepBlizzard()
             -- in lockdown; a refused heal retries on the next sweep.
             if InCombatLockdown() then pcall(gdm.Show, gdm) else gdm:Show() end
         end
-        if gdm:GetAlpha() ~= 0 then gdm:SetAlpha(0) end
+        -- GetAlpha can return a secret number mid-combat in a raid (same
+        -- class as the cursor-position guards elsewhere in this file); a
+        -- secret result can't be safely compared for the ~= 0 skip-optimization,
+        -- so just re-assert 0 unconditionally in that case.
+        local gdmAlpha = gdm:GetAlpha()
+        if issecretvalue and issecretvalue(gdmAlpha) then
+            gdm:SetAlpha(0)
+        elseif gdmAlpha ~= 0 then
+            gdm:SetAlpha(0)
+        end
         local ob = gdm.overflowButton
         if ob then
             if ob.SetIgnoreParentAlpha and not ob:IsIgnoringParentAlpha() then


### PR DESCRIPTION
Bug: reported via Svart; the original report thread went with his PR when his GitHub account was suspended. Fix authored by Svart (svart2521) and re-submitted here on his behalf.

Issue: chat threw a Lua error during raid combat. It did not reproduce solo or at a dummy, and there was no obvious trigger, which is what made it look intermittent.

Root cause: the group-dropdown sweep in EllesmereUIChat_Tabs.lua read gdm:GetAlpha() and compared it against 0 purely to skip a redundant SetAlpha write. Under raid restrictions that read can come back a secret number, and comparing a secret raises. The comparison existed only as an optimisation, so the error had nothing to do with the alpha value itself.

Fix: test issecretvalue first and re-assert alpha 0 unconditionally when the read is secret, keeping the skip only for the readable case. This is the same issecretvalue guard already used throughout the Chat module. Verified in a raid with no error on the sweep.