### PR TITLE
Fix unit frame health fills breaking on window resize

### DIFF
--- a/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
+++ b/EllesmereUIUnitFrames/EllesmereUIUnitFrames.lua
@@ -13112,6 +13112,17 @@ function SetupOptionsPanel()
     end
     _G._EUF_ReloadFrames = ns.ReloadFrames
 
+    -- Rebuild frames on resolution/scale changes. Without this, a window resize
+    -- (DISPLAY_SIZE_CHANGED with no UI-scale change) leaves health fills at stale
+    -- pixel-snapped geometry until /reload. ReloadFrames is throttled and
+    -- combat-safe; C_Timer.After(0) lets the new screen size settle first.
+    local resizeWatcher = CreateFrame("Frame")
+    resizeWatcher:RegisterEvent("DISPLAY_SIZE_CHANGED")
+    resizeWatcher:RegisterEvent("UI_SCALE_CHANGED")
+    resizeWatcher:SetScript("OnEvent", function()
+        C_Timer.After(0, ns.ReloadFrames)
+    end)
+
     -- Fake debuff icons for the boss preview. Three square icons anchored where the
     -- real Debuffs frame would live, sized to match the Simple Debuff Display layout
     -- (frame bar height, growing right-to-left off the frame's left edge). Created on


### PR DESCRIPTION
## What does this PR do?

Unit frame health fills render empty after the WoW window is resized, and only recover on a `/reload`. `EllesmereUIUnitFrames` registers no display or scale listeners, so a pure resolution change (`DISPLAY_SIZE_CHANGED`, which fires without a UI-scale change) never triggers a rebuild, and the bars keep their pre-resize pixel-snapped geometry. The main addon's `scaleWatcher` only re-runs the unit-frame reload through `PP.SetUIScale`, which a plain resize does not reach.

The fix registers `DISPLAY_SIZE_CHANGED` + `UI_SCALE_CHANGED` in the unit-frame addon and re-runs the existing `ns.ReloadFrames` on those events, deferred one frame so the new screen size settles before the rebuild reads `GetPhysicalScreenSize`.

## How was it tested?

Live (Midnight 12.1) on a Hyprland/Wayland desktop, where `Super+F` toggles the game window between windowed and fullscreen and fires `DISPLAY_SIZE_CHANGED`. Before the patch the fills go empty on the toggle and stay empty until `/reload`; after, they refill correctly on every toggle with no manual reload, in and out of combat.

## Screenshots

Before, using Super+F to toggle fullscreen in Hyprland:

![before, using Super+F to toggle fullscreen in hyprland](https://raw.githubusercontent.com/robert-clayton/EllesmereUI/pr-assets/before-superf.png)

After, using Super+F to toggle fullscreen in Hyprland:

![after, using Super+F to toggle fullscreen in hyprland](https://raw.githubusercontent.com/robert-clayton/EllesmereUI/pr-assets/after-superf.png)

## Checklist

- New settings default OFF -> **N/A.** Bug fix, no setting. Criterion 2 exempts genuine bug fixes; the behavior change is broken frames becoming correct frames.
- Zero cost while disabled -> **N/A** for the same reason. As a bug fix it is always on: one frame and two event registrations. Both events fire only on a resolution/UI-scale change, essentially never during play, so the standing cost is nil.
- [x] Cheap while enabled: event-driven, no polling, no per-frame allocations. Two rare events; the `C_Timer.After(0)` is a one-shot next-frame defer, not a recurring timer gate.
- [x] No writes onto Blizzard-owned frames. `SetScript` is on the addon's own `CreateFrame("Frame")`, never a Blizzard frame. Reuses `ns.ReloadFrames`, already combat-safe (its throttle guards restricted Show/Hide behind `InCombatLockdown` and defers via `PLAYER_REGEN_ENABLED`), so no new taint surface.
- [x] Tested in-game on live; no version gates or pre-Midnight APIs added.
