### PR TITLE
Fix the invite / whisper functionality.

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -1683,6 +1683,40 @@ end
 
 local function lerp(a, b, t) return a + (b - a) * t end
 
+-- "Name-Realm" whisper/invite target. With realmName it builds (realm wins,
+-- spaces stripped); with a finished name alone it only collapses a stacked realm.
+function EllesmereUI.BuildFullName(charName, realmName)
+    -- type()/issecretvalue() before any comparison: `== ""` on a secret throws.
+    if type(charName) ~= "string" then return nil end
+    if issecretvalue and issecretvalue(charName) then return charName end
+    if charName == "" then return nil end
+
+    -- Character names hold no hyphen, so the first one splits name from realm.
+    local base, suffix = charName:match("^([^%-]+)%-(.+)$")
+    base = base or charName
+
+    if type(realmName) == "string" and not (issecretvalue and issecretvalue(realmName)) then
+        local realm = (realmName:gsub("%s+", ""))
+        if realm ~= "" then return base .. "-" .. realm end
+    end
+    if not suffix then return base end
+
+    -- Collapse proven repetition only -- a realm may hold a hyphen ("Azjol-Nerub").
+    local segs = {}
+    for seg in suffix:gmatch("[^%-]+") do
+        if segs[#segs] ~= seg then segs[#segs + 1] = seg end
+    end
+    suffix = table.concat(segs, "-")
+    -- A doubled multi-word realm has no adjacent repeats; a half-split catches it.
+    local half = (#suffix - 1) / 2
+    if half > 0 and half == math.floor(half)
+        and suffix:sub(half + 1, half + 1) == "-"
+        and suffix:sub(1, half) == suffix:sub(half + 2) then
+        suffix = suffix:sub(1, half)
+    end
+    return base .. "-" .. suffix
+end
+
 -------------------------------------------------------------------------------
 --  Exports  (shared locals EllesmereUI table for split files)
 -------------------------------------------------------------------------------

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -4673,7 +4673,9 @@ local function MMOpenWhisper(charName, bnetName)
     end
     if charName and charName ~= "" then
         local sendTell = (ChatFrameUtil and ChatFrameUtil.SendTell) or ChatFrame_SendTell
-        if sendTell then sendTell(charName, DEFAULT_CHAT_FRAME) end
+        -- Fix "Name-Realm-Realm" to "Name-Realm"
+        local target = EllesmereUI.BuildFullName(charName) or charName
+        if sendTell then sendTell(target, DEFAULT_CHAT_FRAME) end
     end
 end
 
@@ -4706,7 +4708,8 @@ local function MMBuildSocialTip()
             local right = format("|cffecd672%s|r %s", charName or "?", ga.areaName or "")
             local bnetName   = acc.accountName
             local sameFaction = (not faction) or (faction == playerFaction)
-            local inviteName  = (charName and realmName) and (charName .. "-" .. realmName) or charName
+            -- Fix "Name-Realm-Realm" to "Name-Realm"
+            local inviteName  = EllesmereUI.BuildFullName(charName, realmName)
             ns.Tip_AddClickable(left, right, function(mouseButton)
                 if mouseButton == "LeftButton" then
                     if IsShiftKeyDown() and sameFaction and inviteName then
@@ -4791,7 +4794,7 @@ local function MMBuildGuildTip()
             ns.Tip_AddClickable(left, zone or "", function(mouseButton)
                 if not fname then return end
                 if mouseButton == "LeftButton" then
-                    if IsShiftKeyDown() then C_PartyInfo.InviteUnit(fname)
+                    if IsShiftKeyDown() then C_PartyInfo.InviteUnit(EllesmereUI.BuildFullName(fname) or fname)
                     else MMOpenWhisper(fname, nil) end
                 end
             end, clr, clg, clb, 1, 1, 1)

--- a/EllesmereUIFriends/EllesmereUIFriends.lua
+++ b/EllesmereUIFriends/EllesmereUIFriends.lua
@@ -2350,13 +2350,14 @@ local function SkinFriendsFrame()
                         local charName = cached.gameAccountInfo.characterName
                         local realmName = cached.gameAccountInfo.realmName
                         if charName then
-                            local fullName = realmName and realmName ~= "" and (charName .. "-" .. realmName) or charName
+                            -- Fix "Name-Realm-Realm" to "Name-Realm"
+                            local fullName = EllesmereUI.BuildFullName(charName, realmName)
                             C_PartyInfo.InviteUnit(fullName)
                         end
                     end
                 elseif cached and targetType == FRIENDS_BUTTON_TYPE_WOW then
                     if cached.name and cached.connected then
-                        C_PartyInfo.InviteUnit(cached.name)
+                        C_PartyInfo.InviteUnit(EllesmereUI.BuildFullName(cached.name) or cached.name)
                     end
                 end
                 search:SetText("")

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -2185,7 +2185,8 @@ local function GatherOnlineFriends()
             if online and name then
                 local short = name:match("^([^%-]+)") or name
                 if short ~= myName then
-                    guild[#guild + 1] = { name = short, full = name, class = classFile, zone = zone or "", level = level, kind = "guild" }
+                    -- Fix "Name-Realm-Realm" to "Name-Realm"
+                    guild[#guild + 1] = { name = short, full = EllesmereUI.BuildFullName(name) or name, class = classFile, zone = zone or "", level = level, kind = "guild" }
                 end
             end
         end
@@ -2204,11 +2205,8 @@ local function GatherOnlineFriends()
                     if ci and ci.classFile then classFile = ci.classFile end
                 end
                 local zone = gameInfo.areaName or ""
-                local realm = gameInfo.realmName
-                local full = charName
-                if charName and realm and realm ~= "" then
-                    full = charName .. "-" .. realm
-                end
+                -- Fix "Name-Realm-Realm" to "Name-Realm"
+                local full = EllesmereUI.BuildFullName(charName, gameInfo.realmName) or charName
                 -- Battle tag without the #discriminator (fall back to accountName/RealID)
                 local rawTag = acct.battleTag or acct.accountName
                 local tagName = rawTag and rawTag:match("^([^#]+)") or rawTag
@@ -2244,7 +2242,7 @@ local function GatherOnlineFriends()
             if charName and not seenBNet[charName] then
                 friends[#friends + 1] = {
                     name = charName:match("^([^%-]+)") or charName,
-                    full = charName,
+                    full = EllesmereUI.BuildFullName(charName) or charName,
                     class = info.className and info.className:upper():gsub(" ", ""),
                     zone = info.area or "",
                     level = info.level,
@@ -2351,7 +2349,9 @@ local function FTTOpenWhisper(charName, bnetName)
     end
     if charName and charName ~= "" then
         local sendTell = (ChatFrameUtil and ChatFrameUtil.SendTell) or ChatFrame_SendTell
-        if sendTell then sendTell(charName, DEFAULT_CHAT_FRAME) end
+        -- Fix "Name-Realm-Realm" to "Name-Realm"
+        local target = EllesmereUI.BuildFullName(charName) or charName
+        if sendTell then sendTell(target, DEFAULT_CHAT_FRAME) end
     end
 end
 
@@ -2398,7 +2398,7 @@ local function GetFTTMenu()
     MakeItem("Whisper", -PAD, FTTOpenWhisper)
     MakeItem("Invite", -PAD - RH, function(target)
         if target and target ~= "" and C_PartyInfo and C_PartyInfo.InviteUnit then
-            C_PartyInfo.InviteUnit(target)
+            C_PartyInfo.InviteUnit(EllesmereUI.BuildFullName(target) or target)
         end
     end)
 


### PR DESCRIPTION
## What does this PR do?

I had weird bugs where I couldnt invite friends from the social plugin on the minimap. They just wouldnt get my invites. No chat message either like "Youve invited friend-realm to your party." Left clicking them showed that the realm was added multiple times: The whisper frame showed "To charname-realm-realm-..."

It fixed itself after awhile. IDK when or how.

## How was it tested?

Tested on 12.1 retail infight and outfight.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
