### PR TITLE
Fix: Boss Frame's "Name > Target" shows red instead of class color for the target

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -2649,6 +2649,30 @@ TagFns.tgtcol = function(unit)
     local tunit = unit and (unit .. "target")
     if not tunit or not UnitExists(tunit) then return "" end
     local r, g, b = ns.ResolveUnitNameColor(tunit)
+    if r then
+        return string.format("|cff%02x%02x%02x", math.floor(r * 255 + 0.5),
+            math.floor(g * 255 + 0.5), math.floor(b * 255 + 0.5))
+    end
+    -- Secret class token (identity-restricted target, e.g. a boss's own
+    -- target): try Blizzard's own hex generator first, in case it's allowed
+    -- to declassify where plain string.format on r/g/b is not.
+    if UnitIsPlayer(tunit) and C_ClassColor and C_ClassColor.GetClassColor then
+        local _, class = UnitClass(tunit)
+        if issecretvalue(class) then
+            local cc = C_ClassColor.GetClassColor(class)
+            if cc and cc.GenerateHexColor then
+                local ok, hex = pcall(cc.GenerateHexColor, cc)
+                if ok and type(hex) == "string" then return "|c" .. hex end
+            end
+        end
+    end
+    -- Still nothing usable: fall back to the plain reaction color instead of "".
+    local reaction = UnitReaction(tunit, "player")
+    if reaction and not issecretvalue(reaction) then
+        local c = (ns.Colors and ns.Colors.reaction and ns.Colors.reaction[reaction])
+            or FACTION_BAR_COLORS[reaction]
+        if c then r, g, b = c.r, c.g, c.b end
+    end
     if not r then return "" end
     return string.format("|cff%02x%02x%02x", math.floor(r * 255 + 0.5),
         math.floor(g * 255 + 0.5), math.floor(b * 255 + 0.5))


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1547869283634126909

Boss Frames with a text zone set to "Name > Target" and Class Color enabled show the boss's own name correctly in its reaction color (red, hostile), but the target's name after the separator also shows red instead of its real class color -- unlike the options-panel preview, which correctly shows the boss name red and the target name class-colored (the boss's own red is expected/by design: NPCs have no class, so their name always uses reaction color, matching the health bar and border).

Issue:

A boss's current target ("bossNtarget") is an identity-restricted compound unit, the same category as Target-of-Target/focus-target: UnitClass hands back a SECRET token for it. TagFns.tgtcol (the tag coloring the target segment) could not turn that into the literal hex escape the shared "Name > Target" string needs, so it silently returned "" -- leaving that segment to inherit whatever color came before it in the string, the boss's own hostile-red base color.

Fix:

tgtcol now tries Blizzard's own hex-color generator (ColorMixin:GenerateHexColor, pcall-guarded) on the secret class token first -- it is allowed to declassify a secret color into literal text where plain string.format is not, giving the real class color. If that's ever refused, it falls back to the target's plain reaction color (friend/neutral/hostile, not secret) instead of emitting nothing.