### PR TITLE
Fix(Mythic+ Timer) timer texture bar clipping

### DIFF
--- a/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
+++ b/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
@@ -49,6 +49,66 @@ local function ApplyBarTexture(tex, texKey, r, g, b, a)
     end
 end
 
+-- One full physical pixel. ResourceBars can get away with half a pixel because a
+-- StatusBar clips its own fill texture tightly; our plain SetTexture fills (Melli
+-- etc.) bilinear-filter a full pixel past their rect. Half-px left a visible fringe
+-- past the border on the long continuous TICKS bar (SEGMENTS hid it better between
+-- per-segment borders). Solid ColorTexture bars don't need this; same inset is
+-- harmless and keeps timer/forces paths identical.
+local function GetBarBleedInset(p, forForces)
+    if not p or p.customBorderStyle ~= true then return 0 end
+    if (p.borderSize or 0) <= 0 then return 0 end
+    if forForces and p.borderApplyToForces == false then return 0 end
+    local PP = EllesmereUI and EllesmereUI.PP
+    return (PP and PP.mult or 1) * 1
+end
+
+-- Outer host = border/geometry anchor. Inner clip = bg+fill parent, inset so the
+-- texture cannot sample past the border. Host clips its children so any residual
+-- filter fringe from the clip's textures is still cut off at the host edge
+-- (SetClipsChildren only affects child frames, not a frame's own textures — so the
+-- fill must live on `clip`, not on `host`).
+local function EnsureBarShell(parent, hostKey)
+    local host = parent[hostKey]
+    if host then
+        -- Re-assert: shells created before the TICKS bleed fix may lack this.
+        host:SetClipsChildren(true)
+        return host, host._clip
+    end
+    host = CreateFrame("Frame", nil, parent)
+    host:EnableMouse(false)
+    -- Clip child rendering (the inset `clip` frame + its textures' filter fringe)
+    -- to the host rect so nothing paints past the border's outer edge.
+    host:SetClipsChildren(true)
+    local clip = CreateFrame("Frame", nil, host)
+    clip:EnableMouse(false)
+    host._clip = clip
+    parent[hostKey] = host
+    return host, clip
+end
+
+local function LayoutBarClip(host, clip, inset)
+    clip:ClearAllPoints()
+    if inset > 0 then
+        clip:SetPoint("TOPLEFT", host, "TOPLEFT", inset, -inset)
+        clip:SetPoint("BOTTOMRIGHT", host, "BOTTOMRIGHT", -inset, inset)
+    else
+        clip:SetAllPoints(host)
+    end
+end
+
+-- Build (or reuse) bg+fill textures as children of clip so host clipping applies.
+local function EnsureShellTextures(clip, owner, bgKey, fillKey)
+    if not owner[bgKey] then
+        owner[bgKey] = clip:CreateTexture(nil, "BACKGROUND", nil, 1)
+        owner[bgKey]:SetAllPoints(clip)
+    end
+    if not owner[fillKey] then
+        owner[fillKey] = clip:CreateTexture(nil, "ARTWORK")
+    end
+    return owner[bgKey], owner[fillKey]
+end
+
 local CopyTable = EllesmereUI.Lite.DeepCopy
 
 
@@ -1066,10 +1126,16 @@ local unlockLayoutActive = false -- force preview layout while Unlock Mode is op
 --   - "solid"           -> PP 4-strip system (as everywhere else in the addon)
 --   - any other key     -> textured BackdropTemplate border (Glow, Blizzard,
 --                          Lightspark, SharedMedia, ...)
--- ApplyBorderStyle needs a frame WE own ("borderFrame"). The bars ("_barBg",
--- "_enemyBarBg", segments in "_timerSegBgs") are only textures, so we give each
--- bar a slim carrier frame that sits exactly over its texture (SetAllPoints)
--- and hand THAT frame to ApplyBorderStyle.
+-- ApplyBorderStyle needs a frame WE own ("borderFrame"). Bar shells ("_barHost",
+-- "_enemyBarHost", "_timerSegHosts") are the outer geometry anchors; each holds
+-- an inset clip child for the bg/fill textures so textured fills cannot bleed
+-- past the border (see GetBarBleedInset / EnsureBarShell).
+--
+-- Border carrier is parented to the STANDALONE frame (not the host): the host
+-- uses SetClipsChildren to cut fill fringe, which would also clip an outward
+-- textured border if the border lived inside the host. Frame level is raised
+-- above the host's tick layer every apply so the continuous TICKS fill cannot
+-- paint over the border strips.
 local function ApplyBorderTo(parent, anchor, key, p, size, texKey, r, g, b, a)
     if not parent or not anchor then
         return
@@ -1085,7 +1151,6 @@ local function ApplyBorderTo(parent, anchor, key, p, size, texKey, r, g, b, a)
     if not bf then
         bf = CreateFrame("Frame", nil, parent)
         bf:EnableMouse(false)
-        bf:SetFrameLevel(parent:GetFrameLevel() + 10)
         -- Clip every border (including textured styles with an outward
         -- offsetX/offsetY, e.g. Glow/Blizzard) strictly to the area of "bf"
         -- (== the bar/segment). Without this, textured border styles spill past
@@ -1097,6 +1162,12 @@ local function ApplyBorderTo(parent, anchor, key, p, size, texKey, r, g, b, a)
 
     bf:ClearAllPoints()
     bf:SetAllPoints(anchor)
+    -- Always re-assert above the bar host tree (clip + tick layer). A one-time
+    -- level at create time can lose to a later tick-layer bump on the continuous
+    -- TICKS bar, letting the melli fill paint over the border.
+    local anchorLevel = anchor.GetFrameLevel and anchor:GetFrameLevel() or 0
+    local parentLevel = parent.GetFrameLevel and parent:GetFrameLevel() or 0
+    bf:SetFrameLevel(max(parentLevel + 10, anchorLevel + 20))
 
     if size <= 0 or not anchor:IsShown() then
         bf:Hide()
@@ -1111,6 +1182,14 @@ local function ApplyBorderTo(parent, anchor, key, p, size, texKey, r, g, b, a)
         p.borderTextureShiftX, p.borderTextureShiftY,
         "MythicPlus", size
     )
