### PR TITLE
Add icons to the Bags currency dropdown

### DIFF
--- a/EllesmereUIOptions/EUI_Bags_Options.lua
+++ b/EllesmereUIOptions/EUI_Bags_Options.lua
@@ -549,6 +549,7 @@ initFrame:SetScript("OnEvent", function(self)
                                         local cName = cInfo and cInfo.name or info.name
                                         currencyItems[#currencyItems + 1] = {
                                             key = cID, label = cName,
+                                            icon = (cInfo and cInfo.iconFileID) or info.iconFileID,
                                         }
                                     end
                                 end
@@ -597,6 +598,7 @@ initFrame:SetScript("OnEvent", function(self)
                                 block[#block + 1] = {
                                     key = cID,
                                     label = (cInfo and cInfo.name) or ("Currency " .. cID),
+                                    icon = cInfo and cInfo.iconFileID,
                                 }
                             end
                             for i = #block, 1, -1 do


### PR DESCRIPTION
## What does this PR do?

Show currency icons beside the names in Bags > Enabled Currencies, including retired currencies when a texture is available. Uses the dropdown's existing icon support; search, grouping, and tracking behavior stay unchanged.

## How was it tested?

- Installed the two-line change on live with a verified backup. The supplied after screenshot confirms icons render in the currency dropdown.
- `git diff --check` passed. Retired currencies and missing textures were checked in code, not verified in game.

## Screenshots

Before:

![Currency dropdown before, with names and checkboxes only](https://github.com/user-attachments/assets/8ea876e7-74e2-4121-b37c-f5b15690f161)

After:

![Currency dropdown after, with icons beside currency names](https://github.com/user-attachments/assets/029b7acc-7970-4570-85a8-bd04ae5e6b2a)

## Checklist

- [ ] New settings default **OFF**: no setting added; this visual enhancement appears whenever the dropdown is opened.
- [x] Zero cost while disabled: no new events, polling, or hooks; icons use the existing menu row construction.
- [x] Cheap while enabled: no new polling, timers, or per-frame logic.
- [x] No new writes onto Blizzard-owned frames.
- [x] Tested in-game on live via the supplied screenshot; no version gates or pre-Midnight APIs added.
