### PR TITLE
Fix custom raid-size dimensions reverting with spec overrides

### DIFF
--- a/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
+++ b/EllesmereUIRaidFrames/EllesmereUIRaidFrames.lua
@@ -10903,7 +10903,9 @@ do
                         local liveChild = liveT[k]
                         if type(liveChild) ~= "table" then ok = false; break end
                         local dstChild = dstParent[k]
-                        if type(dstChild) ~= "table" then
+                        -- A shallow parent copy still shares its live children.
+                        -- Detach each shared child before writing preview values.
+                        if type(dstChild) ~= "table" or dstChild == liveChild then
                             dstChild = {}
                             for ck, cv in pairs(liveChild) do dstChild[ck] = cv end
                             dstParent[k] = dstChild


### PR DESCRIPTION
## What does this PR do?

Fixes custom raid-size width and height reverting when a spec override exists. Reported by Drakkarius and confirmed by Krakonovic on 9.1.6: default sizes meant to be 90 kept returning to the healer override's 100, while the 20-player sliders worked.

The real-preview overlay copied the outer table but shared its nested tier tables with the editable profile. Applying effective preview dimensions therefore overwrote the values being edited. Detach each shared child before writing preview values, reusing detached copies for other fields on the same tier. One file, one condition and two comment lines.

## How was it tested?

- User tested the packaged fix in game and confirmed the reported issue is resolved. Exact client build, live/PTR environment, and full spec-switch/reload coverage were not supplied.
- A local standalone harness executes the actual overlay builder extracted from source. Before the fix, it reproduces a saved width changing from 90 to 100. After the fix, all 45 assertions pass, covering all five custom tiers, width/height, sibling fields, anchor markers, 20-player width, repeated edits, preview-only deletion, baseline effective values, missing tiers, and inactive paths.
- Lua 5.4.6 syntax compilation passes; a Lua 5.1 runtime was not used. The changed syntax is Lua 5.1-compatible. EUI style gate and `git diff --check` pass. Locale extraction ran with no content changes.
- Code review covered all three callers, table ownership, override resolution, load order, and performance; no actionable findings.
- The active preview builder adds a table identity check and one shallow copy per affected shared child per rebuild. No new events, hooks, frames, timers, polling, or per-frame work. Inactive overlay paths return before the change. No API or SavedVariables schema changes.

## Screenshots

Before/after screenshots are missing. The user confirmed success in text after testing the ZIP.

## Checklist

- [x] New settings default **OFF** (no behavior change without opt-in) - N/A: no new settings; fixes existing dimension editing.
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built - inactive preview paths return before the changed code; no new registrations or frames.
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations) - copies affected shared tables during existing preview rebuilds and reuses them within that rebuild.
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames - N/A: only addon-owned settings table copies change; no frame writes or hooks added.
- [ ] Tested in-game on live; no version gates or pre-Midnight APIs added - user confirmed the fix in game, but exact build and live/PTR environment are unverified. Verified no new APIs or version gates.

<img src="https://media.giphy.com/media/3oriO6qJiXajN0TyDu/giphy.gif" alt="Celebrating the fix" width="180">