+    -- PP strip container keeps an absolute level from create time; bump it with
+    -- the carrier or the strips can sit under the TICKS tick layer while the
+    -- empty carrier frame alone is "above".
+    local PP = EllesmereUI and EllesmereUI.PP
+    local edges = PP and PP.GetBorders and PP.GetBorders(bf)
+    if edges then
+        edges:SetFrameLevel(bf:GetFrameLevel() + 1)
+    end
 end
 
 ns.ApplyBorder = function()
@@ -1132,26 +1211,34 @@ ns.ApplyBorder = function()
     local texKey = p.borderTexture or "solid"
     local r, g, b, a = p.borderR or 0, p.borderG or 0, p.borderB or 0, p.borderA or 1
 
-    -- Main timer bar. In SEGMENTS mode "_barBg" is only an invisible (Alpha 0) but
-    -- still :IsShown() texture that spans the ENTIRE bar width (including the gaps
-    -- between segments). Bordering it here would draw a border line in the gaps too
-    -- (left/right is hidden by the adjacent segment border, top/bottom is not), so in
-    -- SEGMENTS mode the main border is disabled here; the individual segment borders
-    -- below draw the complete outline.
+    -- Main timer bar. In SEGMENTS mode "_barHost" is only a layout spacer that
+    -- spans the ENTIRE bar width (including the gaps between segments). Bordering
+    -- it here would draw a border line in the gaps too (left/right is hidden by
+    -- the adjacent segment border, top/bottom is not), so in SEGMENTS mode the
+    -- main border is disabled here; the individual segment borders below draw
+    -- the complete outline.
     local isSegmented = (p.timerBarStyle == "SEGMENTS")
+    local barAnchor = f._barHost or f._barBg
     if isSegmented then
-        ApplyBorderTo(f, f._barBg, "_emtBarBorderFrame", p, 0, texKey, r, g, b, a)
+        ApplyBorderTo(f, barAnchor, "_emtBarBorderFrame", p, 0, texKey, r, g, b, a)
     else
-        ApplyBorderTo(f, f._barBg, "_emtBarBorderFrame", p, size, texKey, r, g, b, a)
+        ApplyBorderTo(f, barAnchor, "_emtBarBorderFrame", p, size, texKey, r, g, b, a)
     end
 
     -- Forces bar (skipped when "Apply to Forces Bar" is off in the border cog).
     local forcesSize = size
     if p.borderApplyToForces == false then forcesSize = 0 end
