### PR TITLE
Fix player cast bar restarting when Hover is cast mid-Disintegrate

### DIFF
--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -7753,14 +7753,27 @@ end
 -- what OnEmpowerStop below already does. Instead the live channel is re-queried:
 -- an instantly restarted channel (Clearcasting Arcane Missiles) can deliver the
 -- OLD channel's STOP after the NEW channel's START, and that late stop must not
--- tear down the bar that is still channeling.
+-- tear down the bar that is still channeling. The opposite order happens too:
+-- a channel re-issued mid-flight (Hover cast during Disintegrate) can deliver
+-- its STOP in a frame where UnitChannelInfo is already empty and the re-issuing
+-- START has not landed, so going idle here blanks the bar for that frame and
+-- the retry in OnChannelStart rebuilds it from scratch. Re-check next frame;
+-- a real channel end reads empty both times.
 local function OnChannelStop()
     if not castBarFrame then return end
     if not castBarFrame._channeling then return end
     if UnitChannelInfo("player") then return end
-    castBarFrame._channeling = false
-    castBarFrame._castID = nil
-    ns.ShowIdleCastBar()
+    if castBarFrame._channelStopPending then return end
+    castBarFrame._channelStopPending = true
+    C_Timer.After(0, function()
+        if not castBarFrame then return end
+        castBarFrame._channelStopPending = nil
+        if not castBarFrame._channeling then return end
+        if UnitChannelInfo("player") then return end
+        castBarFrame._channeling = false
+        castBarFrame._castID = nil
+        ns.ShowIdleCastBar()
+    end)
 end
 
 -- Undo the per-stage empower tint and put the configured fill back. Shared by

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -7766,10 +7766,15 @@ local function OnChannelStop()
     if castBarFrame._channelStopPending then return end
     castBarFrame._channelStopPending = true
     C_Timer.After(0, function()
-        if not castBarFrame then return end
         castBarFrame._channelStopPending = nil
         if not castBarFrame._channeling then return end
-        if UnitChannelInfo("player") then return end
+        local name, _, _, _, _, _, _, _, empowering = UnitChannelInfo("player")
+        if name then
+            -- An empower dispatched in the emptied frame was declined by
+            -- OnEmpowerStart, which has no retry; pick it up here.
+            if empowering then OnEmpowerStart() end
+            return
+        end
         castBarFrame._channeling = false
         castBarFrame._castID = nil
         ns.ShowIdleCastBar()


### PR DESCRIPTION
Bug: reported by Discord user 98468387247628288 in EllesmereUI-helper Discord (2026-09-05), filed under Cooldown Manager

Issue: on 9.0.8 an Evoker channeling Disintegrate who casts Hover sometimes sees the Resource Bars cast bar blank and restart instead of carrying on draining. It only happens on some Hover presses.

Root cause: Hover re-issues the running channel, so the client fires a second UNIT_SPELLCAST_CHANNEL_START for the same Disintegrate. The stop for the old issue can land in a frame where UnitChannelInfo is already empty and the new start has not arrived. OnChannelStop in EllesmereUIResourceBars.lua reads that as a real channel end and drops the bar to idle, and the next-frame retry in OnChannelStart rebuilds it from scratch. Whether the two events share a frame is timing, hence intermittent.

Fix: OnChannelStop now re-checks the live channel one frame later and only goes idle when it is still empty, so a re-issued channel keeps its bar. A queued empower starting in that same emptied frame is picked up by the re-check too. Verified in game.

![hover](https://media.giphy.com/media/cArmte7hBPzxt095X6/giphy.gif)
