### PR TITLE
Fix: CDM keybind missing for macros using equip-slot shorthand (/use 13)

### DIFF
--- a/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
+++ b/EllesmereUICooldownManager/EllesmereUICooldownManager.lua
@@ -7596,6 +7596,11 @@ local function _ResolveSlotBinding(slot, key, tier)
             -- through to the body scan, which is the whole point: that answer
             -- is state-dependent and hides the other branches.
             if not _stableMode then return end
+        elseif subType == "item" and id then
+            -- Same contract, item side (e.g. "/use 13" trinket macros): `id`
+            -- is the actual itemID, straight from Blizzard, not the body scan.
+            _SetKeybind(-id, formatted, macroRank)
+            if not _stableMode then return end
         end
         -- For everything else `id` from GetActionInfo is NOT a reliable
         -- identifier -- resolve the real macro index via its name instead


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1540449760836853940

A macro using the equip-slot shorthand for a trinket (#showtooltip 13, /use 13) never shows its keybind on the CDM icon, while the same macro written with the item's full name (#showtooltip/#use Item Name) works.

Issue:

_ResolveSlotBinding's macro branch only special-cased Blizzard's "smart" single-SPELL macro resolution (subType == "spell", where GetActionInfo's id is authoritatively the spellID). It had no equivalent case for Blizzard's single-ITEM resolution (subType == "item"), even though this exact subType is already handled elsewhere in the codebase (ActionBars.lua, CdmHooks.lua's SlotSpellID) as a real, distinct return value. Without that branch, an equip-slot macro fell through entirely to the macro-name/body- scan path with no direct answer available from Blizzard itself.

Fix:

Added an elseif subType == "item" branch mirroring the existing spell one: register the keybind under -id (the actual itemID Blizzard already resolved), then fall through to the body scan in stable mode same as the spell case. 