### PR TITLE
fix(nameplates): keep friendly name-only through an instance

### DIFF
--- a/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
+++ b/EllesmereUINameplates/EllesmereUINameplatesFriendly.lua
@@ -1755,7 +1755,15 @@ function ns.UpdateFriendlyNameplateSystem()
             -- follower dungeon still has to be handed back: zoning straight
             -- from a delve into a dungeon never touches the open-world branch
             -- below, and the plates would stay hidden for the whole run.
-            if euiManagesPlayers then RestoreFriendlyVis() end
+            if euiManagesPlayers then
+                RestoreFriendlyVis()
+                -- Name-only is presentation, not visibility, so it is asserted here as
+                -- well as in the open-world branch. Leaving it out let the health bars
+                -- return on zone-in and stay for the whole instance, since nothing else
+                -- rewrites this CVar until the player is back outside.
+                pcall(SetCVar, "nameplateShowOnlyNameForFriendlyPlayerUnits",
+                    (fp and fp.friendlyNameOnly ~= false) and 1 or 0)
+            end
             pcall(SetCVar, "nameplateShowFriendlyNPCs", 0)
             pcall(SetCVar, "nameplateShowFriendlyNpcs", 0)
         else


### PR DESCRIPTION
Reported by @SellectName (Nameplates): with **Make Friendly Nameplates Name
Only** enabled, friendly health bars come back on entering an instance, and
again on entering combat. Unticking and re-ticking the option fixes it until the
next time.

## Cause

`nameplateShowOnlyNameForFriendlyPlayerUnits` was only re-asserted in the
**open-world** branch of the visibility pass in
`ns.UpdateFriendlyNameplateSystem`.

The in-instance branch manages the NPC visibility CVars and deliberately leaves
player **visibility** alone, which is correct. But name-only is presentation
rather than visibility, and it was dropped along with it. Once that CVar drifted
there was nothing to rewrite it until the player was back outside, which is
exactly the whole-instance symptom.

The combat half is the same branch: the pass is skipped under lockdown and
retried on `PLAYER_REGEN_ENABLED`, which still lands in the in-instance branch
and still does not write it.

His workaround works because the options setter writes the CVar directly.

## What this does not change

`IsNameOnlyMode` is untouched and never depended on instance type, so the mode
was always still enabled. Only the CVar backing it went stale, which is why the
setting still *looked* correct while the bars were showing.

Player visibility is still not forced in instances. The only addition is the
presentation CVar the user explicitly chose.

## Testing

`luac -p` clean, house style check clean. Not click-tested. Reproduction is to
enable name-only, zone into a dungeon, and check friendly players show names
without bars, then pull something and check it survives combat. Worth confirming
separately that a delve or follower dungeon still hands visibility back
correctly, since that capture is restored on the same line.

![](https://media.giphy.com/media/l2JhLztBuOipSkzdK/giphy.gif)
