### PR TITLE
Fix loadout swap lag with mouseover action bars

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -14040,7 +14040,10 @@ function EAB:FinishSetup()
                     if s.mouseoverEnabled and not info.noManagedVisibility then
                         if not (state and state.isHovered) then
                             StopFade(frame)
-                            FadeTo(frame, 0, s.mouseoverSpeed or 0.15)
+                            -- Scripted action swaps clear the cursor for every slot.
+                            -- Use the hover fader so each clear does not restart an
+                            -- expensive AnimationGroup on every mouseover bar.
+                            FadeTo(frame, 0, s.mouseoverSpeed or 0.15, true)
                             if state then state.fadeDir = "out" end
                             if key == "MainBar" then SyncPagingAlpha(0) end
                         end


### PR DESCRIPTION
## What does this PR do?

Fixes loadout swaps stalling and hitting the Lua execution limit when action bars use mouseover visibility. Embrace reproduced this switching MM Single Target and Mythic+ sets in BtWLoadouts; the same swaps worked with all bars Always visible.

Cursor-clear handling was the remaining fade caller using AnimationGroup start/stop on EUI-owned bars. A layout application repeatedly picks up and clears actions, restarting these animations on every non-hovered mouseover bar. Pass the existing manual-fader flag here, matching normal hover fades. Target alpha, easing, duration, hovered-bar handling and combat strata guards remain unchanged. One behavioral line plus a comment; no new settings.

## How was it tested?

- The user reports that the tester confirmed the new mouseover-fader test ZIP works. The exact WoW client build and a dedicated restricted-combat/taint run were not supplied.
- Reviewed code, TOC/load order, fade lifecycle, shared state and cost: no actionable findings.
- Lua 5.1 compilation and regression harness passed. The harness executes extracted production drag/fade functions and covers Always-visible and hovered bars, repeated state, drag cancellation, combat strata guards, fade duration, bounded queue and ticker cleanup.
- With five mouseover bars, 51 synthetic pickup/clear cycles produced 255 AnimationGroup starts before and zero after; 181 cycles produced 905 before and zero after. These are local operation counts, not client timing measurements.
- EUI style gate and `git diff --check` pass. Locale extraction ran with no content changes.
- No new events, hooks, timers or frames. The existing shared OnUpdate interpolates only while fades are active, with no per-tick allocations. Each fade start creates one small queue record; retained entries are bounded to one per fading bar. The non-mouseover path is unchanged.

## Screenshots

Original failure recordings were reviewed during investigation. No hosted before/after screenshots are attached, and the tester supplied success confirmation in text. The before/after pair is missing; the intended visual fade behavior is unchanged.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A: no new settings; fixes existing mouseover behavior.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no new registrations, hooks or frames; changed call is reached only for mouseover-enabled bars.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - event-triggered fade uses the existing bounded animation update, not state polling; no per-tick allocation.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - no new hooks or Blizzard-frame mutations; Blizzard-owned bars already used this fade path, and the fader's OnUpdate belongs to EUI's own frame.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added - tester confirmed the reported case works, but exact client/build and live environment were not supplied. Verified no new APIs or version gates.

<img src="https://media.giphy.com/media/26n6Gx9moCgs1pUuk/giphy.gif" alt="Celebrating the fix" width="180">
