### PR TITLE
Fix(Action Bars): Lua error during delve vehicle combat from cooldown-event taint

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -967,12 +967,16 @@ end
 if ActionBarButtonEventsFrame then ActionBarButtonEventsFrame:UnregisterAllEvents() end
 if ActionBarActionEventsFrame then ActionBarActionEventsFrame:UnregisterAllEvents() end
 do
+    -- ACTIONBAR_UPDATE_COOLDOWN/SPELL_UPDATE_COOLDOWN are deliberately absent:
+    -- Blizzard's dispatch for those runs ActionButton_UpdateCooldown -> SetCooldown,
+    -- the secret-cooldown-under-taint chain already fixed for our own buttons (see
+    -- QuietlyHideBlizzButton's OnShow hook), and registering their shared frame left
+    -- the native call stack tainted for the rest of the tick (ObjectiveTracker
+    -- included). Reproduced in vehicle combat. barFrame below listens instead and
+    -- repaints via the already-safe ForceCooldownPaint.
     local _abefEvents = {
-        "ACTIONBAR_UPDATE_COOLDOWN", "ACTIONBAR_UPDATE_STATE",
+        "ACTIONBAR_UPDATE_STATE",
         "ACTIONBAR_UPDATE_USABLE", "ACTIONBAR_SLOT_CHANGED",
-        -- Spell-typed extra-action buttons (delve abilities) carry no action
-        -- slot, so their cooldown fires SPELL_UPDATE_COOLDOWN not this event.
-        "SPELL_UPDATE_COOLDOWN",
         "UPDATE_SHAPESHIFT_FORM", "PLAYER_ENTERING_WORLD",
     }
     local _aaefEvents = {
@@ -1115,6 +1119,18 @@ do
     -- Exposed for the extra action button's Show-hook refresh in
     -- SetupBlizzardMovableFrame (a reliable trigger for delve entry).
     ns.RefreshBroadcaster = RefreshBroadcasterNeeds
+    -- Cooldown-only repaint for the 7 Blizzard-owned buttons "full" mode used to
+    -- cover via ActionBarButtonEventsFrame's ACTIONBAR_UPDATE_COOLDOWN/
+    -- SPELL_UPDATE_COOLDOWN. ForceCooldownPaint is already the established
+    -- secret-safe path (see its own comment); this just widens its call sites
+    -- to a live event instead of one-shot vehicle-enter/button-reveal moments.
+    local function RepaintVehicleAndExtraCooldowns()
+        if not (_vehNeed or _extraNeed) then return end
+        for i = 1, 6 do
+            ForceCooldownPaint(_G["OverrideActionBarButton" .. i])
+        end
+        ForceCooldownPaint(ExtraActionButton1)
+    end
     local barFrame = ns.TakeShell()
     barFrame:RegisterEvent("UNIT_ENTERED_VEHICLE")
     barFrame:RegisterEvent("UNIT_EXITED_VEHICLE")
@@ -1124,11 +1140,20 @@ do
     barFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
     barFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
     barFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+    -- Registered on OUR OWN frame, never on Blizzard's shared ActionBarButtonEventsFrame
+    -- (see the comment on _abefEvents above for why that specific registration was
+    -- pulled during vehicle combat).
+    barFrame:RegisterEvent("ACTIONBAR_UPDATE_COOLDOWN")
+    barFrame:RegisterEvent("SPELL_UPDATE_COOLDOWN")
     barFrame:SetScript("OnEvent", function(_, event, unit)
         if event == "PLAYER_REGEN_DISABLED" or event == "PLAYER_REGEN_ENABLED" then
             -- Undeferred: the first slot change of the pull can arrive in the
             -- same frame as the lockdown, and the needs are unchanged anyway.
             ApplyBroadcaster()
+            return
+        end
+        if event == "ACTIONBAR_UPDATE_COOLDOWN" or event == "SPELL_UPDATE_COOLDOWN" then
+            RepaintVehicleAndExtraCooldowns()
             return
         end
         C_Timer.After(0, RefreshBroadcasterNeeds) -- deferred so IsShown reflects post-event state


### PR DESCRIPTION
Bug: reported via Svart; fix authored by Svart (svart2521) and re-submitted here on his behalf while his GitHub account is suspended.

Issue: a Lua error during vehicle combat in a delve, with the damage spreading past the action bars -- the objective tracker was caught in the same tick. It only reproduced in a vehicle, which is what made it look like a delve-specific problem rather than a cooldown one.

Root cause: EllesmereUIActionBars.lua registered Blizzard's own ActionBarButtonEventsFrame for ACTIONBAR_UPDATE_COOLDOWN and SPELL_UPDATE_COOLDOWN. Registering their shared frame puts our taint on their dispatch, and that dispatch runs ActionButton_UpdateCooldown into SetCooldown -- the same secret-cooldown-under-taint chain already fixed once for our own buttons in QuietlyHideBlizzButton's OnShow hook. Once it fires, the rest of that tick's native call stack is tainted, which is why an unrelated frame like the objective tracker ends up in the error.

Fix: take both events off Blizzard's broadcaster and register them on our own bar frame, repainting the seven Blizzard-owned buttons (OverrideActionBarButton1-6 and ExtraActionButton1) through ForceCooldownPaint, which is already the established secret-safe path. Coverage is unchanged, including the spell-typed delve buttons that carry no action slot and therefore fire SPELL_UPDATE_COOLDOWN rather than the action-bar event, and the repaint returns immediately unless a vehicle or extra-action button is actually up.