-    ApplyBorderTo(f, f._enemyBarBg, "_emtEnemyBorderFrame", p, forcesSize, texKey, r, g, b, a)
+    ApplyBorderTo(f, f._enemyBarHost or f._enemyBarBg, "_emtEnemyBorderFrame", p, forcesSize, texKey, r, g, b, a)
 
-    -- Segment bars (timer bar SEGMENTS mode)
-    if f._timerSegBgs then
+    -- Segment bars (timer bar SEGMENTS mode) — border each segment host.
+    if f._timerSegHosts then
+        for i, host in ipairs(f._timerSegHosts) do
+            local segSize = isSegmented and size or 0
+            ApplyBorderTo(f, host, "_emtSegBorderFrame" .. i, p, segSize, texKey, r, g, b, a)
+        end
+    elseif f._timerSegBgs then
+        -- Legacy texture-only segments (pre-shell); keep border working if hosts
+        -- were never built this session.
         for i, seg in ipairs(f._timerSegBgs) do
             local segSize = isSegmented and size or 0
             ApplyBorderTo(f, seg, "_emtSegBorderFrame" .. i, p, segSize, texKey, r, g, b, a)
@@ -1374,10 +1461,18 @@ local function CreateStandaloneFrame()
     f._timerDetailFS = f:CreateFontString(nil, "OVERLAY")
     f._timerDetailFS:SetWordWrap(false)
     f._timerDetailFS:SetNonSpaceWrap(false)
-    f._barBg = f:CreateTexture(nil, "BACKGROUND", nil, 1)
-    f._barFill = f:CreateTexture(nil, "ARTWORK")
-    f._seg3 = f:CreateTexture(nil, "OVERLAY")
-    f._seg2 = f:CreateTexture(nil, "OVERLAY")
+    -- Timer bar shell: outer host is the border/geometry anchor; inset clip holds
+    -- bg+fill so textured fills (Melli etc.) cannot bleed past the border.
+    -- Tick markers sit on a sibling layer ABOVE the clip frame (child frames draw
+    -- after parent textures, so ticks cannot live on the host itself).
+    local barHost, barClip = EnsureBarShell(f, "_barHost")
+    f._barBg, f._barFill = EnsureShellTextures(barClip, f, "_barBg", "_barFill")
+    f._barTickLayer = CreateFrame("Frame", nil, barHost)
+    f._barTickLayer:SetAllPoints(barHost)
+    f._barTickLayer:EnableMouse(false)
+    f._barTickLayer:SetFrameLevel(barClip:GetFrameLevel() + 2)
+    f._seg3 = f._barTickLayer:CreateTexture(nil, "OVERLAY")
+    f._seg2 = f._barTickLayer:CreateTexture(nil, "OVERLAY")
     f._threshFS = f:CreateFontString(nil, "OVERLAY")
     f._threshFS:SetParent(f._emtTextLayer)
     f._threshFS:SetWordWrap(false)
@@ -1497,8 +1592,8 @@ local function CreateStandaloneFrame()
     f._enemyFS = f:CreateFontString(nil, "OVERLAY")
     f._enemyFS:SetParent(f._emtTextLayer)
     f._enemyFS:SetWordWrap(false)
-    f._enemyBarBg = f:CreateTexture(nil, "BACKGROUND", nil, 1)
-    f._enemyBarFill = f:CreateTexture(nil, "ARTWORK")
+    local enemyHost, enemyClip = EnsureBarShell(f, "_enemyBarHost")
+    f._enemyBarBg, f._enemyBarFill = EnsureShellTextures(enemyClip, f, "_enemyBarBg", "_enemyBarFill")
     f._previewFS = f:CreateFontString(nil, "OVERLAY")
     f._previewFS:SetWordWrap(false)
 
@@ -1823,9 +1918,9 @@ local function RenderStandalone()
             local segmentGap = segmentedThresholds and max(0, p.timerBarSegmentGap or 2) or 0
             local plusThreeLabelX = max(0, min(_barW_for_thresh, _barW_for_thresh * (plusThreeT / maxTime) - segmentGap / 2))
             local plusTwoLabelX = max(0, min(_barW_for_thresh, _barW_for_thresh * (plusTwoT / maxTime) - segmentGap / 2))
