### PR TITLE
[ koKR ]  Update koKR translation for major modules

### DIFF
--- a/EllesmereUILocales/koKR.lua
+++ b/EllesmereUILocales/koKR.lua
@@ -7011,174 +7011,7 @@ L["Colors the enemy nameplate name text to match the unit's reaction (Hostile or
 --오라/강화 효과 알림
 L["Pick which content the class-special reminders (poisons/rites/imbues/shields) appear in.\nRested areas (cities and inns) always stay hidden."] = "직업 전용 알림(독/의식/무기 부여/보호막)을 표시할 콘텐츠를 선택합니다. 휴식 지역(도시 및 여관)에서는 항상 숨겨집니다."
 
---2026-08-21 신규
-
---핵심 애드온 - 공격대/파티 
-L["Active In"] = "활성화 위치"
-L["Cast On"] = "시전 대상"
-L["    Unit Types"] = "대상 종류"
-L["Disabling both disables this binding."] = "둘 다 해제하면 이 단축키도 비활성화됩니다."
-L["Friendly"] = "아군"
-L["Enemy"] = "적군"
-L["Ping Marker"] = "신호 표시기"
-L["Ping Marker Size"] = "신호 표시기 크기"
-L["Unlimited"] = "제한 없음"
-L["Less Common Filters"] = "기타 필터"
-L["Cast By You"] = "내가 시전함"
-L["From Any Player"] = "모든 플레이어"
-L["Can Apply Aura"] = "내가 시전 가능한 오라"
-L["Shown on Modifier"] = "조합키(Modifier) 사용 시 표시"
-
---핵심 애드온 - 공격대 /파티 - 툴팁
-L["Shows the ping mark on a member's frame when someone pings them (needs Blizzard's Show Pings on Raid Frames setting on)."] = "누군가 파티원을 지정해 신호를 보내면 해당 파티원 프레임에 신호 표시를 나타냅니다 (블리자드 설정의 '공격대 프레임에 신호 표시' 기능이 켜져 있어야 합니다)."
-L["Only show debuffs whose full duration is at most this many seconds. Combines with the filters; Unlimited applies no cap."] = "전체 지속 시간이 이 초 이하인 디바이스만 표시합니다. 필터와 결합됩니다: '제한 없음'은 상한선을 두지 않습니다."
-L["Debuffs caused by any player or player pet. The opposite of Non-Player Auras; checking one clears the other."] = "모든 플레이어나 플레이어의 소환수가 입힌 디바이스입니다. 비플레이어 오라의 반대 개념이며, 하나를 체크하면 다른 하나는 해제됩니다."
-L["Debuffs applied by you or your pet."] = "나 또는 내 소환수가 적용한 디바이스입니다."
-L["Debuffs with the Magic dispel type."] = "마법 해제 유형의 디바이스입니다."
-L["Debuffs with the Curse dispel type."] = "저주 해제 유형의 디바이스입니다."
-L["Debuffs with the Poison dispel type."] = "독 해제 유형의 디바이스입니다."
-L["Debuffs with the Disease dispel type."] = "질병 해제 유형의 디바이스입니다."
-L["Debuffs with the Bleed dispel type."] = "출혈 해제 유형의 디바이스입니다."
-L["Debuffs your own class is able to apply."] = "내 직업이 적용할 수 있는 디바이스입니다."
-
---핵심 애드온 - 행동단축바
-L["Skyriding (Airborne)"] = "하늘 경주 (비행 중)"
-L["Skyriding Mount"] = "하늘 경주 탈것"
-L["Mounted"] = "탈것 탑승 중"
-L["Enemy Target"] = "적 대상"
-
---핵심 애드온 - 행동단축바 - 툴팁
-L["While you are inside a house or plot."] = "집이나 개인 영지 내부에 있을 때 적용됩니다."
-L["A target you can attack."] = "공격 가능한 대상입니다."
-L["Hide while this condition is true"] = "이 조건이 참일 때 숨기기"
-L["Reveal on hover only. Combines with the conditions below: hover-reveals while they all pass, stays hidden while any fails."] = "마우스를 올렸을 때만 표시합니다. 아래 조건들과 결합되어 작동합니다. 조건을 '모두 만족'하면 마우스 오버 시 표시되고, 하나라도 만족하지 못하면 숨겨진 상태를 유지합니다."
-L["Only while AIRBORNE on a glide-capable mount or flight form. For the mount itself, ground included, use Skyriding Mount."] = "활공 가능한 탈것이나 비행 형태를 타고 '공중에 떠 있는' 동안에만 적용됩니다. 지상을 포함하여 탈것 자체를 조건으로 지정하려면 '하늘 경주 탈것'을 사용하세요."
-L["While on a glide-capable mount, ground included, where Blizzard shows its vigor HUD. Skyriding (Airborne) additionally requires you to be flying."] = "블리자드 기본 UI에 기력 바가 표시되는 활공 가능한 탈것에 탑승한 상태(지상 포함)에 적용됩니다. '하늘 경주 (비행 중)' 조건은 여기에 추가로 실제 비행 중이어야 합니다."
-L["Dungeons, raids, scenarios, arenas and battlegrounds. Garrisons do not count."] = "던전, 공격대, 시나리오, 투기장 및 전장입니다. 주둔지는 포함되지 않습니다."
-L["Druid travel, aquatic and flight forms count as mounted."] = "드루이드의 여행, 바다, 비행 형태도 탈것 탑승 상태로 간주합니다."
-
---핵심 애드온 - 이름표
-L["Hide Border"] = "테두리 숨기기"
-L["This option requires Blizzard's Assisted Highlight to be enabled"] = "이 옵션을 사용하려면 블리자드의 '보조 강조 효과'를 활성화해야 합니다"
-L["Assisted Highlight"] = "보조 강조 효과"
-L["Assisted Highlight Outset"] = "보조 강조 효과 돌출"
-L["This option requires a style that draws the glow ring"] = "이 옵션을 사용하려면 빛나는 고리를 그리는 스타일이 필요합니다"
-
---핵심 애드온 - 재사용 대기시간 관리자 
-L["Minimum Width"] = "최소 너비"
-L["Icon Slots Wide (0 = Off)"] = "가로 아이콘 칸 수 (0 = 끔)"
-
---핵심 애드온 - 지원 및 시전바
-L["Queue Timer Style"] = "대기열 타이머 스타일"
-L["Text Offset Y"] = "텍스트 Y축 오프셋"
-L["Not Skyriding (Airborne)"] = "하늘라이딩 중 아님 (공중 비행 중 아님)"
-L["Countdown Text Color"] = "카운트다운 텍스트 색상"
-L["Resting"] = "휴식 중"
-L["In Vehicle"] = "탈것 탑승 중"
-L["While seated in a vehicle."] = "탈것에 탑승해 있는 동안."
-L["While resting, in a city or at an inn."] = "대도시나 여관 등에서 휴식 중인 동안."
-
---핵심 애드온 - 지원 및 시전바 - 툴팁
-L["Moves the countdown number up or down relative to the bar."] = "바를 기준으로 카운트다운 숫자를 위 또는 아래로 이동합니다."
-L["Shows a countdown bar below the queue accept popup indicating how long you have to accept. Works with or without the reskin. Use the swatch and cog to set the countdown text color, text size. bar height and text offset."] = "대기열 수락 팝업 아래에 수락할 수 있는 남은 시간을 나타내는 카운트다운 바를 표시합니다. 리스킨 적용 여부와 관계없이 작동합니다. 색상 견본과 톱니바퀴 아이콘을 사용하여 카운트다운 텍스트 색상, 텍스트 크기, 바 높이, 텍스트 오프셋을 설정하세요."
-L["This element shows as soon as ONE Show condition matches. Hide keeps its meaning in both match modes: a checked Hide always hides, on every row."] = "이 요소는 '표시' 조건 중 하나만 일치해도 즉시 표시됩니다. '숨기기'는 두 일치 모드 모두에서 원래의 의미를 유지합니다. '숨기기'에 체크되어 있으면 모든 행에서 항상 숨겨집니다."
-L["The exact inverse of Skyriding (Airborne): anything that is not airborne on a glide-capable mount or flight form, standing on the ground included."] = "하늘라이딩(공중 비행)의 정반대 조건: 활강 가능한 탈것이나 비행 변신 상태로 공중에 떠 있지 않은 모든 상태(지상에 서 있는 상태 포함)를 의미합니다."
-
---핵심 애드온 - 유닛 프레임 
-L["Hide Trailing Zeros"] = "소수점 끝의 0 숨기기"
-L["Hide these instead of showing them"] = "표시하는 대신 숨기기"
-L["Buffs you can spellsteal or purge"] = "마법 훔치기 또는 해제 가능한 강화 효과"
-L["Major defensive cooldowns"] = "주요 생존기"
-L["Auras with a dispel type you can dispel"] = "내가 해제할 수 있는 유형의 오라"
-L["UNIT FRAME AURA FILTERS"] = "유닛 프레임 오라 필터"
-L["Target Tracked Auras"] = "대상 추적 오라"
-L["Copy Included/Excluded Spells From:"] = "포함/제외된 주문 복사 대상:"
-L["Debuffs Blizzard flags as important"] = "블리자드가 중요하다고 지정한 약화 효과"
-L["Fill Color Settings"] = "채우기 색상 설정"
-L["Dynamic Color"] = "동적 색상"
-L["Only Tracked Auras"] = "추적된 오라만"
-L["Important Only"] = "중요 디버프만"
-L["Important and Own"] = "중요 및 자신의 디버프"
-L["Important or Own"] = "중요 또는 자신의 디버프"
-
---핵심 애드온 - 유닛 프레임 - 툴팁
-L["Shows only this frame's Tracked Auras; add them with Edit Tracked Auras at the top of this menu."] = "이 프레임의 추적된 오라만 표시합니다. 이 메뉴 상단의 '추적된 오라 편집'을 통해 추가할 수 있습니다."
-L["Shows every debuff on this frame."] = "이 프레임에 모든 디버프를 표시합니다."
-L["Shows only the debuffs you apply."] = "자신이 부여한 디버프만 표시합니다."
-L["Shows only debuffs Blizzard flags as important."] = "블리자드가 중요하게 지정한 디버프만 표시합니다."
-L["Shows only the debuffs you apply that Blizzard also flags as important."] = "블리자드가 중요하게 지정한 디버프 중 자신이 부여한 디버프만 표시합니다."
-L["Shows the debuffs you apply plus important debuffs from anyone."] = "자신이 부여한 디버프와 다른 사람이 부여한 중요 디버프를 함께 표시합니다."
-
---핵심 애드온 - 재사용 대기시간 관리자
-L["ARCANE SOUL (SUNFURY)"]         = "비전의 영혼 (태양격노)"
-L["Arcane Soul Helper"]            = "비전의 영혼 도우미"
-L["Minimum Width"] = "최소 너비"
-L["Icon Slots Wide (0 = Off)"] = "가로 아이콘 칸 수 (0 = 끔)"
-L["Stack Text and Glows"] = "중첩 문자 및 반짝임"
-L["Glow at Stacks"] = "지정 중첩에서 반짝임"
-L["Comparison"] = "비교"
-L["Show Stack Text"] = "중첩 문자 표시"
-L["Below (<)"] = "미만 (<)"
-L["At Most (<=)"] = "이하 (<=)"
-L["Exactly (=)"] = "일치 (=)"
-L["At Least (>=)"] = "이상 (>=)"
-L["Above (>)"] = "초과 (>)"
-L["Speed"] = "속도" 
-L["Spell ID"] = "주문 ID"
-L["Stack Thresholds"] = "중첩 기준값"
-
---하우징 방문 메뉴 
-L["House"] = "집"
-L["Leave combat to enable visiting."] = "전투에서 벗어난 후에 방문할 수 있습니다."
-L["Loading houses..."] = "집 목록 불러오는 중…"
-L["No houses found."] = "보유한 집이 없습니다."
-L["View Houses"] = "집 보기"
-L["Visit"] = "방문"
-
---편의 기능 - 오라/강화 효과 알림 - 오라,강화 효과 및 소모품
-L["Wrong Demon"] = "소환 불가 악마"
-L["Allowed Demons"] = "소환 가능 악마"
-L["Imp"] = "임프"
-L["Voidwalker"] = "공허방랑자"
-L["Sayaad"] = "세이야드"
-L["Felhunter"] = "지옥사냥개"
-L["You have not learned %1$s."] = "%1$s를 배우지 않았습니다."
-
---편의 기능 - 오라/강화 효과 알림 - 오라,강화 효과 및 소모품 - 툴팁
-L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "현재 소환된 악마가 '소환 가능 악마'에서 선택한 악마가 아닐 때 알림을 표시합니다. 악마는 해당 소환 주문을 배웠을 때만 활성화되므로, '지옥수호병 소환' 특성을 배우지 않은 전문화나 빌드에서는 지옥수호병만 선택해 두어도 알림이 울리지 않습니다."
-L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "'소환 불가 악마' 알림을 제어하기 위해, 정상 소환으로 간주할 악마들을 선택합니다. 악마는 해당 소환 주문을 배웠을 때만 체크되며, 아무것도 선택하지 않거나 모두 선택하면 알림이 작동하지 않습니다."
-
---편의기능 - 편의기능 - 공격대 도구
-L["QUICK FIRE"] = "빠른 징표"
-L["Enable Quick Fire"] = "빠른 징표 사용"
-L["Place World Marker"] = "세계 징표 놓기"
-L["Undo Last Marker"] = "마지막 징표 되돌리기"
-L["Clear All Markers"] = "모든 징표 지우기"
-
---편의기능 - 편의기능 - 공격대 도구 - 툴팁
-L["Adds three optional world-marker keybinds that remain usable in combat. Place drops the first free marker at the cursor in Star to Skull order; Undo removes the last marker placed through Quick Fire; Clear removes all world markers. Every binding starts empty. Marker changes made elsewhere during combat are picked up afterward."] = "전투 중에도 사용할 수 있는 선택적 세계 징표 단축키 3개를 추가합니다. '놓기(Place)'는 별부터 해골 순서대로 커서 위치에 비어 있는 첫 번째 징표를 배치하고, '되돌리기(Undo)'는 퀵 파이어를 통해 마지막으로 배치한 징표를 제거하며, '지우기(Clear)'는 모든 세계 징표를 제거합니다. 모든 단축키는 처음에는 비어 있습니다. 전투 중에 다른 곳에서 변경된 징표는 전투가 끝난 후 반영됩니다."
-L["Shows the Role Check button in window layouts and enables Right Click: Role Check on Compact Band."] = "창 레이아웃에 역할 확인 버튼을 표시하고, 컴팩트 밴드(Compact Band)에서 우클릭 시 역할 확인 기능을 활성화합니다."
-L["Countdown length in seconds. Compact Band uses First with Ctrl + Left Click, Second with Shift + Left Click, Third with Left Click, and Right Click stops the timer. Set a timer to 0 to disable that shortcut."] = "초 단위의 카운트다운 길이입니다. 컴팩트 밴드(Compact Band)는 Ctrl + 좌클릭 시 첫 번째, Shift + 좌클릭 시 두 번째, 그냥 좌클릭 시 세 번째 타이머가 작동하며, 우클릭하면 타이머가 중지됩니다. 해당 단축키를 비활성화하려면 타이머를 0으로 설정하세요."
-
---편의 기능 - 데이터 바
-L["Combat Status"] = "전투 상태"
-L["Broker Plugin"] = "애드온 단축 아이콘"
-L["Plugin"] = "플러그인"
-L["Select a plugin"] = "표시할 애드온 선택"
-L["Strip Colors"] = "색상 코드 제거"
-L["Match Mode"] = "일치 조건 방식"
-L["Match All Conditions"] = "모든 조건 일치"
-L["Match Any Condition"] = "아무 조건이나 일치"
-
---편의 기능 - 데이터 바 - 툴팁
-L["Every condition you set has to match. The default."] = "설정한 모든 조건이 충족되어야 합니다. (기본값)"
-L["This element shows as soon as ONE condition matches, and a Hide lane then means show while that condition is false."] = "이 요소는 하나의 조건이라도 충족되면 즉시 표시되며, 여기서 '숨기기 라인은 해당 조건이 거짓일 때 표시함을 의미합니다."
-L["Any LibDataBroker plugin registered right now. One block per plugin -- add the block again for a second one."] = "현재 등록된 모든 LibDataBroker 애드온(플러그인)입니다. 플러그인당 하나의 블록이 생성되며, 두 번째 블록을 원하시면 블록을 다시 추가하세요."
-L["Shows the plugin's text. Off leaves an icon-only block that still carries the plugin's tooltip and clicks."] = "플러그인의 텍스트를 표시합니다. 끄면 툴팁과 클릭 기능은 유지되면서 아이콘만 표시되는 블록이 됩니다."
-L["Removes the color codes the plugin writes into its own text, so this block's Text Color applies. Off keeps the plugin's colors."] = "플러그인이 자체 텍스트에 지정한 색상 코드를 제거하여 이 블록의 텍스트 색상이 적용되도록 합니다. 끄면 플러그인 원래의 색상이 유지됩니다."
-L["Holds the block at this width and clips longer text, so a plugin whose text keeps changing length never shifts the blocks beside it. Zero sizes the block to whatever the plugin currently says."] = "블록의 너비를 고정하고 긴 텍스트는 잘라냅니다. 텍스트 길이가 자주 바뀌는 플러그인 때문에 옆의 블록들이 밀려나는 현상을 방지합니다. 0으로 설정하면 플러그인의 현재 텍스트 크기에 맞춰 자동 조절됩니다."
-L["Prefixes the plugin's own name to its text."] = "플러그인의 이름을 텍스트 앞에 접두사로 붙입니다."
-L["Shows the plugin's own icon next to its text."] = "텍스트 옆에 플러그인 고유의 아이콘을 표시합니다."
+--2026-09-08 추가 및 신규
 
 --전체 설정 - 글꼴 
 L["Fonts"] = "글꼴"
@@ -7376,9 +7209,208 @@ L["Outline style override for all Bags text. EUI Global Outline follows the glob
 L["Outline style override for all Quickdraw text. EUI Global Outline follows the global Outline Mode setting above."] = "모든 퀵드로우 텍스트의 외곽선 스타일을 강제로 설정합니다. EUI 전체 외곽선은 위의 전체 외곽선 모드 설정을 따릅니다."
 L["Outline style override for all Resource & Cast Bars text. EUI Global Outline follows the global Outline Mode setting above."] = "모든 자원 및 시전 바 텍스트의 외곽선 스타일을 강제로 설정합니다. EUI 전체 외곽선은 위의 전체 외곽선 모드 설정을 따릅니다."
 
+--핵심 애드온 - 공격대/파티 
+L["Active In"] = "활성화 위치"
+L["Cast On"] = "시전 대상"
+L["    Unit Types"] = "대상 종류"
+L["Disabling both disables this binding."] = "둘 다 해제하면 이 단축키도 비활성화됩니다."
+L["Friendly"] = "아군"
+L["Enemy"] = "적군"
+L["Ping Marker"] = "신호 표시기"
+L["Ping Marker Size"] = "신호 표시기 크기"
+L["Unlimited"] = "제한 없음"
+L["Less Common Filters"] = "기타 필터"
+L["Cast By You"] = "내가 시전함"
+L["From Any Player"] = "모든 플레이어"
+L["Can Apply Aura"] = "내가 시전 가능한 오라"
+L["Shown on Modifier"] = "조합키(Modifier) 사용 시 표시"
+
+--핵심 애드온 - 공격대 /파티 - 툴팁
+L["Shows the ping mark on a member's frame when someone pings them (needs Blizzard's Show Pings on Raid Frames setting on)."] = "누군가 파티원을 지정해 신호를 보내면 해당 파티원 프레임에 신호 표시를 나타냅니다 (블리자드 설정의 '공격대 프레임에 신호 표시' 기능이 켜져 있어야 합니다)."
+L["Only show debuffs whose full duration is at most this many seconds. Combines with the filters; Unlimited applies no cap."] = "전체 지속 시간이 이 초 이하인 디바이스만 표시합니다. 필터와 결합됩니다: '제한 없음'은 상한선을 두지 않습니다."
+L["Debuffs caused by any player or player pet. The opposite of Non-Player Auras; checking one clears the other."] = "모든 플레이어나 플레이어의 소환수가 입힌 디바이스입니다. 비플레이어 오라의 반대 개념이며, 하나를 체크하면 다른 하나는 해제됩니다."
+L["Debuffs applied by you or your pet."] = "나 또는 내 소환수가 적용한 디바이스입니다."
+L["Debuffs with the Magic dispel type."] = "마법 해제 유형의 디바이스입니다."
+L["Debuffs with the Curse dispel type."] = "저주 해제 유형의 디바이스입니다."
+L["Debuffs with the Poison dispel type."] = "독 해제 유형의 디바이스입니다."
+L["Debuffs with the Disease dispel type."] = "질병 해제 유형의 디바이스입니다."
+L["Debuffs with the Bleed dispel type."] = "출혈 해제 유형의 디바이스입니다."
+L["Debuffs your own class is able to apply."] = "내 직업이 적용할 수 있는 디바이스입니다."
+
+--핵심 애드온 - 행동단축바
+L["Skyriding (Airborne)"] = "하늘 경주 (비행 중)"
+L["Skyriding Mount"] = "하늘 경주 탈것"
+L["Mounted"] = "탈것 탑승 중"
+L["Enemy Target"] = "적 대상"
+
+--핵심 애드온 - 행동단축바 - 툴팁
+L["While you are inside a house or plot."] = "집이나 개인 영지 내부에 있을 때 적용됩니다."
+L["A target you can attack."] = "공격 가능한 대상입니다."
+L["Hide while this condition is true"] = "이 조건이 참일 때 숨기기"
+L["Reveal on hover only. Combines with the conditions below: hover-reveals while they all pass, stays hidden while any fails."] = "마우스를 올렸을 때만 표시합니다. 아래 조건들과 결합되어 작동합니다. 조건을 '모두 만족'하면 마우스 오버 시 표시되고, 하나라도 만족하지 못하면 숨겨진 상태를 유지합니다."
+L["Only while AIRBORNE on a glide-capable mount or flight form. For the mount itself, ground included, use Skyriding Mount."] = "활공 가능한 탈것이나 비행 형태를 타고 '공중에 떠 있는' 동안에만 적용됩니다. 지상을 포함하여 탈것 자체를 조건으로 지정하려면 '하늘 경주 탈것'을 사용하세요."
+L["While on a glide-capable mount, ground included, where Blizzard shows its vigor HUD. Skyriding (Airborne) additionally requires you to be flying."] = "블리자드 기본 UI에 기력 바가 표시되는 활공 가능한 탈것에 탑승한 상태(지상 포함)에 적용됩니다. '하늘 경주 (비행 중)' 조건은 여기에 추가로 실제 비행 중이어야 합니다."
+L["Dungeons, raids, scenarios, arenas and battlegrounds. Garrisons do not count."] = "던전, 공격대, 시나리오, 투기장 및 전장입니다. 주둔지는 포함되지 않습니다."
+L["Druid travel, aquatic and flight forms count as mounted."] = "드루이드의 여행, 바다, 비행 형태도 탈것 탑승 상태로 간주합니다."
+
+--핵심 애드온 - 이름표
+L["Hide Border"] = "테두리 숨기기"
+L["This option requires Blizzard's Assisted Highlight to be enabled"] = "이 옵션을 사용하려면 블리자드의 '보조 강조 효과'를 활성화해야 합니다"
+L["Assisted Highlight"] = "보조 강조 효과"
+L["Assisted Highlight Outset"] = "보조 강조 효과 돌출"
+L["This option requires a style that draws the glow ring"] = "이 옵션을 사용하려면 빛나는 고리를 그리는 스타일이 필요합니다"
+
+--핵심 애드온 - 지원 및 시전바
+L["Queue Timer Style"] = "대기열 타이머 스타일"
+L["Text Offset Y"] = "텍스트 Y축 오프셋"
+L["Not Skyriding (Airborne)"] = "하늘라이딩 중 아님 (공중 비행 중 아님)"
+L["Countdown Text Color"] = "카운트다운 텍스트 색상"
+L["Resting"] = "휴식 중"
+L["In Vehicle"] = "탈것 탑승 중"
+L["While seated in a vehicle."] = "탈것에 탑승해 있는 동안."
+L["While resting, in a city or at an inn."] = "대도시나 여관 등에서 휴식 중인 동안."
+
+--핵심 애드온 - 지원 및 시전바 - 툴팁
+L["Moves the countdown number up or down relative to the bar."] = "바를 기준으로 카운트다운 숫자를 위 또는 아래로 이동합니다."
+L["Shows a countdown bar below the queue accept popup indicating how long you have to accept. Works with or without the reskin. Use the swatch and cog to set the countdown text color, text size. bar height and text offset."] = "대기열 수락 팝업 아래에 수락할 수 있는 남은 시간을 나타내는 카운트다운 바를 표시합니다. 리스킨 적용 여부와 관계없이 작동합니다. 색상 견본과 톱니바퀴 아이콘을 사용하여 카운트다운 텍스트 색상, 텍스트 크기, 바 높이, 텍스트 오프셋을 설정하세요."
+L["This element shows as soon as ONE Show condition matches. Hide keeps its meaning in both match modes: a checked Hide always hides, on every row."] = "이 요소는 '표시' 조건 중 하나만 일치해도 즉시 표시됩니다. '숨기기'는 두 일치 모드 모두에서 원래의 의미를 유지합니다. '숨기기'에 체크되어 있으면 모든 행에서 항상 숨겨집니다."
+L["The exact inverse of Skyriding (Airborne): anything that is not airborne on a glide-capable mount or flight form, standing on the ground included."] = "하늘라이딩(공중 비행)의 정반대 조건: 활강 가능한 탈것이나 비행 변신 상태로 공중에 떠 있지 않은 모든 상태(지상에 서 있는 상태 포함)를 의미합니다."
+
+--핵심 애드온 - 유닛 프레임 
+L["Hide Trailing Zeros"] = "소수점 끝의 0 숨기기"
+L["Hide these instead of showing them"] = "표시하는 대신 숨기기"
+L["Buffs you can spellsteal or purge"] = "마법 훔치기 또는 해제 가능한 강화 효과"
+L["Major defensive cooldowns"] = "주요 생존기"
+L["Auras with a dispel type you can dispel"] = "내가 해제할 수 있는 유형의 오라"
+L["UNIT FRAME AURA FILTERS"] = "유닛 프레임 오라 필터"
+L["Target Tracked Auras"] = "대상 추적 오라"
+L["Copy Included/Excluded Spells From:"] = "포함/제외된 주문 복사 대상:"
+L["Debuffs Blizzard flags as important"] = "블리자드가 중요하다고 지정한 약화 효과"
+L["Fill Color Settings"] = "채우기 색상 설정"
+L["Dynamic Color"] = "동적 색상"
+L["Only Tracked Auras"] = "추적된 오라만"
+L["Important Only"] = "중요 디버프만"
+L["Important and Own"] = "중요 및 자신의 디버프"
+L["Important or Own"] = "중요 또는 자신의 디버프"
+L["Not overridable"] = "재정의 불가"
+
+--핵심 애드온 - 유닛 프레임 - 툴팁
+L["Shows only this frame's Tracked Auras; add them with Edit Tracked Auras at the top of this menu."] = "이 프레임의 추적된 오라만 표시합니다. 이 메뉴 상단의 '추적된 오라 편집'을 통해 추가할 수 있습니다."
+L["Shows every debuff on this frame."] = "이 프레임에 모든 디버프를 표시합니다."
+L["Shows only the debuffs you apply."] = "자신이 부여한 디버프만 표시합니다."
+L["Shows only debuffs Blizzard flags as important."] = "블리자드가 중요하게 지정한 디버프만 표시합니다."
+L["Shows only the debuffs you apply that Blizzard also flags as important."] = "블리자드가 중요하게 지정한 디버프 중 자신이 부여한 디버프만 표시합니다."
+L["Shows the debuffs you apply plus important debuffs from anyone."] = "자신이 부여한 디버프와 다른 사람이 부여한 중요 디버프를 함께 표시합니다."
+L["Combines with the conditions below: shows outright once at least one passes, otherwise still reveals on hover. A checked Hide state still hides it, hover included."] = "아래 조건들과 결합됩니다. 조건 중 하나라도 충족되면 즉시 표시되며, 그렇지 않은 경우에도 마우스오버 시 표시됩니다. 숨김 상태에 체크되어 있으면 마우스오버를 포함하여 계속 숨겨집니다."
+L["Makes this the override. It replaces the whole Visibility setting, so the conditions below no longer apply while it does. Click it again to remove the override."] = "이 설정을 재정의(오버라이드)로 지정합니다. 전체 가시성 설정을 대체하므로, 이 설정이 적용되는 동안에는 아래의 조건들이 더 이상 적용되지 않습니다. 해제하려면 다시 클릭하세요."
+L["Not overridable. These conditions are shared and can only be changed while no override is being edited. An override replaces the Visibility setting outright -- Never, Always or Mouseover -- and ignores everything set here while it applies."] = "재정의할 수 없습니다. 이 조건들은 공통으로 공유되며 재정의를 편집하고 있지 않을 때만 변경할 수 있습니다. 재정의가 적용되면 가시성 설정(숨김, 항상 표시, 마우스오버)이 완전히 대체되며 여기에 설정된 모든 항목은 무시됩니다."
+L["Not overridable. These conditions are shared and can only be changed while no override is being edited. An override replaces the Visibility setting outright -- Never, Always or Mouseover -- and ignores everything set here while it applies. Mouseover is sealed here too for this element: its hover mechanism follows the shared setting, so an override could only leave it shown."] = "재정의할 수 없습니다. 이 조건들은 공통으로 공유되며 재정의를 편집하고 있지 않을 때만 변경할 수 있습니다. 재정의가 적용되면 가시성 설정(숨김, 항상 표시, 마우스오버)이 완전히 대체되며 여기에 설정된 모든 항목은 무시됩니다. 이 요소의 마우스오버 기능도 함께 고정되어 있어, 마우스오버 작동 방식은 공통 설정을 따르므로 재정의 시 화면에 표시되는 상태로만 남게 됩니다."
+L["Mouseover is sealed here too for this element: its hover mechanism follows the shared setting, so an override could only leave it shown."] = "이 요소의 마우스오버 기능도 함께 고정되어 있습니다. 마우스오버 작동 방식은 공통 설정을 따르므로 재정의를 통해 화면에 표시되는 상태로만 유지할 수 있습니다."
+
+--핵심 애드온 - 재사용 대기시간 관리자
+L["ARCANE SOUL (SUNFURY)"]         = "비전의 영혼 (태양격노)"
+L["Arcane Soul Helper"]            = "비전의 영혼 도우미"
+L["Minimum Width"] = "최소 너비"
+L["Icon Slots Wide (0 = Off)"] = "가로 아이콘 칸 수 (0 = 끔)"
+L["Stack Text and Glows"] = "중첩 문자 및 반짝임"
+L["Glow at Stacks"] = "지정 중첩에서 반짝임"
+L["Comparison"] = "비교"
+L["Show Stack Text"] = "중첩 문자 표시"
+L["Below (<)"] = "미만 (<)"
+L["At Most (<=)"] = "이하 (<=)"
+L["Exactly (=)"] = "일치 (=)"
+L["At Least (>=)"] = "이상 (>=)"
+L["Above (>)"] = "초과 (>)"
+L["Speed"] = "속도" 
+L["Spell ID"] = "주문 ID"
+L["Stack Thresholds"] = "중첩 기준값"
+L["Show Glows Only in Combat (global)"] = "전투 중일 때만 반짝임 표시 (전역)"
+L["Enable Glow at Stacks"] = "중첩 시 반짝임 활성화"
+L["Enable At Stacks"] = "중첩 도달 시 활성화"
+L["At Stacks"] = "설정 중첩"
+L["Glow at Stacks Comparisons"] = "중첩 시 반짝임 비교 조건"
+L["Select Talent"] = "특성 선택"
+
+--핵심 애드온 - 재사용 대기시간 관리자 - 툴팁
+L["Replaces Buff Glow: the icon glows when its stack count matches the comparison below, using this spell's Buff Glow style (Modern WoW Glow if none is set)."] = "강화 효과 반짝임을 대체합니다. 지정한 주문의 강화 효과 반짝임 스타일(지정된 바가 없는 경우 최신 와우 반짝임 스타일 사용)을 활용하여, 중첩 수가 아래 비교 조건과 일치할 때 아이콘이 반짝입니다."
+L["Not available in Buff Missing mode"] = "강화 효과 누락 모드에서는 사용할 수 없습니다."
+L["Only glow once the buff's stack count matches the comparison set via the gear."] = "톱니바퀴 아이콘을 통해 설정한 비교 조건과 강화 효과의 중첩 수가 일치할 때만 반짝입니다."
+L["Hide every Cooldown Manager glow while you are out of combat: proc glows, active state, max stacks, buff and pandemic glows, cooldown ready glows and bar glows.\n\nThey come back the moment you enter combat, including a glow that started before the pull.\n\nApplies to every CDM bar and to the Tracking Bars at once. Glows from other EllesmereUI modules are not affected.\n\nThe Bar Glows page keeps its own per-mapping Only In Combat toggle; this one applies on top of it."] = "비전투 중일 때 재사용 대기시간 관리장치의 모든 반짝임 효과를 숨깁니다 (발동 반짝임, 활성 상태, 최대 중첩, 강화 효과 및 전염성 지속시간 반짝임, 재사용 대기시간 완료 반짝임, 바 반짝임).\n\n전투에 돌입하는 순간 전투 시작 전에 시작된 반짝임을 포함하여 다시 표시됩니다.\n\n모든 CDM 바와 추적 바에 일괄 적용됩니다. 다른 EllesmereUI 모듈의 반짝임은 영향을 받지 않습니다.\n\n'바 반짝임' 페이지에는 개별 매핑별 '전투 중에만 표시' 토글이 따로 유지되며, 이 설정은 그 위에 추가로 적용됩니다."
+
+--하우징 방문 메뉴 
+L["House"] = "집"
+L["Leave combat to enable visiting."] = "전투에서 벗어난 후에 방문할 수 있습니다."
+L["Loading houses..."] = "집 목록 불러오는 중…"
+L["No houses found."] = "보유한 집이 없습니다."
+L["View Houses"] = "집 보기"
+L["Visit"] = "방문"
+
+--편의 기능 - 오라/강화 효과 알림 - 오라,강화 효과 및 소모품
+L["WARLOCK DEMONS"] = "흑마법사 악마"
+L["Warlock Demon Reminder"] = "흑마법사 악마 소환 알림"
+L["Wrong Demon"] = "소환 불가 악마"
+L["Allowed Demons"] = "소환 가능 악마"
+L["Imp"] = "임프"
+L["Voidwalker"] = "공허방랑자"
+L["Sayaad"] = "세이야드"
+L["Felhunter"] = "지옥사냥개"
+L["You have not learned %1$s."] = "%1$s를 배우지 않았습니다."
+L["Show Icon when Sated"] = "탈진/포만감 시 아이콘 표시"
+L["Show Icon with Ready Text"] = "준비 완료 텍스트와 함께 아이콘 표시"
+L["Ready Size"] = "준비 완료 텍스트 크기"
+
+--편의 기능 - 오라/강화 효과 알림 - 오라,강화 효과 및 소모품 - 툴팁
+L["Max Duration and Less Common Filters"] = "최대 지속시간 및 덜 일반적인 필터"
+L["Enter the maximum debuff duration in seconds:"] = "최대 약화 효과 지속시간(초) 입력:"
+L["Show a reminder when your Warlock's active pet isn't one of the demons picked in Allowed Demons. A demon only counts while its summon spell is known, so leaving only Felguard picked stays silent for specs/builds that haven't talented Summon Felguard."] = "현재 소환된 악마가 '소환 가능 악마'에서 선택한 악마가 아닐 때 알림을 표시합니다. 악마는 해당 소환 주문을 배웠을 때만 활성화되므로, '지옥수호병 소환' 특성을 배우지 않은 전문화나 빌드에서는 지옥수호병만 선택해 두어도 알림이 울리지 않습니다."
+L["Pick which demons count as correct for Wrong Demon. A demon only counts while its summon spell is known; with none picked (or everything picked), the reminder never fires."] = "'소환 불가 악마' 알림을 제어하기 위해, 정상 소환으로 간주할 악마들을 선택합니다. 악마는 해당 소환 주문을 배웠을 때만 체크되며, 아무것도 선택하지 않거나 모두 선택하면 알림이 작동하지 않습니다."
+L["Show the Sated/Exhaustion lockout countdown on the icon."] = "아이콘에 포만감/탈진 재사용 대기시간 카운트다운을 표시합니다."
+L["Once the lockout expires, show a Ready label on the icon in place of the countdown. The visibility rule above still applies."] = "대기시간이 끝나면 카운트다운 대신 아이콘에 '준비 완료' 레이블을 표시합니다. 위의 가시성 규칙은 그대로 적용됩니다."
+
+--편의기능 - 편의기능 - 공격대 도구
+L["QUICK FIRE"] = "빠른 징표"
+L["Enable Quick Fire"] = "빠른 징표 사용"
+L["Place World Marker"] = "세계 징표 놓기"
+L["Undo Last Marker"] = "마지막 징표 되돌리기"
+L["Clear All Markers"] = "모든 징표 지우기"
+
+--편의기능 - 편의기능 - 공격대 도구 - 툴팁
+L["Adds three optional world-marker keybinds that remain usable in combat. Place drops the first free marker at the cursor in Star to Skull order; Undo removes the last marker placed through Quick Fire; Clear removes all world markers. Every binding starts empty. Marker changes made elsewhere during combat are picked up afterward."] = "전투 중에도 사용할 수 있는 선택적 세계 징표 단축키 3개를 추가합니다. '놓기(Place)'는 별부터 해골 순서대로 커서 위치에 비어 있는 첫 번째 징표를 배치하고, '되돌리기(Undo)'는 퀵 파이어를 통해 마지막으로 배치한 징표를 제거하며, '지우기(Clear)'는 모든 세계 징표를 제거합니다. 모든 단축키는 처음에는 비어 있습니다. 전투 중에 다른 곳에서 변경된 징표는 전투가 끝난 후 반영됩니다."
+L["Shows the Role Check button in window layouts and enables Right Click: Role Check on Compact Band."] = "창 레이아웃에 역할 확인 버튼을 표시하고, 컴팩트 밴드(Compact Band)에서 우클릭 시 역할 확인 기능을 활성화합니다."
+L["Countdown length in seconds. Compact Band uses First with Ctrl + Left Click, Second with Shift + Left Click, Third with Left Click, and Right Click stops the timer. Set a timer to 0 to disable that shortcut."] = "초 단위의 카운트다운 길이입니다. 컴팩트 밴드(Compact Band)는 Ctrl + 좌클릭 시 첫 번째, Shift + 좌클릭 시 두 번째, 그냥 좌클릭 시 세 번째 타이머가 작동하며, 우클릭하면 타이머가 중지됩니다. 해당 단축키를 비활성화하려면 타이머를 0으로 설정하세요."
+
+--편의 기능 - 데이터 바
+L["Combat Status"] = "전투 상태"
+L["Broker Plugin"] = "애드온 단축 아이콘"
+L["Plugin"] = "플러그인"
+L["Select a plugin"] = "표시할 애드온 선택"
+L["Strip Colors"] = "색상 코드 제거"
+L["Match Mode"] = "일치 조건 방식"
+L["Match All Conditions"] = "모든 조건 일치"
+L["Match Any Condition"] = "아무 조건이나 일치"
+
+--편의 기능 - 커서
+L["Center Reticle"] = "중앙 십자선 점"
+L["Adds a small filled dot at the center of the cursor circle. Uses the same color and opacity as the circle."] = "커서 원 중앙에 작은 채워진 점을 추가합니다. 원과 동일한 색상 및 투명도가 적용됩니다."
+L["Crosshair Frame Strata"] = "십자선 프레임 레이어 층"
+
+--편의 기능 - 데이터 바 - 툴팁
+L["Every condition you set has to match. The default."] = "설정한 모든 조건이 충족되어야 합니다. (기본값)"
+L["This element shows as soon as ONE condition matches, and a Hide lane then means show while that condition is false."] = "이 요소는 하나의 조건이라도 충족되면 즉시 표시되며, 여기서 '숨기기 라인은 해당 조건이 거짓일 때 표시함을 의미합니다."
+L["Any LibDataBroker plugin registered right now. One block per plugin -- add the block again for a second one."] = "현재 등록된 모든 LibDataBroker 애드온(플러그인)입니다. 플러그인당 하나의 블록이 생성되며, 두 번째 블록을 원하시면 블록을 다시 추가하세요."
+L["Shows the plugin's text. Off leaves an icon-only block that still carries the plugin's tooltip and clicks."] = "플러그인의 텍스트를 표시합니다. 끄면 툴팁과 클릭 기능은 유지되면서 아이콘만 표시되는 블록이 됩니다."
+L["Removes the color codes the plugin writes into its own text, so this block's Text Color applies. Off keeps the plugin's colors."] = "플러그인이 자체 텍스트에 지정한 색상 코드를 제거하여 이 블록의 텍스트 색상이 적용되도록 합니다. 끄면 플러그인 원래의 색상이 유지됩니다."
+L["Holds the block at this width and clips longer text, so a plugin whose text keeps changing length never shifts the blocks beside it. Zero sizes the block to whatever the plugin currently says."] = "블록의 너비를 고정하고 긴 텍스트는 잘라냅니다. 텍스트 길이가 자주 바뀌는 플러그인 때문에 옆의 블록들이 밀려나는 현상을 방지합니다. 0으로 설정하면 플러그인의 현재 텍스트 크기에 맞춰 자동 조절됩니다."
+L["Prefixes the plugin's own name to its text."] = "플러그인의 이름을 텍스트 앞에 접두사로 붙입니다."
+L["Shows the plugin's own icon next to its text."] = "텍스트 옆에 플러그인 고유의 아이콘을 표시합니다."
+
 --UI 모양 변경 -기본 UI 개선 - 블리자드 스킨
 L["Friend Notifications"] = "친구 알림"
+L["Friend Notifications Skin"] = "친구 알림 스킨"
+
+--UI 모양 변경 -기본 UI 개선 - 블리자드 스킨 -툴팁
 L["The Battle.net popup when a friend comes online or goes offline, plus broadcasts and invites."] = "친구가 접속하거나 오프라인 상태가 될 때 뜨는 배틀넷 팝업과 브로드캐스트, 초대 메시지를 관리합니다."
+L["Changing the Friend Notifications reskin requires a UI reload to fully swap between Blizzard and Ellesmere styles."] = "블리자드 기본 스타일과 Ellesmere 스타일 간에 친구 알림 리스킨을 완전히 전환하려면 UI 재접속(리로드)이 필요합니다."
 
 --UI 모양 변경 - 쐐기돌 도구 
 L["INTERRUPT AND VISIBILITY"] = "차단 및 가시성"
@@ -7389,6 +7421,13 @@ L["Range Fade Settings"] = "사거리 흐려짐 설정"
 L["Raid Target Marker"] = "공격대 징표"
 L["Important Cast Glow Settings"] = "중요 시전 반짝임 설정"
 
+--UI 모양 변경 - 데미지창
+L["Outfits"] = "복장"
+L["Show/Hide Windows Keybind"] = "창 표시/숨기기 단축키"
+L["Keybind Scope"] = "단축키 적용 범위"
+L["Include Combat Timer"] = "전투 시간 포함"
+L["Include Spell History"] = "주문 사용 기록 포함"
+
 --UI 모양 변경 - 가방
 L["Show Clear Button"] = "초기화 버튼 표시"
 L["GROUPING"] = "그룹화"
@@ -7396,6 +7435,11 @@ L["Group by Category"] = "카테고리별 그룹화"
 L["Category Sidebar"] = "카테고리 사이드바"
 L["Hide Empty Slots When Grouped"] = "그룹화 시 빈 칸 숨기기"
 L["Hide Bank Tabs in Sidebar"] = "사이드바에서 은행 탭 숨기기"
+L["Stack Splitter"] = "아이템 묶음 분할기"
+L["Auto Split"] = "자동 분할"
+L["Split Stack"] = "묶음 분할"
+L["Empty Slots"] = "빈 슬롯"
+L["No Items"] = "아이템 없음"
 
 --UI 모양 변경 -가방 - 툴팁
 L["Turn on Category Sidebar first, or the sidebar would have nothing left to navigate with."] = "'카테고리 사이드바'를 먼저 켜주세요. 그렇지 않으면 사이드바에서 탐색할 항목이 없"
@@ -7405,6 +7449,9 @@ L["In the OneBank and OneWarbank views, split the grid under expansion headers, 
 L["List item categories in the bank sidebar the way the bags sidebar does -- groups such as The Armory with Weapons and Armor under them. Selecting one filters the grid to that category. Categories that split further list their parts as a third level while selected: Professions by profession, Armor by equipment slot, Trade Goods by material. Spans your character bank and warband together, so a category shows everything you own."] = "가방 사이드바와 마찬가지로 은행 사이드바에 아이템 카테고리를 나열합니다(예: 무기 및 방어구가 속한 무기고 그룹). 항목을 선택하면 해당 카테고리로 격자창이 필터링됩니다. 하위로 나뉘는 카테고리는 선택 시 세 번째 단계로 표시됩니다(예: 전문 기술별 기술, 장비 부위별 방어구, 재질별 무역 상품). 캐릭터 은행과 전투부대가 통합되어 표시되므로, 카테고리 하나로 보유 중인 모든 아이템을 확인할 수 있습니다."
 L["Turn on Nest by Expansion or Group by Category first; the flat view has nowhere to move empty slots to."] = "'확장팩별 중첩' 또는 '카테고리별 그룹화'를 먼저 켜주세요. 기본(평면) 보기에서는 빈 칸을 이동할 공간이 없"
 L["Split items by category -- Armor, Consumables, Professions and so on -- using the same category list, order and renames as the All Items bag view. Nests inside the expansion headers when Nest by Expansion is also on. Categories that split further do so automatically: gear by equipment slot, Professions and Trade Goods by profession and material type."] = "'모든 아이템' 가방 보기와 동일한 카테고리 목록, 순서, 이름을 사용하여 아이템을 카테고리(방어구, 소모품, 전문 기술 등)별로 분류합니다. '확장팩별 중첩'이 켜져 있으면 확장팩 헤더 내부에 중첩됩니다. 세부 분류가 있는 카테고리는 장비 부위별 장비, 전문 기술 및 재질별 전문 기술/무역 상품 등으로 자동 분류됩니다."
+L["Shift-click a stack in the bags or bank to open a split dialog with an Auto Split button, which splits the stack into empty slots repeatedly until only the chosen amount or less remains. Off uses the default split popup."] = "가방이나 은행의 아이템 묶음을 Shift+클릭하면 '자동 분할' 버튼이 포함된 분할 창이 열립니다. 이 기능은 선택한 수량 이하가 남을 때까지 빈 슬롯에 묶음을 반복해서 나누어 담습니다. 끄면 기본 분할 팝업이 대신 사용됩니다."
+L["Drop the individual Tab 1 / Tab 2 / Warbank Tab entries once the category list is doing the navigating. The consolidated views stay. Note that right-clicking a tab entry is the only way to rename a tab or change its deposit filters, so leave this off if you still need that."] = "카테고리 목록이 탐색 기능을 대신 수행하므로 개별 탭 1 / 탭 2 / 전투부대 탭 항목을 제거합니다. 통합 뷰는 유지됩니다. 탭 이름을 변경하거나 보관 필터를 변경하려면 탭을 우클릭하는 것이 유일한 방법이므로, 해당 기능이 필요하다면 이 옵션을 꺼두세요."
+L["While either grouping toggle is on, drop the trailing block of empty slots so the view only shows items. Turn this off to keep the free slots visible for depositing."] = "두 그룹화 토글 중 하나라도 켜져 있는 동안, 마지막에 남는 빈 슬롯 블록을 숨겨 아이템만 표시되도록 합니다. 아이템 보관을 위해 빈 슬롯을 계속 보이게 하려면 이 옵션을 끄세요."
 
 --UI 모양 변경 - 기본 ui 개선 - 툴팁,메뉴&팝업
 L["Restyles Blizzard's on-screen progress bars (event objectives, nameplate counters) to the EUI look. Requires reload to apply.\n\nThese bars are drawn over rather than modified, so if the game ever reports their contents as protected the original bar is shown instead.\n\nUse the cog to set a minimum size, so bars on shrunken nameplates stay readable."] = "블리자드의 기본 화면 진행 바(이벤트 목표, 이름표 카운터 등)를 EUI 스타일로 재디자인합니다. 적용하려면 애드온을 새로고침(리로드)해야 합니다.\n\n이 바들은 기존 바를 수정하는 게 아니라 그 위에 덧그리는 방식이므로, 게임 내에서 해당 콘텐츠를 보호 항목으로 지정할 경우 원래의 기본 바가 대신 표시됩니다.\n\n톱니바퀴 아이콘을 눌러 최소 크기를 설정하면, 작아진 이름표 위의 바도 가독성을 유지할 수 있습니다."


### PR DESCRIPTION

## What does this PR do?

Adds and updates the koKR (Korean) localization for newly added features in EllesmereUI. 
This includes translations for:
- Quality of Life & Skins (Cursor features, Aura/Sated trackers, Friend notifications reskin)
- Auras & Debuffs / Cooldown Manager (Tracking rules, cooldown bars, and buff/debuff priorities)
- Bags & Bank (Visual exceptions and visibility overrides for bag/bank categories)
- Misc & Pets (Warlock Demon Reminder)
- Quickdraw & Damage Meters (Outfits, Spell History settings)

## How was it tested?

Tested in-game on the live retail client. Verified that all translated strings are displayed correctly in the configuration menu without any overlap or line-break issues.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added