### PR TITLE
Fix Warlock FocusKick alerts during interrupt cooldowns

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -6368,12 +6368,13 @@ end
 function ns.ResolveCastableInterrupt(sid)
     if type(sid) ~= "number" or sid <= 0 then return nil end
     local knownInBook = ns.IsSpellInPlayerBook
-    if knownInBook(sid) then return sid end
-    -- Talented into a replacement, stored id is the base form.
+    -- Resolve replacements first: Command Demon can remain known while its
+    -- active pet command has the cooldown we need to check.
     if C_SpellBook and C_SpellBook.FindSpellOverrideByID then
         local ovr = C_SpellBook.FindSpellOverrideByID(sid)
         if ovr and ovr > 0 and ovr ~= sid and knownInBook(ovr) then return ovr end
     end
+    if knownInBook(sid) then return sid end
     -- Talented back out, stored id is the replacement form.
     if C_Spell and C_Spell.GetBaseSpell then
         local base = C_Spell.GetBaseSpell(sid)


### PR DESCRIPTION
## What does this PR do?

Fix FocusKick treating Command Demon as ready while the active Warlock command is on cooldown. Resolve a known active spell override before accepting the stored base spell as known, so the readiness check uses Spell Lock or Axe Toss rather than stopping at Command Demon.

The stored selection is preserved. Existing base-spell and pet-bank fallbacks remain unchanged, and the override is resolved on each existing check so pet/talent changes do not require a cached mapping. Reported by matrixsage on 9.1.4.

## How was it tested?

- Installed the focused patch for live testing; the contributor reported that it looks good in game. Exact client build, individual pet/spec coverage, and a separate combat/taint test were not recorded. PTR testing was not reported.
- 14 mocked Lua 5.1 cases exercise the actual resolver and sound handler: Spell Lock/Axe Toss ready and on cooldown, direct selections, non-Warlock interrupts, pet-bank spells, unknown/invalid selections, same-ID and unknown overrides, and replacement-only spellbook entries. The original code reproduces the false alert in the base-known/override-on-cooldown case.
- Full changed file compiles under Lua 5.1. Diff-scoped EUI style gate and whitespace checks pass; locale extraction has no content changes.
- Code review found no blocking issues. No new frame writes, scripts, hooks, events, timers, allocations, or saved settings. Known base spells now incur an override lookup before the existing known-spell check. Readiness still uses the documented non-secret `isActive` field.

## Screenshots

N/A: cooldown sound gating fix; no visual layout change. The report's spellbook/settings screenshots and an after screenshot are not attached.

## Checklist

- [ ] New settings default **OFF** (no behavior change without opt-in) - N/A: bug fix, no new settings.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no new infrastructure; resolver uses existing FocusKick runtime/options paths.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations).
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no frame writes or script changes in this diff.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added - contributor confirmation above; exact build and broader coverage not recorded.

<img src="https://media.giphy.com/media/VbnUQpnihPSIgIXuZv/giphy.gif" alt="Cat checking the computer" width="180">
