### PR TITLE
Add(Aura Buff Reminders): flask reminder in combat

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1479,18 +1479,28 @@ local function PlayerHasWellFed()
     return false
 end
 
--- Unlike the other consumables this one still answers under restriction: the
--- Midnight flask buffs are whitelisted, so the player's own aura reads back
--- plainly in combat and inside a key. The unwhitelisted legacy TWW IDs and the
--- name scan are unreadable there and sit out.
+-- Unlike the other consumables this one still answers under restriction: a
+-- flask buff reads back plainly for the player whenever the client reports that
+-- aura as non-secret, which the static whitelist only approximates --
+-- ShouldSpellAuraBeSecret is the authority, so an ID missing from the list (the
+-- legacy TWW flasks) is still read when the client allows it.
+-- Absence is only reported when every candidate ID was actually readable: a
+-- skipped ID means "unknown", and claiming the flask is missing off an
+-- incomplete scan is what put the reminder on screen mid-key with a flask up.
 local function PlayerHasFlaskBuff()
     if InPvPInstance() then return true end
     local restricted = EABR.ConsumablePresenceUnverifiable()
+    local unreadable = false
     -- Direct ID lookup for known flask buff IDs (zero allocation)
     for id in pairs(FLASK_BUFF_ID_SET) do
-        if not restricted or NON_SECRET_SPELL_IDS[id] then
+        if not restricted or NON_SECRET_SPELL_IDS[id] or _isRuntimeNonSecret(id) then
             local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
-            if ok and result ~= nil then
+            if not ok then
+                unreadable = true
+            elseif result ~= nil then
+                -- A secret result still means an aura came back: present, but
+                -- its duration cannot be inspected for the threshold.
+                if isSecret(result) then return true end
                 local dur, exp = result.duration, result.expirationTime
                 if dur ~= nil and exp ~= nil and not isSecret(dur) and not isSecret(exp)
                    and IsUnderDuration(dur, exp, "consumable") then
@@ -1498,6 +1508,8 @@ local function PlayerHasFlaskBuff()
                 end
                 return true
             end
+        else
+            unreadable = true
         end
     end
     -- Name-based fallback for flasks not in our ID set (lazy scan)
@@ -1507,6 +1519,7 @@ local function PlayerHasFlaskBuff()
             if FLASK_NAME_SET[aName] then return true end
         end
     end
+    if unreadable then return true end
     return false
 end
 

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -1484,11 +1484,12 @@ local function PlayerHasWellFed()
     return false
 end
 
--- Unlike the other consumables this one still answers under restriction: a
--- flask buff reads back plainly for the player whenever the client reports that
--- aura as non-secret, which the static whitelist only approximates --
--- ShouldSpellAuraBeSecret is the authority, so an ID missing from the list (the
--- legacy TWW flasks) is still read when the client allows it.
+-- Unlike the other consumables this one attempts the read under restriction
+-- instead of bailing outright, so a flask can be reported missing wherever the
+-- client still answers. Where it does not answer the reminder stays silent:
+-- inside a keystone GetPlayerAuraBySpellID returns nil for the player's own
+-- flask even though the ID is whitelisted and the buff is plainly up (verified
+-- in game 2026-09-04), so an empty read there proves nothing.
 local function PlayerHasFlaskBuff()
     if InPvPInstance() then return true end
     local restricted = EABR.ConsumablePresenceUnverifiable()
@@ -1516,6 +1517,9 @@ local function PlayerHasFlaskBuff()
             if FLASK_NAME_SET[aName] then return true end
         end
     end
+    -- Nothing found. Only meaningful where the reads answer at all: under
+    -- restriction an empty result is indistinguishable from an absent flask.
+    if restricted then return true end
     return false
 end
 

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -314,10 +314,13 @@ function EABR.GetShowUnderMinutes()
     return disp.showUnder or 5
 end
 
--- Thresholds apply everywhere except combat and active Mythic+ keys (there a
--- reminder means the buff is fully gone).
+-- Thresholds apply everywhere except combat and active Mythic+ keys, where a
+-- reminder means the buff is fully gone. "Show Below In Combat" opts back in.
 function EABR.ShowUnderThresholdApplies()
-    if InCombat() or InMythicPlusKey() then return false end
+    if InCombat() or InMythicPlusKey() then
+        local disp = db and db.profile and db.profile.display
+        return (disp and disp.showUnderInCombat) == true
+    end
     return true
 end
 
@@ -1476,23 +1479,29 @@ local function PlayerHasWellFed()
     return false
 end
 
