### PR TITLE
Fix standalone Unit Frames font cache on startup

### DIFF
--- a/EllesmereUI_Lite.lua
+++ b/EllesmereUI_Lite.lua
@@ -487,6 +487,11 @@ lifecycleFrame:SetScript("OnEvent", function(self, event, arg1)
             if IS_STANDALONE then
                 _svLoaded = true
                 RerootPreSVDBs()
+                -- Runtime files can cache default fonts before this addon's
+                -- SavedVariables load. Resolve the saved choice when frames init.
+                if EllesmereUI.InvalidateFontCache then
+                    EllesmereUI.InvalidateFontCache()
+                end
             end
         elseif _dbGuardArmed and _parentDBRef and EllesmereUIDB ~= _parentDBRef then
             -- A stale SavedVariables copy from a child's WTF file replaced the central


### PR DESCRIPTION
## What does this PR do?

Fixes a standalone startup path that can leave Unit Frames using Expressway even when the saved global font is Friz Quadrata TT.

Standalone runtime files can call `GetFontPath` before the addon's SavedVariables load, caching the temporary default. Invalidate that cache in the existing standalone `ADDON_LOADED` branch, after database rerooting and before queued initialization. Frame initialization then resolves the saved font choice.

Five lines in `EllesmereUI_Lite.lua`. The full-suite path is unchanged. One startup invalidation; no new timers, event registrations, frames, or per-frame work.

## How was it tested?

- A local Lua harness using font-resolution and Unit Frames cache functions extracted from installed standalone v9.1.6 reproduced the stale Expressway path before the fix. The saved Friz font and module-override cases pass with the fix.
- Expressway defaults and the full-suite path pass before and after the change.
- EUI diff-scoped and staged style checks pass; `git diff --check` passes.
- Syntax checked with the available Lua 5.4 `luac`; the added code uses only Lua 5.1 syntax.
- Applied the equivalent change to installed standalone v9.1.6. The PR author tested it in game on the retail client and confirmed the fix works. Exact client build was not recorded.

Additional reproduction/regression checklist (individual steps not separately recorded): select Friz Quadrata TT, fully exit and relaunch WoW, then inspect target/focus text and target castbar before `/reload`. Repeat with Expressway and a Unit Frames font override; verify `/reload` preserves the selection.

## Screenshots

Before/after screenshots are not available. This restores the selected font; it adds no new UI.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A: bug fix, no new settings.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no new registrations, polling, hooks, or frames; invalidation is confined to standalone startup.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - one invalidation in the existing addon-load handler.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A: only the addon's font cache is invalidated.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added - PR author confirmed the fix works in game on retail; exact client build not recorded. No version gates or APIs added.

[![Cat gives the font fix a thumbs up](https://media.giphy.com/media/gWiUwUOSxZWV7EcZ4o/giphy.gif)](https://giphy.com/gifs/cat-illustration-good-gWiUwUOSxZWV7EcZ4o)

