### PR TITLE
feat(macrofactory): drop the Nature's Swiftness / Convoke druid macro

### DIFF
--- a/EUI_MacroFactory.lua
+++ b/EUI_MacroFactory.lua
@@ -377,7 +377,10 @@ function EllesmereUI.BuildMacroFactory(parent, startY, PP)
     local DRUID_RESTO = {
         { name="EUI_Ironbark", icon="Interface\\Icons\\spell_druid_ironbark", label="Ironbark\n(Focus)", spells={102342}, fixedBody="/cast [@focus,help,nodead][] {1}", fixedTooltip="{1}" }, -- Ironbark
         { name="EUI_InnervateSelf", icon="Interface\\Icons\\spell_nature_lightning", label="Innervate\n(Player)", spells={29166}, fixedBody="/cast [@player] {1}" }, -- Innervate
-        { name="EUI_NSConvoke", icon="Interface\\Icons\\ability_ardenweald_druid", label="Nature's Swiftness\nConvoke", spells={132158, 391528}, fixedBody="/cast [nochanneling] {1}\n/cast {2}\n/cqs", fixedTooltip="{2}" }, -- Nature's Swiftness / Convoke the Spirits
+        -- Nature's Swiftness / Convoke was offered here until it stopped being worth
+        -- macroing: Nature's Swiftness no longer buffs the Regrowths a Convoke casts, and
+        -- with Overgrowth taken the channel's first Regrowth moves Lifebloom off its
+        -- target. Pairing them now costs more than it gives.
     }
 
     -- Evoker (1467=Devastation, 1468=Preservation, 1473=Augmentation)


### PR DESCRIPTION
Reported by @Goat (QoL, 9.1.6): the Macro Factory still offers a Nature's
Swiftness / Convoke macro for Restoration druids, and pairing them is no longer
a good idea.

## Why it goes

Nature's Swiftness no longer buffs the Regrowths that Convoke casts, which was
the entire reason to macro the two together. It is now worse than neutral: with
Overgrowth taken, the first Regrowth of the channel moves Lifebloom onto
whoever that Regrowth happens to land on, so a new user pressing the macro
loses their Lifebloom placement without being told why.

That makes it a trap for exactly the people the Macro Factory is aimed at, which
is how it was found: a new EllesmereUI user opening QoL as Resto.

## What this does and does not touch

Removed from `DRUID_RESTO` only. Nothing else in the factory changes.

Macros a user has already created are left alone and keep working. The factory
only deletes a macro when the user clicks Delete Macro on that entry, so nothing
disappears from anyone's macro list on update; the entry simply stops being
offered.

The localized label stays in the locale files. It is a runtime key rather than a
static one, so `_keys.txt` does not change (verified by running
`.tools/extract-locale-keys.sh`: no diff), and if the macro is ever brought back
the translations are still there.

## Testing

`luac -p` clean; house style check clean. Click-tested: QoL opens on a Resto
druid with the entry gone and the remaining Resto macros still building.

![](https://media.giphy.com/media/aVPS1Ek7RhTtS/giphy.gif)


