### PR TITLE
Fix(qol): Persistent Signup Note cog staying disabled until reload

### DIFF
--- a/EllesmereUIOptions/EUI_QoL_Options.lua
+++ b/EllesmereUIOptions/EUI_QoL_Options.lua
@@ -2607,6 +2607,7 @@ initFrame:SetScript("OnEvent", function(self)
                   if EllesmereUI._applyPersistSignupNote then
                       EllesmereUI._applyPersistSignupNote()
                   end
+                  EllesmereUI:RefreshPage()
               end }
         );  y = y - h
 


### PR DESCRIPTION
## What does this PR do?

Fixes the settings cog next to Quality of Life > Persistent Signup Note staying greyed out and unclickable after you enable the option. Previously the cog only became usable once the options page was rebuilt, which in practice meant after a `/reload`; now it unlocks immediately when the toggle is switched on, and locks again when it is switched off.

The cog re-evaluated its enabled state only inside its `RegisterWidgetRefresh` callback, which runs from `EllesmereUI:RefreshPage()`. The toggle's `setValue` never triggered one, so the button kept the alpha and the mouse blocker it was built with. The fix adds the `EllesmereUI:RefreshPage()` call that the neighbouring Auto Open Containers toggle already makes.

## How was it tested?

Tested in game on the live client.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added