### PR TITLE
perf(core): drop the frame-tree walk at load (419 ms -> 176 ms)

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2399,17 +2399,14 @@ do
     HookPixelSnap(hookFrame:CreateFontString())
     HookPixelSnap(hookFrame:CreateMaskTexture())
 
-    -- Enumerate all existing frame types to catch any we missed
-    local hookedTypes = { Frame = true }
-    local enumObj = EnumerateFrames()
-    while enumObj do
-        local objType = enumObj:GetObjectType()
-        if not enumObj:IsForbidden() and not hookedTypes[objType] then
-            HookPixelSnap(enumObj)
-            hookedTypes[objType] = true
-        end
-        enumObj = EnumerateFrames(enumObj)
-    end
+    -- No frame-tree enumeration here, deliberately. An EnumerateFrames() walk
+    -- used to run at this point "to catch any type we missed": 11,305 frames,
+    -- 248 ms of a 419 ms load, and its only new metatable was StatusBar, which
+    -- the explicit hook below already covers (measured 2026-09-07, identical in
+    -- open world and in a M+ key). It also never saw ItemButton,
+    -- ScrollingMessageFrame or AuraContainer, which this suite creates later, so
+    -- it was not the net it claimed to be. HookPixelSnap dedupes by metatable,
+    -- so every type sharing one hooked here is covered anyway.
 
     -- Also hook ScrollFrame and StatusBar metatables
     HookPixelSnap(CreateFrame("ScrollFrame"))


### PR DESCRIPTION
## What does this PR do?

Removes a full UI frame-tree enumeration that ran at addon load time, cutting the suite's load cost by 58 percent. For the player the UI appears noticeably sooner at login and after every `/reload`.

The PixelPerfect setup in `EllesmereUI.lua` hooks widget metatables so Blizzard's automatic pixel snapping cannot override the addon's own positioning. Alongside its explicit hooks for `Frame`, `Texture`, `FontString`, `MaskTexture`, `ScrollFrame` and `StatusBar`, it also walked the entire frame tree with `EnumerateFrames()`, calling `GetObjectType()` and `IsForbidden()` on every frame, to catch any type the explicit list had missed. Profiled on the live client, that walk stepped over 11,305 frames and cost 248.5 ms of a 419.1 ms load, which is 59 percent of everything the suite spends at login and on every reload.

It never earned that cost. `HookPixelSnap` deduplicates by metatable rather than by object type, and instrumenting which types actually added a hook returned exactly one, `StatusBar`, which the explicit `CreateFrame("StatusBar")` hook six lines further down already covers. The set of hooked metatables after this change is identical to the set before it.

Three further findings from the same instrumentation are kept in the code comment so the loop does not get reintroduced later as a missing safety net. Of the 22 object types the walk visited, 21 contributed nothing, either because they share a metatable that was already hooked or because they carry none of the five texture setters `HookPixelSnap` looks for. The walk never saw `ItemButton`, `ScrollingMessageFrame` or `AuraContainer`, three types this suite creates itself, because those frames do not exist yet when it runs, so the gap it was meant to close had been open all along with no visible consequence. And the visited type list is character-identical in open world and inside a Mythic+ key, which follows from every module declaring `Dependencies: EllesmereUI`: core's main chunk finishes before any module has created a frame, so content cannot change what the walk sees.

Measured result on the same character and the same reload path, before against after: total suite load 419.1 ms to 176.0 ms, of which the `EllesmereUI` main chunk itself went from 282.8 ms to 46.6 ms. As a cross-check, `EllesmereUI.lua` at 12,805 lines now costs 10.9 ms against `EUI_UnlockMode.lua` at 12,881 lines costing 10.6 ms, which is what a file with no remaining load-time work looks like.

## How was it tested?

Live retail client, build 12.1.0 (69587). Verified in game with a load profiler across repeated logins and reloads, before and after the change, on the same character and the same reload path. The type-contribution readout was taken twice, once in open world and once inside a Mythic+ key, and returned an identical result both times.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, this PR adds no settings
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - N/A, no setting involved; the change is a net removal of load-time work
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - removes 248.5 ms of load-time work and adds none
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A, nothing is written; the change only deletes code, and the remaining metatable hooks use `hooksecurefunc`
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
