### PR TITLE
Fix: Chinese/Korean display-locale override renders garbled on a non-matching client

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -1441,6 +1441,16 @@ EllesmereUI.LOCALE_FONT_FALLBACK = LOCALE_FONT_FALLBACK
 EllesmereUI.LOCALE_SCRIPT = EllesmereUI._localeScript
 EllesmereUI.EXPRESSWAY = LOCALE_FONT_FALLBACK or EXPRESSWAY
 
+-- Re-sync once the override-aware effective locale is known (the values above
+-- are captured before EllesmereUIDB's displayLocale override is readable).
+function EllesmereUI.RefreshLocaleFontFallback()
+    LOCALE_FONT_FALLBACK = EllesmereUI._localeFont
+    EllesmereUI.LOCALE_FONT_FALLBACK = LOCALE_FONT_FALLBACK
+    EllesmereUI.LOCALE_SCRIPT = EllesmereUI._localeScript
+    EllesmereUI.EXPRESSWAY = LOCALE_FONT_FALLBACK or EXPRESSWAY
+    EllesmereUI.InvalidateFontCache()
+end
+
 -- Taint-safe print: AddMessage, never global print() (its C-side handler taints the chat
 -- frame). Drops silently in protected instances (raid combat, active M+) to avoid tainting FCF_OpenTemporaryWindow's whisper chain.
 function EllesmereUI.Print(...)

--- a/EllesmereUIOptions/EUI__General_Options.lua
+++ b/EllesmereUIOptions/EUI__General_Options.lua
@@ -648,6 +648,18 @@ EllesmereUI._LEGENDS = {
     },
 }
 
+-- Language-picker font: each entry is entirely one script (even the CJK ones --
+-- their stock font already covers the trailing "(Korean)"-style Latin text, per
+-- the confirmed live render), so a plain per-entry font beats a multi-script
+-- family -- no dependency on how CreateFontFamily buckets accented Latin.
+local LP_FONT_BY_LOCALE = {
+    ruRU = "Fonts\\FRIZQT___CYR.TTF",
+    koKR = "Fonts\\2002.ttf",
+    zhCN = "Fonts\\ARKai_T.ttf",
+    zhTW = "Fonts\\bLEI00D.ttf",
+}
+local LP_ROMAN = EllesmereUI.MEDIA_PATH .. "fonts\\Expressway.TTF"
+
 -- The EUI Legends page: a celebration of the donors and team. Free-form
 -- chrome (no settings widgets) in the Patch Notes / Window Skins hero
 -- design language: dark cards, faint borders, accent bars, alpha hierarchy.
@@ -4050,6 +4062,14 @@ initFrame:SetScript("OnEvent", function(self)
                 ["zhTW"] = { text = "繁體中文 (Traditional Chinese)" },
             }
             local langOrder = { "auto", "enUS", "deDE", "frFR", "esES", "esMX", "itIT", "ptBR", "ruRU", "koKR", "zhCN", "zhTW" }
+            -- Pin each entry to the plain font its own script needs, independent
+            -- of whichever display locale is currently active.
+            for _, key in ipairs(langOrder) do
+                langValues[key].font = LP_FONT_BY_LOCALE[key] or LP_ROMAN
+            end
+            -- "auto"'s own text is translated, not a fixed native-script name, so
+            -- its script follows the ACTIVE locale rather than its own key.
+            langValues["auto"].font = LP_FONT_BY_LOCALE[EllesmereUI.LOCALE] or LP_ROMAN
 
             local function LanguageReload()
                 EllesmereUI:ShowConfirmPopup({

--- a/EllesmereUI_Locale.lua
+++ b/EllesmereUI_Locale.lua
@@ -185,5 +185,8 @@ f:SetScript("OnEvent", function(self, _, loaded)
             C_AddOns.LoadAddOn("EllesmereUILocales")
         end
         Activate()
+        -- EllesmereUI.lua's font system captured _localeFont/_localeScript before
+        -- this override-aware Activate() ran; re-sync it now that they're final.
+        if EllesmereUI.RefreshLocaleFontFallback then EllesmereUI.RefreshLocaleFontFallback() end
     end
 end)


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1548248285649702922

Setting EUI's own Language override to Simplified/Traditional Chinese (or Korean) while the WoW client itself stays English rendered every translated string in the options panel as garbled/tofu boxes.

Issue 1:

EllesmereUI.lua's LOCALE_FONT_FALLBACK (the CJK/Cyrillic glyph-font used by ResolveFontName, the addon's central font resolver) was captured once, at that file's own load time, from EllesmereUI._localeFont. But EllesmereUI_Locale.lua's Activate() only knows the CLIENT locale at that point -- EllesmereUIDB (holding the manual displayLocale override) is not readable yet -- so on an English client LOCALE_FONT_FALLBACK stayed permanently nil regardless of a later Chinese/Korean override, and every font read through it silently fell back to the addon's Western branding font, which has no CJK glyphs at all.

Fix 1:

Added EllesmereUI.RefreshLocaleFontFallback(), which re-derives LOCALE_FONT_FALLBACK (and its EllesmereUI.EXPRESSWAY/LOCALE_SCRIPT mirrors) from the now-final EllesmereUI._localeFont and drops the font cache. Called from EllesmereUI_Locale.lua's ADDON_LOADED handler right after its own override-aware Activate() re-run, so the font system re-syncs the moment the true effective locale is known.

Bug 2 (regression exposed by Fix 1):

Once Fix 1 made the Chinese/Korean options actually render, other entries in the same Language dropdown (Francais, Espanol, Portugues) started showing tofu for their own accented characters while a CJK locale was active.

Issue 2:

The dropdown lists every language's own name at once, so it inherently needs several scripts on screen simultaneously (Latin with diacritics, Cyrillic, Korean, Chinese) -- something no single per-locale font can ever cover. It was relying on the same general locale-following font as everything else, so activating a CJK locale traded one script's correct rendering for another's.

Fix 2:

Each dropdown entry only ever needs ONE script (even the CJK ones -- their stock font already covers the trailing "(Korean)"-style Latin text), so each entry is now pinned to the plain font its own script needs: Expressway for the Latin entries, each CJK/Cyrillic locale's own stock Blizzard font otherwise. The one exception is "Automatic (Client)", whose text is translated rather than a fixed native-script name, so its font follows the currently active locale instead of its own key.