-            local thresholdAnchorBar = f._barBg
+            local thresholdAnchorBar = f._barHost or f._barBg
             if underBarMode and p.showTimerBar == false and p.showEnemyBar ~= false then
-                thresholdAnchorBar = f._enemyBarBg
+                thresholdAnchorBar = f._enemyBarHost or f._enemyBarBg
             end
 
             -- Anchor a FontString at bar-local x = cx in the threshold row.
@@ -2001,6 +2096,7 @@ local function RenderStandalone()
     local function RenderEnemyForces()
         if p.showEnemyBar == false then
             f._enemyFS:Hide()
+            if f._enemyBarHost then f._enemyBarHost:Hide() end
             f._enemyBarBg:Hide()
             f._enemyBarFill:Hide()
             if f._enemyBarText then f._enemyBarText:Hide() end
@@ -2016,7 +2112,9 @@ local function RenderStandalone()
             end
         end
         if not enemyObj then
-            f._enemyFS:Hide(); f._enemyBarBg:Hide(); f._enemyBarFill:Hide()
+            f._enemyFS:Hide()
+            if f._enemyBarHost then f._enemyBarHost:Hide() end
+            f._enemyBarBg:Hide(); f._enemyBarFill:Hide()
             if f._enemyBarText then f._enemyBarText:Hide() end
             return
         end
@@ -2059,16 +2157,22 @@ local function RenderStandalone()
             local besideRoom = (not enemyObj.completed and pctPos == "BESIDE") and 62 or 0
             local barW = math.min(p.barWidth or 210, innerW - TBAR_PAD * 2) - besideRoom
             if barW < 60 then barW = 60 end
-            f._enemyBarBg:ClearAllPoints()
+            local enemyHost, enemyClip = EnsureBarShell(f, "_enemyBarHost")
+            EnsureShellTextures(enemyClip, f, "_enemyBarBg", "_enemyBarFill")
+            local eInset = GetBarBleedInset(p, true)
+            enemyHost:ClearAllPoints()
             if objAlign == "RIGHT" then
-                f._enemyBarBg:SetPoint("TOPRIGHT", f, "TOPRIGHT", -(PAD + TBAR_PAD), y)
+                enemyHost:SetPoint("TOPRIGHT", f, "TOPRIGHT", -(PAD + TBAR_PAD), y)
             elseif objAlign == "CENTER" then
-                f._enemyBarBg:SetPoint("TOP", f, "TOP", 0, y)
+                enemyHost:SetPoint("TOP", f, "TOP", 0, y)
             else
-                f._enemyBarBg:SetPoint("TOPLEFT", f, "TOPLEFT", PAD + TBAR_PAD, y)
+                enemyHost:SetPoint("TOPLEFT", f, "TOPLEFT", PAD + TBAR_PAD, y)
             end
-            f._enemyBarBg:SetSize(barW, ENEMY_BAR_H)
+            enemyHost:SetSize(barW, ENEMY_BAR_H)
+            LayoutBarClip(enemyHost, enemyClip, eInset)
+            enemyHost:Show()
             ApplyBarTexture(f._enemyBarBg, p.enemyBarBgTexture, 0.12, 0.12, 0.12, 0.9)
+            f._enemyBarBg:SetAllPoints(enemyClip)
             f._enemyBarBg:Show()
 
             local eR, eG, eB
@@ -2081,10 +2185,12 @@ local function RenderStandalone()
             end
 
             local epct = enemyObj.completed and 1 or min(1, max(0, pctRaw / 100))
-            local eFillW = max(1, barW * epct)
+            local clipW = max(1, barW - eInset * 2)
+            local clipH = max(1, ENEMY_BAR_H - eInset * 2)
+            local eFillW = max(1, clipW * epct)
             f._enemyBarFill:ClearAllPoints()
-            f._enemyBarFill:SetPoint("TOPLEFT", f._enemyBarBg, "TOPLEFT", 0, 0)
-            f._enemyBarFill:SetSize(eFillW, ENEMY_BAR_H)
+            f._enemyBarFill:SetPoint("TOPLEFT", enemyClip, "TOPLEFT", 0, 0)
+            f._enemyBarFill:SetSize(eFillW, clipH)
             ApplyBarTexture(f._enemyBarFill, p.enemyBarTexture, eR, eG, eB, 0.8)
             f._enemyBarFill:Show()
 
