### PR TITLE
MythicTimer: reserve threshold-label space early for Gaps style too

### DIFF
--- a/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
+++ b/EllesmereUIMythicTimer/EllesmereUIMythicTimer.lua
@@ -2439,7 +2439,8 @@ local function RenderStandalone()
         y = y - (barGap - defaultSandwichGap)
     end
 
-    if underBarMode then
+    -- Gaps style renders threshold labels above the bar too; reserve space early like under-bar mode.
+    if underBarMode or p.timerBarStyle == "SEGMENTS" then
         RenderThresholdText()
     end
 
@@ -2672,7 +2673,7 @@ local function RenderStandalone()
         RenderEnemyForces()
     end
 
-    if not underBarMode then
+    if not (underBarMode or p.timerBarStyle == "SEGMENTS") then
         RenderThresholdText()
     end
 


### PR DESCRIPTION
Fix from Svart. His GitHub account is currently suspended, so this is being submitted on his behalf.

## What does this PR do?

Fixes Mythic+ Timer's threshold time labels (e.g. 19:12/02:36) rendering directly on top of the main clock text (e.g. 23:00/32:00) when Thresholds style is set to Gaps and Enemy Forces Position is set to Bottom.

Gaps style renders the threshold labels above the timer bar, the same as Under Timer Bar mode. But the code only reserved vertical space for that row before positioning the bar when Enemy Forces Position was Under Timer Bar. With Bottom selected, that reservation ran after the bar instead, leaving nothing held open between the clock text and the bar.

Fix: reserve the space early whenever Gaps style (`timerBarStyle == "SEGMENTS"`) is active, not just in Under Timer Bar mode, matching the pattern already used correctly there.

## How was it tested?

Author-tested by Svart; not independently retested in-game by me before opening this on his behalf.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A, this only touches an existing per-render layout branch
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- the change is one extra boolean check in an existing render pass, no new work added
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, this only affects EllesmereUI's own timer frame layout
- [ ] Tested in-game on live; no version gates or pre-Midnight APIs added -- see note above