### PR TITLE
Fix centered cast-bar spell text truncation

### DIFF
--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -8341,9 +8341,7 @@ initFrame:SetScript("OnEvent", function(self)
             pf.spellText:ClearAllPoints()
             pf.spellText:SetJustifyH(jh)
             pf.spellText:SetPoint(pt, pf.bar, pt, xb + (cb.spellTextX or 0), cb.spellTextY or 0)
-            if cbSpellSide == "center" then
-                pf.spellText:SetWidth(cbBarW * 0.6)
-            elseif cbBarW > 0 then
+            if cbBarW > 0 then
                 pf.spellText:SetWidth(cbBarW - 8 - (cb.showTimer and cbTimerW or 0))
             end
             pf.spellText:SetText(EllesmereUI.L("Spell Name"))

--- a/EllesmereUIOptions/EUI_ResourceBars_Options.lua
+++ b/EllesmereUIOptions/EUI_ResourceBars_Options.lua
@@ -8341,7 +8341,9 @@ initFrame:SetScript("OnEvent", function(self)
             pf.spellText:ClearAllPoints()
             pf.spellText:SetJustifyH(jh)
             pf.spellText:SetPoint(pt, pf.bar, pt, xb + (cb.spellTextX or 0), cb.spellTextY or 0)
-            if cbBarW > 0 then
+            if cbSpellSide == "center" then
+                pf.spellText:SetWidth(cbBarW - 8 - (cb.showTimer and 2 * cbTimerW or 0))
+            elseif cbBarW > 0 then
                 pf.spellText:SetWidth(cbBarW - 8 - (cb.showTimer and cbTimerW or 0))
             end
             pf.spellText:SetText(EllesmereUI.L("Spell Name"))

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -6865,7 +6865,11 @@ end
         nameText:ClearAllPoints()
         nameText:SetJustifyH(jh)
         nameText:SetPoint(pt, bar, pt, xb + (cb.spellTextX or 0), cb.spellTextY or 0)
-        nameText:SetWidth(barW - 8 - (cb.showTimer and timerW or 0))
+        if spellSide == "center" then
+            nameText:SetWidth(barW - 8 - (cb.showTimer and 2 * timerW or 0))
+        else
+            nameText:SetWidth(barW - 8 - (cb.showTimer and timerW or 0))
+        end
         nameText:Show()
     else
         nameText:Hide()

--- a/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
+++ b/EllesmereUIResourceBars/EllesmereUIResourceBars.lua
@@ -6865,11 +6865,7 @@ end
         nameText:ClearAllPoints()
         nameText:SetJustifyH(jh)
         nameText:SetPoint(pt, bar, pt, xb + (cb.spellTextX or 0), cb.spellTextY or 0)
-        if spellSide == "center" then
-            nameText:SetWidth(barW * 0.6)
-        else
-            nameText:SetWidth(barW - 8 - (cb.showTimer and timerW or 0))
-        end
+        nameText:SetWidth(barW - 8 - (cb.showTimer and timerW or 0))
         nameText:Show()
     else
         nameText:Hide()


### PR DESCRIPTION
## What does this PR do?

Fixes Gooma's Resource Bars report from 9.1.6: centered cast-bar spell names were capped at 60% of the bar width and truncated earlier than left/right names, including when placed below the bar with Y offset -13.

Replaces the fixed percentage with the available padded width in both the live cast bar and options preview. Centered names reserve twice the timer width so the centered box clears the timer's slot; left/right names retain their existing single reservation. Anchoring and offsets remain unchanged. Two files, no new settings.

## How was it tested?

- Lua 5.1 compilation passed for both changed files.
- EUI diff-scoped style gate and `git diff --check` passed; locale extraction run.
- The previous revision was tested with Death Gate on a Death Knight. That short-name test was insufficient to validate long-name overlap. Following review, both center branches now reserve the timer on both sides. Geometry check: a 200px bar with timer size 11 yields 143.6px text width, with 24.2px clearance on each side inside the padding.
- Updated revision still needs in-game testing with a genuinely long spell name and a right-side timer; previous screenshots do not validate this revision.
- Exact client build was not supplied. A dedicated restricted-combat/taint run and the original long-name firework reproduction remain unverified. This changes width calculations only; no new secret-value reads, frame creation, registrations, hooks, timers, or per-frame work.

## Screenshots

Before screenshots from the reporter and after Death Gate screenshots were reviewed in the development conversation. They are not available as hosted attachments here; the PR's before/after image pair is missing.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A: no new settings; fixes existing centered alignment.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no added work while disabled.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - existing layout calls only.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - existing addon-owned FontStrings only; no new hooks or scripts.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added - in-game testing reported above, but exact client/build unconfirmed. No version gates or APIs added.

![Making room for text](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif)