@@ -2101,7 +2207,7 @@ local function RenderStandalone()
                 f._enemyBarText:SetTextColor(1, 1, 1)
                 f._enemyBarText:SetText(FormatEnemyForcesText(enemyObj, enemyTextFormat, true))
                 f._enemyBarText:ClearAllPoints()
-                f._enemyBarText:SetPoint("CENTER", f._enemyBarBg, "CENTER", 0, 0)
+                f._enemyBarText:SetPoint("CENTER", enemyHost, "CENTER", 0, 0)
                 f._enemyBarText:Show()
             elseif pctPos == "BESIDE" then
                 SetFS(f._enemyBarText, enemyTextSize)
@@ -2114,9 +2220,9 @@ local function RenderStandalone()
                 f._enemyBarText:SetText(FormatEnemyForcesText(enemyObj, enemyTextFormat, true))
                 f._enemyBarText:ClearAllPoints()
                 if objAlign == "RIGHT" then
-                    f._enemyBarText:SetPoint("RIGHT", f._enemyBarBg, "LEFT", -4, 0)
+                    f._enemyBarText:SetPoint("RIGHT", enemyHost, "LEFT", -4, 0)
                 else
-                    f._enemyBarText:SetPoint("LEFT", f._enemyBarBg, "RIGHT", 4, 0)
+                    f._enemyBarText:SetPoint("LEFT", enemyHost, "RIGHT", 4, 0)
                 end
                 f._enemyBarText:Show()
             else
@@ -2342,25 +2448,34 @@ local function RenderStandalone()
         local barW = math.min(p.barWidth or 210, innerW - TBAR_PAD * 2)
         if barW < 60 then barW = 60 end
 
-        f._barBg:ClearAllPoints()
+        local barHost, barClip = EnsureBarShell(f, "_barHost")
+        EnsureShellTextures(barClip, f, "_barBg", "_barFill")
+        local barInset = GetBarBleedInset(p, false)
+        barHost:ClearAllPoints()
         local _barAlign = _ra(p.timerAlign or "CENTER")
         if _barAlign == "RIGHT" then
-            f._barBg:SetPoint("TOPRIGHT", f, "TOPRIGHT", -(PAD + TBAR_PAD), y)
+            barHost:SetPoint("TOPRIGHT", f, "TOPRIGHT", -(PAD + TBAR_PAD), y)
         elseif _barAlign == "LEFT" then
-            f._barBg:SetPoint("TOPLEFT", f, "TOPLEFT", PAD + TBAR_PAD, y)
+            barHost:SetPoint("TOPLEFT", f, "TOPLEFT", PAD + TBAR_PAD, y)
         else
-            f._barBg:SetPoint("TOP", f, "TOP", 0, y)
+            barHost:SetPoint("TOP", f, "TOP", 0, y)
         end
-        f._barBg:SetSize(barW, TBAR_H)
+        barHost:SetSize(barW, TBAR_H)
+        LayoutBarClip(barHost, barClip, barInset)
+        barHost:Show()
+
+        local clipW = max(1, barW - barInset * 2)
+        local clipH = max(1, TBAR_H - barInset * 2)
         ApplyBarTexture(f._barBg, p.barBgTexture, 0.12, 0.12, 0.12, 0.9)
+        f._barBg:SetAllPoints(barClip)
         f._barBg:SetAlpha(1)
         f._barBg:Show()
 
         local fillPct = min(1, elapsed / maxTime)
-        local fillW = max(1, barW * fillPct)
+        local fillW = max(1, clipW * fillPct)
         f._barFill:ClearAllPoints()
-        f._barFill:SetPoint("TOPLEFT", f._barBg, "TOPLEFT", 0, 0)
-        f._barFill:SetSize(fillW, TBAR_H)
+        f._barFill:SetPoint("TOPLEFT", barClip, "TOPLEFT", 0, 0)
+        f._barFill:SetSize(fillW, clipH)
         local _fillA = p.timerInBar and (p.barFillAlphaExpanded or 0.85) or 0.85
         ApplyBarTexture(f._barFill, p.barTexture, timerBarR, timerBarG, timerBarB, _fillA)
         f._barFill:Show()
