### PR TITLE
feat(bags): flag items taken from the mailbox as Recent

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -7555,15 +7555,20 @@ local function StartAddon()
 
     -- A rise flags a new pickup; a drop (sold/used/deleted) lowers the known
     -- total so a later re-acquisition below the old peak still registers as
-    -- new. Frozen entirely at a mailbox or bank/warband bank -- sending,
-    -- receiving, depositing, or withdrawing would otherwise look identical to
-    -- disposing of or looting an item, since bag contents are all this can
-    -- see. MAIL_CLOSED, BANKFRAME_CLOSED, and
+    -- new. Frozen entirely at a bank/warband bank -- depositing and withdrawing
+    -- look identical to disposing of and looting, since bag contents are all
+    -- this can see. MAIL_CLOSED, BANKFRAME_CLOSED, and
     -- PLAYER_INTERACTION_MANAGER_FRAME_HIDE below silently resync once the
     -- mailbox/bank closes, so none of that traffic falsely flags or evicts
     -- anything.
+    --
+    -- A mailbox is only half that problem, so it no longer freezes both ways: a
+    -- RISE there can only be an item arriving (sending lowers a count, never
+    -- raises one), which is what left auction returns landing with no trace.
+    -- Drops stay ignored: sent, sold and deleted are indistinguishable.
     local function DetectNewItems()
-        if not _snapshotReady or MailOpen() or BankOpen() then return end
+        if not _snapshotReady or BankOpen() then return end
+        local atMail = MailOpen()
         local counts, order = TallyItemCounts()
         for _, itemID in ipairs(order) do
             local count = counts[itemID]
@@ -7576,16 +7581,23 @@ local function StartAddon()
                     EUI_Bags._recentItems[old] = nil
                 end
             end
-            _knownItemCounts[itemID] = count
+            if not atMail or count > known then
+                _knownItemCounts[itemID] = count
+            end
         end
         -- Items gone from bags entirely (sold/used/deleted) no longer appear
         -- in `counts`; drop their known peak too. Equipped is not disposed:
         -- without the guard, swapping gear on (peak pruned) and later off
         -- again (count rises from 0) would re-flag every swapped piece as
         -- recent and FIFO-evict genuine loot.
-        for itemID in pairs(_knownItemCounts) do
-            if not counts[itemID] and not C_Item.IsEquippedItem(itemID) then
-                _knownItemCounts[itemID] = nil
+        -- Skipped at the mailbox for the same reason drops are ignored above: an item
+        -- gone from bags there was as likely posted or sent as disposed of, and
+        -- dropping its peak would re-flag it as new the moment it came back.
+        if not atMail then
+            for itemID in pairs(_knownItemCounts) do
+                if not counts[itemID] and not C_Item.IsEquippedItem(itemID) then
+                    _knownItemCounts[itemID] = nil
+                end
             end
         end
     end


### PR DESCRIPTION
Reported by @Thewildone (9.1.6): unsold auction returns taken out of the
mailbox never show up in **Recent Items**, so they have to be hunted down by
hand in the bags. He also noted that what lands in Recent Items generally feels
inconsistent.

## This was working as designed

Recent Items watches bag counts rise. Detection froze completely at a mailbox
or a bank, because from bag contents alone the traffic is ambiguous in both
directions, and on close it resyncs the baseline so nothing that moved while
standing there flags as new. That is also the "inconsistent" part: looted items
flag, mailbox and bank items never do.

## Why the mailbox is not the bank

At a **bank** a rise really is ambiguous, since withdrawing something already
owned looks exactly like acquiring it.

At a **mailbox** it is not. Nothing there can raise a bag count except an item
arriving, because sending only ever lowers one. The ambiguity the freeze was
protecting against lives entirely on the drop side, where sent, sold and
deleted are indistinguishable.

So rises are now read at the mailbox, and drops are still ignored there:
neither the known peak nor the eviction sweep moves on a drop, which preserves
exactly the protection the freeze existed for. The bank is untouched and stays
frozen in both directions.

The comment above the function is corrected in the same commit, since it
described the mailbox as frozen entirely and that is no longer true.

## Worth weighing before merging

This reverses a deliberate decision rather than fixing a fault, so it is a
behaviour change and wants a second opinion.

One consequence to be aware of: `RECENT_MAX` is **15**, so emptying a large
mailbox can push genuinely recent loot out of the list. That is inherent to
treating mail as an acquisition rather than a flaw in this change, but it is
the trade being made.

## Testing

`luac -p` clean; house style check clean. Not click-tested. Reproduction is to
take an unsold auction return out of the mailbox and check it appears under
Recent Items; the regressions to watch for are bank withdrawals **not** being
flagged, and mailing something away not re-flagging it as new when it comes
back.

![](https://media.giphy.com/media/Ddewm2ZUyVvVu/giphy.gif)
