### PR TITLE
fix(unitframes): retry the Player Aura Bars unlock registration

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -2543,8 +2543,31 @@ end
 -- usage, not a verified schema). Both bars use noResize (AuraKit sizes the container
 -- from the active aura count, nothing to drag-resize) and noAnchorTarget (a
 -- dynamically-resizing frame is a bad anchor target for other elements).
+
+-- EllesmereUI's unlock API is published from another file and can arrive after
+-- CreateBars has already run. Both register functions returned silently in that
+-- window and nothing re-drove them, so the bars kept no mover for the session: the
+-- buff frame read as though Blizzard Edit Mode still owned it, and only a live
+-- re-register (toggling Use Blizzard Buffs) brought it back, until the next reload.
+-- Retried the way TryCreateBars retries for ns.db. Giving up stays quiet rather than
+-- erroring, since the API is legitimately absent for the whole session when the
+-- module that publishes it is switched off.
+local UNLOCK_API_RETRY_CAP = 40
+local unlockApiRetries = 0
+local function UnlockApiReady(retry)
+    if EllesmereUI and EllesmereUI.RegisterUnlockElements and EllesmereUI.MakeUnlockElement then
+        unlockApiRetries = 0
+        return true
+    end
+    if unlockApiRetries < UNLOCK_API_RETRY_CAP then
+        unlockApiRetries = unlockApiRetries + 1
+        C_Timer.After(0, retry)
+    end
+    return false
+end
+
 function RegisterPABUnlock()
-    if not (EllesmereUI and EllesmereUI.RegisterUnlockElements and EllesmereUI.MakeUnlockElement) then return end
+    if not UnlockApiReady(RegisterPABUnlock) then return end
     local MK = EllesmereUI.MakeUnlockElement
 
     local function MakeBarElement(key, label, order, isBuff, getParent)
@@ -3835,7 +3858,7 @@ end
 -- bar's key is retired for good and calling UnregisterUnlockElement is correct, not
 -- lossy. Still noResize/noAnchorTarget for the same reason as the default bars.
 local function RegisterPABCustomUnlock()
-    if not (EllesmereUI and EllesmereUI.RegisterUnlockElements and EllesmereUI.MakeUnlockElement) then return end
+    if not UnlockApiReady(RegisterPABCustomUnlock) then return end
     local MK = EllesmereUI.MakeUnlockElement
 
     local prevBuffKeys, prevDebuffKeys = pabRegisteredCustomBuffKeys, pabRegisteredCustomDebuffKeys


### PR DESCRIPTION
Reported by @|Me-Galois|<ε (Unlock Mode, 8.9.4). After a login or `/reload` the
player buff frame behaves as though it still has to be placed through Blizzard
Edit Mode, and the EUI buff styling is not applied. Toggling **Use Blizzard
Buffs** on and back off restores both, until the next reload.

## Why the workaround is the clue

Nothing persistent differs either side of it. The setter stores
`v and true or nil`, so toggling on then off returns the value to `nil`, exactly
what it already was. No saved state changes, which is why no amount of settings
fiddling helps and why it resets every session.

What the toggle actually does is call `PAB_ApplyUseBlizzard()`, which re-runs
`CreateBars()` and the unlock registration -- late enough to succeed.

## Root cause

`RegisterPABUnlock` and `RegisterPABCustomUnlock` both opened with:

```lua
if not (EllesmereUI and EllesmereUI.RegisterUnlockElements and EllesmereUI.MakeUnlockElement) then return end
```

That API is published from another file and can arrive after `CreateBars` has
already run. The bail was silent and nothing re-drove it, so no mover was built
for the whole session and the frame read as Blizzard-owned.

This file already handles the sibling race: `TryCreateBars` retries on a capped
backoff because `ns.db` lands a frame after `PLAYER_LOGIN`. There are two
independent readiness conditions here and only one of them was retried.

That also fits "only on my Mage, other characters on the same profile are fine":
a load-order race turns on init timing, not on saved settings, so it can land
the same way every login on one character and never on another.

## Fix

Both registrations now retry on the same capped, once-a-frame pattern the file
already uses. Giving up after the cap stays quiet rather than erroring, since
the API is legitimately absent for the whole session when the module that
publishes it is switched off, and erroring there would spam every login for
those users.

## Testing

`luac -p` clean; house style check clean. Click-tested in game and behaving
correctly. Worth a confirmation from the reporter as well, since the race is
timing-dependent and landed on his character rather than every character.

![](https://media.giphy.com/media/wKQRIoFXsQIGA/giphy.gif)

