### PR TITLE
Fix trinket glow ignoring Cooldown State Effect None

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmFakeActive.lua
@@ -1198,7 +1198,10 @@ ApplyCdState = function(frame, fc, cas, eff, onCD, ready)
         -- starts a glow when nothing is running, so it cannot stomp another
         -- owner's.
         if not fd._presetCdGlowOn or not glow._glowActive then
-            local gr, gg, gb = ns.ResolveGlowColor and ns.ResolveGlowColor(cas or {})
+            local gr, gg, gb
+            if ns.ResolveGlowColor then
+                gr, gg, gb = ns.ResolveGlowColor(cas)
+            end
             ns.StartNativeGlow(glow, eff == "pixelGlowReady" and 1 or 3, gr or 1, gg or 1, gb or 1)
             fd._presetCdGlowOn = true
         end

--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2642,7 +2642,7 @@ local function EvalCdStateChargeFrame(frame, fd)
         return
     end
     local ssw = ResolveSpellSettings(frame, sidw, ns.GetBarSpellData(bkw))
-    local csew = ssw and ssw.cdStateEffect
+    local csew = ns.GetSpellCdStateEffect(frame, ssw)
     if csew ~= "hiddenReady" and csew ~= "hiddenReadyShift" then
         -- Effect changed or cleared: the desat hook owns every other mode.
         ns._cdStateChargeWatch[frame] = nil
@@ -4033,7 +4033,7 @@ local function DecorateFrame(frame, barData)
                     return
                 end
                 local ss2 = ResolveSpellSettings(frame, sid2, false)
-                local cse = ss2 and ss2.cdStateEffect
+                local cse = ns.GetSpellCdStateEffect(frame, ss2)
                 -- Shift-Icons variants = base hidden mode + a bar-relayout
                 -- flag; normalize here so every comparison below is unchanged.
                 local cseShift = (cse == "hiddenOnCDShift" or cse == "hiddenReadyShift")
@@ -4804,7 +4804,7 @@ do
             if fd and fd.glowOverlay and sid2 and bk2
                and not (ns.PresetHasCdState and ns.PresetHasCdState(frame)) then
                 local ss2 = RSP(frame, sid2, ns.GetBarSpellData(bk2))
-                local cse2 = ss2 and ss2.cdStateEffect
+                local cse2 = ns.GetSpellCdStateEffect(frame, ss2)
                 local plainGlow = cse2 == "pixelGlowReady" or cse2 == "buttonGlowReady"
                 local usableGlow = cse2 == "pixelGlowReadyUsable" or cse2 == "buttonGlowReadyUsable"
                 if plainGlow or usableGlow then
@@ -8217,7 +8217,7 @@ local function CollectAndReanchor()
                                 if fcS then
                                     if fcS._cdStateShiftHidden then blocked = true; break end
                                     local ssS = ResolveSpellSettings(srcList[i], fcS.spellID, sdS, bd.key)
-                                    local effS = ssS and ssS.cdStateEffect
+                                    local effS = ns.GetSpellCdStateEffect(srcList[i], ssS)
                                     if effS == "hiddenOnCDShift" or effS == "hiddenReadyShift" then
                                         blocked = true; break
                                     end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -1291,6 +1291,13 @@ function ns.GetEffectiveCustomActiveState(frameKey)
     return store[frameKey]
 end
 
+-- Preset menus store cooldown effects in customActiveStates, including None.
+-- Never revive an old spell-family/bar-tier effect behind that menu's back.
+function ns.GetSpellCdStateEffect(frame, settings)
+    if frame and ns.CdmIsInjectedFrame and ns.CdmIsInjectedFrame(frame) then return nil end
+    return settings and settings.cdStateEffect
+end
+
 -- Does this icon have a custom Cooldown State Effect (preset cd-state)? Appearance refresh
 -- uses this so it doesn't clear a preset's _cdStateHidden flag: presets store cdState in customActiveStates, not per-bar spellSettings.
 function ns.PresetHasCdState(frame)
