### PR TITLE
Fonts: say what Global Font covers, and what it does not

### DIFF
--- a/EllesmereUIOptions/EUI_Fonts_Options.lua
+++ b/EllesmereUIOptions/EUI_Fonts_Options.lua
@@ -1432,6 +1432,7 @@ function _G._EUI_BuildFontsPage(pageName, parent, yOffset)
 
     _, h = W:DualRow(parent, y,
         { type="dropdown", text="Global Font",
+          tooltip="Sets the font EllesmereUI uses for its own text. Blizzard's own text, such as the quest log and spellbook, keeps the game font until you turn on Apply to All Game Text below.",
           values=fontDropValues, order=fontDropOrder,
           getValue=function()
               local g = EllesmereUI.GetFontsDB().global or "Expressway"


### PR DESCRIPTION
## What does this PR do?

Adds a tooltip to the **Global Font** dropdown. No behavior change.

Global Font styles EllesmereUI's own text. Blizzard's own text is left on the game face unless **Apply to All Game Text** is enabled, which is off by default. That row had no tooltip at all, so someone who picked a font and then saw the quest log, spellbook and achievements keep the default face had nothing to read on the control they had just used, and no reason to look further down the section.

The Apply to All Game Text toggle already explains this well, but its tooltip only helps once you have found the toggle.

Reported by @Fource, who had set a global font and asked why quest text and the spellbook still differed, and apologised in case it was a stupid question. It was not; there was nothing on screen to tell them.

## How was it tested?

Text-only change to one options row. Verified the file still compiles under Lua 5.1 (`luac -p`) and that the tooltip renders in the same position as the sibling Outline Mode row, which is the only other tooltip in that block.

No locale key change: option row `tooltip=` fields are plain strings, not `EllesmereUI.L()` calls, and re-running `.tools/extract-locale-keys.sh` leaves `EllesmereUILocales/_keys.txt` byte-identical.

## Screenshots

Not included; the change is one tooltip string on an existing control.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- a static string on an options row
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added