### PR TITLE
actionbars: keep the broadcaster off while cooldowns are secret

### DIFF
--- a/EllesmereUIActionBars/EllesmereUIActionBars.lua
+++ b/EllesmereUIActionBars/EllesmereUIActionBars.lua
@@ -1037,9 +1037,26 @@ do
     -- raid pull spams it (Jera, 9.0.1). Registered out of combat only, both
     -- edges driven by the REGEN events; PLAYER_ENTERING_WORLD, the other
     -- Update() path, cannot fire under lockdown.
+    -- Cooldowns read SECRET in restricted content, and every dispatch this
+    -- registration drives runs under OUR taint, so Blizzard's own
+    -- ActionButton_ApplyCooldown -> SetCooldown is rejected on every Blizzard
+    -- button the broadcaster still reaches. Live raid report: 511k errors.
+    -- InCombatLockdown() alone was the wrong gate -- it was chosen for the BLOCKED
+    -- SetAttribute, and secrecy is instance-gated, so the whole out-of-combat
+    -- window inside an instance stayed open. The frame goes fully bare, not a
+    -- per-event subset: SLOT_CHANGED, ACTIONBAR_UPDATE_COOLDOWN and PEW all reach it.
+    local function CooldownsSecret()
+        if not (C_Secrets and C_Secrets.ShouldCooldownsBeSecret) then return false end
+        local ok, secret = pcall(C_Secrets.ShouldCooldownsBeSecret)
+        return (ok and secret) and true or false
+    end
     local function ApplyBroadcaster()
         local want = (_vehNeed or _extraNeed) and "full"
             or ((_phNeed or ClassMayPressHold()) and "ph" or "off")
+        -- Folded into `want`, not into slotOK, so the mode comparison below sees the
+        -- change and re-applies; PLAYER_ENTERING_WORLD already re-runs this, which is
+        -- the edge secrecy actually turns on.
+        if want ~= "off" and CooldownsSecret() then want = "off" end
         local slotOK = not InCombatLockdown()
         if want == _broadcasterMode and slotOK == _broadcasterSlot then return end
         _broadcasterMode, _broadcasterSlot = want, slotOK


### PR DESCRIPTION
## The report

A player running BugGrabber, BugSack, RCLootCouncil, BigWigs, LittleWigs, EllesmereUI, Gearmatic, Jiberish Media, RaiderIO and TrueStats hit this **511,955 times** in one session:

```
Blizzard_ActionBar/Shared/ActionButton.lua:847: bad argument #1 to 'SetCooldown'
(Secret values are only allowed during untainted execution for this argument.)
  start=<secret number>  duration=<secret number>  modRate=<secret number>
  ActionButton.lua:866  ActionButton_ApplyCooldown
  ActionButton.lua:842  ActionButton_UpdateCooldown
  ActionButton.lua:575  Update
  ActionButton.lua:544  UpdateAction
  ActionButton.lua:1067 OnActionBarSlotChanged
  ActionButton.lua:939  OnEvent
```

Of that addon list, EllesmereUIActionBars is the only one that touches `ActionBarButtonEventsFrame` — I grepped the others and every one returns zero hooks on that path.

## Cause

Two comments already in this file predict it. On the registration:

> ACTIONBAR_SLOT_CHANGED is the only event in either set that reaches Blizzard's Update(). **The registration is ours, so the dispatch runs under our taint** ... on Blizzard's own ActionButtonN and reported as EllesmereUI.

and elsewhere, naming the call:

> ActionButton_ApplyCooldown with SECRET start/duration (**rejected under taint**)

Cooldown data reads secret in restricted content. Because we own the `RegisterEvent`, Blizzard's own handler runs tainted, and its own `SetCooldown` is refused. The broadcaster dispatches to **every** frame in `self.frames`, so we buy it for the override/extra/empower buttons and it lands on all of `ActionButton1-12` as well.

## Why the existing guard missed it

`slotOK = not InCombatLockdown()` was chosen for the *blocked SetAttribute*. Secrecy is instance-gated, not combat-gated, so the entire out-of-combat window inside an instance was left open — most of a raid night, which is why the count is six figures.

## The fix

Gate the registration on `C_Secrets.ShouldCooldownsBeSecret()` as well.

The whole frame goes bare rather than a per-event subset, because three of the registered events reach that call: `ACTIONBAR_SLOT_CHANGED` via `UpdateAction -> Update`, `ACTIONBAR_UPDATE_COOLDOWN` directly, and `PLAYER_ENTERING_WORLD` via `Update`. Bare is also this module's own baseline — the state every player without a vehicle, extra button or empower already runs permanently.

Folded into `want` rather than `slotOK` so the existing mode comparison sees the change and re-applies. `PLAYER_ENTERING_WORLD` already re-runs `ApplyBroadcaster`, which is the edge secrecy actually turns on, so no new registration is needed.

## Known cost, stated plainly

Inside instances, the override/vehicle bar, ExtraActionButton1 and Evoker press-and-hold lose their Blizzard-side updates. **Nothing that currently works is lost** — those updates raise today rather than completing, so the swipe was already dead. The trade is a silent absence instead of 511k errors, which is the right failure direction.

The narrow regression risk: an Evoker who fills an empower slot *while inside an instance* would not get `pressAndHoldAction` initialised until they leave. Today that path errors instead.

## Testing

Not yet tested in game — I have no way to run it. Checklist for whoever does:

1. Raid or dungeon, out of combat: swap an action bar page. No error, no BugSack spam.
2. Open world: same swap. Cooldown swipes still paint on Blizzard buttons.
3. Evoker: fill an empower slot in the open world, confirm key-up still releases the empower.
4. Vehicle encounter in a raid: override bar appears; cooldowns will not animate (expected, documented above).
5. Delve with ExtraActionButton1, outside an instance: cooldown still paints.

Item 3 is the one this could plausibly regress, and item 4 is the knowingly-degraded case.

![otter](https://media.giphy.com/media/1XPXTWCdXvjJS/giphy.gif)