@@ -5943,7 +5950,7 @@ local function RefreshCDMIconAppearance(barKey)
                 local sd = ns.GetBarSpellData(bk)
                 -- Shared resolver: direct hit + full identity/override matching against the family store, with bar-tier fallback.
                 local ss = ns.ResolveSpellSettings and ns.ResolveSpellSettings(icon, sid, sd, bk)
-                local cse = ss and ss.cdStateEffect
+                local cse = ns.GetSpellCdStateEffect(icon, ss)
                 if (cse == "pixelGlowReady" or cse == "buttonGlowReady"
                     or cse == "pixelGlowReadyUsable" or cse == "buttonGlowReadyUsable") and glowOv then
                     local glowUsable = (cse == "pixelGlowReadyUsable" or cse == "buttonGlowReadyUsable")
@@ -5996,7 +6003,7 @@ local function RefreshCDMIconAppearance(barKey)
             -- Shared resolver: direct hit + full identity/override matching
             -- against the family store, with bar-tier fallback.
             local csSs = ns.ResolveSpellSettings and ns.ResolveSpellSettings(icon, csSid, csSd, csBk)
-            local cse = csSs and csSs.cdStateEffect
+            local cse = ns.GetSpellCdStateEffect(icon, csSs)
             -- Shift-Icons variants behave exactly like their base hidden mode plus the layout flag; normalize so the branches below stay as-is.
             local cseShift = (cse == "hiddenOnCDShift" or cse == "hiddenReadyShift")
             if cse == "hiddenOnCDShift" then cse = "hiddenOnCD"


### PR DESCRIPTION
## What does this PR do?

Fixes preset trinkets glowing even when their Cooldown State Effect menu shows None. Tzahal's Holy profile retained a class-colored ready glow in `spellSettingsCD[-13]`, while the preset menu read `customActiveStates`, where the effect was off. Appearance refreshes and cooldown events could revive the hidden setting.

Generic spell-effect readers now exclude injected preset frames, leaving their custom-state engine authoritative even when the effect is None. The guard covers refresh, desaturation, ready-glow and charge watchers, and the live overflow shift check. Regular tracked spells retain their settings; saved data is preserved. Also preserves all three RGB returns when starting an intentionally enabled preset ready glow, fixing green being rendered as cyan.

## How was it tested?

- User confirmed the v2 test ZIP resolves the reported in-game issue. The report shows EUI 9.1.7; the exact WoW client build and a dedicated restricted-combat/taint run were not supplied.
- Local regression harnesses executed extracted production code under Lua 5.1 with a fixture derived from the affected export: reproduced the original unwanted glow, verified fresh/stale refresh and watcher cleanup, all five injected-frame types, inherited tiers, normal tracked spells, and legitimate custom glow start/stop. Twelve color/style cases also passed.
- All three changed files compile under Lua 5.1. Diff-scoped EUI style gate and `git diff --check` pass. Locale extraction ran with no content changes.
- Review found no blocking findings. No new events, hooks, timers, frames, polling, or per-event allocations. Existing effect reads add a bounded ownership check and skip inappropriate spell-effect work for presets. No API or SavedVariables schema changes.

## Screenshots

Reporter screenshots showing None alongside the unwanted glow were reviewed in the development conversation. They are not hosted/attached here, and no after screenshot was supplied. The PR's before/after screenshot pair is missing; success was confirmed in text.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A: no new settings; fixes existing effect selection.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no new registrations, hooks, polling, or frames; the existing effect lookup gains a small ownership check.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - no new scheduling or allocations.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no new frame writes or hooks; existing frame classification is reused.
- [ ] Tested in-game on live; no version gates or pre-Midnight APIs added - user confirmed the reported case works, but exact client/build and live environment were not supplied. Verified no version gates or older APIs added.

<img src="https://media.giphy.com/media/111ebonMs90YLu/giphy.gif" alt="Thumbs up" width="180">
