### PR TITLE
Nameplates: let the tank has-aggro color reach bosses that have mana

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplates.lua
+++ b/EllesmereUINameplates/EllesmereUINameplates.lua
@@ -5228,8 +5228,19 @@ local function GetReactionColor(unit)
             return MaybeDarken(c.r, c.g, c.b, inCombat)
         end
     end
+    -- A boss the tank is holding is settled at step 9, where "Override Boss colors" decides.
+    -- Step 6b defers bosses here on purpose, but the caster return below fires first for any
+    -- boss carrying a mana pool, so that option could never reach one. Mirrors step 9's test.
+    local bossAggroPending = false
+    if _isBossUnit and isThreatUnit and _isTankRole and threatStatus >= 3 then
+        local hae = defaults.tankHasAggroEnabled
+        if db.tankHasAggroEnabled ~= nil then hae = db.tankHasAggroEnabled end
+        local ovrBoss = defaults.tankHasAggroOverrideBoss
+        if db.tankHasAggroOverrideBoss ~= nil then ovrBoss = db.tankHasAggroOverrideBoss end
+        bossAggroPending = hae and ovrBoss
+    end
     -- 8. Caster
-    if _isCaster then
+    if _isCaster and not bossAggroPending then
         -- DPS/healer No Aggro "Override Caster colors": promotes No Aggro above the caster
         -- color when enabled. Kept separate from the mini-boss override for contrast.
         if dpsNoAggroActive then


### PR DESCRIPTION
## What does this PR do?

A tank holding a boss saw the boss stay on the Spell Casters color instead of the Tank "Has Aggro" color, and no combination of settings could change it.

`GetReactionColor` resolves in numbered priority steps. Step 6b promotes has-aggro above the mini-boss/caster colors and deliberately excludes boss units, with a comment saying why: bosses are meant to be governed by "Override Boss colors" at step 9. But step 8 returns the caster color unconditionally, and it sits between the two.

"Caster" is `UnitHasPowerType(unit, Enum.PowerType.Mana)`, so it covers every boss carrying a mana pool, not just mobs that cast. For those bosses step 8 always returned first and step 9 was unreachable, which means "Override Boss colors" has never done anything for them despite defaulting on.

Step 8 now defers when step 9 will claim the unit. The new guard tests the same two settings step 9 tests, so a profile with Tank Has Aggro off takes the old path unchanged. That setting defaults off, so default profiles see no difference.

## How was it tested?

Reported by @Tomfoolery against Coiled Altar Malacrass: the plate stayed on the caster color while actively tanking, and the same profile colored correctly on mobs without mana. Fix confirmed in game on live by the reporter.

Also checked: losing threat still goes to no-aggro, off-tank coloring is unaffected, and turning Tank Has Aggro off reproduces the previous behavior exactly.

Non-boss casters are unchanged by design. Those are governed by "Override Mini-Boss and Caster colors", which works as documented.

## Screenshots

Not included. The change moves one existing color between two existing swatches, both already user-configurable, so a screenshot shows a boss plate in whichever two colors that profile has set. Happy to add a before/after if review wants one.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; gated behind the existing Tank Has Aggro, which defaults off
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- two locals and two table reads, only on a plate that is a boss while you are a tank holding it
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, no frame code touched
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added