### PR TITLE
Add(Aura Buff Reminders): flask reminder in combat and inside keystones

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1479,18 +1479,28 @@ local function PlayerHasWellFed()
     return false
 end
 
--- Unlike the other consumables this one still answers under restriction: the
--- Midnight flask buffs are whitelisted, so the player's own aura reads back
--- plainly in combat and inside a key. The unwhitelisted legacy TWW IDs and the
--- name scan are unreadable there and sit out.
+-- Unlike the other consumables this one still answers under restriction: a
+-- flask buff reads back plainly for the player whenever the client reports that
+-- aura as non-secret, which the static whitelist only approximates --
+-- ShouldSpellAuraBeSecret is the authority, so an ID missing from the list (the
+-- legacy TWW flasks) is still read when the client allows it.
+-- Absence is only reported when every candidate ID was actually readable: a
+-- skipped ID means "unknown", and claiming the flask is missing off an
+-- incomplete scan is what put the reminder on screen mid-key with a flask up.
 local function PlayerHasFlaskBuff()
     if InPvPInstance() then return true end
     local restricted = EABR.ConsumablePresenceUnverifiable()
+    local unreadable = false
     -- Direct ID lookup for known flask buff IDs (zero allocation)
     for id in pairs(FLASK_BUFF_ID_SET) do
-        if not restricted or NON_SECRET_SPELL_IDS[id] then
+        if not restricted or NON_SECRET_SPELL_IDS[id] or _isRuntimeNonSecret(id) then
             local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
-            if ok and result ~= nil then
+            if not ok then
+                unreadable = true
+            elseif result ~= nil then
+                -- A secret result still means an aura came back: present, but
+                -- its duration cannot be inspected for the threshold.
+                if isSecret(result) then return true end
                 local dur, exp = result.duration, result.expirationTime
                 if dur ~= nil and exp ~= nil and not isSecret(dur) and not isSecret(exp)
                    and IsUnderDuration(dur, exp, "consumable") then
@@ -1498,6 +1508,8 @@ local function PlayerHasFlaskBuff()
                 end
                 return true
             end
+        else
+            unreadable = true
         end
     end
     -- Name-based fallback for flasks not in our ID set (lazy scan)
@@ -1507,6 +1519,7 @@ local function PlayerHasFlaskBuff()
             if FLASK_NAME_SET[aName] then return true end
         end
     end
+    if unreadable then return true end
     return false
 end
 

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1267,15 +1267,17 @@ end
 --  about the player's own auras is readable there, but an engine aura button's
 --  secret IsShown() can be passed to SetAlphaFromBoolean, so the icon hides
 --  itself while the flask is up without this addon learning whether it is.
---  A SLOT rather than a group: one deterministic frame, no pool index to guess.
+--  A GROUP, not a slot: a slot's frame is forbidden to us and every method on
+--  it raises, while a pooled group frame answers IsShown with a usable secret.
+--  maxFrameCount 1 caps it at one acquired frame, and AcquireFrame pops the END
+--  of the available list, so the last owned frame is the one to read.
 --  Returns available (plain boolean), secret (SECRET -- only ever pass it on).
 -------------------------------------------------------------------------------
 function EABR.FlaskPresenceSecret()
     local AK = EllesmereUI.AuraKit
     if not (AK and AK.AurasRestricted and AK.AurasRestricted()) then return false end
     if not AK.CreateContainer then return false end
-    local slot = EABR._flaskSlot
-    if not slot then
+    if not EABR._flaskContainer then
         -- Bare style: the initializer keys styleButtons by the style key, and a
         -- style with regions builds font strings the engine SetText()s unstyled.
         AK.styles["eabrFlaskPresence"] = AK.styles["eabrFlaskPresence"] or { noRegions = true }
@@ -1292,20 +1294,24 @@ function EABR.FlaskPresenceSecret()
         host:Show()
         local include = {}
         for id in pairs(FLASK_BUFF_ID_SET) do include[id] = true end
