### PR TITLE
feat(qol): save signup notes across sessions

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -6389,7 +6389,12 @@ function EllesmereUI:ShowInputPopup(opts)
         popup._placeholder = placeholder
 
         editBox:SetScript("OnTextChanged", function(self)
-            if self:GetText() == "" then placeholder:Show() else placeholder:Hide() end
+            local text = self:GetText() or ""
+            if text == "" then placeholder:Show() else placeholder:Hide() end
+            if popup._maxCount then
+                local count = strlenutf8 and strlenutf8(text) or #text
+                popup._countLabel:SetText(count .. "/" .. popup._maxCount)
+            end
         end)
         popup._editBox = editBox
 
@@ -6510,8 +6515,9 @@ function EllesmereUI:ShowInputPopup(opts)
         WirePopupEscape(popup, dimmer)
 
         editBox:SetScript("OnEnterPressed", function()
+            if popup._multiline then return end
             local txt = editBox:GetText()
-            if txt and txt ~= "" then
+            if txt and (txt ~= "" or popup._allowEmpty) then
                 dimmer:Hide()
                 if popup._onConfirmCb then popup._onConfirmCb(txt) end
             else
@@ -6547,10 +6553,37 @@ function EllesmereUI:ShowInputPopup(opts)
     popup._confirmBtn._lbl:SetText(EllesmereUI.L(opts.confirmText or "Save"))
     popup._onCancel = opts.onDismiss or opts.onCancel or nil
     popup._onConfirmCb = opts.onConfirm or nil
+    popup._allowEmpty = opts.allowEmpty == true
+    popup._multiline = opts.multiline == true
 
     popup._editBox:SetMaxLetters(opts.maxLetters or 30)
+    popup._editBox:SetMultiLine(popup._multiline)
+    popup._editBox:SetJustifyV(popup._multiline and "TOP" or "MIDDLE")
+    popup._inputFrame:SetHeight(opts.inputHeight or 28)
+    popup._editBox:ClearAllPoints()
+    popup._editBox:SetPoint("TOPLEFT", popup._inputFrame, "TOPLEFT", 12, popup._multiline and -8 or -1)
+    popup._editBox:SetPoint("BOTTOMRIGHT", popup._inputFrame, "BOTTOMRIGHT", -12, opts.showCount and 18 or 1)
+    popup._placeholder:ClearAllPoints()
+    if popup._multiline then
+        popup._placeholder:SetPoint("TOPLEFT", popup._editBox, "TOPLEFT", 0, -1)
+    else
+        popup._placeholder:SetPoint("LEFT", popup._editBox, "LEFT", 0, 0)
+    end
+    if opts.showCount and not popup._countLabel then
+        local countLabel = MakeFont(popup._inputFrame, 9, nil, TEXT_DIM.r, TEXT_DIM.g, TEXT_DIM.b, TEXT_DIM.a)
+        countLabel:SetPoint("BOTTOMRIGHT", popup._inputFrame, "BOTTOMRIGHT", -8, 5)
+        popup._countLabel = countLabel
+    end
+    popup._maxCount = opts.showCount and (opts.maxLetters or 0) or nil
+    if popup._countLabel then
+        popup._countLabel:SetShown(popup._maxCount and popup._maxCount > 0)
+    end
     local initText = opts.initialText or ""
     popup._editBox:SetText(initText)
+    if popup._maxCount then
+        local count = strlenutf8 and strlenutf8(initText) or #initText
+        popup._countLabel:SetText(count .. "/" .. popup._maxCount)
+    end
     if initText == "" then popup._placeholder:Show() else popup._placeholder:Hide() end
 
     popup._cancelBtn._resetAnim()
@@ -6600,7 +6633,7 @@ function EllesmereUI:ShowInputPopup(opts)
         popup._scaleWarnLabel:Hide()
     end
 
-    popup:SetHeight(194 + extraH + warnH + scaleWarnH)
+    popup:SetHeight(194 + math.max(0, (opts.inputHeight or 28) - 28) + extraH + warnH + scaleWarnH)
 
     popup._cancelBtn:SetScript("OnClick", function()
         popup._dimmer:Hide()
@@ -6608,7 +6641,7 @@ function EllesmereUI:ShowInputPopup(opts)
     end)
     popup._confirmBtn:SetScript("OnClick", function()
         local txt = popup._editBox:GetText()
-        if txt and txt ~= "" then
+        if txt and (txt ~= "" or opts.allowEmpty) then
             popup._dimmer:Hide()
             if opts.onConfirm then opts.onConfirm(txt) end
         else

--- a/EllesmereUIOptions/EUI_QoL_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_Options.lua
@@ -2597,7 +2597,7 @@ initFrame:SetScript("OnEvent", function(self)
                   end
               end },
             { type="toggle", text="Persistent Signup Note",
-              tooltip="Keeps your note text in the Sign Up dialog instead of clearing it each time you open it.",
+              tooltip="Saves one signup note between reloads and relogs. In Group Finder, choose Copy, press Ctrl+C, then Ctrl+V.",
               getValue=function()
                   return EllesmereUIDB and EllesmereUIDB.persistSignupNote or false
               end,
@@ -2609,6 +2609,67 @@ initFrame:SetScript("OnEvent", function(self)
                   end
               end }
         );  y = y - h
+
+        if not EllesmereUI._prebuilding then
+            local rightRgn = quickSignupRow._rightRegion
+            local function persistOff()
+                return not (EllesmereUIDB and EllesmereUIDB.persistSignupNote)
+            end
+
+            local noteCogBtn = CreateFrame("Button", nil, rightRgn)
+            noteCogBtn:SetSize(26, 26)
+            noteCogBtn:SetPoint("RIGHT", rightRgn._lastInline or rightRgn._control, "LEFT", -9, 0)
+            rightRgn._lastInline = noteCogBtn
+            noteCogBtn:SetFrameLevel(rightRgn:GetFrameLevel() + 5)
+            noteCogBtn:SetAlpha(persistOff() and 0.15 or 0.4)
+            local noteCogTex = noteCogBtn:CreateTexture(nil, "OVERLAY")
+            noteCogTex:SetAllPoints()
+            noteCogTex:SetTexture(EllesmereUI.COGS_ICON)
+            noteCogBtn:SetScript("OnEnter", function(self)
+                self:SetAlpha(0.7)
+                EllesmereUI.ShowWidgetTooltip(self, "Edit the signup note saved between reloads and relogs.")
+            end)
+            noteCogBtn:SetScript("OnLeave", function(self)
+                self:SetAlpha(persistOff() and 0.15 or 0.4)
+                EllesmereUI.HideWidgetTooltip()
+            end)
+            noteCogBtn:SetScript("OnClick", function()
+                EllesmereUI:ShowInputPopup({
+                    title="Signup Note",
+                    message="Saved between reloads and relogs. In Group Finder, choose Copy, press Ctrl+C, then Ctrl+V.",
+                    placeholder="Enter signup note...",
+                    initialText=EllesmereUI.GetPersistentSignupNote
+                        and EllesmereUI.GetPersistentSignupNote() or "",
+                    maxLetters=63,
+                    inputHeight=70,
+                    multiline=true,
+                    showCount=true,
+                    allowEmpty=true,
+                    confirmText="Save",
+                    onConfirm=function(note)
+                        if EllesmereUI.SetPersistentSignupNote then
+                            EllesmereUI.SetPersistentSignupNote(note or "")
+                        end
+                    end,
+                })
+            end)
+
+            local noteCogBlock = CreateFrame("Frame", nil, noteCogBtn)
+            noteCogBlock:SetAllPoints()
+            noteCogBlock:SetFrameLevel(noteCogBtn:GetFrameLevel() + 10)
+            noteCogBlock:EnableMouse(true)
+            noteCogBlock:SetScript("OnEnter", function()
+                EllesmereUI.ShowWidgetTooltip(noteCogBtn, EllesmereUI.DisabledTooltip("Persistent Signup Note"))
+            end)
+            noteCogBlock:SetScript("OnLeave", function() EllesmereUI.HideWidgetTooltip() end)
+
+            EllesmereUI.RegisterWidgetRefresh(function()
+                local off = persistOff()
+                noteCogBtn:SetAlpha(off and 0.15 or 0.4)
+                if off then noteCogBlock:Show() else noteCogBlock:Hide() end
+            end)
+            if persistOff() then noteCogBlock:Show() else noteCogBlock:Hide() end
+        end
 
         _, h = W:Spacer(parent, y, 20);  y = y - h
 
@@ -2808,6 +2869,7 @@ initFrame:SetScript("OnEvent", function(self)
                 EllesmereUIDB.instanceResetAnnounceMsg = ""
                 EllesmereUIDB.quickSignup = false
                 EllesmereUIDB.persistSignupNote = false
+                EllesmereUIDB.signupNote = nil
                 EllesmereUIDB.ahCurrentExpansion = false
                 EllesmereUIDB.healthMacroEnabled = false
                 EllesmereUIDB.healthMacroPrio1 = 1

--- a/EllesmereUIOptions/EUI__General_Options.lua
+++ b/EllesmereUIOptions/EUI__General_Options.lua
@@ -4198,7 +4198,7 @@ initFrame:SetScript("OnEvent", function(self)
                             "trainAllButton", "ahCurrentExpansion", "quickLoot",
                             "autoFillDelete", "skipCinematics", "skipCinematicsAuto",
                             "autoInsertKeystone", "quickSignup",
-                            "persistSignupNote", "hideBlizzardPartyFrame",
+                            "persistSignupNote", "signupNote", "hideBlizzardPartyFrame",
                             "instanceResetAnnounce", "instanceResetAnnounceMsg",
                             "healthMacroEnabled", "healthMacroPrio1", "healthMacroPrio2",
                             "healthMacroPrio3", "foodMacroEnabled", "macroFactory",

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -1404,6 +1404,7 @@ qolFrame:SetScript("OnEvent", function(self)
     do
         local vanilla = LFGListApplicationDialog_Show
         local patched = false
+        local copyHooked = false
         local copyHelper
         local hidingCopyField = false
 
@@ -1445,6 +1446,7 @@ qolFrame:SetScript("OnEvent", function(self)
         end
 
         local function RefreshCopyHelper(dialog)
+            if not Enabled() or not dialog or not dialog:IsShown() then return end
             local description = dialog and dialog.Description
             local editBox = description and description.EditBox
             if not editBox then return end
@@ -1562,17 +1564,11 @@ qolFrame:SetScript("OnEvent", function(self)
                 end)
             end
             LFGListApplicationDialog_UpdateRoles(self)
-            RefreshCopyHelper(self)
             StaticPopupSpecial_Show(self)
         end
 
         EllesmereUI.GetPersistentSignupNote = function()
             return SavedNote()
-        end
-
-        EllesmereUI.SetPersistentSignupNote = function(note)
-            if not EllesmereUIDB then EllesmereUIDB = {} end
-            EllesmereUIDB.signupNote = LimitNote(note)
         end
 
         local function SyncPatch()
@@ -1581,13 +1577,27 @@ qolFrame:SetScript("OnEvent", function(self)
                     LFGListApplicationDialog_Show = PatchedShow
                     patched = true
                 end
+                -- PGF can replace the show function after login; the dialog hook survives it.
+                if LFGListApplicationDialog and not copyHooked then
+                    LFGListApplicationDialog:HookScript("OnShow", RefreshCopyHelper)
+                    copyHooked = true
+                end
+                RefreshCopyHelper(LFGListApplicationDialog)
             else
                 if patched then
-                    LFGListApplicationDialog_Show = vanilla
+                    if LFGListApplicationDialog_Show == PatchedShow then
+                        LFGListApplicationDialog_Show = vanilla
+                    end
                     patched = false
                 end
                 if copyHelper then copyHelper:Hide() end
             end
+        end
+
+        EllesmereUI.SetPersistentSignupNote = function(note)
+            if not EllesmereUIDB then EllesmereUIDB = {} end
+            EllesmereUIDB.signupNote = LimitNote(note)
+            SyncPatch()
         end
 
         EllesmereUI._applyPersistSignupNote = SyncPatch

--- a/EllesmereUIQoL/EllesmereUIQoL.lua
+++ b/EllesmereUIQoL/EllesmereUIQoL.lua
@@ -1404,6 +1404,143 @@ qolFrame:SetScript("OnEvent", function(self)
     do
         local vanilla = LFGListApplicationDialog_Show
         local patched = false
+        local copyHelper
+        local hidingCopyField = false
+
+        local function LimitNote(text)
+            if type(text) ~= "string" then return "" end
+            text = text:gsub("[\r\n]+", " ")
+            local bytes, position, count, last = #text, 1, 0, 0
+            while position <= bytes and count < 63 do
+                local byte = text:byte(position)
+                local width = byte < 128 and 1 or byte < 224 and 2 or byte < 240 and 3 or 4
+                if position + width - 1 > bytes then break end
+                last = position + width - 1
+                position = last + 1
+                count = count + 1
+            end
+            return text:sub(1, last)
+        end
+
+        local function SavedNote()
+            return LimitNote(EllesmereUIDB and EllesmereUIDB.signupNote)
+        end
+
+        local function Enabled()
+            return EllesmereUIDB and EllesmereUIDB.persistSignupNote
+        end
+
+        local function HideCopyField(focusTarget)
+            if not copyHelper then return end
+            copyHelper.buttonText:SetText(EllesmereUI.L("Copy"))
+            if copyHelper.copyBox:IsShown() then
+                hidingCopyField = true
+                copyHelper.copyBox:Hide()
+                copyHelper.copyBox:ClearFocus()
+                hidingCopyField = false
+            end
+            if focusTarget and copyHelper.targetEditBox then
+                copyHelper.targetEditBox:SetFocus()
+            end
+        end
+
+        local function RefreshCopyHelper(dialog)
+            local description = dialog and dialog.Description
+            local editBox = description and description.EditBox
+            if not editBox then return end
+            if SavedNote() == "" then
+                if copyHelper then copyHelper:Hide() end
+                return
+            end
+
+            if not copyHelper then
+                local EG = EllesmereUI.ELLESMERE_GREEN or { r = 0.05, g = 0.82, b = 0.62 }
+                local FONT = EllesmereUI.GetFontPath and EllesmereUI.GetFontPath("main")
+                    or EllesmereUI.EXPRESSWAY or "Fonts\\FRIZQT__.TTF"
+                local PP = EllesmereUI.PP
+
+                local helper = CreateFrame("Frame", nil, dialog)
+                helper:SetAllPoints(dialog)
+                helper:EnableMouse(false)
+
+                local button = CreateFrame("Button", nil, helper)
+                button:SetSize(42, 20)
+                button:SetPoint("LEFT", description, "RIGHT", 4, 0)
+                button:EnableMouse(true)
+
+                local buttonBg = button:CreateTexture(nil, "BACKGROUND")
+                buttonBg:SetAllPoints()
+                buttonBg:SetColorTexture(0.02, 0.03, 0.04, 0.92)
+                local buttonBorder = EllesmereUI.MakeBorder(button, EG.r, EG.g, EG.b, 0.72, PP)
+
+                local buttonText = button:CreateFontString(nil, "OVERLAY")
+                buttonText:SetFont(FONT, 9, "")
+                buttonText:SetPoint("CENTER", 0, 0)
+                buttonText:SetText(EllesmereUI.L("Copy"))
+                buttonText:SetTextColor(EG.r, EG.g, EG.b, 0.92)
+
+                local copyBox = CreateFrame("EditBox", nil, helper)
+                copyBox:SetPoint("TOPLEFT", description, "TOPLEFT", 0, 0)
+                copyBox:SetPoint("BOTTOMRIGHT", description, "BOTTOMRIGHT", 0, 0)
+                copyBox:SetAutoFocus(false)
+                copyBox:SetFont(FONT, 11, "")
+                copyBox:SetTextColor(1, 1, 1, 0.96)
+                copyBox:SetTextInsets(5, 5, 0, 0)
+                copyBox:SetJustifyH("LEFT")
+                copyBox:SetHighlightColor(EG.r, EG.g, EG.b, 0.45)
+                copyBox:EnableMouse(true)
+                local copyBg = copyBox:CreateTexture(nil, "BACKGROUND")
+                copyBg:SetAllPoints()
+                copyBg:SetColorTexture(0.02, 0.03, 0.04, 1)
+                EllesmereUI.MakeBorder(copyBox, EG.r, EG.g, EG.b, 0.9, PP)
+                copyBox:Hide()
+
+                copyBox:SetScript("OnEditFocusLost", function()
+                    if not hidingCopyField and not button:IsMouseOver() then
+                        HideCopyField(false)
+                    end
+                end)
+                copyBox:SetScript("OnKeyUp", function(_, key)
+                    if key == "C" and IsControlKeyDown() then
+                        HideCopyField(true)
+                    end
+                end)
+
+                button:SetScript("OnEnter", function()
+                    buttonBorder:SetColor(EG.r, EG.g, EG.b, 1)
+                    buttonText:SetTextColor(EG.r, EG.g, EG.b, 1)
+                end)
+                button:SetScript("OnLeave", function()
+                    buttonBorder:SetColor(EG.r, EG.g, EG.b, 0.72)
+                    buttonText:SetTextColor(EG.r, EG.g, EG.b, 0.92)
+                end)
+                button:SetScript("OnClick", function()
+                    if copyBox:IsShown() then
+                        HideCopyField(false)
+                        return
+                    end
+                    local note = SavedNote()
+                    if note == "" then return end
+                    copyBox:SetText(note)
+                    copyBox:Show()
+                    copyBox:SetFocus()
+                    copyBox:HighlightText()
+                    buttonText:SetText("Ctrl+C")
+                end)
+
+                helper.button = button
+                helper.buttonText = buttonText
+                helper.copyBox = copyBox
+                copyHelper = helper
+            end
+
+            copyHelper.targetEditBox = editBox
+            copyHelper:SetFrameLevel(dialog:GetFrameLevel() + 20)
+            copyHelper.button:SetFrameLevel(copyHelper:GetFrameLevel() + 1)
+            copyHelper.copyBox:SetFrameLevel(copyHelper:GetFrameLevel() + 2)
+            HideCopyField()
+            copyHelper:Show()
+        end
 
         local function PatchedShow(self, resultID)
             if resultID then
@@ -1425,11 +1562,21 @@ qolFrame:SetScript("OnEvent", function(self)
                 end)
             end
             LFGListApplicationDialog_UpdateRoles(self)
+            RefreshCopyHelper(self)
             StaticPopupSpecial_Show(self)
         end
 
+        EllesmereUI.GetPersistentSignupNote = function()
+            return SavedNote()
+        end
+
+        EllesmereUI.SetPersistentSignupNote = function(note)
+            if not EllesmereUIDB then EllesmereUIDB = {} end
+            EllesmereUIDB.signupNote = LimitNote(note)
+        end
+
         local function SyncPatch()
-            if EllesmereUIDB and EllesmereUIDB.persistSignupNote then
+            if Enabled() then
                 if not patched then
                     LFGListApplicationDialog_Show = PatchedShow
                     patched = true
@@ -1439,6 +1586,7 @@ qolFrame:SetScript("OnEvent", function(self)
                     LFGListApplicationDialog_Show = vanilla
                     patched = false
                 end
+                if copyHelper then copyHelper:Hide() end
             end
         end
 


### PR DESCRIPTION
## What does this PR do?

Adds a saved note of up to 63 characters to the existing **Persistent Signup Note** option. Edit it through the cog, then use **Copy → Ctrl+C → Ctrl+V** in the signup dialog. One-off edits do not overwrite the saved note.

Fixes the Copy button disappearing after relog when PGF persistence is also enabled. Works with PGF One Click Sign Up and EUI Quick Signup. The option stays off by default; an empty saved note shows no Copy button.

## How was it tested?

- **Retail 12.1.0.69587:** save, clear, copy/paste, and relog tested. Confirmed Copy appears with both persistence settings enabled.
- All 11 local Lua regression scenarios, Lua 5.1 syntax checks, locale checks, and `git diff --check` pass.
- `/euidev` and combat results: not reported.

## Screenshots

| Before copying | Ready for Ctrl+C | After pasting |
| --- | --- | --- |
| <img width="348" alt="Signup dialog with Copy button" src="https://github.com/user-attachments/assets/9d4dc568-9b55-4eae-9c2e-504435f6298b" /> | <img width="372" alt="Saved note selected" src="https://github.com/user-attachments/assets/05693291-db8b-4f9c-8c22-70d4fb1574d9" /> | <img width="353" alt="Note pasted into signup field" src="https://github.com/user-attachments/assets/a745e2ad-d475-4c35-a72c-f2fd9fc99dd6" /> |

<details>
<summary>Setting and editor</summary>

<img width="1080" alt="Persistent Signup Note setting and cog" src="https://github.com/user-attachments/assets/bcdd3d30-0b15-4583-a376-f7bd29168dd2" />

| Note editor | Tooltip |
| --- | --- |
| <img width="412" alt="63-character note editor" src="https://github.com/user-attachments/assets/8d7070c6-e2e9-4d41-8332-d33ad58f034b" /> | <img width="576" alt="Setting tooltip" src="https://github.com/user-attachments/assets/4252387d-6776-47fc-9f22-d538600f23b5" /> |

</details>

Screenshots show the unchanged UI before the PGF compatibility fix; relog behavior was confirmed separately.

## Checklist

- [x] Off by default; no behavior change without opt-in.
- [x] No hooks or frames before opt-in; installed hook returns immediately when disabled.
- [x] Event-driven; no polling, timers, or per-frame allocations.
- [x] Addon-owned helper; `HookScript` only on Blizzard frames. Existing upstream signup wrapper retained.
- [x] Tested on live; no version gates or older APIs added.
