### PR TITLE
Fix(BlizzardSkin): Lua error on world cursor tooltips from secret anchor points

### DIFF
--- a/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
+++ b/EllesmereUIBlizzardSkin/EllesmereUIBlizzardSkin.lua
@@ -2374,7 +2374,13 @@ do
         if not af then return end
         local corner = CornerFor(af)
         local point, relTo = tooltip:GetPoint(1)
-        if tooltip:GetNumPoints() == 1 and point == corner and relTo == af then return end
+        -- GetPoint can hand back a SECRET point: Blizzard anchors the world cursor
+        -- tooltip (SetWorldCursor -> GameTooltip_SetDefaultAnchor) from restricted
+        -- code, and comparing a secret raises, so the classification MUST short-circuit
+        -- ahead of the compares. A secret anchor is by definition not ours: treat it as
+        -- a deviation and re-point. Our own write reads back clean, so the early-out works again from the next call on.
+        local secretPt = issecretvalue and (issecretvalue(point) or issecretvalue(relTo))
+        if not secretPt and tooltip:GetNumPoints() == 1 and point == corner and relTo == af then return end
         _fixedEnforcing = true
         tooltip:ClearAllPoints()
         tooltip:SetPoint(corner, af, corner, 0, 0)
@@ -2536,6 +2542,10 @@ do
         if not dir then return end
         if tooltip:IsForbidden() then return end
         local point, relTo, _, x, y = tooltip:GetPoint(1)
+        -- A point written by restricted code (world cursor tooltip) is SECRET:
+        -- find() and == on it raise, and the forced corner cannot be derived from it
+        -- at all. Skip this pass; the next one, after a clean re-anchor, enforces normally.
+        if issecretvalue and (issecretvalue(point) or issecretvalue(x) or issecretvalue(y)) then return end
         if not point then return end
         relTo = relTo or GameTooltipDefaultContainer
         if not relTo then return end


### PR DESCRIPTION
Bugreport: https://discord.com/channels/585577383847788554/1546958546082472076

## What does this PR do?

Fixes a Lua error that fired repeatedly while questing: hovering a world object or NPC under the cursor produced `attempt to compare local 'point' (a secret string value, while execution tainted by 'EllesmereUIBlizzardSkin')`, reported 57 times in a single session. `SetWorldCursor` routes through `GameTooltip_SetDefaultAnchor`, and the anchor Blizzard writes there comes from restricted code, so reading it back with `GetPoint` yields a secret point string. Both of the module's default-anchor enforcers compared that value directly and raised: the fixed tooltip position enforcer (the visible bug) and the growth direction enforcer, which additionally calls `find()` on it and would raise the same way for anyone running Growth Direction on up or down.

Both now classify the value with `issecretvalue` before touching it, short-circuited ahead of the comparisons. The fixed anchor treats a secret point as a deviation and re-points the tooltip onto its own box, which is what it already does for any other anchor that is not its own, so the world cursor tooltip lands where every other default-anchored tooltip does. Growth direction skips that pass instead, since the forced corner cannot be derived from a secret point at all; the next pass, after a clean re-anchor, enforces normally. No settings, hooks, events or anchoring behaviour change beyond the error no longer aborting the enforcement.

## How was it tested?

Tested in game on the live client.

## Screenshots

Not visual.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A, bug fix, no new setting
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - no hooks, events or frames added
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - two `issecretvalue` calls added inside an existing hook path, no allocations, no closures
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - unchanged, existing `hooksecurefunc` post-hooks only
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added