### PR TITLE
Add(Raid Frames): public unit-to-frame lookup for glow addons, no unit comparison needed

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -15316,6 +15316,40 @@ ns._CollectTrackerFrames = function()
     return out
 end
 
+-- Public unit -> frame lookup for any addon wanting our raid or party frame.
+-- LibGetFrame cannot answer on an addon-restricted map: it keeps a cached frame
+-- only when UnitIsUnit(frameUnit, target) is non-secret, and that call is
+-- SecretWhenUnitComparisonRestricted, so every frame is skipped there however
+-- fresh the cache. This compares nothing -- it reads the secure "unit"
+-- attribute the header wrote. Extra frames answer last: they duplicate a unit
+-- already on a real raid button.
+function EllesmereUI.GetUnitFrame(unit)
+    if type(unit) ~= "string" then return nil end
+    local function Find(list)
+        if not list then return nil end
+        for _, btn in ipairs(list) do
+            if btn:IsVisible() then
+                local u = btn:GetAttribute("unit")
+                -- Type check before comparing: a secret attribute is not a
+                -- string, so it is rejected without ever being compared.
+                if type(u) == "string" then
+                    if u == unit then return btn end
+                    -- The header gives the player's own button a raidN token, so
+                    -- a literal compare never finds "player". This is the one
+                    -- place a comparison is needed; it is refused rather than
+                    -- answered on a restricted map, so only a plain true counts.
+                    if unit == "player" then
+                        local ok, same = pcall(UnitIsUnit, u, "player")
+                        if ok and same == true then return btn end
+                    end
+                end
+            end
+        end
+        return nil
+    end
+    return Find(ns._partyAllButtons) or Find(allButtons) or ns._xfUnitToButton[unit]
+end
+
 -- Notifies subscribed providers that our frame set changed, debounced to one
 -- refresh per frame. Driven from the visibility paths -- the one change a
 -- provider cannot learn from its own roster events.


### PR DESCRIPTION
Bug: raid-frame glows from LibGetFrame-based addons (WeakAuras, SmartReminders, WowUtils) silently do nothing in some content while working fine in others. Companion to #1947, which fixes a different half of this.

Issue: an addon asks LibGetFrame for our frame for a unit, gets nil, and skips the glow with no error. Reproduced live on two accounts: every group member's name read plain, the raid button passed every gate that library's scan applies (Button, not forbidden, IsVisible true, no cancelaura type, real global name, a plainly readable unit attribute, three hops under UIParent), and it still resolved zero frames for every unit. Forcing the library's own public ScanForUnitFrames and re-checking changed nothing.

Root cause: found, and it is not ours. LibGetFrame walks UIParent's descendants and guards each node with `frame.IsForbidden and not frame:IsForbidden()`. In 12.x that guard no longer holds: measured in a raid, thousands of objects return **false** from `IsForbidden()` and then raise `"Attempt to access forbidden object from code tainted by an AddOn"` on the very next call, `GetObjectType()`. The walk is driven by `coroutine.resume(co, 0, UIParent)` with the return value discarded, and `coroutine.resume` reports errors by returning `false, err` rather than propagating, so the walk dies silently, `WriteCache` commits the truncated set, and every later rescan dies at the same object.

Replaying that same walk with each call wrapped, in the same raid: aborting at the first error gives `withUnit=0 ERF=0`; continuing past errors gives `withUnit=23 ERF=10` with **2990 errors**. The frames are perfectly reachable -- the library never gets to them. The forbidden children are spread across the whole UI, roughly 2010 directly under UIParent and the rest under unit frames and raid buttons (engine-owned aura containers among them), so this is not specific to our frames and affects every consumer of that library on an affected UI. Two earlier explanations were tested and dropped: a stale cache (forcing the library's own `ScanForUnitFrames` changed nothing) and refused unit comparison (`C_Secrets.CanCompareUnitTokens` returns true in the failing content).

The real fix belongs upstream -- that guard needs to stop trusting `IsForbidden()`, and the walk needs to survive a raising node. This PR is the part we can do ourselves: give consumers a way to resolve our frames without that walk.

Fix: `EllesmereUI.GetUnitFrame(unit)` compares no units. It reads the secure `unit` attribute the header already wrote and returns the visible button carrying it, so it answers wherever the frames exist. The single exception is a `"player"` lookup, since the header stamps that button with a `raidN` token; only there is a comparison attempted, and only a plain `true` is accepted, so a refusal falls through rather than throwing. Extra frames answer last because they duplicate a unit already on a real raid button.

Additive and unused inside the suite -- nothing here depends on it. It exists so a consumer has something to fall back to when the library returns nil. Worth noting alongside #1947 rather than instead of it: that PR addresses a genuinely stale cache, which is the failure users see outside restricted content, and at least one player has confirmed it fixed their case. The two cover different halves.


