### PR TITLE
Raid Frames: Extend the filter "MaxDuration" to Health Bar Color and Glow.

### DIFF
--- a/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
+++ b/EllesmereUIOptions/EUI_RaidFrames_ManagerPages.lua
@@ -1,4 +1,4 @@
-﻿if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_ClientGate.lua)
+if EUI_CLIENT_BLOCKED then return end -- pre-12.1 client failsafe (EllesmereUI_ClientGate.lua)
 -- EUI_RaidFrames_ManagerPages.lua
 -- 12.1 redesigned manager options: the Debuff Manager page (sidebar of
 -- tiles with the undeletable Base Icons tile first) and the Buff Manager page's Base
@@ -1962,7 +1962,10 @@ local function BuildTileDetail(frame, fontPath, t)
             { type = "slider", text = "Thickness", min = 1, max = 4, step = 1,
               getValue = function() return t.glowThickness or 2 end,
               setValue = function(v) TSet("glowThickness", v) end },
-            { type = "label", text = "" }); sy = sy - hh
+            EllesmereUI.MaxDurationDropdown(
+                function() return t.maxDurSec end,
+                function(v) TSet("maxDurSec", v) end,
+                DmApply)); sy = sy - hh
     elseif t.type == "bar" then
         -- BM bar indicator CORE + DISPLAY 1:1 (minus Own Only and the
         -- 12.1-removed Max Duration / Threshold).
@@ -2084,7 +2087,10 @@ local function BuildTileDetail(frame, fontPath, t)
             { type = "slider", text = "Opacity", min = 5, max = 100, step = 1,
               getValue = function() return t.opacity or 45 end,
               setValue = function(v) TSet("opacity", v) end },
-            { type = "label", text = "" }); sy = sy - hh
+            EllesmereUI.MaxDurationDropdown(
+                function() return t.maxDurSec end,
+                function(v) TSet("maxDurSec", v) end,
+                DmApply)); sy = sy - hh
     end
     return sy
 end


### PR DESCRIPTION
Extend the filter "MaxDuration" to Health Bar Color and Glow.

<!-- Thanks for contributing! Please read .github/CONTRIBUTING.md first --
     the checklist below mirrors the acceptance criteria used in review. -->

## What does this PR do?

Adds the "Max Duration" debuff filter to the "Health Bar Color" and "Glow" indicators in Raid Frames > Debuff. 
This control already exists for "Icon" and "Square" indicators. "Health Bar Color" and "Glow" were the only two tile types where it wasn't exposed.

## How was it tested?

Tested directly during a boss fight.

## Screenshots

Before : https://imgur.com/u8BvpPA
After : https://imgur.com/NQIFsBE

## Checklist

<!-- Check what applies; mark N/A where it genuinely does not. -->

- [X] New settings default **OFF** (no behavior change without opt-in)
- [X] Zero cost while disabled: no events registered, no polling, no hooks doing work, no frames built
- [X] Cheap while enabled: event-driven (no polling, no timer-based logic, no per-frame allocations)
- [X] No writes onto Blizzard-owned frames (weak-table pattern used); `HookScript`/`hooksecurefunc` only, never `SetScript` on Blizzard frames
- [X] Tested in-game on live; no version gates or pre-Midnight APIs added
