### PR TITLE
Fix Shadowform stance highlight after Voidform

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -14705,19 +14705,11 @@ function EAB:FinishSetup()
     _petEventFrame:RegisterUnitEvent("UNIT_AURA", "pet")
     _petEventFrame:SetScript("OnEvent", UpdatePetBar)
 
-    -- Stance bar GCD/cooldown swipe. Blizzard drives the shapeshift cooldown
-    -- swipe exclusively through StanceBar frame's UPDATE_SHAPESHIFT_COOLDOWN
-    -- -> StanceBarMixin:UpdateState. HideBlizzardBars() unregisters all
-    -- events on the StanceBar frame, so that path is dead. The swipe only ever appeared
-    -- by accident: a bar transition (form change, Ascendance, etc.) makes
-    -- ValidateActionBarTransition re-Show() StanceBar, whose OnShow -> Update ->
-    -- UpdateState sets the cooldown on the (reparented but identical) StanceButton
-    -- frames before our OnShow hook re-hides the now-empty bar. A plain GCD from a
-    -- spell that does NOT change form fires UPDATE_SHAPESHIFT_COOLDOWN with no
-    -- transition, so nothing ran and the form-lockout swipe was invisible. Mirror
-    -- Blizzard's cooldown update directly on our reused StanceButtons: visual-only
-    -- (CooldownFrame_Set touches no protected state), safe during combat, same as the
-    -- pet PET_BAR_UPDATE_COOLDOWN path above.
+    -- StanceBarMixin:UpdateState owns Blizzard's active highlight and cooldown
+    -- swipe, but HideBlizzardBars unregisters that bar's events. Reconcile both
+    -- visuals on the reused buttons without invoking the hidden bar's layout
+    -- or visibility updates. SetChecked and CooldownFrame_Set are visual-only,
+    -- matching the pet bar painter above.
     -- Per-form memo of the last (start, duration, enable) triple pushed. The
     -- cooldown event refires on every GCD for form classes and the swipe is a
     -- pure function of those three values, so an identical triple is skipped.
@@ -14728,7 +14720,7 @@ function EAB:FinishSetup()
     -- (instanced combat) cannot be compared: that form pushes unconditionally
     -- and drops its memo.
     local stanceLast = {}
-    local function UpdateStanceCooldowns(_, event)
+    local function UpdateStanceState(_, event)
         if event ~= "UPDATE_SHAPESHIFT_COOLDOWN" then wipe(stanceLast) end
         -- Hidden stance bar: skip. The show edge reruns this painter
         -- (ns._eabStanceReconcile), and the event refires every GCD for
@@ -14738,6 +14730,12 @@ function EAB:FinishSetup()
         local numForms = GetNumShapeshiftForms()
         for i = 1, numForms do
             local btn = _G["StanceButton" .. i]
+            if btn then
+                -- Clicks toggle the checked state optimistically; reconcile it
+                -- from the actual form even when the cooldown has not changed.
+                local _, isActive = GetShapeshiftFormInfo(i)
+                btn:SetChecked(isActive)
+            end
             if btn and btn.cooldown then
                 local start, duration, enable = GetShapeshiftFormCooldown(i)
                 if issecretvalue and (issecretvalue(start) or issecretvalue(duration)
@@ -14755,12 +14753,13 @@ function EAB:FinishSetup()
             end
         end
     end
-    ns._eabStanceReconcile = UpdateStanceCooldowns
+    ns._eabStanceReconcile = UpdateStanceState
     local _stanceEventFrame = ns.TakeShell()
     _stanceEventFrame:RegisterEvent("UPDATE_SHAPESHIFT_COOLDOWN")
     _stanceEventFrame:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
+    _stanceEventFrame:RegisterEvent("UPDATE_SHAPESHIFT_FORMS")
     _stanceEventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
-    _stanceEventFrame:SetScript("OnEvent", UpdateStanceCooldowns)
+    _stanceEventFrame:SetScript("OnEvent", UpdateStanceState)
 
 
     -- Talent changes can cause Blizzard to re-show hidden bars.


### PR DESCRIPTION
## What does this PR do?

Fixes the stance bar showing Shadowform as inactive after Voidform ends, while the Shadowform buff (232698) is still present.

EUI disables Blizzard's stance-bar event handling. Its replacement updates cooldowns but leaves the checked state stale. Reconcile the active highlight from `GetShapeshiftFormInfo` on stance events and when the bar becomes visible, independently of cooldown changes.

## How was it tested?

- Reproduced after Voidform on live, then applied the fix to the installed addon. The player retested and reported the highlight working; before/after screenshots below. Exact client build was not recorded.
- Lua 5.1 checks reproduced the stale highlight in the original code and covered active/inactive transitions, unchanged cooldowns, incorrect click toggles, hidden/show transitions, world entry, and empty form lists.
- Full action-bar module compiles under Lua 5.1; `git diff --check` passes.

## Screenshots

Before: Shadowform buff present at the top right, but its stance button above the left end of the bottom action bars lacks the active highlight.

![Before](https://github.com/user-attachments/assets/783cd6b7-f1db-42d1-8ff1-152e2f39ba94)

After: the stance button displays the active highlight with the fix installed.

![After](https://github.com/user-attachments/assets/1a267cff-3762-4ea2-9e17-cf4184dff96c)

## Checklist

- N/A: No new settings; this corrects existing stance-bar behavior.
- [x] Zero cost while disabled: uses the existing action-bar setup and event frame; skips painting a hidden stance bar.
- [x] Cheap while enabled: event-driven, with no polling or new timers.
- [x] No Lua fields or scripts added to Blizzard-owned frames; calls the existing visual `SetChecked` method on reused stance buttons.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added.
