### PR TITLE
fix(unitframes): weapon enchant swipe not hiding duration swipe

### DIFF
--- a/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
+++ b/EllesmereUIUnitFrames/EUI_UnitFrames_WeaponEnchants.lua
@@ -120,6 +120,21 @@ local function MakeButton(host, index)
     return b
 end
 
+-- Duration swipe gate. SetShown alone does not stick: PaintContent's
+-- SetCooldown implicitly re-Shows the frame (documented in AK's
+-- ApplyStyleToRegions), and a cooldown started while it was hidden comes back
+-- as a swipe that never advances -- a frozen wedge on some passes, nothing on
+-- others. SetDrawSwipe is persistent cooldown STYLE (SetCooldown never resets
+-- it, AllowedWhenTainted) and alpha survives any re-show; the texts ride their
+-- own frame above the cooldown, so the alpha misses them. Show/Hide stays in
+-- ApplyStyle: it is combat-blocked on the secure trio's descendants.
+local function ApplySwipeGate(b, hide)
+    if b._hideSwipe == hide then return end
+    b._hideSwipe = hide
+    if b.cd.SetDrawSwipe then b.cd:SetDrawSwipe(not hide) end
+    b.cd:SetAlpha(hide and 0 or 1)
+end
+
 -- Mirrors the display's live style onto one of our buttons; the texcoord
 -- cascade is AK ApplyStyleToRegions' exact order. Called out of combat only
 -- for the secure trio (SetSize is geometry).
@@ -156,7 +171,9 @@ local function ApplyStyle(b, style)
     end
     b.cd:SetReverse(style.cooldownReverse ~= false)
     b.cd:SetDrawEdge(style.cooldownDrawEdge == true)
-    b.cd:SetShown(style.hideSwipe ~= true)
+    local hideSwipe = style.hideSwipe == true
+    ApplySwipeGate(b, hideSwipe)
+    b.cd:SetShown(not hideSwipe)
 
     local path = style.fontPath or STANDARD_TEXT_FONT
     local flag = style.fontFlag or "OUTLINE"
@@ -246,11 +263,14 @@ local function ReadEnchants()
 end
 
 -- Fills one button's CONTENT (legal on protected frames in combat).
-local function PaintContent(b, slot, info)
+local function PaintContent(b, slot, info, hideSwipe)
     b.icon:SetTexture(GetInventoryItemTexture("player", slot))
     local remaining = (info.remainingTimeMs or 0) / 1000
     b._expire = GetTime() + remaining
     b.cd:SetCooldown(GetTime(), remaining)
+    -- Combat-legal half of the gate: ApplyStyle cannot run for the secure
+    -- trio in lockdown, so a swipe toggle flipped there lands here.
+    ApplySwipeGate(b, hideSwipe)
     local ch = info.chargesRemaining or 0
     if ch > 1 then b.charges:SetText(ch); b.charges:Show()
     else b.charges:Hide() end
@@ -313,7 +333,7 @@ local function Paint()
                         b:EnableMouse(info and true or false)
                     end
                     if info then
-                        PaintContent(b, SLOTS[i], info)
+                        PaintContent(b, SLOTS[i], info, style.hideSwipe == true)
                         -- In combat positions are frozen: a button whose
                         -- last-packed cell now belongs to the shifted engine
                         -- run (or to another enchant) goes alpha 0 instead
@@ -345,7 +365,8 @@ local function Paint()
                 b:ClearAllPoints()
                 b:SetPoint(rec.ia, rec.frame, rec.fp,
                     rec.x + sign * idx * cell, rec.y)
-                PaintContent(b, activeInfos[i].slot, activeInfos[i].info)
+                PaintContent(b, activeInfos[i].slot, activeInfos[i].info,
+                    style.hideSwipe == true)
                 b._noTooltip = style.noTooltips == true
                 b:EnableMouse(not b._noTooltip)
                 b:SetAlpha(1)

--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames_PlayerAuraBars.lua
@@ -2637,6 +2637,12 @@ local function RestyleBars()
     AK.styles[STYLE_DEBUFFS] = BuildStyle(false, DefaultDebuffsCfg(s))
     AK.RestyleSoon(STYLE_BUFFS)
     AK.RestyleSoon(STYLE_DEBUFFS)
+    -- RestyleSoon only reaches ENGINE buttons. The weapon-enchant cells
+    -- carry the bar's style too but repaint only from their own Paint, so
+    -- the callers that restyle without ApplyLiveConfig (global font/outline
+    -- changes, profile and spec-override swaps through the
+    -- _EUF_ReloadFrames tail) would leave them on the previous style.
+    if ns.WeaponEnchants_Layout then ns.WeaponEnchants_Layout() end
     SyncCancelCVar()
 end
 ns.PAB_Restyle = RestyleBars


### PR DESCRIPTION
## What does this PR do?

Turning off "Show Duration Swipe" on the Player Aura Bars buff bar now also turns it off on the Weapon Enchants cells. Until now the toggle left the oil and imbue icons with a dark cooldown wedge that sat frozen for the entire duration of the enchant, or with no swipe at all, depending on the pass.

The cells gated the swipe with `Cooldown:SetShown` alone, and `PaintContent`'s `SetCooldown` re-shows the frame in the same pass. A cooldown started while the frame was hidden then renders a wedge that never advances, so which of the two writes landed last for a given button decided what the player saw. The gate now uses persistent cooldown style instead: `SetDrawSwipe` plus alpha 0 on the cooldown frame, change-guarded, applied both from `ApplyStyle` and from `PaintContent` so a toggle flipped during combat still lands. `SetShown` stays in the out-of-combat path, because Show/Hide is blocked on the secure trio's descendants. As a side effect the finish bling on the enchant icons is suppressed as well while the swipe is off.

Second fix in the same area: `RestyleBars` now pokes `WeaponEnchants_Layout`. `AK.RestyleSoon` only reaches engine buttons, so the callers that restyle without `ApplyLiveConfig` (global font and outline changes, profile switches and spec-override swaps through the `_EUF_ReloadFrames` tail) left the enchant cells rendering with the previous profile's style.

## How was it tested?

Tested in game on the live client.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, no new setting; this makes an existing per-bar toggle work on the enchant cells
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - the gate is change-guarded, so a steady state costs one boolean compare per button per paint
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added