### PR TITLE
Fix: enchanting off-hand weapon hides both weapon-enchant reminders

### DIFF
--- a/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
+++ b/EllesmereUIAuraBuffReminders/EllesmereUIAuraBuffReminders.lua
@@ -3482,9 +3482,11 @@ end
 function EABR.EmitWeaponEnchantReminders(missing, co)
     local hasMH, mhExpire, _, _, hasOH, ohExpire = EABR.WeaponEnchants()
     for i = 1, 2 do
-        local slot = (i == 1) and 16 or 17
-        local has = (i == 1) and hasMH or hasOH
-        local expire = (i == 1) and mhExpire or ohExpire
+        local slot, has, expire
+        -- Plain if/else, not "cond and a or b": that idiom silently falls
+        -- through to b whenever a (hasMH) is false, corrupting slot 16.
+        if i == 1 then slot, has, expire = 16, hasMH, mhExpire
+        else slot, has, expire = 17, hasOH, ohExpire end
         local r = EABR._resolved.we[slot]
         local cat = r.cat
         local shouldRemind = false


### PR DESCRIPTION
Bug: https://discord.com/channels/585577383847788554/1548340151544188930

Applying a temporary weapon enchant (oil) to the off-hand weapon made the main-hand reminder disappear too, even though the main hand still had no enchant. Removing the off-hand's enchant brought both reminders back.

Issue:

EmitWeaponEnchantReminders (EllesmereUIAuraBuffReminders.lua) picked each hand's "has enchant" state with the "cond and a or b" idiom:

    local has = (i == 1) and hasMH or hasOH

This idiom silently falls through to b whenever a is falsy. For the main hand (i == 1), whenever hasMH was false (no enchant), the expression evaluated to hasOH instead -- so an unenchanted main hand was read as having the off hand's enchant state. With the off hand freshly enchanted, the main hand's reminder was wrongly suppressed as "not needed yet". The off hand's own slot was unaffected (its branch never depended on a falsy value to pick the right side), which is why enchanting main hand first never showed the bug.

Fix:

Replaced the idiom with a plain if/else that assigns the correct values unconditionally, per slot. 