### PR TITLE
Fix locale font on the first-install popup

### DIFF
--- a/EllesmereUI_FirstInstall.lua
+++ b/EllesmereUI_FirstInstall.lua
@@ -100,7 +100,7 @@ local function SetAddonEnabled(folder, enabled)
 end
 
 local function ShowFirstInstallPopup()
-    local FONT   = EllesmereUI._font or ("Interface\\AddOns\\EllesmereUI\\media\\fonts\\Expressway.ttf")
+    local FONT   = EllesmereUI.GetFontPath()
     local NUM_COLS = #GROUPS
     local COL_W         = 210
     local COL_GAP       = 18


### PR DESCRIPTION
## What does this PR do?

The first-install popup can show missing-glyph boxes on a localized client before the options addon has initialized `EllesmereUI._font`. Its hard-coded Expressway fallback cannot render Chinese. Use the existing locale-aware `GetFontPath()` resolver so the initial setup labels are readable. The core defines this resolver before the popup file loads.

## How was it tested?

- Live macOS client 12.1.0.69587, zhCN: reproduced the boxes with the upstream popup file, then verified readable Chinese after the one-line fix and a UI reload, before opening options.
- Verified the live locale and resolver use `Fonts\ARKai_T.ttf`; the Reload UI button still applies the existing selections.
- Lua 5.1 syntax, `git diff --check`, and the repository's locale-key regeneration check pass (781 keys, no generated-file changes).
- Other locales were not tested in-game; they continue using the existing shared font resolver. No translation strings are added or changed.

## Screenshots

Before:

![Original popup with missing Chinese glyphs](https://raw.githubusercontent.com/hiltay/EllesmereUI/96c04939760ad0d19107b3dcf21572b76e09887f/.github/validation/2026-09-06/first-install-zhCN-before.jpg)

After:

![Popup with readable Chinese labels](https://raw.githubusercontent.com/hiltay/EllesmereUI/96c04939760ad0d19107b3dcf21572b76e09887f/.github/validation/2026-09-06/first-install-zhCN-after.jpg)

## Checklist

- [x] New settings default **OFF** (N/A: no new settings; fixes existing localized setup)
- [x] Zero cost while disabled: no new events, polling, hooks, or frames
- [x] Cheap while enabled: existing popup construction only; no new update work
- [x] No writes onto Blizzard-owned frames; no hook or script changes
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
