### PR TITLE
fix(chat): restore tab spacing and even out the first scrolling gap

### DIFF
--- a/EllesmereUIChat/EllesmereUIChat_Tabs.lua
+++ b/EllesmereUIChat/EllesmereUIChat_Tabs.lua
@@ -530,6 +530,8 @@ local function RefreshNow()
 
     local dockList = GENERAL_CHAT_DOCK and GENERAL_CHAT_DOCK.DOCKED_CHAT_FRAMES
     local count = 0
+    local seenScrolling = false
+    local tabGap = (cfg.tabSpacing or 1) * ((EUI.PP and EUI.PP.mult) or 1)
     if type(dockList) == "table" then
         for i = 1, #dockList do
             local cf = dockList[i]
@@ -550,11 +552,21 @@ local function RefreshNow()
                 -- discriminator is the tab's REAL parent (the scroll
                 -- child), never the temporary flag.
                 local wantParent = strip
-                if scrollChild and tab:GetParent() == scrollChild
-                    and EnsureDynClip() then
+                local isScrolling = scrollChild and tab:GetParent() == scrollChild
+                if isScrolling and EnsureDynClip() then
                     wantParent = dynClip
                 end
                 if g:GetParent() ~= wantParent then g:SetParent(wantParent) end
+
+                -- FCFDock_UpdateTabs leaves one UI unit between tabs in each
+                -- group, but none before the first scrolling tab. Compensate
+                -- on our visual only; never re-anchor Blizzard's click targets.
+                local nativeGap = isScrolling and not seenScrolling and 0 or 1
+                if isScrolling then seenScrolling = true end
+                local leftInset = count == 1 and leftExtend or 0
+                if count > 1 and cfg.extendBgBehindTabs ~= true then
+                    leftInset = tabGap - nativeGap
+                end
 
                 g:ClearAllPoints()
                 local band = ns._chatBgExt
@@ -577,7 +589,7 @@ local function RefreshNow()
                     g:SetPoint("RIGHT", tab, "RIGHT", 0, 0)
                 else
                     -- Island tabs: bottom-aligned to the tab, our height.
-                    g:SetPoint("BOTTOMLEFT", tab, "BOTTOMLEFT", count == 1 and leftExtend or 0, 0)
+                    g:SetPoint("BOTTOMLEFT", tab, "BOTTOMLEFT", leftInset, 0)
                     g:SetPoint("BOTTOMRIGHT", tab, "BOTTOMRIGHT", 0, 0)
                     g:SetHeight(height)
                 end


### PR DESCRIPTION
## What does this PR do?

Fixes Tab Spacing being ignored and the uneven gap between pinned and scrolling chat tabs, reported by Railgun on 9.1.6. This restores the spacing behavior addressed in #1000 for the current ghost-tab renderer.

The slider saved `tabSpacing`, but the renderer never read it. Blizzard leaves one UI unit between tabs within each group and no additional gap before the first scrolling tab. Apply the configured spacing as an inset on EUI's visual tab, compensating for that boundary. Backgrounds and borders follow the same rectangle. Blizzard's tab positions, sizes and click areas remain unchanged; larger spacing narrows the visible label area. Tabs Inside Chat Panel keeps its existing layout.

## How was it tested?

- In-game validation reported by Don: Mythic+ dungeon, LFR and open world with `/euidev` enabled. Spacing was visually fixed and no taint was observed. Exact client build was not recorded.
- Lua 5.1: full-file syntax passed. The actual edited anchoring block passed 96 mocked combinations of pinned/scrolling groups, spacing 0/1/3/10, pixel scales and panel mode. The unmodified code fails the same harness. Blizzard-tab proxies reject writes and unexpected method calls.
- Static taint review found no new Blizzard-frame writes or restricted-value reads in the diff. No new hooks, events, timers or per-frame work; only constant arithmetic in the existing refresh pass.
- Changed-line EUI style gate passed. Locale extraction produced no content changes.

## Screenshots

After: General, Combat Log, Trade and DMs tabs with aligned borders.

![Chat tab spacing after the fix](https://raw.githubusercontent.com/dfrisone/EllesmereUI/68d46cf14c6507519badd2c92c622007f34b4212/pr-assets/chat-spacing-after.png)

Before screenshots were supplied with the original report but are not attached here.

## Checklist

- [ ] New settings default **OFF** (no behavior change without opt-in) -- N/A: no new settings; fixes the existing spacing setting.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- this diff adds none; existing lifecycle unchanged.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- no new scheduling or allocations.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- changes only EUI-owned ghost anchors.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added -- M+, LFR and open world with `/euidev`, as reported above.

<img src="https://media0.giphy.com/media/l3nSQg4ZcjBhbgzrq/source.gif" alt="Satisfying alignment" width="180">