-        local ok, container, slots = pcall(AK.CreateContainer, host, "player", {
+        local ok, container = pcall(AK.CreateContainer, host, "player", {
             point = { "CENTER", host, "CENTER", 0, 0 },
-            slots = {
+            groups = {
                 { key = "flask", filter = { "HELPFUL" }, style = "eabrFlaskPresence",
+                  maxFrameCount = 1,
                   candidateFilters = { includeSpellIDs = include } },
             },
         })
         if not ok then return false end
         EABR._flaskContainer = container
-        slot = slots and slots.flask
-        EABR._flaskSlot = slot
     end
-    if not slot then return false end
-    local okv, vis = pcall(slot.IsShown, slot)
+    local c = EABR._flaskContainer
+    if not c then return false end
+    local okn, n = pcall(c.GetAuraGroupFrameCount, c, "flask")
+    if not okn or type(n) ~= "number" or n < 1 then return false end
+    local okf, frame = pcall(c.GetAuraGroupFrame, c, "flask", n)
+    if not okf or not frame then return false end
+    local okv, vis = pcall(frame.IsShown, frame)
     if not okv then return false end
     return true, vis
 end

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1484,11 +1484,12 @@ local function PlayerHasWellFed()
     return false
 end
 
--- Unlike the other consumables this one still answers under restriction: a
--- flask buff reads back plainly for the player whenever the client reports that
--- aura as non-secret, which the static whitelist only approximates --
--- ShouldSpellAuraBeSecret is the authority, so an ID missing from the list (the
--- legacy TWW flasks) is still read when the client allows it.
+-- Unlike the other consumables this one attempts the read under restriction
+-- instead of bailing outright, so a flask can be reported missing wherever the
+-- client still answers. Where it does not answer the reminder stays silent:
+-- inside a keystone GetPlayerAuraBySpellID returns nil for the player's own
+-- flask even though the ID is whitelisted and the buff is plainly up (verified
+-- in game 2026-09-04), so an empty read there proves nothing.
 local function PlayerHasFlaskBuff()
     if InPvPInstance() then return true end
     local restricted = EABR.ConsumablePresenceUnverifiable()
@@ -1516,6 +1517,9 @@ local function PlayerHasFlaskBuff()
             if FLASK_NAME_SET[aName] then return true end
         end
     end
+    -- Nothing found. Only meaningful where the reads answer at all: under
+    -- restriction an empty result is indistinguishable from an absent flask.
+    if restricted then return true end
     return false
 end
 

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -314,10 +314,13 @@ function EABR.GetShowUnderMinutes()
     return disp.showUnder or 5
 end
 
--- Thresholds apply everywhere except combat and active Mythic+ keys (there a
--- reminder means the buff is fully gone).
+-- Thresholds apply everywhere except combat and active Mythic+ keys, where a
+-- reminder means the buff is fully gone. "Show Below In Combat" opts back in.
 function EABR.ShowUnderThresholdApplies()
-    if InCombat() or InMythicPlusKey() then return false end
+    if InCombat() or InMythicPlusKey() then
+        local disp = db and db.profile and db.profile.display
+        return (disp and disp.showUnderInCombat) == true
+    end
     return true
 end
 
@@ -1476,23 +1479,29 @@ local function PlayerHasWellFed()
     return false
 end
 
+-- Unlike the other consumables this one still answers under restriction: the
+-- Midnight flask buffs are whitelisted, so the player's own aura reads back
+-- plainly in combat and inside a key. The unwhitelisted legacy TWW IDs and the
+-- name scan are unreadable there and sit out.
 local function PlayerHasFlaskBuff()
     if InPvPInstance() then return true end
-    if EABR.ConsumablePresenceUnverifiable() then return true end
+    local restricted = EABR.ConsumablePresenceUnverifiable()
     -- Direct ID lookup for known flask buff IDs (zero allocation)
     for id in pairs(FLASK_BUFF_ID_SET) do
-        local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
-        if ok and result ~= nil then
-            local dur, exp = result.duration, result.expirationTime
-            if dur ~= nil and exp ~= nil and not isSecret(dur) and not isSecret(exp)
-               and IsUnderDuration(dur, exp, "consumable") then
-                return false
+        if not restricted or NON_SECRET_SPELL_IDS[id] then
+            local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
+            if ok and result ~= nil then
+                local dur, exp = result.duration, result.expirationTime
+                if dur ~= nil and exp ~= nil and not isSecret(dur) and not isSecret(exp)
+                   and IsUnderDuration(dur, exp, "consumable") then
+                    return false
+                end
+                return true
             end
-            return true
         end
     end
     -- Name-based fallback for flasks not in our ID set (lazy scan)
-    if _AC.valid then
+    if not restricted and _AC.valid then
         _AC.ensureNames()
         for aName in pairs(_AC.byName) do
             if FLASK_NAME_SET[aName] then return true end
@@ -1855,10 +1864,12 @@ local defaults = {
             frameStrata = "MEDIUM",
             cursorAttach = false,
             -- Global timing pair (minutes). showUnderMPlus is the pre-key
-            -- (Mythic 0 / keystone lobby) threshold; active keys and combat
-            -- ignore thresholds entirely (only fully-missing reminds there).
+            -- (Mythic 0 / keystone lobby) threshold. Active keys and combat
+            -- ignore both (only fully-missing reminds there) until
+            -- showUnderInCombat opts back in.
             showUnder = 5,
             showUnderMPlus = 40,
+            showUnderInCombat = false,
         },
         raidBuffs = {
             enabled = {

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -326,6 +326,11 @@ end
 
 function EABR.IsUnderDuration(duration, expirationTime, sectionKey)
     if not (db and db.profile and duration and expirationTime and sectionKey) then return false end
+    -- Zero means "no timing info", the same sentinel GetEatingExpirationTime
+    -- rejects, not "about to expire": 0 - GetTime() is hugely negative and would
+    -- clear every threshold below. Restricted aura reads hand back a real
+    -- duration with the expiration withheld this way.
+    if duration <= 0 or expirationTime <= 0 then return false end
     if not EABR.ShowUnderThresholdApplies() then return false end
     local thresholdSeconds = EABR.GetShowUnderMinutes() * 60
     if thresholdSeconds > 0 and duration >= thresholdSeconds then
@@ -1484,20 +1489,14 @@ end
 -- aura as non-secret, which the static whitelist only approximates --
 -- ShouldSpellAuraBeSecret is the authority, so an ID missing from the list (the
 -- legacy TWW flasks) is still read when the client allows it.
--- Absence is only reported when every candidate ID was actually readable: a
--- skipped ID means "unknown", and claiming the flask is missing off an
--- incomplete scan is what put the reminder on screen mid-key with a flask up.
 local function PlayerHasFlaskBuff()
     if InPvPInstance() then return true end
     local restricted = EABR.ConsumablePresenceUnverifiable()
-    local unreadable = false
     -- Direct ID lookup for known flask buff IDs (zero allocation)
     for id in pairs(FLASK_BUFF_ID_SET) do
         if not restricted or NON_SECRET_SPELL_IDS[id] or _isRuntimeNonSecret(id) then
             local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
-            if not ok then
-                unreadable = true
-            elseif result ~= nil then
+            if ok and result ~= nil then
                 -- A secret result still means an aura came back: present, but
                 -- its duration cannot be inspected for the threshold.
                 if isSecret(result) then return true end
@@ -1508,8 +1507,6 @@ local function PlayerHasFlaskBuff()
                 end
                 return true
             end
-        else
-            unreadable = true
         end
     end
     -- Name-based fallback for flasks not in our ID set (lazy scan)
@@ -1519,7 +1516,6 @@ local function PlayerHasFlaskBuff()
             if FLASK_NAME_SET[aName] then return true end
         end
     end
-    if unreadable then return true end
     return false
 end
 

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1262,6 +1262,54 @@ for _, id in ipairs({1235113, 1235114, 1235115, 1235116}) do
     FLASK_BUFF_ID_SET[id] = true
 end
 
+-------------------------------------------------------------------------------
+--  Flask presence while aura reads are restricted (keystones, raids). Nothing
+--  about the player's own auras is readable there, but an engine aura button's
+--  secret IsShown() can be passed to SetAlphaFromBoolean, so the icon hides
+--  itself while the flask is up without this addon learning whether it is.
+--  A SLOT rather than a group: one deterministic frame, no pool index to guess.
+--  Returns available (plain boolean), secret (SECRET -- only ever pass it on).
+-------------------------------------------------------------------------------
+function EABR.FlaskPresenceSecret()
+    local AK = EllesmereUI.AuraKit
+    if not (AK and AK.AurasRestricted and AK.AurasRestricted()) then return false end
+    if not AK.CreateContainer then return false end
+    local slot = EABR._flaskSlot
+    if not slot then
+        -- Bare style: the initializer keys styleButtons by the style key, and a
+        -- style with regions builds font strings the engine SetText()s unstyled.
+        AK.styles["eabrFlaskPresence"] = AK.styles["eabrFlaskPresence"] or { noRegions = true }
+        local host = EABR._flaskHost
+        if not host then
+            -- The engine parses from a run-when-visible OnUpdate, so the host
+            -- must be anchored and shown; alpha 0 keeps it out of sight.
+            host = CreateFrame("Frame", nil, UIParent)
+            host:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+            host:SetSize(1, 1)
+            host:SetAlpha(0)
+            EABR._flaskHost = host
+        end
+        host:Show()
+        local include = {}
+        for id in pairs(FLASK_BUFF_ID_SET) do include[id] = true end
+        local ok, container, slots = pcall(AK.CreateContainer, host, "player", {
+            point = { "CENTER", host, "CENTER", 0, 0 },
+            slots = {
+                { key = "flask", filter = { "HELPFUL" }, style = "eabrFlaskPresence",
+                  candidateFilters = { includeSpellIDs = include } },
+            },
+        })
+        if not ok then return false end
+        EABR._flaskContainer = container
+        slot = slots and slots.flask
+        EABR._flaskSlot = slot
+    end
+    if not slot then return false end
+    local okv, vis = pcall(slot.IsShown, slot)
+    if not okv then return false end
+    return true, vis
+end
+
 -- Food Items (Midnight)
 local FOOD_ITEMS = {
     { key="royal_roast",           itemID=242275, name="Royal Roast" },
@@ -1997,6 +2045,10 @@ function EABR.HandleAppearSounds(missing)
     local primed = EABR._soundPrimed
     for i = 1, #missing do
         local dk = missing[i].dismissKey
+        -- Alpha-driven entries are emitted unconditionally and hidden by the
+        -- engine, so this addon cannot tell whether one is actually showing.
+        -- Firing an alert off that would sound with the buff already up.
+        if missing[i].alphaFromSecret then dk = nil end
         if dk and not _dismissedUntilLoad[dk] then
             cur[dk] = true
             if primed and not prev[dk] then
@@ -2133,6 +2185,10 @@ local function ShowCombatIcon(iconIdx, m)
             (not m.isEating) and m.substitute or nil)
     end
     f:Show()
+    -- Stamped, not applied here: every layout pass rewrites alpha from the
+    -- opacity setting, so the secret has to win afterwards.
+    f._alphaFromSecret = m.alphaFromSecret or nil
+    f._alphaSecret = m.alphaSecret
     combatActiveIcons[#combatActiveIcons+1] = f
 end
 
@@ -2152,6 +2208,7 @@ local function LayoutCombatIcons()
     for i, f in ipairs(combatActiveIcons) do
         f:SetSize(sz, sz)
         f:SetAlpha(p.opacity or 1.0)
+        if f._alphaFromSecret then f:SetAlphaFromBoolean(f._alphaSecret, 0, 1) end
         EABR.SizeIconQuality(f, sz)
         EABR.SizeIconBagCount(f, sz)
         f:ClearAllPoints()
@@ -2235,6 +2292,10 @@ local function ShowCursorIcon(iconIdx, m)
             (not m.isEating) and m.substitute or nil)
     end
     f:Show()
+    -- Stamped, not applied here: every layout pass rewrites alpha from the
+    -- opacity setting, so the secret has to win afterwards.
+    f._alphaFromSecret = m.alphaFromSecret or nil
+    f._alphaSecret = m.alphaSecret
     cursorActiveIcons[#cursorActiveIcons+1] = f
 end
 
@@ -2249,6 +2310,7 @@ local function LayoutCursorIcons()
     for i, f in ipairs(cursorActiveIcons) do
         f:SetSize(sz, sz)
         f:SetAlpha(p.opacity or 1.0)
+        if f._alphaFromSecret then f:SetAlphaFromBoolean(f._alphaSecret, 0, 1) end
         EABR.SizeIconQuality(f, sz)
         EABR.SizeIconBagCount(f, sz)
         f:ClearAllPoints()
@@ -2903,6 +2965,7 @@ do
         e.texture = nil; e.label = nil; e.unit = nil; e.desaturated = false
         e.tooltipItem = nil
         e.cat = nil; e.data = nil; e.dismissKey = nil; e.petCycleTotal = nil
+        e.alphaFromSecret = nil; e.alphaSecret = nil
         e.isEating = nil; e.eatingExpirationTime = nil
         e.qualityAtlas = nil
         e.bagCount = nil
@@ -3003,6 +3066,7 @@ local function LayoutIcons()
     for i, btn in ipairs(allIcons) do
         btn:SetSize(sz, sz)
         btn:SetAlpha(p.opacity or 1.0)
+        if btn._alphaFromSecret then btn:SetAlphaFromBoolean(btn._alphaSecret, 0, 1) end
         EABR.SizeIconQuality(btn, sz)
         EABR.SizeIconBagCount(btn, sz)
         btn:ClearAllPoints()
@@ -3015,6 +3079,10 @@ end
 local function ShowIcon(iconIdx, m)
     local btn = GetOrCreateIcon(iconIdx)
     btn._dismissKey = m.dismissKey or nil
+    -- Stamped, not applied here: LayoutIcons rewrites alpha from the opacity
+    -- setting, so the secret has to win afterwards.
+    btn._alphaFromSecret = m.alphaFromSecret or nil
+    btn._alphaSecret = m.alphaSecret
     btn._petCycleTotal = m.petCycleTotal or nil
     -- Right-click is passed through to whatever's behind (e.g. camera drag)
     -- for every other reminder; only a multi-pet cycle button claims it.
@@ -3485,7 +3553,10 @@ local specialsActive = EABR.SectionShows(co.specialsWhereToShow, inInstance)
         -- Flask / Food: remind only when absence is verifiable (the checks
         -- suppress under combat/M+/restriction instead of false-firing).
         if co.enabled.flask and EABR.ConsumableShows(co, "flask", inInstance) then
-            if not PlayerHasFlaskBuff() then
+            -- Under restriction presence is unknowable, so the icon is always
+            -- emitted and its alpha is driven by the engine's answer instead.
+            local flaskSecretOk, flaskSecret = EABR.FlaskPresenceSecret()
+            if flaskSecretOk or not PlayerHasFlaskBuff() then
                 local rf = EABR._resolved.flask
                 local flaskItemID = rf.itemID
                 if flaskItemID and (co.showWithoutItem ~= false or rf.hasBags) then
@@ -3498,6 +3569,10 @@ local specialsActive = EABR.SectionShows(co.specialsWhereToShow, inInstance)
                     e.desaturated = not rf.hasBags
                     e.cat = "consumable"
                     e.dismissKey = "consumable:flask"
+                    if flaskSecretOk then
+                        e.alphaFromSecret = true
+                        e.alphaSecret = flaskSecret
+                    end
                     missing[#missing+1] = e
                 end
             end
@@ -4261,6 +4336,7 @@ local function BeaconLayoutIcons()
             for i, f in ipairs(visIcons) do
                 f:SetSize(sz, sz)
                 f:SetAlpha(p.opacity or 1.0)
+                if f._alphaFromSecret then f:SetAlphaFromBoolean(f._alphaSecret, 0, 1) end
                 f:SetFrameStrata("TOOLTIP")
                 f:SetFrameLevel(9980)
                 f:ClearAllPoints()

--- a/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
@@ -1281,14 +1281,14 @@ initFrame:SetScript("OnEvent", function(self)
         local timingRow
         timingRow, h = W:DualRow(parent, y,
             { type="slider", text="Show Below", min=0, max=60, step=1,
-              tooltip="Show reminders when remaining buff time is below this many minutes.\n0 = only when fully expired.\nIgnored in combat and during Mythic+ keys (then only when the buff is gone).",
+              tooltip="Show reminders when remaining buff time is below this many minutes.\n0 = only when fully expired.\nIgnored in combat and during Mythic+ keys (then only when the buff is gone) unless Show Below In Combat is on.",
               getValue=function() local d = DDB(); return d and d.showUnder or 5 end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.showUnder = v
                   RefreshAll()
               end },
             { type="slider", text="Show Below Pre-Key", min=0, max=60, step=1,
-              tooltip="Reminder threshold while you are in a dungeon before a Mythic+ key starts (Mythic 0 / keystone lobby). Set it high enough that you top up buffs and food before pulling, so you begin the key with enough duration to last it.\n0 = only when fully expired.\nIgnored once the key is active or you are in combat (then only when the buff is fully gone).",
+              tooltip="Reminder threshold while you are in a dungeon before a Mythic+ key starts (Mythic 0 / keystone lobby). Set it high enough that you top up buffs and food before pulling, so you begin the key with enough duration to last it.\n0 = only when fully expired.\nIgnored once the key is active or you are in combat (then only when the buff is fully gone) unless Show Below In Combat is on.",
               getValue=function() local d = DDB(); return d and d.showUnderMPlus or 40 end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.showUnderMPlus = v
@@ -1297,20 +1297,32 @@ initFrame:SetScript("OnEvent", function(self)
         );  y = y - h
         AddMinSuffix(timingRow, "Show Below", "Show Below Pre-Key")
 
-        -- Row 5: Show Tooltips | Opacity
+        -- Row 5: Show Below In Combat | Show Tooltips
         _, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Below In Combat",
+              tooltip="Apply the thresholds above while you are in combat and during an active Mythic+ key, instead of reminding only once a buff is fully gone.\nOff by default: reminders shown in combat cannot be clicked, so they are informational only.",
+              getValue=function() local d = DDB(); return d and d.showUnderInCombat == true end,
+              setValue=function(v)
+                  local d = DDB(); if not d then return end; d.showUnderInCombat = v
+                  RefreshAll()
+              end },
             { type="toggle", text="Show Tooltips",
               tooltip="Show item or spell tooltips when hovering reminder icons.",
               getValue=function() local d = DDB(); return not d or d.showTooltips ~= false end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.showTooltips = v
-              end },
+              end }
+        );  y = y - h
+
+        -- Row 6: Opacity (last row of the display section)
+        _, h = W:DualRow(parent, y,
             { type="slider", text="Opacity", min=0, max=1, step=0.05,
               getValue=function() local d = DDB(); return d and d.opacity or 1 end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.opacity = v
                   RefreshAll(); UpdatePreviewHeader()
-              end }
+              end },
+            { type="label", text="" }
         );  y = y - h
 
         _, h = W:Spacer(parent, y, 20);  y = y - h


### PR DESCRIPTION
## What does this PR do?

Requested by Kira: the flask reminder previously bailed out of every restricted context and reported "flask present", so it could never appear in combat or during a key.

Outside a key it now performs the check instead of bailing, so a missing flask reminds in combat. A new **Show Below In Combat** toggle (off by default) lets the existing Show Below thresholds apply in combat and in an active key, so a flask running out mid-fight reminds at the configured five minutes rather than only once it has gone.

Inside a keystone nothing about the player's own auras is readable, so the reminder is driven by the engine instead. An `AuraContainer` slot filtered to the flask spell IDs supplies a secret boolean, which is handed to `SetAlphaFromBoolean` with `alphaIfTrue` 0: the icon hides itself while the flask is up without this addon ever learning whether it is.

Two limits are inherent. It is binary in a key, because durations stay unreadable, so the threshold only applies outside one. And the icon holds its slot in the row while restricted whether or not it is visible.

## How was it tested?

Verified in a keystone: flask up and no icon, no flask and the icon shows, drinking a flask with the reminder up and watching it disappear. Verified in the open world that the existing behaviour and the threshold are unchanged.

## Screenshots

Behaviour change only; the icon is the existing flask reminder.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added

The presence container is built lazily on first use under restriction and only when the flask reminder is enabled, so a profile with it off builds no frames. The appear-sound is suppressed for engine-driven entries, since the addon cannot tell whether one is visible and would otherwise alert with the flask already up.