### PR TITLE
Fix Extra Action Button staying hidden until reload

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -9532,7 +9532,11 @@ function EAB:RefreshRuntimeVisibility()
                     if vis ~= "in_combat" and vis ~= "out_of_combat" and not s.combatShowEnabled then
                         -- Only Show frames without a state-visibility driver.
                         -- Frames with a driver (any _eabLastVisStr) are managed by the driver.
-                        if not info.isBlizzardMovable and not info.blizzOwnedVisibility and not frame._eabLastVisStr then
+                        -- Movable wrappers are ours: restore them when their hide
+                        -- condition clears. Blizzard still owns child visibility.
+                        if not info.blizzOwnedVisibility and not frame._eabLastVisStr
+                           and (not info.isBlizzardMovable
+                                or EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s)) then
                             frame:Show()
                         end
                     end
@@ -10024,7 +10028,10 @@ function EAB:UpdateHousingVisibility()
                                 bf:Show()
                             end
                             if bf then EFD(bf).visWasShown = nil end
-                        elseif not info.isBlizzardMovable then
+                        -- Restore our movable wrapper, respecting all remaining
+                        -- visibility gates (including pet battles).
+                        elseif not info.isBlizzardMovable
+                           or EAB_VTABLE.ExtraBars.ShouldShowManagedNonSecureBar(s) then
                             frame:Show()
                         end
                         -- Data bars may need to re-hide (max level, max renown, etc.)


### PR DESCRIPTION
## What does this PR do?

Fixes the Extra Action Button staying invisible after an EUI visibility condition clears, until `/reload`.

The visibility paths could hide EUI's movable holder, but both restore paths excluded movable holders. Restore the holder in `RefreshRuntimeVisibility` and `UpdateHousingVisibility` when the existing visibility evaluator permits it. This also covers the Encounter Bar, which uses the same holder path.

Blizzard retains control of the child frames. Restoration remains outside combat and respects disabled/hidden settings, visibility modes, and pet battles. No new events, polling, timers, or frames are added; the change reuses the existing visibility evaluator during refreshes.

## How was it tested?

- User confirmed that `EUI-extra-action-wrapper-test.zip` fixed the reported issue in game.
- Verified that the action-bar source in this PR matches that tested ZIP, ignoring line endings, including after rebasing onto current upstream `main`.
- Lua syntax check passed with `luac` 5.4.6. The EUI style gate passed its Lua 5.1 compatibility and ASCII checks.
- Reviewed both restore paths, holder ownership, and the shared visibility evaluator. The exact tested client build and a full combat/pet-battle/Encounter Bar regression pass were not supplied; those remain unverified.

## Screenshots

Before/after screenshots are not available. The user confirmed the test ZIP's behavior; no screenshots are claimed.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A: bug fix; no new settings.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - No new registrations, hooks, polling, or frames; existing disabled visibility gates remain in use.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - Reuses existing refresh paths and visibility evaluation; no new scheduling or per-frame work.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - Changed Show calls target EUI-owned holders; no new Blizzard-frame fields or scripts.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added - User confirmed the test ZIP worked in game, but live client/build metadata was not supplied. No version gates or pre-Midnight APIs added.

<img src="https://media.giphy.com/media/JrpSdfspE8wuK9jaz1/giphy.gif" alt="A cat coming out of hiding" width="220">