@@ -2372,6 +2487,9 @@ local function RenderStandalone()
         local function _snap(v) return _PP and _PP.SnapForES(v, _es) or v end
 
         local function HideTimerSegments()
+            if f._timerSegHosts then
+                for _, host in ipairs(f._timerSegHosts) do host:Hide() end
+            end
             if f._timerSegBgs then
                 for _, tex in ipairs(f._timerSegBgs) do tex:Hide() end
             end
@@ -2381,14 +2499,25 @@ local function RenderStandalone()
         end
 
         local function EnsureTimerSegments()
+            f._timerSegHosts = f._timerSegHosts or {}
             f._timerSegBgs = f._timerSegBgs or {}
             f._timerSegFills = f._timerSegFills or {}
             for i = 1, 3 do
-                if not f._timerSegBgs[i] then
-                    f._timerSegBgs[i] = f:CreateTexture(nil, "BACKGROUND", nil, 1)
-                end
-                if not f._timerSegFills[i] then
-                    f._timerSegFills[i] = f:CreateTexture(nil, "ARTWORK")
+                if not f._timerSegHosts[i] then
+                    -- Per-segment shell so each segment border can clip its own
+                    -- melli fill without a shared outer border spanning the gaps.
+                    local host = CreateFrame("Frame", nil, f)
+                    host:EnableMouse(false)
+                    host:SetClipsChildren(true)
+                    local clip = CreateFrame("Frame", nil, host)
+                    clip:EnableMouse(false)
+                    host._clip = clip
+                    f._timerSegHosts[i] = host
+                    f._timerSegBgs[i] = clip:CreateTexture(nil, "BACKGROUND", nil, 1)
+                    f._timerSegBgs[i]:SetAllPoints(clip)
+                    f._timerSegFills[i] = clip:CreateTexture(nil, "ARTWORK")
+                else
+                    f._timerSegHosts[i]:SetClipsChildren(true)
                 end
             end
         end
@@ -2396,6 +2525,8 @@ local function RenderStandalone()
         local barStyle = p.timerBarStyle or "TICKS"
         if barStyle == "SEGMENTS" then
             EnsureTimerSegments()
+            -- Host stays shown as the layout spacer for ticks/thresholds; hide
+            -- the continuous fill path so only the three segment shells draw.
             f._barBg:SetAlpha(0)
             f._barFill:Hide()
             f._seg3:Hide()
@@ -2421,19 +2552,27 @@ local function RenderStandalone()
                 local w = x2v - x1
                 if w < 1 then w = 1 end
 
+                local host = f._timerSegHosts[i]
+                local clip = host._clip
+                host:ClearAllPoints()
+                host:SetPoint("TOPLEFT", barHost, "TOPLEFT", x1, 0)
+                host:SetSize(w, TBAR_H)
+                LayoutBarClip(host, clip, barInset)
+                host:Show()
+
                 local bg = f._timerSegBgs[i]
-                bg:ClearAllPoints()
-                bg:SetPoint("TOPLEFT", f._barBg, "TOPLEFT", x1, 0)
-                bg:SetSize(w, TBAR_H)
+                bg:SetAllPoints(clip)
                 ApplyBarTexture(bg, p.barBgTexture, 0.12, 0.12, 0.12, 0.9)
                 bg:Show()
 
                 local segDur = max(1, seg.t2 - seg.t1)
                 local segPct = min(1, max(0, (elapsed - seg.t1) / segDur))
+                local segClipW = max(1, w - barInset * 2)
+                local segClipH = max(1, TBAR_H - barInset * 2)
                 local fill = f._timerSegFills[i]
                 fill:ClearAllPoints()
-                fill:SetPoint("TOPLEFT", bg, "TOPLEFT", 0, 0)
-                fill:SetSize(max(1, w * segPct), TBAR_H)
+                fill:SetPoint("TOPLEFT", clip, "TOPLEFT", 0, 0)
+                fill:SetSize(max(1, segClipW * segPct), segClipH)
                 ApplyBarTexture(fill, p.barTexture, timerBarR, timerBarG, timerBarB, _fillA)
                 if segPct > 0 then fill:Show() else fill:Hide() end
             end
