### PR TITLE
Fix(Damage Meter): uneven Damage Meter bar spacing at any UI scale

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -2174,6 +2174,7 @@ do
             if _G._ERB_Apply then _G._ERB_Apply() end
             if _G._EAB_Apply then _G._EAB_Apply() end
             if _G._ECME_Apply then _G._ECME_Apply() end
+            if _G._EDM_Rescale then _G._EDM_Rescale() end
             -- Re-sync width/height matches against the new grid. UIParent:SetScale()
             -- does NOT fire UI_SCALE_CHANGED (that event is CVar-tied), so no listener
             -- catches this path. Debounced: the Options slider calls this repeatedly

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters.lua
@@ -996,6 +996,30 @@ local function PhysicalPixels(userValue)
     return value
 end
 
+-- Row geometry with both terms on ONE pixel grid. barHeight is stored as a
+-- physical pixel count (plain slider), barSpacing in coordinate units (pixel
+-- slider), so it carries the UI scale it was set at. Snapping only the height
+-- left the stride between two grids and -((i-1) * stride) drifted down the
+-- list: a spacing of 1 then rendered as 0px on some rows and 2px on others, at
+-- a fractional UI scale and equally at a pixel-perfect one whenever the value
+-- had been saved at another scale.
+-- Returns barH, barSp, stride and one physical pixel, in coordinate units.
+local function RowMetrics(heightPx, spacingCoord, es)
+    local PP = EUI and EUI.PP
+    if PP and PP.perfect and PP.SnapForES then
+        if not es or es <= 0 then es = (UIParent and UIParent:GetEffectiveScale()) or 1 end
+        local onePixel = PP.perfect / es
+        local barH = PP.SnapForES((heightPx or 18) * onePixel, es)
+        local barSp = PP.SnapForES(spacingCoord or 2, es)
+        return barH, barSp, barH + barSp, onePixel
+    end
+    local barH, barSp = PhysicalPixels(heightPx or 18), spacingCoord or 2
+    return barH, barSp, barH + barSp, (PP and PP.mult) or 1
+end
+-- On ns as well: CreateDMWindow sits at Lua 5.1's 60-upvalue cap, so its call
+-- sites reach the helper through ns (already one of its upvalues).
+ns._RowMetrics = RowMetrics
+
 -- Number formatting: delegates to the shared EllesmereUI_NumberFormat.lua engine
 -- (breakpoint tables, the CJK wan/yi grouping tables and the
 -- AbbreviateNumbers/CreateAbbreviateConfig plumbing all live there now,
@@ -1438,6 +1462,17 @@ local function TTPhysicalPixels(userValue)
     return PP.SnapForES((userValue or 0) * onePixel, es)
 end
 
+-- Row stride for the tooltip list. TT_BAR_H is a raw coordinate height while the
+-- gap is snapped to whole pixels, so their sum sits between two pixel rows and
+-- -((i-1) * stride) drifts down the list, the same defect the main bars had.
+-- Snap the sum; the row height itself keeps its current size.
+local function TTStride()
+    local sp = TTPhysicalPixels(1)
+    local PP = EUI and EUI.PP
+    if not PP or not PP.SnapForES or not _ttFrame then return TT_BAR_H + sp end
+    return PP.SnapForES(TT_BAR_H + sp, _ttFrame:GetEffectiveScale())
+end
+
 local function BlizzardSkinBordersAvailable()
     return C_AddOns and C_AddOns.IsAddOnLoaded
         and C_AddOns.IsAddOnLoaded("EllesmereUIBlizzardSkin")
@@ -1507,12 +1542,12 @@ end
 local function EnsureTTBar(i)
     if _ttBars[i] then return _ttBars[i] end
     EnsureTooltipFrame()
-    local ttSp = TTPhysicalPixels(1)
+    local ttStride = TTStride()
     local b = {}
     b.row = CreateFrame("Frame", nil, _ttFrame)
     b.row:SetHeight(TT_BAR_H)
-    b.row:SetPoint("TOPLEFT", _ttFrame, "TOPLEFT", 0, -(TT_HDR_H + (i-1) * (TT_BAR_H + ttSp)))
-    b.row:SetPoint("TOPRIGHT", _ttFrame, "TOPRIGHT", 0, -(TT_HDR_H + (i-1) * (TT_BAR_H + ttSp)))
+    b.row:SetPoint("TOPLEFT", _ttFrame, "TOPLEFT", 0, -(TT_HDR_H + (i-1) * ttStride))
+    b.row:SetPoint("TOPRIGHT", _ttFrame, "TOPRIGHT", 0, -(TT_HDR_H + (i-1) * ttStride))
     b.fill = CreateFrame("StatusBar", nil, b.row)
     b.fill:SetAllPoints(); b.fill:SetMinMaxValues(0, 1); b.fill:SetValue(0); b.fill:SetStatusBarTexture(BAR_TEX)
     b.spellIcon = b.row:CreateTexture(nil, "OVERLAY")
@@ -1530,7 +1565,7 @@ local function EnsureTTBar(i)
     return b
 end
 
-local _ttLastSp = -1
+local _ttLastStride = -1
 local _ttSorted = {}
 
 local function PopulatePreview(bar, curSession, curSessionID, curDMType)
@@ -1545,11 +1580,11 @@ local function PopulatePreview(bar, curSession, curSessionID, curDMType)
     if not bar._srcGUID and not bar._src.sourceCreatureID then return false end
     if not C_DamageMeter then return false end
 
-    -- Reposition tooltip bars with physical-pixel spacing (only when spacing changes)
+    -- Reposition tooltip bars with physical-pixel spacing (only when the stride changes)
     local ttSp = TTPhysicalPixels(1)
-    local ttStride = TT_BAR_H + ttSp
-    if ttSp ~= _ttLastSp then
-        _ttLastSp = ttSp
+    local ttStride = TTStride()
+    if ttStride ~= _ttLastStride then
+        _ttLastStride = ttStride
         for ti = 1, #_ttBars do
             local b = _ttBars[ti]
             if b then
@@ -3093,7 +3128,7 @@ local function CreateDMWindow(winIdx)
     local _scrollRefreshPending = false
     viewport:EnableMouseWheel(true)
     viewport:SetScript("OnMouseWheel", function(_, delta)
-        local c = DB(); local step = (PhysicalPixels(c.barHeight or 18) + (c.barSpacing or 2)) * 2
+        local c = DB(); local _, _, step = ns._RowMetrics(c.barHeight or 18, c.barSpacing or 2, frame:GetEffectiveScale()); step = step * 2
         local cur = viewport:GetVerticalScroll() or 0
         local newVal = math.max(0, math.min(_scrollMax, cur - delta * step))
         viewport:SetVerticalScroll(newVal)
@@ -3139,7 +3174,7 @@ local function CreateDMWindow(winIdx)
     local _srcScrollMax = 0
     W.srcViewport:EnableMouseWheel(true)
     W.srcViewport:SetScript("OnMouseWheel", function(_, delta)
-        local c = DB(); local step = (PhysicalPixels(c.barHeight or 18) + (c.barSpacing or 2)) * 2
+        local c = DB(); local _, _, step = ns._RowMetrics(c.barHeight or 18, c.barSpacing or 2, frame:GetEffectiveScale()); step = step * 2
         local cur = W.srcViewport:GetVerticalScroll() or 0
         W.srcViewport:SetVerticalScroll(math.max(0, math.min(_srcScrollMax, cur - delta * step)))
     end)
@@ -3371,8 +3406,8 @@ local function CreateDMWindow(winIdx)
 
     local function RecalcViewport(dataCount)
         if not viewport or not content then return end
-        local c = DB(); local barH = PhysicalPixels(c.barHeight or 18); local barSp = c.barSpacing or 2
-        local totalH = dataCount * (barH + barSp)
+        local c = DB(); local _, _, stride = ns._RowMetrics(c.barHeight or 18, c.barSpacing or 2, frame:GetEffectiveScale())
+        local totalH = dataCount * stride
         content:SetHeight(math.max(10, totalH))
         local viewH = viewport:GetHeight(); if viewH < 1 then viewH = 1 end
         _scrollMax = math.max(0, totalH - viewH)
@@ -3397,11 +3432,10 @@ local function CreateDMWindow(winIdx)
         local playerIdx
         for i, src in ipairs(sources) do if src.isLocalPlayer then playerIdx = i; break end end
         if not playerIdx then W.stickyPlayer.row:Hide(); W.stickySep:Hide(); ResetScrollAnchors(); W.stickyAtTop = false; return end
-        local barH = PhysicalPixels(c.barHeight or 18); local barSp = c.barSpacing or 2; local stride = barH + barSp
+        local barH, _, stride, pxMult = ns._RowMetrics(c.barHeight or 18, c.barSpacing or 2, frame:GetEffectiveScale())
         local scrollVal = viewport:GetVerticalScroll() or 0
         local fullViewH = frame:GetHeight() - GetHeaderH()
         if fullViewH < 1 then fullViewH = 1 end
-        local pxMult = (PP and PP.mult) or 1
         local barTop = (playerIdx - 1) * stride
         local barBot = barTop + barH
         -- Unpin the instant the player bar is fully within the viewport (1px tolerance for float drift)
@@ -3528,7 +3562,7 @@ local function CreateDMWindow(winIdx)
         if session and session.combatSources then
 
             local sources = session.combatSources
-            local c = DB(); local barH = PhysicalPixels(c.barHeight or 18); local barSp = c.barSpacing or 2; local stride = barH + barSp
+            local c = DB(); local barH, barSp, stride = ns._RowMetrics(c.barHeight or 18, c.barSpacing or 2, frame:GetEffectiveScale())
             local leftFS = c.leftFontSize or c.fontSize or 11; local rightFS = c.rightFontSize or c.fontSize or 11
             local fontSize = leftFS -- compat for cacheKey
             local showIcon = (c.iconStyle or "spec") ~= "none"
@@ -3831,8 +3865,7 @@ local function CreateDMWindow(winIdx)
             -- Events come newest-first from API; reverse to oldest-first
             local reversed = {}
             for ri = #events, 1, -1 do reversed[#reversed + 1] = events[ri] end
-            local c = DB(); local barH = PhysicalPixels(c.barHeight or 18)
-            local barSp = c.barSpacing or 2; local stride = barH + barSp
+            local c = DB(); local barH, _, stride = ns._RowMetrics(c.barHeight or 18, c.barSpacing or 2, frame:GetEffectiveScale())
             local leftFS = c.leftFontSize or c.fontSize or 11; local rightFS = c.rightFontSize or c.fontSize or 11
             local texPath, texKey = GetBarTexturePath()
             local deathTime = reversed[#reversed] and reversed[#reversed].timestamp
@@ -3939,13 +3972,12 @@ local function CreateDMWindow(winIdx)
                 local ok, sd = pcall(C_DamageMeter.GetCombatSessionSourceFromType, W.curSession, W.curDMType, guid, cid)
                 if ok then srcData = sd end
             end
-            local c = DB(); local barH = PhysicalPixels(c.barHeight or 18)
+            local c = DB(); local barH, _, stride = ns._RowMetrics(c.barHeight or 18, c.barSpacing or 2, frame:GetEffectiveScale())
             local players = AggregateEnemyPlayers(srcData, GetBreakdownDuration(W.curSession, W.curSessionID))
             if not players then
                 if W.spellPool then for i = 1, BAR_POOL_SIZE do W.spellPool[i].row:Hide() end end
                 return
             end
-            local barSp = c.barSpacing or 2; local stride = barH + barSp
             local leftFS = c.leftFontSize or c.fontSize or 11; local rightFS = c.rightFontSize or c.fontSize or 11
             local texPath, texKey = GetBarTexturePath()
             local maxAmt = players[1].total
@@ -3996,8 +4028,8 @@ local function CreateDMWindow(winIdx)
             if W.spellPool then for i = 1, BAR_POOL_SIZE do W.spellPool[i].row:Hide() end end
             return
         end
-        local spells = srcData.combatSpells; local c = DB(); local barH = PhysicalPixels(c.barHeight or 18)
-        local barSp = c.barSpacing or 2; local stride = barH + barSp; local leftFS = c.leftFontSize or c.fontSize or 11; local rightFS = c.rightFontSize or c.fontSize or 11; local texPath, texKey = GetBarTexturePath()
+        local spells = srcData.combatSpells; local c = DB(); local barH, barSp, stride = ns._RowMetrics(c.barHeight or 18, c.barSpacing or 2, frame:GetEffectiveScale())
+        local leftFS = c.leftFontSize or c.fontSize or 11; local rightFS = c.rightFontSize or c.fontSize or 11; local texPath, texKey = GetBarTexturePath()
         local sorted = {}
         for _, spell in ipairs(spells) do local ok, amt = pcall(function() return spell.totalAmount end); sorted[#sorted + 1] = { spell = spell, amount = (ok and amt) or 0 } end
         -- API returns combatSpells pre-sorted; no table.sort needed
@@ -4477,6 +4509,24 @@ end
 ns.RefreshMeter = function()
     for _, w in ipairs(_windows) do w.Refresh() end
 end
+
+-- Re-lay out every row after a UI scale change. The row stride is derived from
+-- the frame's effective scale, so a new scale invalidates the cached row
+-- anchors; busting _barCacheKey makes the next refresh re-anchor them. Rows are
+-- otherwise only re-anchored on a settings change or from the in-combat ticker,
+-- so out of combat the old grid would survive until the next fight. Deliberately
+-- not _EDM_Apply (a full teardown and rebuild): the core scale slider calls this
+-- on every drag step.
+ns.Rescale = function()
+    for _, w in ipairs(_windows) do
+        w._barCacheKey = nil
+        w.Refresh()
+        if w.sourceOpen and w.RefreshBreakdown then w.RefreshBreakdown() end
+    end
+    if ns.ApplySpellHistory then ns.ApplySpellHistory() end
+end
+-- Called by the core right after PP.SetUIScale, alongside the other modules' re-apply hooks
+_G._EDM_Rescale = ns.Rescale
 
 -- Bust per-class color caches and repaint when global custom class colors change, so bars/text
 -- recolor live without a /reload (color is cached keyed only on classFile, which the palette edit doesn't change).

--- a/EllesmereUIDamageMeters/EllesmereUIDamageMeters_SpellHistory.lua
+++ b/EllesmereUIDamageMeters/EllesmereUIDamageMeters_SpellHistory.lua
@@ -1277,9 +1277,8 @@ local function BuildBarWindow()
     -- Size: width from DB, height auto-calculated from maxBars
     local hdrH = hideTop and 0 or 22
     local maxBars = sh.maxBars or 5
-    local barH = PhysicalPixels(sh.shBarHeight or 18)
-    local barSp = dmCfg.barSpacing or 2
-    local autoH = hdrH + maxBars * (barH + barSp)
+    local _, _, stride = ns._RowMetrics(sh.shBarHeight or 18, dmCfg.barSpacing or 2, _barWin:GetEffectiveScale())
+    local autoH = hdrH + maxBars * stride
     _barWin:SetSize(sh.barWidth or 300, autoH)
     _barWin._locked = sh.barLocked or false
     local pos = sh.barPos
@@ -1305,9 +1304,7 @@ RefreshBarWindow = function()
 
     local dmCfg = ns.EDM.DB()
     local sh = DB()
-    local barH = PhysicalPixels(sh.shBarHeight or 18)
-    local barSp = dmCfg.barSpacing or 2
-    local stride = barH + barSp
+    local barH, barSp, stride = ns._RowMetrics(sh.shBarHeight or 18, dmCfg.barSpacing or 2, _barWin:GetEffectiveScale())
     local texPath = GetBarTexturePath()
     local fontSize = sh.textSize or 11
     local content = _barWin._content


### PR DESCRIPTION
## What does this PR do?

Bar spacing in the Damage Meter is now honored on every row, at any UI scale. A spacing of 1 previously produced a list where some gaps rendered as 0px and others as 2px: the row stride was built from a bar height snapped to the physical pixel grid plus a spacing value that was not, so the sum sat on neither grid and the accumulated row offset drifted down the list. This was most obvious at a fractional UI scale, but it happened just as well at a pixel-perfect one whenever the spacing had been saved at a different scale, because the stored value carries the scale it was set at. Height and spacing are now snapped against the same effective scale, so the stride and every multiple of it land on whole physical pixels. The fix covers the main bar list, the pinned player row, the spell, target and death-recap breakdowns, the hover tooltip and the spell history bar window.

Changing the UI scale also left already-built Damage Meter rows on the old grid until the next fight, because the module had no re-apply hook and its refresh ticker only runs in combat. It now re-lays out its rows when the scale changes, alongside the hooks the other modules already had. This is a cache bust and refresh rather than a full window rebuild, since the core scale slider fires on every drag step.

One visible consequence at fractional UI scales: the default spacing of 2 now renders as the whole pixel count the slider already reports for it, instead of alternating between two values from row to row. Moving the slider one step down gives the smaller gap.

## How was it tested?

Tested in-game on live.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) -- N/A, no new settings; this corrects the rendering of an existing one
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built -- N/A, no new feature to disable; no events or hooks added
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) -- the geometry helper replaces the previous one and runs once per refresh, not per row
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames -- N/A, all frames touched are addon-owned
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added