### PR TITLE
Feat(Aura Buff Reminders): Warlock soulstone visible bugfix and add "Where to Show" setting 

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3400,6 +3400,17 @@ do
                     elseif aura.check == "ownGroupOrSelf" then
                         local hasOwnBuff = EABR.PlayerOwnBuffOnGroupOrSelf(aura.buffIDs)
                         isMissing = hasOwnBuff == false
+                        if isMissing and aura.key == "soulstone" then
+                            local cooldown = C_Spell.GetSpellCooldown(aura.castSpell)
+                            if cooldown and cooldown.isActive then
+                                -- Ignore the ordinary GCD. If duration is restricted,
+                                -- conservatively hide until the active cooldown ends.
+                                local duration = cooldown.duration
+                                if isSecret(duration) or (duration and duration > 1.5) then
+                                    isMissing = false
+                                end
+                            end
+                        end
                     elseif aura.check == "playerSelfCast" then
                         isMissing = not PlayerHasSelfCastAuraByID(aura.buffIDs)
                     elseif aura.isStance then
@@ -5193,6 +5204,11 @@ mainFrame:SetScript("OnEvent", function(_, e, arg1, arg2, arg3)
         C_Timer.After(2.1, RequestRefresh)
     end
 
+    if e == "SPELL_UPDATE_COOLDOWN" then
+        if _cachedPlayerClass == "WARLOCK" then RequestRefresh() end
+        return
+    end
+
     -- All other events: just refresh
     RequestRefresh()
 end)
@@ -5237,6 +5253,7 @@ mainFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 mainFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 mainFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 mainFrame:RegisterEvent("SPELLS_CHANGED")
+mainFrame:RegisterEvent("SPELL_UPDATE_COOLDOWN")
 mainFrame:RegisterEvent("PLAYER_TALENT_UPDATE")
 mainFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 mainFrame:RegisterEvent("PLAYER_LEVEL_CHANGED")

--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -2049,6 +2049,9 @@ local defaults = {
             -- set for the class specials (open world on).
             whereToShow = { open_world = false },
             specialsWhereToShow = {},
+            -- Warlock-section reminders (Soulstone and Wrong Demon) have
+            -- their own visibility settings.
+            warlockWhereToShow = {},
             -- Pets allowed by the wrong-demon reminder. Absent/false = not allowed.
             wrongPetAllowed = { felguard = true },
             preferredFlask = "last_used",
@@ -3335,11 +3338,14 @@ end
 local function CollectAuras(missing, playerClass, specID, inInstance, inCombat)
 local au = db.profile.auras
 do
-    if not EABR.SectionShows(au.whereToShow, inInstance) then return end
+    local auraSectionShows = EABR.SectionShows(au.whereToShow, inInstance)
     for _, aura in ipairs(AURAS) do
         if aura.standalone then
             -- Handled by standalone system, skip
         elseif au.enabled[aura.key] and (aura.class == playerClass)
+           and ((aura.key == "soulstone"
+                 and EABR.SectionShows(db.profile.consumables.warlockWhereToShow, inInstance))
+                or (aura.key ~= "soulstone" and auraSectionShows))
            and ((aura.isStance and GetStanceState(aura.castSpell)) or (not aura.isStance and Known(aura.castSpell)))
            and not (aura.notIfKnown and Known(aura.notIfKnown))
            and not (aura.requireTalent and not Known(aura.requireTalent))
@@ -4007,6 +4013,7 @@ local function Refresh()
             end
             if not suppress and playerClass == "WARLOCK"
                and co.enabled.wrong_pet ~= false
+               and EABR.SectionShows(co.warlockWhereToShow, inInstance)
                and UnitExists("pet") and not UnitIsDead("pet") then
                 local _, familyID = UnitCreatureFamily("pet")
                 familyID = familyID and not (issecretvalue and issecretvalue(familyID)) and familyID or nil

--- a/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
+++ b/EllesmereUIOptions/EUI_AuraBuffReminders_Options.lua
@@ -733,6 +733,7 @@ initFrame:SetScript("OnEvent", function(self)
     local function AWhere() local a = ADB(); if not a then return nil end; a.whereToShow = a.whereToShow or {}; return a.whereToShow end
     local function CWhere() local c = CDB(); if not c then return nil end; c.whereToShow = c.whereToShow or {}; return c.whereToShow end
     local function CSpecialWhere() local c = CDB(); if not c then return nil end; c.specialsWhereToShow = c.specialsWhereToShow or {}; return c.specialsWhereToShow end
+    local function CWarlockWhere() local c = CDB(); if not c then return nil end; c.warlockWhereToShow = c.warlockWhereToShow or {}; return c.warlockWhereToShow end
     local function RShowWhen() local r = RDB(); if not r then return nil end; r.showWhen = r.showWhen or {}; return r.showWhen end
 
     -- Shared reminder-sound catalogue (built + LSM-populated by the QoL
@@ -1676,6 +1677,12 @@ initFrame:SetScript("OnEvent", function(self)
         -----------------------------------------------------------------------
         local warlockHdr
         warlockHdr, h = W:SectionHeader(parent, SECTION_WARLOCK, y);  y = y - h
+
+        _, h = SectionControlRow(parent, y, {
+            whereStore = CWarlockWhere,
+            whereTooltip = "Pick which content these Warlock reminders appear in.\nRested areas (cities and inns) always stay hidden.",
+            onChange = RefreshAll,
+        });  y = y - h
 
         local WARLOCK_PET_ITEMS = {}
         for _, pet in ipairs(_G._EABR_WARLOCK_PETS or {}) do


### PR DESCRIPTION
## Summary

Fixes the Soulstone reminder remaining visible while Soulstone is on cooldown.

Adds a dedicated **Where to Show** setting for Warlock reminders. Soulstone and Wrong Demon now use these visibility settings instead of Soulstone inheriting the general Aura settings.
