### PR TITLE
Fix party and raid custom buff icon border alignment

### DIFF
--- a/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_AuraContainers.lua
@@ -1236,6 +1236,8 @@ local function ApplyBmIconExtra(button, dd, style)
     -- uninstall): Show post-hook re-hides, alpha 0 covers engine paths that
     -- re-show outside the hooked Lua method. Hook installs lazily on first hide.
     if dd.icon then
+        -- Match the unsnapped border strips at fractional icon edges.
+        if EllesmereUI.PP then EllesmereUI.PP.DisablePixelSnap(dd.icon) end
         dd.bmHideIcon = style.hideIcon == true
         dd.icon:SetShown(not dd.bmHideIcon)
         if dd.bmHideIcon and not dd.bmIconHooked then

--- a/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
+++ b/EllesmereUIRaidFrames/EUI_RaidFrames_BuffManager.lua
@@ -1069,6 +1069,7 @@ function ns.BM_CreatePreviewIndicators(f, health, PP)
         fr:Hide()
 
         local tex = fr:CreateTexture(nil, "ARTWORK")
+        if PP then PP.DisablePixelSnap(tex) end
         tex:SetAllPoints()
         tex:SetTexCoord(0.08, 0.92, 0.08, 0.92)
         fr._tex = tex


### PR DESCRIPTION
## What does this PR do?

Explicitly disable pixel snapping on party/raid custom-buff icon textures so they use the same snapping configuration as their border strips. This addresses the reported uneven border at icon size 22 (size 21 appeared correct).

Apply the existing `PP.DisablePixelSnap` helper in the live custom-buff style callback and when creating preview textures. AuraKit runs the initial style callback before registering the icon with the aura engine. The helper caches configured textures and guards secret/forbidden objects.

Reported by Blazen against 9.1.6, with #1474 cited in the report. This change is limited to the raid-frame custom-buff path and its preview.

## How was it tested?

- Contributor tested in a story-mode raid and a follower dungeon with `/euidev` enabled, changing icon sizes, and reported no errors.
- Exact client build was not recorded; PTR testing was not reported.
- Both changed files compile under Lua 5.1.
- EllesmereUI diff-scoped style gate and `git diff --check` pass.
- Locale extraction completed with no content changes.
- Code review checked TOC loading, initialization order, helper guards/cache, and scope. No new globals, events, hooks, timers, frame scripts, or SavedVariables changes. The live path adds a guarded cached helper call per existing style application; preview configuration runs at texture creation. No per-frame allocations added.

## Screenshots

Before screenshots were supplied in the original report but are not attached to this PR. An after screenshot has not been supplied. Before/after attachments are therefore missing.

## Checklist

- [ ] New settings default **OFF** (no behavior change without opt-in) - N/A: bug fix, no new settings.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no new infrastructure; calls only use existing custom-buff styling/preview paths.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations).
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - only addon-created texture configuration through the existing guarded helper; no new frame fields or scripts.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added - contributor testing above; exact build not recorded.

<img src="https://media.giphy.com/media/ICOgUNjpvO0PC/giphy.gif" alt="A happy cat" width="180">