+-- Unlike the other consumables this one still answers under restriction: the
+-- Midnight flask buffs are whitelisted, so the player's own aura reads back
+-- plainly in combat and inside a key. The unwhitelisted legacy TWW IDs and the
+-- name scan are unreadable there and sit out.
 local function PlayerHasFlaskBuff()
     if InPvPInstance() then return true end
-    if EABR.ConsumablePresenceUnverifiable() then return true end
+    local restricted = EABR.ConsumablePresenceUnverifiable()
     -- Direct ID lookup for known flask buff IDs (zero allocation)
     for id in pairs(FLASK_BUFF_ID_SET) do
-        local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
-        if ok and result ~= nil then
-            local dur, exp = result.duration, result.expirationTime
-            if dur ~= nil and exp ~= nil and not isSecret(dur) and not isSecret(exp)
-               and IsUnderDuration(dur, exp, "consumable") then
-                return false
+        if not restricted or NON_SECRET_SPELL_IDS[id] then
+            local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
+            if ok and result ~= nil then
+                local dur, exp = result.duration, result.expirationTime
+                if dur ~= nil and exp ~= nil and not isSecret(dur) and not isSecret(exp)
+                   and IsUnderDuration(dur, exp, "consumable") then
+                    return false
+                end
+                return true
             end
-            return true
         end
     end
     -- Name-based fallback for flasks not in our ID set (lazy scan)
-    if _AC.valid then
+    if not restricted and _AC.valid then
         _AC.ensureNames()
         for aName in pairs(_AC.byName) do
             if FLASK_NAME_SET[aName] then return true end