@@ -2449,9 +2588,15 @@ local function RenderStandalone()
             f._seg3:Hide()
             f._seg2:Hide()
         else
+            -- Ticks sit in the inset clip band so they cannot stick past the
+            -- border the way a full-height mark on the outer host edge would.
+            if f._barTickLayer then
+                f._barTickLayer:SetFrameLevel(barClip:GetFrameLevel() + 2)
+            end
             f._seg3:ClearAllPoints()
-            f._seg3:SetSize(_tickW, TBAR_H)
-            f._seg3:SetPoint("TOPLEFT", f._barBg, "TOPLEFT", _snap(barW * (plusThreeT / maxTime)) - _tickW / 2, 0)
+            f._seg3:SetSize(_tickW, clipH)
+            f._seg3:SetPoint("TOPLEFT", barHost, "TOPLEFT",
+                _snap(barW * (plusThreeT / maxTime)) - _tickW / 2, -barInset)
             if p.timerTickColor or whiteTicks or elapsed > plusThreeT then
                 f._seg3:SetColorTexture(tickR, tickG, tickB, tickA)
             else
@@ -2460,8 +2605,9 @@ local function RenderStandalone()
             f._seg3:Show()
 
             f._seg2:ClearAllPoints()
-            f._seg2:SetSize(_tickW, TBAR_H)
-            f._seg2:SetPoint("TOPLEFT", f._barBg, "TOPLEFT", _snap(barW * (plusTwoT / maxTime)) - _tickW / 2, 0)
+            f._seg2:SetSize(_tickW, clipH)
+            f._seg2:SetPoint("TOPLEFT", barHost, "TOPLEFT",
+                _snap(barW * (plusTwoT / maxTime)) - _tickW / 2, -barInset)
             if p.timerTickColor or whiteTicks or elapsed > plusTwoT then
                 f._seg2:SetColorTexture(tickR, tickG, tickB, tickA)
             else
@@ -2496,9 +2642,9 @@ local function RenderStandalone()
             SetTextDiff(f._barTimerFS, barTimerText)
             f._barTimerFS:ClearAllPoints()
             if p.timerInBarLeftText then
-                f._barTimerFS:SetPoint("LEFT", f._barBg, "LEFT", 5, 0)
+                f._barTimerFS:SetPoint("LEFT", barHost, "LEFT", 5, 0)
             else
-                f._barTimerFS:SetPoint("CENTER", f._barBg, "CENTER", 0, 0)
+                f._barTimerFS:SetPoint("CENTER", barHost, "CENTER", 0, 0)
             end
             f._barTimerFS:Show()
         elseif f._barTimerFS then
@@ -2507,8 +2653,12 @@ local function RenderStandalone()
 
         y = y - TBAR_H - ROW_GAP - 2
     else
+        if f._barHost then f._barHost:Hide() end
         f._barBg:Hide(); f._barFill:Hide()
         f._seg3:Hide(); f._seg2:Hide()
+        if f._timerSegHosts then
+            for _, host in ipairs(f._timerSegHosts) do host:Hide() end
+        end
         if f._timerSegBgs then
             for _, tex in ipairs(f._timerSegBgs) do tex:Hide() end
         end
@@ -3016,4 +3166,3 @@ function EMT:OnEnable()
         })
     end
 end
-


### PR DESCRIPTION
<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Fixes the Mythic+ timer bar texture bleeding under the border (when border is enabled)

## How was it tested?

Game version: Retail 12.1.0.69587

Verified functionality with/without borders enabled, and with "Gaps" and "Ticks" mode enabled.

## Screenshots

### Before:
<img width="496" height="553" alt="Screenshot_20260904_202542" src="https://github.com/user-attachments/assets/57e1fa13-a46d-45d5-bf4f-c6bf8af19959" />

### After:
<img width="394" height="425" alt="Screenshot_20260904_210046" src="https://github.com/user-attachments/assets/1a57b9c5-e78b-4478-a634-9a95a5da95a5" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [N/A] New settings default **OFF** (no behavior change without opt-in)
- [N/A] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [N/A] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [X] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [X] Tested in-game on live; no version gates or pre-Midnight APIs added
