### PR TITLE
BlizzardSkin: reassert Buy's anchor and bound the tab-gap scale

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowEngine.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowEngine.lua
@@ -1250,7 +1250,9 @@ function WSkin.NormalizeTabRow(tabs)
             if prev then
                 local gap = (PP and PP.mult) or 1
                 local es = t.GetEffectiveScale and t:GetEffectiveScale()
-                if PP and PP.perfect and es and es > 0 then
+                -- Bound-check es: a corrupted near-zero scale (left behind by
+                -- another addon) would blow this up into a huge, wrong gap.
+                if PP and PP.perfect and es and es > 0.1 and es < 10 then
                     gap = PP.perfect / es
                 end
                 t:ClearAllPoints()

--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin_WindowPacks.lua
@@ -9485,6 +9485,12 @@ local function Skin_AuctionHouse()
     -- engine's checks all miss and no tab reads as active. Sync the FFD
     -- selection override from the display mode instead (tab.displayMode
     -- compared by reference), refreshed on every SetDisplayMode.
+    -- Reassert Buy's own anchor before chaining Sell/Auctions off it below --
+    -- another addon can leave it repositioned after closing its own AH skin.
+    if _G.AuctionHouseFrameBuyTab then
+        _G.AuctionHouseFrameBuyTab:ClearAllPoints()
+        _G.AuctionHouseFrameBuyTab:SetPoint("BOTTOMLEFT", f, "BOTTOMLEFT", 20, -28)
+    end
     local ahTabs = {}
     for _, n in ipairs({ "AuctionHouseFrameBuyTab", "AuctionHouseFrameSellTab",
                          "AuctionHouseFrameAuctionsTab" }) do


### PR DESCRIPTION
Fix from Svart. His GitHub account is currently suspended, so this is being submitted on his behalf.

## What does this PR do?

Fixes the Auction House's bottom tab row (Buy / Sell / My Auctions) drifting badly out of position after swapping between the base UI and another AH addon skin (e.g. TSM).

Blizzard's tab row is a chain, not three independent anchors: Sell anchors off Buy's edge, Auctions off Sell's. Two bugs compounded here:

1. The re-skin only reasserted anchors for the 2nd+ tabs. A displaced BuyTab -- left that way by the other addon after closing its own AH skin -- threw off everything chained after it, since nothing ever put Buy itself back.
2. The gap-width calculation divided by a tab's `GetEffectiveScale()` with no bounds check. A near-zero leftover scale (also left behind by the other addon hiding a tab) turned what should be a ~1px gap into hundreds of pixels.

Fix: explicitly reassert BuyTab's own default anchor before chaining the rest of the row off it, and bound the effective scale to 0.1-10 before dividing by it.

## How was it tested?

Author-tested by Svart; not independently retested in-game by me before opening this on his behalf.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A, this only runs when the AH re-skin already runs
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- both changes are a handful of extra table reads and one anchor call, only when the tab row is (re)built
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- the anchor reassertion is `ClearAllPoints`/`SetPoint` on Blizzard's own AuctionHouseFrameBuyTab, the same pattern the surrounding re-skin already uses on every other tab in the row
- [ ] Tested in-game on live; no version gates or pre-Midnight APIs added -- see note above