### PR TITLE
Fix(Data Bars): script ran too long from the system tooltip's memory scan

### DIFF
--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -1028,7 +1028,12 @@ ns.BlockFactories.fps = function(blockCfg, slot, content, barCtx)
 
         local now = GetTime()
         -- UpdateAddOnMemoryUsage() iterates every loaded addon and is a noticeable spike; amortise the rescan to once per 30s.
-        if not skipMemoryScan and (now - sysLastMemScanTime) >= 30 then
+        -- Skipped entirely in combat: on a busy pull that spike can push the
+        -- hovered tooltip's whole script past the "script ran too long" watchdog
+        -- (field report: Murder Row, adds casting Felfire Orb). The data is
+        -- already tolerated at up to 30s stale, so holding it longer is not a
+        -- new behaviour; the next out-of-combat hover rescans normally.
+        if not skipMemoryScan and not InCombatLockdown() and (now - sysLastMemScanTime) >= 30 then
             sysLastMemScanTime = now
             UpdateAddOnMemoryUsage()
             local count = 0


### PR DESCRIPTION
Bug: reported via Svart; fix authored by Svart (svart2521) and re-submitted here on his behalf while his GitHub account is suspended. Field report was Murder Row, an add pack casting Felfire Orb.

Issue: hovering the system data bar during a busy pull could throw "script ran too long" and kill the tooltip's script. It only happened in combat and only sometimes, which made it look unrelated to the tooltip itself.

Root cause: the system tooltip calls UpdateAddOnMemoryUsage, which walks every loaded addon. It is already amortised to once per 30 seconds precisely because of the spike it causes, but the amortisation says nothing about when that scan lands. On a frame already contending for its Lua budget mid-pull, the scan runs on top of everything else and pushes the whole tooltip script past the watchdog.

Fix: skip the rescan while in combat. Memory usage is not combat-critical, and the data is already tolerated at up to 30 seconds stale, so holding it a little longer is an extension of that same tolerance rather than new behaviour. The next out-of-combat hover past the 30 second mark rescans exactly as before, and the tooltip's memory section is gated on the table being non-empty, so a first hover that happens to land in combat simply omits the section rather than showing anything empty.