### PR TITLE
Fix(Glows): Classic WoW Glow renders as bare ants with no outer halo

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -10517,7 +10517,19 @@ local function UpdateFlipbook(btn)
 
         _G_Glows.StopAllGlows(wrapper)
         wrapper:Show()
-        _G_Glows.StartFlipBookGlow(wrapper, _ufBtnW, loopEntry, cr, cg, cb, _ufBtnH)
+        -- Classic WoW Glow's own entry is texture-based (IconAlertAnts), unlike
+        -- GCD/Modern WoW Glow's atlas entries, which already draw a second ants
+        -- layer via StartFlipBookGlow's atlas-only block. Without an equivalent
+        -- second layer, a direct Classic pick rendered as ants only -- confirmed
+        -- against real Blizzard proc glow screenshots to visibly lack the outline
+        -- that made it read as "Classic WoW Glow" in the first place. Pass the
+        -- same soft-halo option StartEngineGlow's Action Button Glow stand-in
+        -- already uses for this exact texture, tinted to the user's chosen color.
+        local flipOpts
+        if not loopEntry.atlas and loopEntry.texture then
+            flipOpts = { abgHalo = true, haloR = cr, haloG = cg, haloB = cb }
+        end
+        _G_Glows.StartFlipBookGlow(wrapper, _ufBtnW, loopEntry, cr, cg, cb, _ufBtnH, flipOpts)
         if wfd.ownMask then
             MaskFrameTextures(wrapper, wfd.ownMask)
         end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -2458,7 +2458,19 @@ StartNativeGlow = function(overlay, style, cr, cg, cb, opts)
         _G_Glows.StartAutoCastShine(overlay, pW, cr, cg, cb, 1.0, pH)
     else
         if noColor then cr, cg, cb = nil, nil, nil end
-        _G_Glows.StartFlipBookGlow(overlay, pW, entry, cr, cg, cb, pH)
+        -- Classic WoW Glow's entry is texture-based (IconAlertAnts), unlike
+        -- GCD/Modern WoW Glow's atlas entries, which already draw a second
+        -- ants layer via StartFlipBookGlow's atlas-only block. Without an
+        -- equivalent second layer a direct Classic pick here (Buff Glow
+        -- and proc-glow paths both route through this same StartNativeGlow)
+        -- rendered as ants only, no outline -- same gap already fixed for
+        -- Action Bars' own Classic WoW Glow pick; mirrored here since this
+        -- is a separate call site into the same shared engine.
+        local flipOpts
+        if not entry.atlas and entry.texture then
+            flipOpts = { abgHalo = true, haloR = cr, haloG = cg, haloB = cb }
+        end
+        _G_Glows.StartFlipBookGlow(overlay, pW, entry, cr, cg, cb, pH, flipOpts)
     end
 
     -- Threshold gating: bound every texture the style just created with the

--- a/EllesmereUI_Glows.lua
+++ b/EllesmereUI_Glows.lua
@@ -762,11 +762,12 @@ local function StartFlipBookGlow(wrapper, szOrW, entry, cr, cg, cb, szH, opts)
     end
 
     -- Soft outer halo: matches the halo StartButtonGlow draws behind its ants.
-    -- Keyed on the CALL (opts.abgHalo -- set only by StartEngineGlow's Action
-    -- Button Glow substitution), never on the shared style entry: a direct
-    -- Classic WoW Glow pick and the RestrictionSafeStyle Pixel remap keep
-    -- their own bare-ants look, while the ABG stand-in matches the real
-    -- thing instead of rendering visibly thinner.
+    -- Keyed on the CALL (opts.abgHalo), never on the shared style entry, so
+    -- each caller of this IconAlertAnts texture opts in independently: the two
+    -- direct Classic WoW Glow picks now pass it (bare ants did not match real
+    -- proc glow) and the Action Button Glow stand-in always has.
+    -- RestrictionSafeStyle's Pixel remap never sets it and stays bare -- it is
+    -- a fallback for a driver-based style, not Classic WoW Glow.
     if opts and opts.abgHalo then
         if not d.halo then
             local haloTex = wrapper:CreateTexture(nil, "OVERLAY", nil, 6)


### PR DESCRIPTION
Bug: reported via Svart; fix authored by Svart (svart2521) and re-submitted here on his behalf while his GitHub account is suspended.

Issue: picking Classic WoW Glow did not look like Blizzard's proc glow. It drew the marching ants but none of the surrounding glow, so it read as a thin outline crawling around the icon rather than the effect it is named after.

Root cause: Classic WoW Glow's style entry is texture-based (IconAlertAnts), where the GCD and Modern WoW Glow entries are atlas-based. StartFlipBookGlow has an atlas-only block that draws a second ants layer, so the atlas styles get their outline for free and the texture style gets nothing. The soft halo that fills that gap already existed but was requested only by StartEngineGlow's Action Button Glow substitution, which uses the same texture; the two direct Classic picks never asked for it.

Fix: the direct call sites now request the same halo, tinted to the user's chosen colour -- Action Bars, and the Cooldown Manager path that Buff Glow and proc glow both route through. It stays keyed on the call rather than the shared style entry, so RestrictionSafeStyle's Pixel remap is deliberately left bare: that path is a plain fallback for a driver-based style under 12.1 restrictions, not something presented to the user as Classic WoW Glow.

One change from the original submission was left out. It also retimed ANTS_FRAME_TIME from 0.017 to 0.04, described as matching Blizzard's real cadence. Blizzard animates this 22-frame sheet through TextureUtil.AnimateTexCoords with a 0.01 throttle, which advances floor(accumulated / 0.01) frames per tick and works out to roughly 60 cells per second at 60fps, rising with framerate. The existing 0.017 is that same rate normalised, which is what the comment above it already says; 0.04 would be about 2.4x slower than the effect it is meant to match. Happy to revisit if it looks wrong in game, but it did not seem right to slow it on that basis.