### PR TITLE
Fix independent party Show AFK setting

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -9336,6 +9336,7 @@ do
             "showReadyCheck", "showSummonPending", "showIncomingRez",
             "readyCheckSize", "readyCheckPosition", "readyCheckOffsetX", "readyCheckOffsetY",
             "statusTextPosition", "statusTextOffsetX", "statusTextOffsetY", "statusTextSize", "statusTextColor",
+            "statusShowAFK",
             "showLeaderIcon", "showLeaderIconInCombat", "leaderIconPosition", "leaderIconSize", "leaderIconOffsetX", "leaderIconOffsetY",
             "showCombatIndicator", "combatIndicatorStyle", "combatIndicatorColor", "combatIndicatorCustomColor",
             "combatIndicatorSize", "combatIndicatorPosition", "combatIndicatorOffsetX", "combatIndicatorOffsetY",


### PR DESCRIPTION
## What does this PR do?

Fix the existing **Show AFK** toggle when Party > Indicators is customized independently of raid settings. `statusShowAFK` was missing from the Indicators section map, so the party toggle wrote the raid setting and saved `party_statusShowAFK` overrides were ignored by the party proxy.

Adding the existing key to its section makes party reads, writes, and frame rendering use the custom party value. Synced party settings still inherit the raid value. This is a one-line bug fix with no new settings or duration feature.

## How was it tested?

- Live macOS client 12.1.0.69587, zhCN, using the real player unit in the party frame's existing solo display mode and `/afk`.
- With indicator sync off, party Show AFK on, and raid Show AFK off: upstream rendered no AFK text (effective party value false); the one-line patch rendered the localized AFK label (effective value true).
- Re-enabling indicator sync restored the raid value and hid the AFK label.
- [Six offline behavioral checks](https://raw.githubusercontent.com/hiltay/EllesmereUI/96c04939760ad0d19107b3dcf21572b76e09887f/.github/validation/2026-09-06/party_afk_setting_spec.lua) execute the production setting helpers, proxies, and status painter with WoW API substitutes: upstream fails three cases; this patch passes all six. Checks cover custom enable/disable, stored overrides, synced inheritance, unset overrides, and defaults. Run with Lua 5.1 and the checkout path as its argument. These do not replace live-client testing.
- Lua 5.1 syntax, `git diff --check`, and the repository's locale-key regeneration check pass (781 keys, no generated-file changes).

## Screenshots

The diagnostic line lists: player AFK, indicator sync, party setting, raid setting, effective party setting. The real party player frame is at the upper left.

Before (effective value false; no AFK label):

![Party override ignored before the fix](https://raw.githubusercontent.com/hiltay/EllesmereUI/96c04939760ad0d19107b3dcf21572b76e09887f/.github/validation/2026-09-06/party-afk-setting-before.jpg)

After (effective value true; AFK label visible):

![Party override applied after the fix](https://raw.githubusercontent.com/hiltay/EllesmereUI/96c04939760ad0d19107b3dcf21572b76e09887f/.github/validation/2026-09-06/party-afk-setting-after.jpg)

## Checklist

- [x] New settings default **OFF** (N/A: no new settings; existing defaults unchanged)
- [x] Zero cost while disabled: no new events, polling, hooks, or frames
- [x] Cheap while enabled: uses the existing settings map and repaint paths
- [x] No writes onto Blizzard-owned frames; no hook or script changes
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
