### PR TITLE
Prevent blocked distance checks in reopened party and raid menus

### DIFF
--- a/EllesmereUI_MenuFallbacks.lua
+++ b/EllesmereUI_MenuFallbacks.lua
@@ -384,10 +384,18 @@ local function ModifyReopenedMenu(owner, rootDescription, contextData)
     local setFocus = SET_FOCUS or "Set Focus"
     local follow = FOLLOW or "Follow"
     local raidTarget = RAID_TARGET_ICON or "Raid Target Icon"
+    local trade = TRADE or "Trade"
+    local duel = DUEL or "Duel"
+    local petDuel = PET_BATTLE_PVP_DUEL or "Pet Battle Duel"
+    local achievements = COMPARE_ACHIEVEMENTS or "Compare Achievements"
     for _, d in rootDescription:EnumerateElementDescriptions() do
         local text = MenuUtil.GetElementText(d)
         if d.SetEnabled and (text == setFocus or text == follow or text == raidTarget
+                or text == trade or text == duel or text == petDuel or text == achievements
                 or (HOUSING_OK and text == viewHouses)) then
+            -- Range-gated entries call CheckInteractDistance from Blizzard's
+            -- enabled predicate. Disable them before that predicate can run in
+            -- this tainted reopen; normal secure menus keep their range checks.
             -- Protected from a tainted menu: throws (focus/follow, and every
             -- marker under Raid Target Icon -- SetRaidTarget) or poisons
             -- HouseListFrame for the session (View Houses; the docked button


### PR DESCRIPTION
## What does this PR do?

Prevents the remaining range-gated entries in EUI's reopened party/raid player menu from evaluating `CheckInteractDistance` under tainted execution.

The classifier fallback can reopen a player menu from addon Lua. Blizzard's enabled predicates for Trade, Duel, Pet Battle Duel, and Compare Achievements call `CheckInteractDistance`, which can produce `ADDON_ACTION_BLOCKED`. Extend the existing disabled-entry list to grey out those four actions only in that fallback menu, replacing their enabled predicates before menu initialization. Ordinary menus retain their actions and distance checks.

This addresses a menu-error path consistent with NameeR's v9.0.7 report. The separate symptom of remaining stuck in a raid after leaving has not been reproduced or established as caused by this error; this PR does not claim to fix that state.

## How was it tested?

- Reviewed Blizzard's current unit-menu entry definitions, enabled predicate, menu modifier ordering, and boolean `SetEnabled` handling in the local interface export.
- Local Lua harness using the actual EUI modifier and Blizzard enabled predicate reproduced a blocked distance call before the change and passed afterward. The harness simulates the protected-call failure; it does not reproduce WoW's taint engine.
- Verified fallback behavior, ordinary menus, nonmatching units, localized labels, and missing context. Ordinary menus retain all five distance checks; matching fallback menus execute none.
- EUI diff-scoped and staged style checks, syntax check, and `git diff --check` pass. Syntax checked with available Lua 5.4 `luac`; the added code uses only Lua 5.1 syntax.
- PR author reports completing in-game testing. Specific test outcomes, exact client build, and screenshots were not recorded.

Reproduction/regression checklist (individual outcomes not separately recorded): trigger the fallback for a party/raid player in another zone and verify the menu opens without the blocked call; verify normal nearby-player interactions remain available; separately verify leaving a raid clears the roster display, including after `/reload`.

## Screenshots

Before/after screenshots are not available. The visible change is four additional greyed-out entries in the reopened fallback menu only.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A: focused bug fix; no new settings.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - existing early returns skip the added work outside the matching fallback menu; no new registrations, hooks, or frames.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - four label comparisons in the existing menu loop; no timers or per-frame work.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - only the existing supported menu-description `SetEnabled(false)` customization is extended; no frame writes added.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added - PR author reports in-game testing on the retail installation; exact client build and individual outcomes not recorded. No version gates or APIs added.

[![Cat gives a thumbs up](https://media.giphy.com/media/S2D753TsCrbPsMRTwK/giphy.gif)](https://giphy.com/gifs/thumbs-up-cat-car-awesome-S2D753TsCrbPsMRTwK)


