### PR TITLE
feat(Aura Buff Reminders): Add border settings for buff reminders. Also added Warlock's Soulstone and setting to change font. 

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -112,6 +112,10 @@ end
 --  Font resolution (uses global font system)
 -------------------------------------------------------------------------------
 local function ResolveFontPath(fontName)
+    if fontName and fontName ~= "__global" and EllesmereUI and EllesmereUI.ResolveFontName then
+        local path = EllesmereUI.ResolveFontName(fontName)
+        if path and path ~= "" then return path end
+    end
     if EllesmereUI and EllesmereUI.GetFontPath then
         return EllesmereUI.GetFontPath("auraBuff")
     end
@@ -127,7 +131,7 @@ local _cachedOutline
 local function SetABRFont(fs, font, size)
     if not (fs and fs.SetFont) then return end
     if not _cachedOutline then _cachedOutline = GetABROutline() end
-    if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fs, _cachedOutline == "") end
+    if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(fs, _cachedOutline == "" and GetABRUseShadow()) end
     fs:SetFont(font, size, _cachedOutline)
 end
 
@@ -397,12 +401,19 @@ local NON_SECRET_SPELL_IDS = {
 -------------------------------------------------------------------------------
 local _preCombatAuraCache = {}  -- [spellID] = true/false, snapshotted at REGEN_DISABLED
 
-local function _isRuntimeNonSecret(id)
+function EABR.IsRuntimeNonSecret(id)
     if C_Secrets and C_Secrets.ShouldSpellAuraBeSecret then
-        return not C_Secrets.ShouldSpellAuraBeSecret(id)
+        local ok, secret = pcall(C_Secrets.ShouldSpellAuraBeSecret, id)
+        if not ok or isSecret(secret) then return false end
+        return secret == false
     end
     return true  -- if API missing, assume non-secret (pre-12.0 client)
 end
+
+-- Soulstone is readable on clients/builds where Blizzard explicitly exposes
+-- it. Do not hard-whitelist it on restricted builds: source ownership is the
+-- defining part of this reminder and must never be guessed from secret data.
+if EABR.IsRuntimeNonSecret(20707) then NON_SECRET_SPELL_IDS[20707] = true end
 
 local function SnapshotPlayerAuras()
     wipe(_preCombatAuraCache)
@@ -581,8 +592,9 @@ local function _unitHasBuff(u, spellIDs)
 end
 
 -- True if the buff's source is the player. Non-player units: OOC iteration only, false in combat (caller uses the snapshot).
-local function _unitHasBuffFromPlayer(u, spellIDs)
+local function _unitHasBuffFromPlayer(u, spellIDs, strictSource)
     local inCombat = InCombat()
+    local restricted = EllesmereUI.AuraKit and EllesmereUI.AuraKit.AurasRestricted()
     local idLookup = _idLookupScratch
     wipe(idLookup)
     for j = 1, #spellIDs do idLookup[spellIDs[j]] = true end
@@ -590,29 +602,50 @@ local function _unitHasBuffFromPlayer(u, spellIDs)
     if UnitIsUnit(u, "player") then
         -- Player-self: GetPlayerAuraBySpellID for whitelisted IDs
         for id in pairs(idLookup) do
-            if NON_SECRET_SPELL_IDS[id] then
+            if NON_SECRET_SPELL_IDS[id] or (strictSource and not restricted) then
                 local ok, aura = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
+                if strictSource and (not ok or isSecret(aura)) then return nil end
                 if ok and aura ~= nil and not isSecret(aura) then
                     local fromMe = aura.isFromPlayerOrPlayerPet
-                    if fromMe and not isSecret(fromMe) and fromMe == true then
+                    if strictSource then
+                        if isSecret(fromMe) then return nil end
+                        if fromMe ~= nil then return fromMe == true end
+                        local src = aura.sourceUnit
+                        if isSecret(src) or src == nil then return nil end
+                        return UnitIsUnit(src, "player") == true
+                    elseif fromMe and not isSecret(fromMe) and fromMe == true then
                         return true
                     end
                     local src = aura.sourceUnit
                     if src and not isSecret(src) and UnitIsUnit(src, "player") then
                         return true
                     end
+                    if strictSource and (not src or isSecret(src)) then return nil end
                 end
             end
         end
-        if not inCombat and not (EllesmereUI.AuraKit and EllesmereUI.AuraKit.AurasRestricted()) then
+        -- A strict targeted lookup is authoritative in an unrestricted
+        -- context; avoid a 255-aura fallback scan for every group unit.
+        if strictSource then return false end
+        if not inCombat and not restricted then
             for i = 1, AURA_SCAN_LIMIT do
                 local aura = C_UnitAuras.GetAuraDataByIndex("player", i, "HELPFUL")
                 if not aura then break end
                 local sid = aura.spellId
                 if sid and not isSecret(sid) and idLookup[sid] then
+                    local fromMe = aura.isFromPlayerOrPlayerPet
+                    if strictSource then
+                        if isSecret(fromMe) then return nil end
+                        if fromMe ~= nil then return fromMe == true end
+                        local src = aura.sourceUnit
+                        if isSecret(src) or src == nil then return nil end
+                        return UnitIsUnit(src, "player") == true
+                    end
                     local src = aura.sourceUnit
                     if src and not isSecret(src) and UnitIsUnit(src, "player") then
                         return true
+                    elseif strictSource and (not src or isSecret(src)) then
+                        return nil
                     end
                 end
             end
@@ -624,13 +657,23 @@ local function _unitHasBuffFromPlayer(u, spellIDs)
     -- Fast path: 1 API call per whitelisted ID instead of scanning every aura on the unit via GetAuraDataByIndex.
     local needScan = false
     for id in pairs(idLookup) do
-        if NON_SECRET_SPELL_IDS[id] then
-            local aura = C_UnitAuras.GetUnitAuraBySpellID(u, id)
-            if aura and not isSecret(aura) then
+        if NON_SECRET_SPELL_IDS[id] or (strictSource and not restricted) then
+            local ok, aura = pcall(C_UnitAuras.GetUnitAuraBySpellID, u, id)
+            if strictSource and (not ok or isSecret(aura)) then return nil end
+            if ok and aura and not isSecret(aura) then
+                local fromMe = aura.isFromPlayerOrPlayerPet
+                if strictSource then
+                    if isSecret(fromMe) then return nil end
+                    if fromMe ~= nil then return fromMe == true end
+                    local src = aura.sourceUnit
+                    if isSecret(src) or src == nil then return nil end
+                    return UnitIsUnit(src, "player") == true
+                end
                 local src = aura.sourceUnit
                 if src and not isSecret(src) then
                     if UnitIsUnit(src, "player") then return true end
                 else
+                    if strictSource then return nil end
                     return true  -- sourceUnit unavailable OOC, assume ours
                 end
             end
@@ -640,17 +683,26 @@ local function _unitHasBuffFromPlayer(u, spellIDs)
     end
     if not needScan then return false end
     -- Scan errors under restriction; skip (caller falls back to snapshot).
-    if EllesmereUI.AuraKit and EllesmereUI.AuraKit.AurasRestricted() then return false end
+    if restricted then return false end
     -- Fallback: full scan for non-whitelisted IDs only
     for i = 1, AURA_SCAN_LIMIT do
         local aura = C_UnitAuras.GetAuraDataByIndex(u, i, "HELPFUL")
         if not aura then break end
         local sid = aura.spellId
         if sid and not isSecret(sid) and idLookup[sid] then
+            local fromMe = aura.isFromPlayerOrPlayerPet
+            if strictSource then
+                if isSecret(fromMe) then return nil end
+                if fromMe ~= nil then return fromMe == true end
+                local src = aura.sourceUnit
+                if isSecret(src) or src == nil then return nil end
+                return UnitIsUnit(src, "player") == true
+            end
             local src = aura.sourceUnit
             if src and not isSecret(src) then
                 if UnitIsUnit(src, "player") then return true end
             else
+                if strictSource then return nil end
                 return true  -- sourceUnit unavailable OOC, assume ours
             end
         end
@@ -798,6 +850,41 @@ local function PlayerOwnBuffOnAnyGroupMember(spellIDs)
     end
     -- No reminder if nobody reachable is missing the buff.
     return not anyInRangeWithoutBuff
+end
+
+-- Soulstone differs from targeted maintenance buffs: self is always a valid
+-- destination, and an existing cast on an out-of-range group member still
+-- satisfies the reminder. Returns nil when restricted aura data cannot prove
+-- ownership, allowing the caller to suppress rather than false-fire.
+function EABR.PlayerOwnBuffOnGroupOrSelf(spellIDs)
+    if not spellIDs or not spellIDs[1] then return true end
+    if EllesmereUI.AuraKit and EllesmereUI.AuraKit.AurasRestricted() then
+        for i = 1, #spellIDs do
+            if not NON_SECRET_SPELL_IDS[spellIDs[i]] then return nil end
+        end
+    end
+    local uncertain = false
+    local state = _unitHasBuffFromPlayer("player", spellIDs, true)
+    if state == true then return true elseif state == nil then uncertain = true end
+    if IsInRaid() then
+        for i = 1, GetNumGroupMembers() do
+            local u = "raid" .. i
+            if not UnitIsUnit(u, "player") and UnitExists(u) and UnitIsConnected(u) and UnitIsPlayer(u) then
+                state = _unitHasBuffFromPlayer(u, spellIDs, true)
+                if state == true then return true elseif state == nil then uncertain = true end
+            end
+        end
+    elseif IsInGroup() then
+        for i = 1, GetNumSubgroupMembers() do
+            local u = "party" .. i
+            if UnitExists(u) and UnitIsConnected(u) and UnitIsPlayer(u) then
+                state = _unitHasBuffFromPlayer(u, spellIDs, true)
+                if state == true then return true elseif state == nil then uncertain = true end
+            end
+        end
+    end
+    if uncertain then return nil end
+    return false
 end
 
 -------------------------------------------------------------------------------
@@ -1082,6 +1169,11 @@ local AURAS = {
     { key="timelessness", class="EVOKER", name="Timelessness", castSpell=412710,
       buffIDs={412710}, check="ownOnRaid", combatOk=false,
       specs={1473}, requireInstanceGroup=true },
+    -- Soulstone: satisfied only by this Warlock's own cast, whether it is on
+    -- the player or any connected party/raid member. OOC-only; restricted
+    -- source data is never used to infer ownership.
+    { key="soulstone", class="WARLOCK", name="Soulstone", castSpell=20707,
+      buffIDs={20707}, check="ownGroupOrSelf", combatOk=false },
 }
 
 -------------------------------------------------------------------------------
@@ -1830,6 +1922,46 @@ end
 -------------------------------------------------------------------------------
 --  Defaults
 -------------------------------------------------------------------------------
+-- Reminder icons use the same border vocabulary and tuning as Player Aura
+-- Bars, but keep their own registry key so the result does not depend on the
+-- Unit Frames module being enabled.
+do
+    local function AllBorderSizes(ox, oy, sx, sy)
+        local t = {}
+        for size = 0, 4 do
+            t[size] = { offsetX = ox, offsetY = oy, shiftX = sx, shiftY = sy }
+        end
+        return t
+    end
+    EllesmereUI.RegisterBorderDefaults("aurabuffreminders", {
+        glow = { defaultSize = 1, sizes = AllBorderSizes(0, 0, 0, 0) },
+        blizz = {
+            defaultSize = 4,
+            sizes = {
+                [0] = { offsetX = 0, offsetY = 0, shiftX = 0, shiftY = 0 },
+                [1] = { offsetX = 2, offsetY = 1, shiftX = 0, shiftY = 0 },
+                [2] = { offsetX = 3, offsetY = 1, shiftX = 1, shiftY = 0 },
+                [3] = { offsetX = 4, offsetY = 2, shiftX = 2, shiftY = 0 },
+                [4] = { offsetX = 5, offsetY = 3, shiftX = 2, shiftY = 0 },
+            },
+        },
+        dialog = {
+            defaultSize = 2,
+            sizes = {
+                [0] = { offsetX = 0, offsetY = 0, shiftX = 0, shiftY = 0 },
+                [1] = { offsetX = 2, offsetY = 2, shiftX = 0, shiftY = 0 },
+                [2] = { offsetX = 2, offsetY = 2, shiftX = 0, shiftY = 0 },
+                [3] = { offsetX = 4, offsetY = 4, shiftX = 0, shiftY = 0 },
+                [4] = { offsetX = 8, offsetY = 8, shiftX = 0, shiftY = 0 },
+            },
+        },
+        ["sm:Blizzard Achievement Wood"] = {
+            defaultSize = 1,
+            sizes = AllBorderSizes(1, 1, 0, 0),
+        },
+    })
+end
+
 local defaults = {
     profile = {
         display = {
@@ -1854,6 +1986,16 @@ local defaults = {
             opacity = 1.0,
             frameStrata = "MEDIUM",
             cursorAttach = false,
+            -- Preserve the historical reminder look exactly: black, solid,
+            -- pixel-perfect 1 px. Extra texture controls remain nil until the
+            -- user customizes them.
+            borderTexture = "solid",
+            borderSize = 1,
+            borderR = 0,
+            borderG = 0,
+            borderB = 0,
+            borderA = 1,
+            borderBehind = false,
             -- Global timing pair (minutes). showUnderMPlus is the pre-key
             -- (Mythic 0 / keystone lobby) threshold; active keys and combat
             -- ignore thresholds entirely (only fully-missing reminds there).
@@ -1881,7 +2023,7 @@ local defaults = {
             enabled = {
                 symbiotic=true, battle_stance=true, def_stance=true, berserk_stance=true, shadowform=true,
                 devo_aura=true, bol=true, bof=true, som=true, blistering_scales=true,
-                bestow_weyrnstone=true, timelessness=true,
+                bestow_weyrnstone=true, timelessness=true, soulstone=true,
             },
             -- All buckets (including open world) on by default.
             whereToShow = {},
@@ -2024,6 +2166,60 @@ local function GetStrata()
     return db and db.profile.display.frameStrata or "MEDIUM"
 end
 
+-- Borders live on a dedicated visual child instead of on the reminder
+-- button itself. Besides allowing Border Size 0 without hiding the icon, this
+-- keeps all BackdropTemplate work away from secure action attributes. Secure
+-- owners are never created/restyled under combat lockdown; visual-only combat
+-- and cursor icons can still update immediately.
+function EABR.ApplyIconBorder(f, protectedOwner)
+    if not f or (protectedOwner and InCombatLockdown()) then return end
+    local border = f._eabrBorderFrame
+    if not border then
+        border = CreateFrame("Frame", nil, f)
+        border:SetAllPoints()
+        border:EnableMouse(false)
+        f._eabrBorderFrame = border
+    end
+
+    local p = db and db.profile and db.profile.display
+    local size = (p and p.borderSize) or 1
+    local texture = (p and p.borderTexture) or "solid"
+    local r, g, b, a = (p and p.borderR) or 0, (p and p.borderG) or 0,
+        (p and p.borderB) or 0, (p and p.borderA) or 1
+    local ox, oy = p and p.borderTextureOffset, p and p.borderTextureOffsetY
+    local sx, sy = p and p.borderTextureShiftX, p and p.borderTextureShiftY
+    local behind = p and p.borderBehind == true
+    local level = behind and max(0, f:GetFrameLevel() - 1) or (f:GetFrameLevel() + 3)
+
+    -- Layout refreshes can be frequent in a raid. Restyle only when an actual
+    -- setting or owner-level change occurred; size changes are handled by the
+    -- border frame's anchors/BackdropTemplate size hook.
+    if border._eabrSize == size and border._eabrTexture == texture
+        and border._eabrR == r and border._eabrG == g and border._eabrB == b and border._eabrA == a
+        and border._eabrOX == ox and border._eabrOY == oy and border._eabrSX == sx and border._eabrSY == sy
+        and border._eabrBehind == behind and border._eabrLevel == level then
+        return
+    end
+
+    border:SetFrameLevel(level)
+    EllesmereUI.ApplyBorderStyle(border, size, r, g, b, a, texture,
+        ox, oy, sx, sy, "aurabuffreminders", size)
+    border._eabrSize, border._eabrTexture = size, texture
+    border._eabrR, border._eabrG, border._eabrB, border._eabrA = r, g, b, a
+    border._eabrOX, border._eabrOY, border._eabrSX, border._eabrSY = ox, oy, sx, sy
+    border._eabrBehind, border._eabrLevel = behind, level
+end
+
+function EABR.ApplyAllIconBorders()
+    for _, f in pairs(iconPool) do EABR.ApplyIconBorder(f, true) end
+    for _, f in pairs(combatIconPool) do EABR.ApplyIconBorder(f, false) end
+    for _, f in pairs(cursorIconPool) do EABR.ApplyIconBorder(f, false) end
+    if EABR._providerCastBtn then EABR.ApplyIconBorder(EABR._providerCastBtn, true) end
+    if _B.icons then
+        for _, f in pairs(_B.icons) do EABR.ApplyIconBorder(f, false) end
+    end
+end
+
 function EABR.GetIconTextOverlay(f)
     if f._textOverlay then return f._textOverlay end
     local overlay = CreateFrame("Frame", nil, f)
@@ -2043,8 +2239,7 @@ local function GetOrCreateCombatIcon(index)
     local icon = f:CreateTexture(nil, "ARTWORK")
     icon:SetAllPoints(); icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
     f._icon = icon
-    local PP = EllesmereUI and EllesmereUI.PP
-    if PP then PP.CreateBorder(f, 0, 0, 0, 1, 1, "OVERLAY", 7) end
+    EABR.ApplyIconBorder(f, false)
     local text = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", f, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
@@ -2083,7 +2278,7 @@ local function ShowCombatIcon(iconIdx, m)
     local p = db and db.profile.display
     if p and p.showText and not m.isEating then
         local tc = p.textColor or DEFAULT_TEXT_COLOR
-        local fontPath = ResolveFontPath(p.textFont)
+        local fontPath = ResolveFontPath(p.nameFont)
         local textSize = p.textSize or 11
         local xOff = p.textXOffset or 0
         local yOff = p.textYOffset or -2
@@ -2128,6 +2323,7 @@ local function LayoutCombatIcons()
     for i, f in ipairs(combatActiveIcons) do
         f:SetSize(sz, sz)
         f:SetAlpha(p.opacity or 1.0)
+        EABR.ApplyIconBorder(f, false)
         EABR.SizeIconQuality(f, sz)
         EABR.SizeIconBagCount(f, sz)
         f:ClearAllPoints()
@@ -2148,8 +2344,7 @@ local function GetOrCreateCursorIcon(index)
     local icon = f:CreateTexture(nil, "ARTWORK")
     icon:SetAllPoints(); icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
     f._icon = icon
-    local PP = EllesmereUI and EllesmereUI.PP
-    if PP then PP.CreateBorder(f, 0, 0, 0, 1, 1, "OVERLAY", 7) end
+    EABR.ApplyIconBorder(f, false)
     local text = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", f, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
@@ -2185,7 +2380,7 @@ local function ShowCursorIcon(iconIdx, m)
     local p = db and db.profile.display
     if p and p.showText and not m.isEating then
         local tc = p.textColor or DEFAULT_TEXT_COLOR
-        local fontPath = ResolveFontPath(p.textFont)
+        local fontPath = ResolveFontPath(p.nameFont)
         local textSize = p.textSize or 11
         local xOff = p.textXOffset or 0
         local yOff = p.textYOffset or -2
@@ -2225,6 +2420,7 @@ local function LayoutCursorIcons()
     for i, f in ipairs(cursorActiveIcons) do
         f:SetSize(sz, sz)
         f:SetAlpha(p.opacity or 1.0)
+        EABR.ApplyIconBorder(f, false)
         EABR.SizeIconQuality(f, sz)
         EABR.SizeIconBagCount(f, sz)
         f:ClearAllPoints()
@@ -2247,6 +2443,7 @@ function EABR.LayoutProviderCastHome()
     local baseScale = (p and p.scale) or 1.0
     local sz = floor(ICON_SIZE * baseScale + 0.5)
     btn:SetSize(sz, sz)
+    EABR.ApplyIconBorder(btn, true)
     btn:ClearAllPoints()
     btn:SetPoint("TOPLEFT", iconAnchor, "TOPLEFT", 0, 0)
     EABR.SizeIconQuality(btn, sz)
@@ -2296,8 +2493,7 @@ function EABR.EnsureProviderCastButton()
     local icon = btn:CreateTexture(nil, "ARTWORK")
     icon:SetAllPoints(); icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
     btn._icon = icon
-    local PP = EllesmereUI and EllesmereUI.PP
-    if PP then PP.CreateBorder(btn, 0, 0, 0, 1, 1, "OVERLAY", 7) end
+    EABR.ApplyIconBorder(btn, true)
     local text = EABR.GetIconTextOverlay(btn):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", btn, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
@@ -2373,7 +2569,7 @@ function EABR.SetProviderCastCombatVisible(visible, m)
     local p = db and db.profile and db.profile.display
     if p and p.showText then
         local tc = p.textColor or DEFAULT_TEXT_COLOR
-        SetABRFont(btn._text, ResolveFontPath(p.textFont), p.textSize or 11)
+        SetABRFont(btn._text, ResolveFontPath(p.nameFont), p.textSize or 11)
         btn._text:ClearAllPoints()
         local tp, ip = GetTextAnchorPoints(p)
         btn._text:SetPoint(tp, btn, ip, p.textXOffset or 0, p.textYOffset or -2)
@@ -2584,7 +2780,9 @@ end
 
 function EABR.CreateIconQualityOverlay(f)
     if f._quality then return f._quality end
-    local q = f:CreateTexture(nil, "OVERLAY", nil, 7)
+    -- Keep the crafted-quality badge above the dedicated border child, just
+    -- like count/name text. This matters for the wider textured styles.
+    local q = EABR.GetIconTextOverlay(f):CreateTexture(nil, "OVERLAY", nil, 7)
     q:Hide()
     f._quality = q
     return q
@@ -2618,7 +2816,8 @@ end
 function EABR.CreateIconBagCountOverlay(f)
     if f._bagCount then return f._bagCount end
     local fs = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY")
-    SetABRFont(fs, ResolveFontPath(), 11)
+    local p = db and db.profile.display
+    SetABRFont(fs, ResolveFontPath(p and p.countFont), 11)
     fs:Hide()
     f._bagCount = fs
     return fs
@@ -2630,7 +2829,7 @@ function EABR.SizeIconBagCount(f, sz)
     local p = db and db.profile.display
     local base = (p and p.countSize) or 16
     local fsz = max(6, floor(base * (sz / ICON_SIZE) + 0.5))
-    SetABRFont(fs, ResolveFontPath(p and p.textFont), fsz)
+    SetABRFont(fs, ResolveFontPath(p and p.countFont), fsz)
     local dx = (p and p.countXOffset) or 0
     local dy = (p and p.countYOffset) or 0
     fs:ClearAllPoints()
@@ -2742,7 +2941,7 @@ function EABR.ApplyEatingVisual(f, m)
     local expTime = m.eatingExpirationTime
     if not expTime then return end
     local p = db and db.profile.display
-    local fontPath = ResolveFontPath(p and p.textFont)
+    local fontPath = ResolveFontPath()
     local textSize = max(14, floor(((p and p.textSize) or 11) * 1.15))
     SetABRFont(f._count, fontPath, textSize)
     f._count:SetTextColor(1, 1, 1, 1)
@@ -2787,8 +2986,7 @@ local function GetOrCreateIcon(index)
     local icon = btn:CreateTexture(nil, "ARTWORK")
     icon:SetAllPoints(); icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
     btn._icon = icon
-    local PP = EllesmereUI and EllesmereUI.PP
-    if PP then PP.CreateBorder(btn, 0, 0, 0, 1, 1, "OVERLAY", 7) end
+    EABR.ApplyIconBorder(btn, true)
 
     local text = EABR.GetIconTextOverlay(btn):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", btn, "BOTTOM", 0, -2)
@@ -2979,6 +3177,9 @@ local function LayoutIcons()
     for i, btn in ipairs(allIcons) do
         btn:SetSize(sz, sz)
         btn:SetAlpha(p.opacity or 1.0)
+        -- This layout is OOC-only, so treating every entry as protected also
+        -- covers the provider/main secure buttons without needing pool scans.
+        EABR.ApplyIconBorder(btn, true)
         EABR.SizeIconQuality(btn, sz)
         EABR.SizeIconBagCount(btn, sz)
         btn:ClearAllPoints()
@@ -3026,7 +3227,7 @@ local function ShowIcon(iconIdx, m)
     end
     if p.showText and not m.isEating then
         local tc = p.textColor or DEFAULT_TEXT_COLOR
-        local fontPath = ResolveFontPath(p.textFont)
+        local fontPath = ResolveFontPath(p.nameFont)
         local textSize = p.textSize or 11
         local xOff = p.textXOffset or 0
         local yOff = p.textYOffset or -2
@@ -3164,6 +3365,8 @@ do
                 if inCombat then
                     if aura.isStance or aura.formSpellIDs then
                         canCheck = true
+                    elseif aura.combatOk == false then
+                        canCheck = false
                     elseif aura.buffIDs and aura.buffIDs[1] then
                         for _, id in ipairs(aura.buffIDs) do
                             if not NON_SECRET_SPELL_IDS[id] then canCheck = false; break end
@@ -3189,6 +3392,9 @@ do
                             isMissing = not PlayerOwnBuffOnAnyGroupMember(aura.buffIDs)
                         end
                         if not (IsInGroup() or IsInRaid()) then isMissing = false end
+                    elseif aura.check == "ownGroupOrSelf" then
+                        local hasOwnBuff = EABR.PlayerOwnBuffOnGroupOrSelf(aura.buffIDs)
+                        isMissing = hasOwnBuff == false
                     elseif aura.check == "playerSelfCast" then
                         isMissing = not PlayerHasSelfCastAuraByID(aura.buffIDs)
                     elseif aura.isStance then
@@ -4204,8 +4410,7 @@ local function BeaconMakeIcon(spellID)
     icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
     f._icon = icon
     f._spellID = spellID
-    local PP = EllesmereUI and EllesmereUI.PP
-    if PP then PP.CreateBorder(f, 0, 0, 0, 1, 1, "OVERLAY", 7) end
+    EABR.ApplyIconBorder(f, false)
     local text = EABR.GetIconTextOverlay(f):CreateFontString(nil, "OVERLAY")
     text:SetPoint("TOP", f, "BOTTOM", 0, -2)
     SetABRFont(text, ResolveFontPath(), 11)
@@ -4239,6 +4444,7 @@ local function BeaconLayoutIcons()
                 f:SetAlpha(p.opacity or 1.0)
                 f:SetFrameStrata("TOOLTIP")
                 f:SetFrameLevel(9980)
+                EABR.ApplyIconBorder(f, false)
                 f:ClearAllPoints()
                 f:SetPoint("CENTER", cursorAnchor, "CENTER", startX + (i - 1) * (sz + spacing), -(sz + 8))
             end
@@ -4282,7 +4488,7 @@ local function BeaconApplyText(f)
     local p = db and db.profile.display
     if p and p.showText then
         local tc = p.textColor or DEFAULT_TEXT_COLOR
-        local fontPath = ResolveFontPath(p.textFont)
+        local fontPath = ResolveFontPath(p.nameFont)
         local textSize = p.textSize or 11
         local xOff = p.textXOffset or 0
         local yOff = p.textYOffset or -2
@@ -4538,6 +4744,8 @@ function EABR:OnEnable()
     -- Talent reminder migration handled by EllesmereUIABR_TalentReminders.lua
 
     _G._EABR_RequestRefresh = RequestRefresh
+    _G._EABR_ApplyIconBorder = EABR.ApplyIconBorder
+    _G._EABR_ApplyAllIconBorders = EABR.ApplyAllIconBorders
     _G._EABR_HideAllIcons = HideAllIcons
     _G._EABR_GLOW_VALUES = GLOW_VALUES
     _G._EABR_GLOW_ORDER = GLOW_ORDER
@@ -4635,6 +4843,7 @@ function EABR:OnEnable()
         if EABR._providerCastBtn and not InCombatLockdown() then
             EABR._providerCastBtn:SetFrameStrata(strata)
         end
+        EABR.ApplyAllIconBorders()
     end
     _G._EABR_ApplyStrata = ApplyStrata
 
@@ -4684,13 +4893,22 @@ function EABR:OnEnable()
         local playerClass = GetPlayerClass()
         _needGroupAura = false
         _isEvokerOwnOnRaid = false
+        EABR._needsProviderCoverage = false
         for _, buff in ipairs(RAID_BUFFS) do
-            if buff.class == playerClass then _needGroupAura = true; break end
+            if buff.class == playerClass then
+                _needGroupAura = true
+                EABR._needsProviderCoverage = true
+                break
+            end
         end
         for _, aura in ipairs(AURAS) do
-            if aura.class == playerClass and aura.check == "ownOnRaid" then
+            if aura.class == playerClass
+                and (aura.check == "ownOnRaid" or aura.check == "ownGroupOrSelf")
+                and db.profile.auras.enabled[aura.key] ~= false then
                 _needGroupAura = true
-                _isEvokerOwnOnRaid = true
+                if playerClass == "EVOKER" and aura.check == "ownOnRaid" then
+                    _isEvokerOwnOnRaid = true
+                end
                 break
             end
         end
@@ -4830,7 +5048,8 @@ mainFrame:SetScript("OnEvent", function(_, e, arg1, arg2, arg3)
         MarkDungeonPullStarted()
         -- Drops broad UNIT_AURA in combat unless group tracking is needed: Evoker keeps broad for ownOnRaid cache updates; the provider view ("others missing") keeps it for timely group coverage refreshes.
         local rbSW = db and db.profile.raidBuffs and db.profile.raidBuffs.showWhen
-        local keepBroad = _isEvokerOwnOnRaid or (rbSW and rbSW.othersMissing ~= false)
+        local keepBroad = _isEvokerOwnOnRaid
+            or (EABR._needsProviderCoverage and rbSW and rbSW.othersMissing ~= false)
         if _needGroupAura and not keepBroad then _setBroad(false) end
         -- Only flag Hunter's Mark needed if the target doesn't already have it
         _huntersMarkNeeded = true
@@ -4940,13 +5159,11 @@ mainFrame:SetScript("OnEvent", function(_, e, arg1, arg2, arg3)
         return
     end
 
-    -- Roster changes don't affect player buffs/consumables; skips the full
-    -- refresh (which scans all group members via CountGroupBuffCoverage).
-    -- Exception: the receiver view keys off which CLASSES are present, so a
-    -- joiner/leaver must re-evaluate it.
+    -- Group-targeted reminders also re-evaluate when their holder joins or
+    -- leaves; other classes retain the cheap receiver-view-only behavior.
     if e == "GROUP_ROSTER_UPDATE" then
         local rbSW = db and db.profile.raidBuffs and db.profile.raidBuffs.showWhen
-        if rbSW and rbSW.iAmMissing == true then RequestRefresh() end
+        if _needGroupAura or (rbSW and rbSW.iAmMissing == true) then RequestRefresh() end
         return
     end
 
@@ -5083,7 +5300,7 @@ local SetupReadyCheckManaWarning = function()
         warnFrame:ClearAllPoints()
         warnFrame:SetPoint("CENTER", UIParent, "CENTER",
             (c and c.rcManaWarnX) or 0, 75 + ((c and c.rcManaWarnY) or 0))
-        local font = ResolveFontPath()
+        local font = ResolveFontPath(c and c.rcManaWarnFont)
         local outline = GetABROutline()
         if EllesmereUI and EllesmereUI.PrimeFontShadow then EllesmereUI.PrimeFontShadow(warnFS, outline == "" and GetABRUseShadow()) end
         warnFS:SetFont(font, (c and c.rcManaWarnSize) or 48, outline)

--- a/EllesmereUILocales/deDE.lua
+++ b/EllesmereUILocales/deDE.lua
@@ -7,6 +7,18 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("deDE")
 if not L then return end
 
+L["WARLOCK"] = "HEXENMEISTER"
+L["Soulstone"] = "Seelenstein"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "Zeigt eine Erinnerung an, bis Euer eigener Seelenstein auf Euch oder einem anderen Gruppenmitglied aktiv ist."
+L["Wrong Demon"] = "Falscher Dämon"
+L["Allowed Demons"] = "Erlaubte Dämonen"
+L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "Zeigt eine Erinnerung an, wenn der aktive Begleiter Eures Hexenmeisters keiner der unter „Erlaubte Dämonen“ ausgewählten Dämonen ist. Ein Dämon zählt nur, wenn sein Beschwörungszauber bekannt ist. Ist ausschließlich die Teufelswache ausgewählt, bleibt die Erinnerung daher für Spezialisierungen oder Konfigurationen ohne das Talent „Teufelswache beschwören“ stumm."
+L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "Legt fest, welche Dämonen für „Falscher Dämon“ als korrekt gelten. Ein Dämon zählt nur, wenn sein Beschwörungszauber bekannt ist; ist keiner oder sind alle ausgewählt, wird die Erinnerung nie ausgelöst."
+L["Item Count Font"] = "Schriftart der Gegenstandsanzahl"
+L["Mana Warning Font"] = "Schriftart der Mana-Warnung"
+L["Name Text Size"] = "Textgröße des Namens"
+L["Mana Warning Text Size"] = "Textgröße der Mana-Warnung"
+
 L["    Enemy Units"] = "    Feindliche Einheiten"
 L["    Friendly Units"] = "    Freundliche Einheiten"
 L["  ... and %d more"]  = "  ... und %d weitere"

--- a/EllesmereUILocales/esES.lua
+++ b/EllesmereUILocales/esES.lua
@@ -7,6 +7,23 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("esES")
 if not L then return end
 
+L["WARLOCK"] = "BRUJO"
+L["Soulstone"] = "Piedra de alma"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "Muestra un recordatorio hasta que tu propia Piedra de alma esté activa en ti o en otro miembro del grupo."
+L["Wrong Demon"] = "Demonio incorrecto"
+L["Allowed Demons"] = "Demonios permitidos"
+L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "Muestra un recordatorio cuando la mascota activa de tu brujo no es uno de los demonios seleccionados en Demonios permitidos. Un demonio solo cuenta si conoces su hechizo de invocación, por lo que dejar seleccionado únicamente al guardia vil no muestra avisos para especializaciones o configuraciones sin el talento Invocar guardia vil."
+L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "Elige qué demonios se consideran correctos para Demonio incorrecto. Un demonio solo cuenta si conoces su hechizo de invocación; si no eliges ninguno o los eliges todos, el recordatorio nunca se activa."
+L["Name Font"] = "Fuente del nombre"
+L["Font Outline"] = "Contorno de fuente"
+L["EUI Global Default"] = "Predeterminado global de EUI"
+L["Drop Shadow"] = "Sombra paralela"
+L["Item Count Font"] = "Fuente de cantidad de objetos"
+L["Mana Warning Font"] = "Fuente del aviso de maná"
+L["Name Text Size"] = "Tamaño del texto del nombre"
+L["Item Count Text Size"] = "Tamaño del texto de cantidad de objetos"
+L["Mana Warning Text Size"] = "Tamaño del texto del aviso de maná"
+
 L["BLIZZARD POPUPS & GAME MENU"] = "VENTANAS EMERGENTES Y MENÚ DE JUEGO DE BLIZZARD"
 L["Reskin Popups and Menus"] = "Rediseñar ventanas emergentes y menús"
 L["Reskins Blizzard's right-click context menus and pop-up dialogs with the EUI dark style. Requires reload to apply."] = "Rediseña los menús contextuales y los cuadros de diálogo emergentes de Blizzard con el estilo oscuro de EUI. Requiere recargar la interfaz."

--- a/EllesmereUILocales/esMX.lua
+++ b/EllesmereUILocales/esMX.lua
@@ -7,6 +7,23 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("esMX")
 if not L then return end
 
+L["WARLOCK"] = "BRUJO"
+L["Soulstone"] = "Piedra de alma"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "Muestra un recordatorio hasta que tu propia Piedra de alma esté activa en ti o en otro miembro del grupo."
+L["Wrong Demon"] = "Demonio incorrecto"
+L["Allowed Demons"] = "Demonios permitidos"
+L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "Muestra un recordatorio cuando la mascota activa de tu brujo no es uno de los demonios seleccionados en Demonios permitidos. Un demonio solo cuenta si conoces su hechizo de invocación, por lo que dejar seleccionado únicamente al guardia vil no muestra avisos para especializaciones o configuraciones sin el talento Invocar guardia vil."
+L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "Elige qué demonios se consideran correctos para Demonio incorrecto. Un demonio solo cuenta si conoces su hechizo de invocación; si no eliges ninguno o los eliges todos, el recordatorio nunca se activa."
+L["Name Font"] = "Fuente del nombre"
+L["Font Outline"] = "Contorno de fuente"
+L["EUI Global Default"] = "Predeterminado global de EUI"
+L["Drop Shadow"] = "Sombra paralela"
+L["Item Count Font"] = "Fuente de cantidad de objetos"
+L["Mana Warning Font"] = "Fuente del aviso de maná"
+L["Name Text Size"] = "Tamaño del texto del nombre"
+L["Item Count Text Size"] = "Tamaño del texto de cantidad de objetos"
+L["Mana Warning Text Size"] = "Tamaño del texto del aviso de maná"
+
 L["BLIZZARD POPUPS & GAME MENU"] = "VENTANAS EMERGENTES Y MENÚ DE JUEGO DE BLIZZARD"
 L["Reskin Popups and Menus"] = "Rediseñar ventanas emergentes y menús"
 L["Reskins Blizzard's right-click context menus and pop-up dialogs with the EUI dark style. Requires reload to apply."] = "Rediseña los menús contextuales y los cuadros de diálogo emergentes de Blizzard con el estilo oscuro de EUI. Requiere recargar la interfaz."

--- a/EllesmereUILocales/frFR.lua
+++ b/EllesmereUILocales/frFR.lua
@@ -7,6 +7,20 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("frFR")
 if not L then return end
 
+L["WARLOCK"] = "DÉMONISTE"
+L["Soulstone"] = "Pierre d'âme"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "Affiche un rappel jusqu'à ce que votre propre Pierre d'âme soit active sur vous ou un autre membre du groupe."
+L["Wrong Demon"] = "Mauvais démon"
+L["Allowed Demons"] = "Démons autorisés"
+L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "Affiche un rappel lorsque le familier actif de votre démoniste ne fait pas partie des démons choisis dans Démons autorisés. Un démon ne compte que si son sort d'invocation est connu ; ainsi, ne sélectionner que le gangregarde n'affiche aucun rappel pour les spécialisations ou configurations sans le talent Invocation d'un gangregarde."
+L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "Choisissez les démons considérés comme corrects pour Mauvais démon. Un démon ne compte que si son sort d'invocation est connu ; si aucun ou tous sont sélectionnés, le rappel ne se déclenche jamais."
+L["Name Font"] = "Police du nom"
+L["Font Outline"] = "Contour de police"
+L["Item Count Font"] = "Police du nombre d'objets"
+L["Mana Warning Font"] = "Police de l'alerte de mana"
+L["Name Text Size"] = "Taille du texte du nom"
+L["Mana Warning Text Size"] = "Taille du texte de l'alerte de mana"
+
 L["BLIZZARD POPUPS & GAME MENU"] = "FENÊTRES BLIZZARD ET MENU DU JEU"
 L["Resurrect Accept Glow"] = "Lueur d’acceptation de résurrection"
 L["Adds a glowing, pulsating border around the Accept button of resurrection popups so a pending resurrect is hard to miss. Follows the Element & Text Color setting. Applies instantly, no reload needed."] = "Ajoute une bordure lumineuse et pulsante autour du bouton Accepter des fenêtres de résurrection afin de ne pas manquer une résurrection. Utilise le réglage de couleur des éléments et du texte. Application immédiate sans rechargement."

--- a/EllesmereUILocales/itIT.lua
+++ b/EllesmereUILocales/itIT.lua
@@ -7,6 +7,23 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("itIT")
 if not L then return end
 
+L["WARLOCK"] = "STREGONE"
+L["Soulstone"] = "Pietra dell'Anima"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "Mostra un promemoria finché la tua Pietra dell'Anima non è attiva su di te o su un altro membro del gruppo."
+L["Wrong Demon"] = "Demone errato"
+L["Allowed Demons"] = "Demoni consentiti"
+L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "Mostra un promemoria quando il famiglio attivo del tuo Stregone non è uno dei demoni scelti in Demoni consentiti. Un demone conta solo se conosci il relativo incantesimo di evocazione; selezionando soltanto la Guardia Vil, il promemoria resta inattivo per specializzazioni o configurazioni prive del talento Evoca Guardia Vil."
+L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "Seleziona quali demoni sono considerati corretti per Demone errato. Un demone conta solo se conosci il relativo incantesimo di evocazione; se non ne selezioni nessuno o li selezioni tutti, il promemoria non si attiva mai."
+L["Name Font"] = "Carattere del nome"
+L["Font Outline"] = "Contorno del carattere"
+L["EUI Global Default"] = "Predefinito globale EUI"
+L["Drop Shadow"] = "Ombra esterna"
+L["Item Count Font"] = "Carattere della quantità oggetti"
+L["Mana Warning Font"] = "Carattere dell'avviso mana"
+L["Name Text Size"] = "Dimensione del testo del nome"
+L["Item Count Text Size"] = "Dimensione del testo della quantità oggetti"
+L["Mana Warning Text Size"] = "Dimensione del testo dell'avviso mana"
+
 L["BLIZZARD POPUPS & GAME MENU"] = "POPUP BLIZZARD E MENU DI GIOCO"
 L["Reskin Popups and Menus"] = "Rivesti popup e menu"
 L["Reskins Blizzard's right-click context menus and pop-up dialogs with the EUI dark style. Requires reload to apply."] = "Riveste i menu contestuali e le finestre popup di Blizzard con lo stile scuro EUI. Richiede il ricaricamento dell'interfaccia."

--- a/EllesmereUILocales/koKR.lua
+++ b/EllesmereUILocales/koKR.lua
@@ -8,6 +8,12 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("koKR")
 if not L then return end
 
+L["WARLOCK"] = "흑마법사"
+L["Soulstone"] = "영혼석"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "자신의 영혼석이 자신이나 다른 파티원에게 활성화될 때까지 알림을 표시합니다."
+L["Item Count Font"] = "아이템 개수 글꼴"
+L["Mana Warning Font"] = "마나 경고 글꼴"
+
 L["BLIZZARD POPUPS & GAME MENU"] = "블리자드 팝업 및 게임 메뉴"
 
 -- == Common labels (공용 라벨) =============================================
@@ -7130,7 +7136,6 @@ L["View Houses"] = "집 보기"
 L["Visit"] = "방문"
 
 --편의 기능 - 오라/강화 효과 알림 - 오라,강화 효과 및 소모품
-L["WARLOCK DEMONS"] = "흑마법사 악마"
 L["Wrong Demon"] = "소환 불가 악마"
 L["Allowed Demons"] = "소환 가능 악마"
 L["Imp"] = "임프"

--- a/EllesmereUILocales/ptBR.lua
+++ b/EllesmereUILocales/ptBR.lua
@@ -7,6 +7,12 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("ptBR")
 if not L then return end
 
+L["WARLOCK"] = "BRUXO"
+L["Soulstone"] = "Pedra da Alma"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "Exibe um lembrete até que sua própria Pedra da Alma esteja ativa em você ou em outro membro do grupo."
+L["Item Count Font"] = "Fonte da Contagem de Itens"
+L["Mana Warning Font"] = "Fonte do Aviso de Mana"
+
 L["BLIZZARD POPUPS & GAME MENU"] = "POP-UPS DA BLIZZARD E MENU DO JOGO"
 L["Reskin Popups and Menus"] = "Reestilizar pop-ups e menus"
 L["Reskins Blizzard's right-click context menus and pop-up dialogs with the EUI dark style. Requires reload to apply."] = "Reestiliza os menus de contexto e as janelas pop-up da Blizzard com o estilo escuro da EUI. Requer recarregar a interface."
@@ -5212,8 +5218,7 @@ L["Show a reminder when you don't have an active pet summoned. Only applies to p
 L["Wrong Demon"] = "Demônio Errado"
 L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "Exibe um lembrete quando o ajudante ativo do seu Bruxo não é um dos demônios escolhidos em Demônios Permitidos. Um demônio só conta enquanto seu feitiço de invocação for conhecido, então deixar apenas o Guarda Vil escolhido mantém o lembrete em silêncio para especializações ou configurações que não talentaram Evocar Guarda Vil."
 
--- Warlock demons (Allowed Demons)
-L["WARLOCK DEMONS"] = "DEMÔNIOS DO BRUXO"
+-- Warlock (Allowed Demons)
 L["Allowed Demons"] = "Demônios Permitidos"
 L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "Escolha quais demônios contam como corretos para o Demônio Errado. Um demônio só conta enquanto seu feitiço de invocação for conhecido; com nenhum escolhido (ou todos escolhidos), o lembrete nunca é ativado."
 L["You have not learned %1$s."] = "Você não aprendeu %1$s."

--- a/EllesmereUILocales/ruRU.lua
+++ b/EllesmereUILocales/ruRU.lua
@@ -8,6 +8,20 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("ruRU")
 if not L then return end
 
+L["WARLOCK"] = "ЧЕРНОКНИЖНИК"
+L["Soulstone"] = "Камень души"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "Показывать напоминание, пока ваш собственный камень души не действует на вас или другого участника группы."
+L["Wrong Demon"] = "Неверный демон"
+L["Allowed Demons"] = "Разрешённые демоны"
+L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "Показывать напоминание, если активный питомец чернокнижника не входит в список разрешённых демонов. Демон учитывается только тогда, когда изучено заклинание его призыва, поэтому выбор только Стража Скверны не вызывает напоминание для специализаций или сборок без таланта «Призыв Стража Скверны»."
+L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "Выберите демонов, которые считаются правильными для напоминания «Неверный демон». Демон учитывается только тогда, когда изучено заклинание его призыва; если не выбран ни один или выбраны все, напоминание никогда не срабатывает."
+L["Name Font"] = "Шрифт имени"
+L["Font Outline"] = "Контур шрифта"
+L["Item Count Font"] = "Шрифт количества предметов"
+L["Mana Warning Font"] = "Шрифт предупреждения о мане"
+L["Name Text Size"] = "Размер текста имени"
+L["Mana Warning Text Size"] = "Размер текста предупреждения о мане"
+
 L["BLIZZARD POPUPS & GAME MENU"] = "ОКНА BLIZZARD И ИГРОВОЕ МЕНЮ"
 L["Reskin Popups and Menus"] = "Изменить оформление окон и меню"
 L["Reskins Blizzard's right-click context menus and pop-up dialogs with the EUI dark style. Requires reload to apply."] = "Оформляет контекстные меню и всплывающие окна Blizzard в тёмном стиле EUI. Для применения требуется перезагрузка интерфейса."

--- a/EllesmereUILocales/zhCN.lua
+++ b/EllesmereUILocales/zhCN.lua
@@ -7,6 +7,18 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 local L = EllesmereUI.RegisterLocale("zhCN")
 if not L then return end
 
+L["WARLOCK"] = "术士"
+L["Soulstone"] = "灵魂石"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "在你自己的灵魂石未作用于自己或其他队伍成员时显示提醒。"
+L["Wrong Demon"] = "错误的恶魔"
+L["Allowed Demons"] = "允许的恶魔"
+L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "当术士当前的宠物不在“允许的恶魔”选择中时显示提醒。只有学会对应召唤法术的恶魔才会计入，因此仅选择恶魔卫士时，未学习召唤恶魔卫士天赋的专精或配置不会触发提醒。"
+L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "选择哪些恶魔可被“错误的恶魔”提醒视为正确。只有学会对应召唤法术的恶魔才会计入；未选择任何恶魔或选择全部恶魔时，提醒永远不会触发。"
+L["Item Count Font"] = "物品数量字体"
+L["Mana Warning Font"] = "法力警告字体"
+L["Name Text Size"] = "名称文本大小"
+L["Mana Warning Text Size"] = "法力警告文本大小"
+
 -- == 常用标签 (Common labels) ===============================================
 L["Anchor"] = "锚点"
 L["Anchor Point"] = "锚点位置"

--- a/EllesmereUILocales/zhTW.lua
+++ b/EllesmereUILocales/zhTW.lua
@@ -5,6 +5,12 @@ if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_C
 -- to generate the full remaining key list. Untranslated keys fall back to English.
 local L = EllesmereUI.RegisterLocale("zhTW")
 if not L then return end
+
+L["WARLOCK"] = "術士"
+L["Soulstone"] = "靈魂石"
+L["Show a reminder until your own Soulstone is active on you or another group member."] = "當你自己的靈魂石尚未作用於自己或其他隊伍成員時顯示提醒。"
+L["Item Count Font"] = "物品數量字型"
+L["Mana Warning Font"] = "法力警告字型"
 L["Behind Unit Frame"] = "顯示於單位框架後方"
 
 -- == Common labels =========================================================
@@ -3542,7 +3548,6 @@ L["Vicious Thalassian Flask of Honor"] = "薩拉斯榮譽兇惡精煉藥劑"
 L["Void-Kissed Fish Rolls"]        = "虛無之吻魚肉卷"
 L["Voidscar Arena"]                = "虛無之痕競技場"
 L["Voidwalker"]                    = "虛無行者"
-L["WARLOCK DEMONS"]                = "術士惡魔"
 L["Warped Wise Wings"]             = "扭曲聰魚鰭翼"
 L["Warsong Gulch"]                 = "戰歌峽谷"
 L["Weapon"]                        = "武器"

--- a/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
@@ -20,7 +20,12 @@ local SECTION_CONSUMABLES  = "CONSUMABLES"
 local SECTION_ROGUE        = "ROGUE POISONS"
 local SECTION_PALADIN      = "PALADIN RITES"
 local SECTION_SHAMAN       = "SHAMAN IMBUES & SHIELDS"
+local SECTION_WARLOCK      = "WARLOCK"
 local SPECIAL_WHERE_TIP    = "Pick which content the class-special reminders (poisons/rites/imbues/shields) appear in.\nRested areas (cities and inns) always stay hidden."
+local BORDER_SIZE_ORDER    = { "none", "thin", "normal", "heavy", "strong" }
+local BORDER_SIZE_VALUES   = { none="None", thin="Thin", normal="Normal", heavy="Heavy", strong="Strong" }
+local BORDER_SIZE_NUM      = { none=0, thin=1, normal=2, heavy=3, strong=4 }
+local BORDER_SIZE_KEY      = { [0]="none", [1]="thin", [2]="normal", [3]="heavy", [4]="strong" }
 
 local initFrame = CreateFrame("Frame")
 initFrame:RegisterEvent("PLAYER_LOGIN")
@@ -31,10 +36,7 @@ initFrame:SetScript("OnEvent", function(self)
     local PP = EllesmereUI.PanelPP
 
     local function GetABROptOutline()
-        return (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag()) or ""
-    end
-    local function GetABROptUseShadow()
-        return not EllesmereUI or not EllesmereUI.GetFontUseShadow or EllesmereUI.GetFontUseShadow()
+        return (EllesmereUI and EllesmereUI.GetFontOutlineFlag and EllesmereUI.GetFontOutlineFlag("auraBuff")) or ""
     end
     local function SetPVFont(fs, font, size)
         if not (fs and fs.SetFont) then return end
@@ -54,6 +56,16 @@ initFrame:SetScript("OnEvent", function(self)
         return db and db.profile
     end
     local function DDB()  local p = DB(); return p and p.display end
+
+    local function GetNameFontPath()
+        local d = DDB()
+        local fontName = d and d.nameFont
+        if fontName and fontName ~= "__global" and EllesmereUI.ResolveFontName then
+            local path = EllesmereUI.ResolveFontName(fontName)
+            if path and path ~= "" then return path end
+        end
+        return (EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("auraBuff")) or "Fonts\\ARIALN.TTF"
+    end
 
     local PREVIEW_TEXT_ANCHORS = _G._EABR_TEXT_ANCHORS
     local function GetPreviewTextAnchor(d)
@@ -260,6 +272,10 @@ initFrame:SetScript("OnEvent", function(self)
             local startX = -(totalW / 2) + (sz / 2)
             btn:SetPoint("TOP", btn:GetParent(), "TOP", startX + (i - 1) * (sz + spacing), 0)
 
+            if _G._EABR_ApplyIconBorder then
+                _G._EABR_ApplyIconBorder(btn, false)
+            end
+
             -- Glow
             if not btn._glowWrapper then
                 local w = CreateFrame("Frame", nil, btn)
@@ -291,7 +307,7 @@ initFrame:SetScript("OnEvent", function(self)
 
             -- Text
             if showText then
-                local fontPath = (EllesmereUI and EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("auraBuff")) or "Fonts\\ARIALN.TTF"
+                local fontPath = GetNameFontPath()
                 local textSize = d and d.textSize or 11
                 local textXOff = d and d.textXOffset or 0
                 local textYOff = d and d.textYOffset or -2
@@ -326,6 +342,12 @@ initFrame:SetScript("OnEvent", function(self)
             -- scroll compensation (the height rarely changes here).
             EllesmereUI:SetContentHeaderHeightSilent(TOTAL_H + hintH)
         end
+    end
+
+    local function RefreshBorders()
+        if _G._EABR_ApplyAllIconBorders then _G._EABR_ApplyAllIconBorders() end
+        RefreshAll()
+        UpdatePreviewHeader()
     end
 
     ---------------------------------------------------------------------------
@@ -558,11 +580,27 @@ initFrame:SetScript("OnEvent", function(self)
             if icon.SetSnapToPixelGrid then icon:SetSnapToPixelGrid(false); icon:SetTexelSnappingBias(0) end
             btn._icon = icon
 
-            -- Pixel-perfect 1px black border
-            EllesmereUI.MakeBorder(btn, 0, 0, 0, 1, EllesmereUI.PanelPP)
+            -- The live border helper owns the preview border too, keeping the
+            -- header byte-for-byte aligned with reminder icons.
+            if _G._EABR_ApplyIconBorder then
+                _G._EABR_ApplyIconBorder(btn, false)
+            else
+                local border = CreateFrame("Frame", nil, btn)
+                border:SetAllPoints(); border:EnableMouse(false)
+                btn._eabrBorderFrame = border
+                local pd = DDB()
+                local borderSize = (pd and pd.borderSize) or 1
+                EllesmereUI.ApplyBorderStyle(border, borderSize,
+                    (pd and pd.borderR) or 0, (pd and pd.borderG) or 0,
+                    (pd and pd.borderB) or 0, (pd and pd.borderA) or 1,
+                    (pd and pd.borderTexture) or "solid",
+                    pd and pd.borderTextureOffset, pd and pd.borderTextureOffsetY,
+                    pd and pd.borderTextureShiftX, pd and pd.borderTextureShiftY,
+                    "aurabuffreminders", borderSize)
+            end
 
             -- Text label below icon
-            local fontPath = (EllesmereUI and EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("auraBuff")) or "Fonts\\ARIALN.TTF"
+            local fontPath = GetNameFontPath()
             local textSize = d and d.textSize or 11
             local textXOff = d and d.textXOffset or 0
             local textYOff = d and d.textYOffset or -2
@@ -1016,7 +1054,112 @@ initFrame:SetScript("OnEvent", function(self)
         local displaySection
         displaySection, h = W:SectionHeader(parent, SECTION_DISPLAY, y);  y = y - h
 
-        -- Row 1: Show Name (+ inline swatch + cog) | Show Item Count (+ cog)
+        -- Row 1: Border Style (+ offset cog) | Border Size (+ color swatch)
+        local borderTextureValues, borderTextureOrder = EllesmereUI.GetBorderTextureDropdown()
+        local borderRow
+        borderRow, h = W:DualRow(parent, y,
+            { type="dropdown", text="Border Style",
+              values=borderTextureValues, order=borderTextureOrder,
+              getValue=function() local d = DDB(); return d and d.borderTexture or "solid" end,
+              setValue=function(v)
+                  local d = DDB(); if not d then return end
+                  d.borderTexture = v
+                  d.borderTextureOffset = nil
+                  d.borderTextureOffsetY = nil
+                  d.borderTextureShiftX = nil
+                  d.borderTextureShiftY = nil
+                  local color, behind = EllesmereUI.GetBorderStyleSelectDefaults(v)
+                  d.borderR, d.borderG, d.borderB, d.borderA = color.r, color.g, color.b, 1
+                  d.borderBehind = behind
+                  local defaultSize = EllesmereUI.GetBorderDefaultSize("aurabuffreminders", v)
+                  if defaultSize then d.borderSize = defaultSize end
+                  RefreshBorders()
+                  EllesmereUI:RefreshPage()
+              end },
+            { type="dropdown", text="Border Size",
+              values=BORDER_SIZE_VALUES, order=BORDER_SIZE_ORDER,
+              getValue=function()
+                  local d = DDB()
+                  return BORDER_SIZE_KEY[(d and d.borderSize) or 1] or "thin"
+              end,
+              setValue=function(v)
+                  local d = DDB(); if not d then return end
+                  d.borderSize = BORDER_SIZE_NUM[v] or 1
+                  RefreshBorders()
+              end }
+        );  y = y - h
+
+        if not EllesmereUI._prebuilding then
+            do
+                local rgn = borderRow._leftRegion
+                local _, cogShow = EllesmereUI.BuildCogPopup({
+                    title = "Border Offset",
+                    rows = {
+                        { type="slider", label="Offset X", min=-10, max=10, step=1,
+                          get=function()
+                              local d = DDB(); if not d then return 0 end
+                              if d.borderTextureOffset ~= nil then return d.borderTextureOffset end
+                              return EllesmereUI.GetBorderDefaults("aurabuffreminders", d.borderTexture or "solid", d.borderSize or 1)
+                          end,
+                          set=function(v) local d=DDB(); if d then d.borderTextureOffset=v; RefreshBorders() end end },
+                        { type="slider", label="Offset Y", min=-10, max=10, step=1,
+                          get=function()
+                              local d = DDB(); if not d then return 0 end
+                              if d.borderTextureOffsetY ~= nil then return d.borderTextureOffsetY end
+                              local _, value = EllesmereUI.GetBorderDefaults("aurabuffreminders", d.borderTexture or "solid", d.borderSize or 1)
+                              return value
+                          end,
+                          set=function(v) local d=DDB(); if d then d.borderTextureOffsetY=v; RefreshBorders() end end },
+                        { type="slider", label="Shift X", min=-10, max=10, step=1,
+                          get=function()
+                              local d = DDB(); if not d then return 0 end
+                              if d.borderTextureShiftX ~= nil then return d.borderTextureShiftX end
+                              local _, _, value = EllesmereUI.GetBorderDefaults("aurabuffreminders", d.borderTexture or "solid", d.borderSize or 1)
+                              return value
+                          end,
+                          set=function(v) local d=DDB(); if d then d.borderTextureShiftX=(v ~= 0) and v or nil; RefreshBorders() end end },
+                        { type="slider", label="Shift Y", min=-10, max=10, step=1,
+                          get=function()
+                              local d = DDB(); if not d then return 0 end
+                              if d.borderTextureShiftY ~= nil then return d.borderTextureShiftY end
+                              local _, _, _, value = EllesmereUI.GetBorderDefaults("aurabuffreminders", d.borderTexture or "solid", d.borderSize or 1)
+                              return value
+                          end,
+                          set=function(v) local d=DDB(); if d then d.borderTextureShiftY=(v ~= 0) and v or nil; RefreshBorders() end end },
+                        { type="toggle", label="Show Behind",
+                          get=function() local d=DDB(); return d and d.borderBehind == true end,
+                          set=function(v) local d=DDB(); if d then d.borderBehind=v; RefreshBorders() end end },
+                    },
+                })
+                local cogBtn = MakeCogBtn(rgn, cogShow)
+                local function UpdateBorderCogVisibility()
+                    local d = DDB()
+                    cogBtn:SetShown(d and (d.borderTexture or "solid") ~= "solid")
+                end
+                UpdateBorderCogVisibility()
+                EllesmereUI.RegisterWidgetRefresh(UpdateBorderCogVisibility)
+            end
+
+            do
+                local rgn = borderRow._rightRegion
+                local swatch, updateSwatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel()+5,
+                    function()
+                        local d = DDB()
+                        return (d and d.borderR) or 0, (d and d.borderG) or 0,
+                            (d and d.borderB) or 0, (d and d.borderA) or 1
+                    end,
+                    function(r, g, b, a)
+                        local d = DDB(); if not d then return end
+                        d.borderR, d.borderG, d.borderB, d.borderA = r, g, b, a or 1
+                        RefreshBorders()
+                    end, true, 20)
+                swatch:SetPoint("RIGHT", rgn._lastInline or rgn._control, "LEFT", -12, 0)
+                rgn._lastInline = swatch
+                EllesmereUI.RegisterWidgetRefresh(updateSwatch)
+            end
+        end
+
+        -- Row 2: Show Name (+ inline swatch + cog) | Show Item Count (+ cog)
         local rowText
         rowText, h = W:DualRow(parent, y,
             { type="toggle", text="Show Name",
@@ -1037,12 +1180,21 @@ initFrame:SetScript("OnEvent", function(self)
               end }
         );  y = y - h
 
-        -- Inline cog on Show Item Count (right of row 1): size + offsets
+        -- Inline cog on Show Item Count (right of row 2): size + offsets
         if not EllesmereUI._prebuilding then
             local rgn = rowText._rightRegion
+            local countFontValues, countFontOrder = EllesmereUI.BuildFontDropdownData()
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Item Count Settings",
                 rows = {
+                    { type="dropdown", label="Item Count Font",
+                      values=countFontValues, order=countFontOrder,
+                      get=function() local d = DDB(); return (d and d.countFont) or "__global" end,
+                      set=function(v)
+                          local d = DDB(); if not d then return end
+                          d.countFont = (v ~= "__global") and v or nil
+                          RefreshAll()
+                      end },
                     { type="slider", label="Text Size", min=6, max=30, step=1,
                       get=function() local d = DDB(); return d and d.countSize or 16 end,
                       set=function(v) local d = DDB(); if not d then return end; d.countSize = v; RefreshAll(); UpdatePreviewHeader() end },
@@ -1078,7 +1230,7 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.RegisterWidgetRefresh(UpdateCountCogDisabled)
         end
 
-        -- Row 2: Glow Type (+ inline trio swatch) | Attach Important Buffs to Cursor
+        -- Row 3: Glow Type (+ inline trio swatch) | Attach Important Buffs to Cursor
         local rowGlow
         rowGlow, h = W:DualRow(parent, y,
             { type="dropdown", text="Glow Type",
@@ -1096,7 +1248,7 @@ initFrame:SetScript("OnEvent", function(self)
               setValue=function(v) local d = DDB(); if not d then return end; d.cursorAttach = v; RefreshAll() end }
         );  y = y - h
 
-        -- Inline color swatch on Glow Type (left of row 2)
+        -- Inline color swatch on Glow Type (left of row 3)
         if not EllesmereUI._prebuilding then
             local rgn = rowGlow._leftRegion
             local isNone = function()
@@ -1160,7 +1312,7 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.RegisterWidgetRefresh(UpdateSwatchBlock)
         end
 
-        -- Inline color swatch + cog on Show Name (left of row 1)
+        -- Inline color swatch + cog on Show Name (left of row 2)
         if not EllesmereUI._prebuilding then
             local rgn = rowText._leftRegion
             local swatch = EllesmereUI.BuildColorSwatch(rgn, rgn:GetFrameLevel()+5,
@@ -1187,10 +1339,19 @@ initFrame:SetScript("OnEvent", function(self)
             end)
             swatchBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
 
-            -- Inline cog for name settings (size, anchor, x/y offset)
+            -- Inline cog for name settings (font, size, anchor, x/y offset)
+            local nameFontValues, nameFontOrder = EllesmereUI.BuildFontDropdownData()
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Name Settings",
                 rows = {
+                    { type="dropdown", label="Name Font",
+                      values=nameFontValues, order=nameFontOrder,
+                      get=function() local d = DDB(); return (d and d.nameFont) or "__global" end,
+                      set=function(v)
+                          local d = DDB(); if not d then return end
+                          d.nameFont = (v ~= "__global") and v or nil
+                          RefreshAll(); UpdatePreviewHeader()
+                      end },
                     { type="slider", label="Text Size", min=6, max=30, step=1,
                       get=function() local d = DDB(); return d and d.textSize or 11 end,
                       set=function(v) local d = DDB(); if not d then return end; d.textSize = v; RefreshAll(); UpdatePreviewHeader() end },
@@ -1242,7 +1403,7 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.RegisterWidgetRefresh(UpdateTextInlinesDisabled)
         end
 
-        -- Row 3: Icon Spacing (+ directions cog) | Frame Strata
+        -- Row 4: Icon Spacing (+ directions cog) | Frame Strata
         local rowSliders
         rowSliders, h = W:DualRow(parent, y,
             { type="slider", pixel=true, text="Icon Spacing", min=0, max=50, step=1,
@@ -1277,7 +1438,7 @@ initFrame:SetScript("OnEvent", function(self)
             MakeCogBtn(rgn, cogShow, nil, EllesmereUI.DIRECTIONS_ICON)
         end
 
-        -- Row 4: Show Below | Show Below Pre-Key (global timing, minutes)
+        -- Row 5: Show Below | Show Below Pre-Key (global timing, minutes)
         local timingRow
         timingRow, h = W:DualRow(parent, y,
             { type="slider", text="Show Below", min=0, max=60, step=1,
@@ -1297,7 +1458,7 @@ initFrame:SetScript("OnEvent", function(self)
         );  y = y - h
         AddMinSuffix(timingRow, "Show Below", "Show Below Pre-Key")
 
-        -- Row 5: Show Tooltips | Opacity
+        -- Row 6: Show Tooltips | Opacity
         _, h = W:DualRow(parent, y,
             { type="toggle", text="Show Tooltips",
               tooltip="Show item or spell tooltips when hovering reminder icons.",
@@ -1370,15 +1531,22 @@ initFrame:SetScript("OnEvent", function(self)
             local AURAS = _G._EABR_AURAS or {}
             local gridItems = {}
             for _, aura in ipairs(AURAS) do
-                gridItems[#gridItems+1] = {
-                    label = _G._EABR_SpellName(aura.castSpell, aura.name),
-                    classToken = aura.class,
-                    key = aura.key,
-                    getVal = function() local a = ADB(); return a and a.enabled and a.enabled[aura.key] end,
-                    setVal = function(v) local a = ADB(); if a and a.enabled then a.enabled[aura.key] = v end end,
-                }
+                -- Soulstone is a Warlock-specific group utility reminder and
+                -- is configured in the Warlock section below.
+                if aura.key ~= "soulstone" then
+                    gridItems[#gridItems+1] = {
+                        label = _G._EABR_SpellName(aura.castSpell, aura.name),
+                        classToken = aura.class,
+                        key = aura.key,
+                        getVal = function() local a = ADB(); return a and a.enabled and a.enabled[aura.key] end,
+                        setVal = function(v) local a = ADB(); if a and a.enabled then a.enabled[aura.key] = v end end,
+                    }
+                end
             end
-            h = BuildCheckboxGrid(parent, y, gridItems, function() RefreshAll(); RebuildPreviewHeader() end, _gridCellRefs)
+            h = BuildCheckboxGrid(parent, y, gridItems, function()
+                if _G._EABR_UpdateGroupAuraRegistration then _G._EABR_UpdateGroupAuraRegistration() end
+                RefreshAll(); RebuildPreviewHeader()
+            end, _gridCellRefs)
             y = y - h
         end
 
@@ -1504,10 +1672,10 @@ initFrame:SetScript("OnEvent", function(self)
         _, h = W:Spacer(parent, y, 10);  y = y - h
 
         -----------------------------------------------------------------------
-        --  WARLOCK DEMONS section
+        --  WARLOCK section
         -----------------------------------------------------------------------
         local warlockHdr
-        warlockHdr, h = W:SectionHeader(parent, "WARLOCK DEMONS", y);  y = y - h
+        warlockHdr, h = W:SectionHeader(parent, SECTION_WARLOCK, y);  y = y - h
 
         local WARLOCK_PET_ITEMS = {}
         for _, pet in ipairs(_G._EABR_WARLOCK_PETS or {}) do
@@ -1534,10 +1702,25 @@ initFrame:SetScript("OnEvent", function(self)
               getValue=function() return "_placeholder" end, setValue=function() end }
         );  y = y - h
 
+        local soulstoneRow
+        soulstoneRow, h = W:DualRow(parent, y,
+            { type="toggle", text=_G._EABR_SpellName(20707, "Soulstone"),
+              tooltip="Show a reminder until your own Soulstone is active on you or another group member.",
+              getValue=function() local a = ADB(); return a and a.enabled and a.enabled.soulstone ~= false end,
+              setValue=function(v)
+                  local a = ADB()
+                  if a and a.enabled then a.enabled.soulstone = v end
+                  if _G._EABR_UpdateGroupAuraRegistration then _G._EABR_UpdateGroupAuraRegistration() end
+                  RefreshAll(); RebuildPreviewHeader()
+              end },
+            { type="label", text="" }
+        );  y = y - h
+
         local wcc = RAID_CLASS_COLORS and RAID_CLASS_COLORS.WARLOCK
         if wcc then
             if warlockRow._leftRegion._label then warlockRow._leftRegion._label:SetTextColor(wcc.r, wcc.g, wcc.b, 1) end
             if warlockRow._rightRegion._label then warlockRow._rightRegion._label:SetTextColor(wcc.r, wcc.g, wcc.b, 1) end
+            if soulstoneRow._leftRegion._label then soulstoneRow._leftRegion._label:SetTextColor(wcc.r, wcc.g, wcc.b, 1) end
         end
 
         if not EllesmereUI._prebuilding then
@@ -1832,9 +2015,19 @@ initFrame:SetScript("OnEvent", function(self)
                 if RefreshRcwEye then RefreshRcwEye() end
                 if _G._EABR_RCWarnPreview then _G._EABR_RCWarnPreview() end
             end
+            leftRgn._rcwFontValues, leftRgn._rcwFontOrder = EllesmereUI.BuildFontDropdownData()
             local _, cogShow = EllesmereUI.BuildCogPopup({
                 title = "Mana Warning Settings",
                 rows = {
+                    { type="dropdown", label="Mana Warning Font",
+                      values=leftRgn._rcwFontValues, order=leftRgn._rcwFontOrder,
+                      get=function() local c = CDB(); return (c and c.rcManaWarnFont) or "__global" end,
+                      set=function(v)
+                          local c = CDB(); if not c then return end
+                          c.rcManaWarnFont = (v ~= "__global") and v or nil
+                          if _G._EABR_RCWarnApply then _G._EABR_RCWarnApply() end
+                          ShowPreviewFromCog()
+                      end },
                     { type="slider", label="Text Size", min=10, max=72, step=1,
                       get=function() local c = CDB(); return c and c.rcManaWarnSize or 48 end,
                       set=function(v) local c = CDB(); if not c then return end; c.rcManaWarnSize = v
@@ -1922,15 +2115,14 @@ initFrame:SetScript("OnEvent", function(self)
             EllesmereUI.RegisterWidgetRefresh(UpdateRcwInlinesDisabled)
         end
 
-        -- Wire up click mappings for preview hit overlays. Both display-level
-        -- targets are rowText -- the first DISPLAY row, which also hosts the
-        -- Show Name toggle.
+        -- Wire up click mappings for preview hit overlays.
         wipe(_eabrClickMappings)
-        _eabrClickMappings.display = { section = displaySection, target = rowText }
+        _eabrClickMappings.display = { section = displaySection, target = borderRow }
         _eabrClickMappings.showText = { section = displaySection, target = rowText }
         _eabrClickMappings.raidbuff = { section = raidBufHdr, target = raidBufHdr }
         _eabrClickMappings.aura = { section = auraHdr, target = auraHdr }
         _eabrClickMappings.consumable = { section = consumHdr, target = consumFirstRow }
+        _eabrClickMappings["item:soulstone"] = { section = warlockHdr, target = soulstoneRow }
 
         -- Per-item mappings: grid cells for individual raid buffs / auras
         for k, cell in pairs(_gridCellRefs) do

--- a/EllesmereUIOptions/EUI_Fonts_Options.lua
+++ b/EllesmereUIOptions/EUI_Fonts_Options.lua
@@ -401,7 +401,20 @@ local function TileAuraBuffReminders(parent, y, W, tile)
         return NoteRow(parent, y, EllesmereUI.Lf("Enable %1$s to edit its text settings.", EllesmereUI.L(tile.display)))
     end
     local function db() return _G._EABR_AceDB and _G._EABR_AceDB.profile end
-    _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display),
+    local nameFontValues, nameFontOrder = EllesmereUI.BuildFontDropdownData()
+    _, h = W:DualRow(parent, y, ModuleOutlineCfg(tile.folder, tile.display), BLANK());  y = y - h
+    _, h = W:DualRow(parent, y,
+        { type = "dropdown", text = "Name Font",
+          values = nameFontValues, order = nameFontOrder,
+          getValue = function()
+              local p = db()
+              return (p and p.display and p.display.nameFont) or "__global"
+          end,
+          setValue = function(v)
+              local p = db(); if not (p and p.display) then return end
+              p.display.nameFont = (v ~= "__global") and v or nil
+              if _G._EABR_RequestRefresh then _G._EABR_RequestRefresh() end
+          end },
         { type = "slider", text = "Name Text Size", min = 6, max = 30, step = 1,
           getValue = function()
               local p = db()
@@ -413,6 +426,17 @@ local function TileAuraBuffReminders(parent, y, W, tile)
               if _G._EABR_RequestRefresh then _G._EABR_RequestRefresh() end
           end });  y = y - h
     _, h = W:DualRow(parent, y,
+        { type = "dropdown", text = "Item Count Font",
+          values = nameFontValues, order = nameFontOrder,
+          getValue = function()
+              local p = db()
+              return (p and p.display and p.display.countFont) or "__global"
+          end,
+          setValue = function(v)
+              local p = db(); if not (p and p.display) then return end
+              p.display.countFont = (v ~= "__global") and v or nil
+              if _G._EABR_RequestRefresh then _G._EABR_RequestRefresh() end
+          end },
         { type = "slider", text = "Item Count Text Size", min = 6, max = 30, step = 1,
           getValue = function()
               local p = db()
@@ -422,6 +446,18 @@ local function TileAuraBuffReminders(parent, y, W, tile)
               local p = db(); if not (p and p.display) then return end
               p.display.countSize = v
               if _G._EABR_RequestRefresh then _G._EABR_RequestRefresh() end
+          end });  y = y - h
+    _, h = W:DualRow(parent, y,
+        { type = "dropdown", text = "Mana Warning Font",
+          values = nameFontValues, order = nameFontOrder,
+          getValue = function()
+              local p = db()
+              return (p and p.consumables and p.consumables.rcManaWarnFont) or "__global"
+          end,
+          setValue = function(v)
+              local p = db(); if not (p and p.consumables) then return end
+              p.consumables.rcManaWarnFont = (v ~= "__global") and v or nil
+              if _G._EABR_RCWarnApply then _G._EABR_RCWarnApply() end
           end },
         { type = "slider", text = "Mana Warning Text Size", min = 10, max = 72, step = 1,
           getValue = function()

--- a/EllesmereUIOptions/EUI__General_Options.lua
+++ b/EllesmereUIOptions/EUI__General_Options.lua
@@ -979,7 +979,7 @@ EllesmereUI._WHATSNEW_PATCHES = {
                 title  = "Warlock Demon Reminder",
                 desc   = "Allowed Demons picks which demons count as correct for any Warlock spec, and the Missing Pet reminder now summons on click",
                 nav    = { module = "EllesmereUIAuraBuffReminders", page = "Auras, Buffs & Consumables",
-                           section = "WARLOCK DEMONS", highlight = "Wrong Demon" },
+                           section = "WARLOCK", highlight = "Wrong Demon" },
             },
             {
                 module = "Blizz UI Enhanced",

--- a/EllesmereUI_Profiles.lua
+++ b/EllesmereUI_Profiles.lua
@@ -1377,8 +1377,10 @@ local REFRESH_ADDON_STEPS = {
             EllesmereUI._applySecondaryStats()
         end
     end,
-    -- AuraBuffReminders (refresh + position)
+    -- AuraBuffReminders (style + refresh + position)
     function()
+        if _G._EABR_UpdateGroupAuraRegistration then _G._EABR_UpdateGroupAuraRegistration() end
+        if _G._EABR_ApplyAllIconBorders then _G._EABR_ApplyAllIconBorders() end
         if _G._EABR_RequestRefresh then _G._EABR_RequestRefresh() end
         if _G._EABR_ApplyUnlockPos then _G._EABR_ApplyUnlockPos() end
     end,

--- a/EllesmereUI_SpecOverrides.lua
+++ b/EllesmereUI_SpecOverrides.lua
@@ -100,7 +100,7 @@ local REFRESH_FNS = {
     EllesmereUIDamageMeters      = { "_EDM_Apply" },
     EllesmereUIDataBars          = { "_EDB_Apply" },
     EllesmereUIQuickdraw         = { "_EQD_Apply" },
-    EllesmereUIAuraBuffReminders = { "_EABR_RequestRefresh", "_EABR_ApplyUnlockPos" },
+    EllesmereUIAuraBuffReminders = { "_EABR_UpdateGroupAuraRegistration", "_EABR_ApplyAllIconBorders", "_EABR_RequestRefresh", "_EABR_ApplyUnlockPos" },
     -- Capture/apply-blacklisted (see FOLDER_BLACKLIST); insurance so a leaked
     -- key can never hit the unmapped-folder fallback's full RefreshAllAddons.
     EllesmereUIDragonRiding      = { "_EDR_Rebuild" },


### PR DESCRIPTION
## Summary

This PR expands the Aura & Buff Reminders module with additional appearance controls, a Warlock Soulstone reminder, improved font configuration, and complete localization support.

## New Features

### Reminder Border Customization

- Added configurable **Border Style** and **Border Size** options for reminder icons.
- Uses the same border system and visual behavior as other EUI modules.
- The default remains a **1 px solid black border**, preserving the existing appearance.
- Textured border regions are created lazily and do not require per-frame updates.

### Warlock Soulstone Reminder

- Added a dedicated **Soulstone** reminder for Warlocks.
- Checks whether the player's own Soulstone is active on:
  - The player
  - A party member
  - A raid member
- The reminder is located under the renamed **Warlock** section.

### Font Settings

Added individual font selection and text-size settings for:

- Reminder names
- Item counts
- Low-mana warnings

These settings are available both in their relevant cog menus and on the centralized **Global Settings → Fonts → Aura & Buff Reminders** page.

All Aura & Buff Reminder text now consistently inherits the single **Module Outline** setting. Redundant per-text outline options were removed to keep the configuration clear and predictable.

## Localization

Added or updated translations for all supported locales:

- German
- Spanish (Spain)
- Spanish (Latin America)
- French
- Italian
- Korean
- Portuguese (Brazil)
- Russian
- Simplified Chinese
- Traditional Chinese

## Secret and Taint Safety

- Soulstone is added to the non-secret spell whitelist only when Blizzard's runtime API explicitly reports it as non-secret.
- Secret values are never coerced, compared, or used as booleans.
- Aura API calls that may return restricted data are protected and validated.
- If Soulstone ownership cannot be determined safely, the result is treated as unknown and the reminder is suppressed instead of making an unsafe assumption.
- Source ownership is never guessed from secret or unavailable aura data.
- Restricted group aura scanning is avoided during combat.
- No protected or Blizzard-owned frame state is modified.
- Reminder borders use addon-owned child regions.
- Configuration and runtime state remain in addon-owned tables.
- No insecure hooks or per-frame polling loops were introduced.

## Compatibility

- Existing profiles retain their previous visual appearance.
- Existing default settings remain unchanged.
- Previously stored per-text outline overrides are safely ignored.

## Checklist

- [x] New settings default **OFF** — N/A: Border Style defaults to **Solid**, preserving the existing appearance
- [x] Zero cost while disabled — no new events, hooks, or update loops
- [x] Cheap while enabled — textured border regions are created lazily and require no per-frame updates
- [x] No writes onto Blizzard-owned frames — state remains in external tables and addon-owned child regions
- [x] Tested in-game on live