### PR TITLE
Fix Great Vault Escape handling when opened through macros or other addons

### DIFF
--- a/EllesmereUI.lua
+++ b/EllesmereUI.lua
@@ -11526,6 +11526,24 @@ initFrame:SetScript("OnEvent", function(self, event)
             frame:HookScript("OnShow", RefreshProxy)
             frame:HookScript("OnHide", RefreshProxy)
         end
+
+        -- Register the Vault once, regardless of which shortcut opens it.
+        local function RegisterVaultEscapeClose()
+            if not WeeklyRewardsFrame then return false end
+            EllesmereUI.RegisterEscapeClose(WeeklyRewardsFrame)
+            RefreshProxy()
+            return true
+        end
+
+        if not RegisterVaultEscapeClose() then
+            local vaultLoader = CreateFrame("Frame")
+            vaultLoader:RegisterEvent("ADDON_LOADED")
+            vaultLoader:SetScript("OnEvent", function(self, event, addonName)
+                if addonName == "Blizzard_WeeklyRewards" and RegisterVaultEscapeClose() then
+                    self:UnregisterEvent("ADDON_LOADED")
+                end
+            end)
+        end
     end
 
     -- Create native minimap button

--- a/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
+++ b/EllesmereUIDataBars/EllesmereUIDataBars_Blocks.lua
@@ -6223,7 +6223,6 @@ local function GVToggleVault()
     end
     local wrf = _G.WeeklyRewardsFrame
     if not wrf then return end
-    if EllesmereUI.RegisterEscapeClose then EllesmereUI.RegisterEscapeClose(wrf) end
     wrf:SetShown(not wrf:IsShown())
 end
 

--- a/EllesmereUIMinimap/EllesmereUIMinimap.lua
+++ b/EllesmereUIMinimap/EllesmereUIMinimap.lua
@@ -1452,12 +1452,6 @@ end
 local _greatVaultBtn = nil
 local GREAT_VAULT_WHOLE_ATLAS = "greatVault-whole-normal"
 
-local function RegisterVaultEscClose()
-    local wrf = _G.WeeklyRewardsFrame
-    if not wrf or not EllesmereUI.RegisterEscapeClose then return end
-    EllesmereUI.RegisterEscapeClose(wrf)
-end
-
 local function ColorizeVaultText(text, r, g, b)
     r = math.floor(math.max(0, math.min(1, r or 1)) * 255 + 0.5)
     g = math.floor(math.max(0, math.min(1, g or 1)) * 255 + 0.5)
@@ -1679,7 +1673,6 @@ local function ToggleGreatVault()
     if Load and IsLoaded and not IsLoaded("Blizzard_WeeklyRewards") then
         Load("Blizzard_WeeklyRewards")
     end
-    RegisterVaultEscClose()
     if WeeklyRewardsFrame then
         WeeklyRewardsFrame:SetShown(not WeeklyRewardsFrame:IsShown())
     end


### PR DESCRIPTION
## What does this PR do?

Make Escape close the Great Vault consistently when it is opened through another addon or a macro, as it already does through EllesmereUI's minimap and Data Bars shortcuts.

Currently, those EUI shortcuts register the Vault with the shared Escape handler when clicked. Opening it through another route first misses that registration. Register it once when the Vault UI is available instead, and remove the repeated registrations from the shortcuts.

## How was it tested?

- Lua 5.1 compilation passed for all three changed files; `git diff --check` passed.
- Mocked behavior checks passed for late loading, an already-loaded hidden or visible Vault, repeated opening and closing, listener cleanup, and Escape with another EUI window open.
- Installed locally with backup and hash verification. In-game testing is not yet confirmed.

## Checklist

- N/A: No new settings; this fixes inconsistent existing Escape behavior.
- N/A: No separate enable/disable setting. The load listener unregisters once the Vault is registered.
- [x] Cheap while enabled: event-driven, no polling or timers.
- [x] No writes onto Blizzard-owned frames; uses the existing Escape handler's `HookScript` integration.
- [ ] Tested in-game on live. No version gates or pre-Midnight APIs added.
