### PR TITLE
cdm: keep per-spell Duration Text through a reanchor

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
+++ b/EllesmereUICooldownManager/EllesmereUICdmHooks.lua
@@ -2231,6 +2231,24 @@ end
 --  ns._cdmAnyChargeHideCdText (~0 cost when unused).
 -------------------------------------------------------------------------------
 
+-- Per-spell Duration Text layered onto a bar-derived hide flag, for the paths that hold only
+-- barData: the reanchor assign loop and the Only Show Numbers restore tail. The appearance
+-- pass does not call this -- it resolves ssb itself, and re-resolving there would replace a
+-- correct value with a worse one. Keyed on the DISPLAYED id, never fc.spellID: for a buff
+-- whose base is a shared spec spell the base misses the entry and lets one icon's setting
+-- shadow another's, the same rule the appearance pass documents at its own resolve.
+-- ~= nil, not truthiness: a per-spell ON must beat a bar that is OFF.
+function ns.CdmDurationHideFor(frame, barKey, baseHide)
+    if not ns._cdmAnySpellDurationText then return baseHide end
+    local fcd = _ecmeFC[frame]
+    local sidD = (ns.GetCanonicalSpellIDForFrame and ns.GetCanonicalSpellIDForFrame(frame))
+        or (fcd and fcd.spellID)
+    if not (sidD and barKey and ns.ResolveSpellSettings) then return baseHide end
+    local ssD = ns.ResolveSpellSettings(frame, sidD, ns.GetBarSpellData(barKey), barKey)
+    if ssD and ssD.showCooldownText ~= nil then return not ssD.showCooldownText end
+    return baseHide
+end
+
 -- Effective SetHideCountdownNumbers value: layers the per-spell "Hide CD Text
 -- (Charges)" toggle on the caller's baseHide (numbers already hidden by the bar
 -- / per-icon showCooldownText). Returns baseHide unchanged for anything that is
@@ -2857,7 +2875,10 @@ local function ApplyOnlyNumbers(frame, fd, barData)
         local cd = fd.cooldown or frame.Cooldown or frame._cooldown
         if cd then
             if cd.SetDrawSwipe then cd:SetDrawSwipe(true) end
-            if cd.SetHideCountdownNumbers then cd:SetHideCountdownNumbers(not ns.CdmDurationTextOn(barData)) end
+            if cd.SetHideCountdownNumbers then
+                cd:SetHideCountdownNumbers(
+                    ns.CdmDurationHideFor(frame, barData.key, not ns.CdmDurationTextOn(barData)))
+            end
         end
         -- Square border / shape ring re-apply on the next style pass
         -- (DecorateFrame / RefreshCDMIconAppearance via BuildAllCDMBars).
@@ -3253,6 +3274,7 @@ local function DecorateFrame(frame, barData)
                 if ss2 and ss2.maxStacksGlow and ss2.maxStacksGlow > 0 then ns._cdmAnyMaxStacksGlow = true end
                 if ss2 and ss2.activeGlow and ss2.activeGlow > 0 then ns._cdmAnyActiveGlow = true end
                 if ss2 and ss2.chargeHideCdText then ns._cdmAnyChargeHideCdText = true end
+                if ss2 and ss2.showCooldownText ~= nil then ns._cdmAnySpellDurationText = true end
                 if ss2 and ss2.hideChargeText then ns._cdmAnyHideChargeText = true end
                 if ss2 and ss2.suppressGCD then ns._cdmAnySuppressGcd = true end
                 if ss2 and ss2.reverseSwipe then ns._cdmAnyReverseSwipe = true end
@@ -8306,7 +8328,7 @@ local function CollectAndReanchor()
                             fdRv._revKind = wantRev
                             frame.Cooldown:SetReverse(wantRev)
                         end
-                        local hcd = hideCDText
+                        local hcd = ns.CdmDurationHideFor(frame, barKey, hideCDText)
                         if ns.CdmShouldHideCountdown then hcd = ns.CdmShouldHideCountdown(frame, hcd) end
                         frame.Cooldown:SetHideCountdownNumbers(hcd)
                     end

--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -1445,6 +1445,21 @@ function ns.RescanChargeCdTextFlag()
     end)
 end
 
+-- Per-spell Duration Text gate: set ns._cdmAnySpellDurationText once if any saved spell
+-- (any spec) overrides showCooldownText either way. ~= nil, not truthiness: a per-spell
+-- ON must beat a bar that is OFF, same as the options resolver reads it.
+function ns.RescanSpellDurationTextFlag()
+    if ns._cdmAnySpellDurationText or ns._spellDurationTextFlagScanned then return end
+    if not EllesmereUIDB then return end
+    ns._spellDurationTextFlagScanned = true
+    ns.ForEachSavedSettingsBlock(function(ss)
+        if ss.showCooldownText ~= nil then
+            ns._cdmAnySpellDurationText = true
+            return true
+        end
+    end)
+end
+
 -- "Hide Charge Text" gate: set ns._cdmAnyHideChargeText once if any saved spell
 -- (any spec) has the toggle on. The appearance pass consults it to reach
 -- WatchZeroChargeTextIfEnabled for users of neither the bar-level zero-charge
