### PR TITLE
Quickdraw: drop the item range check that fires ADDON_ACTION_BLOCKED

### DIFF
--- a/EllesmereUIQuickdraw/EllesmereUIQuickdraw.lua
+++ b/EllesmereUIQuickdraw/EllesmereUIQuickdraw.lua
@@ -2170,14 +2170,20 @@ local USABILITY_TINT = {
 -- for a kind with nothing to say.
 --
 -- Every call here is secret-SAFE, and that was checked rather than assumed:
--- C_Spell.IsSpellUsable, C_Spell.IsSpellInRange, C_Item.IsUsableItem,
--- C_Item.ItemHasRange and C_Item.IsItemInRange all carry no
--- SecretWhenCooldownsRestricted flag in the generated documentation, unlike
+-- C_Spell.IsSpellUsable, C_Spell.IsSpellInRange and C_Item.IsUsableItem carry
+-- no SecretWhenCooldownsRestricted flag in the generated documentation, unlike
 -- the cooldown and charge getters two functions up. So these results may be
 -- branched on. Do not add a kind here without checking its getter the same
 -- way -- a mount's usability, for one, has to come from the Mount Journal
 -- rather than from its summon spell, which is not in the spellbook and
 -- answers unusable for every mount.
+--
+-- Secret-safe is only half of it, and the other half is a DIFFERENT predicate.
+-- The spell getters are AllowedWhenTainted and may be called from here.
+-- C_Item.IsItemInRange is AllowedWhenUntainted: calling it from addon code
+-- fires ADDON_ACTION_BLOCKED, and a blocked call cannot answer false, so the
+-- range tint it was meant to produce never appeared in the first place. Check
+-- BOTH predicates before adding a getter here.
 --
 -- Out of range OUTRANKS the other two, matching every action bar: a spell you
 -- cannot reach is the thing to say first, and it is the state a step forward
@@ -2206,10 +2212,8 @@ local function SlotUsability(slot)
 
     elseif k == "item" then
         if type(slot.id) ~= "number" then return nil end
-        if C_Item.ItemHasRange(slot.id)
-           and C_Item.IsItemInRange(slot.id, "target") == false then
-            return "OUTOFRANGE"
-        end
+        -- No OUTOFRANGE for items: the getter that would answer it is blocked
+        -- for addons (see the predicate note above). Usability still applies.
         local usable, noPower = C_Item.IsUsableItem(slot.id)
         if usable then return nil end
         return noPower and "NOPOWER" or "UNUSABLE"


### PR DESCRIPTION
Fixes #1963.

## What does this PR do?

Removes the item range check in `SlotUsability` that fires `ADDON_ACTION_BLOCKED` every time a palette holding an item is opened, and corrects the predicate note above it.

The full capture, the predicate table and the reasoning are in #1963. The short version: the note above `SlotUsability` checked `SecretWhenCooldownsRestricted`, which is the secret-value predicate. Taint is a separate one, and there the getters differ -- `C_Spell.IsSpellInRange` and `C_Spell.IsSpellUsable` are `AllowedWhenTainted`, while `C_Item.IsItemInRange` is `AllowedWhenUntainted`.

**Nothing is lost.** A blocked call cannot answer `false`, so `OUTOFRANGE` for items could never have been returned -- the branch only ever cost an error. Spell range is untouched, and item usability still tints: `C_Item.IsUsableItem` sits two lines below, is reached in the same pass, and raises no blocked action of its own.

I corrected the note as well, since leaving it would invite the same mistake for the next getter added there.

### One thing I could not resolve

`C_Item.ItemHasRange` and `C_Item.IsUsableItem` carry the same `AllowedWhenUntainted` predicate, yet neither shows up as a blocked action -- `ItemHasRange` must have returned true for the `and` to reach line 2210 at all. So in practice only the call taking a **unit token** is blocked. I did not want to guess at that in a comment, and I deliberately left the other two alone: removing getters that are demonstrably still working would be a bigger change than the bug warrants. If you know the rule there, the note is easy to sharpen.

## How was it tested?

Honestly: **not verified in game.** The diagnosis rests on the captured error with its full stack plus the predicates in the generated API documentation, and the change only removes a call. Syntax checked with `luac5.1 -p`; the diff is ASCII-only, Lua 5.1, no version gates.

What a live test would show is the absence of an error, which the removal guarantees by construction -- the blocked call is simply gone. Happy to exercise a specific palette or item if you want that confirmed first.

## Screenshots

Not applicable. The removed branch could not produce a visible state: a blocked call never returns `false`, so no item ever received the `OUTOFRANGE` tint. Nothing that was on screen before looks different now.

## Checklist

- [x] New settings default **OFF** -- N/A, no setting added
- [x] Zero cost while disabled -- N/A, nothing added; this removes two calls from the paint path
- [x] Cheap while enabled: one getter fewer per item cell per paint
- [x] No writes onto Blizzard-owned frames -- N/A, untouched
- [ ] Tested in-game on live -- **no**, see above. No version gates or pre-Midnight APIs added.