@@ -1855,10 +1864,12 @@ local defaults = {
             frameStrata = "MEDIUM",
             cursorAttach = false,
             -- Global timing pair (minutes). showUnderMPlus is the pre-key
-            -- (Mythic 0 / keystone lobby) threshold; active keys and combat
-            -- ignore thresholds entirely (only fully-missing reminds there).
+            -- (Mythic 0 / keystone lobby) threshold. Active keys and combat
+            -- ignore both (only fully-missing reminds there) until
+            -- showUnderInCombat opts back in.
             showUnder = 5,
             showUnderMPlus = 40,
+            showUnderInCombat = false,
         },
         raidBuffs = {
             enabled = {

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -326,6 +326,11 @@ end
 
 function EABR.IsUnderDuration(duration, expirationTime, sectionKey)
     if not (db and db.profile and duration and expirationTime and sectionKey) then return false end
+    -- Zero means "no timing info", the same sentinel GetEatingExpirationTime
+    -- rejects, not "about to expire": 0 - GetTime() is hugely negative and would
+    -- clear every threshold below. Restricted aura reads hand back a real
+    -- duration with the expiration withheld this way.
+    if duration <= 0 or expirationTime <= 0 then return false end
     if not EABR.ShowUnderThresholdApplies() then return false end
     local thresholdSeconds = EABR.GetShowUnderMinutes() * 60
     if thresholdSeconds > 0 and duration >= thresholdSeconds then
@@ -1484,20 +1489,14 @@ end
 -- aura as non-secret, which the static whitelist only approximates --
 -- ShouldSpellAuraBeSecret is the authority, so an ID missing from the list (the
 -- legacy TWW flasks) is still read when the client allows it.
--- Absence is only reported when every candidate ID was actually readable: a
--- skipped ID means "unknown", and claiming the flask is missing off an
--- incomplete scan is what put the reminder on screen mid-key with a flask up.
 local function PlayerHasFlaskBuff()
     if InPvPInstance() then return true end
     local restricted = EABR.ConsumablePresenceUnverifiable()
-    local unreadable = false
     -- Direct ID lookup for known flask buff IDs (zero allocation)
     for id in pairs(FLASK_BUFF_ID_SET) do
         if not restricted or NON_SECRET_SPELL_IDS[id] or _isRuntimeNonSecret(id) then
             local ok, result = pcall(C_UnitAuras.GetPlayerAuraBySpellID, id)
-            if not ok then
-                unreadable = true
-            elseif result ~= nil then
+            if ok and result ~= nil then
                 -- A secret result still means an aura came back: present, but
                 -- its duration cannot be inspected for the threshold.
                 if isSecret(result) then return true end
@@ -1508,8 +1507,6 @@ local function PlayerHasFlaskBuff()
                 end
                 return true
             end
-        else
-            unreadable = true
         end
     end
     -- Name-based fallback for flasks not in our ID set (lazy scan)
@@ -1519,7 +1516,6 @@ local function PlayerHasFlaskBuff()
             if FLASK_NAME_SET[aName] then return true end
         end
     end
-    if unreadable then return true end
     return false
 end
 

--- a/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
@@ -1281,14 +1281,14 @@ initFrame:SetScript("OnEvent", function(self)
         local timingRow
         timingRow, h = W:DualRow(parent, y,
             { type="slider", text="Show Below", min=0, max=60, step=1,
-              tooltip="Show reminders when remaining buff time is below this many minutes.\n0 = only when fully expired.\nIgnored in combat and during Mythic+ keys (then only when the buff is gone).",
+              tooltip="Show reminders when remaining buff time is below this many minutes.\n0 = only when fully expired.\nIgnored in combat and during Mythic+ keys (then only when the buff is gone) unless Show Below In Combat is on.",
               getValue=function() local d = DDB(); return d and d.showUnder or 5 end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.showUnder = v
                   RefreshAll()
               end },
             { type="slider", text="Show Below Pre-Key", min=0, max=60, step=1,
-              tooltip="Reminder threshold while you are in a dungeon before a Mythic+ key starts (Mythic 0 / keystone lobby). Set it high enough that you top up buffs and food before pulling, so you begin the key with enough duration to last it.\n0 = only when fully expired.\nIgnored once the key is active or you are in combat (then only when the buff is fully gone).",
+              tooltip="Reminder threshold while you are in a dungeon before a Mythic+ key starts (Mythic 0 / keystone lobby). Set it high enough that you top up buffs and food before pulling, so you begin the key with enough duration to last it.\n0 = only when fully expired.\nIgnored once the key is active or you are in combat (then only when the buff is fully gone) unless Show Below In Combat is on.",
               getValue=function() local d = DDB(); return d and d.showUnderMPlus or 40 end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.showUnderMPlus = v
@@ -1297,20 +1297,32 @@ initFrame:SetScript("OnEvent", function(self)
         );  y = y - h
         AddMinSuffix(timingRow, "Show Below", "Show Below Pre-Key")
 
-        -- Row 5: Show Tooltips | Opacity
+        -- Row 5: Show Below In Combat | Show Tooltips
         _, h = W:DualRow(parent, y,
+            { type="toggle", text="Show Below In Combat",
+              tooltip="Apply the thresholds above while you are in combat and during an active Mythic+ key, instead of reminding only once a buff is fully gone.\nOff by default: reminders shown in combat cannot be clicked, so they are informational only.",
+              getValue=function() local d = DDB(); return d and d.showUnderInCombat == true end,
+              setValue=function(v)
+                  local d = DDB(); if not d then return end; d.showUnderInCombat = v
+                  RefreshAll()
+              end },
             { type="toggle", text="Show Tooltips",
               tooltip="Show item or spell tooltips when hovering reminder icons.",
               getValue=function() local d = DDB(); return not d or d.showTooltips ~= false end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.showTooltips = v
-              end },
+              end }
+        );  y = y - h
+
+        -- Row 6: Opacity (last row of the display section)
+        _, h = W:DualRow(parent, y,
             { type="slider", text="Opacity", min=0, max=1, step=0.05,
               getValue=function() local d = DDB(); return d and d.opacity or 1 end,
               setValue=function(v)
                   local d = DDB(); if not d then return end; d.opacity = v
                   RefreshAll(); UpdatePreviewHeader()
-              end }
+              end },
+            { type="label", text="" }
         );  y = y - h
 
         _, h = W:Spacer(parent, y, 20);  y = y - h


### PR DESCRIPTION
## What does this PR do?

Requested by Kira. The flask check bailed out of every restricted context through `ConsumablePresenceUnverifiable` and reported "flask present", so the reminder could never appear in combat.

It now performs the read instead of bailing, so a missing flask reminds in combat wherever the client still answers. A new **Show Below In Combat** toggle (off by default) lets the existing Show Below thresholds apply in combat, so a flask running low reminds at the configured five minutes rather than only once it has gone.

Three correctness fixes came out of testing this. `ShouldSpellAuraBeSecret` is now the authority on whether an aura is readable rather than the hand-maintained whitelist. A zero `expirationTime` is treated as unknown rather than as about to expire: a restricted read hands back a real duration with the expiration withheld as 0, and `expirationTime - GetTime()` then clears every threshold, so a fresh one-hour flask read as seconds from expiring. That guard lives in the shared `IsUnderDuration`, so it covers food, weapon enchants, poisons and rites too. And an empty read no longer proves absence.

Scope note: inside a Mythic+ key the reminder stays silent. Verified in game that `GetPlayerAuraBySpellID` returns nil there for the player's own whitelisted flask while the buff is plainly up, the index scan errors, and `UNIT_AURA` is `SecretWhenAurasRestricted`. Nothing can distinguish "you have a flask" from "I cannot see", so silence is the only honest option rather than firing over an active flask.

## How was it tested?

Verified in game in combat outside a key, and in a key confirming the reminder does not fire over an active flask.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added