@@ -7733,6 +7748,7 @@ BuildAllCDMBars = function()
     EnsureFocusKickBar()
     ns.RescanMaxStacksGlowFlag()  -- set the Max Stacks Glow gate (once) before refresh
     ns.RescanChargeCdTextFlag()   -- set the Hide CD Text (Charges) gate (once) before refresh
+    ns.RescanSpellDurationTextFlag()  -- and the per-spell Duration Text gate
     ns.RescanHideChargeTextFlag() -- set the Hide Charge Text gate (once) before refresh
     ns.RescanSuppressGcdFlag()    -- set the per-spell Suppress GCD gate (once) before refresh
     ns.RescanChargeStyleFlag()    -- set the Hide Swipe (Charges) gate (once) before refresh

--- a/EllesmereUIOptions/EUI_CooldownManager_Options.lua
+++ b/EllesmereUIOptions/EUI_CooldownManager_Options.lua
@@ -10824,7 +10824,7 @@ initFrame:SetScript("OnEvent", function(self)
                                 rows = {
                                     { type="toggle", label="Show Duration",
                                       get=function() if ss.showCooldownText ~= nil then return ss.showCooldownText end return (cdmBd and cdmBd.showCooldownText) ~= false end,
-                                      set=function(v) EnsureSS(); ss.showCooldownText = v; if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end if row._updateLabel then row._updateLabel() end end },
+                                      set=function(v) EnsureSS(); ss.showCooldownText = v; ns._cdmAnySpellDurationText = true; if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end if row._updateLabel then row._updateLabel() end end },
                                     { type="slider", label="Size", min=6, max=30, step=1,
                                       get=function() return ss.cooldownFontSize or (cdmBd and cdmBd.cooldownFontSize) or 12 end,
                                       set=function(v) EnsureSS(); ss.cooldownFontSize = v; if ns.RefreshCDMIconAppearance then ns.RefreshCDMIconAppearance(barKey) end if row._updateLabel then row._updateLabel() end end },


### PR DESCRIPTION
## Report

From @Lee, 9.1.7, Cooldown Manager:

> Tracking Infusion of Light on hpal, show duration turned off in options. CD duration text appears and doesn't follow the text formatting.
> Steps: gain Infusion of Light. Gain another charge of it, or gain another buff of some sort.

Also running **Visibility When Missing: Hidden (shift icons)**.

## Cause

`CollectAndReanchor`'s assign loop derives the countdown flag from **bar data alone** and applies it to every frame:

```lua
local hideCDText = not ns.CdmDurationTextOn(barData)
...
local hcd = hideCDText
frame.Cooldown:SetHideCountdownNumbers(hcd)
```

Nothing there consults `ss.showCooldownText`, so each reflow re-asserted the bar's value over the per-spell one. Both of his repro steps force a reflow, and **Hidden (shift icons)** makes the set re-lay-out constantly, so it fired repeatedly.

That also explains "doesn't follow the text formatting": this path re-enables only the *number*. It never re-applies his per-spell size (6 against the bar's 12), colour or position, because the appearance pass had no reason to style a FontString meant to stay hidden.

The custom icon and Holy Paladin are incidental -- any per-spell Duration Text override on a reflowing bar reproduces it.

## Fix

A small resolver, `ns.CdmDurationHideFor(frame, barKey, baseHide)`, called from the two paths that hold only `barData`: the reanchor assign loop, and the Only Show Numbers restore tail (which had the same stomp through a different trigger).

Two details it is deliberate about:

**Keyed on the DISPLAYED id**, via `GetCanonicalSpellIDForFrame`, never `fc.spellID`. This file already documents why at the appearance pass's own resolve: for a buff whose base is a shared spec spell, the base misses the entry outright *and* lets one icon's setting shadow another's. Infusion of Light is exactly that shape.

**Not added to `CdmShouldHideCountdown`.** That was my first attempt and it was wrong twice over -- it resolves by `fc.spellID`, and the appearance pass already layers `ssb.showCooldownText` correctly, so re-resolving there replaced a correct value with a worse one and thrashed the `ssRSid`/`ssIdsFor` caches between two different ids.

## Cost

Gated behind `ns._cdmAnySpellDurationText`, mirroring `_cdmAnyChargeHideCdText` exactly: a login rescan (`RescanSpellDurationTextFlag`, beside its siblings in `BuildAllCDMBars`), the `DecorateFrame` sweep, and the options write so it arms without a reload. A profile with no per-spell override returns on the first line and never resolves anything.

## Testing

Not tested in game. Checklist:

1. Holy Paladin, Infusion of Light, per-spell Show Duration **off**. Gain it, gain a second charge, gain an unrelated buff. No number at any point.
2. Per-spell Show Duration **on** while the bar's is **off** -- number appears, in the per-spell size and colour. This is what catches a truthiness mistake.
3. No per-spell overrides anywhere: unchanged, and the flag stays nil.
4. Toggle Only Show Numbers off on a buff bar whose spell has Duration Text off -- no number should return.
5. Charges/Stacks Only and Hide CD Text (Charges) still behave.
6. Two icons on one bar whose buffs share a base spell -- each keeps its own setting.

Item 6 is the one the canonical-id choice exists for.

![otter](https://media.giphy.com/media/1XPXTWCdXvjJS/giphy.gif)