### PR TITLE
New entry point for drawing overlay icons

### DIFF
--- a/EllesmereUIBags/EllesmereUIBags.lua
+++ b/EllesmereUIBags/EllesmereUIBags.lua
@@ -2984,6 +2984,15 @@ function EUI_Bags.SetBindTypeText(fs, isWuE, bindType, quality)
 end
 
 -------------------------------------------------------------------------------
+--  Third-party item overlay icons (opt-in extension point for compatibility bridges with addons like CanIMogIt)
+-------------------------------------------------------------------------------
+EUI_Bags.itemOverlayIcons = EUI_Bags.itemOverlayIcons or {}
+
+function EUI_Bags.RegisterItemOverlayIcon(name, updateFn)
+    EUI_Bags.itemOverlayIcons[name] = updateFn
+end
+
+-------------------------------------------------------------------------------
 --  RenderButton
 -------------------------------------------------------------------------------
 local function RenderButton(btn, data, _, col, row, startX, currentY, _, interactiveEmpties)
@@ -3249,6 +3258,12 @@ local function RenderButton(btn, data, _, col, row, startX, currentY, _, interac
 
     end
     UpdatePawnArrow(btn, data.itemLink)
+
+    -- Allows drawing overlays for external addons
+    for _, fn in pairs(EUI_Bags.itemOverlayIcons) do
+        fn(btn, data)
+    end
+
     -- Same requery the native container update does after re-assigning a slot: the
     -- cursor can be resting on this button while the repaint moves another item under
     -- it, and nothing re-reads the tooltip until the mouse moves (it kept showing the


### PR DESCRIPTION
## What does this PR do?

This PR integrates a new entry-point that allows plugging third-party addons like CanIMogIt (which draws a small icon representing whether items can be transmogged) with EllemereUI's bags.

See [the compatibility patch](https://github.com/ssj17vegeta/EllesmereUIBags_CanIMogIt) for its intended use-case.

Without having both [CanIMogIt](https://www.wowinterface.com/downloads/info24015-CanIMogIt.html) and [its compatibility patch](https://github.com/ssj17vegeta/EllesmereUIBags_CanIMogIt) I made, the modification does nothing (since EUI_Bags.itemOverlayIcons == {} thus the loop gets out immediately).

## How was it tested?

Latest live Midnight build as of September 11th 2026.

Basically, have a transmoggable/collectible item in your bag, CanIMogIt's transmog-status icon should appear if you have CanIMogIt and [its compatibility patch](https://github.com/ssj17vegeta/EllesmereUIBags_CanIMogIt) installed.

Tests made : not-transmogged item bought, switched it between bank, guild bank, different bags, icon shows up fine in own bag, no LUA error, no perceivable slowdown.

## Screenshots

<img width="499" height="190" alt="Capture d&#39;écran_20260911_122405" src="https://github.com/user-attachments/assets/5cba9a9d-3762-4e2f-8956-7a2c708b0fd3" />

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [x] New settings default **OFF** (no behavior change without opt-in)
- [x] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [x] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [x] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added
