### PR TITLE
Fix(QoL): AH Current Expansion Only filter never applied

### DIFF
--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -797,10 +797,18 @@ qolFrame:SetScript("OnEvent", function(self)
             if not AuctionHouseFrame or not AuctionHouseFrame.SearchBar then return end
             C_Timer.After(0, function()
                 local fb = AuctionHouseFrame.SearchBar.FilterButton
-                if not fb or not fb.filters then return end
+                if not fb or not fb.GetFilters or not fb.ToggleFilter then return end
                 if not (Enum and Enum.AuctionHouseFilter and Enum.AuctionHouseFilter.CurrentExpansionOnly) then return end
-                fb.filters[Enum.AuctionHouseFilter.CurrentExpansionOnly] = true
-                AuctionHouseFrame.SearchBar:UpdateClearFiltersButton()
+                local filterEnum = Enum.AuctionHouseFilter.CurrentExpansionOnly
+                local filters = fb:GetFilters()
+                -- Direct fb.filters[...] mutation never reaches the search query;
+                -- ToggleFilter is the only path that actually re-runs the AH search.
+                if not (filters and filters[filterEnum]) then
+                    fb:ToggleFilter(filterEnum)
+                end
+                if AuctionHouseFrame.SearchBar.UpdateClearFiltersButton then
+                    AuctionHouseFrame.SearchBar:UpdateClearFiltersButton()
+                end
             end)
         end)
     end


### PR DESCRIPTION
Bug: reported via Svart; the original report thread went with his PR when his GitHub account was suspended. Fix authored by Svart (svart2521) and re-submitted here on his behalf.

Issue: with the Current Expansion Only auction house option enabled, the filter appeared set but searches still returned items from every expansion. The checkbox looking correct is what made this hard to spot.

Root cause: the auto-filter in EllesmereUIQoL.lua assigned straight into AuctionHouseFrame.SearchBar.FilterButton.filters. That table only backs the checkbox state; it is not what the search query reads, so nothing reached the query. Blizzard's own search bar never mutates it directly either.

Fix: go through FilterButton:ToggleFilter, the path Blizzard's search bar uses, and read current state with GetFilters so an already-set filter is not toggled back off. The existence guards now test for those two methods instead of the internal table, and UpdateClearFiltersButton is called only if present. Verified in game with a search returning current-expansion items only.