### PR TITLE
Fix(Nameplates): target arrows stranded at the wide fallback position

### DIFF
--- a/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
+++ b/EllesmereUINameplates/EUI_Nameplates_AuraContainers.lua
@@ -1321,7 +1321,19 @@ local function ReanchorArrows(plate)
     local ds, bs, cs = ns.GetAuraSlots()
     local leftC, rightC, leftKey, rightKey
     local function consider(slotVal, c, key)
-        if not c then return end
+        -- The buffs container hides itself (AnchorNPContainer) for non-attackable
+        -- units, but stays a live, non-nil frame -- anchoring an arrow to a hidden
+        -- container's geometry pins it to whatever stale layout it had before being
+        -- hidden, instead of collapsing with it. Skip anything not actually shown.
+        if not c or not c:IsShown() then return end
+        -- A settings change (e.g. moving this row to a different slot) doesn't
+        -- retroactively re-anchor every already-visible plate's container --
+        -- AnchorNPContainer stamps container._npcSlotVal with whatever slot it
+        -- was ACTUALLY last anchored at, which can lag behind the live slotVal
+        -- this function just read from GetAuraSlots() for a plate that hasn't
+        -- been re-attached since. Trusting a stale container's geometry here
+        -- anchors the arrow to wherever the row used to be, not where it is.
+        if c._npcSlotVal ~= slotVal then return end
         if slotVal == "left" and not leftC then leftC = c; leftKey = key end
         if slotVal == "right" and not rightC then rightC = c; rightKey = key end
     end

--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -7085,6 +7085,10 @@ function NameplateFrame:RefreshCastIconSideReserve()
     self:UpdateClassification()
     self:UpdateRaidIcon()
     PositionArrowsOutsideAuras(self)
+    -- Without this, a cast bar showing/hiding shoves an already container-hugging
+    -- arrow back out to the coarse fallback position (same gap as the target-swap
+    -- path -- see NameplateFrame's isTarget branch).
+    if ns.NPC_ReanchorArrows then ns.NPC_ReanchorArrows(self) end
 end
 
 function NameplateFrame:RefreshNamePosition(localOnly)
@@ -7300,6 +7304,11 @@ function NameplateFrame:ApplyTarget()
             self.leftArrow:Show()
             self.rightArrow:Show()
             PositionArrowsOutsideAuras(self)
+            -- The coarse pass above only flanks health/name; a plate that already
+            -- has a live aura container needs the hugging override too, or a
+            -- fresh target selection leaves the arrows stuck at the wide fallback
+            -- until an unrelated RAID_TARGET_UPDATE happens to fire afterward.
+            if ns.NPC_ReanchorArrows then ns.NPC_ReanchorArrows(self) end
         elseif self.leftArrow then
             self.leftArrow:Hide()
             self.rightArrow:Hide()


### PR DESCRIPTION
Bug: reported via Svart; fix authored by Svart (svart2521) and re-submitted here on his behalf while his GitHub account is suspended.

Issue: the target arrows sat too far out from the nameplate, flanking the whole plate instead of hugging the auras the way they normally do. It corrected itself at random, which made it look intermittent rather than tied to anything in particular.

Root cause: the arrows have two positioning passes in EllesmereUINameplates.lua -- a coarse one that flanks health and name, and an override that hugs a live aura container. Selecting a new target and any cast bar show or hide both ran only the coarse pass, so a plate that already had a container kept its arrows at the wide fallback until an unrelated RAID_TARGET_UPDATE happened to re-run the override, which is what made the correction look random. Separately, two container states were being trusted when they should not be: the buffs container hides itself for a non-attackable unit but stays a live frame, so anchoring to it pinned the arrow to the layout it held before hiding rather than collapsing with it; and a settings change that moves a row to a different slot does not retroactively re-anchor plates that are already visible, so a container's stamped slot can lag the live one and the arrow lands where the row used to be.

Fix: both paths call ReanchorArrows after the coarse pass, matching the existing call site elsewhere in the file. The container selection now skips a container that is not actually shown, and one whose stamped slot no longer matches the live slot.